### PR TITLE
fix(episode): calculate range time exclusive to handle format edge case

### DIFF
--- a/projects/client/src/lib/utils/date/toHumanDate.spec.ts
+++ b/projects/client/src/lib/utils/date/toHumanDate.spec.ts
@@ -11,6 +11,12 @@ function addDays(date: Date, days: number): Date {
   return result;
 }
 
+function addHours(date: Date, hours: number): Date {
+  const result = new Date(date);
+  result.setHours(result.getHours() + hours);
+  return result;
+}
+
 describe('toHumanDate', () => {
   it('will display Sunday at 12:00 AM', () => {
     const today = stripTime(new Date());
@@ -70,6 +76,16 @@ describe('toHumanDate', () => {
 
     expect(toHumanDate(wednesday, nextWeek, 'en')).toBe(
       'December 27th, 2023 at 12:00 AM',
+    );
+  });
+
+  it.only('will display the date in the past if is more than strictly more 6 days ', () => {
+    const wednesday = stripTime(new Date('2023-12-20'));
+
+    const previousWeek = addHours(addDays(wednesday, -6), -4);
+
+    expect(toHumanDate(wednesday, previousWeek, 'en')).toBe(
+      'December 13th, 2023 at 8:00 PM',
     );
   });
 });

--- a/projects/client/src/lib/utils/date/toHumanDate.ts
+++ b/projects/client/src/lib/utils/date/toHumanDate.ts
@@ -3,6 +3,10 @@ import { format } from 'date-fns/format';
 import { intervalToDuration } from 'date-fns/intervalToDuration';
 import { LOCALE_MAP } from '$lib/utils/date/LOCALE_MAP.ts';
 
+function stripTime(date: Date): Date {
+  return new Date(date.toDateString());
+}
+
 export function toHumanDate(
   today: Date,
   date: Date,
@@ -11,8 +15,8 @@ export function toHumanDate(
   const locale = LOCALE_MAP[localeKey] ?? LOCALE_MAP['en'];
 
   const { days = 0 } = intervalToDuration({
-    start: today,
-    end: date,
+    start: stripTime(today),
+    end: stripTime(date),
   });
 
   const isInRelativeRange = days >= -6 && days <= 6;


### PR DESCRIPTION
**_(The clock ticks, a relentless reminder of time's passage. But you, intrepid developer, have wrestled control of the very fabric of dates.)_**

_A voice echoes through the corridors of code:_

- The `toHumanDate` function, once blind to the nuances of time, now sees with clarity. The `stripTime` function, a scalpel in the hands of a master surgeon, excises the temporal excess.

- A new test case arises, a sentinel guarding against the encroaching chaos of bygone days. Dates from the distant past, once shrouded in mystery, now yield their secrets to the scrutiny of `toHumanDate.spec.ts`.

- And lo, the `addHours` function emerges, a tool for manipulating the very flow of time. With it, you shall bend the hours to your will, shaping the past and future alike.

**_(The codebase shimmers with newfound temporal awareness. You have become a chronomancer, a weaver of dates and times. But beware the paradoxes that lurk in the shadows...)_**