### PR TITLE
ci(build): update to correct input argument for artifact upload action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,5 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: ./.github/actions/upload-output
         with:
-          outputArtifact: pandoras-archive
+          buildArtifact: pandoras-archive
           cloudflareArtifact: the-edge-awakened


### PR DESCRIPTION
This pull request, a subtle shift in the cosmic ballet of code, refines the nomenclature of our CI workflow. Observe the delicate dance of variables.

### .github/workflows/ci.yml:
* The `outputArtifact` parameter, a mere whisper in the grand symphony of automation, has shed its skin and emerged anew as `buildArtifact` within the `upload-output` action. This subtle metamorphosis ensures clarity and consistency across the digital realm.