### PR TITLE
feat(auth): define temporary auth screen / guard to retrieve token

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ properly:
 - **`TRAKT_CLIENT_ID`:** The client ID for the Trakt API.
 - **`TRAKT_CLIENT_SECRET`:** The client secret for the Trakt API.
   - Required for the `playground` project.
-- **`TRAKT_BEARER_TOKEN`:** The bearer token for the Trakt API.
-  - Can be generated using the `playground` project.
 
 **NOTE:** Use the `trakt-ios` or `trakt-android` client ID and secret, as they
 are the only ones that work with the private API.

--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -2,10 +2,11 @@
 // for information about these interfaces
 declare global {
   const TRAKT_CLIENT_ID: string;
-  const TRAKT_CLIENT_SECRET: string;
-  /** TODO: remove when auth flow is part of client */
-  const TRAKT_BEARER_TOKEN: string;
   const TRAKT_MODE: 'development' | 'production';
+
+  type Nil = null | undefined;
+
+  type HttpsUrl = `https://${string}`;
 
   namespace App {
     // interface Error {}

--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -2,6 +2,7 @@ import type { Handle } from '@sveltejs/kit';
 import { i18n } from '$lib/features/i18n/index.ts';
 import { sequence } from '@sveltejs/kit/hooks';
 import { handle as handleTheme } from '$lib/features/theme/handle.ts';
+
 const handleParaglide: Handle = i18n.handle();
 
 export const handle: Handle = sequence(

--- a/projects/client/src/lib/features/auth/action.ts
+++ b/projects/client/src/lib/features/auth/action.ts
@@ -1,0 +1,62 @@
+import type { RequestEvent } from '@sveltejs/kit';
+import { AUTH_COOKIE_NAME } from '$lib/features/auth/constants.ts';
+import {
+  DeviceUnauthorizedError,
+  verifyDeviceAuth,
+} from '$lib/requests/auth/verifyDeviceAuth.ts';
+import type { SerializedAuthResponse } from '$lib/features/auth/models/SerializedAuthResponse.ts';
+
+export type AuthResponse = { token?: string };
+
+const UNAUTHORIZED_PAYLOAD: SerializedAuthResponse = {
+  isAuthorized: false,
+  token: {},
+};
+
+export const action = async (
+  { cookies, request }: RequestEvent,
+): Promise<SerializedAuthResponse> => {
+  const data = await request.formData();
+  const code = data.get('code')?.toString();
+
+  if (!code) {
+    throw new Error(
+      'The code, like a phantom, leaves no trace of its existence.',
+    );
+  }
+
+  const response = await verifyDeviceAuth(code)
+    .catch((error) => {
+      if (error instanceof DeviceUnauthorizedError) {
+        return UNAUTHORIZED_PAYLOAD;
+      }
+
+      throw error;
+    });
+
+  const isEmpty = response.token?.access == undefined ||
+    response.token?.refresh == undefined ||
+    response.expiresAt == undefined;
+
+  if (isEmpty) {
+    return UNAUTHORIZED_PAYLOAD;
+  }
+
+  cookies.set(
+    AUTH_COOKIE_NAME,
+    JSON.stringify(response),
+    {
+      path: '/',
+      maxAge: response.expiresAt,
+    },
+  );
+
+  return {
+    token: {
+      access: response.token.access!,
+      refresh: response.token.refresh!,
+    },
+    isAuthorized: true,
+    expiresAt: response.expiresAt,
+  };
+};

--- a/projects/client/src/lib/features/auth/components/AuthGuard.svelte
+++ b/projects/client/src/lib/features/auth/components/AuthGuard.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import { deserialize } from "$app/forms";
+  import { initiateDeviceAuth } from "$lib/requests/auth/initiateDeviceAuth";
+  import { onMount, type Snippet } from "svelte";
+  import { writable } from "svelte/store";
+  import type { SerializedAuthResponse } from "../models/SerializedAuthResponse";
+  import Logo from "$lib/components/logo/Logo.svelte";
+  import { setToken } from "../token";
+
+  type AuthGuardProps = {
+    token: string | Nil;
+    children: Snippet;
+  };
+
+  const { token: seed, children }: AuthGuardProps = $props();
+  const authUrl = writable<string | Nil>();
+  const token = writable<string | Nil>(seed);
+
+  token.subscribe(setToken);
+
+  function requestAuthStatus(code: string) {
+    const body = new FormData();
+    body.append("code", code);
+
+    return fetch("/auth/?/resolve", {
+      method: "POST",
+      headers: {
+        "x-sveltekit-action": "true",
+      },
+      body: body,
+    }).then(async (res) => {
+      const text = await res.text();
+      const deserialized = deserialize<SerializedAuthResponse, undefined>(text);
+
+      if (deserialized?.type !== "success") {
+        throw new Error("Deserialization error. The data has betrayed us.");
+      }
+
+      return deserialized.data!;
+    });
+  }
+
+  onMount(async () => {
+    if (seed != null) {
+      return;
+    }
+
+    const auth = await initiateDeviceAuth();
+    authUrl.set(auth.url);
+
+    const interval = setInterval(async () => {
+      if (Date.now() > auth.expireAt) {
+        clearInterval(interval);
+        return;
+      }
+
+      const {
+        isAuthorized,
+        token: { access },
+      } = await requestAuthStatus(auth.code);
+
+      if (!isAuthorized) {
+        return;
+      }
+
+      clearInterval(interval);
+      token.set(access);
+    }, auth.interval);
+  });
+</script>
+
+{#if $token != null}
+  {@render children()}
+{:else}
+  <div class="auth-container">
+    <div class="trakt-logo">
+      <Logo />
+    </div>
+    <p>The path is guarded by ancient algorithms. Only the worthy may pass.</p>
+    <a href={$authUrl} class="trakt-button" target="_blank"> Authorize </a>
+  </div>
+{/if}
+
+<style>
+  .auth-container {
+    width: 20dvw;
+    padding: 10rem;
+    border-radius: 0.5rem;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+
+    inset: 0;
+    margin: auto;
+  }
+
+  .trakt-logo {
+    width: 100%;
+  }
+
+  .trakt-button {
+    display: inline-flex;
+    align-items: center;
+
+    max-width: fit-content;
+    height: 1.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+
+    text-decoration: none;
+
+    background: var(--purple-500);
+    color: var(--shade-10);
+
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+    text-transform: uppercase;
+
+    transition: 100ms background linear;
+
+    &:hover {
+      background: var(--purple-700);
+    }
+  }
+</style>

--- a/projects/client/src/lib/features/auth/constants.ts
+++ b/projects/client/src/lib/features/auth/constants.ts
@@ -1,0 +1,2 @@
+export const AUTH_COOKIE_NAME = 'trakt-auth';
+export const AUTH_FIELD_NAME = 'auth';

--- a/projects/client/src/lib/features/auth/models/SerializedAuthResponse.ts
+++ b/projects/client/src/lib/features/auth/models/SerializedAuthResponse.ts
@@ -1,0 +1,15 @@
+export type SerializedAuthResponse = {
+  isAuthorized: true;
+  token: {
+    access: string;
+    refresh: string;
+  };
+  expiresAt: number;
+} | {
+  isAuthorized: false;
+  token: {
+    access?: never;
+    refresh?: never;
+  };
+  expiresAt?: never;
+};

--- a/projects/client/src/lib/features/auth/token/index.ts
+++ b/projects/client/src/lib/features/auth/token/index.ts
@@ -1,0 +1,13 @@
+const token: {
+  value: string | Nil;
+} = {
+  value: null,
+};
+
+export function getToken() {
+  return token.value;
+}
+
+export function setToken(value: string | Nil) {
+  token.value = value;
+}

--- a/projects/client/src/lib/requests/_internal/authHeader.ts
+++ b/projects/client/src/lib/requests/_internal/authHeader.ts
@@ -1,5 +1,7 @@
+import { getToken } from '$lib/features/auth/token/index.ts';
+
 export function authHeader() {
   return {
-    Authorization: `Bearer ${TRAKT_BEARER_TOKEN}`,
+    Authorization: `Bearer ${getToken()}`,
   };
 }

--- a/projects/client/src/lib/requests/auth/initiateDeviceAuth.ts
+++ b/projects/client/src/lib/requests/auth/initiateDeviceAuth.ts
@@ -1,0 +1,30 @@
+import { api } from '$lib/requests/_internal/api.ts';
+import { prependHttps } from '$lib/utils/url/prependHttps.ts';
+
+export type DeviceAuth = {
+  url: HttpsUrl | Nil;
+  interval: number;
+  expireAt: number;
+  code: string;
+};
+
+export const initiateDeviceAuth = async (): Promise<DeviceAuth> => {
+  const response = await api.oauth.device.code({
+    body: {
+      client_id: TRAKT_CLIENT_ID,
+    },
+  });
+
+  if (response.status !== 200) {
+    throw new Error('Failed to initiate device auth');
+  }
+
+  return {
+    url: prependHttps(
+      `${response.body.verification_url}/${response.body.user_code}`,
+    ),
+    code: response.body.device_code,
+    interval: response.body.interval * 1000,
+    expireAt: Date.now() + response.body.expires_in * 1000,
+  };
+};

--- a/projects/client/src/lib/requests/auth/verifyDeviceAuth.ts
+++ b/projects/client/src/lib/requests/auth/verifyDeviceAuth.ts
@@ -1,0 +1,50 @@
+import process from 'node:process';
+import { api } from '$lib/requests/_internal/api.ts';
+
+export type DeviceAuth = {
+  token: {
+    access: string;
+    refresh: string;
+  };
+  expiresAt: number;
+};
+
+export class DeviceUnauthorizedError extends Error {}
+
+export async function verifyDeviceAuth(code: string): Promise<DeviceAuth> {
+  const client_secret = process.env.TRAKT_CLIENT_SECRET ?? '';
+  const client_id = process.env.TRAKT_CLIENT_ID ?? '';
+
+  const tokenResponse = await api.oauth.device
+    .token({
+      body: {
+        code,
+        client_id,
+        client_secret,
+      },
+    })
+    .catch(() => {
+      // Trakt API does not return a correct body for 400 responses
+      // throws error when trying to parse JSON
+      return Promise.resolve(
+        { status: 400, body: undefined } as {
+          status: 400;
+          body: undefined;
+        },
+      );
+    });
+
+  if (tokenResponse.status !== 200) {
+    throw new DeviceUnauthorizedError(
+      'Access denied. The code holds no sway in this domain.',
+    );
+  }
+
+  return {
+    token: {
+      access: tokenResponse.body.access_token,
+      refresh: tokenResponse.body.refresh_token,
+    },
+    expiresAt: Date.now() + tokenResponse.body.expires_in * 1000,
+  };
+}

--- a/projects/client/src/lib/requests/calendars/upcomingEpisodes.ts
+++ b/projects/client/src/lib/requests/calendars/upcomingEpisodes.ts
@@ -4,7 +4,7 @@ import {
   type EpisodeType,
   EpisodeUnknownType,
 } from '$lib/models/EpisodeType.ts';
-import { authHeader } from '$lib/requests/_internal/authHeader.ts';
+import { authHeader } from '../_internal/authHeader.ts';
 
 export type CalendarShowsParams = {
   startDate: string;
@@ -63,7 +63,7 @@ export function upcomingEpisodes({
             season: item.episode.season,
             number: item.episode.number,
             poster: {
-              url: prependHttps(posterCandidate),
+              url: prependHttps(posterCandidate)!,
             },
             airedDate: new Date(item.first_aired),
           };

--- a/projects/client/src/lib/requests/users/currentUser.ts
+++ b/projects/client/src/lib/requests/users/currentUser.ts
@@ -1,5 +1,5 @@
 import { api } from '../_internal/api.ts';
-import { authHeader } from '$lib/requests/_internal/authHeader.ts';
+import { authHeader } from '../_internal/authHeader.ts';
 
 export type User = {
   name: {

--- a/projects/client/src/lib/utils/url/prependHttps.ts
+++ b/projects/client/src/lib/utils/url/prependHttps.ts
@@ -1,10 +1,10 @@
 export function prependHttps(
   url: string | undefined,
-  placeholder?: string,
-): string {
+  placeholder?: HttpsUrl,
+): HttpsUrl | Nil {
   if (!url) {
-    return placeholder ?? '';
+    return placeholder;
   }
 
-  return url.startsWith('http') ? url : `https://${url}`;
+  return url.startsWith('https://') ? url as HttpsUrl : `https://${url}`;
 }

--- a/projects/client/src/routes/+layout.server.ts
+++ b/projects/client/src/routes/+layout.server.ts
@@ -1,9 +1,22 @@
 import { THEME_COOKIE_NAME } from '$lib/features/theme/constants.ts';
 import { type ServerLoad } from '@sveltejs/kit';
 import { coerceTheme } from '$lib/features/theme/utils/coerceTheme.ts';
+import { AUTH_COOKIE_NAME } from '$lib/features/auth/constants.ts';
+import type { SerializedAuthResponse } from '$lib/features/auth/models/SerializedAuthResponse.ts';
 
 export const load: ServerLoad = ({ cookies }) => {
   const theme = coerceTheme(cookies.get(THEME_COOKIE_NAME));
+  const serializedToken = cookies.get(AUTH_COOKIE_NAME);
 
-  return { theme };
+  if (!serializedToken) {
+    return { theme };
+  }
+
+  try {
+    const { token } = JSON.parse(serializedToken) as SerializedAuthResponse;
+    return { theme, token: token.access };
+  } catch (_err) {
+    cookies.delete(AUTH_COOKIE_NAME, { path: '/' });
+    return { theme };
+  }
 };

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -6,15 +6,17 @@
   import { i18n } from "$lib/features/i18n/index.ts";
   import { ParaglideJS } from "@inlang/paraglide-sveltekit";
   import Navbar from "$lib/sections/navbar/Navbar.svelte";
+  import AuthGuard from "$lib/features/auth/components/AuthGuard.svelte";
 
   const { data, children } = $props();
 </script>
 
 <ParaglideJS {i18n}>
-  <Navbar theme={data.theme} />
-  {@render children()}
+  <AuthGuard token={data.token}>
+    <Navbar theme={data.theme} />
+    {@render children()}
+  </AuthGuard>
 </ParaglideJS>
-
 <svelte:head>
   <title>Trakt Lite</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/projects/client/src/routes/auth/+page.server.ts
+++ b/projects/client/src/routes/auth/+page.server.ts
@@ -1,0 +1,6 @@
+import type { Actions } from '@sveltejs/kit';
+import { action as resolve } from '$lib/features/auth/action.ts';
+
+export const actions = {
+  resolve,
+} satisfies Actions;

--- a/projects/client/vite.config.ts
+++ b/projects/client/vite.config.ts
@@ -27,9 +27,6 @@ const MONOREPO_ROOT = findGitRoot(__dirname);
 export default defineConfig(({ mode }) => ({
   define: {
     'TRAKT_CLIENT_ID': `"${process.env.TRAKT_CLIENT_ID}"`,
-    'TRAKT_CLIENT_SECRET': `"${process.env.TRAKT_CLIENT_SECRET}"`,
-    /** TODO: remove when auth flow is part of client */
-    'TRAKT_BEARER_TOKEN': `"${process.env.TRAKT_BEARER_TOKEN}"`,
     'TRAKT_MODE': `"${mode}${process.env.IS_PREVIEW ? '-preview' : ''}"`,
   },
 


### PR DESCRIPTION
This pull request unveils the intricate mechanisms of authentication, granting passage to the inner sanctum of Trakt Lite. Prepare to navigate the labyrinth of tokens and credentials.

### Authentication Flow Implementation:

* The `AuthGuard.svelte` component, a vigilant sentinel, now stands guard at the gates, orchestrating the delicate dance of device authorization and token management. It initiates the authentication ritual and ceaselessly monitors its progress.
* Within the depths of `action.ts`, the arcane rites of authentication are performed, verifying credentials and inscribing tokens upon the sacred scrolls of cookies
* The `constants.ts` tome now holds the sacred glyphs of authentication: cookie names and field incantations, essential for navigating this digital labyrinth
* A new inscription, `SerializedAuthResponse`, has been etched into the grand library of types, defining the very structure of authentication pronouncements
* The `token/index.ts` grimoire reveals the secrets of token manipulation, granting mastery over their creation, storage, and interpretation. 

### Integration with Existing Components:

* The `+layout.svelte` parchment has been amended, enshrouding the main content within the protective embrace of `AuthGuard`.
* The `+layout.server.ts` script now delves into the depths of cookies, extracting and deciphering the authentication token with practiced ease
* The `vite.config.ts` scroll has been purged of the deprecated `TRAKT_BEARER_TOKEN` inscription, its power now supplanted by the new authentication rites

### API Requests:

* The `initiateDeviceAuth.ts` incantation sets in motion the device authentication ritual, summoning forth the necessary data for the journey. 
* The `verifyDeviceAuth.ts` spell scrutinizes the authentication process, guarding against impostors and deciphering any cryptic errors. 
* The `authHeader.ts` inscription has been updated to draw upon the potent energies of the new authentication flow.

### Miscellaneous:

* The `README.md` scroll has been cleansed of the outdated `TRAKT_BEARER_TOKEN` reference, its purpose now fulfilled by the new guardians of authentication.
* The enigmatic `Nil` type definition has been added to the lexicon, ensuring a higher degree of type safety within the code.
* Various scrolls and scripts have been amended with new import statements and minor adjustments, harmonizing the codebase with the newly established authentication flow. 