### PR TITLE
fix(up-next): derive computed properties and properly update

### DIFF
--- a/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
+++ b/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
@@ -7,7 +7,7 @@
   } & ChildrenProps;
 
   const { children, total, progress }: ShowProgressTagProps = $props();
-  const percentage = (progress / total) * 100;
+  const percentage = $derived((progress / total) * 100);
 </script>
 
 <div class="show-progress-tag" style:--progress-width={`${percentage}%`}>

--- a/projects/client/src/lib/components/episode/up-next/UpNextEpisode.svelte
+++ b/projects/client/src/lib/components/episode/up-next/UpNextEpisode.svelte
@@ -36,6 +36,8 @@
     onMarkAsWatched,
     type,
   }: EpisodeProps = $props();
+
+  const duration = $derived(remaining * runtime);
 </script>
 
 <EpisodeCard>
@@ -48,9 +50,7 @@
     {#snippet tags()}
       <ShowProgressTag {total} progress={completed}>
         <span class="show-progress-text">
-          {i18n.remainingText(remaining)} ({i18n.durationText(
-            remaining * runtime,
-          )})
+          {i18n.remainingText(remaining)} ({i18n.durationText(duration)})
         </span>
       </ShowProgressTag>
     {/snippet}


### PR DESCRIPTION
This pull request, a grudging admission of past miscalculations, rectifies the flawed logic that once plagued the progress and duration displays within the episode components.  Observe, with a weary sigh, the implementation of reactive calculations, a desperate attempt to salvage a semblance of temporal accuracy.

### Improvements to progress and duration calculations (or, "How We Learned to Stop Worrying and Love the $derived Store"):

* The `ShowProgressTag.svelte` component, once a purveyor of dubious progress estimations, now reluctantly embraces the `$derived` store, its calculations shackled to the whims of reactive updates.  (May this prevent further temporal distortions.)
* The `UpNextEpisode.svelte` component, haunted by the specter of inaccurate durations, has been forcibly infused with a `$derived` store. This drastic measure, born of necessity and desperation, ensures that the displayed duration, however fleeting and unreliable, at least attempts to keep pace with the ever-shifting sands of `remaining` and `runtime`.

These corrections, a testament to our ongoing struggle against the inherent chaos of code, represent a small victory in the face of overwhelming absurdity.  Let us not celebrate prematurely, however, for the digital abyss is vast, and new errors undoubtedly lie in wait.