### PR TITLE
ci / lock deno version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Summon the Digital Oracle aka Install Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          # FIXME: switch to v2.x once https://github.com/denoland/deno/issues/26960 is resolved
+          deno-version: v2.0.x
 
       - name: Gather the Tools aka Install Dependencies
         run: 'deno task install'
@@ -87,7 +88,8 @@ jobs:
       - name: Summon the Digital Oracle aka Install Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          # FIXME: switch to v2.x once https://github.com/denoland/deno/issues/26960 is resolved
+          deno-version: v2.0.x
 
       - name: Gather the Tools aka Install Dependencies
         run: 'deno task install'


### PR DESCRIPTION
This pull request includes updates to the CI workflow configuration in the `.github/workflows/ci.yml` file. The updates address a versioning issue with Deno.

Changes to CI workflow configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL61-R62): Updated the `deno-version` to `v2.0.x` with a comment to switch back to `v2.x` once the issue denoland/deno#26960 is resolved. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL61-R62) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL90-R92)