### PR TITLE
feat(section-list): define smooth entry/exit shadow based on position

### DIFF
--- a/projects/client/src/lib/components/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/section-list/SectionList.svelte
@@ -8,12 +8,21 @@
   } & ChildrenProps;
 
   const { children, title }: SectionListProps = $props();
-  const layoutDistanceSide = varToPixels("--layout-distance-side");
+  const sideDistance = varToPixels("--layout-distance-side");
+  const windowShadowWidth = varToPixels("--ni-64");
 
   const scrollX = writable({ left: 0, right: 0 });
 
-  const isLeftShadowVisible = $derived($scrollX.left > layoutDistanceSide);
-  const isRightShadowVisible = $derived($scrollX.right > layoutDistanceSide);
+  const isLeftShadowVisible = $derived($scrollX.left > sideDistance);
+  const isRightShadowVisible = $derived($scrollX.right > sideDistance);
+
+  const leftShadowIntensity = $derived(
+    ($scrollX.left - sideDistance) / windowShadowWidth,
+  );
+
+  const rightShadowIntensity = $derived(
+    ($scrollX.right - sideDistance) / windowShadowWidth,
+  );
 </script>
 
 <section class="section-list-container">
@@ -23,6 +32,8 @@
     class="section-list"
     class:section-list-left-shadow={isLeftShadowVisible}
     class:section-list-right-shadow={isRightShadowVisible}
+    style:--left-shadow-opacity={leftShadowIntensity}
+    style:--right-shadow-opacity={rightShadowIntensity}
   >
     <div use:scrollTracking={scrollX} class="section-list-horizontal-scroll">
       {@render children()}
@@ -55,11 +66,11 @@
     position: relative;
 
     &.section-list-left-shadow::before {
-      opacity: 1;
+      opacity: var(--left-shadow-opacity);
     }
 
     &.section-list-right-shadow::after {
-      opacity: 1;
+      opacity: var(--right-shadow-opacity);
     }
 
     &::before {
@@ -86,7 +97,6 @@
         var(--height-section-list) - var(--layout-distance-scroll-card)
       );
 
-      transition: opacity var(--transition-increment) ease-in-out;
       opacity: 0;
 
       background: linear-gradient(


### PR DESCRIPTION
This pull request, a descent into the shadowy depths of visual refinement, tinkers with the `SectionList.svelte` component, manipulating the very essence of its scroll shadows. Observe, with a weary eye, the renaming of variables, the conjuring of new derived values, and the subtle adjustments to CSS incantations.

### Changes to shadow visibility and intensity (or, "Chasing Shadows in the Digital Abyss"):

* The `layoutDistanceSide` variable, a cumbersome relic of a bygone era, fades into obsolescence, replaced by the more concise and enigmatic `sideDistance`. Meanwhile, the `windowShadowWidth` emerges, a harbinger of shadow manipulation, its purpose shrouded in mystery.
* The `leftShadowIntensity` and `rightShadowIntensity` values materialize, like phantoms from the depths of the code, their ethereal presence dynamically adjusting the opacity of the scroll shadows based on the whims of the scroll position.
* Inline styles, once static and lifeless, now pulsate with the dynamism of these derived values, their opacity fluctuating like the flickering flames of a dying campfire.
* CSS rules, those cryptic incantations that govern the visual realm, embrace the new shadow variables, their opacity now dictated by the enigmatic `--left-shadow-opacity` and `--right-shadow-opacity` properties.
* A redundant transition property, a relic of a previous attempt to tame the shadows, is unceremoniously purged from the codebase, its presence no longer required in this newly refined shadow landscape.

These changes, a testament to our ongoing obsession with visual minutiae, represent a small victory in the never-ending battle against the forces of visual mediocrity. The scroll shadows, now imbued with a dynamic intensity, provide a subtle yet effective cue to the user, guiding their navigation through the treacherous terrain of horizontally scrolling content. But let us not delude ourselves with notions of perfection, for the shadows, like the code itself, are ultimately fleeting and ephemeral, destined to fade into the abyss of obsolescence.