### PR TITLE
feat(locale): define prettier locale icon

### DIFF
--- a/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
+++ b/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
@@ -34,6 +34,17 @@
 </script>
 
 <div class="locale-picker-container">
+  <svg
+    class="locale-icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24px"
+    viewBox="0 -960 960 960"
+    width="24px"
+    fill="currentColor"
+    ><path
+      d="M480-80q-82 0-155-31.5t-127.5-86Q143-252 111.5-325T80-480q0-83 31.5-155.5t86-127Q252-817 325-848.5T480-880q83 0 155.5 31.5t127 86q54.5 54.5 86 127T880-480q0 82-31.5 155t-86 127.5q-54.5 54.5-127 86T480-80Zm0-82q26-36 45-75t31-83H404q12 44 31 83t45 75Zm-104-16q-18-33-31.5-68.5T322-320H204q29 50 72.5 87t99.5 55Zm208 0q56-18 99.5-55t72.5-87H638q-9 38-22.5 73.5T584-178ZM170-400h136q-3-20-4.5-39.5T300-480q0-21 1.5-40.5T306-560H170q-5 20-7.5 39.5T160-480q0 21 2.5 40.5T170-400Zm216 0h188q3-20 4.5-39.5T580-480q0-21-1.5-40.5T574-560H386q-3 20-4.5 39.5T380-480q0 21 1.5 40.5T386-400Zm268 0h136q5-20 7.5-39.5T800-480q0-21-2.5-40.5T790-560H654q3 20 4.5 39.5T660-480q0 21-1.5 40.5T654-400Zm-16-240h118q-29-50-72.5-87T584-782q18 33 31.5 68.5T638-640Zm-234 0h152q-12-44-31-83t-45-75q-26 36-45 75t-31 83Zm-200 0h118q9-38 22.5-73.5T376-782q-56 18-99.5 55T204-640Z"
+    /></svg
+  >
   <select onchange={(ev) => switchToLanguage(ev.currentTarget.value)}>
     {#each availableLanguageTags as tag}
       <option
@@ -42,6 +53,7 @@
         aria-label={tagToTitle[tag]}
       >
         {tagToFlag[tag]}
+        {tagToTitle[tag]}
       </option>
     {/each}
   </select>
@@ -49,9 +61,17 @@
 
 <style>
   .locale-picker-container {
+    position: relative;
     width: var(--ni-48);
     height: var(--ni-48);
     border-radius: 50%;
+
+    .locale-icon {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
 
     &:hover {
       background-color: color-mix(
@@ -59,21 +79,19 @@
         var(--color-background) 30%,
         transparent 70%
       );
-
-      backdrop-filter: blur(8px);
     }
   }
 
   select {
     width: 100%;
-    font-size: var(--ni-32);
-    line-height: var(--ni-52);
+    height: 100%;
+    font-size: var(--ni-16);
     border: none;
-    border-radius: 5px;
     background-color: transparent;
     text-align: center;
     appearance: none;
     cursor: pointer;
+    opacity: 0;
   }
 
   select:focus {


### PR DESCRIPTION
This pull request, a crusade against visual monotony and accessibility oversights, descends upon the `LocalePicker` component, armed with a fresh icon and a renewed sense of purpose. Observe, with a weary eye, the integration of visual cues, the clarification of language options, and the meticulous tweaking of CSS parameters.

### Visual and accessibility improvements (or, "Making the Locale Picker Less of an Eyesore"):

* A new SVG icon, a beacon of visual clarity, emerges from the depths of the design abyss, its purpose to adorn the `LocalePicker.svelte` file and provide a much-needed visual cue for users (who, let's face it, are probably too busy scrolling through cat videos to notice the tiny flag icon).
* The `LocalePicker.svelte` component, once a bastion of cryptic flag-based representation, now embraces the noble cause of accessibility, displaying the language title alongside its corresponding flag. This enlightened approach, a testament to our grudging acceptance of web standards, ensures that users with visual impairments (or those who simply can't tell their flags apart) can navigate the language options with ease.

### Styling adjustments (or, "The never-ending battle against CSS entropy"):

* The CSS within `LocalePicker.svelte`, a battlefield of conflicting styles and arcane incantations, undergoes a strategic reorganization, carefully positioning the new SVG icon within the locale picker container. This meticulous alignment, a testament to our obsessive pursuit of pixel perfection, ensures that the icon sits squarely in its designated spot, like a well-behaved soldier on parade.
* The `select` element, once a hulking monolith of default styles, is subjected to a series of CSS transformations, its height stretched to 100%, its font size reduced to a more manageable scale, and its very essence rendered transparent and hidden by default. These adjustments, a desperate attempt to tame the unruly beast of browser inconsistencies, aim to create a more visually appealing and user-friendly locale selection experience.

These changes, a minor victory in the ongoing war against visual clutter and accessibility nightmares, represent a small step towards a more inclusive and user-friendly interface. The `LocalePicker`, now adorned with a helpful icon and clear language labels, stands as a testament to our begrudging acceptance of web standards. But let's not get too complacent, for the digital landscape is a constantly shifting battlefield, and new challenges undoubtedly await us in the never-ending struggle for online accessibility.