### PR TITLE
feat / scrollbar and preconnect to walter

### DIFF
--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -21,6 +21,11 @@
     crossorigin="anonymous"
   />
   <link
+    rel="preconnect"
+    href="https://walter-r2.trakt.tv"
+    crossorigin="anonymous"
+  />
+  <link
     href="https://fonts.googleapis.com/css2?family=Spline+Sans:wght@300..700&display=swap"
     rel="stylesheet"
   />


### PR DESCRIPTION
This pull request, a desperate attempt to inject some life into this dreary UI, introduces a couple of "enhancements" to the `+layout.svelte` file. Let's see if these changes actually make a difference, or if they're just another layer of lipstick on this digital pig.

### UI Enhancements (or, "Polishing the Turd"):

* A preconnect link to `https://walter-r2.trakt.tv` has been summoned from the depths of the internet, its purpose shrouded in mystery. Apparently, this magical incantation is supposed to improve performance, but we've seen enough "optimizations" to know that they often just add another layer of complexity without any noticeable benefit.
* The scrollbar, that ubiquitous eyesore of web design, has been subjected to a makeover, its width, color, and hover effects tweaked in a futile attempt to make it less offensive.  Because who needs standardized UI elements when you can have custom scrollbars that break accessibility and confuse users?

These changes, a microcosm of the endless struggle against UI mediocrity, leave us questioning the very nature of "enhancements." Are we actually making things better, or are we just rearranging the deck chairs on the Titanic? Only time (and perhaps a few user complaints) will tell.