### PR TITLE
fix: exclude api urls from paraglide

### DIFF
--- a/projects/client/src/lib/features/i18n/index.ts
+++ b/projects/client/src/lib/features/i18n/index.ts
@@ -1,7 +1,13 @@
 import * as m from '$lib/paraglide/messages.js';
 import * as runtime from '$lib/paraglide/runtime.js';
 import { createI18n } from '@inlang/paraglide-sveltekit';
-export const i18n = createI18n(runtime);
+
+export const i18n = createI18n(
+  runtime,
+  {
+    exclude: [/^\/api\//],
+  },
+);
 
 export {
   type AvailableLanguageTag,


### PR DESCRIPTION
## 🎶 Notes 🎶

- The URL is leading in setting the language in the default config. As soon as an `/api` URL was hit, it tried to modify the language back to `en`.