### PR TITLE
feat(button): add disabled state for light mode

### DIFF
--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -37,7 +37,4 @@
 
   --color-surface-button-vip: var(--red-500);
   --color-foreground-button-vip: var(--shade-10);
-
-  --color-surface-button-disabled: var(--shade-800);
-  --color-foreground-button-disabled: var(--shade-400);
 }

--- a/projects/client/src/style/theme/modes.css
+++ b/projects/client/src/style/theme/modes.css
@@ -11,6 +11,9 @@
   --color-card-background: var(--shade-50);
 
   --color-border-avatar: var(--shade-600);
+
+  --color-surface-button-disabled: var(--shade-200);
+  --color-foreground-button-disabled: var(--shade-600);
 }
 
 [data-theme='dark'] {
@@ -28,4 +31,7 @@
   --color-text-finale-tag: var(--shade-10);
   --color-background-finale-tag: var(--red-700);
   --color-border-avatar: var(--shade-50);
+
+  --color-surface-button-disabled: var(--shade-800);
+  --color-foreground-button-disabled: var(--shade-400);
 }


### PR DESCRIPTION
This pull request, a clandestine operation in the shadowy realm of CSS variables, shuffles the `--color-surface-button-disabled` and `--color-foreground-button-disabled` variables between global and mode-specific stylesheets like a pair of shifty card sharps. Let's see if this reshuffling actually improves anything, or if it's just another pointless exercise in code rearrangement.

### Changes to global styles (or, "The Great Variable Vanishing Act"):

* The `global.css` file, once a sanctuary for all-encompassing style declarations, has been robbed of its `--color-surface-button-disabled` and `--color-foreground-button-disabled` variables. These seemingly essential properties, now vanished without a trace, leave us questioning the very foundation of our design system.

### Changes to mode-specific styles (or, "The Variable Cloning Conspiracy"):

* The `modes.css` file, a haven for light and dark theme variations, has become a breeding ground for duplicate variables. The `--color-surface-button-disabled` and `--color-foreground-button-disabled` variables, once peacefully residing in the global stylesheet, now appear in both the light and dark theme sections, like ghostly apparitions haunting the codebase.

This reshuffling of variables, a move as enigmatic as it is pointless, leaves us pondering the true motives behind this pull request. Are we witnessing a desperate attempt to optimize performance by reducing global styles? Or is this merely a chaotic exercise in code rearrangement, a digital shell game designed to confuse and confound any developer who dares to delve into the depths of the theme styles? Only time (and perhaps a thorough code review) will tell.