### PR TITLE
feat(genre): clip genre list when not on large screens

### DIFF
--- a/projects/client/src/lib/sections/summary/components/MediaSummaryInfo.svelte
+++ b/projects/client/src/lib/sections/summary/components/MediaSummaryInfo.svelte
@@ -5,15 +5,18 @@
   import GenreList from "$lib/components/summary/GenreList.svelte";
   import RatingList from "$lib/components/summary/RatingList.svelte";
   import * as m from "$lib/features/i18n/messages";
+  import { useMedia, WellKnownMediaQuery } from "$lib/utils/css/useMedia";
   import type { MediaSummary } from "./MediaSummary";
   import type { MediaSummaryProps } from "./MediaSummaryProps";
 
   const { media, ratings }: MediaSummaryProps<MediaSummary> = $props();
+  const isLargeDisplay = useMedia(WellKnownMediaQuery.large);
+  const genreCount = $derived($isLargeDisplay ? -1 : 3);
 </script>
 
 <div class="trakt-summary-header">
   <h3>{media.title}</h3>
-  <GenreList genres={media.genres} />
+  <GenreList genres={media.genres.slice(0, genreCount)} />
 </div>
 
 <RatingList {ratings} />

--- a/projects/client/src/lib/utils/css/useMedia.ts
+++ b/projects/client/src/lib/utils/css/useMedia.ts
@@ -5,6 +5,7 @@ export const enum WellKnownMediaQuery {
   mobile = '(max-width: 480px)',
   tablet = '(min-width: 481px) and (max-width: 768px)',
   desktop = '(min-width: 769px)',
+  large = '(min-width: 1024px)',
 }
 
 export function useMedia(query: string) {


### PR DESCRIPTION
This pull request, a desperate attempt to appease the fickle gods of responsive design, fiddles with the `MediaSummaryInfo.svelte` component and its associated media queries like a caffeinated monkey trying to solve a Rubik's Cube. Observe, with a mix of amusement and pity, the introduction of conditional logic and the expansion of the media query arsenal.

### Enhancements to MediaSummaryInfo component (or, "Genre Tetris"):

* The `MediaSummaryInfo.svelte` component, once a static display of media details, now contorts itself like a circus performer, its logic twisted and manipulated by the `useMedia` and `WellKnownMediaQuery` imports. This newfound flexibility, a desperate attempt to accommodate the ever-growing menagerie of screen sizes, promises to adjust the number of displayed genres based on the whims of the device. (Because who needs consistent information architecture when you can have a UI that plays hide-and-seek with important details?)

### Updates to media queries (or, "The Media Query Arms Race"):

* The `useMedia.ts` file, a repository of CSS sorcery, expands its arsenal, adding a new media query for large displays to its already bloated collection. This escalation in the media query arms race, a testament to our collective obsession with catering to every conceivable screen size, leaves us wondering if we've reached the point of diminishing returns (and if anyone actually owns a screen that large).

These changes, a microcosm of the endless struggle against the tyranny of responsive design, leave us with a sense of both accomplishment and futility. The `MediaSummaryInfo` component, now capable of contorting itself to fit any screen size, may provide a slightly less jarring experience for users with unusually large or small devices. But let's not delude ourselves into thinking that we've achieved true responsiveness, for the digital landscape is a constantly shifting battlefield, and new screen sizes (and new design trends) will inevitably emerge, demanding further tweaks and adjustments in our never-ending quest for the perfect user interface.