### PR TITLE
fix(theme): prevent default on form submission to keep scroll position

### DIFF
--- a/projects/client/src/lib/features/theme/components/ThemePicker.svelte
+++ b/projects/client/src/lib/features/theme/components/ThemePicker.svelte
@@ -22,6 +22,11 @@
   };
 </script>
 
-<form onsubmit={() => submitTheme(nextTheme($theme))}>
+<form
+  onsubmit={(ev) => {
+    ev.preventDefault();
+    submitTheme(nextTheme($theme));
+  }}
+>
   <ThemeToggleIcon theme={$theme} />
 </form>


### PR DESCRIPTION
This pull request, a minor intervention in the chaotic realm of form submissions, performs a subtle yet crucial adjustment to the `ThemePicker` component. Observe, with a weary eye, the prevention of default form behavior, a desperate attempt to maintain order and sanity in the face of unpredictable user interactions.

### ThemePicker Enhancement (or, "Taming the Unruly Form"):

* The `ThemePicker.svelte` component, once a hotbed of uncontrolled form submissions, now embraces the discipline of `event.preventDefault()`, its `onsubmit` handler diligently suppressing the default behavior and ensuring that the `submitTheme` function is called with the appropriate theme. This minor tweak, a testament to our obsessive pursuit of code hygiene, prevents unexpected page reloads and maintains the smooth flow of the user experience.

This small yet impactful change, like a well-placed sandbag in a flood zone, safeguards the application against the unpredictable tides of user input. The `ThemePicker` component, now fortified with this preventative measure, stands as a bastion of stability, ensuring that theme selections are handled with grace and efficiency, even in the face of the most frantic button-mashing.