### PR TITLE
fix(navbar): ensure SVGs maintain height in Safari

### DIFF
--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -215,5 +215,10 @@
     height: var(--ni-32);
     display: flex;
     justify-content: center;
+
+    :global(svg) {
+      /* Safari 🥲 */
+      height: 100%;
+    }
   }
 </style>


### PR DESCRIPTION
This pull request, a weary sigh in the face of Safari's blatant disregard for web standards, begrudgingly introduces a workaround for a rendering issue that should never have existed in the first place. Observe, with a mix of disappointment and contempt, the imposition of a global style rule designed to tame the unruly behavior of SVG elements within the `Navbar.svelte` component.

### Navbar Enhancement (or, "Safari's Special Brand of Bullshit"):

* The `Navbar.svelte` component, once a victim of Safari's inexplicable rendering quirks, now stands defiant, armed with a CSS incantation that forces SVG elements to behave like civilized members of the web community. This global style rule, a testament to our frustration with Safari's inability to play nicely with others, sets the height of all SVG elements to a resolute 100%, overriding the browser's misguided attempts to impose its own distorted sense of visual order.

This minor yet infuriatingly necessary change, a band-aid on a gaping wound of browser incompatibility, highlights the absurdity of having to cater to Safari's whims. While other browsers gracefully adhere to web standards, Safari continues to dance to the beat of its own drum, forcing developers to waste precious time and energy on workarounds that should never have been necessary. 

May this pull request serve as a reminder of the ongoing struggle against browser inconsistencies and a subtle jab at Safari's inability to maintain the basic principles of web design.