### PR TITLE
fix(show): display show cover as fallback for up next in summary

### DIFF
--- a/projects/client/src/lib/components/episode/next/NextEpisode.svelte
+++ b/projects/client/src/lib/components/episode/next/NextEpisode.svelte
@@ -3,6 +3,7 @@
   import CardFooter from "$lib/components/card/CardFooter.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import type { EpisodeType } from "$lib/models/EpisodeType";
+  import { EPISODE_PLACEHOLDER } from "$lib/utils/constants";
   import EpisodeCard from "../card/EpisodeCard.svelte";
   import EpisodeCover from "../card/EpisodeCover.svelte";
   import type { EpisodeIntl } from "../EpisodeIntl";
@@ -10,7 +11,7 @@
 
   type EpisodeProps = {
     i18n: EpisodeIntl;
-    posterUrl: string;
+    posterUrl: string | Nil;
     showTitle: string;
     episodeTitle: string;
     episodeNumber: number;
@@ -49,7 +50,7 @@
   <EpisodeCover
     {i18n}
     {type}
-    src={`${posterUrl}`}
+    src={`${posterUrl ?? EPISODE_PLACEHOLDER}`}
     alt={`${showTitle} - ${episodeTitle}`}
     {isLoading}
   >

--- a/projects/client/src/lib/components/episode/upcoming/UpcomingEpisode.svelte
+++ b/projects/client/src/lib/components/episode/upcoming/UpcomingEpisode.svelte
@@ -2,6 +2,7 @@
   import CardFooter from "$lib/components/card/CardFooter.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import { type EpisodeType } from "$lib/models/EpisodeType";
+  import { EPISODE_PLACEHOLDER } from "$lib/utils/constants";
   import EpisodeCard from "../card/EpisodeCard.svelte";
   import EpisodeCover from "../card/EpisodeCover.svelte";
   import type { EpisodeIntl } from "../EpisodeIntl";
@@ -9,7 +10,7 @@
 
   type EpisodeProps = {
     i18n: EpisodeIntl;
-    posterUrl: string;
+    posterUrl: string | Nil;
     showTitle: string;
     episodeTitle: string;
     episodeNumber: number;
@@ -36,7 +37,7 @@
   <EpisodeCover
     {i18n}
     {type}
-    src={`${posterUrl}`}
+    src={`${posterUrl ?? EPISODE_PLACEHOLDER}`}
     alt={`${showTitle} - ${episodeTitle}`}
   >
     {#snippet tags()}

--- a/projects/client/src/lib/models/EpisodeEntry.ts
+++ b/projects/client/src/lib/models/EpisodeEntry.ts
@@ -6,7 +6,7 @@ export type EpisodeEntry = {
   number: number;
   title: string;
   poster: {
-    url: string;
+    url: string | Nil;
   };
   airedDate: Date;
   type: EpisodeType;

--- a/projects/client/src/lib/models/ShowMeta.ts
+++ b/projects/client/src/lib/models/ShowMeta.ts
@@ -2,4 +2,7 @@ export type ShowMeta = {
   id: number;
   slug: string;
   title: string;
+  cover: {
+    url: string | Nil;
+  };
 };

--- a/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
@@ -6,7 +6,6 @@ import {
   EpisodeUnknownType,
 } from '$lib/models/EpisodeType.ts';
 import type { ShowMeta } from '$lib/models/ShowMeta.ts';
-import { EPISODE_PLACEHOLDER } from '$lib/utils/constants.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import { api, type ApiParams } from '../../_internal/api.ts';
@@ -25,8 +24,11 @@ function mapResponseToEpisodeEntry(
 ): UpcomingEpisodeEntry {
   const posterCandidate = findDefined(
     item.episode.images?.screenshot.at(1) ??
-      item.episode.images?.screenshot.at(0) ??
-      item.show.images?.fanart.at(1) ??
+      item.episode.images?.screenshot.at(0),
+  );
+
+  const showCoverCandidate = findDefined(
+    item.show.images?.fanart.at(1) ??
       item.show.images?.fanart.at(0),
   );
 
@@ -36,6 +38,9 @@ function mapResponseToEpisodeEntry(
       id: item.show.ids.trakt,
       slug: item.show.ids.slug,
       title: item.show.title,
+      cover: {
+        url: prependHttps(showCoverCandidate),
+      },
     },
     type: item.episode.episode_type as EpisodeType ??
       EpisodeUnknownType.Unknown,
@@ -43,7 +48,7 @@ function mapResponseToEpisodeEntry(
     season: item.episode.season,
     number: item.episode.number,
     poster: {
-      url: prependHttps(posterCandidate, EPISODE_PLACEHOLDER),
+      url: prependHttps(posterCandidate),
     },
     airedDate: new Date(item.first_aired),
   };

--- a/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
@@ -5,7 +5,6 @@ import {
   type EpisodeType,
   EpisodeUnknownType,
 } from '$lib/models/EpisodeType.ts';
-import { EPISODE_PLACEHOLDER } from '$lib/utils/constants.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import { api, type ApiParams } from '../../_internal/api.ts';
 
@@ -25,7 +24,7 @@ export function mapResponseToShowProgress(
     season: episode.season,
     number: episode.number,
     poster: {
-      url: prependHttps(posterCandidate, EPISODE_PLACEHOLDER),
+      url: prependHttps(posterCandidate),
     },
     airedDate: new Date(episode.first_aired),
     total: item.aired,

--- a/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
@@ -6,7 +6,6 @@ import {
 } from '$lib/models/EpisodeType.ts';
 import type { Paginatable } from '$lib/models/Paginatable.ts';
 import type { ShowMeta } from '$lib/models/ShowMeta.ts';
-import { EPISODE_PLACEHOLDER } from '$lib/utils/constants.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import type { EpisodeProgressEntry } from '../../../models/EpisodeProgressEntry.ts';
 import { api, type ApiParams } from '../../_internal/api.ts';
@@ -29,8 +28,9 @@ function mapResponseToUpNextEntry(item: UpNextResponse[0]): UpNextEntry {
   const episode = item.progress.next_episode;
 
   const posterCandidate = episode.images!.screenshot.at(1) ??
-    episode.images!.screenshot.at(0) ??
-    item.show.images!.fanart.at(1) ??
+    episode.images!.screenshot.at(0);
+
+  const showCoverCandidate = item.show.images!.fanart.at(1) ??
     item.show.images!.fanart.at(0);
 
   return {
@@ -38,12 +38,15 @@ function mapResponseToUpNextEntry(item: UpNextResponse[0]): UpNextEntry {
       title: item.show.title,
       id: item.show.ids.trakt,
       slug: item.show.ids.slug,
+      cover: {
+        url: prependHttps(showCoverCandidate),
+      },
     },
     title: episode.title,
     season: episode.season,
     number: episode.number,
     poster: {
-      url: prependHttps(posterCandidate, EPISODE_PLACEHOLDER),
+      url: prependHttps(posterCandidate),
     },
     airedDate: new Date(episode.first_aired),
     id: episode.ids.trakt,

--- a/projects/client/src/lib/sections/up-next/NextEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/up-next/NextEpisodeItem.svelte
@@ -26,7 +26,7 @@
   i18n={EpisodeIntlProvider}
   episodeNumber={episode.number}
   seasonNumber={episode.season}
-  posterUrl={episode.poster.url}
+  posterUrl={episode.poster.url ?? show.cover.url}
   showTitle={show.title}
   episodeTitle={episode.title}
   completed={episode.completed}

--- a/projects/client/src/lib/sections/upcoming-schedule/UpcomingSchedule.svelte
+++ b/projects/client/src/lib/sections/upcoming-schedule/UpcomingSchedule.svelte
@@ -18,7 +18,7 @@
       i18n={EpisodeIntlProvider}
       episodeNumber={entry.number}
       seasonNumber={entry.season}
-      posterUrl={entry.poster.url}
+      posterUrl={entry.poster.url ?? entry.show.cover.url}
       showTitle={entry.show.title}
       episodeTitle={entry.title}
       airedDate={entry.airedDate}

--- a/projects/client/src/routes/show/[slug]/useShow.ts
+++ b/projects/client/src/routes/show/[slug]/useShow.ts
@@ -44,7 +44,7 @@ export function useShow(slug: string) {
     : createQuery(showIntlQuery({ slug, ...getLanguageAndRegion() }));
 
   return {
-    show: derived(show, ($movie) => $movie.data),
+    show: derived(show, ($show) => $show.data),
     ratings: derived(ratings, ($ratings) => $ratings.data),
     progress: derived(progress, ($progress) => $progress.data),
     intl: derived(


### PR DESCRIPTION
## 🎶 Notes 🎶

- Splits up show cover from episode poster
- Moves the episode placeholder to the `UpcomingEpisode` component

## 👀 Example 👀
In the show page, we can use the show fanart if there is no episode image:
<img width="1121" alt="Screenshot 2024-12-09 at 11 51 48" src="https://github.com/user-attachments/assets/f06bad76-9019-4fff-956b-42a21a06370d">
