### PR TITLE
refactor(section-list): make safari play with out of bounds values

### DIFF
--- a/projects/client/src/lib/components/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/section-list/SectionList.svelte
@@ -30,15 +30,29 @@
   let horizontalScrollContainer: HTMLDivElement;
 
   function scrollToLeft() {
-    horizontalScrollContainer.scrollBy({
-      left: -window.innerWidth / 2,
+    const left = Math.max(
+      0,
+      horizontalScrollContainer.scrollLeft - window.innerWidth / 2,
+    );
+
+    horizontalScrollContainer.scrollTo({
+      left,
       behavior: "smooth",
     });
   }
 
   function scrollToRight() {
-    horizontalScrollContainer.scrollBy({
-      left: window.innerWidth / 2,
+    const maxScrollLeft =
+      horizontalScrollContainer.scrollWidth -
+      horizontalScrollContainer.clientWidth;
+
+    const left = Math.min(
+      maxScrollLeft,
+      horizontalScrollContainer.scrollLeft + window.innerWidth / 2,
+    );
+
+    horizontalScrollContainer.scrollTo({
+      left,
       behavior: "smooth",
     });
   }


### PR DESCRIPTION
This pull request, a begrudging concession to the limitations of Safari's rendering engine, attempts to bring a semblance of order and precision to the `SectionList` component's horizontal scrolling functionality. Observe, with a weary sigh and a hint of contempt for Apple's disregard for web standards, the implementation of boundary checks and scroll position calculations, a desperate attempt to prevent users from getting lost in the infinite abyss of horizontally arranged content (or, more likely, just prevent Safari from mangling the layout).

### Improvements to horizontal scrolling (or, "Taming the Safari Scroll Gremlins"):

* The `scrollToLeft` and `scrollToRight` functions, once carefree adventurers in the realm of scroll manipulation, now find themselves shackled by the constraints of `Math.max` and `Math.min`. These mathematical boundaries, a testament to our frustration with Safari's inability to handle even the most basic scrolling operations without introducing visual glitches and layout inconsistencies, ensure that scroll positions remain within the realm of the possible, preventing users from venturing into the uncharted territories of negative scroll values or exceeding the finite limits of the scrollable content.

This minor yet infuriatingly necessary adjustment, like a duct-taped fix on a leaky faucet, highlights the absurdity of having to cater to Safari's quirks. While other browsers gracefully handle horizontal scrolling with predictable precision, Safari continues to stumble and falter, forcing developers to waste precious time and energy on workarounds that should never have been necessary. 

May this pull request serve as a reminder of the ongoing struggle against browser inconsistencies and a subtle jab at Safari's inability to maintain even the most basic principles of web design.