### PR TITLE
fix(error): place error page below the header

### DIFF
--- a/projects/client/src/lib/pages/errors/ErrorPage.svelte
+++ b/projects/client/src/lib/pages/errors/ErrorPage.svelte
@@ -9,11 +9,6 @@
 
 <svelte:head>
   <title>{title}</title>
-  <style>
-    .trakt-navbar-spacer {
-      display: none;
-    }
-  </style>
 </svelte:head>
 
 <main class="error-page">


### PR DESCRIPTION
## 👀 Example 👀
<img width="1224" alt="Screenshot 2024-12-10 at 16 26 25" src="https://github.com/user-attachments/assets/5d9704c0-270e-47fa-a194-6ed5fdfe139a">
