### PR TITLE
fix: set initial render value before mounting

### DIFF
--- a/projects/client/src/lib/guards/_internal/RenderForDevice.svelte
+++ b/projects/client/src/lib/guards/_internal/RenderForDevice.svelte
@@ -25,7 +25,7 @@
   );
   const shouldRenderDesktop = $derived(isAvailableForDesktop && $isDesktop);
 
-  const shouldRender = useDebouncedValue(false, time.seconds(1) / 60);
+  const shouldRender = useDebouncedValue(time.seconds(1) / 60);
 
   $effect(() => {
     shouldRender.set(

--- a/projects/client/src/lib/stores/useDebouncedValue.ts
+++ b/projects/client/src/lib/stores/useDebouncedValue.ts
@@ -1,15 +1,20 @@
 import { debounce } from '$lib/utils/timing/debounce.ts';
 import { get, type Writable, writable } from 'svelte/store';
 
-export function useDebouncedValue<T>(
-  initial: T | Nil,
-  delay: number,
-): Writable<T | Nil> {
-  const value = writable(initial);
+export function useDebouncedValue<T>(delay: number): Writable<T | Nil> {
+  const value = writable<T | Nil>(null);
 
-  const set = debounce((newValue: T) => {
+  const debouncedSet = debounce((newValue: T | Nil) => {
     value.set(newValue);
   }, delay);
+
+  const set = (newValue: T | Nil) => {
+    if (get(value) == null) {
+      return value.set(newValue);
+    }
+
+    return debouncedSet(newValue);
+  };
 
   const update = (fn: (current: T | Nil) => T) => {
     set(fn(get(value)));


### PR DESCRIPTION
This pull request includes changes to improve the rendering logic and the `useDebouncedValue` store in the Svelte project. The most important changes include adding a new method to the `useDebouncedValue` store and updating the rendering logic to use this new method.

Enhancements to rendering logic and debouncing:

* [`projects/client/src/lib/guards/_internal/RenderForDevice.svelte`](diffhunk://#diff-c9209c821d9b0de5a5f5d61d451ea20f837852df814b391c1bab3f09e04737a6R30-R38): Added a new effect that uses the `setImmediate` method to immediately update the `shouldRender` value based on various device conditions.

Enhancements to `useDebouncedValue` store:

* [`projects/client/src/lib/stores/useDebouncedValue.ts`](diffhunk://#diff-6dacdce82c034873e14905d11066d0de09e6496fb50f3c1a8036186c51bda881L7-R10): Modified the `useDebouncedValue` function to return an object that includes a new `setImmediate` method, allowing immediate updates to the value without waiting for the debounce delay. [[1]](diffhunk://#diff-6dacdce82c034873e14905d11066d0de09e6496fb50f3c1a8036186c51bda881L7-R10) [[2]](diffhunk://#diff-6dacdce82c034873e14905d11066d0de09e6496fb50f3c1a8036186c51bda881R21)