### PR TITLE
feat: move theme and locale picker to footer

### DIFF
--- a/projects/client/src/lib/sections/footer/Footer.svelte
+++ b/projects/client/src/lib/sections/footer/Footer.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import FooterContent from "./components/FooterContent.svelte";
   import FooterImage from "./components/FooterImage.svelte";
 </script>
 
 <footer class="trakt-footer">
-  <FooterImage />
+  <RenderFor device={["tablet-lg", "desktop"]} audience="all">
+    <FooterImage />
+  </RenderFor>
   <FooterContent />
 </footer>
 
@@ -14,5 +17,10 @@
     margin-top: var(--ni-120);
     padding-left: var(--layout-distance-side);
     padding-right: var(--layout-distance-side);
+
+    @media (max-width: 768px) {
+      margin-top: var(--ni-60);
+      height: auto;
+    }
   }
 </style>

--- a/projects/client/src/lib/sections/footer/components/FooterActions.svelte
+++ b/projects/client/src/lib/sections/footer/components/FooterActions.svelte
@@ -1,0 +1,25 @@
+<script>
+  import LocalePicker from "$lib/features/i18n/components/LocalePicker.svelte";
+  import ThemePicker from "$lib/features/theme/components/ThemePicker.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import ExternalLinks from "./ExternalLinks.svelte";
+</script>
+
+<div class="trakt-footer-actions">
+  <LocalePicker />
+  <ThemePicker />
+  <RenderFor device={["tablet-lg", "desktop"]} audience="all">
+    <ExternalLinks />
+  </RenderFor>
+</div>
+
+<style>
+  .trakt-footer-actions {
+    display: flex;
+    align-items: center;
+
+    :global(.trakt-external-links) {
+      margin-left: var(--ni-80);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/footer/components/FooterBar.svelte
+++ b/projects/client/src/lib/sections/footer/components/FooterBar.svelte
@@ -11,5 +11,6 @@
     padding: var(--ni-40);
     display: flex;
     justify-content: space-between;
+    align-items: center;
   }
 </style>

--- a/projects/client/src/lib/sections/footer/components/FooterContent.svelte
+++ b/projects/client/src/lib/sections/footer/components/FooterContent.svelte
@@ -1,18 +1,22 @@
 <script>
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import CopyRight from "./CopyRight.svelte";
-  import ExternalLinks from "./ExternalLinks.svelte";
+  import FooterActions from "./FooterActions.svelte";
 
   import FooterBar from "./FooterBar.svelte";
   import FooterLogo from "./FooterLogo.svelte";
 </script>
 
 <div class="trakt-footer-content">
-  <FooterBar>
-    <FooterLogo />
-  </FooterBar>
+  <RenderFor device={["tablet-lg", "desktop"]} audience="all">
+    <FooterBar>
+      <FooterLogo />
+    </FooterBar>
+  </RenderFor>
+
   <FooterBar>
     <CopyRight />
-    <ExternalLinks />
+    <FooterActions />
   </FooterBar>
 </div>
 

--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -2,8 +2,8 @@
   import Link from "$lib/components/link/Link.svelte";
   import Logo from "$lib/components/logo/Logo.svelte";
   import LogoMark from "$lib/components/logo/LogoMark.svelte";
-  import LocalePicker from "$lib/features/i18n/components/LocalePicker.svelte";
-  import ThemePicker from "$lib/features/theme/components/ThemePicker.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { onMount } from "svelte";
   import JoinTraktButton from "./components/JoinTraktButton.svelte";
@@ -46,8 +46,6 @@
       <RenderFor audience="public">
         <JoinTraktButton />
       </RenderFor>
-      <LocalePicker />
-      <ThemePicker />
       <RenderFor
         audience="authenticated"
         device={["tablet-sm", "tablet-lg", "desktop"]}

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -7,7 +7,6 @@
   import AuthProvider from "$lib/features/auth/components/AuthProvider.svelte";
   import LocaleProvider from "$lib/features/i18n/components/LocaleProvider.svelte";
   import ThemeProvider from "$lib/features/theme/components/ThemeProvider.svelte";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
   import Footer from "$lib/sections/footer/Footer.svelte";
   import Navbar from "$lib/sections/navbar/Navbar.svelte";
   import { QueryClientProvider } from "@tanstack/svelte-query";
@@ -108,9 +107,7 @@
             <div class="trakt-layout-content">
               {@render children()}
             </div>
-            <RenderFor device={["tablet-lg", "desktop"]} audience="all">
-              <Footer />
-            </RenderFor>
+            <Footer />
           </div>
 
           <SvelteQueryDevtools


### PR DESCRIPTION
## 🎶 Notes 🎶

- Moves the theme and locale pickers to the footer
- The footer will now also be visible on smaller devices, though only the copyright notice and the pickers will be shown.
- Design changes are still TO DO.

## 👀 Examples 👀
<img width="976" alt="Screenshot 2024-12-11 at 17 22 02" src="https://github.com/user-attachments/assets/0c780a1d-a5a6-4c5b-b669-171c87a234e9" />

<img width="601" alt="Screenshot 2024-12-11 at 17 22 11" src="https://github.com/user-attachments/assets/ef387cf0-283f-42af-a32c-38c7aaf3f14f" />
