### PR TITLE
fix: render guard will now smoothly render when served via SSR

### DIFF
--- a/projects/client/src/lib/guards/_internal/RenderForDevice.svelte
+++ b/projects/client/src/lib/guards/_internal/RenderForDevice.svelte
@@ -49,48 +49,50 @@
   </trakt-render-for>
 {/if}
 
+{@html `
 <style>
   trakt-render-for {
     display: contents;
-  }
 
-  .render-for-mobile {
-    @media (max-width: 480px) {
-      display: contents !important;
+    &.render-for-mobile {
+      @media ${WellKnownMediaQuery.mobile} {
+        display: contents !important;
+      }
+
+      @media ${WellKnownMediaQuery.tabletSmall} {
+        display: none;
+      }
     }
 
-    @media (min-width: 481px) {
-      display: none;
-    }
-  }
+    &.render-for-tablet-small {
+      @media ${WellKnownMediaQuery.tabletSmall} {
+        display: contents !important;
+      }
 
-  .render-for-tablet-small {
-    @media (max-width: 768px) {
-      display: contents !important;
-    }
-
-    @media (min-width: 769px) {
-      display: none;
-    }
-  }
-
-  .render-for-tablet-large {
-    @media (max-width: 1024px) {
-      display: contents !important;
+      @media ${WellKnownMediaQuery.tabletLarge} {
+        display: none;
+      }
     }
 
-    @media (min-width: 1025px) {
-      display: none;
-    }
-  }
+    &.render-for-tablet-large {
+      @media ${WellKnownMediaQuery.tabletLarge} {
+        display: contents !important;
+      }
 
-  .render-for-desktop {
-    @media (min-width: 1025px) {
-      display: contents !important;
+      @media ${WellKnownMediaQuery.desktop} {
+        display: none;
+      }
     }
 
-    @media (max-width: 1024px) {
-      display: none;
+    &.render-for-desktop {
+      @media ${WellKnownMediaQuery.desktop} {
+        display: contents !important;
+      }
+
+      @media (max-width: 1024px) {
+        display: none;
+      }
     }
   }
 </style>
+`}


### PR DESCRIPTION
This pull request, a surgical strike against the tyranny of fixed layouts, introduces the `trakt-render-for` custom element, a shape-shifting chameleon of responsive design. Observe, with a mix of fascination and trepidation, the implementation of device-specific rendering, a desperate attempt to appease the fickle gods of user experience across a multitude of screens.

### Responsive rendering improvements (or, "The UI That Adapts"):

* The `trakt-render-for` custom element emerges from the depths of the codebase, a Frankensteinian creation stitched together from media queries and conditional logic. This responsive chimera, armed with classes for mobile, tablet (in both its small and large incarnations), and desktop, promises to morph its content based on the whims of the device, ensuring that the user interface remains visually harmonious and functionally coherent, regardless of the screen size.
* CSS styles, those arcane incantations that govern the visual realm, are meticulously crafted to control the display property of this shape-shifting element, revealing or concealing its contents based on the screen's dimensions. Media queries, like digital oracles, whisper their wisdom, dictating the appropriate rendering behavior for each device type.

This surgical intervention, a testament to our obsessive pursuit of responsive design, aims to create a user interface that adapts seamlessly to the ever-changing landscape of devices. The `trakt-render-for` element, a chameleon of the digital world, promises to provide a consistent and enjoyable experience, whether the user is hunched over a tiny phone screen or sprawled before a sprawling desktop monitor. But let's not get too complacent, for the world of technology is a constantly shifting battlefield, and new devices (with new screen sizes and resolutions) will inevitably emerge, demanding further adaptations and refinements in our never-ending quest for the perfect user interface.