### PR TITLE
fix: allow movie / show access for public

### DIFF
--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -66,7 +66,9 @@
       <RenderFor audience="public">
         <JoinTraktButton />
       </RenderFor>
-      <ProfileButton />
+      <RenderFor audience="authenticated">
+        <ProfileButton />
+      </RenderFor>
     </div>
   </nav>
 

--- a/projects/client/src/routes/movies/+page.svelte
+++ b/projects/client/src/routes/movies/+page.svelte
@@ -9,14 +9,22 @@
   import TrendingMovies from "$lib/sections/trending/TrendingMovies.svelte";
   import { DEFAULT_COVER } from "$lib/utils/constants";
 
-  const { user } = useUser();
+  const { current } = useUser();
 </script>
 
+<!-- TODO: @seferturan hide actions for unauthorized users -->
 <div class="trakt-shows">
   <RenderFor audience="authenticated">
-    <BackgroundCoverImage src={$user?.cover.url ?? DEFAULT_COVER} type="main" />
+    <BackgroundCoverImage src={current().cover.url} type="main" />
     <TrendingMovies />
     <RecommendedMovies title={m.your_recommendations()} />
+    <AnticipatedMovies />
+    <PopularMovies />
+  </RenderFor>
+
+  <RenderFor audience="public">
+    <BackgroundCoverImage src={DEFAULT_COVER} type="main" />
+    <TrendingMovies />
     <AnticipatedMovies />
     <PopularMovies />
   </RenderFor>

--- a/projects/client/src/routes/shows/+page.svelte
+++ b/projects/client/src/routes/shows/+page.svelte
@@ -9,14 +9,22 @@
   import TrendingShows from "$lib/sections/trending/TrendingShows.svelte";
   import { DEFAULT_COVER } from "$lib/utils/constants";
 
-  const { user } = useUser();
+  const { current } = useUser();
 </script>
 
+<!-- TODO: @seferturan hide actions for unauthorized users -->
 <div class="trakt-shows">
   <RenderFor audience="authenticated">
-    <BackgroundCoverImage src={$user?.cover.url ?? DEFAULT_COVER} type="main" />
+    <BackgroundCoverImage src={current().cover.url} type="main" />
     <TrendingShows />
     <RecommendedShows title={m.your_recommendations()} />
+    <AnticipatedShows />
+    <PopularShows />
+  </RenderFor>
+
+  <RenderFor audience="public">
+    <BackgroundCoverImage src={DEFAULT_COVER} type="main" />
+    <TrendingShows />
     <AnticipatedShows />
     <PopularShows />
   </RenderFor>


### PR DESCRIPTION
This pull request includes updates to the `Navbar` component and modifications to the movies and shows pages to enhance user experience based on authentication status. The key changes involve conditional rendering for authenticated and public users, and a minor update to the user state management.

### Enhancements to user experience based on authentication status:

* [`projects/client/src/lib/sections/navbar/Navbar.svelte`](diffhunk://#diff-0def10aba32bee4b78011d9a94d0e879e4f7365e7a5cdbc1c5203de9501805f7R69-R71): Added conditional rendering to display the `ProfileButton` for authenticated users only.
* [`projects/client/src/routes/movies/+page.svelte`](diffhunk://#diff-141219cff5c205d305cfa49319709ef59f0e3f8b8297d5f0da6bdaba5122d26bL12-R30): Updated the user state management from `user` to `current` and added conditional rendering to display different content for authenticated and public users.
* [`projects/client/src/routes/shows/+page.svelte`](diffhunk://#diff-45fe340fda2e61d571222b9881c9d87f5bce09f42fd11b73581f56d1dcff1c3aL12-R30): Updated the user state management from `user` to `current` and added conditional rendering to display different content for authenticated and public users.