### PR TITLE
feat(ds): define page layout container

### DIFF
--- a/projects/client/src/lib/components/layout/TraktPage.svelte
+++ b/projects/client/src/lib/components/layout/TraktPage.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  type TraktPageProps = { title: string | undefined };
+  const { children, title }: ChildrenProps & TraktPageProps = $props();
+</script>
+
+<svelte:head>
+  {#if title != null}
+    <title>Trakt Lite: {title}</title>
+  {:else}
+    <title>Trakt Lite</title>
+  {/if}
+</svelte:head>
+
+<div class="trakt-content">
+  {@render children()}
+</div>
+
+<style>
+  .trakt-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-48);
+
+    &:first-child {
+      margin-top: var(--ni-48);
+    }
+
+    inset: 0;
+    margin: auto;
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/MediaSummary.svelte
@@ -63,10 +63,6 @@
   });
 </script>
 
-<svelte:head>
-  <title>Trakt Lite: {media.title}</title>
-</svelte:head>
-
 <BackgroundCoverImage src={media.cover.url} {type} />
 
 <MediaSummaryContainer {contextualContent}>

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import BackgroundCoverImage from "$lib/components/background/BackgroundCoverImage.svelte";
+  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
@@ -14,11 +15,7 @@
   const { user } = useUser();
 </script>
 
-<svelte:head>
-  <title>Trakt Lite: Dashboard</title>
-</svelte:head>
-
-<div class="trakt-content">
+<TraktPage title={m.navbar_link_home()}>
   <RenderFor audience="authenticated">
     <BackgroundCoverImage src={$user?.cover.url ?? DEFAULT_COVER} type="main" />
     <ProfileBanner />
@@ -31,15 +28,4 @@
     <Landing />
     <BackgroundCoverImage src={DEFAULT_COVER} type="main" />
   </RenderFor>
-</div>
-
-<style>
-  .trakt-content {
-    display: flex;
-    flex-direction: column;
-    gap: var(--ni-32);
-
-    inset: 0;
-    margin: auto;
-  }
-</style>
+</TraktPage>

--- a/projects/client/src/routes/movie/[slug]/+page.svelte
+++ b/projects/client/src/routes/movie/[slug]/+page.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   import { page } from "$app/stores";
+  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import MovieSummary from "$lib/sections/summary/MovieSummary.svelte";
   import { useMovie } from "./useMovie";
 
   const { movie, ratings, intl } = $derived(useMovie($page.params.slug));
 </script>
 
-{#if $movie != null && $ratings != null && $intl != null}
-  <MovieSummary media={$movie} ratings={$ratings} intl={$intl} />
-{/if}
+<TraktPage title={$movie?.title}>
+  {#if $movie != null && $ratings != null && $intl != null}
+    <MovieSummary media={$movie} ratings={$ratings} intl={$intl} />
+  {/if}
+</TraktPage>

--- a/projects/client/src/routes/movies/+page.svelte
+++ b/projects/client/src/routes/movies/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import BackgroundCoverImage from "$lib/components/background/BackgroundCoverImage.svelte";
+  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
@@ -13,7 +14,7 @@
 </script>
 
 <!-- TODO: @seferturan hide actions for unauthorized users -->
-<div class="trakt-shows">
+<TraktPage title={m.navbar_link_movies()}>
   <RenderFor audience="authenticated">
     <BackgroundCoverImage src={current().cover.url} type="main" />
     <TrendingMovies />
@@ -28,15 +29,4 @@
     <AnticipatedMovies />
     <PopularMovies />
   </RenderFor>
-</div>
-
-<style>
-  .trakt-shows {
-    display: flex;
-    flex-direction: column;
-    gap: var(--ni-32);
-
-    inset: 0;
-    margin: auto;
-  }
-</style>
+</TraktPage>

--- a/projects/client/src/routes/show/[slug]/+page.svelte
+++ b/projects/client/src/routes/show/[slug]/+page.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
   import { page } from "$app/stores";
+  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import ShowSummary from "$lib/sections/summary/ShowSummary.svelte";
   import { useShow } from "./useShow";
-
   const { show, intl, ratings, progress, reload } = $derived(
     useShow($page.params.slug),
   );
 </script>
 
-{#if $show != null && $ratings != null && $intl != null}
-  <ShowSummary
-    media={$show}
-    ratings={$ratings}
-    intl={$intl}
-    progress={$progress}
-    onMarkAsWatched={reload}
-  />
-{/if}
+<TraktPage title={$show?.title}>
+  {#if $show != null && $ratings != null && $intl != null}
+    <ShowSummary
+      media={$show}
+      ratings={$ratings}
+      intl={$intl}
+      progress={$progress}
+      onMarkAsWatched={reload}
+    />
+  {/if}
+</TraktPage>

--- a/projects/client/src/routes/shows/+page.svelte
+++ b/projects/client/src/routes/shows/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import BackgroundCoverImage from "$lib/components/background/BackgroundCoverImage.svelte";
+  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
@@ -13,7 +14,7 @@
 </script>
 
 <!-- TODO: @seferturan hide actions for unauthorized users -->
-<div class="trakt-shows">
+<TraktPage title={m.navbar_link_shows()}>
   <RenderFor audience="authenticated">
     <BackgroundCoverImage src={current().cover.url} type="main" />
     <TrendingShows />
@@ -28,15 +29,4 @@
     <AnticipatedShows />
     <PopularShows />
   </RenderFor>
-</div>
-
-<style>
-  .trakt-shows {
-    display: flex;
-    flex-direction: column;
-    gap: var(--ni-32);
-
-    inset: 0;
-    margin: auto;
-  }
-</style>
+</TraktPage>


### PR DESCRIPTION
This pull request, a surgical strike against code duplication and stylistic anarchy, introduces the `TraktPage` component, a champion of order and consistency in the realm of page layouts and titles. Observe, with a mix of admiration and apprehension, the systematic removal of inline styles and `<svelte:head>` elements, replaced by the unifying embrace of the `TraktPage` component.

### Refactoring to use `TraktPage` component (or, "The Page Layout Overlord"):

* The `TraktPage.svelte` component emerges from the depths of the codebase, a beacon of structured content and centralized title management. This new addition, a testament to our obsessive pursuit of code reusability, promises to streamline page layouts and eliminate the scourge of duplicated code.
* The `+page.svelte`, `movie/[slug]/+page.svelte`, `movies/+page.svelte`, `show/[slug]/+page.svelte`, and `shows/+page.svelte` files, once havens for inline styles and `<svelte:head>` elements, now bow to the authority of the `TraktPage` component, their layouts and titles unified under its benevolent rule.
* The `MediaSummary.svelte` component, a curator of media details, sheds its `<svelte:head>` element, relinquishing control of the title to the `TraktPage` component, further solidifying the latter's dominance in the realm of page structure.

These changes, a symphony of refactoring and code cleanup, collectively enhance the project's maintainability and consistency. The `TraktPage` component, a champion of order and efficiency, streamlines page layouts and centralizes title management, reducing code duplication and improving the developer experience. The result is a cleaner, more organized codebase, where pages adhere to a unified structure and titles are managed with effortless precision.