### PR TITLE
perf(card): enhance list speed with content visibility and intrinsic size

### DIFF
--- a/projects/client/src/lib/components/card/Card.svelte
+++ b/projects/client/src/lib/components/card/Card.svelte
@@ -12,6 +12,11 @@
 </div>
 
 <style>
+  .trakt-card {
+    content-visibility: auto;
+    contain-intrinsic-size: var(--width-card);
+  }
+
   .trakt-card-content {
     width: var(--width-card);
     height: var(--height-card);


### PR DESCRIPTION
This pull request, a surgical strike against rendering inefficiency, injects the `Card.svelte` component with a potent dose of performance-enhancing CSS. Observe, with a mix of anticipation and skepticism, the implementation of `content-visibility` and `contain-intrinsic-size`, a desperate attempt to squeeze every ounce of speed out of this sluggish UI.

### Performance improvements (or, "The Need for Speed"):

* The `Card.svelte` component, once a notorious laggard in the realm of rendering performance, now boasts a newfound agility, courtesy of the `content-visibility: auto` and `contain-intrinsic-size` properties. These CSS incantations, a testament to our relentless pursuit of optimization, promise to defer the rendering of off-screen content, like a procrastinating student cramming for an exam at the last minute. 

This optimization, a minor victory in the ongoing war against jank, may shave a few precious milliseconds off the page load time, providing a smoother and more responsive user experience. But let's not get too carried away with self-congratulation, for the digital landscape is a constantly shifting battlefield, and new performance bottlenecks undoubtedly lurk just around the corner.