### PR TITLE
perf(card): set appropriate width to eliminate scroll jump

### DIFF
--- a/projects/client/src/lib/components/card/Card.svelte
+++ b/projects/client/src/lib/components/card/Card.svelte
@@ -13,6 +13,9 @@
 
 <style>
   .trakt-card {
+    min-width: var(--width-card);
+    min-height: var(--height-card);
+
     content-visibility: auto;
     contain-intrinsic-size: var(--width-card);
   }

--- a/projects/client/src/lib/components/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/section-list/SectionList.svelte
@@ -209,7 +209,7 @@
 
     display: flex;
     height: var(--height-section-list);
-    gap: var(--ni-16);
+    gap: var(--ni-8);
     overflow-x: auto;
     scroll-snap-type: x proximity;
 


### PR DESCRIPTION
This pull request, a minor intervention in the realm of visual aesthetics, descends upon the `projects/client/src/lib/components` directory, armed with a CSS ruler and a keen eye for detail. Observe, with a mix of curiosity and indifference, the subtle adjustments to card sizing and section list spacing, a desperate attempt to impose order on the chaotic world of pixels and layouts.

### Styling improvements (or, "The Pixel Pushers' Picnic"):

* The `Card.svelte` component, once a free-spirited entity with no regard for dimensional constraints, now finds itself bound by the rigid confines of minimum width and height properties. This stylistic straightjacket, a testament to our obsessive pursuit of visual consistency, ensures that cards, regardless of their content, adhere to a predefined size, like unruly schoolchildren forced to stand in line.
* The `SectionList.svelte` component, a purveyor of horizontally arranged items, undergoes a subtle transformation, its gap between items shrinking from a spacious `var(--ni-16)` to a more intimate `var(--ni-8)`. This minor adjustment, a nod to the ever-growing density of information in the digital age, promises a more compact layout (or perhaps just a subtle attempt to cram more content onto the screen).

These changes, a minor skirmish in the ongoing war against visual inconsistency, may bring a fleeting sense of satisfaction to the designers among us. But let's not get too carried away with self-congratulation, for the digital landscape is a constantly shifting battlefield, and new design trends (and new screen sizes) will inevitably emerge, demanding further tweaks and adjustments in our never-ending quest for the perfect user interface.