### PR TITLE
feat(footer): synchronize footer image with current active image

### DIFF
--- a/projects/client/src/lib/components/background/BackgroundCoverImage.svelte
+++ b/projects/client/src/lib/components/background/BackgroundCoverImage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import type { MediaType } from "$lib/models/MediaType";
+  import { useCover } from "./useCover";
 
   type ImageBackgroundProps = {
     src: string;
@@ -8,6 +9,10 @@
   };
 
   const { src, type }: ImageBackgroundProps = $props();
+
+  const cover = $derived(useCover());
+
+  $effect.pre(() => cover.set(src));
 </script>
 
 <div class="background-cover-image">

--- a/projects/client/src/lib/components/background/CoverProvider.svelte
+++ b/projects/client/src/lib/components/background/CoverProvider.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { useCover } from "./useCover";
+
+  const { children }: ChildrenProps = $props();
+
+  useCover();
+</script>
+
+{@render children()}

--- a/projects/client/src/lib/components/background/useCover.ts
+++ b/projects/client/src/lib/components/background/useCover.ts
@@ -1,0 +1,17 @@
+import { getContext, setContext } from 'svelte';
+import { type Writable, writable } from 'svelte/store';
+
+const COVER_CONTEXT_KEY = Symbol('cover');
+
+type CoverContextData = Writable<string>;
+
+export function useCover(initialCover?: string) {
+  const cover = getContext<CoverContextData>(COVER_CONTEXT_KEY) ??
+    setContext(
+      COVER_CONTEXT_KEY,
+      getContext<CoverContextData>(COVER_CONTEXT_KEY) ??
+        writable<string>(initialCover),
+    );
+
+  return cover;
+}

--- a/projects/client/src/lib/sections/footer/components/FooterImage.svelte
+++ b/projects/client/src/lib/sections/footer/components/FooterImage.svelte
@@ -1,17 +1,13 @@
 <script lang="ts">
-  import { useUser } from "$lib/features/auth/stores/useUser";
+  import { useCover } from "$lib/components/background/useCover";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
-  import { DEFAULT_COVER } from "$lib/utils/constants";
 
-  const { user } = useUser();
+  const cover = $derived(useCover());
 </script>
 
 <div class="trakt-footer-bg">
   <div class="trakt-footer-bg-overlay">
-    <CrossOriginImage
-      src={$user?.cover.url ?? DEFAULT_COVER}
-      alt={`Background for footer`}
-    />
+    <CrossOriginImage src={$cover} alt={`Background for footer`} />
   </div>
 </div>
 

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
   import "../style";
 
   import { page } from "$app/stores";
+  import CoverProvider from "$lib/components/background/CoverProvider.svelte";
   import AnalyticsProvider from "$lib/features/analytics/AnalyticsProvider.svelte";
   import PageView from "$lib/features/analytics/PageView.svelte";
   import AuthProvider from "$lib/features/auth/components/AuthProvider.svelte";
@@ -103,22 +104,24 @@
   <AuthProvider token={data.auth.token} url={data.auth.url}>
     <AnalyticsProvider>
       <LocaleProvider>
-        <ThemeProvider theme={data.theme}>
-          <div class="trakt-layout-wrapper">
-            <Navbar />
-            <div class="trakt-layout-content">
-              {@render children()}
+        <CoverProvider>
+          <ThemeProvider theme={data.theme}>
+            <div class="trakt-layout-wrapper">
+              <Navbar />
+              <div class="trakt-layout-content">
+                {@render children()}
+              </div>
+              <Footer />
             </div>
-            <Footer />
-          </div>
-          <RenderFor audience="all" device={["mobile"]}>
-            <MobileNavbar />
-          </RenderFor>
-          <SvelteQueryDevtools
-            buttonPosition="bottom-left"
-            styleNonce="opacity: 0.5"
-          />
-        </ThemeProvider>
+            <RenderFor audience="all" device={["mobile"]}>
+              <MobileNavbar />
+            </RenderFor>
+            <SvelteQueryDevtools
+              buttonPosition="bottom-left"
+              styleNonce="opacity: 0.5"
+            />
+          </ThemeProvider>
+        </CoverProvider>
       </LocaleProvider>
 
       {#key $page.url.pathname}


### PR DESCRIPTION
This pull request, a surgical intervention in the realm of image management, introduces the `useCover` hook, a centralized authority figure in the chaotic world of background visuals. Observe, with a mix of curiosity and apprehension, the grafting of this new hook onto unsuspecting components and the establishment of a `CoverProvider` regime within the application's layout.

### Introduction of `useCover` hook (or, "The Image Overlord"):

* The `useCover` hook emerges from the depths of the codebase, wielding the arcane power of Svelte's context API to manage cover images with an iron fist. This new addition, a self-proclaimed image overlord, promises to bring order and consistency to the unruly world of background visuals, ensuring that components across the application adhere to its strict visual dictates.

### Component updates to use `useCover` (or, "Bow Down to the New Regime"):

* The `BackgroundCoverImage.svelte` component, once a free spirit in the realm of background imagery, now finds itself shackled to the `useCover` hook, its autonomy curtailed in the name of visual conformity.
* The `FooterImage.svelte` component, a humble decorator of the application's lower extremities, suffers a similar fate, its image management logic now dictated by the all-powerful `useCover` hook.

### Layout updates to include `CoverProvider` (or, "The Contextual Conquest"):

* The `CoverProvider.svelte` component materializes, a shadowy figure lurking in the depths of the layout, its purpose to establish a cover context and impose its visual will upon its unsuspecting children.
* The `+layout.svelte` component, a foundational pillar of the application's structure, now plays host to the `CoverProvider`, ensuring that its influence permeates every corner of the user interface.

These changes, a testament to our obsessive pursuit of code organization and visual consistency, collectively aim to streamline image management and enhance the user experience. The `useCover` hook, a centralized authority figure in the world of cover images, promises to reduce code duplication and improve maintainability. The `CoverProvider` component, a shadowy enforcer of visual conformity, ensures that cover images are handled with consistency and predictability throughout the application. But let's not get too complacent, for the digital landscape is a constantly shifting battlefield, and new challenges undoubtedly await us in the never-ending quest for the perfect user interface.