### PR TITLE
fix(navbar): logo in safari

### DIFF
--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -148,7 +148,7 @@
 
     :global(svg) {
       /* Safari 🥲 */
-      height: 100%;
+      height: var(--ni-32);
     }
   }
 </style>


### PR DESCRIPTION
## 👀 Examples 👀
Before:
<img width="613" alt="Screenshot 2024-12-16 at 09 42 48" src="https://github.com/user-attachments/assets/5bd33bf1-3be5-4a11-9294-720ccb99e006" />

After:
<img width="613" alt="Screenshot 2024-12-16 at 09 42 55" src="https://github.com/user-attachments/assets/2ec9fff6-32f1-4617-9b00-648c1b91144e" />
