### PR TITLE
feat(media): mark movie and show as watched from card

### DIFF
--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -34,5 +34,10 @@
       gap: var(--ni-4);
       overflow: hidden;
     }
+
+    .card-footer-actions {
+      display: flex;
+      gap: var(--ni-4);
+    }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import MarkAsWatchedActionButton from "$lib/components/buttons/mark-as-watched/MarkAsWatchedActionButton.svelte";
   import WatchlistActionButton from "$lib/components/buttons/watchlist/WatchlistActionButton.svelte";
   import CardFooter from "$lib/components/card/CardFooter.svelte";
   import EpisodeCard from "$lib/components/episode/card/EpisodeCard.svelte";
@@ -14,6 +15,7 @@
   import type { EpisodeCount } from "$lib/requests/models/EpisodeCount";
   import type { MovieSummary } from "$lib/requests/models/MovieSummary";
   import type { ShowSummary } from "$lib/requests/models/ShowSummary";
+  import { useMarkAsWatched } from "$lib/stores/useMarkAsWatched";
   import { useWatchlist } from "$lib/stores/useWatchlist";
   import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
@@ -32,6 +34,13 @@
     removeFromWatchlist,
   } = $derived(
     useWatchlist({
+      type,
+      id: media.id,
+    }),
+  );
+
+  const { isMarkingAsWatched, isWatched, markAsWatched } = $derived(
+    useMarkAsWatched({
       type,
       id: media.id,
     }),
@@ -69,6 +78,12 @@
           onRemove={removeFromWatchlist}
           isWatchlisted={$isWatchlisted}
           isWatchlistUpdating={$isWatchlistUpdating}
+        />
+        <MarkAsWatchedActionButton
+          title={media.title}
+          isWatched={$isWatched}
+          isMarkingAsWatched={$isMarkingAsWatched}
+          onWatch={markAsWatched}
         />
       </RenderFor>
     {/snippet}


### PR DESCRIPTION
This pull request, a surgical enhancement to the `MediaItem` component, injects it with the power to mark movies and shows as "watched," leaving a trail of updated imports, modified logic, and stylistic refinements in its wake. Observe, with a mix of curiosity and anticipation, the integration of new components and stores, the subtle dance of state management, and the addition of CSS classes to accommodate this newfound functionality.

### New Feature: Mark as Watched (or, "Conquering the Watchlist"):

* The `MediaItem.svelte` component, once a mere displayer of media information, now emerges as a tool of user agency, empowered by the `MarkAsWatchedActionButton` component and the `useMarkAsWatched` store. This dynamic duo, a testament to our commitment to user empowerment, allows users to mark media items as watched with a satisfying click, their viewing progress meticulously tracked and recorded for posterity.

### Style Updates (or, "The CSS Stylist's Intervention"):

* The `CardFooter.svelte` component, a humble container for supplementary information, receives a stylish upgrade, its CSS arsenal now equipped with the `.card-footer-actions` class. This new addition, a testament to our dedication to visual organization, ensures that action buttons, including the newly introduced "Mark as Watched" button, are displayed with clarity and consistency, their placement carefully orchestrated to avoid visual clutter and enhance user interaction.

These changes, a subtle yet impactful enhancement to the user interface, collectively empower users to manage their media consumption with greater control and precision. The "Mark as Watched" feature, a digital stamp of completion, allows users to track their progress through the vast expanse of movies and TV shows, while the CSS updates ensure that these new interactive elements are seamlessly integrated into the visual landscape. The result is a more engaging and user-friendly experience, where users can effortlessly mark their media milestones and navigate the Trakt Lite universe with a newfound sense of accomplishment.