### PR TITLE
feat(api): define history remove endpoint

### DIFF
--- a/projects/api/src/contracts/sync/_internal/response/historyRemoveResponseSchema.ts
+++ b/projects/api/src/contracts/sync/_internal/response/historyRemoveResponseSchema.ts
@@ -1,0 +1,7 @@
+import { z } from '../../../_internal/z.ts';
+import { historyRequestSchema } from '../request/historyRequestSchema.ts';
+
+export const historyRemoveResponseSchema = z.object({
+  removed: z.object({ movies: z.number(), episodes: z.number() }),
+  not_found: historyRequestSchema,
+});

--- a/projects/api/src/contracts/sync/index.ts
+++ b/projects/api/src/contracts/sync/index.ts
@@ -6,6 +6,7 @@ import { statsQuerySchema } from '../_internal/request/statsQuerySchema.ts';
 import type { z } from '../_internal/z.ts';
 import { historyRequestSchema } from './_internal/request/historyRequestSchema.ts';
 import { watchlistRequestSchema } from './_internal/request/watchlistRequestSchema.ts';
+import { historyRemoveResponseSchema } from './_internal/response/historyRemoveResponseSchema.ts';
 import { historyResponseSchema } from './_internal/response/historyResponseSchema.ts';
 import { upNextResponseSchema } from './_internal/response/upNextResponseSchema.ts';
 import { watchlistResponseSchema } from './_internal/response/watchlistResponseSchema.ts';
@@ -31,6 +32,14 @@ const history = builder.router({
     body: historyRequestSchema,
     responses: {
       200: historyResponseSchema,
+    },
+  },
+  remove: {
+    method: 'POST',
+    path: '/remove',
+    body: historyRequestSchema,
+    responses: {
+      200: historyRemoveResponseSchema,
     },
   },
 }, {

--- a/projects/client/src/lib/requests/sync/removeWatchedRequest.ts
+++ b/projects/client/src/lib/requests/sync/removeWatchedRequest.ts
@@ -1,0 +1,22 @@
+import { authHeader } from '$lib/features/auth/stores/authHeader.ts';
+import type { HistoryRequest } from '@trakt/api';
+import { api, type ApiParams } from '../_internal/api.ts';
+
+type RemoveWatchedParams = {
+  body: HistoryRequest;
+} & ApiParams;
+
+export function removeWatchedRequest(
+  { body, fetch }: RemoveWatchedParams,
+): Promise<boolean> {
+  return api({ fetch })
+    .sync
+    .history
+    .remove({
+      body,
+      extraHeaders: {
+        ...authHeader(),
+      },
+    })
+    .then(({ status }) => status === 200);
+}


### PR DESCRIPTION
This pull request, a digital eraser for the annals of media consumption, introduces a new endpoint for purging watched history items from the Trakt Lite universe. Observe, with a mix of curiosity and trepidation, the addition of a new response schema, the expansion of the API contract, and the implementation of a client-side request function capable of erasing the traces of past viewing pleasures.

### API Schema and Contract Updates (or, "The Rewriting of History"):

* The `historyRemoveResponseSchema` materializes, a digital shroud for the remnants of deleted history items, its structure meticulously defined to encapsulate the echoes of purged viewing records.
* The `sync/index.ts` file, a gateway to data synchronization, undergoes a transformation, its `history` router now equipped with a new `remove` endpoint, its purpose to obliterate the traces of past media consumption with surgical precision.

### Client Request Implementation (or, "The Memory Wipe"):

* The `removeWatchedRequest` function emerges, a digital hitman, its mission to carry out the user's orders for history removal. Armed with authentication headers and response status validation, this function promises to execute its task with ruthless efficiency, leaving no trace of the deleted viewing records.

These changes, a testament to our commitment to user agency and the impermanence of digital footprints, collectively empower users to rewrite their viewing history and selectively erase the evidence of their past media indulgences. The new endpoint, a portal to digital oblivion, offers a way to cleanse the slate and start anew, while the client-side request function ensures that this purging process is carried out with the utmost efficiency and discretion.