### PR TITLE
fix(search): increase search content size

### DIFF
--- a/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
+++ b/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
@@ -126,7 +126,7 @@
     .trakt-search-results {
       position: absolute;
       min-height: calc(var(--height-result-item) * 7);
-      min-width: 100%;
+      min-width: var(--ni-280);
 
       top: 120%;
       left: 0;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Make search results a bit more usable on smaller screens
- Temporary fix until we add the new design

## 👀 Examples 👀
Before:
<img width="369" alt="Screenshot 2024-12-21 at 14 19 44" src="https://github.com/user-attachments/assets/34c9fddc-5107-4209-91ee-e1614fc230d8" />

After:
<img width="369" alt="Screenshot 2024-12-21 at 14 19 58" src="https://github.com/user-attachments/assets/45419483-c715-4fd4-a2ab-fe5630f9ca25" />
