### PR TITLE
feat(requests): add staleTime for all queries and enhance invalidator

### DIFF
--- a/projects/client/src/lib/features/auth/queries/currentUserHistoryQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserHistoryQuery.ts
@@ -133,7 +133,9 @@ const currentUserWatchedShowsRequest = (
 
 export const currentUserHistoryQueryKey = [
   'currentUserHistory',
-  InvalidateAction.MarkAsWatched,
+  InvalidateAction.MarkAsWatched('show'),
+  InvalidateAction.MarkAsWatched('movie'),
+  InvalidateAction.MarkAsWatched('episode'),
 ] as const;
 export const currentUserHistoryQuery = ({ fetch }: ApiParams = {}) => ({
   queryKey: currentUserHistoryQueryKey,

--- a/projects/client/src/lib/requests/models/InvalidateAction.ts
+++ b/projects/client/src/lib/requests/models/InvalidateAction.ts
@@ -1,12 +1,13 @@
 import type { MediaType } from '$lib/models/MediaType.ts';
 
 export type InvalidateActionOptions =
-  | 'invalidate:mark_as_watched'
+  | `invalidate:mark_as_watched:${MediaType}`
   | 'invalidate:auth'
   | `invalidate:watchlisted:${MediaType}`;
 
 export const InvalidateAction = {
-  MarkAsWatched: 'invalidate:mark_as_watched' as InvalidateActionOptions,
+  MarkAsWatched: (type: MediaType): InvalidateActionOptions =>
+    `invalidate:mark_as_watched:${type}` as InvalidateActionOptions,
   Watchlisted: (type: MediaType): InvalidateActionOptions =>
     `invalidate:watchlisted:${type}`,
   Auth: 'invalidate:auth' as InvalidateActionOptions,

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
@@ -1,5 +1,6 @@
 import type { RecommendedMovieResponse } from '$lib/api.ts';
 import { authHeader } from '$lib/features/auth/stores/authHeader.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MovieSummary } from '$lib/requests/models/MovieSummary.ts';
 import { api, type ApiParams } from '../../_internal/api.ts';
 import { mapMovieResponseToMovieSummary } from '../../_internal/mapMovieResponseToMovieSummary.ts';
@@ -47,7 +48,10 @@ function recommendMoviesRequest(
     });
 }
 
-const recommendedMoviesQueryKey = ['recommendedMovies'] as const;
+const recommendedMoviesQueryKey = [
+  'recommendedMovies',
+  InvalidateAction.MarkAsWatched('movie'),
+] as const;
 export const recommendedMoviesQuery = (
   params: RecommendedMoviesParams = {},
 ) => ({

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
@@ -1,6 +1,7 @@
 import type { RecommendedShowResponse } from '$lib/api.ts';
 import { authHeader } from '$lib/features/auth/stores/authHeader.ts';
 import { type EpisodeCount } from '$lib/requests/models/EpisodeCount.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaSummary } from '$lib/requests/models/MediaSummary.ts';
 import { api, type ApiParams } from '../../_internal/api.ts';
 import { mapShowResponseToShowSummary } from '../../_internal/mapShowResponseToShowSummary.ts';
@@ -48,7 +49,11 @@ function recommendShowsRequest(
     });
 }
 
-const recommendedShowsQueryKey = ['recommendedShows'] as const;
+const recommendedShowsQueryKey = [
+  'recommendedShows',
+  InvalidateAction.MarkAsWatched('show'),
+  InvalidateAction.MarkAsWatched('episode'),
+] as const;
 export const recommendedShowsQuery = (
   params: RecommendedShowsParams = {},
 ) => ({

--- a/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
@@ -67,7 +67,8 @@ export function upNextRequest(
 }
 export const upNextQueryKey = [
   'upNext',
-  InvalidateAction.MarkAsWatched,
+  InvalidateAction.MarkAsWatched('show'),
+  InvalidateAction.MarkAsWatched('episode'),
 ] as const;
 export const upNextQuery = (
   params: UpNextParams = {},

--- a/projects/client/src/lib/sections/landing/useTrendingItems.ts
+++ b/projects/client/src/lib/sections/landing/useTrendingItems.ts
@@ -1,4 +1,5 @@
 import { shuffle } from '$lib/utils/array/shuffle.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { createQuery } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 import {
@@ -11,13 +12,15 @@ import {
 const RANDOM_SHOW_COUNT = 2;
 
 export function useTrendingItems() {
-  const trendingShows = createQuery(
-    showTrendingQuery(),
-  );
+  const trendingShows = createQuery({
+    ...showTrendingQuery(),
+    staleTime: time.hours(1),
+  });
 
-  const trendingMovies = createQuery(
-    movieTrendingQuery(),
-  );
+  const trendingMovies = createQuery({
+    ...movieTrendingQuery(),
+    staleTime: time.hours(1),
+  });
 
   return {
     shows: derived(

--- a/projects/client/src/lib/sections/lists/stores/useAnticipatedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useAnticipatedList.ts
@@ -4,6 +4,7 @@ import {
   movieAnticipatedQuery,
 } from '$lib/requests/queries/movies/movieAnticipatedQuery.ts';
 import { showAnticipatedQuery } from '$lib/requests/queries/shows/showAnticipatedQuery.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { createQuery, type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
@@ -34,7 +35,10 @@ function typeToQuery(type: MediaType): CreateQueryOptions<AnticipatedMedia> {
 export function useAnticipatedList(
   { type }: AnticipatedListStoreProps,
 ) {
-  const query = createQuery(typeToQuery(type));
+  const query = createQuery({
+    ...typeToQuery(type),
+    staleTime: time.hours(1),
+  });
   const list = derived(query, ($query) => $query.data ?? []);
 
   return {

--- a/projects/client/src/lib/sections/lists/stores/useCalendarEpisodes.ts
+++ b/projects/client/src/lib/sections/lists/stores/useCalendarEpisodes.ts
@@ -18,7 +18,7 @@ export function useCalendarEpisodes() {
       startDate: assertDefined(YYYY_MM_DD, 'Could not extract current date.'),
       days: 14,
     }),
-    staleTime: time.minutes(5),
+    staleTime: time.hours(1),
     refetchOnWindowFocus: true,
   });
 

--- a/projects/client/src/lib/sections/lists/stores/usePopularList.ts
+++ b/projects/client/src/lib/sections/lists/stores/usePopularList.ts
@@ -5,6 +5,7 @@ import {
   type PopularShow,
   showPopularQuery,
 } from '$lib/requests/queries/shows/showPopularQuery.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { createQuery, type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
@@ -36,7 +37,10 @@ function typeToQuery(
 export function usePopularList(
   { type, limit = 25 }: PopularListStoreProps,
 ) {
-  const query = createQuery(typeToQuery({ type, limit }));
+  const query = createQuery({
+    ...typeToQuery({ type, limit }),
+    staleTime: time.hours(1),
+  });
   const list = derived(query, ($query) => $query.data ?? []);
 
   return {

--- a/projects/client/src/lib/sections/lists/stores/useRecommendationList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRecommendationList.ts
@@ -7,6 +7,7 @@ import {
   type RecommendedShow,
   recommendedShowsQuery,
 } from '$lib/requests/queries/recommendations/recommendedShowsQuery.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { createQuery, type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
@@ -31,7 +32,10 @@ function typeToQuery(type: MediaType): CreateQueryOptions<RecommendedMedia> {
 export function useRecommendationList(
   { type }: RecommendationListStoreProps,
 ) {
-  const query = createQuery(typeToQuery(type));
+  const query = createQuery({
+    ...typeToQuery(type),
+    staleTime: time.hours(24),
+  });
   const list = derived(query, ($query) => $query.data ?? []);
 
   return {

--- a/projects/client/src/lib/sections/lists/stores/useRelatedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRelatedList.ts
@@ -5,6 +5,7 @@ import {
   type PopularShow,
 } from '$lib/requests/queries/shows/showPopularQuery.ts';
 import { showRelatedQuery } from '$lib/requests/queries/shows/showRelatedQuery.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { createQuery, type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
@@ -34,7 +35,10 @@ function typeToQuery(
 export function useRelatedList(
   { type, slug }: PopularListStoreProps,
 ) {
-  const query = createQuery(typeToQuery({ type, slug }));
+  const query = createQuery({
+    ...typeToQuery({ type, slug }),
+    staleTime: time.days(7),
+  });
   const list = derived(query, ($query) => $query.data ?? []);
 
   return {

--- a/projects/client/src/lib/sections/lists/stores/useTrendingList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useTrendingList.ts
@@ -7,6 +7,7 @@ import {
   showTrendingQuery,
   type TrendingShow,
 } from '$lib/requests/queries/shows/showTrendingQuery.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { createQuery, type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
@@ -38,7 +39,10 @@ function typeToQuery(
 export function useTrendingList(
   { type, limit = 25 }: TrendingListStoreProps,
 ) {
-  const query = createQuery(typeToQuery({ type, limit }));
+  const query = createQuery({
+    ...typeToQuery({ type, limit }),
+    staleTime: time.hours(1),
+  });
   const list = derived(query, ($query) => $query.data ?? []);
 
   return {

--- a/projects/client/src/lib/sections/lists/stores/useWatchlistList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useWatchlistList.ts
@@ -8,6 +8,7 @@ import {
   showWatchlistQuery,
   type WatchlistShow,
 } from '$lib/requests/queries/users/showWatchlistQuery.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { createQuery, type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
@@ -40,7 +41,10 @@ function typeToQuery(
 }
 
 export function useWatchlistList(params: WatchListStoreProps) {
-  const query = createQuery(typeToQuery(params));
+  const query = createQuery({
+    ...typeToQuery(params),
+    staleTime: time.hours(1),
+  });
   const list = derived(
     query,
     ($query) => ($query.data ?? []).map((item) => item.mediaItem),

--- a/projects/client/src/lib/stores/useMarkAsWatched.ts
+++ b/projects/client/src/lib/stores/useMarkAsWatched.ts
@@ -74,7 +74,7 @@ export function useMarkAsWatched({ type, id }: MarkAsWatchedStoreProps) {
     isMarkingAsWatched.set(false);
 
     _isWatched.set(result);
-    await invalidate(InvalidateAction.MarkAsWatched);
+    await invalidate(InvalidateAction.MarkAsWatched(type));
   };
 
   return {

--- a/projects/client/src/routes/movies/[slug]/useMovie.ts
+++ b/projects/client/src/routes/movies/[slug]/useMovie.ts
@@ -4,40 +4,46 @@ import { movieRatingQuery } from '$lib/requests/queries/movies/movieRatingQuery.
 import { movieStatsQuery } from '$lib/requests/queries/movies/movieStatsQuery.ts';
 import { movieSummaryQuery } from '$lib/requests/queries/movies/movieSummaryQuery.ts';
 import { movieWatchersQuery } from '$lib/requests/queries/movies/movieWatchersQuery.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { createQuery } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
 export function useMovie(slug: string) {
-  const movie = createQuery(
-    movieSummaryQuery({
+  const movie = createQuery({
+    ...movieSummaryQuery({
       slug,
     }),
-  );
+    staleTime: time.days(1),
+  });
 
-  const ratings = createQuery(
-    movieRatingQuery({
+  const ratings = createQuery({
+    ...movieRatingQuery({
       slug,
     }),
-  );
+    staleTime: time.days(1),
+  });
 
-  const stats = createQuery(
-    movieStatsQuery({
+  const stats = createQuery({
+    ...movieStatsQuery({
       slug,
     }),
-  );
+    staleTime: time.minutes(30),
+  });
 
-  const watchers = createQuery(
-    movieWatchersQuery({
+  const watchers = createQuery({
+    ...movieWatchersQuery({
       slug,
     }),
-  );
+    staleTime: time.minutes(5),
+  });
 
   const locale = languageTag();
 
   const isLocaleSkipped = locale === 'en';
-  const intl = isLocaleSkipped
-    ? movie
-    : createQuery(movieIntlQuery({ slug, ...getLanguageAndRegion() }));
+  const intl = isLocaleSkipped ? movie : createQuery({
+    ...movieIntlQuery({ slug, ...getLanguageAndRegion() }),
+    staleTime: time.days(7),
+  });
 
   return {
     movie: derived(movie, ($movie) => $movie.data),

--- a/projects/client/src/routes/shows/[slug]/useShow.ts
+++ b/projects/client/src/routes/shows/[slug]/useShow.ts
@@ -1,53 +1,47 @@
-import {
-  showProgressQuery,
-} from '$lib/requests/queries/shows/showProgressQuery.ts';
-import { createQuery } from '@tanstack/svelte-query';
-import { derived } from 'svelte/store';
-import { showRatingQuery } from '../../../lib/requests/queries/shows/showRatingQuery.ts';
-import { showSummaryQuery } from '../../../lib/requests/queries/shows/showSummaryQuery.ts';
-
 import { getLanguageAndRegion, languageTag } from '$lib/features/i18n/index.ts';
 import { showIntlQuery } from '$lib/requests/queries/shows/showIntlQuery.ts';
+import { showProgressQuery } from '$lib/requests/queries/shows/showProgressQuery.ts';
+import { showRatingQuery } from '$lib/requests/queries/shows/showRatingQuery.ts';
 import { showStatsQuery } from '$lib/requests/queries/shows/showStatsQuery.ts';
+import { showSummaryQuery } from '$lib/requests/queries/shows/showSummaryQuery.ts';
 import { showWatchersQuery } from '$lib/requests/queries/shows/showWatchersQuery.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { createQuery } from '@tanstack/svelte-query';
+import { derived } from 'svelte/store';
 
 export function useShow(slug: string) {
-  const show = createQuery(
-    showSummaryQuery({
-      slug,
-    }),
-  );
+  const show = createQuery({
+    ...showSummaryQuery({ slug }),
+    staleTime: time.days(1),
+  });
 
-  const ratings = createQuery(
-    showRatingQuery({
-      slug,
-    }),
-  );
+  const ratings = createQuery({
+    ...showRatingQuery({ slug }),
+    staleTime: time.days(1),
+  });
 
-  const stats = createQuery(
-    showStatsQuery({
-      slug,
-    }),
-  );
+  const stats = createQuery({
+    ...showStatsQuery({ slug }),
+    staleTime: time.minutes(30),
+  });
 
-  const watchers = createQuery(
-    showWatchersQuery({
-      slug,
-    }),
-  );
+  const watchers = createQuery({
+    ...showWatchersQuery({ slug }),
+    staleTime: time.minutes(5),
+  });
 
-  const progress = createQuery(
-    showProgressQuery({
-      slug,
-    }),
-  );
+  const progress = createQuery({
+    ...showProgressQuery({ slug }),
+    staleTime: time.days(1),
+  });
 
   const locale = languageTag();
   const isLocaleSkipped = locale === 'en';
 
-  const intl = isLocaleSkipped
-    ? derived(show, ($show) => $show)
-    : createQuery(showIntlQuery({ slug, ...getLanguageAndRegion() }));
+  const intl = isLocaleSkipped ? show : createQuery({
+    ...showIntlQuery({ slug, ...getLanguageAndRegion() }),
+    staleTime: time.days(7),
+  });
 
   return {
     show: derived(show, ($show) => $show.data),


### PR DESCRIPTION
This pull request, a symphony of optimization and code refinement, conducts a meticulous audit of query keys and stale times, leaving a trail of updated configurations and enhanced data handling in its wake. Observe, with a mix of admiration and weariness, the meticulous adjustments to invalidation actions, the harmonization of query keys, and the strategic deployment of stale time settings.

### Updates to InvalidateAction (or, "The Invalidation Evolution"):

* The `InvalidateAction`, a guardian of data freshness, expands its repertoire, now wielding the power to differentiate between media types. The `MarkAsWatched` action, once a blunt instrument of invalidation, now accepts a `MediaType` parameter, allowing for more targeted and precise cache invalidation.

### Query Key Updates (or, "The Keymaster's Symphony"):

* The `currentUserHistoryQueryKey`, a keeper of user viewing history, joins the invalidation evolution, incorporating media types into its structure, ensuring that cache invalidation remains synchronized with the user's media consumption habits.
* The `recommendedMoviesQuery`, `recommendedShowsQuery`, and `upNextQuery` keys, like finely tuned instruments in an orchestra, harmonize their invalidation actions, each specifying the appropriate `MediaType` for the `MarkAsWatched` action, creating a symphony of cache coherence.

### Stale Time Adjustments (or, "The Temporal Tamers"):

* Stale times, those arbiters of data freshness, are meticulously adjusted across various queries, their values carefully chosen to balance data accuracy with performance efficiency. Trending items, anticipated lists, popular lists, and watchlist items, those fleeting entities of the digital realm, are granted a `staleTime` of 1 hour, ensuring that their information remains relatively up-to-date. Recommendation lists, those more enduring sources of inspiration, are granted a more generous `staleTime` of 24 hours, reducing the frequency of unnecessary refetches.

### Use of `time` Utility (or, "The Timekeepers"):

* The `time` utility, a master of temporal calculations, emerges from the shadows, its purpose to ensure that `staleTime` settings across the project adhere to a consistent unit of measurement. This standardization, a testament to our obsessive pursuit of code clarity, prevents confusion and ensures that time-based configurations are easily understood and maintained.

### Refactoring `useMovie` and `useShow` (or, "The Hook Harmonizers"):

* The `useMovie` and `useShow` hooks, those providers of media details, undergo a subtle yet significant transformation, their code now adorned with `staleTime` settings for their respective queries. This harmonization of data freshness ensures that movie and show details are retrieved with a consistent level of accuracy, further contributing to the application's overall performance and reliability.

These changes, a testament to our ongoing quest for code optimization and data integrity, collectively enhance the efficiency and predictability of the application's data fetching mechanisms. The result is a more responsive and user-friendly experience, where data is fresh, caches are coherent, and users can navigate the Trakt Lite universe with confidence, knowing that the information they see is as up-to-date as possible.