### PR TITLE
fix(navbar): do not re-use ids in svg

### DIFF
--- a/projects/client/src/lib/sections/navbar/BetaBadge.svelte
+++ b/projects/client/src/lib/sections/navbar/BetaBadge.svelte
@@ -16,7 +16,6 @@
   </g>
   <defs>
     <filter
-      id="a"
       width="52"
       height="32"
       x=".358398"


### PR DESCRIPTION
## 🎶 Notes 🎶
With should probably follow this up with a more standardized fix 😅

## 👀 Examples 👀
Before:
<img width="390" alt="Screenshot 2024-12-22 at 20 12 03" src="https://github.com/user-attachments/assets/edf08b8c-0477-4f0e-a4a7-11c1276f0e80" />

After:
<img width="390" alt="Screenshot 2024-12-22 at 20 12 14" src="https://github.com/user-attachments/assets/968d2ed2-c74d-4218-bd49-63f1b300c691" />
