### PR TITLE
fix(dropdown): close dropdown when item is clicked

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -36,6 +36,7 @@ module.exports = {
         'card',
         'coming-soon',
         'ds',
+        'dropdown',
         'episode',
         'footer',
         'guards',

--- a/projects/client/src/lib/components/dropdown/DropdownList.spec.ts
+++ b/projects/client/src/lib/components/dropdown/DropdownList.spec.ts
@@ -55,4 +55,26 @@ describe('DropdownList', () => {
       expect(list).not.toBeInTheDocument();
     });
   });
+
+  it('should close the dropdown when clicking an item', async () => {
+    render(DropdownList, {
+      props: {
+        ...defaultProps,
+      },
+    });
+
+    const dropdownButton = screen.getByRole('button', {
+      name: /click here/i,
+    });
+
+    await fireEvent.click(dropdownButton);
+    const list = screen.getByRole('list');
+    expect(list).toBeInTheDocument();
+
+    const item = screen.getByRole('listitem');
+    await fireEvent.click(item);
+    await waitFor(() => {
+      expect(list).not.toBeInTheDocument();
+    });
+  });
 });

--- a/projects/client/src/lib/components/dropdown/DropdownList.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownList.svelte
@@ -48,7 +48,7 @@
   {#if $isDropdownOpen}
     <div class="trakt-list" transition:slide={{ duration: 150 }}>
       <div class="spacer"></div>
-      <ul>
+      <ul onclickcapture={() => isDropdownOpen.set(false)}>
         {@render items()}
       </ul>
     </div>


### PR DESCRIPTION
This pull request includes changes to the `DropdownList` component and its corresponding tests to improve functionality and user experience. The most important changes include adding a new test to ensure the dropdown closes when an item is clicked and modifying the component to close the dropdown on item click.

Improvements to functionality:

* [`projects/client/src/lib/components/dropdown/DropdownList.svelte`](diffhunk://#diff-cacd087cc936682b113b7d35ea4d4224f3242ed06364ae47a6f42bf4d8fac822L51-R51): Modified the `ul` element to close the dropdown when an item is clicked by setting `isDropdownOpen` to `false`.

Enhancements to testing:

* [`projects/client/src/lib/components/dropdown/DropdownList.spec.ts`](diffhunk://#diff-e1bbecc0a7d75eb0117ae5f6c754a280904ea04aa9291e9be25f863d496e92c5R58-R79): Added a new test case to verify that the dropdown closes when an item is clicked.