### PR TITLE
fix: account for the greatness which is Safari...

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
     "redhat.vscode-yaml",
     "phoenisx.cssvar",
     "jacobcassidy.css-nesting-syntax-highlighting",
-    "svelte.svelte-vscode"
+    "svelte.svelte-vscode",
+    "sibiraj-s.vscode-scss-formatter"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,5 +65,8 @@
   },
   "[jsonc]": {
     "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "vscode.css-language-features"
   }
 }

--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -46,57 +46,46 @@
 {/if}
 
 <style lang="scss">
-  .trakt-action-button {
-    @each $color in "purple", "red", "blue", "default" {
-      &[data-color="#{$color}"] {
-        $background-color: var(--color-background-#{$color});
-        $foreground-color: var(--color-foreground-#{$color});
+  @use "../../../style/mixins/index.scss" as *;
 
-        &[data-variant="primary"] {
-          $hover: var(--color-background-#{$color}-hover);
+  @mixin variant-styles($variant, $background-color, $foreground-color) {
+    &[data-variant="#{$variant}"] {
+      --color-background-action-button: #{$background-color};
+      --color-foreground-action-button: #{$foreground-color};
 
-          --color-background-action-button: #{$background-color};
-          --color-foreground-action-button: #{$foreground-color};
-
-          &:hover,
-          &:focus-visible {
-            --color-background-action-button: #{$foreground-color};
-            --color-foreground-action-button: #{$background-color};
-          }
-        }
-
-        &[data-variant="secondary"] {
+      @include mouse {
+        &:hover,
+        &:focus-visible {
           --color-background-action-button: #{$foreground-color};
           --color-foreground-action-button: #{$background-color};
-
-          &:hover,
-          &:focus-visible {
-            --color-background-action-button: #{$background-color};
-            --color-foreground-action-button: #{$foreground-color};
-          }
         }
+      }
+    }
+  }
 
+  @mixin color-styles($color) {
+    &[data-color="#{$color}"] {
+      $background-color: var(--color-background-#{$color});
+      $foreground-color: var(--color-foreground-#{$color});
+
+      @include variant-styles("primary", $background-color, $foreground-color);
+
+      @include variant-styles(
+        "secondary",
+        $foreground-color,
+        $background-color
+      );
+
+      @include mouse {
         &:focus-visible {
-          outline: var(--border-thickness-xs)
-            solid
+          outline: var(--border-thickness-xs) solid
             var(--color-foreground-action-button);
         }
       }
     }
+  }
 
-    &[disabled] {
-      cursor: not-allowed;
-      color: var(--color-foreground-button-disabled);
-      background: var(
-        --color-background-button-disabled,
-        var(--color-surface-button-disabled)
-      );
-
-      &::before {
-        display: none;
-      }
-    }
-
+  .trakt-action-button {
     all: unset;
 
     cursor: pointer;
@@ -112,8 +101,27 @@
     flex-shrink: 0;
 
     border-radius: var(--border-radius-m);
+    background-color: var(--color-background-action-button);
+    color: var(--color-foreground-action-button);
 
     transition: background-color var(--transition-increment) ease-in-out;
+
+    @each $color in "purple", "red", "blue", "default" {
+      @include color-styles($color);
+    }
+
+    &[disabled] {
+      cursor: not-allowed;
+      color: var(--color-foreground-button-disabled);
+      background: var(
+        --color-background-button-disabled,
+        var(--color-surface-button-disabled)
+      );
+
+      &::before {
+        display: none;
+      }
+    }
 
     &:active {
       transform: scale(0.95);
@@ -123,8 +131,5 @@
           infinite;
       }
     }
-
-    background-color: var(--color-background-action-button);
-    color: var(--color-foreground-action-button);
   }
 </style>

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -80,6 +80,46 @@
 {/if}
 
 <style lang="scss">
+  @use "../../../style/mixins/index.scss" as *;
+
+  @mixin variant-styles($variant, $background-color, $foreground-color) {
+    &[data-variant="#{$variant}"] {
+      --color-background-button: #{$background-color};
+      --color-foreground-button: #{$foreground-color};
+
+      &:not([data-style="textured"]):not([data-style="ghost"]) {
+        @include mouse {
+          &:hover,
+          &:focus-visible {
+            --color-foreground-button: #{$background-color};
+            --color-background-button: #{$foreground-color};
+          }
+        }
+      }
+    }
+  }
+
+  @mixin color-styles($color) {
+    &[data-color="#{$color}"] {
+      $background-color: var(--color-background-#{$color});
+      $foreground-color: var(--color-foreground-#{$color});
+
+      @include variant-styles("primary", $background-color, $foreground-color);
+      @include variant-styles(
+        "secondary",
+        $foreground-color,
+        $background-color
+      );
+
+      @include mouse {
+        &:focus-visible {
+          outline: var(--border-thickness-xs) solid
+            var(--color-foreground-button);
+        }
+      }
+    }
+  }
+
   .trakt-button {
     --color-background-button-outline: color-mix(
       in srgb,
@@ -99,65 +139,11 @@
     --color-highlight: color-mix(in srgb, white 52%, transparent 48%);
     --color-shadow: color-mix(in srgb, black 32%, transparent 68%);
 
-    &.trakt-button-link {
-      &[data-style="ghost"] {
-        &.trakt-link-active {
-          color: var(--color-background-button);
-        }
-      }
-    }
-
-    @each $color in "purple", "red", "blue", "default", "custom" {
-      &[data-color="#{$color}"] {
-        $background-color: var(--color-background-#{$color});
-        $foreground-color: var(--color-foreground-#{$color});
-
-        &[data-variant="primary"] {
-          --color-background-button: #{$background-color};
-          --color-foreground-button: #{$foreground-color};
-
-          &:not([data-style="textured"]):not([data-style="ghost"]) {
-            &:hover,
-            &:focus-visible {
-              --color-foreground-button: #{$background-color};
-              --color-background-button: #{$foreground-color};
-            }
-          }
-        }
-
-        &[data-variant="secondary"] {
-          --color-background-button: #{$foreground-color};
-          --color-foreground-button: #{$background-color};
-
-          &:not([data-style="textured"]):not([data-style="ghost"]) {
-            &:hover,
-            &:focus-visible {
-              --color-foreground-button: #{$foreground-color};
-              --color-background-button: #{$background-color};
-            }
-          }
-        }
-
-        &:focus-visible {
-          outline: var(--border-thickness-xs)
-            solid
-            var(--color-foreground-button);
-        }
-      }
-    }
-
-    &[data-alignment="default"] {
-      justify-content: space-between;
-    }
-
-    &[data-alignment="centered"] {
-      justify-content: center;
-    }
-
     all: unset;
     display: flex;
     align-items: center;
     gap: var(--ni-16);
+    min-width: var(--ni-96);
     padding: var(--ni-16);
     flex-shrink: 0;
     cursor: pointer;
@@ -175,6 +161,26 @@
     transition: var(--transition-increment) ease-in-out;
     transition-property: box-shadow outline padding transform color background;
 
+    &.trakt-button-link {
+      &[data-style="ghost"] {
+        &.trakt-link-active {
+          color: var(--color-background-button);
+        }
+      }
+    }
+
+    @each $color in "purple", "red", "blue", "default", "custom" {
+      @include color-styles($color);
+    }
+
+    &[data-alignment="default"] {
+      justify-content: space-between;
+    }
+
+    &[data-alignment="centered"] {
+      justify-content: center;
+    }
+
     &[data-size="small"] {
       --scale-factor-button: 0.75;
     }
@@ -183,10 +189,6 @@
       --scale-factor-button: 0.75;
       --button-height: var(--ni-24);
       padding: var(--ni-4) var(--ni-10);
-    }
-
-    & {
-      min-width: var(--ni-96);
     }
 
     &,
@@ -223,9 +225,11 @@
       transition: opacity var(--transition-increment) ease-in-out;
     }
 
-    &:hover::before,
-    &:focus-visible::before {
-      opacity: 1;
+    @include mouse {
+      &:hover::before,
+      &:focus-visible::before {
+        opacity: 1;
+      }
     }
 
     &:active::before {
@@ -256,29 +260,29 @@
       background: transparent;
       color: inherit;
 
-      &:hover:not([disabled]) {
-        color: var(--color-foreground-button);
-      }
-
       &[disabled] {
         color: var(--color-foreground-button-disabled);
       }
 
-      &:hover:not([disabled]) {
-        &[data-variant="primary"] {
-          background: color-mix(
-            in srgb,
-            var(--color-background-button) 60%,
-            transparent 40%
-          );
-        }
+      @include mouse {
+        &:hover:not([disabled]) {
+          color: var(--color-foreground-button);
 
-        &[data-variant="secondary"] {
-          background: color-mix(
-            in srgb,
-            var(--color-foreground-button) 10%,
-            transparent 90%
-          );
+          &[data-variant="primary"] {
+            background: color-mix(
+              in srgb,
+              var(--color-background-button) 60%,
+              transparent 40%
+            );
+          }
+
+          &[data-variant="secondary"] {
+            background: color-mix(
+              in srgb,
+              var(--color-foreground-button) 10%,
+              transparent 90%
+            );
+          }
         }
       }
 

--- a/projects/client/src/lib/components/dropdown/DropdownItem.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.svelte
@@ -41,7 +41,9 @@
   {/if}
 </li>
 
-<style>
+<style lang="scss">
+  @use "../../../style/mixins/index" as *;
+
   li {
     text-decoration: none;
     list-style-type: none;
@@ -71,8 +73,10 @@
     &[data-style="normal"] {
       color: var(--purple-800);
 
-      &:hover {
-        background: var(--purple-100);
+      @include mouse {
+        &:hover {
+          background: var(--purple-100);
+        }
       }
 
       &:active {
@@ -88,8 +92,10 @@
     &[data-style="danger"] {
       color: var(--red-600);
 
-      &:hover {
-        background: var(--red-100);
+      @include mouse {
+        &:hover {
+          background: var(--red-100);
+        }
       }
 
       &:active {

--- a/projects/client/src/lib/components/link/Link.svelte
+++ b/projects/client/src/lib/components/link/Link.svelte
@@ -37,7 +37,9 @@
   {@render children?.()}
 {/if}
 
-<style>
+<style lang="scss">
+  @use "../../../style/mixins/index" as *;
+
   .trakt-link {
     -webkit-tap-highlight-color: transparent;
     color: inherit;
@@ -46,7 +48,8 @@
     transition: color var(--transition-increment) ease-in-out;
     display: inherit;
 
-    :global(p, span) {
+    :global(p),
+    :globla(span) {
       color: inherit;
     }
 
@@ -75,9 +78,11 @@
         color: var(--color-foreground);
       }
 
-      &:hover,
-      &:focus-visible {
-        color: var(--color-link-active);
+      @include mouse {
+        &:hover,
+        &:focus-visible {
+          color: var(--color-link-active);
+        }
       }
 
       &.trakt-link-active {
@@ -86,8 +91,10 @@
           color: var(--color-link-active);
         }
 
-        &:hover {
-          color: var(--color-foreground);
+        @include mouse {
+          &:hover {
+            color: var(--color-foreground);
+          }
         }
       }
     }
@@ -100,8 +107,10 @@
         color: var(--red-300);
       }
 
-      &:hover {
-        color: var(--blue-600);
+      @include mouse {
+        &:hover {
+          color: var(--blue-600);
+        }
       }
     }
   }

--- a/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
+++ b/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
@@ -74,7 +74,9 @@
   </select>
 </div>
 
-<style>
+<style lang="scss">
+  @use "../../../../style/mixins/index" as *;
+
   .locale-picker-container {
     position: relative;
     width: var(--ni-48);
@@ -90,12 +92,14 @@
       transform: translate(-50%, -50%);
     }
 
-    &:hover {
-      background-color: color-mix(
-        in srgb,
-        var(--color-background) 30%,
-        transparent 70%
-      );
+    @include mouse {
+      &:hover {
+        background-color: color-mix(
+          in srgb,
+          var(--color-background) 30%,
+          transparent 70%
+        );
+      }
     }
   }
 

--- a/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
+++ b/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
@@ -56,7 +56,9 @@
   {/if}
 </div>
 
-<style>
+<style lang="scss">
+  @use "../../../../../style/mixins/index" as *;
+
   @keyframes slide-left-to-right {
     0% {
       background-position: 200% 0;
@@ -163,11 +165,13 @@
       :global(a.trakt-link) {
         transition: background-color var(--transition-increment) ease-in-out;
 
-        &:hover,
-        &:focus-visible {
-          background: var(--purple-900);
-          color: var(--shade-10);
-          border-radius: var(--border-radius-m);
+        @include mouse {
+          &:hover,
+          &:focus-visible {
+            background: var(--purple-900);
+            color: var(--shade-10);
+            border-radius: var(--border-radius-m);
+          }
         }
 
         &:active {

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -53,51 +53,6 @@
       color: var(--color-foreground);
       font-family: "Spline Sans", Arial, sans-serif;
     }
-
-    @media (hover: hover) and (pointer: fine) {
-      ::-webkit-scrollbar {
-        width: var(--ni-8);
-        height: var(--ni-8);
-      }
-
-      body,
-      html {
-        &::-webkit-scrollbar-thumb {
-          background-color: color-mix(
-            in srgb,
-            var(--color-foreground) 30%,
-            transparent 70%
-          );
-        }
-      }
-
-      ::-webkit-scrollbar-thumb {
-        background-color: color-mix(
-          in srgb,
-          var(--color-foreground) 0%,
-          transparent 100%
-        );
-        border-radius: var(--border-radius-xs);
-        backdrop-filter: blur(var(--ni-4));
-        opacity: 0;
-      }
-
-      :hover::-webkit-scrollbar-thumb {
-        background-color: color-mix(
-          in srgb,
-          var(--color-foreground) 50%,
-          transparent 50%
-        );
-      }
-
-      ::-webkit-scrollbar-thumb:hover {
-        background-color: color-mix(
-          in srgb,
-          var(--color-foreground) 100%,
-          transparent 0%
-        );
-      }
-    }
   </style>
 </svelte:head>
 
@@ -134,7 +89,9 @@
   </AuthProvider>
 </QueryClientProvider>
 
-<style>
+<style lang="scss">
+  @use "../style/mixins/index" as *;
+
   :global(.tsqd-open-btn-container) {
     opacity: 0.25;
   }
@@ -147,5 +104,50 @@
 
   .trakt-layout-content {
     flex: 1;
+  }
+
+  @include mouse {
+    :global(::-webkit-scrollbar) {
+      width: var(--ni-8);
+      height: var(--ni-8);
+    }
+
+    :global(body),
+    :global(html) {
+      &::-webkit-scrollbar-thumb {
+        background-color: color-mix(
+          in srgb,
+          var(--color-foreground) 30%,
+          transparent 70%
+        );
+      }
+    }
+
+    :global(::-webkit-scrollbar-thumb) {
+      background-color: color-mix(
+        in srgb,
+        var(--color-foreground) 0%,
+        transparent 100%
+      );
+      border-radius: var(--border-radius-xs);
+      backdrop-filter: blur(var(--ni-4));
+      opacity: 0;
+    }
+
+    :global(:hover::-webkit-scrollbar-thumb) {
+      background-color: color-mix(
+        in srgb,
+        var(--color-foreground) 50%,
+        transparent 50%
+      );
+    }
+
+    :global(::-webkit-scrollbar-thumb:hover) {
+      background-color: color-mix(
+        in srgb,
+        var(--color-foreground) 100%,
+        transparent 0%
+      );
+    }
   }
 </style>

--- a/projects/client/src/style/mixins/index.scss
+++ b/projects/client/src/style/mixins/index.scss
@@ -1,0 +1,11 @@
+@mixin mouse {
+  @media (hover: hover) and (pointer: fine) {
+    @content;
+  }
+}
+
+@mixin touch {
+  @media (hover: none) and (pointer: coarse) {
+    @content;
+  }
+}


### PR DESCRIPTION
Read More: https://css-tricks.com/annoying-mobile-double-tap-link-issue/

This pull request, a desperate cry for sanity in the face of Safari's relentless assault on web standards, attempts to quell the "annoying mobile double-tap link issue" with a targeted application of hover and focus-visible styles.  Observe, with a mix of weary resignation and simmering rage, the introduction of SCSS mixins, the refactoring of button styles, and the begrudging acceptance of browser-specific hacks.

### SCSS Support and Mixins (or, "The CSS Alchemist's Workshop"):

* The `mixins/index.scss` file, a cauldron of reusable styles, welcomes new additions: the `mouse` and `touch` mixins, a pair of magical concoctions designed to conditionally apply styles based on the user's input method. This innovation, a desperate attempt to tame the wild inconsistencies of browser behavior, promises to bring a semblance of order to the chaotic world of hover and touch interactions.

### Component Style Refactoring (or, "The Great CSS Restructuring, Part II"):

* The `ActionButton.svelte`, `Button.svelte`, `DropdownItem.svelte`, and `Link.svelte` components, once victims of Safari's double-tap tyranny, now stand defiant, their stylesheets refactored to utilize the `mouse` mixin, ensuring that hover and focus-visible styles are applied only when a mouse is detected. This surgical intervention, a testament to our frustration with Safari's blatant disregard for web standards, aims to restore sanity to the user experience, preventing accidental double-tap activations and preserving the sanctity of single clicks.

### Layout and Miscellaneous (or, "The Usual Suspects"):

* The `.vscode/extensions.json` and `.vscode/settings.json` files, those guardians of developer sanity, welcome the SCSS formatter into their ranks, ensuring that code remains consistently styled and visually appealing, even in the face of Safari's relentless attempts to undermine our efforts.
* The `+layout.svelte` component, a canvas for global styles, undergoes a transformation, its scrollbar styles now encapsulated within the `mouse` mixin, further solidifying the distinction between mouse and touch interactions.

This pull request, a battle cry against browser inconsistency and a desperate plea for sanity in the world of web development, highlights the absurdity of having to cater to Safari's whims. While other browsers gracefully handle hover and focus-visible states without wreaking havoc on touch interactions, Safari continues to defy logic and web standards, forcing developers to waste precious time and energy on workarounds that should never have been necessary.

May this pull request serve as a reminder of the ongoing struggle against browser quirks and a subtle jab at Safari's inability to maintain even the most basic principles of web design.