### PR TITLE
refactor: extract sass utilities for media queries

### DIFF
--- a/projects/client/deno.json
+++ b/projects/client/deno.json
@@ -4,6 +4,8 @@
     "$lib/": "./src/lib/",
     "$mocks": "./src/mocks",
     "$mocks/": "./src/mocks/",
+    "$style": "./src/style",
+    "$style/": "./src/style/",
     "$test": "./test",
     "$test/": "./test/",
     "$env/static/public": "./.svelte-kit/ambient.d.ts",

--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -46,7 +46,7 @@
 {/if}
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   @mixin variant-styles($variant, $background-color, $foreground-color) {
     &[data-variant="#{$variant}"] {

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -80,7 +80,7 @@
 {/if}
 
 <style lang="scss">
-  @use "$style/mixins/index.scss" as *;
+  @use "$style/scss/mixins/index.scss" as *;
 
   @mixin variant-styles($variant, $background-color, $foreground-color) {
     &[data-variant="#{$variant}"] {

--- a/projects/client/src/lib/components/dropdown/DropdownItem.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.svelte
@@ -42,7 +42,7 @@
 </li>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   li {
     text-decoration: none;

--- a/projects/client/src/lib/components/icons/MarkAsWatchedIcon.svelte
+++ b/projects/client/src/lib/components/icons/MarkAsWatchedIcon.svelte
@@ -59,7 +59,7 @@
 </svg>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   path {
     transition: opacity var(--transition-increment) ease-in-out;

--- a/projects/client/src/lib/components/icons/WatchlistIcon.svelte
+++ b/projects/client/src/lib/components/icons/WatchlistIcon.svelte
@@ -50,7 +50,7 @@
 </svg>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   path {
     transition: opacity var(--transition-increment) ease-in-out;

--- a/projects/client/src/lib/components/layout/TraktPage.svelte
+++ b/projects/client/src/lib/components/layout/TraktPage.svelte
@@ -82,7 +82,7 @@
 </div>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   .trakt-content {
     --content-gap: var(--ni-48);

--- a/projects/client/src/lib/components/layout/TraktPage.svelte
+++ b/projects/client/src/lib/components/layout/TraktPage.svelte
@@ -81,7 +81,9 @@
   {@render children()}
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   .trakt-content {
     --content-gap: var(--ni-48);
 
@@ -96,7 +98,7 @@
       margin-top: var(--content-gap);
     }
 
-    @media (max-width: 480px) {
+    @include for-mobile {
       --content-gap: var(--ni-18);
 
       &:first-child {

--- a/projects/client/src/lib/components/link/Link.svelte
+++ b/projects/client/src/lib/components/link/Link.svelte
@@ -38,7 +38,7 @@
 {/if}
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   .trakt-link {
     -webkit-tap-highlight-color: transparent;
@@ -49,7 +49,7 @@
     display: inherit;
 
     :global(p),
-    :globla(span) {
+    :global(span) {
       color: inherit;
     }
 

--- a/projects/client/src/lib/components/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/section-list/ShadowList.svelte
@@ -107,7 +107,7 @@
 </section>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   .shadow-list-container,
   .shadow-list,

--- a/projects/client/src/lib/components/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/section-list/ShadowList.svelte
@@ -106,7 +106,9 @@
   </div>
 </section>
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   .shadow-list-container,
   .shadow-list,
   .shadow-list-empty-state {
@@ -119,7 +121,7 @@
     gap: var(--ni-32);
     transition: gap var(--transition-increment) ease-in-out;
 
-    @media screen and (max-width: 480px) {
+    @include for-mobile {
       gap: var(--ni-16);
     }
   }
@@ -160,11 +162,11 @@
     color: var(--color-text-primary);
     transition: font-size calc(var(--transition-increment) * 2) ease-in-out;
 
-    @media (max-width: 768px) {
+    @include for-tablet-sm {
       font-size: var(--ni-32);
     }
 
-    @media (max-width: 480px) {
+    @include for-mobile {
       font-size: var(--ni-24);
     }
   }

--- a/projects/client/src/lib/components/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/section-list/ShadowList.svelte
@@ -148,9 +148,13 @@
     gap: var(--ni-16);
 
     margin: 0;
-    margin-left: calc(var(--ni-64) + var(--layout-distance-side));
+    margin-left: calc(var(--ni-72) + var(--layout-distance-side));
     margin-right: var(--layout-distance-side);
     transition: margin-left calc(var(--transition-increment) * 2) ease-in-out;
+
+    @include for-tablet-sm-and-below {
+      margin-left: calc(var(--layout-distance-side));
+    }
   }
 
   .shadow-list-actions {

--- a/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
+++ b/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
@@ -75,7 +75,7 @@
 </div>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   .locale-picker-container {
     position: relative;

--- a/projects/client/src/lib/guards/_internal/RenderForDevice.svelte
+++ b/projects/client/src/lib/guards/_internal/RenderForDevice.svelte
@@ -50,7 +50,7 @@
 {/if}
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   trakt-render-for {
     display: contents;

--- a/projects/client/src/lib/guards/_internal/RenderForDevice.svelte
+++ b/projects/client/src/lib/guards/_internal/RenderForDevice.svelte
@@ -49,7 +49,9 @@
   </trakt-render-for>
 {/if}
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   trakt-render-for {
     display: contents;
   }
@@ -57,7 +59,7 @@
   .render-for-mobile {
     display: none;
 
-    @media (max-width: 480px) {
+    @include for-mobile {
       display: contents !important;
     }
   }
@@ -65,7 +67,7 @@
   .render-for-tablet-small {
     display: none;
 
-    @media (min-width: 481px) and (max-width: 768px) {
+    @include for-tablet-sm {
       display: contents !important;
     }
   }
@@ -73,13 +75,13 @@
   .render-for-tablet-large {
     display: none;
 
-    @media (min-width: 769px) and (max-width: 1023px) {
+    @include for-tablet-lg {
       display: contents !important;
     }
   }
 
   .render-for-desktop {
-    @media (min-width: 1024px) {
+    @include for-desktop {
       display: contents !important;
     }
   }

--- a/projects/client/src/lib/guards/_internal/RenderForInput.svelte
+++ b/projects/client/src/lib/guards/_internal/RenderForInput.svelte
@@ -33,7 +33,7 @@
 {/if}
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   trakt-render-for {
     display: contents;

--- a/projects/client/src/lib/guards/_internal/RenderForInput.svelte
+++ b/projects/client/src/lib/guards/_internal/RenderForInput.svelte
@@ -32,7 +32,9 @@
   </trakt-render-for>
 {/if}
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   trakt-render-for {
     display: contents;
   }
@@ -40,7 +42,7 @@
   .render-for-mouse {
     display: none;
 
-    @media (hover: hover) and (pointer: fine) {
+    @include for-mouse {
       display: contents !important;
     }
   }
@@ -48,7 +50,7 @@
   .render-for-touch {
     display: none;
 
-    @media (hover: none) and (pointer: coarse) {
+    @include for-touch {
       display: contents !important;
     }
   }

--- a/projects/client/src/lib/sections/footer/Footer.svelte
+++ b/projects/client/src/lib/sections/footer/Footer.svelte
@@ -11,14 +11,16 @@
   <FooterContent />
 </footer>
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   .trakt-footer {
     height: var(--ni-300);
     margin-top: var(--ni-120);
     padding-left: var(--layout-distance-side);
     padding-right: var(--layout-distance-side);
 
-    @media (max-width: 768px) {
+    @include for-tablet-sm-and-below {
       margin-top: var(--ni-60);
       height: auto;
     }

--- a/projects/client/src/lib/sections/footer/Footer.svelte
+++ b/projects/client/src/lib/sections/footer/Footer.svelte
@@ -12,7 +12,7 @@
 </footer>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   .trakt-footer {
     height: var(--ni-300);

--- a/projects/client/src/lib/sections/footer/components/FooterBar.svelte
+++ b/projects/client/src/lib/sections/footer/components/FooterBar.svelte
@@ -7,7 +7,7 @@
 </div>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   .trakt-footer-bar {
     padding: var(--ni-40);

--- a/projects/client/src/lib/sections/footer/components/FooterBar.svelte
+++ b/projects/client/src/lib/sections/footer/components/FooterBar.svelte
@@ -6,14 +6,16 @@
   {@render children?.()}
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   .trakt-footer-bar {
     padding: var(--ni-40);
     display: flex;
     justify-content: space-between;
     align-items: center;
 
-    @media (max-width: 768px) {
+    @include for-tablet-sm-and-below {
       padding: var(--ni-12) var(--ni-16);
     }
   }

--- a/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
+++ b/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
@@ -57,7 +57,7 @@
 </div>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   @keyframes slide-left-to-right {
     0% {

--- a/projects/client/src/lib/sections/profile-banner/ProfileBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfileBanner.svelte
@@ -32,7 +32,9 @@
   </div>
 {/if}
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   .profile-banner-container {
     margin-left: calc(var(--ni-52) + var(--layout-distance-side));
     display: flex;
@@ -41,7 +43,7 @@
     transition: var(--transition-increment) ease-in-out;
     transition-property: margin-left scale height;
 
-    @media (max-width: 480px) {
+    @include for-mobile {
       margin-left: 0;
       scale: 0.75;
       height: 75%;

--- a/projects/client/src/lib/sections/profile-banner/ProfileBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfileBanner.svelte
@@ -33,7 +33,7 @@
 {/if}
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   .profile-banner-container {
     margin-left: calc(var(--ni-52) + var(--layout-distance-side));

--- a/projects/client/src/lib/sections/profile-banner/ProfileBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfileBanner.svelte
@@ -36,7 +36,7 @@
   @use "$style/scss/mixins/index" as *;
 
   .profile-banner-container {
-    margin-left: calc(var(--ni-52) + var(--layout-distance-side));
+    margin-left: calc(var(--ni-72) + var(--layout-distance-side));
     display: flex;
     align-items: center;
     gap: var(--ni-16);
@@ -44,7 +44,7 @@
     transition-property: margin-left scale height;
 
     @include for-mobile {
-      margin-left: 0;
+      margin-left: var(--ni-neg-16);
       scale: 0.75;
       height: 75%;
     }

--- a/projects/client/src/lib/sections/profile/components/ProfileContainer.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileContainer.svelte
@@ -30,14 +30,16 @@
   {/if}
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   .trakt-profile-container {
     display: grid;
     gap: var(--ni-32);
     grid-template-columns: 1fr 2fr 1fr;
     margin: 0 var(--ni-56);
 
-    @media (max-width: 768px) {
+    @include for-tablet-sm-and-below {
       grid-template-columns: 1fr;
       margin: 0 var(--ni-16);
 

--- a/projects/client/src/lib/sections/profile/components/ProfileContainer.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileContainer.svelte
@@ -31,7 +31,7 @@
 </div>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   .trakt-profile-container {
     display: grid;

--- a/projects/client/src/lib/sections/profile/components/ProfileHistorySummary.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileHistorySummary.svelte
@@ -35,7 +35,7 @@
 </div>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   .trakt-profile-history-summary {
     height: var(--ni-104);

--- a/projects/client/src/lib/sections/profile/components/ProfileHistorySummary.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileHistorySummary.svelte
@@ -34,7 +34,9 @@
   </div>
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   .trakt-profile-history-summary {
     height: var(--ni-104);
     border-radius: var(--ni-12);
@@ -45,7 +47,7 @@
     gap: var(--ni-20);
     box-shadow: 0 var(--ni-4) var(--ni-8) 0 rgba(0, 0, 0, 0.24);
 
-    @media (max-width: 1024px) {
+    @include for-desktop {
       height: var(--ni-176);
 
       .trakt-profile-history-content {

--- a/projects/client/src/lib/sections/summary/components/MediaDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/MediaDetails.svelte
@@ -88,7 +88,7 @@
 </div>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   .trakt-summary-details {
     display: flex;

--- a/projects/client/src/lib/sections/summary/components/MediaDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/MediaDetails.svelte
@@ -87,7 +87,9 @@
   </div>
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   .trakt-summary-details {
     display: flex;
     flex-direction: column;
@@ -99,7 +101,7 @@
     grid-template-columns: 1fr 1fr;
     gap: var(--ni-16);
 
-    @media (max-width: 480px) {
+    @include for-mobile {
       grid-template-columns: 1fr;
     }
   }

--- a/projects/client/src/lib/sections/summary/components/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/MediaSummary.svelte
@@ -121,7 +121,7 @@
 </MediaSummaryContainer>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   :global(.trakt-info-actions) {
     @include for-tablet-sm-and-below {

--- a/projects/client/src/lib/sections/summary/components/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/MediaSummary.svelte
@@ -120,9 +120,11 @@
   <MediaDetails {media} {studios} {crew} />
 </MediaSummaryContainer>
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   :global(.trakt-info-actions) {
-    @media ((max-width: 768px)) {
+    @include for-tablet-sm-and-below {
       display: flex;
       flex-flow: column;
 

--- a/projects/client/src/lib/sections/summary/components/MediaSummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/MediaSummaryContainer.svelte
@@ -30,7 +30,7 @@
 </div>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   .trakt-summary-container {
     display: grid;

--- a/projects/client/src/lib/sections/summary/components/MediaSummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/MediaSummaryContainer.svelte
@@ -29,14 +29,16 @@
   {/if}
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   .trakt-summary-container {
     display: grid;
     gap: var(--ni-32);
     grid-template-columns: minmax(var(--ni-320), 1fr) 2fr 1fr;
     margin: 0 var(--ni-56);
 
-    @media (max-width: 768px) {
+    @include for-tablet-sm-and-below {
       grid-template-columns: 1fr;
 
       .trakt-summary-children {

--- a/projects/client/src/lib/stores/css/useMedia.ts
+++ b/projects/client/src/lib/stores/css/useMedia.ts
@@ -1,15 +1,25 @@
 import { browser } from '$app/environment';
+import {
+  breakpointDesktop,
+  breakpointMobile,
+  breakpointTabletLgMax,
+  breakpointTabletLgMin,
+  breakpointTabletSmMax,
+  breakpointTabletSmMin,
+} from '$style/scss/variables/index.ts';
 import { onDestroy, onMount } from 'svelte';
 import { writable } from 'svelte/store';
 
-export const enum WellKnownMediaQuery {
-  mobile = '(max-width: 480px)',
-  tabletSmall = '(min-width: 481px) and (max-width: 768px)',
-  tabletLarge = '(min-width: 769px) and (max-width: 1023px)',
-  desktop = '(min-width: 1024px)',
-  mouse = '(hover: hover) and (pointer: fine)',
-  touch = '(hover: none) and (pointer: coarse)',
-}
+export const WellKnownMediaQuery = {
+  mobile: `(max-width: ${breakpointMobile})`,
+  tabletSmall:
+    `(min-width: ${breakpointTabletSmMin}) and (max-width: ${breakpointTabletSmMax})`,
+  tabletLarge:
+    `(min-width: ${breakpointTabletLgMin}) and (max-width: ${breakpointTabletLgMax})`,
+  desktop: `(min-width: ${breakpointDesktop})`,
+  mouse: '(hover: hover) and (pointer: fine)',
+  touch: '(hover: none) and (pointer: coarse)',
+};
 
 type MediaCallback = () => void;
 

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -90,7 +90,7 @@
 </QueryClientProvider>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   :global(.tsqd-open-btn-container) {
     opacity: 0.25;

--- a/projects/client/src/routes/_design_system/buttons/+page.svelte
+++ b/projects/client/src/routes/_design_system/buttons/+page.svelte
@@ -145,7 +145,9 @@
   </div>
 </main>
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   main {
     display: flex;
     flex-direction: column;
@@ -153,7 +155,7 @@
     padding-top: var(--ni-32);
     align-items: center;
 
-    @media (max-width: 768px) {
+    @include for-tablet-sm-and-below {
       .button-display {
         flex-direction: column;
         align-items: center;

--- a/projects/client/src/routes/_design_system/buttons/+page.svelte
+++ b/projects/client/src/routes/_design_system/buttons/+page.svelte
@@ -146,7 +146,7 @@
 </main>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   main {
     display: flex;

--- a/projects/client/src/routes/_design_system/dropdown/+page.svelte
+++ b/projects/client/src/routes/_design_system/dropdown/+page.svelte
@@ -79,7 +79,7 @@
 </main>
 
 <style lang="scss">
-  @use "$style/mixins/index" as *;
+  @use "$style/scss/mixins/index" as *;
 
   main {
     display: flex;

--- a/projects/client/src/routes/_design_system/dropdown/+page.svelte
+++ b/projects/client/src/routes/_design_system/dropdown/+page.svelte
@@ -78,7 +78,9 @@
   </div>
 </main>
 
-<style>
+<style lang="scss">
+  @use "$style/mixins/index" as *;
+
   main {
     display: flex;
     flex-direction: column;
@@ -86,7 +88,7 @@
     padding-top: var(--ni-32);
     align-items: center;
 
-    @media (max-width: 768px) {
+    @include for-tablet-sm-and-below {
       .button-display {
         flex-direction: column;
         align-items: center;

--- a/projects/client/src/style/layout/index.css
+++ b/projects/client/src/style/layout/index.css
@@ -26,6 +26,6 @@
   /**
    * Structural variables
    */
-  --layout-distance-side: 2.5vw;
+  --layout-distance-side: var(--ni-24);
   --layout-distance-scroll-card: var(--ni-16);
 }

--- a/projects/client/src/style/mixins/index.scss
+++ b/projects/client/src/style/mixins/index.scss
@@ -9,3 +9,39 @@
     @content;
   }
 }
+
+@mixin for-mobile {
+  @media (max-width: 480px) {
+    @content;
+  }
+}
+
+@mixin for-tablet-sm {
+  @media (min-width: 481px) and (max-width: 768px) {
+    @content;
+  }
+}
+
+@mixin for-tablet-sm-and-below {
+  @media (max-width: 768px) {
+    @content;
+  }
+}
+
+@mixin for-tablet-lg {
+  @media (min-width: 769px) and (max-width: 1023px) {
+    @content;
+  }
+}
+
+@mixin for-tablet-lg-and-below {
+  @media (max-width: 1023px) {
+    @content;
+  }
+}
+
+@mixin for-desktop {
+  @media (min-width: 1024px) {
+    @content;
+  }
+}

--- a/projects/client/src/style/scss/mixins/index.scss
+++ b/projects/client/src/style/scss/mixins/index.scss
@@ -1,3 +1,5 @@
+@use '../variables/index.scss' as *;
+
 @mixin for-mouse {
   @media (hover: hover) and (pointer: fine) {
     @content;
@@ -11,37 +13,37 @@
 }
 
 @mixin for-mobile {
-  @media (max-width: 480px) {
+  @media (max-width: $breakpoint-mobile) {
     @content;
   }
 }
 
 @mixin for-tablet-sm {
-  @media (min-width: 481px) and (max-width: 768px) {
+  @media (min-width: $breakpoint-tablet-sm-min) and (max-width: $breakpoint-tablet-sm-max) {
     @content;
   }
 }
 
 @mixin for-tablet-sm-and-below {
-  @media (max-width: 768px) {
+  @media (max-width: $breakpoint-tablet-sm-max) {
     @content;
   }
 }
 
 @mixin for-tablet-lg {
-  @media (min-width: 769px) and (max-width: 1023px) {
+  @media (min-width: $breakpoint-tablet-lg-min) and (max-width: $breakpoint-tablet-lg-max) {
     @content;
   }
 }
 
 @mixin for-tablet-lg-and-below {
-  @media (max-width: 1023px) {
+  @media (max-width: $breakpoint-tablet-lg-max) {
     @content;
   }
 }
 
 @mixin for-desktop {
-  @media (min-width: 1024px) {
+  @media (min-width: $breakpoint-desktop) {
     @content;
   }
 }

--- a/projects/client/src/style/scss/variables/index.module.scss
+++ b/projects/client/src/style/scss/variables/index.module.scss
@@ -1,0 +1,10 @@
+@use './index.scss' as *;
+
+:export {
+  breakpointMobile: $breakpoint-mobile;
+  breakpointTabletSmMin: $breakpoint-tablet-sm-min;
+  breakpointTabletSmMax: $breakpoint-tablet-sm-max;
+  breakpointTabletLgMin: $breakpoint-tablet-lg-min;
+  breakpointTabletLgMax: $breakpoint-tablet-lg-max;
+  breakpointDesktop: $breakpoint-desktop;
+}

--- a/projects/client/src/style/scss/variables/index.scss
+++ b/projects/client/src/style/scss/variables/index.scss
@@ -1,0 +1,6 @@
+$breakpoint-mobile: 480px;
+$breakpoint-tablet-sm-min: 481px;
+$breakpoint-tablet-sm-max: 768px;
+$breakpoint-tablet-lg-min: 769px;
+$breakpoint-tablet-lg-max: 1023px;
+$breakpoint-desktop: 1024px;

--- a/projects/client/src/style/scss/variables/index.ts
+++ b/projects/client/src/style/scss/variables/index.ts
@@ -1,0 +1,43 @@
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import * as exports from '$style/scss/variables/index.module.scss';
+
+const variables = exports as unknown as {
+  breakpointDesktop: `${string}px`;
+  breakpointMobile: `${string}px`;
+  breakpointTabletLgMax: `${string}px`;
+  breakpointTabletLgMin: `${string}px`;
+  breakpointTabletSmMax: `${string}px`;
+  breakpointTabletSmMin: `${string}px`;
+};
+
+assertDefined(
+  variables.breakpointMobile,
+  '!! breakpointMobile not loaded from SCSS !!',
+);
+assertDefined(
+  variables.breakpointTabletSmMin,
+  '!! breakpointTabletSmMin not loaded from SCSS !!',
+);
+assertDefined(
+  variables.breakpointTabletSmMax,
+  '!! breakpointTabletSmMax not loaded from SCSS !!',
+);
+assertDefined(
+  variables.breakpointTabletLgMin,
+  '!! breakpointTabletLgMin not loaded from SCSS !!',
+);
+assertDefined(
+  variables.breakpointTabletLgMax,
+  '!! breakpointTabletLgMax not loaded from SCSS !!',
+);
+assertDefined(
+  variables.breakpointDesktop,
+  '!! breakpointDesktop not loaded from SCSS !!',
+);
+
+export const breakpointDesktop = variables.breakpointDesktop;
+export const breakpointMobile = variables.breakpointMobile;
+export const breakpointTabletLgMax = variables.breakpointTabletLgMax;
+export const breakpointTabletLgMin = variables.breakpointTabletLgMin;
+export const breakpointTabletSmMax = variables.breakpointTabletSmMax;
+export const breakpointTabletSmMin = variables.breakpointTabletSmMin;

--- a/projects/client/test/mocks/variables.mock.ts
+++ b/projects/client/test/mocks/variables.mock.ts
@@ -1,0 +1,13 @@
+import { writable } from 'svelte/store';
+import { vi } from 'vitest';
+
+export const urlProxy = writable(new URL('https://example.com'));
+
+vi.mock('$style/scss/variables/index.module.scss', () => ({
+  breakpointDesktop: '1337px',
+  breakpointMobile: '1337px',
+  breakpointTabletLgMax: '1337px',
+  breakpointTabletLgMin: '1337px',
+  breakpointTabletSmMax: '1337px',
+  breakpointTabletSmMin: '1337px',
+}));

--- a/projects/client/vitest-setup.ts
+++ b/projects/client/vitest-setup.ts
@@ -6,6 +6,7 @@ import './test/mocks/matchMedia.mock.ts';
 import './test/mocks/messages.mock.ts';
 import './test/mocks/navigation.mock.ts';
 import './test/mocks/stores.mock.ts';
+import './test/mocks/variables.mock.ts';
 
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { server } from './src/mocks/server.ts';


### PR DESCRIPTION
This pull request primarily focuses on converting the CSS styles in multiple Svelte components to SCSS and utilizing mixins for media queries. The changes aim to enhance maintainability and consistency across the project.

The most important changes include:

### Conversion to SCSS and Use of Mixins

* [`projects/client/src/lib/components/layout/TraktPage.svelte`](diffhunk://#diff-51592528b760ee22d4e9525405c22454f913c01aea5fbdf82f1a42dc57142639L84-R86): Converted CSS to SCSS and used the `for-mobile` mixin for mobile-specific styles. [[1]](diffhunk://#diff-51592528b760ee22d4e9525405c22454f913c01aea5fbdf82f1a42dc57142639L84-R86) [[2]](diffhunk://#diff-51592528b760ee22d4e9525405c22454f913c01aea5fbdf82f1a42dc57142639L99-R101)
* [`projects/client/src/lib/components/section-list/ShadowList.svelte`](diffhunk://#diff-75b6a56b53dd6540bdeee9533e11c0bfef6b850842ccc0d1e2c8bb91302d0027L109-R111): Converted CSS to SCSS and applied the `for-mobile` and `for-tablet-sm` mixins for responsive design. [[1]](diffhunk://#diff-75b6a56b53dd6540bdeee9533e11c0bfef6b850842ccc0d1e2c8bb91302d0027L109-R111) [[2]](diffhunk://#diff-75b6a56b53dd6540bdeee9533e11c0bfef6b850842ccc0d1e2c8bb91302d0027L122-R124) [[3]](diffhunk://#diff-75b6a56b53dd6540bdeee9533e11c0bfef6b850842ccc0d1e2c8bb91302d0027L153-R155) [[4]](diffhunk://#diff-75b6a56b53dd6540bdeee9533e11c0bfef6b850842ccc0d1e2c8bb91302d0027L171-R177)
* [`projects/client/src/lib/guards/_internal/RenderForDevice.svelte`](diffhunk://#diff-c9209c821d9b0de5a5f5d61d451ea20f837852df814b391c1bab3f09e04737a6L52-R84): Switched to SCSS and used mixins such as `for-mobile`, `for-tablet-sm`, `for-tablet-lg`, and `for-desktop` for device-specific styles.
* [`projects/client/src/lib/sections/footer/Footer.svelte`](diffhunk://#diff-1aee961c08aa24c8cf5a8c37e81db519307e4cd60b1d59de65ca763388eafbe2L14-R23): Updated to SCSS and utilized the `for-tablet-sm-and-below` mixin for responsive footer styling.
* [`projects/client/src/style/mixins/index.scss`](diffhunk://#diff-fef624150216b0584c03b129d0945d81c989dcef6b0d4e4c47f0c986662a4153R12-R47): Added several new mixins (`for-mobile`, `for-tablet-sm`, `for-tablet-sm-and-below`, `for-tablet-lg`, `for-tablet-lg-and-below`, `for-desktop`) to handle media queries more efficiently.