### PR TITLE
ci: configure concurrency for ci/cd pipelines

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,9 @@ jobs:
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: cd-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Retrieving the Sacred Artifact
         uses: dawidd6/action-download-artifact@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     if: github.event.pull_request.draft == false
     name: The Scrutiny of Change
     runs-on: ubuntu-latest
+    concurrency:
+      group: ci-${{ github.ref }}
+      cancel-in-progress: true
     outputs:
       api_source: ${{ steps.changes.outputs.api_source }}
       client_source: ${{ steps.changes.outputs.client_source }}
@@ -51,6 +54,9 @@ jobs:
       }}
     name: The Interrogation Room (Test)
     runs-on: ubuntu-latest
+    concurrency:
+      group: ci-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Secure the Evidence aka Checkout Code
@@ -79,6 +85,9 @@ jobs:
   build:
     name: The Forge (Build)
     runs-on: ubuntu-latest
+    concurrency:
+      group: ci-${{ github.ref }}
+      cancel-in-progress: true
     needs: test
 
     steps:


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to add concurrency control, ensuring that only one instance of a workflow runs at a time for a given ref. This helps to avoid conflicts and redundant runs.

Concurrency control added to workflows:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R15-R17): Added concurrency control to the `deploy` job to cancel any in-progress runs for the same ref.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR17-R19): Added concurrency control to the `The Scrutiny of Change` job to cancel any in-progress runs for the same ref.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR57-R59): Added concurrency control to the `The Interrogation Room (Test)` job to cancel any in-progress runs for the same ref.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR88-R90): Added concurrency control to the `The Forge (Build)` job to cancel any in-progress runs for the same ref.