### PR TITLE
ci: enable fixup/squash lint on forks

### DIFF
--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -18,6 +18,6 @@ jobs:
         uses: wagoid/commitlint-github-action@v3
 
       - name: Exterminating the Fixup Fiends
-        uses: matijs/no-fixups-action@v1.0.2
+        uses: vladjerca/no-fixups-action@main
         with:
           skip-checkout: true


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pr_gate.yml` file. The change updates the GitHub Action used for preventing fixup commits from `matijs/no-fixups-action@v1.0.2` to `vladjerca/no-fixups-action@main`.

PR opened on original: https://github.com/matijs/no-fixups-action/pull/24