### PR TITLE
fix: use page store instead of window.location

### DIFF
--- a/projects/client/src/lib/components/buttons/share/ShareButton.svelte
+++ b/projects/client/src/lib/components/buttons/share/ShareButton.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages";
 
+  import { page } from "$app/stores";
   import ShareIcon from "$lib/components/icons/ShareIcon.svelte";
   import ActionButton from "../ActionButton.svelte";
 
   const { title } = $props();
-  const url = window.location.href;
-
   const data = $derived({
     title,
     text: m.where_to_watch_on_trakt({ title }),
-    url,
+    url: $page.url.toString(),
   });
 
   const isShareable = $derived(

--- a/projects/client/src/lib/features/analytics/PageView.svelte
+++ b/projects/client/src/lib/features/analytics/PageView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from "$app/stores";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import AnonymousAnalytics from "./AnonymousAnalytics.svelte";
   import { useAnalytics } from "./useAnalytics";
@@ -10,8 +11,8 @@
 
   const record = async () =>
     analytics.record(eventName, {
-      page_location: window.location.href,
-      page_path: window.location.pathname,
+      page_location: $page.url.href,
+      page_path: $page.url.pathname,
     });
 </script>
 

--- a/projects/client/src/lib/features/auth/components/AuthProvider.svelte
+++ b/projects/client/src/lib/features/auth/components/AuthProvider.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { replaceState } from "$app/navigation";
+  import { page } from "$app/stores";
   import { onMount } from "svelte";
   import { AuthEndpoint } from "../AuthEndpoint";
   import type { SerializedAuthResponse } from "../models/SerializedAuthResponse";
@@ -30,7 +31,7 @@
   }
 
   onMount(async () => {
-    const url = new URL(window.location.href);
+    const url = new URL($page.url.href);
     const queryParams = url.searchParams;
     const code = queryParams.get("code");
 


### PR DESCRIPTION
This pull request, a much-needed intervention in the chaotic world of URL handling, finally drags the client project kicking and screaming into the modern era of reactive programming.  Observe, with a weary sigh of relief, the eradication of the dreaded `window.location` and the triumphant ascension of the elegant `$page` store.

### Changes related to URL handling (or, "We Finally Joined the 21st Century"):

* The `ShareButton.svelte` component, once a purveyor of stale and outdated URLs, now basks in the radiant glow of reactivity, thanks to the `$page.url.toString()` incantation. No more embarrassing mishaps with outdated links – this component is now synchronized with the application's internal state, like a well-trained bloodhound sniffing out the freshest URLs.
* The `PageView.svelte` component, a diligent observer of user behavior (and potential privacy violator), also gets a taste of the reactive Kool-Aid, its `record` function now sipping from the fountain of `$page` store wisdom. This ensures consistency and reduces the risk of errors, because let's face it, even the most sophisticated surveillance systems need to be reliable.
* The `AuthProvider.svelte` component, a guardian of user identity (and occasional source of frustration), joins the reactive revolution, its URL parsing logic now powered by the `$page` store. This upgrade, like a software update that actually improves things, ensures that authentication flows remain smooth and synchronized, preventing those dreaded "unexpected redirect" moments that make you want to hurl your laptop out the window.

### Imports added for `$page` store (or, "The Imports Get a VIP Pass"):

* The `ShareButton.svelte`, `PageView.svelte`, and `AuthProvider.svelte` components, now eager to bask in the reactive glory of the `$page` store, dutifully add the necessary import statements, like eager fans lining up for autographs from their favorite code celebrities.

These changes, a small step for the codebase, but a giant leap for maintainability and user experience, collectively enhance the application's URL handling capabilities and bring us closer to a world where URLs are no longer a source of frustration and confusion.  

**Important:** This will guarantee properties dependent on url can be derived and react to changes. (Because apparently, we needed a pull request to achieve something that should have been the default behavior all along. *Sigh*)