### PR TITLE
fix: skip mouse events for ios hack

### DIFF
--- a/projects/client/src/lib/utils/actions/triggerWithTouch.ts
+++ b/projects/client/src/lib/utils/actions/triggerWithTouch.ts
@@ -6,6 +6,14 @@
  */
 export function triggerWithTouch(node: HTMLElement) {
   const handleTouchEnd = (event: PointerEvent) => {
+    // TODO: improvement, ideally we apply this only for iOS devices
+    // iPad and iPhone to be more specific, investigate how to consistently detect them
+    const isMouse = event.pointerType === 'mouse';
+
+    if (!isMouse) {
+      return;
+    }
+
     const isElement = event.target instanceof HTMLElement;
     if (!isElement) {
       return;


### PR DESCRIPTION
Issue: #222 

This pull request, a reluctant concession to the quirks of touch-based interactions, attempts to tame the unruly behavior of the `triggerWithTouch` utility function. Observe, with a weary sigh, the addition of a `pointerType` check, a desperate attempt to ensure that this touch-sensitive function doesn't accidentally trigger on mouse events (because apparently, the digital world can't quite grasp the fundamental difference between a finger and a cursor).

### Improvements to `triggerWithTouch` function (or, "The Mouse vs. Touch Showdown"):

* The `triggerWithTouch` function, once a trigger-happy enthusiast of all input types, now exercises a modicum of restraint, its code adorned with a condition that checks the event's `pointerType`. This newfound discernment, a testament to our ongoing struggle against the inconsistencies of cross-platform development, ensures that the function only proceeds if the input originates from a genuine mouse click, preventing unintended activations and preserving the sanctity of touch-based interactions.

This minor yet crucial adjustment, like a bouncer enforcing a strict dress code at a nightclub, aims to maintain order and predictability in the realm of user interactions. But let's not get too complacent, for the digital landscape is a constantly shifting battlefield, and new input methods (and new browser quirks) may emerge, demanding further refinements and adaptations in our never-ending quest for a harmonious user experience.

(And let's not forget the ominous note about future iOS refinements, a subtle reminder that the touch-based world is a minefield of platform-specific inconsistencies, where even the most carefully crafted code can fall victim to the capricious whims of Apple's walled garden.)