### PR TITLE
fix: fix gravatar profile picture

### DIFF
--- a/projects/client/src/app.html
+++ b/projects/client/src/app.html
@@ -11,7 +11,7 @@
       http-equiv="Content-Security-Policy"
       content="
         default-src 'self';
-        img-src 'self' data: https://*.trakt.tv;
+        img-src 'self' data: https://*.trakt.tv https://secure.gravatar.com;
         script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.trakt.tv https://*.googletagmanager.com;
         script-src-elem 'self' 'unsafe-inline' https://*.googletagmanager.com https://*.cloudflareinsights.com;
         connect-src 'self' https://*.jsdelivr.net https://*.googleapis.com https://*.gstatic.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.trakt.tv;


### PR DESCRIPTION
This PR adds `https://secure.gravatar.com` to the img-src CSP to allow profile pictures from gravatar to work

![image](https://github.com/user-attachments/assets/9eb77280-0c9b-40f8-8ad5-deb4690c2518)

![image](https://github.com/user-attachments/assets/fd30f991-74c7-4a5e-bc05-4ca743ceaac9)