### PR TITLE
fix(summary): only request progress for authenticated users

### DIFF
--- a/projects/client/src/lib/sections/summary/ShowSummary.svelte
+++ b/projects/client/src/lib/sections/summary/ShowSummary.svelte
@@ -2,20 +2,19 @@
   import * as m from "$lib/features/i18n/messages";
 
   import RenderFor from "$lib/guards/RenderFor.svelte";
-  import type { EpisodeProgressEntry } from "$lib/models/EpisodeProgressEntry";
   import type { MediaStats } from "$lib/models/MediaStats";
   import type { MediaStudio } from "$lib/models/MediaStudio";
   import type { Season } from "$lib/models/Season";
   import type { MediaCrew } from "$lib/requests/models/MediaCrew";
   import type { ShowSummary } from "$lib/requests/models/ShowSummary";
   import NextEpisodeItem from "$lib/sections/lists/components/NextEpisodeItem.svelte";
+  import { useShowProgress } from "$lib/stores/useShowProgress";
   import RelatedList from "../lists/RelatedList.svelte";
   import SeasonList from "../lists/SeasonList.svelte";
   import MediaSummary from "./components/MediaSummary.svelte";
   import type { MediaSummaryProps } from "./components/MediaSummaryProps";
 
   type ShowSummaryProps = MediaSummaryProps<ShowSummary> & {
-    progress?: EpisodeProgressEntry;
     stats: MediaStats;
     studios: MediaStudio[];
     crew: MediaCrew;
@@ -29,16 +28,17 @@
     watchers,
     studios,
     intl,
-    progress,
     crew,
     seasons,
   }: ShowSummaryProps = $props();
+
+  const { progress } = $derived(useShowProgress(media.slug));
 </script>
 
 {#snippet contextualContent()}
   <RenderFor device={["desktop"]} audience="authenticated">
-    {#if progress}
-      <NextEpisodeItem episode={progress} show={media} />
+    {#if $progress}
+      <NextEpisodeItem episode={$progress} show={media} />
     {/if}
   </RenderFor>
 {/snippet}

--- a/projects/client/src/lib/stores/useShowProgress.spec.ts
+++ b/projects/client/src/lib/stores/useShowProgress.spec.ts
@@ -1,0 +1,23 @@
+import QueryTestBed from '$test/beds/query/QueryTestBed.svelte';
+
+import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
+import { ShowSiloProgressMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloProgressMappedMock.ts';
+import { waitForQueryResult } from '$test/beds/query/waitForQueryResult.ts';
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { useShowProgress } from './useShowProgress.ts';
+
+describe('store: useShowProgress', () => {
+  describe('show: Silo (2023)', () => {
+    it('should return progress', async () => {
+      render(QueryTestBed, {
+        props: {
+          queryFactory: () => useShowProgress(ShowSiloMappedMock.slug).progress,
+        },
+      });
+
+      const result = await waitForQueryResult();
+      expect(result).to.deep.equal(ShowSiloProgressMappedMock);
+    });
+  });
+});

--- a/projects/client/src/lib/stores/useShowProgress.ts
+++ b/projects/client/src/lib/stores/useShowProgress.ts
@@ -1,0 +1,15 @@
+import { showProgressQuery } from '$lib/requests/queries/shows/showProgressQuery.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { createQuery } from '@tanstack/svelte-query';
+import { derived } from 'svelte/store';
+
+export function useShowProgress(slug: string) {
+  const progress = createQuery({
+    ...showProgressQuery({ slug }),
+    staleTime: time.days(1),
+  });
+
+  return {
+    progress: derived(progress, ($progress) => $progress.data),
+  };
+}

--- a/projects/client/src/routes/shows/[slug]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/+page.svelte
@@ -9,7 +9,6 @@
     intl,
     ratings,
     stats,
-    progress,
     watchers,
     studios,
     crew,
@@ -32,7 +31,6 @@
       watchers={$watchers!}
       stats={$stats!}
       intl={$intl!}
-      progress={$progress!}
       studios={$studios!}
       crew={$crew!}
       seasons={$seasons!}

--- a/projects/client/src/routes/shows/[slug]/useShow.spec.ts
+++ b/projects/client/src/routes/shows/[slug]/useShow.spec.ts
@@ -5,7 +5,6 @@ import { MediaWatchingMappedMock } from '$mocks/data/summary/common/mapped/Media
 import { ShowSiloJapaneseMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloJapaneseMappedMock.ts';
 import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
 import { ShowSiloPeopleMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts';
-import { ShowSiloProgressMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloProgressMappedMock.ts';
 import { ShowSiloRatingsMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloRatingsMappedMock.ts';
 import { ShowSiloSeasonsMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts';
 import { ShowSiloStatsMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloStatsMappedMock.ts';
@@ -65,17 +64,6 @@ describe('store: useShow', () => {
 
       const result = await waitForQueryResult();
       expect(result).to.deep.equal(ShowSiloRatingsMappedMock);
-    });
-
-    it('should return progress', async () => {
-      render(QueryTestBed, {
-        props: {
-          queryFactory: () => useShow(ShowSiloMappedMock.slug).progress,
-        },
-      });
-
-      const result = await waitForQueryResult();
-      expect(result).to.deep.equal(ShowSiloProgressMappedMock);
     });
 
     it('should return crew', async () => {

--- a/projects/client/src/routes/shows/[slug]/useShow.ts
+++ b/projects/client/src/routes/shows/[slug]/useShow.ts
@@ -1,7 +1,6 @@
 import { getLanguageAndRegion, languageTag } from '$lib/features/i18n/index.ts';
 import { showIntlQuery } from '$lib/requests/queries/shows/showIntlQuery.ts';
 import { showPeopleQuery } from '$lib/requests/queries/shows/showPeopleQuery.ts';
-import { showProgressQuery } from '$lib/requests/queries/shows/showProgressQuery.ts';
 import { showRatingQuery } from '$lib/requests/queries/shows/showRatingQuery.ts';
 import { showSeasonsQuery } from '$lib/requests/queries/shows/showSeasonsQuery.ts';
 import { showStatsQuery } from '$lib/requests/queries/shows/showStatsQuery.ts';
@@ -33,11 +32,6 @@ export function useShow(slug: string) {
     staleTime: time.minutes(5),
   });
 
-  const progress = createQuery({
-    ...showProgressQuery({ slug }),
-    staleTime: time.days(1),
-  });
-
   const studios = createQuery({
     ...showStudiosQuery({ slug }),
     staleTime: time.days(1),
@@ -67,7 +61,6 @@ export function useShow(slug: string) {
     stats,
     watchers,
     studios,
-    progress,
     crew,
     seasons,
     intl,
@@ -84,7 +77,6 @@ export function useShow(slug: string) {
     ratings: derived(ratings, ($ratings) => $ratings.data),
     stats: derived(stats, ($stats) => $stats.data),
     watchers: derived(watchers, ($watchers) => $watchers.data),
-    progress: derived(progress, ($progress) => $progress.data),
     studios: derived(studios, ($studios) => $studios.data),
     crew: derived(crew, ($crew) => $crew.data),
     seasons: derived(


### PR DESCRIPTION
## 🎶 Notes 🎶
Fixes an issue where progress was being requested for a show summary page even when not logged in.
<img width="397" alt="Screenshot 2025-01-07 at 17 32 07" src="https://github.com/user-attachments/assets/38312335-de23-4963-9b0a-b876c148fcd3" />
