### PR TITLE
fix: detecting a shows as watched when it has specials

### DIFF
--- a/projects/client/src/lib/features/auth/queries/currentUserHistoryQuery.spec.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserHistoryQuery.spec.ts
@@ -1,0 +1,22 @@
+import QueryTestBed from '$test/beds/query/QueryTestBed.svelte';
+
+import { UserHistoryMappedMock } from '$mocks/data/users/UserHistoryMappedMock';
+import { waitForQueryResult } from '$test/beds/query/waitForQueryResult.ts';
+import { createQuery } from '@tanstack/svelte-query';
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { currentUserHistoryQuery } from './currentUserHistoryQuery';
+
+describe('currentUserHistoryQuery', () => {
+  it('should query for user user history', async () => {
+    render(QueryTestBed, {
+      props: {
+        queryFactory: () => createQuery(currentUserHistoryQuery()),
+        mapper: (response) => response?.data,
+      },
+    });
+
+    const result = await waitForQueryResult();
+    expect(result).to.deep.equal(UserHistoryMappedMock);
+  });
+});

--- a/projects/client/src/lib/features/auth/queries/currentUserHistoryQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserHistoryQuery.ts
@@ -77,6 +77,7 @@ function mapWatchedShowResponse(
   const aired = entry.show.aired_episodes;
 
   const episodes = seasons
+    .filter((season) => season.number !== 0)
     .flatMap((season) =>
       season
         .episodes

--- a/projects/client/src/mocks/data/users/UserHistoryMappedMock.ts
+++ b/projects/client/src/mocks/data/users/UserHistoryMappedMock.ts
@@ -1,0 +1,81 @@
+export const UserHistoryMappedMock = {
+  'movies': new Map([
+    [916302, {
+      'id': 916302,
+      'plays': 1,
+      'watchedAt': '2024-12-27T16:15:28.000Z',
+    }],
+  ]),
+  shows: new Map([
+    [147971, {
+      episodes: [
+        {
+          'episode': 1,
+          'plays': 1,
+          'season': 1,
+          'watchedAt': '2024-12-27T16:28:32.000Z',
+        },
+        {
+          'episode': 2,
+          'plays': 1,
+          'season': 1,
+          'watchedAt': '2024-12-27T16:28:32.000Z',
+        },
+        {
+          'episode': 3,
+          'plays': 1,
+          'season': 1,
+          'watchedAt': '2024-12-27T16:28:32.000Z',
+        },
+        {
+          'episode': 4,
+          'plays': 1,
+          'season': 1,
+          'watchedAt': '2024-12-27T16:28:32.000Z',
+        },
+        {
+          'episode': 5,
+          'plays': 1,
+          'season': 1,
+          'watchedAt': '2024-12-27T16:28:32.000Z',
+        },
+        {
+          'episode': 6,
+          'plays': 1,
+          'season': 1,
+          'watchedAt': '2024-12-27T16:28:32.000Z',
+        },
+        {
+          'episode': 7,
+          'plays': 1,
+          'season': 1,
+          'watchedAt': '2024-12-27T16:28:32.000Z',
+        },
+        {
+          'episode': 8,
+          'plays': 1,
+          'season': 1,
+          'watchedAt': '2024-12-27T16:28:32.000Z',
+        },
+      ],
+      'id': 147971,
+      'isWatched': true,
+      'plays': 8,
+      'watchedAt': '2024-12-27T16:28:32.000Z',
+    }],
+    [180770, {
+      episodes: [
+        {
+          'episode': 1,
+          'plays': 1,
+          'season': 1,
+          'watchedAt': '2024-12-27T16:13:42.000Z',
+        },
+      ],
+      'id': 180770,
+      'isWatched': false,
+      'plays': 1,
+      'watchedAt': '2024-12-27T16:13:42.000Z',
+    }],
+  ]),
+};

--- a/projects/client/src/mocks/data/users/WatchedShowsResponseMock.ts
+++ b/projects/client/src/mocks/data/users/WatchedShowsResponseMock.ts
@@ -19,6 +19,16 @@ export const WatchedShowsResponseMock = [
     },
     'seasons': [
       {
+        'number': 0,
+        'episodes': [
+          {
+            'number': 1,
+            'plays': 1,
+            'last_watched_at': '2024-12-27T16:28:32.000Z',
+          },
+        ],
+      },
+      {
         'number': 1,
         'episodes': [
           {

--- a/projects/client/test/beds/query/_internal/QueryRunner.svelte
+++ b/projects/client/test/beds/query/_internal/QueryRunner.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { derived, type Readable } from "svelte/store";
   import { QUERY_TEST_ID } from "./constants";
+  import { replacer } from "./replacer";
 
   const {
     queryFactory,
@@ -13,4 +14,4 @@
   const readable = derived(queryFactory(), mapper);
 </script>
 
-<pre data-testid={QUERY_TEST_ID}>{JSON.stringify($readable)}</pre>
+<pre data-testid={QUERY_TEST_ID}>{JSON.stringify($readable, replacer)}</pre>

--- a/projects/client/test/beds/query/_internal/replacer.ts
+++ b/projects/client/test/beds/query/_internal/replacer.ts
@@ -1,0 +1,10 @@
+export function replacer(_: string, value: any) {
+  if (value instanceof Map) {
+    return {
+      dataType: 'Map',
+      data: Array.from(value.entries()),
+    };
+  }
+
+  return value;
+}

--- a/projects/client/test/beds/query/_internal/reviver.ts
+++ b/projects/client/test/beds/query/_internal/reviver.ts
@@ -1,0 +1,9 @@
+export function reviver(_: string, value: any) {
+  const isMapValue = typeof value === 'object' && value?.dataType === 'Map';
+
+  if (isMapValue) {
+    return new Map(value.data);
+  }
+
+  return value;
+}

--- a/projects/client/test/beds/query/waitForQueryResult.ts
+++ b/projects/client/test/beds/query/waitForQueryResult.ts
@@ -1,6 +1,7 @@
 import { screen, waitFor } from '@testing-library/svelte';
 import { expect } from 'vitest';
 import { QUERY_TEST_ID } from './_internal/constants.ts';
+import { reviver } from './_internal/reviver.ts';
 
 export function waitForQueryResult() {
   return waitFor(() => {
@@ -12,6 +13,6 @@ export function waitForQueryResult() {
     expect(content).toBeDefined();
     expect(content).not.toEqual('');
 
-    return JSON.parse(content);
+    return JSON.parse(content, reviver);
   });
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- A show would not be marked as `watched` even when all episodes were seen.
- Also adds support for `Map` responses to the test bed.

## 👀 Example 👀
Before:
<img width="1464" alt="Screenshot 2025-01-08 at 12 42 52" src="https://github.com/user-attachments/assets/ee892d62-9632-4629-bfe8-2a35900bc6a9" />

After:
<img width="1464" alt="Screenshot 2025-01-08 at 12 41 43" src="https://github.com/user-attachments/assets/4820b23c-33a9-4c5c-815d-1a02e37a9a4c" />
