### PR TITLE
feat: take media item statuses into count

### DIFF
--- a/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
@@ -3,6 +3,7 @@ import { genreResponseSchema } from './genreResponseSchema.ts';
 import { imagesResponseSchema } from './imagesResponseSchema.ts';
 import { movieCertificationResponseSchema } from './movieCertificationResponseSchema.ts';
 import { movieIdsResponseSchema } from './movieIdsResponseSchema.ts';
+import { statusResponseSchema } from './statusResponseSchema.ts';
 
 export const movieResponseSchema = z.object({
   title: z.string(),
@@ -36,7 +37,7 @@ export const movieResponseSchema = z.object({
   /***
    * Available if requesting extended `full`.
    */
-  status: z.string().optional(),
+  status: statusResponseSchema.optional(),
   /***
    * Available if requesting extended `full`.
    */

--- a/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
@@ -6,7 +6,7 @@ import { movieIdsResponseSchema } from './movieIdsResponseSchema.ts';
 
 export const movieResponseSchema = z.object({
   title: z.string(),
-  year: z.number(),
+  year: z.number().optional(),
   ids: movieIdsResponseSchema,
   /***
    * Available if requesting extended `cloud9`.

--- a/projects/api/src/contracts/_internal/response/showResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showResponseSchema.ts
@@ -3,6 +3,7 @@ import { genreResponseSchema } from './genreResponseSchema.ts';
 import { imagesResponseSchema } from './imagesResponseSchema.ts';
 import { showCertificationResponseSchema } from './showCertificationResponseSchema.ts';
 import { showIdsResponseSchema } from './showIdsResponseSchema.ts';
+import { statusResponseSchema } from './statusResponseSchema.ts';
 
 export const showResponseSchema = z.object({
   title: z.string(),
@@ -55,7 +56,7 @@ export const showResponseSchema = z.object({
   /**
    * Available if requesting extended `full`.
    */
-  status: z.string().optional(),
+  status: statusResponseSchema.optional(),
   /**
    * Available if requesting extended `full`.
    */

--- a/projects/api/src/contracts/_internal/response/statusResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/statusResponseSchema.ts
@@ -1,0 +1,15 @@
+import { z } from '../z.ts';
+
+export const statusResponseSchema = z.enum([
+  'released',
+  'planned',
+  'post production',
+  'canceled',
+  'in production',
+  'rumored',
+  'ended',
+  'returning series',
+  'pilot',
+  'continuing',
+  'upcoming',
+]);

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -16,6 +16,7 @@ import {
   peopleResponseSchema,
 } from '../_internal/response/peopleResponseSchema.ts';
 import { ratingsResponseSchema } from '../_internal/response/ratingsResponseSchema.ts';
+import { statusResponseSchema } from '../_internal/response/statusResponseSchema.ts';
 import { studiosResponseSchema } from '../_internal/response/studiosResponseSchema.ts';
 import { translationResponseSchema } from '../_internal/response/translationResponseSchema.ts';
 import { profileResponseSchema } from '../_internal/response/userProfileResponseSchema.ts';
@@ -143,6 +144,7 @@ export type MovieIdParams = z.infer<typeof idParamsSchema>;
 export type MovieResponse = z.infer<typeof movieResponseSchema>;
 export type MovieRatingsResponse = z.infer<typeof ratingsResponseSchema>;
 export type Genre = z.infer<typeof genreResponseSchema>;
+export type StatusResponse = z.infer<typeof statusResponseSchema>;
 export type Job = z.infer<typeof jobResponseSchema>;
 export type StudiosResponse = z.infer<typeof studiosResponseSchema>;
 export type WatchNowResponse = z.infer<typeof watchNowResponseSchema>;

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -227,5 +227,19 @@
   "expand_media_overview": "Übersicht über {title} erweitern",
   "season_episode_number_label": "Staffel {season} • Folge {number}",
   "share_title": "Teile {title}",
-  "where_to_watch_on_trakt": "Finde heraus, wo du {title} auf Trakt sehen kannst!"
+  "where_to_watch_on_trakt": "Finde heraus, wo du {title} auf Trakt sehen kannst!",
+  "status": "Status",
+  "status_released": "Veröffentlicht",
+  "status_planned": "Geplant",
+  "status_post_production": "Postproduktion",
+  "status_canceled": "Abgesetzt",
+  "status_in_production": "In Produktion",
+  "status_rumored": "Gerücht",
+  "status_ended": "Beendet",
+  "status_returning_series": "Fortlaufende Serie",
+  "status_pilot": "Pilot",
+  "status_continuing": "Wird fortgesetzt",
+  "status_upcoming": "Demnächst",
+  "status_unknown": "Unbekannt",
+  "expected_premiere": "Erwartete Premiere"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -227,5 +227,19 @@
   "expand_media_overview": "Expand {title} overview",
   "season_episode_number_label": "Season {season} • Episode {number}",
   "share_title": "Share {title}",
-  "where_to_watch_on_trakt": "See where to watch {title} on Trakt!"
+  "where_to_watch_on_trakt": "See where to watch {title} on Trakt!",
+  "status": "Status",
+  "status_released": "Released",
+  "status_planned": "Planned",
+  "status_post_production": "Post-Production",
+  "status_canceled": "Canceled",
+  "status_in_production": "In Production",
+  "status_rumored": "Rumored",
+  "status_ended": "Ended",
+  "status_returning_series": "Returning Series",
+  "status_pilot": "Pilot",
+  "status_continuing": "Continuing",
+  "status_upcoming": "Upcoming",
+  "status_unknown": "Unknown",
+  "expected_premiere": "Expected Premiere"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -227,5 +227,19 @@
   "expand_media_overview": "Expandir descripción de {title}",
   "season_episode_number_label": "Temporada {season} • Episodio {number}",
   "share_title": "Comparte {title}",
-  "where_to_watch_on_trakt": "¡Descubre dónde ver {title} en Trakt!"
+  "where_to_watch_on_trakt": "¡Descubre dónde ver {title} en Trakt!",
+  "status": "Estado",
+  "status_released": "Lanzado",
+  "status_planned": "Planeado",
+  "status_post_production": "Postproducción",
+  "status_canceled": "Cancelado",
+  "status_in_production": "En producción",
+  "status_rumored": "Rumoreado",
+  "status_ended": "Finalizado",
+  "status_returning_series": "Regresa",
+  "status_pilot": "Piloto",
+  "status_continuing": "Continúa",
+  "status_upcoming": "Próximamente",
+  "status_unknown": "Desconocido",
+  "expected_premiere": "Estreno Esperado"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -227,5 +227,19 @@
   "expand_media_overview": "Expandir descripción de {title}",
   "season_episode_number_label": "Temporada {season} • Episodio {number}",
   "share_title": "Comparte {title}",
-  "where_to_watch_on_trakt": "¡Mira dónde ver {title} en Trakt!"
+  "where_to_watch_on_trakt": "¡Mira dónde ver {title} en Trakt!",
+  "status": "Estado",
+  "status_released": "Lanzado",
+  "status_planned": "Planeado",
+  "status_post_production": "Post-Producción",
+  "status_canceled": "Cancelado",
+  "status_in_production": "En Producción",
+  "status_rumored": "Rumoreado",
+  "status_ended": "Finalizado",
+  "status_returning_series": "Regresa",
+  "status_pilot": "Piloto",
+  "status_continuing": "Continuando",
+  "status_upcoming": "Próximamente",
+  "status_unknown": "Desconocido",
+  "expected_premiere": "Estreno Esperado"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -227,5 +227,19 @@
   "expand_media_overview": "Développer la description de {title}",
   "season_episode_number_label": "Saison {season} • Épisode {number}",
   "share_title": "Partager {title}",
-  "where_to_watch_on_trakt": "Où regarder {title} sur Trakt !"
+  "where_to_watch_on_trakt": "Où regarder {title} sur Trakt !",
+  "status": "Statut",
+  "status_released": "Sorti",
+  "status_planned": "Planifié",
+  "status_post_production": "Post-Production",
+  "status_canceled": "Annulé",
+  "status_in_production": "En production",
+  "status_rumored": "Rumeur",
+  "status_ended": "Terminé",
+  "status_returning_series": "Série de retour",
+  "status_pilot": "Pilote",
+  "status_continuing": "Continue",
+  "status_upcoming": "À venir",
+  "status_unknown": "Inconnu",
+  "expected_premiere": "Première attendue"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -227,5 +227,19 @@
   "expand_media_overview": "Découvrir plus sur {title}",
   "season_episode_number_label": "Saison {season} • Épisode {number}",
   "share_title": "Partager {title}",
-  "where_to_watch_on_trakt": "Où regarder {title} sur Trakt !"
+  "where_to_watch_on_trakt": "Où regarder {title} sur Trakt !",
+  "status": "Statut",
+  "status_released": "Sorti",
+  "status_planned": "Prévu",
+  "status_post_production": "Post-production",
+  "status_canceled": "Annulé",
+  "status_in_production": "En production",
+  "status_rumored": "Rumeur",
+  "status_ended": "Terminé",
+  "status_returning_series": "Série de retour",
+  "status_pilot": "Pilote",
+  "status_continuing": "En cours",
+  "status_upcoming": "À venir",
+  "status_unknown": "Inconnu",
+  "expected_premiere": "Première attendue"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -227,5 +227,19 @@
   "expand_media_overview": "{title} の概要を表示",
   "season_episode_number_label": "シーズン{season}・エピソード{number}",
   "share_title": "{title}を共有する",
-  "where_to_watch_on_trakt": "Traktで{title}を視聴できる場所をチェック！"
+  "where_to_watch_on_trakt": "Traktで{title}を視聴できる場所をチェック！",
+  "status": "ステータス",
+  "status_released": "公開済",
+  "status_planned": "計画中",
+  "status_post_production": "ポストプロダクション",
+  "status_canceled": "中止",
+  "status_in_production": "制作中",
+  "status_rumored": "噂",
+  "status_ended": "終了",
+  "status_returning_series": "継続シリーズ",
+  "status_pilot": "パイロット版",
+  "status_continuing": "継続中",
+  "status_upcoming": "近日公開",
+  "status_unknown": "不明",
+  "expected_premiere": "公開予定"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -227,5 +227,19 @@
   "expand_media_overview": "Bekijk {title} overzicht",
   "season_episode_number_label": "Seizoen {season} • Aflevering {number}",
   "share_title": "Deel {title}",
-  "where_to_watch_on_trakt": "Bekijk waar je {title} kunt kijken op Trakt!"
+  "where_to_watch_on_trakt": "Bekijk waar je {title} kunt kijken op Trakt!",
+  "status": "Status",
+  "status_released": "Uitgebracht",
+  "status_planned": "Gepland",
+  "status_post_production": "Post-productie",
+  "status_canceled": "Geannuleerd",
+  "status_in_production": "In productie",
+  "status_rumored": "Geruchten",
+  "status_ended": "Beëindigd",
+  "status_returning_series": "Terugkerende serie",
+  "status_pilot": "Pilot",
+  "status_continuing": "Lopend",
+  "status_upcoming": "Aankomend",
+  "status_unknown": "Onbekend",
+  "expected_premiere": "Verwachte première"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -227,5 +227,19 @@
   "expand_media_overview": "Expandir a visão geral de {title}",
   "season_episode_number_label": "Temporada {season} • Episódio {number}",
   "share_title": "Compartilhar {title}",
-  "where_to_watch_on_trakt": "Onde assistir {title} no Trakt!"
+  "where_to_watch_on_trakt": "Onde assistir {title} no Trakt!",
+  "status": "Status",
+  "status_released": "Lançado",
+  "status_planned": "Planejado",
+  "status_post_production": "Pós-Produção",
+  "status_canceled": "Cancelado",
+  "status_in_production": "Em Produção",
+  "status_rumored": "Rumores",
+  "status_ended": "Finalizado",
+  "status_returning_series": "Série Retornando",
+  "status_pilot": "Piloto",
+  "status_continuing": "Contínuo",
+  "status_upcoming": "Próximo",
+  "status_unknown": "Desconhecido",
+  "expected_premiere": "Estreia Esperada"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -227,5 +227,19 @@
   "expand_media_overview": "Detaliază prezentarea {title}",
   "season_episode_number_label": "Sezon {season} • Episod {number}",
   "share_title": "Distribuie {title}",
-  "where_to_watch_on_trakt": "Vezi unde să vizionezi {title} pe Trakt!"
+  "where_to_watch_on_trakt": "Vezi unde să vizionezi {title} pe Trakt!",
+  "status": "Stare",
+  "status_released": "Lansat",
+  "status_planned": "Planificat",
+  "status_post_production": "Post-producție",
+  "status_canceled": "Anulat",
+  "status_in_production": "În producție",
+  "status_rumored": "Zvonit",
+  "status_ended": "Terminat",
+  "status_returning_series": "Serialul revine",
+  "status_pilot": "Pilot",
+  "status_continuing": "În desfășurare",
+  "status_upcoming": "Urmează",
+  "status_unknown": "Necunoscut",
+  "expected_premiere": "Premiera Așteptată"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -227,5 +227,19 @@
   "expand_media_overview": "Розгорнути огляд {title}",
   "season_episode_number_label": "Сезон {season} • Епізод {number}",
   "share_title": "Поділитись {title}",
-  "where_to_watch_on_trakt": "Де дивитись {title} на Trakt!"
+  "where_to_watch_on_trakt": "Де дивитись {title} на Trakt!",
+  "status": "Статус",
+  "status_released": "Випущено",
+  "status_planned": "Заплановано",
+  "status_post_production": "Пост-продакшн",
+  "status_canceled": "Скасовано",
+  "status_in_production": "У виробництві",
+  "status_rumored": "Чутки",
+  "status_ended": "Завершено",
+  "status_returning_series": "Повертається",
+  "status_pilot": "Пілот",
+  "status_continuing": "Триває",
+  "status_upcoming": "Скоро",
+  "status_unknown": "Невідомо",
+  "expected_premiere": "Очікувана прем'єра"
 }

--- a/projects/client/src/lib/requests/_internal/mapMovieResponseToMovieSummary.ts
+++ b/projects/client/src/lib/requests/_internal/mapMovieResponseToMovieSummary.ts
@@ -76,6 +76,7 @@ export function mapMovieResponseToMovieSummary(
       ),
     },
     genres: movie.genres ?? [],
+    status: movie.status ?? 'unknown',
     overview: movie.overview ?? 'TBD',
     trailer: prependHttps(
       movie.trailer,

--- a/projects/client/src/lib/requests/_internal/mapShowResponseToShowSummary.ts
+++ b/projects/client/src/lib/requests/_internal/mapShowResponseToShowSummary.ts
@@ -73,6 +73,7 @@ export function mapShowResponseToShowSummary(
       ),
     },
     genres: show.genres ?? [],
+    status: show.status ?? 'unknown',
     overview: show.overview ?? 'TBD',
     trailer: prependHttps(
       show.trailer,

--- a/projects/client/src/lib/requests/models/MediaStatus.ts
+++ b/projects/client/src/lib/requests/models/MediaStatus.ts
@@ -1,0 +1,3 @@
+import type { StatusResponse } from '@trakt/api';
+
+export type MediaStatus = StatusResponse | 'unknown';

--- a/projects/client/src/lib/requests/models/MediaSummary.ts
+++ b/projects/client/src/lib/requests/models/MediaSummary.ts
@@ -1,4 +1,5 @@
 import type { Genre } from '$lib/api.ts';
+import type { MediaStatus } from './MediaStatus';
 
 type ImageUrls = {
   medium: string;
@@ -24,6 +25,7 @@ export type MediaSummary = {
     url: string;
   };
   genres: Genre[];
+  status: MediaStatus;
   overview: string;
   trailer: string;
   airedDate: Date;

--- a/projects/client/src/lib/sections/lists/stores/useComingSoon.ts
+++ b/projects/client/src/lib/sections/lists/stores/useComingSoon.ts
@@ -1,8 +1,16 @@
 import type { MediaType } from '$lib/models/MediaType.ts';
+import type { MediaStatus } from '$lib/requests/models/MediaStatus';
 import {
   useWatchlistList,
 } from '$lib/sections/lists/stores/useWatchlistList.ts';
 import { derived } from 'svelte/store';
+
+const IN_PROGRESS_STATUSES: MediaStatus[] = [
+  'planned',
+  'post production',
+  'in production',
+  'upcoming',
+] as const;
 
 export function useComingSoon(type: MediaType) {
   const { list: watchlist, isLoading } = useWatchlistList({
@@ -13,7 +21,13 @@ export function useComingSoon(type: MediaType) {
   const list = derived(
     watchlist,
     ($watchlist) =>
-      $watchlist.filter((item) => item?.airedDate.getTime() > Date.now())
+      $watchlist
+        .filter((item) => {
+          const isUpcomingItem = item.airedDate.getTime() > Date.now();
+          const isInProgressItem = IN_PROGRESS_STATUSES.includes(item.status);
+
+          return isUpcomingItem && isInProgressItem;
+        })
         .sort((a, b) => a.airedDate.getTime() - b.airedDate.getTime()),
   );
 

--- a/projects/client/src/lib/sections/summary/components/MediaDetails.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/MediaDetails.spec.ts
@@ -1,0 +1,108 @@
+import { MAX_DATE } from '$lib/utils/constants';
+import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock';
+import { MovieHereticPeopleMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticPeopleMappedMock';
+import { MovieHereticStudiosMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticStudiosMappedMock';
+import MediaDetails, { type MediaDetailsProps } from './MediaDetails.svelte';
+
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import type { MediaSummary } from './MediaSummary';
+
+describe('MediaDetails', () => {
+  const defaultProps: MediaDetailsProps = {
+    //See TODO in MovieHereticMappedMock.ts for why this is cast
+    media: MovieHereticMappedMock as unknown as MediaSummary,
+    studios: MovieHereticStudiosMappedMock,
+    crew: MovieHereticPeopleMappedMock,
+  };
+
+  it('should display the media details sections', async () => {
+    render(
+      MediaDetails,
+      {
+        props: {
+          ...defaultProps,
+        },
+      },
+    );
+
+    const premieredLabel = screen.getByText('Premiered');
+    const runtimeLabel = screen.getByText('Runtime');
+    const directorLabel = screen.getByText('Director');
+    const writerLabel = screen.getByText('Writer');
+    const countryLabel = screen.getByText('Country');
+    const languageLabel = screen.getByText('Language');
+    const studioLabel = screen.getByText('Studio');
+    const genreLabel = screen.getByText('Genre');
+
+    expect(premieredLabel).toBeInTheDocument();
+    expect(runtimeLabel).toBeInTheDocument();
+    expect(directorLabel).toBeInTheDocument();
+    expect(writerLabel).toBeInTheDocument();
+    expect(countryLabel).toBeInTheDocument();
+    expect(languageLabel).toBeInTheDocument();
+    expect(studioLabel).toBeInTheDocument();
+    expect(genreLabel).toBeInTheDocument();
+  });
+
+  it('should distinguish upcoming items', async () => {
+    const nextYear = new Date();
+    nextYear.setFullYear(nextYear.getFullYear() + 1);
+
+    render(
+      MediaDetails,
+      {
+        props: {
+          ...defaultProps,
+          media: {
+            ...defaultProps.media,
+            airedDate: nextYear,
+          },
+        },
+      },
+    );
+
+    const premiereLabel = screen.getByText('Expected Premiere');
+    expect(premiereLabel).toBeInTheDocument();
+  });
+
+  it('should show the status if there is no known year for an item', async () => {
+    render(
+      MediaDetails,
+      {
+        props: {
+          ...defaultProps,
+          media: {
+            ...defaultProps.media,
+            year: undefined,
+            airedDate: MAX_DATE,
+          },
+        },
+      },
+    );
+
+    const statusLabel = screen.getByText('Status');
+    const premieredLabel = screen.queryByText('Premiered');
+
+    expect(statusLabel).toBeInTheDocument();
+    expect(premieredLabel).not.toBeInTheDocument();
+  });
+
+  it('should hide undefined values', async () => {
+    render(
+      MediaDetails,
+      {
+        props: {
+          ...defaultProps,
+          media: {
+            ...defaultProps.media,
+            country: undefined,
+          },
+        },
+      },
+    );
+
+    const countryLabel = screen.queryByText('Country');
+    expect(countryLabel).not.toBeInTheDocument();
+  });
+});

--- a/projects/client/src/lib/sections/summary/components/MediaDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/MediaDetails.svelte
@@ -36,11 +36,23 @@
   const toCrewMemberWithJob = (person: CrewMember) =>
     `${person.name} (${toTranslatedValue("job", person.job)})`;
 
+  const mainItemDetail = () => {
+    if (media.year) {
+      const isUpcomingItem = media.airedDate > new Date();
+      return {
+        title: isUpcomingItem ? m.expected_premiere() : m.premiered(),
+        values: [toHumanDay(media.airedDate, getLocale())],
+      };
+    }
+
+    return {
+      title: m.status(),
+      values: [toTranslatedValue("status", media.status)],
+    };
+  };
+
   const mediaDetails = [
-    {
-      title: m.premiered(),
-      values: [toHumanDay(media.airedDate, getLocale())],
-    },
+    mainItemDetail(),
     {
       title: m.runtime(),
       values: [toHumanDuration({ minutes: media.runtime }, languageTag())],

--- a/projects/client/src/lib/sections/summary/components/MediaDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/MediaDetails.svelte
@@ -14,7 +14,7 @@
   import MediaCollapsableValues from "./MediaCollapsableValues.svelte";
   import YoutubeButton from "./YoutubeButton.svelte";
 
-  type MediaDetailsProps = {
+  export type MediaDetailsProps = {
     media: MediaSummary;
     studios: MediaStudio[];
     crew: MediaCrew;

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts
@@ -11,6 +11,7 @@ export const MovieHereticMappedMock = {
     'horror',
     'thriller',
   ],
+  'status': 'released',
   'id': 916302,
   'overview':
     'Two young missionaries are forced to prove their faith when they knock on the wrong door and are greeted by a diabolical Mr. Reed, becoming ensnared in his deadly game of cat-and-mouse.',

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts
@@ -1,3 +1,9 @@
+/*
+  TODO: the return type should be MovieSummary
+  airedDate should be a Date object. However, JSON.stringify does not
+  play nicely with dates, and already converts them to a string
+  before the replacer function is called.
+*/
 export const MovieHereticMappedMock = {
   'cover': {
     'url': {

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticPeopleMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticPeopleMappedMock.ts
@@ -1,4 +1,6 @@
-export const MovieHereticPeopleMappedMock = {
+import type { MediaCrew } from '$lib/requests/models/MediaCrew';
+
+export const MovieHereticPeopleMappedMock: MediaCrew = {
   'directors': [
     {
       'job': 'Director',

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticStudiosMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticStudiosMappedMock.ts
@@ -1,0 +1,30 @@
+export const MovieHereticStudiosMappedMock = [
+  {
+    'name': 'Shiny Penny',
+    'country': undefined,
+    'ids': {
+      'slug': 'shiny-penny',
+    },
+  },
+  {
+    'name': 'Beck/Woods',
+    'country': undefined,
+    'ids': {
+      'slug': 'beck-woods',
+    },
+  },
+  {
+    'name': 'A24',
+    'country': 'us',
+    'ids': {
+      'slug': 'a24',
+    },
+  },
+  {
+    'name': 'CatchLight Studios',
+    'country': undefined,
+    'ids': {
+      'slug': 'catchlight-studios-670133a6-7993-41ee-a05a-a806f40a1288',
+    },
+  },
+];

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts
@@ -25,6 +25,7 @@ export const ShowSiloMappedMock = {
   'year': 2023,
   'runtime': 60,
   'slug': 'silo',
+  'status': 'returning series',
   'tagline': 'The truth will surface.',
   'thumb': {
     'url':


### PR DESCRIPTION
## 🎶 Notes 🎶
- Fixes the issue reported here: https://github.com/trakt/trakt-lite/issues/223
- The coming soon section now takes statuses into count. Movies that are canceled will no longer show up.
  - Only movies with a status that would indicate it is actually coming is taken into count:
    - i.e.: `planned`, `post production`, `in production` & `upcoming`
  - This also filters out movies that were released, but have no known release date.
- This also fixed a related issue in the media details. When there is no usable premiere date, the status will be shown.
- Also updates the label of the premiere date if it's in the future.

## 👀 Examples 👀
**Show only relevant upcoming movies**
Before:
<img width="1464" alt="Screenshot 2025-01-08 at 13 58 55" src="https://github.com/user-attachments/assets/b1c0a0f9-a34d-4cbf-99cf-32626f2f4561" />

After:
<img width="1464" alt="Screenshot 2025-01-08 at 13 59 06" src="https://github.com/user-attachments/assets/314d81ae-02b9-47bc-b6ab-2bf69e4d095d" />


**Showing status instead of date**
Before:
<img width="1464" alt="Screenshot 2025-01-08 at 14 00 10" src="https://github.com/user-attachments/assets/c8a04278-aef4-430d-ad70-47b60abea76b" />

After:
<img width="1464" alt="Screenshot 2025-01-07 at 20 54 15" src="https://github.com/user-attachments/assets/9f6c27c7-9c44-473a-8744-5fc58f5562ae" />

**Premiere date example**
<img width="1464" alt="Screenshot 2025-01-07 at 21 26 20" src="https://github.com/user-attachments/assets/48cab378-2e97-4d78-ac06-7d0181c6e5db" />
