### PR TITLE
chore: allow i2.wp.com images in csp

### DIFF
--- a/projects/client/src/app.html
+++ b/projects/client/src/app.html
@@ -12,7 +12,7 @@
       http-equiv="Content-Security-Policy"
       content="
         default-src 'self';
-        img-src 'self' data: https://*.trakt.tv https://secure.gravatar.com;
+        img-src 'self' data: https://*.trakt.tv https://secure.gravatar.com https://i2.wp.com/;
         script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.trakt.tv https://*.googletagmanager.com;
         script-src-elem 'self' 'unsafe-inline' https://*.googletagmanager.com https://*.cloudflareinsights.com;
         connect-src 'self' https://*.jsdelivr.net https://*.googleapis.com https://*.gstatic.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.trakt.tv;


### PR DESCRIPTION
## 🎶 Notes 🎶
Fixes this:
<img width="1067" alt="Screenshot 2025-01-09 at 10 23 56" src="https://github.com/user-attachments/assets/f38fa1c3-e868-4618-9827-0951aaf22455" />
