### PR TITLE
fix(button): define missing ni for correct margin compensation

### DIFF
--- a/projects/client/src/style/numeric-increments/index.css
+++ b/projects/client/src/style/numeric-increments/index.css
@@ -86,6 +86,7 @@
   --ni-neg-0: 0rem;
   --ni-neg-2: -0.125rem;
   --ni-neg-4: -0.25rem;
+  --ni-neg-6: -0.3125rem;
   --ni-neg-8: -0.375rem;
   --ni-neg-10: -0.625rem;
   --ni-neg-12: -0.75rem;


### PR DESCRIPTION
This pull request includes several changes to the `projects/client/src/style/numeric-increments/index.css` file, focusing on enhancing the numeric increment variables. The most important change is the addition of a new negative increment variable.

Enhancements to numeric increment variables:

* [`projects/client/src/style/numeric-increments/index.css`](diffhunk://#diff-2660499bf8399a149d8081c7c95aea7f3506baf116e2d9e2cef1ebfeecddaa58R89): Added a new variable `--ni-neg-6` with a value of `-0.3125rem`.