### PR TITLE
ci: add coverage location prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
+          prefix: ${{github.workspace}}
           coverageLocations: |
             ${{github.workspace}}/projects/client/coverage/clover.xml:clover
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change adds a `prefix` parameter to the `with` section, which uses the `${{github.workspace}}` variable.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR90): Added `prefix` parameter to the `with` section to specify the workspace directory for coverage reports.