### PR TITLE
ci / use istanbul coverage reporter

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -27,7 +27,7 @@
     "npm:@ts-rest/core@^3.51.0": "3.51.0_zod@3.23.8",
     "npm:@ts-rest/open-api@^3.51.0": "3.51.0_@ts-rest+core@3.51.0__zod@3.23.8_zod@3.23.8_openapi3-ts@2.0.2",
     "npm:@types/eslint@^9.6.1": "9.6.1",
-    "npm:@vitest/coverage-v8@^2.1.6": "2.1.8_vitest@2.1.8__jsdom@25.0.1__msw@2.6.8___typescript@5.7.2__vite@5.4.11___sass-embedded@1.83.0__sass-embedded@1.83.0__typescript@5.7.2_jsdom@25.0.1_msw@2.6.8__typescript@5.7.2_sass-embedded@1.83.0_typescript@5.7.2",
+    "npm:@vitest/coverage-istanbul@^2.1.8": "2.1.8_vitest@2.1.8__jsdom@25.0.1__msw@2.6.8___typescript@5.7.2__vite@5.4.11___sass-embedded@1.83.0__sass-embedded@1.83.0__typescript@5.7.2_jsdom@25.0.1_msw@2.6.8__typescript@5.7.2_sass-embedded@1.83.0_typescript@5.7.2",
     "npm:date-fns@^4.1.0": "4.1.0",
     "npm:eslint-plugin-svelte@^2.46.0": "2.46.0_eslint@9.15.0_svelte@5.2.9__acorn@8.14.0_postcss@8.4.49",
     "npm:eslint@^9.15.0": "9.15.0",
@@ -114,11 +114,80 @@
         "picocolors"
       ]
     },
+    "@babel/compat-data@7.26.3": {
+      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g=="
+    },
+    "@babel/core@7.26.0": {
+      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+      "dependencies": [
+        "@ampproject/remapping",
+        "@babel/code-frame",
+        "@babel/generator",
+        "@babel/helper-compilation-targets",
+        "@babel/helper-module-transforms",
+        "@babel/helpers",
+        "@babel/parser",
+        "@babel/template",
+        "@babel/traverse",
+        "@babel/types",
+        "convert-source-map",
+        "debug",
+        "gensync",
+        "json5",
+        "semver@6.3.1"
+      ]
+    },
+    "@babel/generator@7.26.3": {
+      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+      "dependencies": [
+        "@babel/parser",
+        "@babel/types",
+        "@jridgewell/gen-mapping",
+        "@jridgewell/trace-mapping@0.3.25",
+        "jsesc"
+      ]
+    },
+    "@babel/helper-compilation-targets@7.25.9": {
+      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+      "dependencies": [
+        "@babel/compat-data",
+        "@babel/helper-validator-option",
+        "browserslist",
+        "lru-cache@5.1.1",
+        "semver@6.3.1"
+      ]
+    },
+    "@babel/helper-module-imports@7.25.9": {
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "dependencies": [
+        "@babel/traverse",
+        "@babel/types"
+      ]
+    },
+    "@babel/helper-module-transforms@7.26.0_@babel+core@7.26.0": {
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-module-imports",
+        "@babel/helper-validator-identifier",
+        "@babel/traverse"
+      ]
+    },
     "@babel/helper-string-parser@7.25.9": {
       "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA=="
     },
     "@babel/helper-validator-identifier@7.25.9": {
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="
+    },
+    "@babel/helper-validator-option@7.25.9": {
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw=="
+    },
+    "@babel/helpers@7.26.0": {
+      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "dependencies": [
+        "@babel/template",
+        "@babel/types"
+      ]
     },
     "@babel/parser@7.26.3": {
       "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
@@ -132,15 +201,32 @@
         "regenerator-runtime"
       ]
     },
+    "@babel/template@7.25.9": {
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "dependencies": [
+        "@babel/code-frame",
+        "@babel/parser",
+        "@babel/types"
+      ]
+    },
+    "@babel/traverse@7.26.4": {
+      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+      "dependencies": [
+        "@babel/code-frame",
+        "@babel/generator",
+        "@babel/parser",
+        "@babel/template",
+        "@babel/types",
+        "debug",
+        "globals@11.12.0"
+      ]
+    },
     "@babel/types@7.26.3": {
       "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
       "dependencies": [
         "@babel/helper-string-parser",
         "@babel/helper-validator-identifier"
       ]
-    },
-    "@bcoe/v8-coverage@0.2.3": {
-      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@bufbuild/protobuf@2.2.3": {
       "integrity": "sha512-tFQoXHJdkEOSwj5tRIZSPNUuXK3RaR7T1nUrPgbYX1pUbvqqaaZAsfo+NXBPsz5rZMSKVFrgK1WL8Q/MSLvprg=="
@@ -1842,7 +1928,7 @@
         "fast-glob",
         "is-glob",
         "minimatch@9.0.5",
-        "semver",
+        "semver@7.6.3",
         "ts-api-utils"
       ]
     },
@@ -1863,19 +1949,17 @@
         "eslint-visitor-keys@4.2.0"
       ]
     },
-    "@vitest/coverage-v8@2.1.8_vitest@2.1.8__jsdom@25.0.1__msw@2.6.8___typescript@5.7.2__vite@5.4.11___sass-embedded@1.83.0__sass-embedded@1.83.0__typescript@5.7.2_jsdom@25.0.1_msw@2.6.8__typescript@5.7.2_sass-embedded@1.83.0_typescript@5.7.2": {
-      "integrity": "sha512-2Y7BPlKH18mAZYAW1tYByudlCYrQyl5RGvnnDYJKW5tCiO5qg3KSAy3XAxcxKz900a0ZXxWtKrMuZLe3lKBpJw==",
+    "@vitest/coverage-istanbul@2.1.8_vitest@2.1.8__jsdom@25.0.1__msw@2.6.8___typescript@5.7.2__vite@5.4.11___sass-embedded@1.83.0__sass-embedded@1.83.0__typescript@5.7.2_jsdom@25.0.1_msw@2.6.8__typescript@5.7.2_sass-embedded@1.83.0_typescript@5.7.2": {
+      "integrity": "sha512-cSaCd8KcWWvgDwEJSXm0NEWZ1YTiJzjicKHy+zOEbUm0gjbbkz+qJf1p8q71uBzSlS7vdnZA8wRLeiwVE3fFTA==",
       "dependencies": [
-        "@ampproject/remapping",
-        "@bcoe/v8-coverage",
+        "@istanbuljs/schema",
         "debug",
         "istanbul-lib-coverage",
+        "istanbul-lib-instrument",
         "istanbul-lib-report",
         "istanbul-lib-source-maps",
         "istanbul-reports",
-        "magic-string@0.30.14",
         "magicast",
-        "std-env",
         "test-exclude",
         "tinyrainbow",
         "vitest@2.1.8_jsdom@25.0.1_msw@2.6.8__typescript@5.7.2_vite@5.4.11__sass-embedded@1.83.0_sass-embedded@1.83.0_typescript@5.7.2"
@@ -2127,6 +2211,15 @@
         "fill-range"
       ]
     },
+    "browserslist@4.24.2": {
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+      "dependencies": [
+        "caniuse-lite",
+        "electron-to-chromium",
+        "node-releases",
+        "update-browserslist-db"
+      ]
+    },
     "btoa-lite@1.0.0": {
       "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="
     },
@@ -2141,6 +2234,9 @@
     },
     "callsites@3.1.0": {
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+    },
+    "caniuse-lite@1.0.30001673": {
+      "integrity": "sha512-WTrjUCSMp3LYX0nE12ECkV0a+e6LC85E0Auz75555/qr78Oc8YWhEPNfDd6SHdtlCMSzqtuXY0uyEMNRcsKpKw=="
     },
     "capnp-ts@0.7.0": {
       "integrity": "sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==",
@@ -2242,6 +2338,9 @@
     },
     "consola@3.2.3": {
       "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ=="
+    },
+    "convert-source-map@2.0.0": {
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "cookie@0.6.0": {
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
@@ -2347,6 +2446,9 @@
       "dependencies": [
         "safe-buffer"
       ]
+    },
+    "electron-to-chromium@1.5.47": {
+      "integrity": "sha512-zS5Yer0MOYw4rtK2iq43cJagHZ8sXN0jDHDKzB+86gSBSAI4v07S97mcq+Gs2vclAxSh1j7vOAHxSVgduiiuVQ=="
     },
     "emoji-regex@8.0.0": {
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
@@ -2454,7 +2556,7 @@
       "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
       "dependencies": [
         "eslint",
-        "semver"
+        "semver@7.6.3"
       ]
     },
     "eslint-plugin-svelte@2.46.0_eslint@9.15.0_svelte@5.2.9__acorn@8.14.0_postcss@8.4.49": {
@@ -2470,7 +2572,7 @@
         "postcss-load-config",
         "postcss-safe-parser",
         "postcss-selector-parser",
-        "semver",
+        "semver@7.6.3",
         "svelte",
         "svelte-eslint-parser"
       ]
@@ -2719,6 +2821,9 @@
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
+    "gensync@1.0.0-beta.2": {
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+    },
     "get-caller-file@2.0.5": {
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
@@ -2754,6 +2859,9 @@
         "package-json-from-dist",
         "path-scurry"
       ]
+    },
+    "globals@11.12.0": {
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globals@14.0.0": {
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="
@@ -2899,6 +3007,16 @@
     "istanbul-lib-coverage@3.2.2": {
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="
     },
+    "istanbul-lib-instrument@6.0.3": {
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/parser",
+        "@istanbuljs/schema",
+        "istanbul-lib-coverage",
+        "semver@7.6.3"
+      ]
+    },
     "istanbul-lib-report@3.0.1": {
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dependencies": [
@@ -2967,6 +3085,9 @@
         "xml-name-validator"
       ]
     },
+    "jsesc@3.1.0": {
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="
+    },
     "json-buffer@3.0.1": {
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
@@ -2991,7 +3112,7 @@
         "lodash.isstring",
         "lodash.once",
         "ms",
-        "semver"
+        "semver@7.6.3"
       ]
     },
     "jwa@1.4.1": {
@@ -3079,6 +3200,12 @@
     "lru-cache@10.4.3": {
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
+    "lru-cache@5.1.1": {
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dependencies": [
+        "yallist"
+      ]
+    },
     "lz-string@1.5.0": {
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
     },
@@ -3105,7 +3232,7 @@
     "make-dir@4.0.0": {
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dependencies": [
-        "semver"
+        "semver@7.6.3"
       ]
     },
     "merge2@1.4.1": {
@@ -3216,6 +3343,9 @@
     "node-forge@1.3.1": {
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
+    "node-releases@2.0.18": {
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
+    },
     "nwsapi@2.2.13": {
       "integrity": "sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ=="
     },
@@ -3305,7 +3435,7 @@
     "path-scurry@1.11.1": {
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dependencies": [
-        "lru-cache",
+        "lru-cache@10.4.3",
         "minipass"
       ]
     },
@@ -3664,6 +3794,9 @@
         "node-forge"
       ]
     },
+    "semver@6.3.1": {
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+    },
     "semver@7.6.3": {
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
     },
@@ -3701,7 +3834,7 @@
         "@img/sharp-win32-x64",
         "color",
         "detect-libc",
-        "semver"
+        "semver@7.6.3"
       ]
     },
     "shebang-command@2.0.0": {
@@ -4033,6 +4166,14 @@
         "webpack-virtual-modules"
       ]
     },
+    "update-browserslist-db@1.1.1_browserslist@4.24.2": {
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "dependencies": [
+        "browserslist",
+        "escalade",
+        "picocolors"
+      ]
+    },
     "uri-js@4.4.1": {
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": [
@@ -4312,6 +4453,9 @@
     "y18n@5.0.8": {
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
+    "yallist@3.1.1": {
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
     "yaml@1.10.2": {
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
@@ -4378,7 +4522,7 @@
             "npm:@testing-library/user-event@^14.5.2",
             "npm:@ts-rest/core@^3.51.0",
             "npm:@types/eslint@^9.6.1",
-            "npm:@vitest/coverage-v8@^2.1.6",
+            "npm:@vitest/coverage-istanbul@^2.1.8",
             "npm:date-fns@^4.1.0",
             "npm:eslint-plugin-svelte@^2.46.0",
             "npm:eslint@^9.15.0",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -32,7 +32,7 @@
     "@testing-library/svelte": "^5.2.6",
     "@testing-library/user-event": "^14.5.2",
     "@types/eslint": "^9.6.1",
-    "@vitest/coverage-v8": "^2.1.6",
+    "@vitest/coverage-istanbul": "^2.1.8",
     "eslint": "^9.15.0",
     "eslint-plugin-svelte": "^2.46.0",
     "globals": "^15.12.0",

--- a/projects/client/vite.config.ts
+++ b/projects/client/vite.config.ts
@@ -73,6 +73,9 @@ export default defineConfig(({ mode }) => ({
     ],
     environment: 'jsdom',
     setupFiles: ['./vitest-setup.ts'],
+    coverage: {
+      provider: 'istanbul',
+    },
   },
 
   resolve: process.env.VITEST


### PR DESCRIPTION
This pull request, a desperate attempt to resuscitate the dying embers of code coverage reporting, performs a provider transplant on the `projects/client` package, replacing the failing V8 coverage provider with the more reliable Istanbul. Observe, with a mix of hope and trepidation, the surgical replacement of dependencies and the meticulous reconfiguration of coverage settings.

### Dependencies update (or, "The Coverage Provider Transplant"):

* The `package.json` file, a repository of project dependencies, undergoes a delicate operation, its `@vitest/coverage-v8` dependency excised and replaced with the more robust `@vitest/coverage-istanbul`. This transplant, a desperate attempt to revive the failing code coverage reporting, promises to restore the vital signs of test coverage and provide a clearer picture of the project's health.

### Configuration update (or, "The Configuration Conjuror"):

* The `vite.config.ts` file, a master of project configuration, receives a new incantation, its coverage settings now aligned with the Istanbul provider. This adjustment, a subtle yet crucial step in the transplant process, ensures that the new provider is properly integrated and its reports accurately reflect the project's code coverage.

These changes, a testament to our unwavering commitment to code quality and testing transparency, collectively aim to resuscitate the code coverage reporting and provide a more accurate and reliable assessment of the project's test coverage. The replacement of the V8 provider with Istanbul, coupled with the updated configuration, promises to breathe new life into the coverage reports, ensuring that developers have a clear and comprehensive understanding of the project's testing landscape.