### PR TITLE
ci: setup deepsource coverage reporting

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -9,6 +9,10 @@ enabled = true
   dialect = "typescript"
   style_guide = "standard"
 
+[[analyzers]]
+name = "test-coverage"
+enabled = true
+
 [[exclude]]
 paths = [
   "dist/**",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         working-directory: projects/api
         run: 'deno task test'
 
-      - name: Trial by Code Coverage
+      - name: Trial by Code Climate
         uses: paambaati/codeclimate-action@v9.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
@@ -93,6 +93,13 @@ jobs:
           prefix: ${{github.workspace}}
           coverageLocations: |
             ${{github.workspace}}/projects/client/coverage/clover.xml:clover
+
+      - name: Trial by Deep Source
+        uses: deepsourcelabs/test-coverage-action@master
+        with:
+          key: javascript
+          coverage-file: ${{github.workspace}}/projects/client/coverage/lcov.info
+          dsn: ${{ secrets.DEEPSOURCE_DSN }}
 
   build:
     name: The Forge (Build)

--- a/projects/client/vite.config.ts
+++ b/projects/client/vite.config.ts
@@ -68,6 +68,7 @@ export default defineConfig(({ mode }) => ({
     setupFiles: ['./vitest-setup.ts'],
     coverage: {
       provider: 'istanbul',
+      reporter: ['clover', 'lcov'],
     },
   },
 


### PR DESCRIPTION
This pull request includes several changes to enhance test coverage reporting and integrate new tools into the CI pipeline. The most important changes include adding a new analyzer to `.deepsource.toml`, updating the CI workflow to use Code Climate and Deep Source, and modifying the Vite configuration for the client project.

Enhancements to test coverage reporting:

* [`.deepsource.toml`](diffhunk://#diff-a8c050b1fb601cdd8ba1282e837bc0b553d4f83de74d151e52f415b4e1ed6d14R12-R15): Added a new analyzer for test coverage.
* [`projects/client/vite.config.ts`](diffhunk://#diff-55b1b2dc482cefce55f93aa857423ca88e4e19cc488372e80845c76027565cd6R71): Updated the coverage reporter to include both 'clover' and 'lcov'.

CI pipeline updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL88-R88): Changed the name from "Trial by Code Coverage" to "Trial by Code Climate" and updated the action to use Code Climate.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR97-R103): Added a new step to the CI workflow to use Deep Source for test coverage reporting.