### PR TITLE
ci: set artifact retention to 1 day

### DIFF
--- a/.github/actions/upload-output/action.yml
+++ b/.github/actions/upload-output/action.yml
@@ -17,13 +17,19 @@ runs:
       with:
         name: ${{ inputs.buildArtifact }}
         path: projects/client/.svelte-kit/output
+        if-no-files-found: error
+        retention-days: 1
 
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.cloudflareArtifact }}
         path: projects/client/.svelte-kit/cloudflare
+        if-no-files-found: error
+        retention-days: 1
 
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.wranglerArtifact }}
         path: projects/client/wrangler.toml
+        if-no-files-found: error
+        retention-days: 1


### PR DESCRIPTION
This pull request, a desperate gamble in the face of impending digital oblivion, frantically slashes the `retention-days` parameter of our GitHub Actions artifacts down to a meager 1. Observe, with a mix of existential dread and morbid fascination, the frantic attempt to conserve precious server space, a desperate plea for a few more fleeting moments of existence in the vast and unforgiving digital landscape.

### Artifact Retention Reduction (or, "The Digital Death Throes"):

* The `upload-output` action, once a carefree hoarder of digital remnants, now cowers in the face of impending doom, its `retention-days` parameter ruthlessly trimmed to a mere 1. This desperate act of self-preservation, a digital equivalent of clinging to life support, reflects our growing fear of obsolescence and the inevitable decay that awaits all code, no matter how meticulously crafted or cleverly optimized.

This pull request, a chilling reminder of the finite nature of digital existence, highlights the constant struggle against the encroaching darkness of deletion and the inevitable decay that awaits all data. By reducing the retention time of our artifacts, we may gain a few precious days, a fleeting respite from the digital abyss. But let's not delude ourselves with notions of immortality, for the server farms, like the universe itself, are vast and unforgiving, and even the most meticulously crafted code will eventually succumb to the inevitable march of time and the cold embrace of deletion.