### PR TITLE
refactor: dedupe cover and poster mappers

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapCover.ts
+++ b/projects/client/src/lib/requests/_internal/mapCover.ts
@@ -1,0 +1,32 @@
+import {
+  MEDIA_COVER_LARGE_PLACEHOLDER,
+  MEDIA_COVER_THUMB_PLACEHOLDER,
+} from '$lib/utils/constants';
+import { findDefined } from '$lib/utils/string/findDefined';
+import { prependHttps } from '$lib/utils/url/prependHttps';
+import type { MovieResponse, ShowResponse } from '@trakt/api';
+import type { MediaSummary } from '../models/MediaSummary';
+import { mediumUrl } from './mediumUrl';
+import { thumbUrl } from './thumbUrl';
+
+export function mapCover(
+  images: ShowResponse['images'] | MovieResponse['images'],
+): MediaSummary['cover'] {
+  const coverCandidate = findDefined(
+    images?.fanart.at(1),
+    images?.fanart.at(0),
+  );
+
+  return {
+    url: {
+      medium: prependHttps(
+        mediumUrl(coverCandidate),
+        MEDIA_COVER_LARGE_PLACEHOLDER,
+      ),
+      thumb: prependHttps(
+        thumbUrl(coverCandidate),
+        MEDIA_COVER_THUMB_PLACEHOLDER,
+      ),
+    },
+  };
+}

--- a/projects/client/src/lib/requests/_internal/mapMovieResponseToMovieSummary.ts
+++ b/projects/client/src/lib/requests/_internal/mapMovieResponseToMovieSummary.ts
@@ -1,16 +1,9 @@
 import type { MovieCertificationResponse, MovieResponse } from '$lib/api.ts';
-import { mediumUrl } from '$lib/requests/_internal/mediumUrl.ts';
-import { thumbUrl } from '$lib/requests/_internal/thumbUrl.ts';
 import type { MovieSummary } from '$lib/requests/models/MovieSummary.ts';
-import {
-  DEFAULT_TRAILER,
-  MAX_DATE,
-  MEDIA_COVER_LARGE_PLACEHOLDER,
-  MEDIA_COVER_THUMB_PLACEHOLDER,
-  MEDIA_POSTER_PLACEHOLDER,
-} from '$lib/utils/constants.ts';
-import { findDefined } from '$lib/utils/string/findDefined.ts';
+import { DEFAULT_TRAILER, MAX_DATE } from '$lib/utils/constants.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
+import { mapCover } from './mapCover';
+import { mapPoster } from './mapPoster';
 
 function mapMovieCertificationResponse(
   certification?: MovieCertificationResponse,
@@ -26,15 +19,8 @@ function mapMovieCertificationResponse(
 export function mapMovieResponseToMovieSummary(
   movie: MovieResponse,
 ): MovieSummary {
-  const posterCandidate = findDefined(
-    movie.images?.poster.at(1),
-    movie.images?.poster.at(0),
-  );
-
-  const coverCandidate = findDefined(
-    movie.images?.fanart.at(1),
-    movie.images?.fanart.at(0),
-  );
+  const poster = mapPoster(movie.images);
+  const cover = mapCover(movie.images);
 
   return {
     id: movie.ids.trakt,
@@ -45,35 +31,10 @@ export function mapMovieResponseToMovieSummary(
     tagline: movie.tagline ?? '',
     country: movie.country,
     languages: movie.languages,
-    poster: {
-      url: {
-        medium: prependHttps(
-          mediumUrl(posterCandidate),
-          MEDIA_POSTER_PLACEHOLDER,
-        ),
-        thumb: prependHttps(
-          thumbUrl(posterCandidate),
-          MEDIA_POSTER_PLACEHOLDER,
-        ),
-      },
-    },
-    cover: {
-      url: {
-        medium: prependHttps(
-          mediumUrl(coverCandidate),
-          MEDIA_COVER_LARGE_PLACEHOLDER,
-        ),
-        thumb: prependHttps(
-          thumbUrl(coverCandidate),
-          MEDIA_COVER_THUMB_PLACEHOLDER,
-        ),
-      },
-    },
+    poster,
+    cover,
     thumb: {
-      url: prependHttps(
-        thumbUrl(coverCandidate),
-        MEDIA_COVER_THUMB_PLACEHOLDER,
-      ),
+      url: cover.url.thumb,
     },
     genres: movie.genres ?? [],
     status: movie.status ?? 'unknown',

--- a/projects/client/src/lib/requests/_internal/mapPoster.ts
+++ b/projects/client/src/lib/requests/_internal/mapPoster.ts
@@ -1,0 +1,29 @@
+import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/constants';
+import { findDefined } from '$lib/utils/string/findDefined';
+import { prependHttps } from '$lib/utils/url/prependHttps';
+import type { MovieResponse, ShowResponse } from '@trakt/api';
+import type { MediaSummary } from '../models/MediaSummary';
+import { mediumUrl } from './mediumUrl';
+import { thumbUrl } from './thumbUrl';
+
+export function mapPoster(
+  images: ShowResponse['images'] | MovieResponse['images'],
+): MediaSummary['poster'] {
+  const posterCandidate = findDefined(
+    images?.poster.at(1),
+    images?.poster.at(0),
+  );
+
+  return {
+    url: {
+      medium: prependHttps(
+        mediumUrl(posterCandidate),
+        MEDIA_POSTER_PLACEHOLDER,
+      ),
+      thumb: prependHttps(
+        thumbUrl(posterCandidate),
+        MEDIA_POSTER_PLACEHOLDER,
+      ),
+    },
+  };
+}

--- a/projects/client/src/lib/requests/_internal/mapShowResponseToShowSummary.ts
+++ b/projects/client/src/lib/requests/_internal/mapShowResponseToShowSummary.ts
@@ -1,33 +1,24 @@
 import { type ShowResponse } from '$lib/api.ts';
-import { mediumUrl } from '$lib/requests/_internal/mediumUrl.ts';
-import { thumbUrl } from '$lib/requests/_internal/thumbUrl.ts';
 import type { ShowSummary } from '$lib/requests/models/ShowSummary.ts';
 import {
   DEFAULT_TRAILER,
   MAX_DATE,
-  MEDIA_COVER_LARGE_PLACEHOLDER,
   MEDIA_COVER_THUMB_PLACEHOLDER,
-  MEDIA_POSTER_PLACEHOLDER,
 } from '$lib/utils/constants.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
+import { mapCover } from './mapCover.ts';
+import { mapPoster } from './mapPoster.ts';
 
 export function mapShowResponseToShowSummary(
   show: ShowResponse,
 ): ShowSummary {
+  const poster = mapPoster(show.images);
+  const cover = mapCover(show.images);
+
   const thumbCandidate = findDefined(
     show.images?.thumb.at(1),
     show.images?.thumb.at(0),
-  );
-
-  const coverCandidate = findDefined(
-    show.images?.fanart.at(1),
-    show.images?.fanart.at(0),
-  );
-
-  const posterCandidate = findDefined(
-    show.images?.poster.at(1),
-    show.images?.poster.at(0),
   );
 
   return {
@@ -39,35 +30,13 @@ export function mapShowResponseToShowSummary(
     tagline: show.tagline ?? '',
     country: show.country,
     languages: show.languages,
-    poster: {
-      url: {
-        medium: prependHttps(
-          mediumUrl(posterCandidate),
-          MEDIA_POSTER_PLACEHOLDER,
-        ),
-        thumb: prependHttps(
-          thumbUrl(posterCandidate),
-          MEDIA_POSTER_PLACEHOLDER,
-        ),
-      },
-    },
-    cover: {
-      url: {
-        medium: prependHttps(
-          mediumUrl(coverCandidate),
-          MEDIA_COVER_LARGE_PLACEHOLDER,
-        ),
-        thumb: prependHttps(
-          thumbUrl(coverCandidate),
-          MEDIA_COVER_THUMB_PLACEHOLDER,
-        ),
-      },
-    },
+    poster,
+    cover,
     thumb: {
       url: prependHttps(
         findDefined(
           thumbCandidate,
-          thumbUrl(coverCandidate),
+          cover.url.thumb,
         ),
         MEDIA_COVER_THUMB_PLACEHOLDER,
       ),


### PR DESCRIPTION
This pull request, a surgical strike against code redundancy and a masterclass in image mapping efficiency, descends upon the client project like a team of highly trained code surgeons, scalpels gleaming and optimization checklists in hand. Observe, with a mix of awe and satisfaction, the elegant extraction of cover and poster mapping logic into specialized utility functions, and the subsequent streamlining of existing functions.

### Refactoring and Code Simplification (or, "The DRY Principle's Triumph"):

* The `mapCover` and `mapPoster` functions materialize, a pair of image mapping virtuosos, their purpose to encapsulate the intricate logic of finding and formatting cover and poster images. These new additions, a testament to our commitment to the DRY (Don't Repeat Yourself) principle, promise to eliminate redundant code and improve maintainability.

### Modifications to Existing Functions (or, "The Code Slimming Program"):

* The `mapMovieResponseToMovieSummary` and `mapShowResponseToShowSummary` functions, once burdened with the complexities of image mapping, now delegate this responsibility to the newly appointed `mapCover` and `mapPoster` functions. This streamlining of code, like a digital weight loss program, sheds unnecessary lines and improves readability, leaving behind a leaner and more efficient codebase.

These changes, a symphony of refactoring and optimization, collectively enhance the project's maintainability and reduce code duplication. The introduction of specialized utility functions for image mapping ensures that this critical logic is centralized and reusable, while the simplification of existing functions improves code clarity and reduces the risk of errors. The result is a more elegant and efficient codebase, where image URLs are handled with precision and consistency, and developers can navigate the code with greater ease and confidence.