### PR TITLE
revert / cf adapter upgrade

### DIFF
--- a/.github/actions/upload-output/action.yml
+++ b/.github/actions/upload-output/action.yml
@@ -18,7 +18,12 @@ runs:
         include-hidden-files: true
         if-no-files-found: error
         name: ${{ inputs.buildArtifact }}
-        path: projects/client/.svelte-kit
+        path: projects/client/.svelte-kit/output
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.cloudflareArtifact }}
+        path: projects/client/.svelte-kit/cloudflare
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/upload-output/action.yml
+++ b/.github/actions/upload-output/action.yml
@@ -15,8 +15,6 @@ runs:
   steps:
     - uses: actions/upload-artifact@v4
       with:
-        include-hidden-files: true
-        if-no-files-found: error
         name: ${{ inputs.buildArtifact }}
         path: projects/client/.svelte-kit/output
 
@@ -27,6 +25,5 @@ runs:
 
     - uses: actions/upload-artifact@v4
       with:
-        if-no-files-found: error
         name: ${{ inputs.wranglerArtifact }}
         path: projects/client/wrangler.toml

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ jobs:
           if_no_artifact_found: warn
           run_id: ${{ github.event.workflow_run.id }}
           name: the-edge-awakened
-          path: ./.svelte-kit
+          path: ./.svelte-kit/cloudflare
 
       - name: Download Wrangler Configuration
         uses: dawidd6/action-download-artifact@v6
@@ -37,7 +37,7 @@ jobs:
       - name: Check Artifacts
         id: check_artifacts
         run: |
-          if [ -d "./.svelte-kit" ] && [ -f "./wrangler.toml" ]; then
+          if [ -d "./.svelte-kit/cloudflare" ] && [ -f "./wrangler.toml" ]; then
             echo "artifacts_found=true" >> $GITHUB_ENV
           else
             echo "artifacts_found=false" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,5 +136,6 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: ./.github/actions/upload-output
         with:
-          buildArtifact: the-edge-awakened
+          buildArtifact: pandoras-archive
+          cloudflareArtifact: the-edge-awakened
           wranglerArtifact: the-edge-config

--- a/deno.lock
+++ b/deno.lock
@@ -14,7 +14,7 @@
     "npm:@inlang/paraglide-sveltekit@~0.15.5": "0.15.5_@sveltejs+kit@2.15.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.17.3____acorn@8.14.0___vite@6.0.7____sass-embedded@1.83.1___sass-embedded@1.83.1__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_svelte@5.17.3__acorn@8.14.0_vite@6.0.7__sass-embedded@1.83.1_sass-embedded@1.83.1",
     "npm:@playwright/test@^1.49.1": "1.49.1",
     "npm:@sveltejs/adapter-auto@^3.3.1": "3.3.1_@sveltejs+kit@2.15.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.17.3____acorn@8.14.0___vite@6.0.7____sass-embedded@1.83.1___sass-embedded@1.83.1__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_svelte@5.17.3__acorn@8.14.0_vite@6.0.7__sass-embedded@1.83.1_sass-embedded@1.83.1",
-    "npm:@sveltejs/adapter-cloudflare@5": "5.0.0_@sveltejs+kit@2.15.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.17.3____acorn@8.14.0___vite@6.0.7____sass-embedded@1.83.1___sass-embedded@1.83.1__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_wrangler@3.101.0__@cloudflare+workers-types@4.20250109.0__esbuild@0.17.19_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_svelte@5.17.3__acorn@8.14.0_vite@6.0.7__sass-embedded@1.83.1_@cloudflare+workers-types@4.20250109.0_sass-embedded@1.83.1",
+    "npm:@sveltejs/adapter-cloudflare@4.9.0": "4.9.0_@sveltejs+kit@2.15.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.17.3____acorn@8.14.0___vite@6.0.7____sass-embedded@1.83.1___sass-embedded@1.83.1__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_wrangler@3.101.0__@cloudflare+workers-types@4.20250109.0__esbuild@0.17.19_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_svelte@5.17.3__acorn@8.14.0_vite@6.0.7__sass-embedded@1.83.1_@cloudflare+workers-types@4.20250109.0_sass-embedded@1.83.1",
     "npm:@sveltejs/enhanced-img@~0.4.4": "0.4.4_svelte@5.17.3__acorn@8.14.0_vite@6.0.7__sass-embedded@1.83.1_sass-embedded@1.83.1",
     "npm:@sveltejs/kit@^2.15.2": "2.15.2_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_svelte@5.17.3__acorn@8.14.0_vite@6.0.7__sass-embedded@1.83.1_sass-embedded@1.83.1",
     "npm:@sveltejs/vite-plugin-svelte@^5.0.3": "5.0.3_svelte@5.17.3__acorn@8.14.0_vite@6.0.7__sass-embedded@1.83.1_sass-embedded@1.83.1",
@@ -3506,8 +3506,8 @@
         "import-meta-resolve"
       ]
     },
-    "@sveltejs/adapter-cloudflare@5.0.0_@sveltejs+kit@2.15.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.17.3____acorn@8.14.0___vite@6.0.7____sass-embedded@1.83.1___sass-embedded@1.83.1__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_wrangler@3.101.0__@cloudflare+workers-types@4.20250109.0__esbuild@0.17.19_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_svelte@5.17.3__acorn@8.14.0_vite@6.0.7__sass-embedded@1.83.1_@cloudflare+workers-types@4.20250109.0_sass-embedded@1.83.1": {
-      "integrity": "sha512-YYfkdEajp4sALHFYeIUUQTGC3M1ZicrYYSVz1zmYwR2DKT59dwygYsdufI4L6ONNsDdRh3xeojjo8sO3V9dHcw==",
+    "@sveltejs/adapter-cloudflare@4.9.0_@sveltejs+kit@2.15.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.17.3____acorn@8.14.0___vite@6.0.7____sass-embedded@1.83.1___sass-embedded@1.83.1__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_wrangler@3.101.0__@cloudflare+workers-types@4.20250109.0__esbuild@0.17.19_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.17.3___acorn@8.14.0__vite@6.0.7___sass-embedded@1.83.1__sass-embedded@1.83.1_svelte@5.17.3__acorn@8.14.0_vite@6.0.7__sass-embedded@1.83.1_@cloudflare+workers-types@4.20250109.0_sass-embedded@1.83.1": {
+      "integrity": "sha512-o7o8wXy5zDsEuE9oPWSHO5tAuPEulZZg2QavFdc00fcIHh1dxgCyIRZa5LPjAE8EcdJOh+8SFkhFgVRdCfOBvQ==",
       "dependencies": [
         "@cloudflare/workers-types",
         "@sveltejs/kit",
@@ -6274,7 +6274,7 @@
             "npm:@inlang/paraglide-sveltekit@~0.15.5",
             "npm:@playwright/test@^1.49.1",
             "npm:@sveltejs/adapter-auto@^3.3.1",
-            "npm:@sveltejs/adapter-cloudflare@5",
+            "npm:@sveltejs/adapter-cloudflare@4.9.0",
             "npm:@sveltejs/enhanced-img@~0.4.4",
             "npm:@sveltejs/kit@^2.15.2",
             "npm:@sveltejs/vite-plugin-svelte@^5.0.3",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -25,7 +25,7 @@
     "@google/generative-ai": "^0.21.0",
     "@playwright/test": "^1.49.1",
     "@sveltejs/adapter-auto": "^3.3.1",
-    "@sveltejs/adapter-cloudflare": "^5.0.0",
+    "@sveltejs/adapter-cloudflare": "4.9.0",
     "@sveltejs/enhanced-img": "^0.4.4",
     "@sveltejs/kit": "^2.15.2",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",


### PR DESCRIPTION
Cloudflare build doesn't like external dependencies: https://github.com/trakt/trakt-lite/actions/runs/12756619076/job/35555130981#step:5:72


## CI/CD Workflow Adjustments and Dependency Downgrade

This pull request addresses an ongoing issue with the Cloudflare adapter by modifying artifact paths, introducing new artifacts, and temporarily downgrading a package dependency.

### Workflow Updates

- Updated the `path` for the `buildArtifact` and added a new `cloudflareArtifact` upload step in the `upload-output` action. This change ensures that the correct artifacts are uploaded for deployment.
- Modified the path for the `the-edge-awakened` artifact and updated the artifact check condition in the CD workflow. This adjustment aligns the workflow with the new artifact paths.
- Changed the `buildArtifact` name and added a new `cloudflareArtifact` in the CI workflow, reflecting the updated artifact structure.

### Dependency Downgrade

- Downgraded the `@sveltejs/adapter-cloudflare` dependency from version `5.0.0` to `4.9.0` in `projects/client/package.json`. This temporary downgrade addresses compatibility issues and ensures a stable deployment process until a permanent solution is found.

(These changes, like a detective meticulously retracing their steps to uncover a hidden clue, address a persistent issue in the CI/CD pipeline. The updated artifact paths and the dependency downgrade ensure a smoother and more reliable deployment process, while the new artifacts provide additional resources for debugging and analysis.)

