### PR TITLE
fix: message used for page title on Watchlist

### DIFF
--- a/projects/client/src/routes/watchlist/+page.svelte
+++ b/projects/client/src/routes/watchlist/+page.svelte
@@ -13,7 +13,7 @@
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_COVER}
-  title={m.navbar_link_movies()}
+  title={m.navbar_link_watchlist()}
 >
   <CoverImageSetter src={current().cover.url} type="main" />
 


### PR DESCRIPTION
The page title for the watchlist route was incorrectly set to "Movies" rather than "Watchlist". This PR fixes that.

Before:
![image](https://github.com/user-attachments/assets/3125866c-d64b-404d-86e7-ed6341827f3e)
After:
![image](https://github.com/user-attachments/assets/00bfb0ad-6015-40f0-ac63-64b10065e51d)


## Pull Request Checklist

Before you dim the lights and raise the curtain on your cinematic masterpiece,
make sure your pull request has passed these critical checks:

- [x] **Clear and Concise Title:** Does your title shine a spotlight on the
      essence of your changes?
- [x] **Detailed Description:** Have you set the stage with a compelling
      narrative that explains the "why" and "how" of your changes?
- [x] **Screenshots/Videos:** Have you captured the magic with visual evidence
      that showcases your changes in action?
- [x] **Tests:** Has your code undergone a rigorous dress rehearsal with unit
      tests to ensure it performs flawlessly under pressure?
- [x] **Coding Standards:** Does your code adhere to the project's style guide,
      ensuring it's as elegant as a film score?
- [x] **Commit Messages:** Are your commit messages clear and concise, guiding
      the audience through the evolution of your code?
- [x] **Documentation:** If your changes impact the script, have you updated the
      documentation accordingly?
- [x] **Code Review:** Are you prepared to embrace feedback from the discerning
      eyes of the project maintainers and fellow contributors?
