### PR TITLE
feat: add summary page for people

### DIFF
--- a/projects/api/src/contracts/people/_internal/response/peopleSummaryResponseSchema.ts
+++ b/projects/api/src/contracts/people/_internal/response/peopleSummaryResponseSchema.ts
@@ -1,0 +1,60 @@
+import { z } from '../../../_internal/z.ts';
+
+export const peopleSummaryResponseSchema = z.object({
+  name: z.string(),
+  ids: z.object({
+    slug: z.string(),
+    trakt: z.number(),
+    tvdb: z.number().optional(),
+    imdb: z.string().optional(),
+    tmdb: z.number().optional(),
+  }),
+  /***
+   * Available if requesting extended `full`.
+   */
+  social_ids: z.object({
+    twitter: z.string().nullable(),
+    facebook: z.string().nullable(),
+    instagram: z.string().nullable(),
+    wikipedia: z.string().nullable(),
+  }).optional(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  biography: z.string().optional(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  birthday: z.string().optional(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  death: z.string().nullable().optional(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  birthplace: z.string().optional(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  homepage: z.string().nullable().optional(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  gender: z.enum(['male', 'female', 'non_binary']).nullable().optional(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  known_for_department: z.string().optional(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  updated_at: z.string().optional(),
+  /***
+   * Available if requesting extended `cloud9`.
+   */
+  images: z.object({
+    headshot: z.array(z.string()),
+    fanart: z.array(z.string()),
+  }).optional(),
+});

--- a/projects/api/src/contracts/people/index.ts
+++ b/projects/api/src/contracts/people/index.ts
@@ -1,0 +1,23 @@
+import { builder } from '../_internal/builder.ts';
+import { extendedQuerySchemaFactory } from '../_internal/request/extendedQuerySchemaFactory.ts';
+import { idParamsSchema } from '../_internal/request/idParamsSchema.ts';
+import type { z } from '../_internal/z.ts';
+import { peopleSummaryResponseSchema } from './_internal/response/peopleSummaryResponseSchema.ts';
+
+export const people = builder.router({
+  summary: {
+    path: '/:id',
+    pathParams: idParamsSchema,
+    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    method: 'GET',
+    responses: {
+      200: peopleSummaryResponseSchema,
+    },
+  },
+}, {
+  pathPrefix: '/people',
+});
+
+export type PeopleSummaryResponse = z.infer<
+  typeof peopleSummaryResponseSchema
+>;

--- a/projects/api/src/contracts/traktContract.ts
+++ b/projects/api/src/contracts/traktContract.ts
@@ -3,6 +3,7 @@ import { calendars } from './calendars/index.ts';
 import { checkin } from './checkin/index.ts';
 import { movies } from './movies/index.ts';
 import { oauth } from './oauth/index.ts';
+import { people } from './people/index.ts';
 import { recommendations } from './recommendations/index.ts';
 import { search } from './search/index.ts';
 import { shows } from './shows/index.ts';
@@ -20,4 +21,5 @@ export const traktContract = builder
     movies,
     shows,
     search,
+    people,
   });

--- a/projects/api/src/index.ts
+++ b/projects/api/src/index.ts
@@ -5,6 +5,7 @@ import { Environment } from './Environment.ts';
 export type * from './contracts/calendars/index.ts';
 export type * from './contracts/movies/index.ts';
 export type * from './contracts/oauth/index.ts';
+export type * from './contracts/people/index.ts';
 export type * from './contracts/recommendations/index.ts';
 export type * from './contracts/search/index.ts';
 export type * from './contracts/shows/index.ts';

--- a/projects/client/src/lib/requests/models/PersonSummary.ts
+++ b/projects/client/src/lib/requests/models/PersonSummary.ts
@@ -1,0 +1,5 @@
+export type PersonSummary = {
+  name: string;
+  biography: string;
+  headShotUrl: HttpsUrl;
+};

--- a/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.spec.ts
@@ -1,0 +1,20 @@
+import { ShowSiloPersonMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloPersonMappedMock.js';
+import { ShowSiloPersonResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloPersonResponseMock.js';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { createQuery } from '@tanstack/svelte-query';
+import { describe, expect, it } from 'vitest';
+import { peopleSummaryQuery } from './peopleSummaryQuery.js';
+
+describe('peopleSummaryQuery', () => {
+  it('should query for Silo (2023)', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          peopleSummaryQuery({ slug: ShowSiloPersonResponseMock.ids.slug }),
+        ),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(ShowSiloPersonMappedMock);
+  });
+});

--- a/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
@@ -1,0 +1,57 @@
+import type { PersonSummary } from '$lib/requests/models/PersonSummary.ts';
+import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/constants.ts';
+import { findDefined } from '$lib/utils/string/findDefined.ts';
+import { prependHttps } from '$lib/utils/url/prependHttps.ts';
+import type { PeopleSummaryResponse } from '@trakt/api';
+import { api, type ApiParams } from '../../_internal/api.ts';
+
+type PersonSummaryParams = { slug: string } & ApiParams;
+
+function mapPeopleResponseToPersonSummary(
+  peopleSummaryResponse: PeopleSummaryResponse,
+): PersonSummary {
+  const headshotCandidate = findDefined(
+    peopleSummaryResponse.images?.headshot?.at(1),
+    peopleSummaryResponse.images?.headshot?.at(0),
+  );
+
+  return {
+    name: peopleSummaryResponse.name,
+    biography: peopleSummaryResponse.biography ?? '',
+    headShotUrl: prependHttps(
+      headshotCandidate,
+      MEDIA_POSTER_PLACEHOLDER,
+    ),
+  };
+}
+
+function peopleSummaryRequest(
+  { fetch, slug }: PersonSummaryParams,
+): Promise<PersonSummary> {
+  return api({ fetch })
+    .people
+    .summary({
+      params: {
+        id: slug,
+      },
+      query: {
+        extended: 'full,cloud9',
+      },
+    })
+    .then(({ status, body }) => {
+      if (status !== 200) {
+        throw new Error('Failed to fetch person summary');
+      }
+
+      return mapPeopleResponseToPersonSummary(body);
+    });
+}
+
+export const peopleSummaryQueryKey = (id: string) =>
+  ['peopleSummary', id] as const;
+export const peopleSummaryQuery = (
+  params: PersonSummaryParams,
+) => ({
+  queryKey: peopleSummaryQueryKey(params.slug),
+  queryFn: () => peopleSummaryRequest(params),
+});

--- a/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import CardCover from "$lib/components/card/CardCover.svelte";
+  import Link from "$lib/components/link/Link.svelte";
   import PersonCard from "$lib/components/people/card/PersonCard.svelte";
   import * as m from "$lib/features/i18n/messages";
   import type { CastMember } from "$lib/requests/models/MediaCrew";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
   type CastMemberItemProps = {
     castMember: CastMember;
@@ -11,19 +13,21 @@
   const { castMember }: CastMemberItemProps = $props();
 </script>
 
-<div class="trakt-cast-member">
-  <PersonCard>
-    <CardCover
-      src={castMember.headShotUrl}
-      alt={`${m.person_headshot({ person: castMember.name })}`}
-      style="flat"
-    ></CardCover>
-  </PersonCard>
-  <div>
-    <p class="secondary ellipsis actor-name">{castMember.name}</p>
-    <p class="small secondary ellipsis">{castMember.characterName}</p>
+<Link focusable={false} href={UrlBuilder.people(castMember.id)}>
+  <div class="trakt-cast-member">
+    <PersonCard>
+      <CardCover
+        src={castMember.headShotUrl}
+        alt={`${m.person_headshot({ person: castMember.name })}`}
+        style="flat"
+      ></CardCover>
+    </PersonCard>
+    <div>
+      <p class="secondary ellipsis actor-name">{castMember.name}</p>
+      <p class="small secondary ellipsis">{castMember.characterName}</p>
+    </div>
   </div>
-</div>
+</Link>
 
 <style>
   .trakt-cast-member {

--- a/projects/client/src/lib/sections/summary/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/PeopleSummary.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import type { PersonSummary } from "$lib/requests/models/PersonSummary";
+  import ActorSummary from "./components/ActorSummary.svelte";
+
+  const {
+    person,
+  }: {
+    person: PersonSummary;
+  } = $props();
+</script>
+
+<ActorSummary {person} />

--- a/projects/client/src/lib/sections/summary/components/ActorSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/ActorSummary.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
+  import type { PersonSummary } from "$lib/requests/models/PersonSummary";
+  import MediaOverview from "./MediaOverview.svelte";
+  import MediaSummaryContainer from "./MediaSummaryContainer.svelte";
+  import MediaSummaryHeader from "./MediaSummaryHeader.svelte";
+  import MediaTitle from "./MediaTitle.svelte";
+
+  const {
+    person,
+  }: {
+    person: PersonSummary;
+  } = $props();
+</script>
+
+<MediaSummaryContainer>
+  {#snippet poster()}
+    <SummaryPoster src={person.headShotUrl} alt={person.name} />
+  {/snippet}
+
+  <MediaSummaryHeader title={person.name}>
+    <MediaTitle title={person.name} />
+  </MediaSummaryHeader>
+
+  <MediaOverview title={person.name} overview={person.biography} />
+</MediaSummaryContainer>

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -14,6 +14,7 @@ export const UrlBuilder = {
   show: (id: string) => `/shows/${id}`,
   movies: () => '/movies',
   movie: (id: string) => `/movies/${id}`,
+  people: (id: string) => `/people/${id}`,
   episode: (id: string, season: number, episode: number) =>
     `/shows/${id}/seasons/${season}/episodes/${episode}`,
   profile: {

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloPersonMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloPersonMappedMock.ts
@@ -1,0 +1,9 @@
+import type { PersonSummary } from '$lib/requests/models/PersonSummary';
+
+export const ShowSiloPersonMappedMock: PersonSummary = {
+  biography:
+    'Rebecca Louisa Ferguson Sundström (born October 19, 1983) is a Swedish actress. She began her acting career with the Swedish soap opera Nya tider (1999–2000) and went on to star in the slasher film Drowning Ghost (2004). She came to international prominence with her portrayal of Elizabeth Woodville in the British television miniseries The White Queen (2013), for which she was nominated for a Golden Globe for Best Actress in a Miniseries or Television Film. In 2023, she starred in the Apple TV+ science fiction drama series Silo.\n\nFerguson starred as MI6 agent Ilsa Faust in the action spy film Mission: Impossible – Rogue Nation (2015) and its sequels Mission: Impossible – Fallout (2018) and Mission: Impossible – Dead Reckoning Part One (2023). She also played Jenny Lind in the musical film The Greatest Showman (2017) and acted in science fiction horror film Life (2017), starred in the horror film Doctor Sleep (2019), and had supporting parts in the comedy-drama Florence Foster Jenkins (2016), the mystery thriller The Girl on the Train (2016), and the science fiction film Men in Black: International (2019). She portrayed Lady Jessica in the sci-fi epic Dune (2021) and reprised her role in its sequel Dune: Part Two (2024).',
+  headShotUrl:
+    'https://walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
+  name: 'Rebecca Ferguson',
+};

--- a/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloPersonResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloPersonResponseMock.ts
@@ -1,0 +1,36 @@
+import type { PeopleSummaryResponse } from '@trakt/api';
+
+export const ShowSiloPersonResponseMock: PeopleSummaryResponse = {
+  'name': 'Rebecca Ferguson',
+  'ids': {
+    'trakt': 447271,
+    'slug': 'rebecca-ferguson',
+    'imdb': 'nm0272581',
+    'tmdb': 933238,
+  },
+  'images': {
+    'headshot': [
+      'image.tmdb.org/t/p/original/6NRlV9oUipeak7r00V6k73Jb7we.jpg',
+      'walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
+    ],
+    'fanart': [
+      'image.tmdb.org/t/p/w1280/krrZTVEqrYwu6vR3f4NWgdSZg8X.jpg',
+      'walter-r2.trakt.tv/images/people/000/447/271/fanarts/medium/0b95a133bb.jpg.webp',
+    ],
+  },
+  'social_ids': {
+    'twitter': null,
+    'facebook': null,
+    'instagram': 'rebecca_ferguson',
+    'wikipedia': null,
+  },
+  'biography':
+    'Rebecca Louisa Ferguson Sundström (born October 19, 1983) is a Swedish actress. She began her acting career with the Swedish soap opera Nya tider (1999–2000) and went on to star in the slasher film Drowning Ghost (2004). She came to international prominence with her portrayal of Elizabeth Woodville in the British television miniseries The White Queen (2013), for which she was nominated for a Golden Globe for Best Actress in a Miniseries or Television Film. In 2023, she starred in the Apple TV+ science fiction drama series Silo.\n\nFerguson starred as MI6 agent Ilsa Faust in the action spy film Mission: Impossible – Rogue Nation (2015) and its sequels Mission: Impossible – Fallout (2018) and Mission: Impossible – Dead Reckoning Part One (2023). She also played Jenny Lind in the musical film The Greatest Showman (2017) and acted in science fiction horror film Life (2017), starred in the horror film Doctor Sleep (2019), and had supporting parts in the comedy-drama Florence Foster Jenkins (2016), the mystery thriller The Girl on the Train (2016), and the science fiction film Men in Black: International (2019). She portrayed Lady Jessica in the sci-fi epic Dune (2021) and reprised her role in its sequel Dune: Part Two (2024).',
+  'birthday': '1983-10-19',
+  'death': null,
+  'birthplace': 'Stockholm, Sweden',
+  'homepage': null,
+  'known_for_department': 'acting',
+  'gender': 'female',
+  'updated_at': '2025-01-13T16:57:08.000Z',
+};

--- a/projects/client/src/mocks/handlers.ts
+++ b/projects/client/src/mocks/handlers.ts
@@ -10,6 +10,7 @@ import { MovieHereticStatsResponseMock } from './data/summary/movies/heretic/res
 import { MovieStudiosResponseMock } from './data/summary/movies/heretic/response/MovieStudiosResponseMock.ts';
 import { ShowSiloLanguageResponseMock } from './data/summary/shows/silo/response/ShowSiloLanguageResponseMock.ts';
 import { ShowSiloPeopleResponseMock } from './data/summary/shows/silo/response/ShowSiloPeopleResponseMock.ts';
+import { ShowSiloPersonResponseMock } from './data/summary/shows/silo/response/ShowSiloPersonResponseMock.ts';
 import { ShowSiloProgressResponseMock } from './data/summary/shows/silo/response/ShowSiloProgressResponseMock.ts';
 import { ShowSiloRatingsResponseMock } from './data/summary/shows/silo/response/ShowSiloRatingsResponseMock.ts';
 import { ShowSiloResponseMock } from './data/summary/shows/silo/response/ShowSiloResponseMock.ts';
@@ -179,6 +180,15 @@ const sync = [
   ),
 ];
 
+const people = [
+  http.get(
+    `http://localhost/people/${ShowSiloPersonResponseMock.ids.slug}`,
+    () => {
+      return HttpResponse.json(ShowSiloPersonResponseMock);
+    },
+  ),
+];
+
 const auth = [
   http.post(`${TRAKT_TARGET_ENVIRONMENT}/oauth/token`, () => {
     return HttpResponse.json(AuthResponseMock);
@@ -191,4 +201,5 @@ export const handlers = [
   ...shows,
   ...sync,
   ...auth,
+  ...people,
 ];

--- a/projects/client/src/routes/people/[slug]/+page.svelte
+++ b/projects/client/src/routes/people/[slug]/+page.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import TraktPage from "$lib/components/layout/TraktPage.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import PeopleSummary from "$lib/sections/summary/PeopleSummary.svelte";
+  import { usePerson } from "./usePerson";
+
+  const { person, isLoading } = $derived(usePerson(page.params.slug));
+</script>
+
+<TraktPage audience="all" title={$person?.name} image={$person?.headShotUrl}>
+  {#if !$isLoading}
+    <PeopleSummary person={$person!} />
+  {:else}
+    <!-- TODO: remove this when we have empty state, currently prevents content jumps -->
+    <RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>
+      <div style="height: 100dvh; display:flex"></div>
+    </RenderFor>
+  {/if}
+</TraktPage>

--- a/projects/client/src/routes/people/[slug]/+page.ts
+++ b/projects/client/src/routes/people/[slug]/+page.ts
@@ -1,0 +1,16 @@
+import { peopleSummaryQuery } from '$lib/requests/queries/people/peopleSummaryQuery';
+import { assertDefined } from '$lib/utils/assert/assertDefined';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ parent, params, fetch }) => {
+  const { queryClient, isBot } = await parent();
+
+  if (isBot) {
+    await queryClient.prefetchQuery(
+      peopleSummaryQuery({
+        slug: assertDefined(params.slug, 'Slug is required'),
+        fetch,
+      }),
+    );
+  }
+};

--- a/projects/client/src/routes/people/[slug]/usePerson.ts
+++ b/projects/client/src/routes/people/[slug]/usePerson.ts
@@ -1,0 +1,18 @@
+import { peopleSummaryQuery } from '$lib/requests/queries/people/peopleSummaryQuery';
+import { time } from '$lib/utils/timing/time.ts';
+import { createQuery } from '@tanstack/svelte-query';
+import { derived } from 'svelte/store';
+
+export function usePerson(slug: string) {
+  const person = createQuery({
+    ...peopleSummaryQuery({
+      slug,
+    }),
+    staleTime: time.days(1),
+  });
+
+  return {
+    isLoading: derived(person, ($person) => $person.isPending),
+    person: derived(person, ($person) => $person.data),
+  };
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds summary page for people.
- You can click on an actor on a show/movie summary page to get there.
- Will get follow-ups:
  - Default to a placeholder background image when there is none.
    - The background image of the item you came from is retained; e.g. if you click on an actor from the `Heretic` page, it will keep that background image.
  - Add a list with `known for`/`most popular` shows/movies that actor has been in.

## 👀 Example 👀

https://github.com/user-attachments/assets/083d0fd9-d5f3-4d35-88f2-a8f337df5a90

