### PR TITLE
fix: remove non-scopeable selectors

### DIFF
--- a/projects/client/src/lib/sections/lists/SeasonList.svelte
+++ b/projects/client/src/lib/sections/lists/SeasonList.svelte
@@ -92,11 +92,3 @@
     {/if}
   {/snippet}
 </ShadowList>
-
-<style>
-  :global(.shadow-list-container) {
-    :global(.trakt-dropdown-list-container[data-size="small"]) {
-      margin-right: var(--ni-neg-36);
-    }
-  }
-</style>

--- a/projects/client/src/lib/sections/summary/components/MediaOverview.svelte
+++ b/projects/client/src/lib/sections/summary/components/MediaOverview.svelte
@@ -11,15 +11,6 @@
   const { title, overview }: MediaOverviewProps = $props();
 </script>
 
-<ClampedText
-  classList="trakt-media-overview secondary"
-  label={m.expand_media_overview({ title })}
->
+<ClampedText classList="secondary" label={m.expand_media_overview({ title })}>
   {overview}
 </ClampedText>
-
-<style>
-  :global(.trakt-media-overview) {
-    line-height: 150%;
-  }
-</style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- I'll need to look into this a bit more as a follow up. We have more cases where we use global in the root of style tags. But not all of them have this issue 🤔

## 👀 Example 👀
Fixes these:
<img width="1254" alt="Screenshot 2025-01-14 at 22 34 38" src="https://github.com/user-attachments/assets/c8fe2305-1b3b-4b91-b2f0-f5e94a543483" />
