### PR TITLE
fix(requests): favor actor person headshot over character headshot

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapPeopleResponseToMediaCrew.ts
+++ b/projects/client/src/lib/requests/_internal/mapPeopleResponseToMediaCrew.ts
@@ -21,8 +21,8 @@ function toCastMember(
   castResponse: CastResponse,
 ): CastMember {
   const headshotCandidate = findDefined(
-    castResponse.images?.headshot?.at(1),
-    castResponse.images?.headshot?.at(0),
+    castResponse.person.images?.headshot?.at(1),
+    castResponse.person.images?.headshot?.at(0),
   );
 
   return ({


### PR DESCRIPTION
## 🎶 Notes 🎶

- For now always use the person headshot instead of the character one; the latter seems to have wrong headshots.

## 👀 Example 👀
Before:
![image](https://github.com/user-attachments/assets/c413ebb5-6321-43d5-bae8-85b0e234c76c)

After:
<img width="341" alt="Screenshot 2025-01-15 at 14 35 42" src="https://github.com/user-attachments/assets/6de11d9d-97bf-41bb-ade1-1625bf3bf8aa" />
