### PR TITLE
fix: return year for past dates

### DIFF
--- a/projects/client/src/lib/utils/formatting/date/toHumanETA.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanETA.spec.ts
@@ -48,4 +48,9 @@ describe('toHumanETA', () => {
     const targetDate = new Date('2023-01-03');
     expect(toHumanETA(today, targetDate, 'ro-ro')).toBe('poimâine');
   });
+
+  it('should return the year for past dates', () => {
+    const targetDate = new Date('2022-12-31');
+    expect(toHumanETA(today, targetDate, 'en')).toBe('2022');
+  });
 });

--- a/projects/client/src/lib/utils/formatting/date/toHumanETA.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanETA.ts
@@ -10,7 +10,13 @@ export function toHumanETA(
     (targetDate.getTime() - today.getTime()) / MS_PER_DAY,
   );
 
+  const isPastDate = days < 0;
   const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+  const year = targetDate.getFullYear().toString();
+
+  if (isPastDate) {
+    return year;
+  }
 
   if (days <= 6) {
     return rtf.format(days, 'day');
@@ -26,5 +32,5 @@ export function toHumanETA(
     return rtf.format(months, 'month');
   }
 
-  return targetDate.getFullYear().toString();
+  return year;
 }


### PR DESCRIPTION
## Temporal Precision: Accurate Handling of Past Dates in `toHumanETA`

This pull request refines the `toHumanETA` function, ensuring it accurately handles past dates by displaying the year instead of relative time.

### Changes to handle past dates

- The `toHumanETA` function now includes a check for past dates. If the provided date is in the past, the function returns the year of that date. This prevents displaying inaccurate relative time descriptions like "1 year ago" for dates far in the past.

### Updates to test cases

- A new test case has been added to verify that the function correctly returns the year for past dates, ensuring the accuracy and reliability of this new behavior.

(This change, like a meticulous historian correcting a timeline, ensures that the `toHumanETA` function accurately represents the passage of time, even for events that have long since faded into the annals of history. By displaying the year for past dates, we prevent temporal paradoxes and maintain the integrity of the Trakt Lite timeline.)