### PR TITLE
feat(episode): coalesce episodes for season releases and define chip

### DIFF
--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -252,5 +252,6 @@
   "trending_shows": "Trending Shows",
   "trending_movies": "Trending Movies",
   "view_all": "View All",
-  "go_to_page_number": "Go to page {number}"
+  "go_to_page_number": "Go to page {number}",
+  "full_season": "Full Season"
 }

--- a/projects/client/src/lib/components/episode/EpisodeIntl.ts
+++ b/projects/client/src/lib/components/episode/EpisodeIntl.ts
@@ -17,4 +17,5 @@ export type EpisodeIntl = {
   timestampText: (date: Date) => string;
   durationText: (duration: number) => string;
   remainingText: (remaining: number) => string;
+  fullSeasonText: () => string;
 };

--- a/projects/client/src/lib/components/episode/EpisodeIntlProvider.ts
+++ b/projects/client/src/lib/components/episode/EpisodeIntlProvider.ts
@@ -32,4 +32,5 @@ export const EpisodeIntlProvider: EpisodeIntl = {
   timestampText: (next) => toHumanDate(new Date(), next, getLocale()),
   durationText: (minutes) => toHumanDuration({ minutes }, languageTag()),
   remainingText: (count) => m.remaining_episodes({ count }),
+  fullSeasonText: () => m.full_season(),
 };

--- a/projects/client/src/lib/components/episode/card/EpisodeCover.svelte
+++ b/projects/client/src/lib/components/episode/card/EpisodeCover.svelte
@@ -40,10 +40,20 @@
       EpisodeFinaleType.Series,
     ].includes(type as EpisodeFinaleType),
   );
+
+  const isFullSeason = $derived(type === "full_season");
 </script>
 
 <CardCover {src} {alt} {isLoading}>
   {#snippet tags()}
+    {#if isFullSeason}
+      <EpisodeStatusTag
+        --color-background-status-tag={"var(--color-background-full-season-tag)"}
+        --color-text-status-tag={"var(--color-text-full-season-tag)"}
+      >
+        {i18n.fullSeasonText()}
+      </EpisodeStatusTag>
+    {/if}
     {#if isFinale}
       <EpisodeStatusTag
         --color-background-status-tag={"var(--color-background-finale-tag)"}

--- a/projects/client/src/lib/models/EpisodeType.ts
+++ b/projects/client/src/lib/models/EpisodeType.ts
@@ -18,8 +18,13 @@ export enum EpisodeStandardType {
   Standard = 'standard',
 }
 
+export enum EpisodeComputedType {
+  FullSeason = 'full_season',
+}
+
 export type EpisodeType =
   | EpisodeFinaleType
   | EpisodePremiereType
   | EpisodeUnknownType
-  | EpisodeStandardType;
+  | EpisodeStandardType
+  | EpisodeComputedType;

--- a/projects/client/src/lib/requests/_internal/coalesceEpisodes.spec.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceEpisodes.spec.ts
@@ -1,0 +1,210 @@
+import { EpisodeComputedType } from '$lib/models/EpisodeType';
+import { describe, expect, it } from 'vitest';
+import type { UpcomingEpisodeEntry } from '../queries/calendars/upcomingEpisodesQuery';
+import { coalesceEpisodes } from './coalesceEpisodes';
+
+describe('coalesceEpisodes', () => {
+  it('should coalesce season premiere and finale into full season', () => {
+    const show = { id: 1, title: 'Test Show' };
+    const episodes = [
+      {
+        show,
+        season: 1,
+        episode: 1,
+        type: 'season_premiere',
+        airDate: new Date('2024-01-01'),
+      } as unknown as UpcomingEpisodeEntry,
+      {
+        show,
+        season: 1,
+        episode: 10,
+        type: 'season_finale',
+        airDate: new Date('2024-03-01'),
+      } as unknown as UpcomingEpisodeEntry,
+    ];
+
+    const result = coalesceEpisodes(episodes);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      ...episodes[0],
+      type: EpisodeComputedType.FullSeason,
+      season: 1,
+      show,
+    });
+  });
+
+  it('should not coalesce regular episodes', () => {
+    const show = { id: 1, title: 'Test Show' };
+    const episodes = [
+      {
+        show,
+        season: 1,
+        episode: 1,
+        type: 'regular',
+        airDate: new Date('2024-01-01'),
+      } as unknown as UpcomingEpisodeEntry,
+
+      {
+        show,
+        season: 1,
+        episode: 2,
+        type: 'regular',
+        airDate: new Date('2024-01-08'),
+      } as unknown as UpcomingEpisodeEntry,
+    ];
+
+    const result = coalesceEpisodes(episodes);
+
+    expect(result).toEqual(episodes);
+  });
+
+  it('should sort episodes by air date', () => {
+    const show = { id: 1, title: 'Test Show' };
+    const episodes = [
+      {
+        show,
+        season: 1,
+        episode: 2,
+        type: 'regular',
+        airDate: new Date('2024-01-08'),
+      } as unknown as UpcomingEpisodeEntry,
+      {
+        show,
+        season: 1,
+        episode: 1,
+        type: 'regular',
+        airDate: new Date('2024-01-01'),
+      } as unknown as UpcomingEpisodeEntry,
+    ];
+
+    const result = coalesceEpisodes(episodes);
+
+    expect(result[0].airDate).toEqual(new Date('2024-01-01'));
+    expect(result[1].airDate).toEqual(new Date('2024-01-08'));
+  });
+
+  it('should not coalesce if there is no season finale', () => {
+    const show = { id: 1, title: 'Test Show' };
+    const episodes = [
+      {
+        show,
+        season: 1,
+        episode: 1,
+        type: 'season_premiere',
+        airDate: new Date('2024-01-01'),
+      } as unknown as UpcomingEpisodeEntry,
+      {
+        show,
+        season: 1,
+        episode: 2,
+        type: 'regular',
+        airDate: new Date('2024-03-01'),
+      } as unknown as UpcomingEpisodeEntry,
+    ];
+
+    const result = coalesceEpisodes(episodes);
+
+    expect(result).toEqual(episodes);
+  });
+
+  it('should not coalesce if there is no season premiere', () => {
+    const show = { id: 1, title: 'Test Show' };
+    const episodes = [
+      {
+        show,
+        season: 1,
+        episode: 9,
+        type: 'regular',
+        airDate: new Date('2024-01-01'),
+      } as unknown as UpcomingEpisodeEntry,
+      {
+        show,
+        season: 1,
+        episode: 10,
+        type: 'season_finale',
+        airDate: new Date('2024-03-01'),
+      } as unknown as UpcomingEpisodeEntry,
+    ];
+
+    const result = coalesceEpisodes(episodes);
+
+    expect(result).toEqual(episodes);
+  });
+
+  it('should not coalesce if one episode from multiple shows', () => {
+    const show1 = { id: 1, title: 'Test Show 1' };
+    const show2 = { id: 2, title: 'Test Show 2' };
+    const episodes = [
+      {
+        show: show1,
+        season: 1,
+        episode: 1,
+        type: 'season_premiere',
+        airDate: new Date('2024-01-01'),
+      } as unknown as UpcomingEpisodeEntry,
+      {
+        show: show2,
+        season: 1,
+        episode: 10,
+        type: 'season_finale',
+        airDate: new Date('2024-03-01'),
+      } as unknown as UpcomingEpisodeEntry,
+    ];
+
+    const result = coalesceEpisodes(episodes);
+
+    expect(result).toEqual(episodes);
+  });
+
+  it('should coalesce multiple shows if they fulfill the criteria', () => {
+    const show1 = { id: 1, title: 'Test Show 1' };
+    const show2 = { id: 2, title: 'Test Show 2' };
+    const episodes = [
+      {
+        show: show1,
+        season: 1,
+        episode: 1,
+        type: 'season_premiere',
+        airDate: new Date('2024-01-01'),
+      } as unknown as UpcomingEpisodeEntry,
+      {
+        show: show2,
+        season: 1,
+        episode: 1,
+        type: 'season_premiere',
+        airDate: new Date('2024-01-01'),
+      } as unknown as UpcomingEpisodeEntry,
+      {
+        show: show1,
+        season: 1,
+        episode: 10,
+        type: 'season_finale',
+        airDate: new Date('2024-03-01'),
+      } as unknown as UpcomingEpisodeEntry,
+      {
+        show: show2,
+        season: 1,
+        episode: 10,
+        type: 'season_finale',
+        airDate: new Date('2024-03-01'),
+      } as unknown as UpcomingEpisodeEntry,
+    ];
+
+    const result = coalesceEpisodes(episodes);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      ...episodes[0],
+      type: EpisodeComputedType.FullSeason,
+      season: 1,
+      show: show1,
+    });
+    expect(result[1]).toEqual({
+      ...episodes[1],
+      type: EpisodeComputedType.FullSeason,
+      season: 1,
+      show: show2,
+    });
+  });
+});

--- a/projects/client/src/lib/requests/_internal/coalesceEpisodes.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceEpisodes.ts
@@ -1,0 +1,47 @@
+import { EpisodeComputedType } from '$lib/models/EpisodeType.ts';
+import type { UpcomingEpisodeEntry } from '../queries/calendars/upcomingEpisodesQuery.ts';
+
+export function coalesceEpisodes(episodes: UpcomingEpisodeEntry[]) {
+  const grouped = episodes.reduce(
+    (acc, episode) => {
+      const key = `${episode.show.id}-${episode.season}`;
+      acc[key] ??= {
+        episodes: [],
+        show: episode.show,
+        season: episode.season,
+      };
+      acc[key].episodes.push(episode);
+      return acc;
+    },
+    {} as Record<
+      string,
+      {
+        episodes: typeof episodes;
+        show: typeof episodes[0]['show'];
+        season: number;
+      }
+    >,
+  );
+
+  const coalesced = Object.values(grouped).flatMap((
+    { episodes, show, season },
+  ) => {
+    const hasSeasonPremiere = episodes.some((ep) =>
+      ep.type === 'season_premiere'
+    );
+    const hasSeasonFinale = episodes.some((ep) => ep.type === 'season_finale');
+
+    if (hasSeasonPremiere && hasSeasonFinale) {
+      return [{
+        ...episodes[0],
+        type: EpisodeComputedType.FullSeason,
+        season,
+        show,
+      }];
+    }
+
+    return episodes;
+  });
+
+  return coalesced.sort((a, b) => a.airDate.getTime() - b.airDate.getTime());
+}

--- a/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
@@ -1,4 +1,5 @@
 import type { EpisodeEntry } from '$lib/models/EpisodeEntry.ts';
+import { coalesceEpisodes } from '$lib/requests/_internal/coalesceEpisodes.ts';
 import { mapEpisodeResponseToEpisodeEntry } from '$lib/requests/_internal/mapEpisodeResponseToEpisodeEntry.ts';
 import { mapShowResponseToShowSummary } from '$lib/requests/_internal/mapShowResponseToShowSummary.ts';
 import type { ShowSummary } from '$lib/requests/models/ShowSummary.ts';
@@ -35,11 +36,13 @@ function upcomingEpisodesRequest({
         throw new Error('Failed to fetch calendar');
       }
 
-      return body
+      const episodes = body
         .map((item) => ({
           show: mapShowResponseToShowSummary(item.show),
           ...mapEpisodeResponseToEpisodeEntry(item.episode),
         }));
+
+      return coalesceEpisodes(episodes);
     });
 }
 

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -39,6 +39,9 @@
   --color-text-finale-tag: var(--shade-10);
   --color-background-finale-tag: var(--red-700);
 
+  --color-text-full-season-tag: var(--shade-10);
+  --color-background-full-season-tag: var(--purple-500);
+
   --color-text-info-tag: var(--shade-10);
   --color-background-info-tag: var(--purple-400);
 

--- a/projects/client/src/style/theme/modes.css
+++ b/projects/client/src/style/theme/modes.css
@@ -31,12 +31,6 @@
 
   --color-card-background: var(--shade-920);
 
-  --color-text-premiere-tag: var(--shade-10);
-  --color-background-premiere-tag: var(--green-700);
-
-  --color-text-finale-tag: var(--shade-10);
-  --color-background-finale-tag: var(--red-700);
-
   --color-surface-button-disabled: var(--shade-800);
   --color-foreground-button-disabled: var(--shade-400);
 


### PR DESCRIPTION
## Full Season Feature and Episode Handling Enhancements

This pull request introduces a new "Full Season" feature to improve the handling and display of episodes that encompass an entire season.

### New Episode Type and Handling

- Added a new `EpisodeComputedType` enum with `FullSeason` as a value to represent episodes that cover a full season.
- Updated the `EpisodeType` type to include the new `FullSeason` enum value.

### Updates to Episode Components

- Added a new method `fullSeasonText` to the `EpisodeIntl` type and implemented it in the `EpisodeIntlProvider` to provide localized text for "Full Season".
- Modified the `EpisodeCover` component to display a "Full Season" status tag when applicable.

### Coalescing Episodes

- Created a new function `coalesceEpisodes` to combine season premiere and finale episodes into a single "Full Season" episode, simplifying the display and handling of such episodes.
- Added comprehensive tests for the `coalesceEpisodes` function to ensure it correctly handles various scenarios and edge cases.

### Additional Changes

- Integrated the `coalesceEpisodes` function into the `upcomingEpisodesRequest` function to process episodes before returning them, ensuring consistent handling of "Full Season" episodes.
- Added new CSS variables for the "Full Season" status tag colors, maintaining visual consistency with other UI elements.

(This pull request, like a meticulous archivist organizing a vast collection, introduces a new category for "Full Season" episodes, ensuring they are handled and displayed correctly throughout the application. The refactored components, updated types, and new utility functions contribute to a more streamlined and informative user experience.)

![image](https://github.com/user-attachments/assets/1fbcf594-3ad4-424e-8d41-30a6fd559492)
