### PR TITLE
fix: breaking order of images

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapCover.ts
+++ b/projects/client/src/lib/requests/_internal/mapCover.ts
@@ -12,10 +12,7 @@ import { thumbUrl } from './thumbUrl';
 export function mapCover(
   images: ShowResponse['images'] | MovieResponse['images'],
 ): MediaSummary['cover'] {
-  const coverCandidate = findDefined(
-    images?.fanart.at(1),
-    images?.fanart.at(0),
-  );
+  const coverCandidate = findDefined(...(images?.fanart ?? []));
 
   return {
     url: {

--- a/projects/client/src/lib/requests/_internal/mapEpisodeResponseToEpisodeEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapEpisodeResponseToEpisodeEntry.ts
@@ -15,10 +15,7 @@ type EpisodeResponse =
 export function mapEpisodeResponseToEpisodeEntry(
   episode: EpisodeResponse,
 ): EpisodeEntry {
-  const posterCandidate = findDefined(
-    episode.images?.screenshot.at(1),
-    episode.images?.screenshot.at(0),
-  );
+  const posterCandidate = findDefined(...(episode.images?.screenshot ?? []));
 
   const airDate = new Date(episode.first_aired);
 

--- a/projects/client/src/lib/requests/_internal/mapPeopleResponseToMediaCrew.ts
+++ b/projects/client/src/lib/requests/_internal/mapPeopleResponseToMediaCrew.ts
@@ -21,8 +21,7 @@ function toCastMember(
   castResponse: CastResponse,
 ): CastMember {
   const headshotCandidate = findDefined(
-    castResponse.person.images?.headshot?.at(1),
-    castResponse.person.images?.headshot?.at(0),
+    ...(castResponse.person.images?.headshot ?? []),
   );
 
   return ({

--- a/projects/client/src/lib/requests/_internal/mapPoster.ts
+++ b/projects/client/src/lib/requests/_internal/mapPoster.ts
@@ -10,8 +10,7 @@ export function mapPoster(
   images: ShowResponse['images'] | MovieResponse['images'],
 ): MediaSummary['poster'] {
   const posterCandidate = findDefined(
-    images?.poster.at(1),
-    images?.poster.at(0),
+    ...(images?.poster ?? []),
   );
 
   return {

--- a/projects/client/src/lib/requests/_internal/mapShowResponseToShowSummary.ts
+++ b/projects/client/src/lib/requests/_internal/mapShowResponseToShowSummary.ts
@@ -13,8 +13,7 @@ export function mapShowResponseToShowSummary(
   const cover = mapCover(show.images);
 
   const thumbCandidate = findDefined(
-    show.images?.thumb.at(1),
-    show.images?.thumb.at(0),
+    ...(show.images?.thumb ?? []),
   );
 
   return {

--- a/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
@@ -11,8 +11,7 @@ function mapPeopleResponseToPersonSummary(
   peopleSummaryResponse: PeopleSummaryResponse,
 ): PersonSummary {
   const headshotCandidate = findDefined(
-    peopleSummaryResponse.images?.headshot?.at(1),
-    peopleSummaryResponse.images?.headshot?.at(0),
+    ...(peopleSummaryResponse.images?.headshot ?? []),
   );
 
   return {

--- a/projects/client/src/lib/requests/queries/search/searchQuery.ts
+++ b/projects/client/src/lib/requests/queries/search/searchQuery.ts
@@ -1,7 +1,6 @@
 import type { Genre, SearchResultResponse } from '$lib/api.ts';
 import type { MediaType } from '$lib/models/MediaType.ts';
-import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/constants.ts';
-import { prependHttps } from '$lib/utils/url/prependHttps.ts';
+import { mapPoster } from '$lib/requests/_internal/mapPoster.ts';
 import { api, type ApiParams } from '../../_internal/api.ts';
 
 export type SearchParams = {
@@ -17,7 +16,7 @@ export type SearchResult = {
   genres: Genre[];
   runtime: number | Nil;
   poster: {
-    url: string;
+    url: HttpsUrl;
   };
 };
 
@@ -46,11 +45,7 @@ function mapToSearchResultEntry(
     genres: media.genres ?? [],
     runtime: media.runtime,
     poster: {
-      url: prependHttps(
-        media.images?.poster.at(1) ??
-          media.images?.poster.at(0),
-        MEDIA_POSTER_PLACEHOLDER,
-      ),
+      url: mapPoster(media.images).url.thumb,
     },
   };
 }

--- a/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
@@ -5,6 +5,7 @@ import {
   EpisodeUnknownType,
 } from '$lib/models/EpisodeType.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import { api, type ApiParams } from '../../_internal/api.ts';
 
@@ -15,8 +16,7 @@ export function mapResponseToShowProgress(
 ): EpisodeProgressEntry {
   const episode = item.next_episode;
 
-  const posterCandidate = episode.images?.screenshot.at(1) ??
-    episode.images?.screenshot.at(0);
+  const posterCandidate = findDefined(...(episode.images?.screenshot ?? []));
 
   return {
     id: episode.ids.trakt,

--- a/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticPeopleResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticPeopleResponseMock.ts
@@ -17,19 +17,19 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/lzCB9YN6MjGosh8v27o6omhSmjL.jpg',
             'walter-r2.trakt.tv/images/people/000/004/705/headshots/thumb/55cd537cc1.jpg.webp',
+            'image.tmdb.org/t/p/original/lzCB9YN6MjGosh8v27o6omhSmjL.jpg',
           ],
           'fanart': [
-            'image.tmdb.org/t/p/w1280/dF4EwB8oyrgKQnjOwUWGbF3yNTH.jpg',
             'walter-r2.trakt.tv/images/people/000/004/705/fanarts/medium/75cc921525.jpg.webp',
+            'image.tmdb.org/t/p/w1280/dF4EwB8oyrgKQnjOwUWGbF3yNTH.jpg',
           ],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/lzCB9YN6MjGosh8v27o6omhSmjL.jpg',
           'walter-r2.trakt.tv/images/people/000/004/705/headshots/thumb/55cd537cc1.jpg.webp',
+          'image.tmdb.org/t/p/original/lzCB9YN6MjGosh8v27o6omhSmjL.jpg',
         ],
       },
     },
@@ -48,16 +48,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/3a8jTH1q4p9G4QHlLynFnNBbv57.jpg',
             'walter-r2.trakt.tv/images/people/001/075/624/headshots/thumb/f25b061dd4.jpg.webp',
+            'image.tmdb.org/t/p/original/3a8jTH1q4p9G4QHlLynFnNBbv57.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/3a8jTH1q4p9G4QHlLynFnNBbv57.jpg',
           'walter-r2.trakt.tv/images/people/001/075/624/headshots/thumb/f25b061dd4.jpg.webp',
+          'image.tmdb.org/t/p/original/3a8jTH1q4p9G4QHlLynFnNBbv57.jpg',
         ],
       },
     },
@@ -76,16 +76,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/7yFO6DB8O7FmkJpi2mBRJZApbiQ.jpg',
             'walter-r2.trakt.tv/images/people/000/597/826/headshots/thumb/aa952fefe6.jpg.webp',
+            'image.tmdb.org/t/p/original/7yFO6DB8O7FmkJpi2mBRJZApbiQ.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/7yFO6DB8O7FmkJpi2mBRJZApbiQ.jpg',
           'walter-r2.trakt.tv/images/people/000/597/826/headshots/thumb/aa952fefe6.jpg.webp',
+          'image.tmdb.org/t/p/original/7yFO6DB8O7FmkJpi2mBRJZApbiQ.jpg',
         ],
       },
     },
@@ -104,19 +104,19 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/tgF5PeH4xwz32FjB80n5aFiuHX.jpg',
             'walter-r2.trakt.tv/images/people/000/413/327/headshots/thumb/2a4168772c.jpg.webp',
+            'image.tmdb.org/t/p/original/tgF5PeH4xwz32FjB80n5aFiuHX.jpg',
           ],
           'fanart': [
-            'image.tmdb.org/t/p/w1280/qFaDcKhndF2YsfOL1ywinoRfSAb.jpg',
             'walter-r2.trakt.tv/images/people/000/413/327/fanarts/medium/01a9a86c38.jpg.webp',
+            'image.tmdb.org/t/p/w1280/qFaDcKhndF2YsfOL1ywinoRfSAb.jpg',
           ],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/tgF5PeH4xwz32FjB80n5aFiuHX.jpg',
           'walter-r2.trakt.tv/images/people/000/413/327/headshots/thumb/2a4168772c.jpg.webp',
+          'image.tmdb.org/t/p/original/tgF5PeH4xwz32FjB80n5aFiuHX.jpg',
         ],
       },
     },
@@ -135,16 +135,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/rEcGyAm06RMBgR8T7xPOjZNMElO.jpg',
             'walter-r2.trakt.tv/images/people/001/119/654/headshots/thumb/bf246a5e3a.jpg.webp',
+            'image.tmdb.org/t/p/original/rEcGyAm06RMBgR8T7xPOjZNMElO.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/rEcGyAm06RMBgR8T7xPOjZNMElO.jpg',
           'walter-r2.trakt.tv/images/people/001/119/654/headshots/thumb/bf246a5e3a.jpg.webp',
+          'image.tmdb.org/t/p/original/rEcGyAm06RMBgR8T7xPOjZNMElO.jpg',
         ],
       },
     },
@@ -163,16 +163,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/47bJBypW6YVBeQuTaaQQuusGRMm.jpg',
             'walter-r2.trakt.tv/images/people/000/918/391/headshots/thumb/9c6d5de83f.jpg.webp',
+            'image.tmdb.org/t/p/original/47bJBypW6YVBeQuTaaQQuusGRMm.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/47bJBypW6YVBeQuTaaQQuusGRMm.jpg',
           'walter-r2.trakt.tv/images/people/000/918/391/headshots/thumb/9c6d5de83f.jpg.webp',
+          'image.tmdb.org/t/p/original/47bJBypW6YVBeQuTaaQQuusGRMm.jpg',
         ],
       },
     },
@@ -191,16 +191,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/zrIAFLGWhpvCsKk5oQDUNgmQQcH.jpg',
             'walter-r2.trakt.tv/images/people/004/119/501/headshots/thumb/3b3d999544.jpg.webp',
+            'image.tmdb.org/t/p/original/zrIAFLGWhpvCsKk5oQDUNgmQQcH.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/zrIAFLGWhpvCsKk5oQDUNgmQQcH.jpg',
           'walter-r2.trakt.tv/images/people/004/119/501/headshots/thumb/3b3d999544.jpg.webp',
+          'image.tmdb.org/t/p/original/zrIAFLGWhpvCsKk5oQDUNgmQQcH.jpg',
         ],
       },
     },
@@ -219,16 +219,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/qBrsyaF4EM6cdBQfU7XnyFmx7Ym.jpg',
             'walter-r2.trakt.tv/images/people/000/776/688/headshots/thumb/d629e49aab.jpg.webp',
+            'image.tmdb.org/t/p/original/qBrsyaF4EM6cdBQfU7XnyFmx7Ym.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/qBrsyaF4EM6cdBQfU7XnyFmx7Ym.jpg',
           'walter-r2.trakt.tv/images/people/000/776/688/headshots/thumb/d629e49aab.jpg.webp',
+          'image.tmdb.org/t/p/original/qBrsyaF4EM6cdBQfU7XnyFmx7Ym.jpg',
         ],
       },
     },
@@ -269,16 +269,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/kMuEZEvppyRzsNV8uxpqfmOXdMY.jpg',
             'walter-r2.trakt.tv/images/people/000/310/402/headshots/thumb/b786a1fb1e.jpg.webp',
+            'image.tmdb.org/t/p/original/kMuEZEvppyRzsNV8uxpqfmOXdMY.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/kMuEZEvppyRzsNV8uxpqfmOXdMY.jpg',
           'walter-r2.trakt.tv/images/people/000/310/402/headshots/thumb/b786a1fb1e.jpg.webp',
+          'image.tmdb.org/t/p/original/kMuEZEvppyRzsNV8uxpqfmOXdMY.jpg',
         ],
       },
     },
@@ -297,16 +297,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/369PZgmVmiMMzlqfrxrjg1zb0xl.jpg',
             'walter-r2.trakt.tv/images/people/002/195/383/headshots/thumb/dde9f0dc4e.jpg.webp',
+            'image.tmdb.org/t/p/original/369PZgmVmiMMzlqfrxrjg1zb0xl.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/369PZgmVmiMMzlqfrxrjg1zb0xl.jpg',
           'walter-r2.trakt.tv/images/people/002/195/383/headshots/thumb/dde9f0dc4e.jpg.webp',
+          'image.tmdb.org/t/p/original/369PZgmVmiMMzlqfrxrjg1zb0xl.jpg',
         ],
       },
     },
@@ -325,16 +325,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/5hzt5EAtXZfZatJCFctVpLyOJ3A.jpg',
             'walter-r2.trakt.tv/images/people/000/996/294/headshots/thumb/bbb7d1275b.jpg.webp',
+            'image.tmdb.org/t/p/original/5hzt5EAtXZfZatJCFctVpLyOJ3A.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/5hzt5EAtXZfZatJCFctVpLyOJ3A.jpg',
           'walter-r2.trakt.tv/images/people/000/996/294/headshots/thumb/bbb7d1275b.jpg.webp',
+          'image.tmdb.org/t/p/original/5hzt5EAtXZfZatJCFctVpLyOJ3A.jpg',
         ],
       },
     },
@@ -353,16 +353,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/bm9kCJzFiOfiA9Tv84eKocvgS97.jpg',
             'walter-r2.trakt.tv/images/people/003/058/237/headshots/thumb/bb81a3f466.jpg.webp',
+            'image.tmdb.org/t/p/original/bm9kCJzFiOfiA9Tv84eKocvgS97.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/bm9kCJzFiOfiA9Tv84eKocvgS97.jpg',
           'walter-r2.trakt.tv/images/people/003/058/237/headshots/thumb/bb81a3f466.jpg.webp',
+          'image.tmdb.org/t/p/original/bm9kCJzFiOfiA9Tv84eKocvgS97.jpg',
         ],
       },
     },
@@ -381,16 +381,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/linaIZJqleeWHjonIdDtISzVYrX.jpg',
             'walter-r2.trakt.tv/images/people/003/335/090/headshots/thumb/d12413a443.jpg.webp',
+            'image.tmdb.org/t/p/original/linaIZJqleeWHjonIdDtISzVYrX.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/linaIZJqleeWHjonIdDtISzVYrX.jpg',
           'walter-r2.trakt.tv/images/people/003/335/090/headshots/thumb/d12413a443.jpg.webp',
+          'image.tmdb.org/t/p/original/linaIZJqleeWHjonIdDtISzVYrX.jpg',
         ],
       },
     },
@@ -409,16 +409,16 @@ export const MovieHereticPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/dffZ1aJIUuuEuilmtvTkoGvm95j.jpg',
             'walter-r2.trakt.tv/images/people/000/197/574/headshots/thumb/80e3e863a0.jpg.webp',
+            'image.tmdb.org/t/p/original/dffZ1aJIUuuEuilmtvTkoGvm95j.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/dffZ1aJIUuuEuilmtvTkoGvm95j.jpg',
           'walter-r2.trakt.tv/images/people/000/197/574/headshots/thumb/80e3e863a0.jpg.webp',
+          'image.tmdb.org/t/p/original/dffZ1aJIUuuEuilmtvTkoGvm95j.jpg',
         ],
       },
     },

--- a/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticResponseMock.ts
@@ -65,21 +65,21 @@ export const MovieHereticResponseMock: MovieResponse = {
   'certification': 'R',
   'images': {
     'fanart': [
-      'image.tmdb.org/t/p/w1280/ag66gJCiZ06q1GSJuQlhGLi3Udx.jpg',
       'walter-r2.trakt.tv/images/movies/000/916/302/fanarts/medium/626327d7b4.jpg.webp',
+      'image.tmdb.org/t/p/w1280/ag66gJCiZ06q1GSJuQlhGLi3Udx.jpg',
     ],
     'poster': [
-      'image.tmdb.org/t/p/w342/ojQOGq9zMiW976jGE4etunK9Wuv.jpg',
       'walter-r2.trakt.tv/images/movies/000/916/302/posters/thumb/db9d66deb8.jpg.webp',
+      'image.tmdb.org/t/p/w342/ojQOGq9zMiW976jGE4etunK9Wuv.jpg',
     ],
     'logo': [
-      'assets.fanart.tv/fanart/movies/1138194/hdmovielogo/heretic-66a2560b44b86.png',
       'walter-r2.trakt.tv/images/movies/000/916/302/logos/medium/36726904e9.png.webp',
+      'assets.fanart.tv/fanart/movies/1138194/hdmovielogo/heretic-66a2560b44b86.png',
     ],
     'clearart': [],
     'banner': [
-      'assets.fanart.tv/fanart/movies/1138194/moviebanner/heretic-672505e5892dd.jpg',
       'walter-r2.trakt.tv/images/movies/000/916/302/banners/medium/cc91e5409f.jpg.webp',
+      'assets.fanart.tv/fanart/movies/1138194/moviebanner/heretic-672505e5892dd.jpg',
     ],
     'thumb': [],
   },

--- a/projects/client/src/mocks/data/summary/movies/matrix/MovieMatrixResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/matrix/MovieMatrixResponseMock.ts
@@ -84,20 +84,20 @@ export const MovieMatrixResponseMock: MovieResponse = {
       'walter-r2.trakt.tv/images/movies/000/000/481/posters/thumb/373310d2ee.jpg.webp',
     ],
     'logo': [
-      'assets.fanart.tv/fanart/movies/603/hdmovielogo/the-matrix-5190bfebe0bcf.png',
       'walter-r2.trakt.tv/images/movies/000/000/481/logos/medium/f5e05ed291.png.webp',
+      'assets.fanart.tv/fanart/movies/603/hdmovielogo/the-matrix-5190bfebe0bcf.png',
     ],
     'clearart': [
-      'assets.fanart.tv/fanart/movies/603/hdmovieclearart/the-matrix-5197b6d243b93.png',
       'walter-r2.trakt.tv/images/movies/000/000/481/cleararts/medium/a01dd6ff88.png.webp',
+      'assets.fanart.tv/fanart/movies/603/hdmovieclearart/the-matrix-5197b6d243b93.png',
     ],
     'banner': [
-      'assets.fanart.tv/fanart/movies/603/moviebanner/the-matrix-514dc837d1387.jpg',
       'walter-r2.trakt.tv/images/movies/000/000/481/banners/medium/035f31fce0.jpg.webp',
+      'assets.fanart.tv/fanart/movies/603/moviebanner/the-matrix-514dc837d1387.jpg',
     ],
     'thumb': [
-      'assets.fanart.tv/fanart/movies/603/moviethumb/the-matrix-58678e15757df.jpg',
       'walter-r2.trakt.tv/images/movies/000/000/481/thumbs/medium/f81f544f62.jpg.webp',
+      'assets.fanart.tv/fanart/movies/603/moviethumb/the-matrix-58678e15757df.jpg',
     ],
   },
 };

--- a/projects/client/src/mocks/data/summary/shows/devs/ShowDevsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/devs/ShowDevsResponseMock.ts
@@ -71,28 +71,28 @@ export const ShowDevsResponseMock: ShowResponse = {
   ],
   'images': {
     'fanart': [
-      'image.tmdb.org/t/p/w1280/5yf5yfogIxhHhDU7F2Nuk1BsTYQ.jpg',
       'walter-r2.trakt.tv/images/shows/000/147/971/fanarts/medium/e9507d40da.jpg.webp',
+      'image.tmdb.org/t/p/w1280/5yf5yfogIxhHhDU7F2Nuk1BsTYQ.jpg',
     ],
     'poster': [
-      'image.tmdb.org/t/p/w342/uv63iNWOh69bSJYJQZjiX6n8B3m.jpg',
       'walter-r2.trakt.tv/images/shows/000/147/971/posters/thumb/b5fe0d9957.jpg.webp',
+      'image.tmdb.org/t/p/w342/uv63iNWOh69bSJYJQZjiX6n8B3m.jpg',
     ],
     'logo': [
-      'assets.fanart.tv/fanart/tv/364149/hdtvlogo/devs-5e62a65787812.png',
       'walter-r2.trakt.tv/images/shows/000/147/971/logos/medium/409bb7e516.png.webp',
+      'assets.fanart.tv/fanart/tv/364149/hdtvlogo/devs-5e62a65787812.png',
     ],
     'clearart': [
-      'assets.fanart.tv/fanart/tv/364149/hdclearart/devs-5e68b13fc11e7.png',
       'walter-r2.trakt.tv/images/shows/000/147/971/cleararts/medium/097852fbfd.png.webp',
+      'assets.fanart.tv/fanart/tv/364149/hdclearart/devs-5e68b13fc11e7.png',
     ],
     'banner': [
-      'assets.fanart.tv/fanart/tv/364149/tvbanner/devs-5e68989a33757.jpg',
       'walter-r2.trakt.tv/images/shows/000/147/971/banners/medium/c26f0754cf.jpg.webp',
+      'assets.fanart.tv/fanart/tv/364149/tvbanner/devs-5e68989a33757.jpg',
     ],
     'thumb': [
-      'assets.fanart.tv/fanart/tv/364149/tvthumb/devs-5e68971a85fb4.jpg',
       'walter-r2.trakt.tv/images/shows/000/147/971/thumbs/medium/7d0e3d4bbc.jpg.webp',
+      'assets.fanart.tv/fanart/tv/364149/tvthumb/devs-5e68971a85fb4.jpg',
     ],
   },
 };

--- a/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloPeopleResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloPeopleResponseMock.ts
@@ -18,19 +18,19 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/6NRlV9oUipeak7r00V6k73Jb7we.jpg',
             'walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
+            'image.tmdb.org/t/p/original/6NRlV9oUipeak7r00V6k73Jb7we.jpg',
           ],
           'fanart': [
-            'image.tmdb.org/t/p/w1280/krrZTVEqrYwu6vR3f4NWgdSZg8X.jpg',
             'walter-r2.trakt.tv/images/people/000/447/271/fanarts/medium/0b95a133bb.jpg.webp',
+            'image.tmdb.org/t/p/w1280/krrZTVEqrYwu6vR3f4NWgdSZg8X.jpg',
           ],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/6NRlV9oUipeak7r00V6k73Jb7we.jpg',
           'walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
+          'image.tmdb.org/t/p/original/6NRlV9oUipeak7r00V6k73Jb7we.jpg',
         ],
       },
     },
@@ -50,8 +50,8 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/eggJAnJxpn8wYraX7ea5svETB54.jpg',
             'walter-r2.trakt.tv/images/people/000/412/328/headshots/thumb/35b36ce399.jpg.webp',
+            'image.tmdb.org/t/p/original/eggJAnJxpn8wYraX7ea5svETB54.jpg',
           ],
           'fanart': [
             'image.tmdb.org/t/p/w1280/aqNJrAxudMRNo8jg3HOUQqdl2xr.jpg',
@@ -60,8 +60,8 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/eggJAnJxpn8wYraX7ea5svETB54.jpg',
           'walter-r2.trakt.tv/images/people/000/412/328/headshots/thumb/35b36ce399.jpg.webp',
+          'image.tmdb.org/t/p/original/eggJAnJxpn8wYraX7ea5svETB54.jpg',
         ],
       },
     },
@@ -81,16 +81,16 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/vH8JrqdHaoFeGos44XeKTNuQMKE.jpg',
             'walter-r2.trakt.tv/images/people/000/016/797/headshots/thumb/987b640c84.jpg.webp',
+            'image.tmdb.org/t/p/original/vH8JrqdHaoFeGos44XeKTNuQMKE.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/vH8JrqdHaoFeGos44XeKTNuQMKE.jpg',
           'walter-r2.trakt.tv/images/people/000/016/797/headshots/thumb/987b640c84.jpg.webp',
+          'image.tmdb.org/t/p/original/vH8JrqdHaoFeGos44XeKTNuQMKE.jpg',
         ],
       },
     },
@@ -110,16 +110,16 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/tf3mYLcxXBUIWExWPsvGgr0aonc.jpg',
             'walter-r2.trakt.tv/images/people/000/748/739/headshots/thumb/628b796714.jpg.webp',
+            'image.tmdb.org/t/p/original/tf3mYLcxXBUIWExWPsvGgr0aonc.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/tf3mYLcxXBUIWExWPsvGgr0aonc.jpg',
           'walter-r2.trakt.tv/images/people/000/748/739/headshots/thumb/628b796714.jpg.webp',
+          'image.tmdb.org/t/p/original/tf3mYLcxXBUIWExWPsvGgr0aonc.jpg',
         ],
       },
     },
@@ -139,16 +139,16 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/9FDEwdZHfZqWRTrhfG4X58chM9x.jpg',
             'walter-r2.trakt.tv/images/people/000/627/038/headshots/thumb/ba0377d6b0.jpg.webp',
+            'image.tmdb.org/t/p/original/9FDEwdZHfZqWRTrhfG4X58chM9x.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/9FDEwdZHfZqWRTrhfG4X58chM9x.jpg',
           'walter-r2.trakt.tv/images/people/000/627/038/headshots/thumb/ba0377d6b0.jpg.webp',
+          'image.tmdb.org/t/p/original/9FDEwdZHfZqWRTrhfG4X58chM9x.jpg',
         ],
       },
     },
@@ -168,19 +168,19 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/gmVYPHJgmRVIzhaVYMns4kgBVqm.jpg',
             'walter-r2.trakt.tv/images/people/000/014/904/headshots/thumb/d67b0392d8.jpg.webp',
+            'image.tmdb.org/t/p/original/gmVYPHJgmRVIzhaVYMns4kgBVqm.jpg',
           ],
           'fanart': [
-            'image.tmdb.org/t/p/w1280/r4ITMrrWblan1EI1SnQk62AM71h.jpg',
             'walter-r2.trakt.tv/images/people/000/014/904/fanarts/medium/d1d079093c.jpg.webp',
+            'image.tmdb.org/t/p/w1280/r4ITMrrWblan1EI1SnQk62AM71h.jpg',
           ],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/gmVYPHJgmRVIzhaVYMns4kgBVqm.jpg',
           'walter-r2.trakt.tv/images/people/000/014/904/headshots/thumb/d67b0392d8.jpg.webp',
+          'image.tmdb.org/t/p/original/gmVYPHJgmRVIzhaVYMns4kgBVqm.jpg',
         ],
       },
     },
@@ -200,19 +200,19 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/hsCu1JUzQQ4pl7uFxAVFLOs9yHh.jpg',
             'walter-r2.trakt.tv/images/people/000/015/518/headshots/thumb/7aa5eb6e65.jpg.webp',
+            'image.tmdb.org/t/p/original/hsCu1JUzQQ4pl7uFxAVFLOs9yHh.jpg',
           ],
           'fanart': [
-            'image.tmdb.org/t/p/w1280/8FlxH4q1plGzdoJmK2VHgap3Ly7.jpg',
             'walter-r2.trakt.tv/images/people/000/015/518/fanarts/medium/efd64dfbec.jpg.webp',
+            'image.tmdb.org/t/p/w1280/8FlxH4q1plGzdoJmK2VHgap3Ly7.jpg',
           ],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/hsCu1JUzQQ4pl7uFxAVFLOs9yHh.jpg',
           'walter-r2.trakt.tv/images/people/000/015/518/headshots/thumb/7aa5eb6e65.jpg.webp',
+          'image.tmdb.org/t/p/original/hsCu1JUzQQ4pl7uFxAVFLOs9yHh.jpg',
         ],
       },
     },
@@ -232,16 +232,16 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/ixNSdZDJ6fZzZc2Pdx4Dwr8wHir.jpg',
             'walter-r2.trakt.tv/images/people/000/431/779/headshots/thumb/d9ba2e0cd9.jpg.webp',
+            'image.tmdb.org/t/p/original/ixNSdZDJ6fZzZc2Pdx4Dwr8wHir.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/ixNSdZDJ6fZzZc2Pdx4Dwr8wHir.jpg',
           'walter-r2.trakt.tv/images/people/000/431/779/headshots/thumb/d9ba2e0cd9.jpg.webp',
+          'image.tmdb.org/t/p/original/ixNSdZDJ6fZzZc2Pdx4Dwr8wHir.jpg',
         ],
       },
     },
@@ -261,16 +261,16 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/cpHNAqOBP8SIcml1A8ODmtuEyNh.jpg',
             'walter-r2.trakt.tv/images/people/000/668/720/headshots/thumb/f9a6bc12fd.jpg.webp',
+            'image.tmdb.org/t/p/original/cpHNAqOBP8SIcml1A8ODmtuEyNh.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/cpHNAqOBP8SIcml1A8ODmtuEyNh.jpg',
           'walter-r2.trakt.tv/images/people/000/668/720/headshots/thumb/f9a6bc12fd.jpg.webp',
+          'image.tmdb.org/t/p/original/cpHNAqOBP8SIcml1A8ODmtuEyNh.jpg',
         ],
       },
     },
@@ -290,16 +290,16 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/4LDy6vhBZ11kOevBdAGBRM34d3L.jpg',
             'walter-r2.trakt.tv/images/people/001/477/761/headshots/thumb/32559bdf7c.jpg.webp',
+            'image.tmdb.org/t/p/original/4LDy6vhBZ11kOevBdAGBRM34d3L.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/4LDy6vhBZ11kOevBdAGBRM34d3L.jpg',
           'walter-r2.trakt.tv/images/people/001/477/761/headshots/thumb/32559bdf7c.jpg.webp',
+          'image.tmdb.org/t/p/original/4LDy6vhBZ11kOevBdAGBRM34d3L.jpg',
         ],
       },
     },
@@ -319,16 +319,16 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/3WEi0WnyzqJ4kENQA81H2baLwWH.jpg',
             'walter-r2.trakt.tv/images/people/001/350/141/headshots/thumb/862651c2ae.jpg.webp',
+            'image.tmdb.org/t/p/original/3WEi0WnyzqJ4kENQA81H2baLwWH.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/3WEi0WnyzqJ4kENQA81H2baLwWH.jpg',
           'walter-r2.trakt.tv/images/people/001/350/141/headshots/thumb/862651c2ae.jpg.webp',
+          'image.tmdb.org/t/p/original/3WEi0WnyzqJ4kENQA81H2baLwWH.jpg',
         ],
       },
     },
@@ -348,16 +348,16 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/dXYJxqSowCeyEr03cWYzbA7a33.jpg',
             'walter-r2.trakt.tv/images/people/000/107/387/headshots/thumb/9f71e2f97c.jpg.webp',
+            'image.tmdb.org/t/p/original/dXYJxqSowCeyEr03cWYzbA7a33.jpg',
           ],
           'fanart': [],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/dXYJxqSowCeyEr03cWYzbA7a33.jpg',
           'walter-r2.trakt.tv/images/people/000/107/387/headshots/thumb/9f71e2f97c.jpg.webp',
+          'image.tmdb.org/t/p/original/dXYJxqSowCeyEr03cWYzbA7a33.jpg',
         ],
       },
     },
@@ -377,19 +377,19 @@ export const ShowSiloPeopleResponseMock: PeopleResponse = {
         },
         'images': {
           'headshot': [
-            'image.tmdb.org/t/p/original/rwrPdKGwXnByxUVMxMf8Y7oswi3.jpg',
             'walter-r2.trakt.tv/images/people/000/014/103/headshots/thumb/2e92bf71ee.jpg.webp',
+            'image.tmdb.org/t/p/original/rwrPdKGwXnByxUVMxMf8Y7oswi3.jpg',
           ],
           'fanart': [
-            'image.tmdb.org/t/p/w1280/u10HTGpohNBtGuVKGaIqtITpU05.jpg',
             'walter-r2.trakt.tv/images/people/000/014/103/fanarts/medium/c7e995bfac.jpg.webp',
+            'image.tmdb.org/t/p/w1280/u10HTGpohNBtGuVKGaIqtITpU05.jpg',
           ],
         },
       },
       'images': {
         'headshot': [
-          'image.tmdb.org/t/p/original/rwrPdKGwXnByxUVMxMf8Y7oswi3.jpg',
           'walter-r2.trakt.tv/images/people/000/014/103/headshots/thumb/2e92bf71ee.jpg.webp',
+          'image.tmdb.org/t/p/original/rwrPdKGwXnByxUVMxMf8Y7oswi3.jpg',
         ],
       },
     },

--- a/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloPersonResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloPersonResponseMock.ts
@@ -10,12 +10,12 @@ export const ShowSiloPersonResponseMock: PeopleSummaryResponse = {
   },
   'images': {
     'headshot': [
-      'image.tmdb.org/t/p/original/6NRlV9oUipeak7r00V6k73Jb7we.jpg',
       'walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
+      'image.tmdb.org/t/p/original/6NRlV9oUipeak7r00V6k73Jb7we.jpg',
     ],
     'fanart': [
-      'image.tmdb.org/t/p/w1280/krrZTVEqrYwu6vR3f4NWgdSZg8X.jpg',
       'walter-r2.trakt.tv/images/people/000/447/271/fanarts/medium/0b95a133bb.jpg.webp',
+      'image.tmdb.org/t/p/w1280/krrZTVEqrYwu6vR3f4NWgdSZg8X.jpg',
     ],
   },
   'social_ids': {

--- a/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloProgressResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloProgressResponseMock.ts
@@ -244,8 +244,8 @@ export const ShowSiloProgressResponseMock: ShowProgressResponse = {
     'episode_type': 'standard',
     'images': {
       'screenshot': [
-        'image.tmdb.org/t/p/w1280/gB2lEpKUvTshTdq00IRjQHFgG4J.jpg',
         'walter-r2.trakt.tv/images/episodes/012/105/048/screenshots/medium/2f894ac614.jpg.webp',
+        'image.tmdb.org/t/p/w1280/gB2lEpKUvTshTdq00IRjQHFgG4J.jpg',
       ],
     },
   },
@@ -301,8 +301,8 @@ export const ShowSiloProgressResponseMock: ShowProgressResponse = {
     'episode_type': 'season_premiere',
     'images': {
       'screenshot': [
-        'image.tmdb.org/t/p/w1280/kB5wWdEknKlBJ8iGEYQyTJWTSZv.jpg',
         'walter-r2.trakt.tv/images/episodes/012/105/047/screenshots/medium/bbe831c174.jpg.webp',
+        'image.tmdb.org/t/p/w1280/kB5wWdEknKlBJ8iGEYQyTJWTSZv.jpg',
       ],
     },
   },

--- a/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloResponseMock.ts
@@ -80,28 +80,28 @@ export const ShowSiloResponseMock: ShowResponse = {
   ],
   'images': {
     'fanart': [
-      'image.tmdb.org/t/p/w1280/n5FPNMJ0eRoiQrKGfUQQRAZeaxg.jpg',
       'walter-r2.trakt.tv/images/shows/000/180/770/fanarts/medium/80d39f8578.jpg.webp',
+      'image.tmdb.org/t/p/w1280/n5FPNMJ0eRoiQrKGfUQQRAZeaxg.jpg',
     ],
     'poster': [
-      'image.tmdb.org/t/p/w342/tlliQuCupf8fpTH7RAor3aKMGy.jpg',
       'walter-r2.trakt.tv/images/shows/000/180/770/posters/thumb/5312f1d1cf.jpg.webp',
+      'image.tmdb.org/t/p/w342/tlliQuCupf8fpTH7RAor3aKMGy.jpg',
     ],
     'logo': [
-      'assets.fanart.tv/fanart/tv/403245/hdtvlogo/wool-640b57ff556b2.png',
       'walter-r2.trakt.tv/images/shows/000/180/770/logos/medium/b0c9a10541.png.webp',
+      'assets.fanart.tv/fanart/tv/403245/hdtvlogo/wool-640b57ff556b2.png',
     ],
     'clearart': [
-      'assets.fanart.tv/fanart/tv/403245/hdclearart/silo-644fec3fe0fe0.png',
       'walter-r2.trakt.tv/images/shows/000/180/770/cleararts/medium/924d053dc2.png.webp',
+      'assets.fanart.tv/fanart/tv/403245/hdclearart/silo-644fec3fe0fe0.png',
     ],
     'banner': [
-      'assets.fanart.tv/fanart/tv/403245/tvbanner/silo-640f4c666e9f7.jpg',
       'walter-r2.trakt.tv/images/shows/000/180/770/banners/medium/24d0a4847e.jpg.webp',
+      'assets.fanart.tv/fanart/tv/403245/tvbanner/silo-640f4c666e9f7.jpg',
     ],
     'thumb': [
-      'assets.fanart.tv/fanart/tv/403245/tvthumb/silo-640f444ce6025.jpg',
       'walter-r2.trakt.tv/images/shows/000/180/770/thumbs/medium/dddaaead2f.jpg.webp',
+      'assets.fanart.tv/fanart/tv/403245/tvthumb/silo-640f444ce6025.jpg',
     ],
   },
 };


### PR DESCRIPTION
## Image Mapping Refinement and Code Simplification

This pull request focuses on improving the handling of image candidates in various mapping functions throughout the codebase.

### Refactoring to Use the Spread Operator

- Several functions responsible for mapping image URLs have been refactored to utilize the spread operator (`...`) in conjunction with the `findDefined` function. This change simplifies the code and improves readability by reducing the need for nested conditional statements.

### Updating Import Paths and Types

- The `searchQuery.ts` file has been updated to replace direct imports of `MEDIA_POSTER_PLACEHOLDER` and `prependHttps` with the more comprehensive `mapPoster` function. This change promotes consistency and reduces code duplication.
- The type of the `poster.url` field has been updated to `HttpsUrl` to ensure type safety and clarity.
- The `showProgressQuery.ts` file now imports `findDefined` from the `string` utility module, ensuring consistency in import paths and code organization.

(These changes, like a skilled surgeon performing a delicate operation, carefully refine the codebase to improve readability and maintainability. The use of the spread operator simplifies image mapping logic, while the updated import paths and types enhance code consistency and organization.)