### PR TITLE
fix(search): disable anchor re-triggers on search result items

### DIFF
--- a/projects/client/src/lib/components/link/Link.svelte
+++ b/projects/client/src/lib/components/link/Link.svelte
@@ -9,12 +9,14 @@
     target,
     color = "default",
     focusable = true,
+    retrigger = true,
     ...props
   }: ChildrenProps &
     HTMLAnchorProps &
     HTMLElementProps & {
       color?: "default" | "classic" | "inherit";
       focusable?: boolean;
+      retrigger?: boolean;
     } = $props();
 
   const { isActive } = $derived(useActiveLink(href));
@@ -24,7 +26,7 @@
   <a
     {href}
     {target}
-    use:triggerWithTouch
+    use:triggerWithTouch={retrigger}
     use:triggerWithKeyboard
     data-sveltekit-keepfocus
     tabindex={focusable ? 0 : -1}

--- a/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
+++ b/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
@@ -40,6 +40,7 @@
       {#each $results as result}
         <Link
           href={UrlBuilder.media(result.type, result.slug)}
+          retrigger={false}
           onclick={() => {
             inputElement.value = "";
             clear();

--- a/projects/client/src/lib/utils/actions/triggerWithTouch.ts
+++ b/projects/client/src/lib/utils/actions/triggerWithTouch.ts
@@ -1,10 +1,23 @@
+import { NOOP_FN } from '../constants';
+
 /**
  * This function is needed to handle touch events on iOS devices.
  * On iOS, touch events do not trigger click events by immediately in certain scenarios.
  * This utility ensures that a click event is triggered when a touch event ends,
  * providing a consistent user experience across different devices.
  */
-export function triggerWithTouch(node: HTMLElement) {
+export function triggerWithTouch(
+  node: HTMLElement,
+  enabled = true,
+) {
+  // TODO(@seferturan): investigate why we need to disable for search items
+  // relates to https://github.com/trakt/trakt-lite/issues/291
+  if (!enabled) {
+    return {
+      destroy: NOOP_FN,
+    };
+  }
+
   const handleTouchEnd = (event: PointerEvent) => {
     // TODO: improvement, ideally we apply this only for iOS devices
     // iPad and iPhone to be more specific, investigate how to consistently detect them


### PR DESCRIPTION
## Refining Touch Interactions: The `retrigger` Property for Links

This pull request enhances the `Link` component with a new `retrigger` property, providing finer control over touch event behavior.

### Link Component Updates

- Added a `retrigger` property to the `Link` component. This property determines whether touch events should trigger a click event, allowing for more nuanced handling of touch interactions.
- Set `retrigger` to `false` for search result links within the `SearchInput` component. This prevents accidental clicks when users are simply scrolling through search results on touch devices.

### `triggerWithTouch` Utility Update

- Modified the `triggerWithTouch` utility to accept an `enabled` parameter. This parameter mirrors the functionality of the `retrigger` property, providing a consistent way to control touch-triggered clicks across different components.

(These changes, like a skilled conductor fine-tuning an orchestra, refine the interplay between touch events and link navigation. The `retrigger` property and the updated `triggerWithTouch` utility provide a more nuanced and controlled approach to touch interactions, preventing unintended clicks and ensuring a smoother user experience.)

Temp fix for: https://github.com/trakt/trakt-lite/issues/291

Initial approach was reverted: `touchend` would have too many edge-cases when scrolling content.