### PR TITLE
feat / anticipated and popular list drilldown 

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -54,6 +54,7 @@ module.exports = {
         'out-now',
         'profile',
         'pr_gate',
+        'popular',
         'pwa',
         'readme',
         'recommendations',

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "Alle erwarteten Filme anzeigen",
   "view_all_anticipated_shows": "Alle erwarteten Serien anzeigen",
   "anticipated_movies": "Erwartete Filme",
-  "anticipated_shows": "Erwartete Serien"
+  "anticipated_shows": "Erwartete Serien",
+  "view_all_popular_movies": "Alle beliebten Filme ansehen",
+  "view_all_popular_shows": "Alle beliebten Serien ansehen",
+  "popular_movies": "Beliebte Filme",
+  "popular_shows": "Beliebte Serien"
 }

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -256,5 +256,9 @@
   "full_season": "Ganze Staffel",
   "remove_from_watchlist_warning": "Möchtest du {title} wirklich von deiner Liste zum Schauen entfernen?",
   "view_all_recommended_movies": "Alle empfohlenen Filme anzeigen",
-  "view_all_recommended_shows": "Alle empfohlenen Serien anzeigen"
+  "view_all_recommended_shows": "Alle empfohlenen Serien anzeigen",
+  "view_all_anticipated_movies": "Alle erwarteten Filme anzeigen",
+  "view_all_anticipated_shows": "Alle erwarteten Serien anzeigen",
+  "anticipated_movies": "Erwartete Filme",
+  "anticipated_shows": "Erwartete Serien"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "View all anticipated movies",
   "view_all_anticipated_shows": "View all anticipated shows",
   "anticipated_movies": "Anticipated Movies",
-  "anticipated_shows": "Anticipated Shows"
+  "anticipated_shows": "Anticipated Shows",
+  "view_all_popular_movies": "View all popular movies",
+  "view_all_popular_shows": "View all popular shows",
+  "popular_movies": "Popular Movies",
+  "popular_shows": "Popular Shows"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -256,5 +256,9 @@
   "full_season": "Full Season",
   "remove_from_watchlist_warning": "Are you sure you want to remove {title} from your Watchlist?",
   "view_all_recommended_movies": "View all recommended movies",
-  "view_all_recommended_shows": "View all recommended shows"
+  "view_all_recommended_shows": "View all recommended shows",
+  "view_all_anticipated_movies": "View all anticipated movies",
+  "view_all_anticipated_shows": "View all anticipated shows",
+  "anticipated_movies": "Anticipated Movies",
+  "anticipated_shows": "Anticipated Shows"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "Ver todos los filmes esperados",
   "view_all_anticipated_shows": "Ver todas las series esperadas",
   "anticipated_movies": "Películas anticipadas",
-  "anticipated_shows": "Series anticipadas"
+  "anticipated_shows": "Series anticipadas",
+  "view_all_popular_movies": "Ver todas las películas populares",
+  "view_all_popular_shows": "Ver todas las series populares",
+  "popular_movies": "Películas populares",
+  "popular_shows": "Series populares"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -256,5 +256,9 @@
   "full_season": "Temporada completa",
   "remove_from_watchlist_warning": "¿Seguro que quieres quitar {title} de tu lista de pendientes?",
   "view_all_recommended_movies": "Ver todas las recomendaciones de películas",
-  "view_all_recommended_shows": "Ver todas las recomendaciones de series"
+  "view_all_recommended_shows": "Ver todas las recomendaciones de series",
+  "view_all_anticipated_movies": "Ver todos los filmes esperados",
+  "view_all_anticipated_shows": "Ver todas las series esperadas",
+  "anticipated_movies": "Películas anticipadas",
+  "anticipated_shows": "Series anticipadas"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "Ver todas las pelis anticipadas",
   "view_all_anticipated_shows": "Ver todas las series anticipadas",
   "anticipated_movies": "Películas Anticipadas",
-  "anticipated_shows": "Series Anticipadas"
+  "anticipated_shows": "Series Anticipadas",
+  "view_all_popular_movies": "Ver todas las pelis populares",
+  "view_all_popular_shows": "Ver todas las series populares",
+  "popular_movies": "Pelis populares",
+  "popular_shows": "Series populares"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -256,5 +256,9 @@
   "full_season": "Temporada Completa",
   "remove_from_watchlist_warning": "¿Seguro que quieres quitar {title} de tu lista de pendientes?",
   "view_all_recommended_movies": "Ver todas las pelis recomendadas",
-  "view_all_recommended_shows": "Ver todas las series recomendadas"
+  "view_all_recommended_shows": "Ver todas las series recomendadas",
+  "view_all_anticipated_movies": "Ver todas las pelis anticipadas",
+  "view_all_anticipated_shows": "Ver todas las series anticipadas",
+  "anticipated_movies": "Películas Anticipadas",
+  "anticipated_shows": "Series Anticipadas"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -256,5 +256,9 @@
   "full_season": "Saison complète",
   "remove_from_watchlist_warning": "Voulez-vous vraiment retirer {title} de votre liste à voir?",
   "view_all_recommended_movies": "Voir tous les films recommandés",
-  "view_all_recommended_shows": "Voir toutes les séries recommandées"
+  "view_all_recommended_shows": "Voir toutes les séries recommandées",
+  "view_all_anticipated_movies": "Voir tous les films attendus",
+  "view_all_anticipated_shows": "Voir toutes les séries attendues",
+  "anticipated_movies": "Films attendus",
+  "anticipated_shows": "Séries attendues"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "Voir tous les films attendus",
   "view_all_anticipated_shows": "Voir toutes les séries attendues",
   "anticipated_movies": "Films attendus",
-  "anticipated_shows": "Séries attendues"
+  "anticipated_shows": "Séries attendues",
+  "view_all_popular_movies": "Voir tous les films populaires",
+  "view_all_popular_shows": "Voir toutes les séries populaires",
+  "popular_movies": "Films populaires",
+  "popular_shows": "Séries populaires"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -256,5 +256,9 @@
   "full_season": "Saison Complète",
   "remove_from_watchlist_warning": "Êtes-vous sûr de vouloir retirer {title} de votre liste de « à voir » ?",
   "view_all_recommended_movies": "Voir tous les films recommandés",
-  "view_all_recommended_shows": "Voir toutes les séries recommandées"
+  "view_all_recommended_shows": "Voir toutes les séries recommandées",
+  "view_all_anticipated_movies": "Voir tous les films attendus",
+  "view_all_anticipated_shows": "Voir toutes les séries attendues",
+  "anticipated_movies": "Films attendus",
+  "anticipated_shows": "Séries attendues"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "Voir tous les films attendus",
   "view_all_anticipated_shows": "Voir toutes les séries attendues",
   "anticipated_movies": "Films attendus",
-  "anticipated_shows": "Séries attendues"
+  "anticipated_shows": "Séries attendues",
+  "view_all_popular_movies": "Voir tous les films populaires",
+  "view_all_popular_shows": "Voir toutes les séries populaires",
+  "popular_movies": "Films populaires",
+  "popular_shows": "Séries populaires"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "近日公開の映画をすべて表示",
   "view_all_anticipated_shows": "近日公開の番組をすべて表示",
   "anticipated_movies": "期待の作品",
-  "anticipated_shows": "期待のシリーズ"
+  "anticipated_shows": "期待のシリーズ",
+  "view_all_popular_movies": "View all popular movies",
+  "view_all_popular_shows": "View all popular shows",
+  "popular_movies": "Popular Movies",
+  "popular_shows": "Popular Shows"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -256,5 +256,9 @@
   "full_season": "フルシーズン",
   "remove_from_watchlist_warning": "「{title}」をウォッチリストから削除してもよろしいですか？",
   "view_all_recommended_movies": "おすすめの作品をすべて見る",
-  "view_all_recommended_shows": "おすすめの作品をすべて見る"
+  "view_all_recommended_shows": "おすすめの作品をすべて見る",
+  "view_all_anticipated_movies": "近日公開の映画をすべて表示",
+  "view_all_anticipated_shows": "近日公開の番組をすべて表示",
+  "anticipated_movies": "期待の作品",
+  "anticipated_shows": "期待のシリーズ"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "Bekijk alle verwachte films",
   "view_all_anticipated_shows": "Bekijk alle verwachte series",
   "anticipated_movies": "Verwachte films",
-  "anticipated_shows": "Verwachte series"
+  "anticipated_shows": "Verwachte series",
+  "view_all_popular_movies": "Bekijk alle populaire films",
+  "view_all_popular_shows": "Bekijk alle populaire series",
+  "popular_movies": "Populaire Films",
+  "popular_shows": "Populaire Series"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -256,5 +256,9 @@
   "full_season": "Volledig Seizoen",
   "remove_from_watchlist_warning": "Weet je zeker dat je {title} van je kijklijst wilt verwijderen?",
   "view_all_recommended_movies": "Bekijk alle aanbevolen films",
-  "view_all_recommended_shows": "Bekijk alle aanbevolen series"
+  "view_all_recommended_shows": "Bekijk alle aanbevolen series",
+  "view_all_anticipated_movies": "Bekijk alle verwachte films",
+  "view_all_anticipated_shows": "Bekijk alle verwachte series",
+  "anticipated_movies": "Verwachte films",
+  "anticipated_shows": "Verwachte series"
 }

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "Zobacz wszystkie wyczekiwane filmy",
   "view_all_anticipated_shows": "Zobacz wszystkie wyczekiwane seriale",
   "anticipated_movies": "Oczekiwane Filmy",
-  "anticipated_shows": "Oczekiwane Seriale"
+  "anticipated_shows": "Oczekiwane Seriale",
+  "view_all_popular_movies": "Zobacz wszystkie popularne filmy",
+  "view_all_popular_shows": "Zobacz wszystkie popularne seriale",
+  "popular_movies": "Popularne filmy",
+  "popular_shows": "Popularne seriale"
 }

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -256,5 +256,9 @@
   "full_season": "Pełny sezon",
   "remove_from_watchlist_warning": "Na pewno chcesz usunąć {title} z listy do obejrzenia?",
   "view_all_recommended_movies": "Zobacz wszystkie polecane filmy",
-  "view_all_recommended_shows": "Zobacz wszystkie polecane seriale"
+  "view_all_recommended_shows": "Zobacz wszystkie polecane seriale",
+  "view_all_anticipated_movies": "Zobacz wszystkie wyczekiwane filmy",
+  "view_all_anticipated_shows": "Zobacz wszystkie wyczekiwane seriale",
+  "anticipated_movies": "Oczekiwane Filmy",
+  "anticipated_shows": "Oczekiwane Seriale"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -256,5 +256,9 @@
   "full_season": "Temporada Completa",
   "remove_from_watchlist_warning": "Tem certeza que quer remover {title} da sua lista para ver?",
   "view_all_recommended_movies": "Ver todos os filmes recomendados",
-  "view_all_recommended_shows": "Ver todas as séries recomendadas"
+  "view_all_recommended_shows": "Ver todas as séries recomendadas",
+  "view_all_anticipated_movies": "Ver todos os lançamentos aguardados",
+  "view_all_anticipated_shows": "Ver todas as séries aguardadas",
+  "anticipated_movies": "Filmes Aguardados",
+  "anticipated_shows": "Séries Aguardadas"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "Ver todos os lançamentos aguardados",
   "view_all_anticipated_shows": "Ver todas as séries aguardadas",
   "anticipated_movies": "Filmes Aguardados",
-  "anticipated_shows": "Séries Aguardadas"
+  "anticipated_shows": "Séries Aguardadas",
+  "view_all_popular_movies": "Ver todos os filmes populares",
+  "view_all_popular_shows": "Ver todas as séries populares",
+  "popular_movies": "Filmes Populares",
+  "popular_shows": "Séries Populares"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "Vezi toate filmele așteptate",
   "view_all_anticipated_shows": "Vezi toate serialele așteptate",
   "anticipated_movies": "Filme anticipate",
-  "anticipated_shows": "Seriale anticipate"
+  "anticipated_shows": "Seriale anticipate",
+  "view_all_popular_movies": "Vezi toate filmele populare",
+  "view_all_popular_shows": "Vezi toate serialele populare",
+  "popular_movies": "Filme populare",
+  "popular_shows": "Seriale populare"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -256,5 +256,9 @@
   "full_season": "Sezon complet",
   "remove_from_watchlist_warning": "Sigur vrei să elimini {title} din lista ta de vizionat?",
   "view_all_recommended_movies": "Vezi toate filmele recomandate",
-  "view_all_recommended_shows": "Vezi toate serialele recomandate"
+  "view_all_recommended_shows": "Vezi toate serialele recomandate",
+  "view_all_anticipated_movies": "Vezi toate filmele așteptate",
+  "view_all_anticipated_shows": "Vezi toate serialele așteptate",
+  "anticipated_movies": "Filme anticipate",
+  "anticipated_shows": "Seriale anticipate"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -256,5 +256,9 @@
   "full_season": "Повний сезон",
   "remove_from_watchlist_warning": "Ви впевнені, що хочете видалити {title} зі свого списку перегляду?",
   "view_all_recommended_movies": "Дивитись всі рекомендовані фільми",
-  "view_all_recommended_shows": "Дивитись всі рекомендовані серіали"
+  "view_all_recommended_shows": "Дивитись всі рекомендовані серіали",
+  "view_all_anticipated_movies": "Переглянути всі очікувані фільми",
+  "view_all_anticipated_shows": "Переглянути всі очікувані серіали",
+  "anticipated_movies": "Очікувані фільми",
+  "anticipated_shows": "Очікувані серіали"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -260,5 +260,9 @@
   "view_all_anticipated_movies": "Переглянути всі очікувані фільми",
   "view_all_anticipated_shows": "Переглянути всі очікувані серіали",
   "anticipated_movies": "Очікувані фільми",
-  "anticipated_shows": "Очікувані серіали"
+  "anticipated_shows": "Очікувані серіали",
+  "view_all_popular_movies": "Переглянути всі популярні фільми",
+  "view_all_popular_shows": "Переглянути всі популярні серіали",
+  "popular_movies": "Популярні фільми",
+  "popular_shows": "Популярні серіали"
 }

--- a/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
@@ -1,5 +1,8 @@
+import type { Paginatable } from '$lib/models/Paginatable.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { mapMovieResponseToMovieSummary } from '$lib/requests/_internal/mapMovieResponseToMovieSummary.ts';
 import { type MovieSummary } from '$lib/requests/models/MovieSummary.ts';
+import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { api, type ApiParams } from '../../_internal/api.ts';
 
 type MoviePopularParams = {
@@ -8,8 +11,8 @@ type MoviePopularParams = {
 } & ApiParams;
 
 function moviePopularRequest(
-  { fetch, page = 1, limit = 10 }: MoviePopularParams,
-): Promise<MovieSummary[]> {
+  { fetch, limit = DEFAULT_PAGE_SIZE, page = 1 }: MoviePopularParams,
+): Promise<Paginatable<MovieSummary>> {
   return api({ fetch })
     .movies
     .popular({
@@ -19,19 +22,23 @@ function moviePopularRequest(
         page,
       },
     })
-    .then(({ status, body }) => {
+    .then(({ status, body, headers }) => {
       if (status !== 200) {
         throw new Error('Failed to fetch popular movies');
       }
 
-      return body.map(mapMovieResponseToMovieSummary);
+      return {
+        entries: body.map(mapMovieResponseToMovieSummary),
+        page: extractPageMeta(headers),
+      };
     });
 }
 
-const moviePopularQueryKey = ['moviePopular'] as const;
+const moviePopularQueryKey = (params: MoviePopularParams) =>
+  ['moviePopular', params.limit, params.page] as const;
 export const moviePopularQuery = (
   params: MoviePopularParams = {},
 ) => ({
-  queryKey: moviePopularQueryKey,
+  queryKey: moviePopularQueryKey(params),
   queryFn: () => moviePopularRequest(params),
 });

--- a/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
@@ -1,30 +1,39 @@
 import { type ShowResponse } from '$lib/api.ts';
+import type { Paginatable } from '$lib/models/Paginatable.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { type EpisodeCount } from '$lib/requests/models/EpisodeCount.ts';
 import type { ShowSummary } from '$lib/requests/models/ShowSummary.ts';
+import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { api, type ApiParams } from '../../_internal/api.ts';
 import { mapShowResponseToShowSummary } from '../../_internal/mapShowResponseToShowSummary.ts';
+
+export type PopularShow = ShowSummary & Partial<EpisodeCount>;
 
 type ShowPopularParams = {
   page?: number;
   limit?: number;
 } & ApiParams;
 
-export type PopularShow = ShowSummary & EpisodeCount;
+function mapShowResponseToEpisodeCount(show: ShowResponse) {
+  const { aired_episodes } = show;
 
-export function mapResponseToPopularShow(
-  show: ShowResponse,
-): PopularShow {
+  if (!aired_episodes || aired_episodes === 0) {
+    return {};
+  }
+
+  return { episode: { count: aired_episodes } };
+}
+
+export function mapResponseToPopularShow(show: ShowResponse): PopularShow {
   return {
-    episode: {
-      count: show.aired_episodes ?? NaN,
-    },
     ...mapShowResponseToShowSummary(show),
+    ...mapShowResponseToEpisodeCount(show),
   };
 }
 
 function showPopularRequest(
-  { fetch, page = 1, limit = 10 }: ShowPopularParams,
-): Promise<ShowSummary[]> {
+  { fetch, page = 1, limit = DEFAULT_PAGE_SIZE }: ShowPopularParams,
+): Promise<Paginatable<PopularShow>> {
   return api({ fetch })
     .shows
     .popular({
@@ -34,19 +43,23 @@ function showPopularRequest(
         page,
       },
     })
-    .then(({ status, body }) => {
+    .then(({ status, body, headers }) => {
       if (status !== 200) {
         throw new Error('Failed to fetch popular shows');
       }
 
-      return body.map(mapResponseToPopularShow);
+      return {
+        entries: body.map(mapResponseToPopularShow),
+        page: extractPageMeta(headers),
+      };
     });
 }
 
-const showPopularQueryKey = ['showPopular'] as const;
+const showPopularQueryKey = (params: ShowPopularParams) =>
+  ['showPopular', params.limit, params.page] as const;
 export const showPopularQuery = (
   params: ShowPopularParams = {},
 ) => ({
-  queryKey: showPopularQueryKey,
+  queryKey: showPopularQueryKey(params),
   queryFn: () => showPopularRequest(params),
 });

--- a/projects/client/src/lib/sections/lists/AnticipatedList.svelte
+++ b/projects/client/src/lib/sections/lists/AnticipatedList.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
-  import AnticipatedTag from "$lib/components/media/tags/AnticipatedTag.svelte";
-  import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import type { MediaType } from "$lib/models/MediaType";
-  import MediaItem from "./components/MediaItem.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import AnticipatedMediaItem from "./components/AnticipatedMediaItem.svelte";
+  import ViewAllButton from "./components/ViewAllButton.svelte";
   import { useAnticipatedList } from "./stores/useAnticipatedList";
   import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
 
   type TrendingListProps = {
     title: string;
+    drilldownLabel: string;
     type: MediaType;
   };
 
-  const { title, type }: TrendingListProps = $props();
+  const { title, drilldownLabel, type }: TrendingListProps = $props();
 
   const { list } = useAnticipatedList({ type });
 </script>
@@ -24,10 +25,13 @@
   --height-list={mediaListHeightResolver(type)}
 >
   {#snippet item(media)}
-    <MediaItem {type} {media}>
-      {#snippet tags()}
-        <AnticipatedTag i18n={TagIntlProvider} score={media.score} />
-      {/snippet}
-    </MediaItem>
+    <AnticipatedMediaItem {type} {media} />
+  {/snippet}
+
+  {#snippet actions()}
+    <ViewAllButton
+      href={UrlBuilder.anticipated({ type })}
+      label={drilldownLabel}
+    />
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/lists/AnticipatedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/AnticipatedPaginatedList.svelte
@@ -4,6 +4,7 @@
   import Paginator from "$lib/components/lists/paginated-list/Paginator.svelte";
   import { PaginatorIntlProvider } from "$lib/components/lists/paginated-list/PaginatorIntlProvider";
   import type { MediaType } from "$lib/models/MediaType";
+  import { PAGE_UPPER_LIMIT } from "$lib/utils/constants";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import { writable } from "svelte/store";
   import AnticipatedMediaItem from "./components/AnticipatedMediaItem.svelte";
@@ -35,7 +36,7 @@
   $effect(() => {
     const total = $page.total;
     if (!total) return;
-    last.set(total);
+    last.set(Math.min(total, PAGE_UPPER_LIMIT));
   });
 </script>
 

--- a/projects/client/src/lib/sections/lists/AnticipatedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/AnticipatedPaginatedList.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { page as pageState } from "$app/state";
+  import PaginatedList from "$lib/components/lists/paginated-list/PaginatedList.svelte";
+  import Paginator from "$lib/components/lists/paginated-list/Paginator.svelte";
+  import { PaginatorIntlProvider } from "$lib/components/lists/paginated-list/PaginatorIntlProvider";
+  import type { MediaType } from "$lib/models/MediaType";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { writable } from "svelte/store";
+  import AnticipatedMediaItem from "./components/AnticipatedMediaItem.svelte";
+  import { useAnticipatedList } from "./stores/useAnticipatedList";
+  import { mediaCardWidthResolver } from "./utils/mediaCardWidthResolver";
+  import { mediaPageLimitResolver } from "./utils/mediaPageLimitResolver";
+
+  type AnticipatedListProps = {
+    title: string;
+    type: MediaType;
+  };
+
+  const { title, type }: AnticipatedListProps = $props();
+
+  const current = $derived(
+    parseInt(pageState.url.searchParams.get("page") ?? "1"),
+  );
+
+  const { list, page } = $derived(
+    useAnticipatedList({
+      type,
+      page: current,
+      limit: mediaPageLimitResolver(type),
+    }),
+  );
+
+  const last = writable(Infinity);
+
+  $effect(() => {
+    const total = $page.total;
+    if (!total) return;
+    last.set(total);
+  });
+</script>
+
+<PaginatedList
+  {title}
+  items={$list}
+  --width-item={mediaCardWidthResolver(type)}
+>
+  {#snippet item(media)}
+    <AnticipatedMediaItem {type} {media} />
+  {/snippet}
+
+  {#snippet actions()}
+    <Paginator
+      i18n={PaginatorIntlProvider}
+      {current}
+      first={1}
+      last={$last}
+      hrefFactory={(page) => UrlBuilder.anticipated({ type, page })}
+    />
+  {/snippet}
+</PaginatedList>

--- a/projects/client/src/lib/sections/lists/PopularList.svelte
+++ b/projects/client/src/lib/sections/lists/PopularList.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import type { MediaType } from "$lib/models/MediaType";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import MediaItem from "./components/MediaItem.svelte";
+  import ViewAllButton from "./components/ViewAllButton.svelte";
   import { usePopularList } from "./stores/usePopularList";
   import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
 
   type PopularListProps = {
     title: string;
+    drilldownLabel: string;
     type: MediaType;
   };
 
-  const { title, type }: PopularListProps = $props();
+  const { title, drilldownLabel, type }: PopularListProps = $props();
 
   const { list } = usePopularList({ type });
 </script>
@@ -23,5 +26,9 @@
 >
   {#snippet item(media)}
     <MediaItem {type} {media} />
+  {/snippet}
+
+  {#snippet actions()}
+    <ViewAllButton href={UrlBuilder.popular({ type })} label={drilldownLabel} />
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/lists/PopularPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/PopularPaginatedList.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { page as pageState } from "$app/state";
+  import PaginatedList from "$lib/components/lists/paginated-list/PaginatedList.svelte";
+  import Paginator from "$lib/components/lists/paginated-list/Paginator.svelte";
+  import { PaginatorIntlProvider } from "$lib/components/lists/paginated-list/PaginatorIntlProvider";
+  import type { MediaType } from "$lib/models/MediaType";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { writable } from "svelte/store";
+  import MediaItem from "./components/MediaItem.svelte";
+  import { usePopularList } from "./stores/usePopularList";
+  import { mediaCardWidthResolver } from "./utils/mediaCardWidthResolver";
+  import { mediaPageLimitResolver } from "./utils/mediaPageLimitResolver";
+
+  type PopularListProps = {
+    title: string;
+    type: MediaType;
+  };
+
+  const { title, type }: PopularListProps = $props();
+
+  const current = $derived(
+    parseInt(pageState.url.searchParams.get("page") ?? "1"),
+  );
+
+  const { list, page } = $derived(
+    usePopularList({
+      type,
+      page: current,
+      limit: mediaPageLimitResolver(type),
+    }),
+  );
+
+  const last = writable(Infinity);
+
+  $effect(() => {
+    const total = $page.total;
+    if (!total) return;
+    last.set(total);
+  });
+</script>
+
+<PaginatedList
+  {title}
+  items={$list}
+  --width-item={mediaCardWidthResolver(type)}
+>
+  {#snippet item(media)}
+    <MediaItem {type} {media} />
+  {/snippet}
+
+  {#snippet actions()}
+    <Paginator
+      i18n={PaginatorIntlProvider}
+      {current}
+      first={1}
+      last={$last}
+      hrefFactory={(page) => UrlBuilder.popular({ type, page })}
+    />
+  {/snippet}
+</PaginatedList>

--- a/projects/client/src/lib/sections/lists/PopularPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/PopularPaginatedList.svelte
@@ -4,6 +4,7 @@
   import Paginator from "$lib/components/lists/paginated-list/Paginator.svelte";
   import { PaginatorIntlProvider } from "$lib/components/lists/paginated-list/PaginatorIntlProvider";
   import type { MediaType } from "$lib/models/MediaType";
+  import { PAGE_UPPER_LIMIT } from "$lib/utils/constants";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import { writable } from "svelte/store";
   import MediaItem from "./components/MediaItem.svelte";
@@ -35,7 +36,7 @@
   $effect(() => {
     const total = $page.total;
     if (!total) return;
-    last.set(total);
+    last.set(Math.min(total, PAGE_UPPER_LIMIT));
   });
 </script>
 

--- a/projects/client/src/lib/sections/lists/TrendingPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/TrendingPaginatedList.svelte
@@ -4,6 +4,7 @@
   import Paginator from "$lib/components/lists/paginated-list/Paginator.svelte";
   import { PaginatorIntlProvider } from "$lib/components/lists/paginated-list/PaginatorIntlProvider";
   import type { MediaType } from "$lib/models/MediaType";
+  import { PAGE_UPPER_LIMIT } from "$lib/utils/constants";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import { writable } from "svelte/store";
   import TrendingMediaItem from "./components/TrendingMediaItem.svelte";
@@ -35,7 +36,7 @@
   $effect(() => {
     const total = $page.total;
     if (!total) return;
-    last.set(total);
+    last.set(Math.min(total, PAGE_UPPER_LIMIT));
   });
 </script>
 

--- a/projects/client/src/lib/sections/lists/components/AnticipatedMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/AnticipatedMediaItem.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import AnticipatedTag from "$lib/components/media/tags/AnticipatedTag.svelte";
+  import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
+  import type { AnticipatedMediaItem } from "../stores/useAnticipatedList";
+  import MediaItem from "./MediaItem.svelte";
+  import type { MediaItemProps } from "./MediaItemProps";
+
+  const { type, media }: MediaItemProps<AnticipatedMediaItem> = $props();
+</script>
+
+<MediaItem {type} {media}>
+  {#snippet tags()}
+    <AnticipatedTag i18n={TagIntlProvider} score={media.score} />
+  {/snippet}
+</MediaItem>

--- a/projects/client/src/lib/sections/lists/components/AvailableMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/AvailableMediaItem.svelte
@@ -2,13 +2,13 @@
   import MarkAsWatchedButton from "$lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte";
   import WatchlistButton from "$lib/components/buttons/watchlist/WatchlistButton.svelte";
   import CardFooter from "$lib/components/card/CardFooter.svelte";
-  import EpisodeCard from "$lib/components/episode/card/EpisodeCard.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import MediaCover from "$lib/components/media/card/MediaCover.svelte";
   import PosterCard from "$lib/components/media/card/PosterCard.svelte";
   import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
 
+  import ShowCard from "$lib/components/media/card/ShowCard.svelte";
   import EpisodeTag from "$lib/components/media/tags/EpisodeTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import { useMarkAsWatched } from "$lib/stores/useMarkAsWatched";
@@ -96,9 +96,9 @@
 {/if}
 
 {#if type === "show"}
-  <EpisodeCard>
+  <ShowCard>
     {@render content(media.thumb.url)}
-  </EpisodeCard>
+  </ShowCard>
 {/if}
 
 <style>

--- a/projects/client/src/lib/sections/lists/components/FutureMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/FutureMediaItem.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import WatchlistButton from "$lib/components/buttons/watchlist/WatchlistButton.svelte";
   import CardFooter from "$lib/components/card/CardFooter.svelte";
-  import EpisodeCard from "$lib/components/episode/card/EpisodeCard.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import MediaCover from "$lib/components/media/card/MediaCover.svelte";
   import PosterCard from "$lib/components/media/card/PosterCard.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
 
+  import ShowCard from "$lib/components/media/card/ShowCard.svelte";
   import AirTag from "$lib/components/media/tags/AirTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import { useWatchlist } from "$lib/stores/useWatchlist";
@@ -73,9 +73,9 @@
 {/if}
 
 {#if type === "show"}
-  <EpisodeCard>
+  <ShowCard>
     {@render content(media.thumb.url)}
-  </EpisodeCard>
+  </ShowCard>
 {/if}
 
 <style>

--- a/projects/client/src/lib/utils/constants.ts
+++ b/projects/client/src/lib/utils/constants.ts
@@ -50,3 +50,4 @@ export const NOOP_FN = () => {
 
 export const DEFAULT_PAGE_SIZE = 15;
 export const RECOMMENDED_UPPER_LIMIT = 100;
+export const PAGE_UPPER_LIMIT = 25;

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -31,7 +31,7 @@ export const UrlBuilder = {
     return trendingMediaUrl + buildParamString({ page });
   },
   recommended: ({ type, page }: PaginatableMediaPageUrl) => {
-    const trendingMediaUrl = (() => {
+    const recommendedMediaUrl = (() => {
       switch (type) {
         case 'show':
           return '/shows/recommended';
@@ -40,10 +40,10 @@ export const UrlBuilder = {
       }
     })();
 
-    return trendingMediaUrl + buildParamString({ page });
+    return recommendedMediaUrl + buildParamString({ page });
   },
   anticipated: ({ type, page }: PaginatableMediaPageUrl) => {
-    const trendingMediaUrl = (() => {
+    const anticipatedMediaUrl = (() => {
       switch (type) {
         case 'show':
           return '/shows/anticipated';
@@ -52,7 +52,19 @@ export const UrlBuilder = {
       }
     })();
 
-    return trendingMediaUrl + buildParamString({ page });
+    return anticipatedMediaUrl + buildParamString({ page });
+  },
+  popular: ({ type, page }: PaginatableMediaPageUrl) => {
+    const popularMediaUrl = (() => {
+      switch (type) {
+        case 'show':
+          return '/shows/popular';
+        case 'movie':
+          return '/movies/popular';
+      }
+    })();
+
+    return popularMediaUrl + buildParamString({ page });
   },
   movies: () => '/movies',
   movie: (id: string) => `/movies/${id}`,

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -6,7 +6,25 @@ type PaginatableMediaPageUrl = {
   page?: number;
 };
 
+const mediaDrilldownFactory =
+  (category: string) => ({ type, page }: PaginatableMediaPageUrl) => {
+    const baseUrl = `/${type}s/${category}`;
+    return baseUrl + buildParamString({ page });
+  };
+
 export const UrlBuilder = {
+  trending(params: PaginatableMediaPageUrl) {
+    return mediaDrilldownFactory('trending')(params);
+  },
+  recommended(params: PaginatableMediaPageUrl) {
+    return mediaDrilldownFactory('recommended')(params);
+  },
+  anticipated(params: PaginatableMediaPageUrl) {
+    return mediaDrilldownFactory('anticipated')(params);
+  },
+  popular(params: PaginatableMediaPageUrl) {
+    return mediaDrilldownFactory('popular')(params);
+  },
   home: () => '/',
   shows: () => '/shows',
   media: (type: MediaType, id: string) => {
@@ -18,54 +36,6 @@ export const UrlBuilder = {
     }
   },
   show: (id: string) => `/shows/${id}`,
-  trending: ({ type, page }: PaginatableMediaPageUrl) => {
-    const trendingMediaUrl = (() => {
-      switch (type) {
-        case 'show':
-          return '/shows/trending';
-        case 'movie':
-          return '/movies/trending';
-      }
-    })();
-
-    return trendingMediaUrl + buildParamString({ page });
-  },
-  recommended: ({ type, page }: PaginatableMediaPageUrl) => {
-    const recommendedMediaUrl = (() => {
-      switch (type) {
-        case 'show':
-          return '/shows/recommended';
-        case 'movie':
-          return '/movies/recommended';
-      }
-    })();
-
-    return recommendedMediaUrl + buildParamString({ page });
-  },
-  anticipated: ({ type, page }: PaginatableMediaPageUrl) => {
-    const anticipatedMediaUrl = (() => {
-      switch (type) {
-        case 'show':
-          return '/shows/anticipated';
-        case 'movie':
-          return '/movies/anticipated';
-      }
-    })();
-
-    return anticipatedMediaUrl + buildParamString({ page });
-  },
-  popular: ({ type, page }: PaginatableMediaPageUrl) => {
-    const popularMediaUrl = (() => {
-      switch (type) {
-        case 'show':
-          return '/shows/popular';
-        case 'movie':
-          return '/movies/popular';
-      }
-    })();
-
-    return popularMediaUrl + buildParamString({ page });
-  },
   movies: () => '/movies',
   movie: (id: string) => `/movies/${id}`,
   people: (id: string) => `/people/${id}`,

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -42,6 +42,18 @@ export const UrlBuilder = {
 
     return trendingMediaUrl + buildParamString({ page });
   },
+  anticipated: ({ type, page }: PaginatableMediaPageUrl) => {
+    const trendingMediaUrl = (() => {
+      switch (type) {
+        case 'show':
+          return '/shows/anticipated';
+        case 'movie':
+          return '/movies/anticipated';
+      }
+    })();
+
+    return trendingMediaUrl + buildParamString({ page });
+  },
   movies: () => '/movies',
   movie: (id: string) => `/movies/${id}`,
   people: (id: string) => `/people/${id}`,

--- a/projects/client/src/routes/movies/+page.svelte
+++ b/projects/client/src/routes/movies/+page.svelte
@@ -37,7 +37,11 @@
       {type}
     />
   {/if}
-  <AnticipatedList title={m.most_anticipated()} {type} />
+  <AnticipatedList
+    drilldownLabel={m.view_all_anticipated_movies()}
+    title={m.most_anticipated()}
+    {type}
+  />
   <PopularList title={m.most_popular()} {type} />
 {/snippet}
 

--- a/projects/client/src/routes/movies/+page.svelte
+++ b/projects/client/src/routes/movies/+page.svelte
@@ -42,7 +42,11 @@
     title={m.most_anticipated()}
     {type}
   />
-  <PopularList title={m.most_popular()} {type} />
+  <PopularList
+    drilldownLabel={m.view_all_popular_movies()}
+    title={m.most_popular()}
+    {type}
+  />
 {/snippet}
 
 <TraktPage

--- a/projects/client/src/routes/movies/anticipated/+page.svelte
+++ b/projects/client/src/routes/movies/anticipated/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+  import TraktPage from "$lib/components/layout/TraktPage.svelte";
+  import * as m from "$lib/features/i18n/messages";
+
+  import AnticipatedPaginatedList from "$lib/sections/lists/AnticipatedPaginatedList.svelte";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+</script>
+
+<TraktPage
+  audience="all"
+  image={DEFAULT_SHARE_MOVIE_COVER}
+  title={m.anticipated_movies()}
+>
+  <AnticipatedPaginatedList title={m.anticipated_movies()} type="movie" />
+</TraktPage>

--- a/projects/client/src/routes/movies/popular/+page.svelte
+++ b/projects/client/src/routes/movies/popular/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+  import TraktPage from "$lib/components/layout/TraktPage.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import PopularPaginatedList from "$lib/sections/lists/PopularPaginatedList.svelte";
+
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+</script>
+
+<TraktPage
+  audience="all"
+  image={DEFAULT_SHARE_MOVIE_COVER}
+  title={m.popular_movies()}
+>
+  <PopularPaginatedList title={m.popular_movies()} type="movie" />
+</TraktPage>

--- a/projects/client/src/routes/shows/+page.svelte
+++ b/projects/client/src/routes/shows/+page.svelte
@@ -39,7 +39,11 @@
       {type}
     />
   {/if}
-  <AnticipatedList title={m.most_anticipated()} {type} />
+  <AnticipatedList
+    drilldownLabel={m.view_all_anticipated_shows()}
+    title={m.most_anticipated()}
+    {type}
+  />
   <PopularList title={m.most_popular()} {type} />
 {/snippet}
 

--- a/projects/client/src/routes/shows/+page.svelte
+++ b/projects/client/src/routes/shows/+page.svelte
@@ -44,7 +44,11 @@
     title={m.most_anticipated()}
     {type}
   />
-  <PopularList title={m.most_popular()} {type} />
+  <PopularList
+    drilldownLabel={m.view_all_popular_shows()}
+    title={m.most_popular()}
+    {type}
+  />
 {/snippet}
 
 <TraktPage

--- a/projects/client/src/routes/shows/anticipated/+page.svelte
+++ b/projects/client/src/routes/shows/anticipated/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+  import TraktPage from "$lib/components/layout/TraktPage.svelte";
+  import * as m from "$lib/features/i18n/messages";
+
+  import AnticipatedPaginatedList from "$lib/sections/lists/AnticipatedPaginatedList.svelte";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
+</script>
+
+<TraktPage
+  audience="all"
+  image={DEFAULT_SHARE_SHOW_COVER}
+  title={m.anticipated_shows()}
+>
+  <AnticipatedPaginatedList title={m.anticipated_shows()} type="show" />
+</TraktPage>

--- a/projects/client/src/routes/shows/popular/+page.svelte
+++ b/projects/client/src/routes/shows/popular/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+  import TraktPage from "$lib/components/layout/TraktPage.svelte";
+  import * as m from "$lib/features/i18n/messages";
+
+  import PopularPaginatedList from "$lib/sections/lists/PopularPaginatedList.svelte";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
+</script>
+
+<TraktPage
+  audience="all"
+  image={DEFAULT_SHARE_SHOW_COVER}
+  title={m.popular_shows()}
+>
+  <PopularPaginatedList title={m.popular_shows()} type="show" />
+</TraktPage>


### PR DESCRIPTION
## Internationalization and Pagination Enhancements

This pull request focuses on improving internationalization support and adding pagination functionality to movie and show queries.

### i18n Updates

- Added new translations for anticipated and popular movies and shows in various languages, including German, English, Spanish, French, Japanese, Dutch, Polish, Portuguese, Romanian, and Ukrainian. These additions ensure that the application is accessible and localized for a wider audience.

### Query Function Enhancements

- Introduced pagination support to `movieAnticipatedQuery.ts`, `moviePopularQuery.ts`, `showAnticipatedQuery.ts`, and `showPopularQuery.ts` by adding the `Paginatable` type, `extractPageMeta` function, and `DEFAULT_PAGE_SIZE` constant. This allows for more efficient loading and display of large lists of movies and shows.
- Updated the query keys to include pagination parameters, ensuring proper caching and invalidation of paginated queries.
- Added the `mapShowResponseToEpisodeCount` function to `showPopularQuery.ts` to include episode count information in the response, providing users with more context about the shows.

### List Components

- Enhanced `RecommendedList.svelte` to include a "View All" button with a drilldown label for better navigation, providing a clearer path for users to explore all recommendations.
- Added `RecommendedPaginatedList.svelte` to display paginated lists of recommended items with a paginator, improving the browsing experience for large lists.

### Miscellaneous

- Added "drilldown" to the `cSpell.words` list in `.vscode/settings.json` for spellchecking, ensuring consistency across the project.

(These changes, like a skilled cartographer charting new territories, enhance the application's navigation and organization. The updated translations and new pagination features contribute to a more user-friendly and accessible experience, while the codebase remains organized and maintainable.)