### PR TITLE
feat(card): define single action cards

### DIFF
--- a/projects/client/src/lib/components/card/Card.svelte
+++ b/projects/client/src/lib/components/card/Card.svelte
@@ -26,7 +26,6 @@
     height: var(--height-card);
 
     border-radius: var(--border-radius-m);
-    overflow: hidden;
     background: var(--color-card-background);
     box-shadow: var(--ni-0) var(--ni-8) var(--ni-8) var(--ni-0)
       color-mix(in srgb, var(--color-shadow) 25%, transparent 75%);

--- a/projects/client/src/lib/components/card/CardCover.svelte
+++ b/projects/client/src/lib/components/card/CardCover.svelte
@@ -55,6 +55,9 @@
   }
 
   .card-cover {
+    border-top-left-radius: var(--border-radius-m);
+    border-top-right-radius: var(--border-radius-m);
+    overflow: hidden;
     position: relative;
   }
 

--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -20,22 +20,35 @@
 
 <style>
   .card-footer {
+    position: relative;
+
     height: calc(var(--height-card) - var(--height-card-cover));
-    display: flex;
     padding: var(--ni-8);
-    gap: var(--ni-8);
-    align-items: center;
-    justify-content: space-between;
     box-sizing: border-box;
+
+    display: flex;
+    gap: var(--ni-8);
+    justify-content: space-between;
 
     .card-footer-information {
       display: flex;
       flex-direction: column;
       gap: var(--ni-4);
       overflow: hidden;
+
+      &:global(:has(> :nth-child(2))) {
+        justify-content: center;
+      }
+
+      &:global(:has(> :nth-child(1)):not(:has(> :nth-child(2)))) {
+        margin-top: var(--ni-8);
+      }
     }
 
     .card-footer-actions {
+      position: absolute;
+      bottom: var(--ni-neg-16);
+      right: var(--ni-8);
       display: flex;
       gap: var(--ni-4);
     }

--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { CardFooterProps } from "./CardFooterProps";
 
-  const { children, actions }: CardFooterProps = $props();
+  const { children, action }: CardFooterProps = $props();
 </script>
 
 <div class="card-footer">
@@ -11,9 +11,9 @@
     </div>
   {/if}
 
-  {#if actions}
-    <div class="card-footer-actions">
-      {@render actions()}
+  {#if action}
+    <div class="card-footer-action">
+      {@render action()}
     </div>
   {/if}
 </div>
@@ -45,7 +45,7 @@
       }
     }
 
-    .card-footer-actions {
+    .card-footer-action {
       position: absolute;
       bottom: var(--ni-neg-16);
       right: var(--ni-8);

--- a/projects/client/src/lib/components/card/CardFooterProps.ts
+++ b/projects/client/src/lib/components/card/CardFooterProps.ts
@@ -1,5 +1,5 @@
 import type { Snippet } from 'svelte';
 
 export type CardFooterProps = Partial<ChildrenProps> & {
-  actions?: Snippet;
+  action?: Snippet;
 };

--- a/projects/client/src/lib/components/lists/grid-list/GridList.svelte
+++ b/projects/client/src/lib/components/lists/grid-list/GridList.svelte
@@ -59,8 +59,8 @@
     grid-template-columns: repeat(auto-fill, var(--width-item));
     /* TODO: investigate how we can better distribute empty spaces (@anodpixels) */
     justify-content: center;
-    grid-column-gap: var(--ni-8);
-    grid-row-gap: var(--ni-16);
+    grid-column-gap: var(--ni-12);
+    grid-row-gap: var(--ni-24);
 
     @include for-mobile {
       grid-template-columns: 1fr;

--- a/projects/client/src/lib/sections/lists/RecentlyWatchedList.svelte
+++ b/projects/client/src/lib/sections/lists/RecentlyWatchedList.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import MarkAsWatchedAction from "../media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import EpisodeItem from "./components/EpisodeItem.svelte";
   import MediaItem from "./components/MediaItem.svelte";
   import { useRecentlyWatchedList } from "./stores/useRecentlyWatchedList";
@@ -31,7 +33,18 @@
     {/if}
 
     {#if media.type === "movie"}
-      <MediaItem type={"movie"} media={media.movie} />
+      <MediaItem type={media.type} media={media.movie}>
+        {#snippet action()}
+          <RenderFor audience="authenticated">
+            <MarkAsWatchedAction
+              style="action"
+              title={media.movie.title}
+              type={media.type}
+              media={media.movie}
+            />
+          </RenderFor>
+        {/snippet}
+      </MediaItem>
     {/if}
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/lists/components/AvailableMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/AvailableMediaItem.svelte
@@ -11,7 +11,7 @@
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { MediaItemProps } from "./MediaItemProps";
 
-  const { type, media, tags: externalTags, actions }: MediaItemProps = $props();
+  const { type, media, tags: externalTags, action }: MediaItemProps = $props();
 </script>
 
 {#snippet defaultTags(media: MediaItemProps["media"])}
@@ -35,7 +35,7 @@
     </MediaCover>
   </Link>
 
-  <CardFooter {actions}>
+  <CardFooter {action}>
     <Link href={UrlBuilder.media(type, media.slug)}>
       <p class="recommendation-title small ellipsis">
         {media.title}

--- a/projects/client/src/lib/sections/lists/components/AvailableMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/AvailableMediaItem.svelte
@@ -4,17 +4,14 @@
   import MediaCover from "$lib/components/media/card/MediaCover.svelte";
   import PosterCard from "$lib/components/media/card/PosterCard.svelte";
   import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
 
   import ShowCard from "$lib/components/media/card/ShowCard.svelte";
   import EpisodeTag from "$lib/components/media/tags/EpisodeTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
-  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
-  import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { MediaItemProps } from "./MediaItemProps";
 
-  const { type, media, tags: externalTags }: MediaItemProps = $props();
+  const { type, media, tags: externalTags, actions }: MediaItemProps = $props();
 </script>
 
 {#snippet defaultTags(media: MediaItemProps["media"])}
@@ -38,23 +35,12 @@
     </MediaCover>
   </Link>
 
-  <CardFooter>
+  <CardFooter {actions}>
     <Link href={UrlBuilder.media(type, media.slug)}>
       <p class="recommendation-title small ellipsis">
         {media.title}
       </p>
     </Link>
-    {#snippet actions()}
-      <RenderFor audience="authenticated">
-        <WatchlistAction style="action" title={media.title} {type} {media} />
-        <MarkAsWatchedAction
-          style="action"
-          title={media.title}
-          type={media.type}
-          {media}
-        />
-      </RenderFor>
-    {/snippet}
   </CardFooter>
 {/snippet}
 

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -64,7 +64,7 @@
         {episode.season}x{episode.number}
       </p>
     {/if}
-    {#snippet actions()}
+    {#snippet action()}
       {#if isFuture === false}
         <RenderFor audience="authenticated">
           <MarkAsWatchedAction

--- a/projects/client/src/lib/sections/lists/components/FutureMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/FutureMediaItem.svelte
@@ -3,16 +3,14 @@
   import Link from "$lib/components/link/Link.svelte";
   import MediaCover from "$lib/components/media/card/MediaCover.svelte";
   import PosterCard from "$lib/components/media/card/PosterCard.svelte";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
 
   import ShowCard from "$lib/components/media/card/ShowCard.svelte";
   import AirTag from "$lib/components/media/tags/AirTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
-  import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { MediaItemProps } from "./MediaItemProps";
 
-  const { type, media, tags: externalTags }: MediaItemProps = $props();
+  const { type, media, tags: externalTags, actions }: MediaItemProps = $props();
 </script>
 
 {#snippet defaultTags(media: MediaItemProps["media"])}
@@ -32,17 +30,12 @@
     </MediaCover>
   </Link>
 
-  <CardFooter>
+  <CardFooter {actions}>
     <Link href={UrlBuilder.media(type, media.slug)}>
       <p class="recommendation-title small ellipsis">
         {media.title}
       </p>
     </Link>
-    {#snippet actions()}
-      <RenderFor audience="authenticated">
-        <WatchlistAction style="action" title={media.title} {type} {media} />
-      </RenderFor>
-    {/snippet}
   </CardFooter>
 {/snippet}
 

--- a/projects/client/src/lib/sections/lists/components/FutureMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/FutureMediaItem.svelte
@@ -10,7 +10,7 @@
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { MediaItemProps } from "./MediaItemProps";
 
-  const { type, media, tags: externalTags, actions }: MediaItemProps = $props();
+  const { type, media, tags: externalTags, action }: MediaItemProps = $props();
 </script>
 
 {#snippet defaultTags(media: MediaItemProps["media"])}
@@ -30,7 +30,7 @@
     </MediaCover>
   </Link>
 
-  <CardFooter {actions}>
+  <CardFooter {action}>
     <Link href={UrlBuilder.media(type, media.slug)}>
       <p class="recommendation-title small ellipsis">
         {media.title}

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -5,7 +5,7 @@
   import FutureMediaItem from "./FutureMediaItem.svelte";
   import type { MediaItemProps } from "./MediaItemProps";
 
-  const { type, media, tags, actions }: MediaItemProps = $props();
+  const { type, media, tags, action }: MediaItemProps = $props();
 </script>
 
 {#snippet defaultAction()}
@@ -20,12 +20,7 @@
 {/snippet}
 
 {#if media.airDate > new Date()}
-  <FutureMediaItem {type} {media} {tags} actions={actions ?? defaultAction} />
+  <FutureMediaItem {type} {media} {tags} action={action ?? defaultAction} />
 {:else}
-  <AvailableMediaItem
-    {type}
-    {media}
-    {tags}
-    actions={actions ?? defaultAction}
-  />
+  <AvailableMediaItem {type} {media} {tags} action={action ?? defaultAction} />
 {/if}

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -1,13 +1,31 @@
 <script lang="ts">
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import AvailableMediaItem from "./AvailableMediaItem.svelte";
   import FutureMediaItem from "./FutureMediaItem.svelte";
   import type { MediaItemProps } from "./MediaItemProps";
 
-  const { type, media, tags }: MediaItemProps = $props();
+  const { type, media, tags, actions }: MediaItemProps = $props();
 </script>
 
+{#snippet defaultAction()}
+  <RenderFor audience="authenticated">
+    <WatchlistAction
+      style="action"
+      title={media.title}
+      type={media.type}
+      {media}
+    />
+  </RenderFor>
+{/snippet}
+
 {#if media.airDate > new Date()}
-  <FutureMediaItem {type} {media} {tags} />
+  <FutureMediaItem {type} {media} {tags} actions={actions ?? defaultAction} />
 {:else}
-  <AvailableMediaItem {type} {media} {tags} />
+  <AvailableMediaItem
+    {type}
+    {media}
+    {tags}
+    actions={actions ?? defaultAction}
+  />
 {/if}

--- a/projects/client/src/lib/sections/lists/components/MediaItemProps.ts
+++ b/projects/client/src/lib/sections/lists/components/MediaItemProps.ts
@@ -8,5 +8,5 @@ export type MediaItemProps<T = MovieSummary | (ShowSummary & EpisodeCount)> = {
   media: T;
   type: MediaType;
   tags?: Snippet<[MediaItemProps['media']]>;
-  actions?: Snippet;
+  action?: Snippet;
 };

--- a/projects/client/src/lib/sections/lists/components/MediaItemProps.ts
+++ b/projects/client/src/lib/sections/lists/components/MediaItemProps.ts
@@ -8,4 +8,5 @@ export type MediaItemProps<T = MovieSummary | (ShowSummary & EpisodeCount)> = {
   media: T;
   type: MediaType;
   tags?: Snippet<[MediaItemProps['media']]>;
+  actions?: Snippet;
 };

--- a/projects/client/src/lib/sections/lists/components/NextEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/NextEpisodeItem.svelte
@@ -53,7 +53,7 @@
     <p class="episode-title small ellipsis">
       {episode.season}x{episode.number} - {episode.title}
     </p>
-    {#snippet actions()}
+    {#snippet action()}
       <MarkAsWatchedAction
         style="action"
         type="episode"

--- a/projects/client/src/lib/sections/lists/watchlist/OutNowList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/OutNowList.svelte
@@ -3,6 +3,9 @@
 
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { MediaSummary } from "$lib/requests/models/MediaSummary";
+  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import FindMoviesLink from "../components/FindMoviesLink.svelte";
   import MediaItem from "../components/MediaItem.svelte";
   import { mediaListHeightResolver } from "../utils/mediaListHeightResolver";
@@ -24,15 +27,28 @@
   );
 </script>
 
+{#snippet item(media: MediaSummary)}
+  <MediaItem type={media.type} {media}>
+    {#snippet actions()}
+      <RenderFor audience="authenticated">
+        <MarkAsWatchedAction
+          style="action"
+          title={media.title}
+          type={media.type}
+          {media}
+        />
+      </RenderFor>
+    {/snippet}
+  </MediaItem>
+{/snippet}
+
 <SectionList
   id={`out-now-list-${type}`}
   items={$list.sort(compare)}
   {title}
+  {item}
   --height-list={mediaListHeightResolver(type)}
 >
-  {#snippet item(media)}
-    <MediaItem {type} {media} />
-  {/snippet}
   {#snippet empty()}
     {#if !$isLoading}
       <p class="small">{m.out_now_empty()}</p>

--- a/projects/client/src/lib/sections/lists/watchlist/OutNowList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/OutNowList.svelte
@@ -29,7 +29,7 @@
 
 {#snippet item(media: MediaSummary)}
   <MediaItem type={media.type} {media}>
-    {#snippet actions()}
+    {#snippet action()}
       <RenderFor audience="authenticated">
         <MarkAsWatchedAction
           style="action"

--- a/projects/client/src/style/layout/index.css
+++ b/projects/client/src/style/layout/index.css
@@ -2,9 +2,9 @@
   /**
    * Card dimensions
    */
-  --width-poster-card: var(--ni-156);
-  --height-poster-card: var(--ni-292);
-  --height-poster-card-cover: var(--ni-248);
+  --width-poster-card: var(--ni-136);
+  --height-poster-card: var(--ni-256);
+  --height-poster-card-cover: var(--ni-196);
 
   --width-show-card: var(--ni-212);
   --height-show-card: var(--ni-176);
@@ -16,21 +16,34 @@
 
   --width-person-card: var(--ni-120);
   --height-person-card: var(--ni-176);
+  --height-person-summary: var(--ni-32);
   --height-person-card-cover: var(--ni-176);
 
   /**
    * List dimensions
    */
-  --height-episode-list: var(--ni-192);
-  --height-show-list: var(--ni-192);
-  --height-person-list: var(--ni-232);
+  --height-episode-list: calc(
+    var(--height-episode-card) + var(--layout-distance-scroll-card)
+      + var(--layout-scrollbar-width)
+  );
+  --height-show-list: calc(
+    var(--height-show-card) + var(--layout-distance-scroll-card)
+      + var(--layout-scrollbar-width)
+  );
+  --height-person-list: calc(
+    var(--height-person-card) + var(--layout-distance-scroll-card)
+      + var(--layout-scrollbar-width)
+      + var(--height-person-summary)
+  );
   --height-poster-list: calc(
     var(--height-poster-card) + var(--layout-distance-scroll-card)
+      + var(--layout-scrollbar-width)
   );
 
   /**
    * Structural variables
    */
   --layout-distance-side: var(--ni-24);
-  --layout-distance-scroll-card: var(--ni-16);
+  --layout-distance-scroll-card: var(--ni-24);
+  --layout-scrollbar-width: var(--ni-8);
 }


### PR DESCRIPTION
## Media Item Component Enhancement and Layout Refinement

This pull request focuses on improving the layout and functionality of media item components, enhancing their visual appeal and consistency.

### Style and Structure Updates

- Removed the `overflow: hidden` property from the `Card` component and added it to the `CardCover` component, along with `border-radius`. This change ensures that the card cover image is properly masked within the rounded corners of the card, while allowing content within the card to overflow if necessary.
- Adjusted the layout of the `CardFooter` component by adding `position: relative` and modifying the arrangement of its elements. This change improves the visual organization and alignment of the card footer content.

### Media Item Component Enhancements

- Updated the `AvailableMediaItem` and `FutureMediaItem` components to accept an `actions` prop, allowing for more flexible and customizable actions to be displayed within the card footer.
- Added a default action snippet to the `MediaItem` component and passed the `actions` prop to child components, streamlining the process of adding actions to media items.

### Layout Dimension Adjustments

- Adjusted dimensions for poster cards, show cards, and list heights in the layout styles to ensure better alignment and visual consistency across different media types and screen sizes.

### Type Updates

- Added an `actions` property to the `MediaItemProps` type, providing type safety and clarity for the new action handling functionality.

(These changes, like a meticulous architect refining a blueprint, enhance the visual appeal and flexibility of media item components. The updated styles, layout adjustments, and new action handling capabilities contribute to a more polished and user-friendly interface.)

<img width="200" alt="image" src="https://github.com/user-attachments/assets/8b0f5e9e-d79e-4a6b-b63f-da4b1d1c7ecb" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/410c2aa1-18b9-46a0-9fa2-df0d0986f408" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/29cdb680-970e-42a3-9d2d-15666fcc808a" />

