### PR TITLE
fix(list): scroll shadow over action button

### DIFF
--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -178,7 +178,7 @@
       top: 0;
 
       width: var(--ni-56);
-      height: calc(var(--height-list) - var(--layout-distance-scroll-card));
+      height: var(--height-list);
 
       opacity: 0;
 
@@ -200,6 +200,13 @@
         color-mix(in srgb, var(--color-background) 73%, transparent 27%) 74%,
         color-mix(in srgb, var(--color-background) 86%, transparent 14%) 86%,
         var(--color-background) 100%
+      );
+
+      mask-image: linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, 1) 0%,
+        rgba(0, 0, 0, 1) 75%,
+        rgba(255, 255, 255, 0) 100%
       );
     }
   }


### PR DESCRIPTION
## 🎶 Notes 🎶

- With the single action button requiring a bit more space, the scroll shadow looks weird:
  - It has a hard cut off over the button.
  - When increasing the size to cover the button, it can still have a visual hard cut off depending on the background image.
- The bottom of the shadow is now a bit more transparent.

## 👀 Examples 👀
Before:
<img width="234" alt="Screenshot 2025-01-20 at 19 17 17" src="https://github.com/user-attachments/assets/fd15f5f8-dbb0-486a-a335-185f8ff16303" />

With increased shadow:
<img width="234" alt="Screenshot 2025-01-20 at 19 37 46" src="https://github.com/user-attachments/assets/7ad5625a-c8e2-4a48-af72-886fb264f611" />

Final:
<img width="234" alt="Screenshot 2025-01-20 at 19 38 34" src="https://github.com/user-attachments/assets/e9fce304-7ace-4892-8ce2-467f826922aa" />
