### PR TITLE
fix(profile): do not overflow stats container

### DIFF
--- a/projects/client/src/lib/sections/profile/components/ProfileHistorySummary.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileHistorySummary.svelte
@@ -45,6 +45,7 @@
     padding: var(--ni-24);
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
     gap: var(--ni-8);
     box-shadow: 0 var(--ni-4) var(--ni-8) 0 rgba(0, 0, 0, 0.24);
   }
@@ -52,5 +53,15 @@
   .trakt-profile-history-content {
     display: flex;
     justify-content: space-between;
+    gap: var(--ni-8);
+  }
+
+  @include for-mobile {
+    .trakt-profile-history-summary {
+      height: var(--ni-168);
+    }
+    .trakt-profile-history-content {
+      flex-direction: column;
+    }
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- I checked all translations on iPhone SE size, everything should fix now.
- Minor tweak to properly fill the container.
- Fixes https://github.com/trakt/trakt-lite/issues/282

## 👀 Example 👀
Before:
<img width="529" alt="Screenshot 2025-01-21 at 10 03 19" src="https://github.com/user-attachments/assets/9514501d-2ec3-46f3-b3e1-bcb6c3728e20" />

After:
<img width="529" alt="Screenshot 2025-01-21 at 10 04 37" src="https://github.com/user-attachments/assets/4a5ddc27-5996-4423-8c37-67bb908b5c91" />
