### PR TITLE
fix: account for negative letter spacing cutting off text

### DIFF
--- a/projects/client/src/style/typography/index.css
+++ b/projects/client/src/style/typography/index.css
@@ -41,6 +41,7 @@ h1 {
   font-style: normal;
   font-weight: 600;
   letter-spacing: -0.18rem;
+  padding-right: 0.18rem;
 }
 
 h2 {
@@ -48,6 +49,7 @@ h2 {
   font-style: normal;
   font-weight: 600;
   letter-spacing: -0.14rem;
+  padding-right: 0.14rem;
 }
 
 h3 {
@@ -55,6 +57,7 @@ h3 {
   font-style: normal;
   font-weight: 600;
   letter-spacing: -0.12rem;
+  padding-right: 0.12rem;
 }
 
 h4 {
@@ -62,6 +65,7 @@ h4 {
   font-style: normal;
   font-weight: 600;
   letter-spacing: -0.1rem;
+  padding-right: 0.1rem;
 }
 
 h5 {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes https://github.com/trakt/trakt-lite/issues/281
- Using negative letter spacing cuts off the last letter.
- This is a bit of a hacky solution imo, if you have a better idea please let me know.

## 👀 Example 👀
Before:
<img width="909" alt="Screenshot 2025-01-21 at 10 57 27" src="https://github.com/user-attachments/assets/b2150c67-f33c-470b-a6c2-50517681d44b" />

After:
<img width="909" alt="Screenshot 2025-01-21 at 10 57 32" src="https://github.com/user-attachments/assets/fe9a00f3-a804-4f11-b112-cba770b4a752" />
