### PR TITLE
feat(pwa): allow trakt images to be cached in service worker

### DIFF
--- a/projects/client/static/service-worker.js
+++ b/projects/client/static/service-worker.js
@@ -38,13 +38,21 @@ const DOMAINS = {
   styles: [
     'cdn.jsdelivr.net',
   ],
+  images: [
+    'walter-r2.trakt.tv',
+  ]
 };
 
 const HOSTNAME_WHITELIST = [
   ...DOMAINS.fonts,
   ...DOMAINS.styles,
+  ...DOMAINS.images,
   self.location.hostname,
 ];
+
+const isTraktImage = (url) => {
+  return DOMAINS.images.includes(url.hostname) && /\.(jpg|jpeg|png|gif|webp)$/i.test(url.pathname);
+};
 
 // The Util Function to hack URLs of intercepted requests
 const getFixedUrl = (req) => {
@@ -116,7 +124,11 @@ self.addEventListener('fetch', (event) => {
   // Upgrade from Jake's to Surma's: https://gist.github.com/surma/eb441223daaedf880801ad80006389f1
   const cached = caches.match(event.request);
   const fixedUrl = getFixedUrl(event.request);
-  const fetched = fetch(fixedUrl, { cache: 'no-store' });
+  const fetchOptions = {
+    cache: 'no-store',
+    ...(isTraktImage(url) ? { mode: 'no-cors' } : {})
+  };
+  const fetched = fetch(fixedUrl, fetchOptions);
   const fetchedCopy = fetched.then((resp) => resp.clone());
 
   // Call respondWith() with whatever we get first.


### PR DESCRIPTION
## Service Worker Enhancement for Image Handling

This pull request updates the service worker to handle image requests from a new domain and optimizes fetch options for improved performance.

### Handling New Image Domain

- Added `walter-r2.trakt.tv` to the `DOMAINS.images` array and updated the `HOSTNAME_WHITELIST` to include this new domain. This allows the service worker to handle image requests from this domain and ensure proper caching.

### Optimizing Fetch Options

- Introduced the `isTraktImage` function to identify image requests from the new domain by checking the URL and file extension.
- Modified the fetch event listener to use `no-cors` mode for image requests from the new domain. This ensures proper handling of these requests, even if they don't have the same origin as the current page.

(These changes, like a seasoned detective meticulously examining evidence, enhance the service worker's ability to handle image requests from the new domain, improving performance and ensuring a smoother user experience.)