### PR TITLE
fix(button): ellipses in buttons

### DIFF
--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -217,6 +217,12 @@
       gap: var(--ni-8);
     }
 
+    .button-label {
+      // Needed to make ellipses work with flex
+      // https://css-tricks.com/flexbox-truncated-text/
+      min-width: 0;
+    }
+
     p,
     .button-label,
     .button-icon {


### PR DESCRIPTION
## 🎶 Notes 🎶

- https://css-tricks.com/flexbox-truncated-text/

## 👀 Example 👀
Before:
<img width="234" alt="Screenshot 2025-01-23 at 16 12 34" src="https://github.com/user-attachments/assets/d7f5b5f7-db66-442e-8575-1c6e33b6380d" />

After:
<img width="234" alt="Screenshot 2025-01-23 at 16 12 16" src="https://github.com/user-attachments/assets/cef8d35f-44f0-446c-aba7-d80888aa3f4b" />
