### PR TITLE
feat: poster actions

### DIFF
--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -278,5 +278,6 @@
   "favorite_movies": "Lieblingsfilme",
   "favorite_shows": "Lieblingsserien",
   "favorite_movies_empty": "Your favorite movies list is empty.",
-  "favorite_shows_empty": "Your favorite shows list is empty."
+  "favorite_shows_empty": "Your favorite shows list is empty.",
+  "stream_on": "Streamen auf"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -278,5 +278,6 @@
   "favorite_movies": "Favorite Movies",
   "favorite_shows": "Favorite Shows",
   "favorite_movies_empty": "Your favorite movies list is empty.",
-  "favorite_shows_empty": "Your favorite shows list is empty."
+  "favorite_shows_empty": "Your favorite shows list is empty.",
+  "stream_on": "Stream on"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -278,5 +278,6 @@
   "favorite_movies": "Películas favoritas",
   "favorite_shows": "Series favoritas",
   "favorite_movies_empty": "Tu lista de favoritos está vacía. ¡Es hora de encontrar algunas joyas!",
-  "favorite_shows_empty": "Tu lista de favoritos está vacía. ¡Hora de descubrir nuevas series!"
+  "favorite_shows_empty": "Tu lista de favoritos está vacía. ¡Hora de descubrir nuevas series!",
+  "stream_on": "Ver en streaming"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -278,5 +278,6 @@
   "favorite_movies": "Películas Favoritas",
   "favorite_shows": "Series Favoritas",
   "favorite_movies_empty": "Tu lista de favoritos está vacía.",
-  "favorite_shows_empty": "Tu lista de favoritos está vacía."
+  "favorite_shows_empty": "Tu lista de favoritos está vacía.",
+  "stream_on": "Ver en línea"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -278,5 +278,6 @@
   "favorite_movies": "Films préférés",
   "favorite_shows": "Séries préférées",
   "favorite_movies_empty": "Votre liste de favoris est vide.",
-  "favorite_shows_empty": "Votre liste d'émissions favorites est vide."
+  "favorite_shows_empty": "Votre liste d'émissions favorites est vide.",
+  "stream_on": "En diffusion sur"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -278,5 +278,6 @@
   "favorite_movies": "Films favoris",
   "favorite_shows": "Séries favorites",
   "favorite_movies_empty": "Votre liste de favoris est vide.",
-  "favorite_shows_empty": "Votre liste de séries préférées est vide."
+  "favorite_shows_empty": "Votre liste de séries préférées est vide.",
+  "stream_on": "En streaming sur"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -278,5 +278,6 @@
   "favorite_movies": "お気に入り作品",
   "favorite_shows": "お気に入り作品",
   "favorite_movies_empty": "お気に入りの作品リストは空です。",
-  "favorite_shows_empty": "お気に入りの番組リストは空です。"
+  "favorite_shows_empty": "お気に入りの番組リストは空です。",
+  "stream_on": "配信で見る"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -278,5 +278,6 @@
   "favorite_movies": "Favoriete films",
   "favorite_shows": "Favoriete series",
   "favorite_movies_empty": "Je lijst met favorieten is leeg.",
-  "favorite_shows_empty": "Je favoriete series lijst is leeg."
+  "favorite_shows_empty": "Je favoriete series lijst is leeg.",
+  "stream_on": "Streamen op"
 }

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -278,5 +278,6 @@
   "favorite_movies": "Ulubione Filmy",
   "favorite_shows": "Ulubione Seriale",
   "favorite_movies_empty": "Twoja lista ulubionych pozycji jest pusta.",
-  "favorite_shows_empty": "Twoja lista ulubionych seriali jest pusta."
+  "favorite_shows_empty": "Twoja lista ulubionych seriali jest pusta.",
+  "stream_on": "Oglądaj na"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -278,5 +278,6 @@
   "favorite_movies": "Filmes Favoritos",
   "favorite_shows": "Séries Favoritas",
   "favorite_movies_empty": "Sua lista de favoritos está vazia. Que tal adicionar um clássico?",
-  "favorite_shows_empty": "Sua lista de séries favoritas está vazia. Hora de maratonar algo novo!"
+  "favorite_shows_empty": "Sua lista de séries favoritas está vazia. Hora de maratonar algo novo!",
+  "stream_on": "Assista em"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -278,5 +278,6 @@
   "favorite_movies": "Filme preferate",
   "favorite_shows": "Seriale preferate",
   "favorite_movies_empty": "Your favorite movies list is empty.",
-  "favorite_shows_empty": "Your favorite shows list is empty."
+  "favorite_shows_empty": "Your favorite shows list is empty.",
+  "stream_on": "Vezi pe platforme"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -278,5 +278,6 @@
   "favorite_movies": "Улюблені фільми",
   "favorite_shows": "Улюблені серіали",
   "favorite_movies_empty": "Ваш список улюбленого кіно порожній.",
-  "favorite_shows_empty": "Ваш список улюблених серіалів порожній."
+  "favorite_shows_empty": "Ваш список улюблених серіалів порожній.",
+  "stream_on": "Дивись на"
 }

--- a/projects/client/src/lib/components/summary/SummaryPoster.svelte
+++ b/projects/client/src/lib/components/summary/SummaryPoster.svelte
@@ -7,18 +7,27 @@
     src: string;
     alt: string;
     href?: string;
+    target?: "_blank" | "_self" | "_parent" | "_top";
+    hoverOverlay?: Snippet;
     actions?: Snippet;
   };
 
-  const { src, alt, href, actions }: SummaryPosterProps = $props();
+  const { src, alt, href, actions, hoverOverlay, target }: SummaryPosterProps =
+    $props();
 </script>
 
 <div class="trakt-summary-poster-container">
-  <div class="trakt-summary-poster">
-    <Link {href}>
+  <div class="trakt-summary-poster" class:has-active-overlay={hoverOverlay}>
+    <Link {href} {target}>
       <CrossOriginImage {src} {alt} />
     </Link>
   </div>
+
+  {#if hoverOverlay}
+    <div class="trakt-summary-poster-overlay">
+      {@render hoverOverlay()}
+    </div>
+  {/if}
 
   {@render actions?.()}
 </div>
@@ -29,16 +38,41 @@
     display: flex;
     flex-direction: column;
     gap: var(--ni-16);
+    position: relative;
+  }
+
+  .trakt-summary-poster :global(img),
+  .trakt-summary-poster-overlay {
+    border-radius: var(--border-radius-xxl);
+    width: var(--ni-320);
+    height: var(--ni-480);
   }
 
   .trakt-summary-poster {
     :global(img) {
-      border-radius: var(--border-radius-xxl);
       align-self: stretch;
-      width: var(--ni-320);
-      height: var(--ni-480);
-
       box-shadow: 0px 7.673px 23.02px 0px rgba(0, 0, 0, 0.56);
+      transition: var(--transition-increment) ease-in-out;
+      transition-property: filter border;
+      box-sizing: border-box;
+    }
+  }
+
+  .trakt-summary-poster-overlay {
+    position: absolute;
+    opacity: 0;
+    transition: opacity var(--transition-increment) ease-in-out;
+    pointer-events: none;
+  }
+
+  .has-active-overlay:hover {
+    :global(img) {
+      filter: saturate(30%);
+      border: var(--ni-2) solid var(--color-foreground);
+    }
+
+    & + .trakt-summary-poster-overlay {
+      opacity: 1;
     }
   }
 </style>

--- a/projects/client/src/lib/components/summary/SummaryPoster.svelte
+++ b/projects/client/src/lib/components/summary/SummaryPoster.svelte
@@ -12,8 +12,14 @@
     actions?: Snippet;
   };
 
-  const { src, alt, href, actions, hoverOverlay, target }: SummaryPosterProps =
-    $props();
+  const {
+    src,
+    alt,
+    href,
+    actions,
+    hoverOverlay,
+    target = "_blank",
+  }: SummaryPosterProps = $props();
 </script>
 
 <div class="trakt-summary-poster-container">

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -13,6 +13,7 @@
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { EpisodeSummaryProps } from "./components/EpisodeSummaryProps";
   import MediaMetaInfo from "./components/media/MediaMetaInfo.svelte";
+  import WatchNowOverlay from "./components/overlay/WatchNowOverlay.svelte";
   import RateNowButton from "./components/rating/RateNowButton.svelte";
   import SummaryActions from "./components/summary/SummaryActions.svelte";
   import SummaryContainer from "./components/summary/SummaryContainer.svelte";
@@ -63,10 +64,13 @@
 <SummaryContainer>
   {#snippet poster()}
     <SummaryPoster
-      href={UrlBuilder.show(show.slug)}
       src={show.poster.url.medium}
       alt={title}
+      href={$watchNow?.preferred?.link}
     >
+      {#snippet hoverOverlay()}
+        <WatchNowOverlay service={$watchNow?.preferred} />
+      {/snippet}
       {#snippet actions()}
         <RenderFor device={["tablet-lg", "desktop"]} audience="authenticated">
           {@render mediaActions()}

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -15,6 +15,7 @@
   import { useWatchNow } from "$lib/stores/useWatchNow";
   import type { Snippet } from "svelte";
   import MediaMetaInfo from "../media/MediaMetaInfo.svelte";
+  import WatchNowOverlay from "../overlay/WatchNowOverlay.svelte";
   import RateNowButton from "../rating/RateNowButton.svelte";
   import SummaryActions from "../summary/SummaryActions.svelte";
   import SummaryContainer from "../summary/SummaryContainer.svelte";
@@ -79,7 +80,14 @@
 
 <SummaryContainer {contextualContent}>
   {#snippet poster()}
-    <SummaryPoster src={media.poster.url.medium} alt={title}>
+    <SummaryPoster
+      src={media.poster.url.medium}
+      alt={title}
+      href={$watchNow?.preferred?.link}
+    >
+      {#snippet hoverOverlay()}
+        <WatchNowOverlay service={$watchNow?.preferred} />
+      {/snippet}
       {#snippet actions()}
         <RenderFor device={["tablet-lg", "desktop"]} audience="authenticated">
           {@render mediaActions()}

--- a/projects/client/src/lib/sections/summary/components/overlay/WatchNowOverlay.svelte
+++ b/projects/client/src/lib/sections/summary/components/overlay/WatchNowOverlay.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import WatchNowServiceLogo from "$lib/components/buttons/watch-now/_internal/WatchNowServiceLogo.svelte";
+  import { WatchNowButtonIntlProvider } from "$lib/components/buttons/watch-now/WatchNowButtonIntlProvider";
+  import PlayIcon from "$lib/components/icons/PlayIcon.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import type { WatchNowStreaming } from "$lib/requests/models/WatchNowServices";
+
+  const {
+    service,
+  }: {
+    service?: WatchNowStreaming;
+  } = $props();
+</script>
+
+{#if service}
+  <div class="trakt-watch-now-overlay">
+    <div class="trakt-watch-now-source">
+      <h6 class="uppercase">{m.stream_on()}</h6>
+      <WatchNowServiceLogo
+        source={service.source}
+        i18n={WatchNowButtonIntlProvider}
+      />
+    </div>
+    <div class="trakt-watch-now-play">
+      <PlayIcon />
+    </div>
+  </div>
+{/if}
+
+<style>
+  .trakt-watch-now-overlay {
+    --source-shadow: var(--ni-2) var(--ni-2) var(--ni-4)
+      var(--color-background-purple);
+
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+  }
+
+  .trakt-watch-now-source {
+    position: absolute;
+    top: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--ni-8);
+    text-shadow: var(--source-shadow);
+    padding: var(--ni-8);
+
+    :global(.trakt-watch-now-service-logo) {
+      filter: drop-shadow(var(--source-shadow));
+      height: var(--ni-40);
+      width: auto;
+    }
+  }
+
+  .trakt-watch-now-play {
+    border-radius: 50%;
+    background-color: var(--color-background-purple);
+    padding: var(--ni-16);
+    width: var(--ni-56);
+    height: var(--ni-56);
+
+    :global(svg) {
+      width: 100%;
+      height: 100%;
+    }
+  }
+</style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds support for rendering a hover overlay on summary posters.
- Adds a hover overlay for preferred watch now services.
- Summary posters are now clickable to take you to a preferred service.
- Will probably needs styling changes after @anodpixels has had a look.

## 👀 Example 👀

https://github.com/user-attachments/assets/98d6f16c-923d-4c58-84f3-9e42858d9c6f

