### PR TITLE
fix / consistently use cover image

### DIFF
--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -4,7 +4,7 @@
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
-  import Redirect from "../router/Redirect.svelte";
+  import Redirect from "../../components/router/Redirect.svelte";
 
   type TraktPageProps = {
     title: string | undefined;

--- a/projects/client/src/lib/sections/layout/TraktPageCoverSetter.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPageCoverSetter.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
+  import { useUser } from "$lib/features/auth/stores/useUser";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { DEFAULT_COVER } from "$lib/utils/constants";
+
+  const { current } = useUser();
+</script>
+
+<RenderFor audience="authenticated">
+  <CoverImageSetter src={current().cover.url} type="main" />
+</RenderFor>
+<RenderFor audience="public">
+  <CoverImageSetter src={DEFAULT_COVER} type="main" />
+</RenderFor>

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import Landing from "$lib/sections/landing/Landing.svelte";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import UpNextList from "$lib/sections/lists/UpNextList.svelte";
   import UpcomingList from "$lib/sections/lists/UpcomingList.svelte";
   import ComingSoonList from "$lib/sections/lists/watchlist/ComingSoonList.svelte";

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-  import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import Landing from "$lib/sections/landing/Landing.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import UpNextList from "$lib/sections/lists/UpNextList.svelte";
   import UpcomingList from "$lib/sections/lists/UpcomingList.svelte";
   import ComingSoonList from "$lib/sections/lists/watchlist/ComingSoonList.svelte";
   import OutNowList from "$lib/sections/lists/watchlist/OutNowList.svelte";
   import ProfileBanner from "$lib/sections/profile-banner/ProfileBanner.svelte";
-  import { DEFAULT_COVER, DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
 
   const { current } = useUser();
 </script>
@@ -20,8 +20,9 @@
   image={DEFAULT_SHARE_COVER}
   title={m.navbar_link_home()}
 >
+  <TraktPageCoverSetter />
+
   <RenderFor audience="authenticated">
-    <CoverImageSetter src={current().cover.url} type="main" />
     <ProfileBanner />
     <UpNextList />
     <OutNowList title={m.out_now_title()} />
@@ -30,6 +31,5 @@
   </RenderFor>
   <RenderFor audience="public">
     <Landing />
-    <CoverImageSetter src={DEFAULT_COVER} type="main" />
   </RenderFor>
 </TraktPage>

--- a/projects/client/src/routes/_design_system/assets/+page.svelte
+++ b/projects/client/src/routes/_design_system/assets/+page.svelte
@@ -5,10 +5,10 @@
   import Button from "$lib/components/buttons/Button.svelte";
   import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
   import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import ShadowList from "$lib/components/lists/section-list/ShadowList.svelte";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import { resolveEnvironmentUri } from "$lib/features/image/components/resolveEnvironmentUri";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import { usePopularList } from "$lib/sections/lists/popular/usePopularList";
   import { useTrendingList } from "$lib/sections/lists/trending/useTrendingList";
   import { shuffle } from "$lib/utils/array/shuffle";

--- a/projects/client/src/routes/movies/+page.svelte
+++ b/projects/client/src/routes/movies/+page.svelte
@@ -1,42 +1,36 @@
 <script lang="ts">
-  import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
-  import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import AnticipatedList from "$lib/sections/lists/anticipated/AnticipatedList.svelte";
   import PopularList from "$lib/sections/lists/popular/PopularList.svelte";
   import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
   import TrendingList from "$lib/sections/lists/trending/TrendingList.svelte";
-  import {
-    DEFAULT_COVER,
-    DEFAULT_SHARE_MOVIE_COVER,
-  } from "$lib/utils/constants";
-
-  const { current } = useUser();
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
 
   const type = "movie";
-
-  type MovieContentProps = {
-    cover: { url: string };
-    isAuthorized: boolean;
-  };
 </script>
 
-{#snippet content({ cover: { url }, isAuthorized }: MovieContentProps)}
-  <CoverImageSetter src={url} type="main" />
+<TraktPage
+  audience="all"
+  image={DEFAULT_SHARE_MOVIE_COVER}
+  title={m.navbar_link_movies()}
+>
+  <TraktPageCoverSetter />
+
   <TrendingList
     title={m.trending_now()}
     drilldownLabel={m.view_all_trending_movies()}
     {type}
   />
-  {#if isAuthorized}
+  <RenderFor audience="authenticated">
     <RecommendedList
       drilldownLabel={m.view_all_recommended_movies()}
       title={m.your_recommendations()}
       {type}
     />
-  {/if}
+  </RenderFor>
   <AnticipatedList
     drilldownLabel={m.view_all_anticipated_movies()}
     title={m.most_anticipated()}
@@ -47,24 +41,4 @@
     title={m.most_popular()}
     {type}
   />
-{/snippet}
-
-<TraktPage
-  audience="all"
-  image={DEFAULT_SHARE_MOVIE_COVER}
-  title={m.navbar_link_movies()}
->
-  <RenderFor audience="authenticated">
-    {@render content({
-      ...current(),
-      isAuthorized: true,
-    })}
-  </RenderFor>
-
-  <RenderFor audience="public">
-    {@render content({
-      cover: { url: DEFAULT_COVER },
-      isAuthorized: false,
-    })}
-  </RenderFor>
 </TraktPage>

--- a/projects/client/src/routes/movies/+page.svelte
+++ b/projects/client/src/routes/movies/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import AnticipatedList from "$lib/sections/lists/anticipated/AnticipatedList.svelte";
   import PopularList from "$lib/sections/lists/popular/PopularList.svelte";
   import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";

--- a/projects/client/src/routes/movies/[slug]/+page.svelte
+++ b/projects/client/src/routes/movies/[slug]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import MovieSummary from "$lib/sections/summary/MovieSummary.svelte";
   import { useMovie } from "./useMovie";
 

--- a/projects/client/src/routes/movies/anticipated/+page.svelte
+++ b/projects/client/src/routes/movies/anticipated/+page.svelte
@@ -1,6 +1,6 @@
 <script>
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
 
   import AnticipatedPaginatedList from "$lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte";
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";

--- a/projects/client/src/routes/movies/anticipated/+page.svelte
+++ b/projects/client/src/routes/movies/anticipated/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
 
   import AnticipatedPaginatedList from "$lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte";
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
@@ -11,5 +12,7 @@
   image={DEFAULT_SHARE_MOVIE_COVER}
   title={m.anticipated_movies()}
 >
+  <TraktPageCoverSetter />
+
   <AnticipatedPaginatedList title={m.anticipated_movies()} type="movie" />
 </TraktPage>

--- a/projects/client/src/routes/movies/popular/+page.svelte
+++ b/projects/client/src/routes/movies/popular/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import PopularPaginatedList from "$lib/sections/lists/popular/PopularPaginatedList.svelte";
 
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
@@ -11,5 +12,7 @@
   image={DEFAULT_SHARE_MOVIE_COVER}
   title={m.popular_movies()}
 >
+  <TraktPageCoverSetter />
+
   <PopularPaginatedList title={m.popular_movies()} type="movie" />
 </TraktPage>

--- a/projects/client/src/routes/movies/popular/+page.svelte
+++ b/projects/client/src/routes/movies/popular/+page.svelte
@@ -1,6 +1,6 @@
 <script>
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import PopularPaginatedList from "$lib/sections/lists/popular/PopularPaginatedList.svelte";
 
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";

--- a/projects/client/src/routes/movies/recommended/+page.svelte
+++ b/projects/client/src/routes/movies/recommended/+page.svelte
@@ -1,6 +1,6 @@
 <script>
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
 
   import RecommendedPaginatedList from "$lib/sections/lists/recommended/RecommendedPaginatedList.svelte";
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";

--- a/projects/client/src/routes/movies/recommended/+page.svelte
+++ b/projects/client/src/routes/movies/recommended/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
 
   import RecommendedPaginatedList from "$lib/sections/lists/recommended/RecommendedPaginatedList.svelte";
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
@@ -11,5 +12,7 @@
   image={DEFAULT_SHARE_MOVIE_COVER}
   title={m.recommended_movies()}
 >
+  <TraktPageCoverSetter />
+
   <RecommendedPaginatedList title={m.recommended_movies()} type="movie" />
 </TraktPage>

--- a/projects/client/src/routes/movies/trending/+page.svelte
+++ b/projects/client/src/routes/movies/trending/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
 
   import TrendingPaginatedList from "$lib/sections/lists/trending/TrendingPaginatedList.svelte";
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
@@ -11,5 +12,7 @@
   image={DEFAULT_SHARE_MOVIE_COVER}
   title={m.trending_movies()}
 >
+  <TraktPageCoverSetter />
+
   <TrendingPaginatedList title={m.trending_movies()} type="movie" />
 </TraktPage>

--- a/projects/client/src/routes/movies/trending/+page.svelte
+++ b/projects/client/src/routes/movies/trending/+page.svelte
@@ -1,6 +1,6 @@
 <script>
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
 
   import TrendingPaginatedList from "$lib/sections/lists/trending/TrendingPaginatedList.svelte";
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";

--- a/projects/client/src/routes/people/[slug]/+page.svelte
+++ b/projects/client/src/routes/people/[slug]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import PeopleSummary from "$lib/sections/summary/PeopleSummary.svelte";
   import { usePerson } from "./usePerson";
 

--- a/projects/client/src/routes/profile/me/+page.svelte
+++ b/projects/client/src/routes/profile/me/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import Profile from "$lib/sections/profile/Profile.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
 
@@ -14,8 +14,8 @@
   image={DEFAULT_SHARE_COVER}
   title={m.profile()}
 >
+  <TraktPageCoverSetter />
   {#if current() != null}
-    <CoverImageSetter src={current().cover.url} type="main" />
     <Profile />
   {/if}
 </TraktPage>

--- a/projects/client/src/routes/profile/me/+page.svelte
+++ b/projects/client/src/routes/profile/me/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import Profile from "$lib/sections/profile/Profile.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
 

--- a/projects/client/src/routes/shows/+page.svelte
+++ b/projects/client/src/routes/shows/+page.svelte
@@ -1,44 +1,37 @@
 <script lang="ts">
-  import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
-  import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import AnticipatedList from "$lib/sections/lists/anticipated/AnticipatedList.svelte";
   import PopularList from "$lib/sections/lists/popular/PopularList.svelte";
   import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
   import TrendingList from "$lib/sections/lists/trending/TrendingList.svelte";
 
-  import {
-    DEFAULT_COVER,
-    DEFAULT_SHARE_SHOW_COVER,
-  } from "$lib/utils/constants";
-
-  const { current } = useUser();
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
 
   const type = "show";
-
-  type ShowContentProps = {
-    cover: { url: string };
-    isAuthorized: boolean;
-  };
 </script>
 
-{#snippet content({ cover: { url }, isAuthorized }: ShowContentProps)}
-  <CoverImageSetter src={url} type="main" />
+<TraktPage
+  audience="all"
+  image={DEFAULT_SHARE_SHOW_COVER}
+  title={m.navbar_link_shows()}
+>
+  <TraktPageCoverSetter />
 
   <TrendingList
     title={m.trending_now()}
     drilldownLabel={m.view_all_trending_shows()}
     {type}
   />
-  {#if isAuthorized}
+  <RenderFor audience="authenticated">
     <RecommendedList
       title={m.your_recommendations()}
       drilldownLabel={m.view_all_recommended_shows()}
       {type}
     />
-  {/if}
+  </RenderFor>
   <AnticipatedList
     drilldownLabel={m.view_all_anticipated_shows()}
     title={m.most_anticipated()}
@@ -49,24 +42,4 @@
     title={m.most_popular()}
     {type}
   />
-{/snippet}
-
-<TraktPage
-  audience="all"
-  image={DEFAULT_SHARE_SHOW_COVER}
-  title={m.navbar_link_shows()}
->
-  <RenderFor audience="authenticated">
-    {@render content({
-      ...current(),
-      isAuthorized: true,
-    })}
-  </RenderFor>
-
-  <RenderFor audience="public">
-    {@render content({
-      cover: { url: DEFAULT_COVER },
-      isAuthorized: false,
-    })}
-  </RenderFor>
 </TraktPage>

--- a/projects/client/src/routes/shows/+page.svelte
+++ b/projects/client/src/routes/shows/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import AnticipatedList from "$lib/sections/lists/anticipated/AnticipatedList.svelte";
   import PopularList from "$lib/sections/lists/popular/PopularList.svelte";
   import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";

--- a/projects/client/src/routes/shows/[slug]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import ShowSummary from "$lib/sections/summary/ShowSummary.svelte";
   import { useShow } from "./useShow";
   import { useShowDetails } from "./useShowDetails";

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import EpisodeSummary from "$lib/sections/summary/EpisodeSummary.svelte";
   import { useShow } from "../../../../useShow";
   import { useEpisode } from "./useEpisode";

--- a/projects/client/src/routes/shows/anticipated/+page.svelte
+++ b/projects/client/src/routes/shows/anticipated/+page.svelte
@@ -1,6 +1,6 @@
 <script>
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
 
   import AnticipatedPaginatedList from "$lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte";
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";

--- a/projects/client/src/routes/shows/anticipated/+page.svelte
+++ b/projects/client/src/routes/shows/anticipated/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
 
   import AnticipatedPaginatedList from "$lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte";
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
@@ -11,5 +12,7 @@
   image={DEFAULT_SHARE_SHOW_COVER}
   title={m.anticipated_shows()}
 >
+  <TraktPageCoverSetter />
+
   <AnticipatedPaginatedList title={m.anticipated_shows()} type="show" />
 </TraktPage>

--- a/projects/client/src/routes/shows/popular/+page.svelte
+++ b/projects/client/src/routes/shows/popular/+page.svelte
@@ -1,6 +1,6 @@
 <script>
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
 
   import PopularPaginatedList from "$lib/sections/lists/popular/PopularPaginatedList.svelte";
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";

--- a/projects/client/src/routes/shows/popular/+page.svelte
+++ b/projects/client/src/routes/shows/popular/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
 
   import PopularPaginatedList from "$lib/sections/lists/popular/PopularPaginatedList.svelte";
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
@@ -11,5 +12,7 @@
   image={DEFAULT_SHARE_SHOW_COVER}
   title={m.popular_shows()}
 >
+  <TraktPageCoverSetter />
+
   <PopularPaginatedList title={m.popular_shows()} type="show" />
 </TraktPage>

--- a/projects/client/src/routes/shows/recommended/+page.svelte
+++ b/projects/client/src/routes/shows/recommended/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
 
   import RecommendedPaginatedList from "$lib/sections/lists/recommended/RecommendedPaginatedList.svelte";
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
@@ -11,5 +12,7 @@
   image={DEFAULT_SHARE_SHOW_COVER}
   title={m.recommended_shows()}
 >
+  <TraktPageCoverSetter />
+
   <RecommendedPaginatedList title={m.recommended_shows()} type="show" />
 </TraktPage>

--- a/projects/client/src/routes/shows/recommended/+page.svelte
+++ b/projects/client/src/routes/shows/recommended/+page.svelte
@@ -1,6 +1,6 @@
 <script>
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
 
   import RecommendedPaginatedList from "$lib/sections/lists/recommended/RecommendedPaginatedList.svelte";
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";

--- a/projects/client/src/routes/shows/trending/+page.svelte
+++ b/projects/client/src/routes/shows/trending/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
 
   import TrendingPaginatedList from "$lib/sections/lists/trending/TrendingPaginatedList.svelte";
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
@@ -11,5 +12,7 @@
   image={DEFAULT_SHARE_SHOW_COVER}
   title={m.trending_shows()}
 >
+  <TraktPageCoverSetter />
+
   <TrendingPaginatedList title={m.trending_shows()} type="show" />
 </TraktPage>

--- a/projects/client/src/routes/shows/trending/+page.svelte
+++ b/projects/client/src/routes/shows/trending/+page.svelte
@@ -1,6 +1,6 @@
 <script>
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
 
   import TrendingPaginatedList from "$lib/sections/lists/trending/TrendingPaginatedList.svelte";
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";

--- a/projects/client/src/routes/watchlist/+page.svelte
+++ b/projects/client/src/routes/watchlist/+page.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
 
-  import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
-  import { useUser } from "$lib/features/auth/stores/useUser";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import WatchlistList from "$lib/sections/lists/watchlist/WatchlistList.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
-
-  const { current } = useUser();
 </script>
 
 <TraktPage
@@ -15,7 +12,7 @@
   image={DEFAULT_SHARE_COVER}
   title={m.navbar_link_watchlist()}
 >
-  <CoverImageSetter src={current().cover.url} type="main" />
+  <TraktPageCoverSetter />
 
   <WatchlistList
     title={m.watchlist_movies()}

--- a/projects/client/src/routes/watchlist/+page.svelte
+++ b/projects/client/src/routes/watchlist/+page.svelte
@@ -2,8 +2,8 @@
   import * as m from "$lib/features/i18n/messages.ts";
 
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
-  import TraktPage from "$lib/components/layout/TraktPage.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import WatchlistList from "$lib/sections/lists/watchlist/WatchlistList.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
 


### PR DESCRIPTION
## Layout Refactoring and Cover Image Handling

This pull request streamlines the layout and cover image handling across various pages in the client project, improving code organization and maintainability.

### Layout Component Refactoring

- Renamed and moved the `TraktPage` component from the `components/layout` directory to the `sections/layout` directory. This change improves the organization of layout-related components and ensures a more logical structure within the codebase.

### Cover Image Handling

- Introduced a new `TraktPageCoverSetter` component to centralize the logic for setting cover images. This component handles cover image setting for both authenticated and public users, promoting code reusability and consistency.
- Replaced direct usage of `CoverImageSetter` in various pages with the new `TraktPageCoverSetter` component, ensuring a unified approach to cover image handling across the application.

### Page Updates

- Updated import paths for `TraktPage` in multiple route files to reflect the new directory structure, ensuring that the application can correctly locate and utilize the refactored component.
- Integrated the `TraktPageCoverSetter` component in various movie and show pages, replacing inline cover image setting logic and promoting a more modular and maintainable code structure.

(These changes, like a meticulous architect reorganizing blueprints, streamline the layout and cover image handling logic. The refactored components and centralized cover image handling contribute to a cleaner and more maintainable codebase, making it easier to understand, update, and extend.)