### PR TITLE
feat / define ttl as part of defineQuery

### DIFF
--- a/projects/client/src/lib/features/auth/queries/currentUserFavoritesQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserFavoritesQuery.ts
@@ -106,4 +106,5 @@ export const currentUserFavoritesQuery = defineQuery({
     };
   },
   schema: UserFavoritesSchema,
+  ttl: Infinity,
 });

--- a/projects/client/src/lib/features/auth/queries/currentUserHistoryQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserHistoryQuery.ts
@@ -120,4 +120,5 @@ export const currentUserHistoryQuery = defineQuery({
     shows: toMap(shows, mapWatchedShowResponse, (entry) => entry.id),
   }),
   schema: UserHistorySchema,
+  ttl: Infinity,
 });

--- a/projects/client/src/lib/features/auth/queries/currentUserRatingsQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserRatingsQuery.ts
@@ -82,4 +82,5 @@ export const currentUserRatingsQuery = defineQuery({
     episodes: toMap(episodes, mapRatedEpisodeResponse, (entry) => entry.id),
   }),
   schema: UserRatingsSchema,
+  ttl: Infinity,
 });

--- a/projects/client/src/lib/features/auth/queries/currentUserSettingsQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserSettingsQuery.ts
@@ -134,4 +134,5 @@ export const currentUserSettingsQuery = defineQuery({
   request: currentUserRequest,
   mapper: mapUserSettingsResponse,
   schema: UserSettingsSchema,
+  ttl: Infinity,
 });

--- a/projects/client/src/lib/features/auth/queries/currentUserWatchlistQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserWatchlistQuery.ts
@@ -101,4 +101,5 @@ export const currentUserWatchlistQuery = defineQuery({
     shows: toMap(shows, mapWatchlistedShowResponse, (entry) => entry.id),
   }),
   schema: UserWatchlistSchema,
+  ttl: Infinity,
 });

--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -10,30 +10,11 @@ import {
 } from '../queries/currentUserWatchlistQuery.ts';
 
 export function useUser() {
-  const userQueryResponse = useQuery({
-    ...currentUserSettingsQuery(),
-    staleTime: Infinity,
-  });
-
-  const historyQueryResponse = useQuery({
-    ...currentUserHistoryQuery(),
-    staleTime: Infinity,
-  });
-
-  const watchlistQueryResponse = useQuery({
-    ...currentUserWatchlistQuery(),
-    staleTime: Infinity,
-  });
-
-  const ratingsQueryResponse = useQuery({
-    ...currentUserRatingsQuery(),
-    staleTime: Infinity,
-  });
-
-  const favoritesQueryResponse = useQuery({
-    ...currentUserFavoritesQuery(),
-    staleTime: Infinity,
-  });
+  const userQueryResponse = useQuery(currentUserSettingsQuery());
+  const historyQueryResponse = useQuery(currentUserHistoryQuery());
+  const watchlistQueryResponse = useQuery(currentUserWatchlistQuery());
+  const ratingsQueryResponse = useQuery(currentUserRatingsQuery());
+  const favoritesQueryResponse = useQuery(currentUserFavoritesQuery());
 
   const user = derived(userQueryResponse, ($query) => $query.data);
   const history = derived(historyQueryResponse, ($query) => $query.data);

--- a/projects/client/src/lib/features/query/defineQuery.ts
+++ b/projects/client/src/lib/features/query/defineQuery.ts
@@ -31,6 +31,7 @@ type DefineQueryProps<
   mapper: MapperDefinition<TInput, TOutput, TRequestParams>;
   schema: TOutput;
   ttl?: number;
+  refetchOnWindowFocus?: boolean;
 };
 
 export const QUERY_ID = 'query';
@@ -78,6 +79,7 @@ export function defineQuery<
         request(requestParams)
           .then((data) => mapper(data, requestParams)),
       staleTime: params.ttl,
+      refetchOnWindowFocus: params.refetchOnWindowFocus,
     };
   };
 }

--- a/projects/client/src/lib/features/query/defineQuery.ts
+++ b/projects/client/src/lib/features/query/defineQuery.ts
@@ -30,7 +30,7 @@ type DefineQueryProps<
   request: RequestDefinition<TInput, TRequestParams>;
   mapper: MapperDefinition<TInput, TOutput, TRequestParams>;
   schema: TOutput;
-  ttl?: number;
+  ttl: number | Nil;
   refetchOnWindowFocus?: boolean;
 };
 
@@ -78,7 +78,7 @@ export function defineQuery<
       queryFn: () =>
         request(requestParams)
           .then((data) => mapper(data, requestParams)),
-      staleTime: params.ttl,
+      staleTime: params.ttl == null ? undefined : params.ttl,
       refetchOnWindowFocus: params.refetchOnWindowFocus,
     };
   };

--- a/projects/client/src/lib/features/query/defineQuery.ts
+++ b/projects/client/src/lib/features/query/defineQuery.ts
@@ -30,6 +30,7 @@ type DefineQueryProps<
   request: RequestDefinition<TInput, TRequestParams>;
   mapper: MapperDefinition<TInput, TOutput, TRequestParams>;
   schema: TOutput;
+  ttl?: number;
 };
 
 export const QUERY_ID = 'query';
@@ -76,6 +77,7 @@ export function defineQuery<
       queryFn: () =>
         request(requestParams)
           .then((data) => mapper(data, requestParams)),
+      staleTime: params.ttl,
     };
   };
 }

--- a/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
@@ -3,7 +3,9 @@ import { coalesceEpisodes } from '$lib/requests/_internal/coalesceEpisodes.ts';
 import { mapEpisodeResponseToEpisodeEntry } from '$lib/requests/_internal/mapEpisodeResponseToEpisodeEntry.ts';
 import { mapShowResponseToShowSummary } from '$lib/requests/_internal/mapShowResponseToShowSummary.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { EpisodeEntrySchema } from '../../models/EpisodeEntry.ts';
 
@@ -41,7 +43,7 @@ const upcomingEpisodesRequest = (
 
 export const upcomingEpisodesQuery = defineQuery({
   key: 'upcomingEpisodes',
-  invalidations: [],
+  invalidations: [InvalidateAction.Watchlisted('show')],
   dependencies: (params) => [params.startDate, params.days],
   request: upcomingEpisodesRequest,
   mapper: (response) => {
@@ -53,4 +55,6 @@ export const upcomingEpisodesQuery = defineQuery({
     return coalesceEpisodes(episodes);
   },
   schema: UpcomingEpisodeEntrySchema.array(),
+  ttl: time.minutes(30),
+  refetchOnWindowFocus: true,
 });

--- a/projects/client/src/lib/requests/queries/episode/episodeIntlQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeIntlQuery.ts
@@ -5,6 +5,7 @@ import type {
 } from '$lib/features/i18n/index.ts';
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import {
   type EpisodeIntl,
   EpisodeIntlSchema,
@@ -73,4 +74,5 @@ export const episodeIntlQuery = defineQuery({
       .map(mapEpisodeIntlResponse)
       .at(0),
   schema: EpisodeIntlSchema.optional(),
+  ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/episode/episodeRatingQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeRatingQuery.ts
@@ -1,6 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaRatingSchema } from '$lib/requests/models/MediaRating.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { mapRatingResponseToMediaRating } from '../../_internal/mapRatingResponseToMediaRating.ts';
 
 type EpisodeRatingParams = {
@@ -40,4 +41,5 @@ export const episodeRatingQuery = defineQuery({
   request: episodeRatingRequest,
   mapper: mapRatingResponseToMediaRating,
   schema: MediaRatingSchema,
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/episode/episodeStatsQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeStatsQuery.ts
@@ -2,6 +2,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapStatsResponseToMediaStats } from '$lib/requests/_internal/mapStatsResponseToMediaStats.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaStatsSchema } from '$lib/requests/models/MediaStats.ts';
+import { time } from '$lib/utils/timing/time';
 
 type EpisodeStatsParams = {
   slug: string;
@@ -37,4 +38,5 @@ export const episodeStatsQuery = defineQuery({
   request: episodeStatsRequest,
   mapper: mapStatsResponseToMediaStats,
   schema: MediaStatsSchema,
+  ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/episode/episodeSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeSummaryQuery.ts
@@ -2,6 +2,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapEpisodeResponseToEpisodeEntry } from '$lib/requests/_internal/mapEpisodeResponseToEpisodeEntry.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeEntrySchema } from '$lib/requests/models/EpisodeEntry.ts';
+import { time } from '$lib/utils/timing/time';
 
 type EpisodeSummaryParams = {
   slug: string;
@@ -40,4 +41,5 @@ export const episodeSummaryQuery = defineQuery({
   request: episodeSummaryRequest,
   mapper: mapEpisodeResponseToEpisodeEntry,
   schema: EpisodeEntrySchema,
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/episode/episodeWatchNowQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeWatchNowQuery.ts
@@ -1,5 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { mapWatchNowResponseToWatchNowDetails } from '../../_internal/mapWatchNowResponseToWatchNowDetails.ts';
 import { WatchNowServicesSchema } from '../../models/WatchNowServices.ts';
 
@@ -35,4 +36,5 @@ export const episodeWatchNowQuery = defineQuery({
   mapper: (response, params) =>
     mapWatchNowResponseToWatchNowDetails(response, params.country),
   schema: WatchNowServicesSchema,
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/episode/episodeWatchersQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeWatchersQuery.ts
@@ -1,6 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapWatcherResponseToActiveWatcher } from '$lib/requests/_internal/mapWatcherResponseToActiveWatcher.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { ActiveWatcherSchema } from '../../models/ActiveWatcher.ts';
 
 type EpisodeWatchersParams =
@@ -36,4 +37,5 @@ export const episodeWatchersQuery = defineQuery({
   dependencies: (params) => [params.slug, params.season, params.episode],
   invalidations: [],
   schema: ActiveWatcherSchema.array(),
+  ttl: time.minutes(15),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
@@ -4,6 +4,7 @@ import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapMovieResponseToMovieSummary } from '../../_internal/mapMovieResponseToMovieSummary.ts';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
@@ -58,4 +59,5 @@ export const movieAnticipatedQuery = defineQuery({
     page: extractPageMeta(response.headers),
   }),
   schema: PaginatableSchemaFactory(AnticipatedMovieSchema),
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieFavoritesQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieFavoritesQuery.ts
@@ -3,6 +3,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapMovieResponseToMovieSummary } from '$lib/requests/_internal/mapMovieResponseToMovieSummary.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import {
   type FavoritedEntry,
   FavoritedEntrySchema,
@@ -48,4 +49,5 @@ export const movieFavoritesQuery = defineQuery({
   request: favoritedMoviesRequest,
   mapper: (data) => data.map(mapFavoritedMovieResponse),
   schema: FavoritedEntrySchema.array(),
+  ttl: time.hours(1),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieIntlQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieIntlQuery.ts
@@ -5,6 +5,7 @@ import type {
 } from '$lib/features/i18n/index.ts';
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { type MediaIntl, MediaIntlSchema } from '../../models/MediaIntl.ts';
 
 type MovieIntlParams = {
@@ -62,4 +63,5 @@ export const movieIntlQuery = defineQuery({
       .map(mapMovieIntlResponse)
       .at(0),
   schema: MediaIntlSchema.optional(),
+  ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/movies/moviePeopleQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePeopleQuery.ts
@@ -2,6 +2,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapPeopleResponseToMediaCrew } from '$lib/requests/_internal/mapPeopleResponseToMediaCrew.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaCrewSchema } from '$lib/requests/models/MediaCrew.ts';
+import { time } from '$lib/utils/timing/time';
 
 type MoviePeopleParams = {
   slug: string;
@@ -35,4 +36,5 @@ export const moviePeopleQuery = defineQuery({
   request: moviePeopleRequest,
   mapper: (body) => mapPeopleResponseToMediaCrew(body),
   schema: MediaCrewSchema,
+  ttl: time.days(30),
 });

--- a/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
@@ -3,6 +3,7 @@ import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { mapMovieResponseToMovieSummary } from '../../_internal/mapMovieResponseToMovieSummary.ts';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
 
@@ -41,4 +42,5 @@ export const moviePopularQuery = defineQuery({
     page: extractPageMeta(response.headers),
   }),
   schema: PaginatableSchemaFactory(MovieEntrySchema),
+  ttl: time.hours(1),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieRatingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieRatingQuery.ts
@@ -1,6 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaRatingSchema } from '$lib/requests/models/MediaRating.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { mapRatingResponseToMediaRating } from '../../_internal/mapRatingResponseToMediaRating.ts';
 
 type MovieRatingParams = { slug: string } & ApiParams;
@@ -33,4 +34,5 @@ export const movieRatingQuery = defineQuery({
   request: movieRatingRequest,
   mapper: mapRatingResponseToMediaRating,
   schema: MediaRatingSchema,
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
@@ -1,5 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapMovieResponseToMovieSummary } from '../../_internal/mapMovieResponseToMovieSummary.ts';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
@@ -36,4 +37,5 @@ export const movieRelatedQuery = defineQuery({
   request: movieRelatedRequest,
   mapper: (response) => response.map(mapMovieResponseToMovieSummary),
   schema: z.array(MovieEntrySchema),
+  ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieStatsQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieStatsQuery.ts
@@ -2,6 +2,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapStatsResponseToMediaStats } from '$lib/requests/_internal/mapStatsResponseToMediaStats.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaStatsSchema } from '$lib/requests/models/MediaStats.ts';
+import { time } from '$lib/utils/timing/time';
 
 type MovieStatsParams = {
   slug: string;
@@ -32,4 +33,5 @@ export const movieStatsQuery = defineQuery({
   request: movieStatsRequest,
   mapper: mapStatsResponseToMediaStats,
   schema: MediaStatsSchema,
+  ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieStudiosQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieStudiosQuery.ts
@@ -1,5 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { mapStudioResponseToMediaStudio } from '../../_internal/mapStudioResponseToMediaStudio.ts';
 import { MediaStudioSchema } from '../../models/MediaStudio.ts';
 
@@ -32,4 +33,5 @@ export const movieStudiosQuery = defineQuery({
   request: movieStudiosRequest,
   mapper: (body) => body.map(mapStudioResponseToMediaStudio),
   schema: MediaStudioSchema.array(),
+  ttl: time.days(30),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieSummaryQuery.ts
@@ -2,6 +2,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapMovieResponseToMovieSummary } from '$lib/requests/_internal/mapMovieResponseToMovieSummary.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaEntrySchema } from '$lib/requests/models/MediaEntry.ts';
+import { time } from '$lib/utils/timing/time';
 
 type MovieSummaryParams = { slug: string } & ApiParams;
 
@@ -33,4 +34,5 @@ export const movieSummaryQuery = defineQuery({
   request: movieSummaryRequest,
   mapper: mapMovieResponseToMovieSummary,
   schema: MediaEntrySchema,
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
@@ -4,6 +4,7 @@ import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapMovieResponseToMovieSummary } from '../../_internal/mapMovieResponseToMovieSummary.ts';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
@@ -58,4 +59,5 @@ export const movieTrendingQuery = defineQuery({
     page: extractPageMeta(response.headers),
   }),
   schema: PaginatableSchemaFactory(TrendingMovieSchema),
+  ttl: time.hours(1),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieWatchNowQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieWatchNowQuery.ts
@@ -1,5 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { mapWatchNowResponseToWatchNowDetails } from '../../_internal/mapWatchNowResponseToWatchNowDetails.ts';
 import { WatchNowServicesSchema } from '../../models/WatchNowServices.ts';
 
@@ -35,4 +36,5 @@ export const movieWatchNowQuery = defineQuery({
   mapper: (response, params) =>
     mapWatchNowResponseToWatchNowDetails(response, params.country),
   schema: WatchNowServicesSchema,
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieWatchersQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieWatchersQuery.ts
@@ -1,6 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapWatcherResponseToActiveWatcher } from '$lib/requests/_internal/mapWatcherResponseToActiveWatcher.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { ActiveWatcherSchema } from '../../models/ActiveWatcher.ts';
 
 type MovieWatchersParams = { slug: string } & ApiParams;
@@ -31,4 +32,5 @@ export const movieWatchersQuery = defineQuery({
   dependencies: (params) => [params.slug],
   invalidations: [],
   schema: ActiveWatcherSchema.array(),
+  ttl: time.minutes(15),
 });

--- a/projects/client/src/lib/requests/queries/people/peopleMovieCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleMovieCreditsQuery.ts
@@ -2,6 +2,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapMovieResponseToMovieSummary } from '$lib/requests/_internal/mapMovieResponseToMovieSummary.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaEntrySchema } from '$lib/requests/models/MediaEntry.ts';
+import { time } from '$lib/utils/timing/time';
 
 type PeopleMovieCreditsParams = { slug: string } & ApiParams;
 
@@ -34,4 +35,5 @@ export const peopleMovieCreditsQuery = defineQuery({
   mapper: (response) =>
     response.map(({ movie }) => mapMovieResponseToMovieSummary(movie)),
   schema: MediaEntrySchema.array(),
+  ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/people/peopleShowCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleShowCreditsQuery.ts
@@ -2,6 +2,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapShowResponseToShowSummary } from '$lib/requests/_internal/mapShowResponseToShowSummary.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
+import { time } from '$lib/utils/timing/time';
 
 type PeopleShowCreditsParams = { slug: string } & ApiParams;
 
@@ -34,4 +35,5 @@ export const peopleShowCreditsQuery = defineQuery({
   mapper: (response) =>
     response.map(({ show }) => mapShowResponseToShowSummary(show)),
   schema: ShowEntrySchema.array(),
+  ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
@@ -3,6 +3,7 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { PersonSummarySchema } from '$lib/requests/models/PersonSummary.ts';
 import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/constants.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
+import { time } from '$lib/utils/timing/time';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import type { PeopleSummaryResponse } from '@trakt/api';
 
@@ -54,4 +55,5 @@ export const peopleSummaryQuery = defineQuery({
   request: peopleSummaryRequest,
   mapper: mapPeopleResponseToPersonSummary,
   schema: PersonSummarySchema,
+  ttl: time.days(30),
 });

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
@@ -2,6 +2,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import type { z } from 'zod';
 import { mapMovieResponseToMovieSummary } from '../../_internal/mapMovieResponseToMovieSummary.ts';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
@@ -47,4 +48,5 @@ export const recommendedMoviesQuery = defineQuery({
   request: recommendedMoviesRequest,
   mapper: (body) => body.map(mapMovieResponseToMovieSummary),
   schema: RecommendedMovieSchema.array(),
+  ttl: time.hours(24),
 });

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
@@ -3,6 +3,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapShowResponseToShowSummary } from '../../_internal/mapShowResponseToShowSummary.ts';
 import { MediaEntrySchema } from '../../models/MediaEntry.ts';
@@ -58,4 +59,5 @@ export const recommendedShowsQuery = defineQuery({
       },
     })),
   schema: RecommendedShowSchema.array(),
+  ttl: time.hours(24),
 });

--- a/projects/client/src/lib/requests/queries/search/searchQuery.ts
+++ b/projects/client/src/lib/requests/queries/search/searchQuery.ts
@@ -4,6 +4,7 @@ import { mapMovieResponseToMovieSummary } from '$lib/requests/_internal/mapMovie
 import { mapShowResponseToShowSummary } from '$lib/requests/_internal/mapShowResponseToShowSummary.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaEntrySchema } from '$lib/requests/models/MediaEntry.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import type { MediaEntry } from '../../models/MediaEntry.ts';
 
 type SearchParams = {
@@ -62,4 +63,5 @@ export const searchQuery = defineQuery({
       .map(mapToSearchResultEntry)
       .filter((value) => !isGarbage(value)),
   schema: MediaEntrySchema.array(),
+  ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
@@ -5,6 +5,7 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapShowResponseToShowSummary } from '../../_internal/mapShowResponseToShowSummary.ts';
 import { ShowEntrySchema } from '../../models/ShowEntry.ts';
@@ -67,4 +68,5 @@ export const showAnticipatedQuery = defineQuery({
     page: extractPageMeta(response.headers),
   }),
   schema: PaginatableSchemaFactory(AnticipatedShowSchema),
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showFavoritesQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showFavoritesQuery.ts
@@ -3,6 +3,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapShowResponseToShowSummary } from '$lib/requests/_internal/mapShowResponseToShowSummary.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import {
   type FavoritedEntry,
   FavoritedEntrySchema,
@@ -48,4 +49,5 @@ export const showFavoritesQuery = defineQuery({
   request: favoritedShowsRequest,
   mapper: (data) => data.map(mapFavoritedShowResponse),
   schema: FavoritedEntrySchema.array(),
+  ttl: time.hours(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showIntlQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showIntlQuery.ts
@@ -5,6 +5,7 @@ import type {
 } from '$lib/features/i18n/index.ts';
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { type MediaIntl, MediaIntlSchema } from '../../models/MediaIntl.ts';
 
 type ShowIntlParams = {
@@ -62,4 +63,5 @@ export const showIntlQuery = defineQuery({
       .map(mapShowIntlResponse)
       .at(0),
   schema: MediaIntlSchema.optional(),
+  ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/shows/showPeopleQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showPeopleQuery.ts
@@ -2,6 +2,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapPeopleResponseToMediaCrew } from '$lib/requests/_internal/mapPeopleResponseToMediaCrew.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaCrewSchema } from '$lib/requests/models/MediaCrew.ts';
+import { time } from '$lib/utils/timing/time';
 
 type ShowPeopleParams = {
   slug: string;
@@ -35,4 +36,5 @@ export const showPeopleQuery = defineQuery({
   request: showPeopleRequest,
   mapper: (body) => mapPeopleResponseToMediaCrew(body),
   schema: MediaCrewSchema,
+  ttl: time.days(30),
 });

--- a/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
@@ -5,6 +5,7 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapShowResponseToShowSummary } from '../../_internal/mapShowResponseToShowSummary.ts';
 import { ShowEntrySchema } from '../../models/ShowEntry.ts';
@@ -61,4 +62,5 @@ export const showPopularQuery = defineQuery({
     page: extractPageMeta(response.headers),
   }),
   schema: PaginatableSchemaFactory(PopularShowSchema),
+  ttl: time.hours(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
@@ -11,6 +11,7 @@ import {
 } from '$lib/requests/models/EpisodeType.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
+import { time } from '$lib/utils/timing/time';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 
 const showProgressRequest = (
@@ -76,4 +77,5 @@ export const showProgressQuery = defineQuery({
   request: showProgressRequest,
   mapper: mapShowProgressResponse,
   schema: EpisodeProgressEntrySchema,
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showRatingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRatingQuery.ts
@@ -1,6 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaRatingSchema } from '$lib/requests/models/MediaRating.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { mapRatingResponseToMediaRating } from '../../_internal/mapRatingResponseToMediaRating.ts';
 
 type ShowRatingParams = {
@@ -35,4 +36,5 @@ export const showRatingQuery = defineQuery({
   request: showRatingRequest,
   mapper: mapRatingResponseToMediaRating,
   schema: MediaRatingSchema,
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
@@ -2,6 +2,7 @@ import { type ShowResponse } from '$lib/api.ts';
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import type { z } from 'zod';
 import { mapShowResponseToShowSummary } from '../../_internal/mapShowResponseToShowSummary.ts';
 import { ShowEntrySchema } from '../../models/ShowEntry.ts';
@@ -48,4 +49,5 @@ export const showRelatedQuery = defineQuery({
   request: showRelatedRequest,
   mapper: (body) => body.map(mapResponseToRelatedShow),
   schema: RelatedShowSchema.array(),
+  ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/shows/showSeasonEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSeasonEpisodesQuery.ts
@@ -1,6 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeEntrySchema } from '$lib/requests/models/EpisodeEntry.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { mapEpisodeResponseToEpisodeEntry } from '../../_internal/mapEpisodeResponseToEpisodeEntry.ts';
 
 type ShowSeasonEpisodeParams = {
@@ -37,4 +38,5 @@ export const showSeasonEpisodesQuery = defineQuery({
   request: showSeasonEpisodesRequest,
   mapper: (body) => body.map(mapEpisodeResponseToEpisodeEntry),
   schema: EpisodeEntrySchema.array(),
+  ttl: time.hours(6),
 });

--- a/projects/client/src/lib/requests/queries/shows/showSeasonsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSeasonsQuery.ts
@@ -1,6 +1,7 @@
 import type { SeasonsResponse } from '$lib/api.ts';
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { type Season, SeasonSchema } from '../../models/Season.ts';
 
@@ -47,4 +48,5 @@ export const showSeasonsQuery = defineQuery({
       .map(mapSeasonResponseToSeason)
       .filter((season) => season.episodes.count > 0 && season.number !== 0),
   schema: z.array(SeasonSchema),
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showStatsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showStatsQuery.ts
@@ -2,6 +2,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapStatsResponseToMediaStats } from '$lib/requests/_internal/mapStatsResponseToMediaStats.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaStatsSchema } from '$lib/requests/models/MediaStats.ts';
+import { time } from '$lib/utils/timing/time';
 
 type ShowStatsParams = {
   slug: string;
@@ -32,4 +33,5 @@ export const showStatsQuery = defineQuery({
   request: showStatsRequest,
   mapper: mapStatsResponseToMediaStats,
   schema: MediaStatsSchema,
+  ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/shows/showStudiosQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showStudiosQuery.ts
@@ -1,6 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaStudioSchema } from '$lib/requests/models/MediaStudio.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { mapStudioResponseToMediaStudio } from '../../_internal/mapStudioResponseToMediaStudio.ts';
 
 type ShowStudiosParams = {
@@ -32,4 +33,5 @@ export const showStudiosQuery = defineQuery({
   request: showStudiosRequest,
   mapper: (body) => body.map(mapStudioResponseToMediaStudio),
   schema: MediaStudioSchema.array(),
+  ttl: time.days(30),
 });

--- a/projects/client/src/lib/requests/queries/shows/showSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSummaryQuery.ts
@@ -2,6 +2,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapShowResponseToShowSummary } from '$lib/requests/_internal/mapShowResponseToShowSummary.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaEntrySchema } from '$lib/requests/models/MediaEntry.ts';
+import { time } from '$lib/utils/timing/time';
 
 type ShowSummaryParams = { slug: string } & ApiParams;
 
@@ -33,4 +34,5 @@ export const showSummaryQuery = defineQuery({
   request: showSummaryRequest,
   mapper: mapShowResponseToShowSummary,
   schema: MediaEntrySchema,
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
@@ -5,6 +5,7 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapShowResponseToShowSummary } from '../../_internal/mapShowResponseToShowSummary.ts';
 import { ShowEntrySchema } from '../../models/ShowEntry.ts';
@@ -64,4 +65,5 @@ export const showTrendingQuery = defineQuery({
     page: extractPageMeta(response.headers),
   }),
   schema: PaginatableSchemaFactory(TrendingShowSchema),
+  ttl: time.hours(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showWatchNowQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showWatchNowQuery.ts
@@ -1,5 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { mapWatchNowResponseToWatchNowDetails } from '../../_internal/mapWatchNowResponseToWatchNowDetails.ts';
 import { WatchNowServicesSchema } from '../../models/WatchNowServices.ts';
 
@@ -35,4 +36,5 @@ export const showWatchNowQuery = defineQuery({
   mapper: (response, params) =>
     mapWatchNowResponseToWatchNowDetails(response, params.country),
   schema: WatchNowServicesSchema,
+  ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showWatchersQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showWatchersQuery.ts
@@ -1,6 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapWatcherResponseToActiveWatcher } from '$lib/requests/_internal/mapWatcherResponseToActiveWatcher.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { ActiveWatcherSchema } from '../../models/ActiveWatcher.ts';
 
 type ShowWatchersParams = { slug: string } & ApiParams;
@@ -31,4 +32,5 @@ export const showWatchersQuery = defineQuery({
   dependencies: (params) => [params.slug],
   invalidations: [],
   schema: ActiveWatcherSchema.array(),
+  ttl: time.minutes(15),
 });

--- a/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
@@ -8,6 +8,7 @@ import { EpisodeProgressEntrySchema } from '$lib/requests/models/EpisodeProgress
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
+import { time } from '$lib/utils/timing/time';
 import { z } from 'zod';
 
 export const UpNextEntrySchema = EpisodeProgressEntrySchema.merge(z.object({
@@ -82,4 +83,6 @@ export const upNextQuery = defineQuery({
     page: extractPageMeta(response.headers),
   }),
   schema: PaginatableSchemaFactory(UpNextEntrySchema),
+  ttl: time.minutes(30),
+  refetchOnWindowFocus: true,
 });

--- a/projects/client/src/lib/requests/queries/users/episodeHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/episodeHistoryQuery.ts
@@ -6,6 +6,7 @@ import { api, type ApiParams } from '$lib/requests/api';
 import { EpisodeEntrySchema } from '$lib/requests/models/EpisodeEntry';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry';
+import { time } from '$lib/utils/timing/time';
 import { z } from 'zod';
 
 type EpisodeHistoryParams = {
@@ -70,4 +71,5 @@ export const episodeHistoryQuery = defineQuery({
   request: episodeHistoryRequest,
   mapper: (body) => body.map(mapResponseToHistory),
   schema: HistoryEpisodeSchema.array(),
+  ttl: time.hours(1),
 });

--- a/projects/client/src/lib/requests/queries/users/movieHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieHistoryQuery.ts
@@ -3,6 +3,7 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapMovieResponseToMovieSummary } from '$lib/requests/_internal/mapMovieResponseToMovieSummary.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { time } from '$lib/utils/timing/time';
 import { z } from 'zod';
 import { MovieEntrySchema } from '../../models/MovieEntry';
 
@@ -63,4 +64,5 @@ export const movieHistoryQuery = defineQuery({
   request: movieHistoryRequest,
   mapper: (body) => body.map(mapResponseToHistory),
   schema: HistoryMovieSchema.array(),
+  ttl: time.hours(6),
 });

--- a/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
@@ -4,6 +4,7 @@ import { mapMovieResponseToMovieSummary } from '$lib/requests/_internal/mapMovie
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { ListItemSchemaFactory } from '$lib/requests/models/ListItem.ts';
+import { time } from '$lib/utils/timing/time';
 import { z } from 'zod';
 import { MovieEntrySchema } from '../../models/MovieEntry';
 
@@ -51,4 +52,5 @@ export const movieWatchlistQuery = defineQuery({
   request: watchlistRequest,
   mapper: (body) => body.map(mapResponseToWatchlist),
   schema: WatchlistMovieSchema.array(),
+  ttl: time.hours(1),
 });

--- a/projects/client/src/lib/requests/queries/users/showHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showHistoryQuery.ts
@@ -4,6 +4,7 @@ import { mapEpisodeResponseToEpisodeEntry } from '$lib/requests/_internal/mapEpi
 import { mapShowResponseToShowSummary } from '$lib/requests/_internal/mapShowResponseToShowSummary.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { time } from '$lib/utils/timing/time';
 import { z } from 'zod';
 import { EpisodeEntrySchema } from '../../models/EpisodeEntry';
 import { ShowEntrySchema } from '../../models/ShowEntry';
@@ -67,4 +68,5 @@ export const showHistoryQuery = defineQuery({
   request: showHistoryRequest,
   mapper: (body) => body.map(mapResponseToHistory),
   schema: HistoryShowSchema.array(),
+  ttl: time.hours(6),
 });

--- a/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
@@ -4,6 +4,7 @@ import { mapShowResponseToShowSummary } from '$lib/requests/_internal/mapShowRes
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { ListItemSchemaFactory } from '$lib/requests/models/ListItem.ts';
+import { time } from '$lib/utils/timing/time';
 import { z } from 'zod';
 import { ShowEntrySchema } from '../../models/ShowEntry';
 
@@ -51,4 +52,5 @@ export const showWatchlistQuery = defineQuery({
   request: watchlistRequest,
   mapper: (body) => body.map(mapResponseToWatchlist),
   schema: WatchlistShowSchema.array(),
+  ttl: time.hours(1),
 });

--- a/projects/client/src/lib/requests/queries/watchnow/watchNowSourcesQuery.ts
+++ b/projects/client/src/lib/requests/queries/watchnow/watchNowSourcesQuery.ts
@@ -60,4 +60,5 @@ export const watchNowSourcesQuery = defineQuery({
       return countrySources.map(mapWatchNowSourceResponse);
     }, (_, entry) => extractCountryCode(entry)),
   schema: WatchNowSourceListSchema,
+  ttl: Infinity,
 });

--- a/projects/client/src/lib/sections/landing/useTrendingItems.ts
+++ b/projects/client/src/lib/sections/landing/useTrendingItems.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '$lib/features/query/useQuery.ts';
 import { shuffle } from '$lib/utils/array/shuffle.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 import {
   movieTrendingQuery,
@@ -12,15 +11,8 @@ import {
 const RANDOM_SHOW_COUNT = 2;
 
 export function useTrendingItems() {
-  const trendingShows = useQuery({
-    ...showTrendingQuery(),
-    staleTime: time.hours(1),
-  });
-
-  const trendingMovies = useQuery({
-    ...movieTrendingQuery(),
-    staleTime: time.hours(1),
-  });
+  const trendingShows = useQuery(showTrendingQuery());
+  const trendingMovies = useQuery(movieTrendingQuery());
 
   return {
     shows: derived(

--- a/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
+++ b/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
@@ -5,7 +5,6 @@ import {
   movieAnticipatedQuery,
 } from '$lib/requests/queries/movies/movieAnticipatedQuery.ts';
 import { showAnticipatedQuery } from '$lib/requests/queries/shows/showAnticipatedQuery.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 export type AnticipatedEntry = AnticipatedMovie;
@@ -36,10 +35,7 @@ function typeToQuery(
 export function useAnticipatedList(
   props: AnticipatedListStoreProps,
 ) {
-  const query = useQuery({
-    ...typeToQuery(props),
-    staleTime: time.hours(1),
-  });
+  const query = useQuery(typeToQuery(props));
 
   return {
     list: derived(query, ($query) => $query.data?.entries ?? []),

--- a/projects/client/src/lib/sections/lists/popular/usePopularList.ts
+++ b/projects/client/src/lib/sections/lists/popular/usePopularList.ts
@@ -5,7 +5,6 @@ import {
   type PopularShow,
   showPopularQuery,
 } from '$lib/requests/queries/shows/showPopularQuery.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 import type { MediaType } from '../../../requests/models/MediaType.ts';
 
@@ -37,10 +36,7 @@ function typeToQuery(
 export function usePopularList(
   props: PopularListStoreProps,
 ) {
-  const query = useQuery({
-    ...typeToQuery(props),
-    staleTime: time.hours(1),
-  });
+  const query = useQuery(typeToQuery(props));
 
   return {
     list: derived(query, ($query) => $query.data?.entries ?? []),

--- a/projects/client/src/lib/sections/lists/recommended/useRecommendedList.ts
+++ b/projects/client/src/lib/sections/lists/recommended/useRecommendedList.ts
@@ -8,7 +8,6 @@ import {
   type RecommendedShow,
   recommendedShowsQuery,
 } from '$lib/requests/queries/recommendations/recommendedShowsQuery.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
@@ -39,10 +38,7 @@ function typeToQuery(
 export function useRecommendedList(
   props: RecommendationListStoreProps,
 ) {
-  const query = useQuery({
-    ...typeToQuery(props),
-    staleTime: time.hours(24),
-  });
+  const query = useQuery(typeToQuery(props));
   const list = derived(query, ($query) => $query.data ?? []);
 
   return {

--- a/projects/client/src/lib/sections/lists/stores/useCalendarEpisodes.ts
+++ b/projects/client/src/lib/sections/lists/stores/useCalendarEpisodes.ts
@@ -2,7 +2,6 @@ import { useQuery } from '$lib/features/query/useQuery';
 import { upcomingEpisodesQuery } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 const ONE_DAY = 1000 * 60 * 60 * 24;
@@ -14,14 +13,10 @@ function daysAgo(days: number) {
 export function useCalendarEpisodes() {
   const [YYYY_MM_DD] = daysAgo(0).toISOString().split('T');
 
-  const query = useQuery({
-    ...upcomingEpisodesQuery({
-      startDate: assertDefined(YYYY_MM_DD, 'Could not extract current date.'),
-      days: 14,
-    }),
-    staleTime: time.hours(1),
-    refetchOnWindowFocus: true,
-  });
+  const query = useQuery(upcomingEpisodesQuery({
+    startDate: assertDefined(YYYY_MM_DD, 'Could not extract current date.'),
+    days: 14,
+  }));
 
   const calendar = derived(
     query,

--- a/projects/client/src/lib/sections/lists/stores/useCreditsList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useCreditsList.ts
@@ -2,7 +2,6 @@ import { useQuery } from '$lib/features/query/useQuery';
 import type { MediaType } from '$lib/requests/models/MediaType';
 import { peopleMovieCreditsQuery } from '$lib/requests/queries/people/peopleMovieCreditsQuery';
 import { peopleShowCreditsQuery } from '$lib/requests/queries/people/peopleShowCreditsQuery';
-import { time } from '$lib/utils/timing/time';
 import { derived } from 'svelte/store';
 
 type UseCreditsListProps = {
@@ -24,10 +23,7 @@ function typeToQuery(
 }
 
 export function useCreditsList({ type, slug }: UseCreditsListProps) {
-  const query = useQuery({
-    ...typeToQuery({ type, slug }),
-    staleTime: time.days(1),
-  });
+  const query = useQuery(typeToQuery({ type, slug }));
 
   const list = derived(query, ($query) => $query.data ?? []);
 

--- a/projects/client/src/lib/sections/lists/stores/useFavoritesList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useFavoritesList.ts
@@ -3,7 +3,6 @@ import type { MediaType } from '$lib/requests/models/MediaType';
 import { movieFavoritesQuery } from '$lib/requests/queries/movies/movieFavoritesQuery';
 import { showFavoritesQuery } from '$lib/requests/queries/shows/showFavoritesQuery';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState';
-import { time } from '$lib/utils/timing/time';
 import { derived } from 'svelte/store';
 
 type UseFavoritesProps = {
@@ -22,10 +21,7 @@ function typeToQuery(
 }
 
 export function useFavoritesList({ type }: UseFavoritesProps) {
-  const query = useQuery({
-    ...typeToQuery({ type }),
-    staleTime: time.hours(1),
-  });
+  const query = useQuery(typeToQuery({ type }));
 
   return {
     list: derived(query, ($query) => $query.data ?? []),

--- a/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
@@ -6,7 +6,6 @@ import {
   movieHistoryQuery,
 } from '$lib/requests/queries/users/movieHistoryQuery.ts';
 import { getPastMonthRange } from '$lib/utils/date/getPastMonthRange.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived, type Readable } from 'svelte/store';
 
 const HISTORY_LIMIT = 1000;
@@ -40,10 +39,7 @@ function getQueryParams() {
 }
 
 export function useRecentlyWatchedMovies() {
-  const query = useQuery({
-    ...movieHistoryQuery(getQueryParams()),
-    staleTime: time.hours(1),
-  });
+  const query = useQuery(movieHistoryQuery(getQueryParams()));
 
   return {
     list: derived(
@@ -60,10 +56,7 @@ export function useRecentlyWatchedMovies() {
 }
 
 export function useRecentlyWatchedEpisodes() {
-  const query = useQuery({
-    ...episodeHistoryQuery(getQueryParams()),
-    staleTime: time.hours(1),
-  });
+  const query = useQuery(episodeHistoryQuery(getQueryParams()));
 
   return {
     list: derived(

--- a/projects/client/src/lib/sections/lists/stores/useRelatedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRelatedList.ts
@@ -5,7 +5,6 @@ import {
   type RelatedShow,
   showRelatedQuery,
 } from '$lib/requests/queries/shows/showRelatedQuery.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 import type { MediaType } from '../../../requests/models/MediaType.ts';
@@ -34,10 +33,7 @@ function typeToQuery(
 export function useRelatedList(
   { type, slug }: PopularListStoreProps,
 ) {
-  const query = useQuery({
-    ...typeToQuery({ type, slug }),
-    staleTime: time.days(7),
-  });
+  const query = useQuery(typeToQuery({ type, slug }));
   const list = derived(query, ($query) => $query.data ?? []);
 
   return {

--- a/projects/client/src/lib/sections/lists/stores/useSeasonEpisodes.ts
+++ b/projects/client/src/lib/sections/lists/stores/useSeasonEpisodes.ts
@@ -1,17 +1,13 @@
 import { useQuery } from '$lib/features/query/useQuery';
 import { showSeasonEpisodesQuery } from '$lib/requests/queries/shows/showSeasonEpisodesQuery.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 export const useSeasonEpisodes = (slug: string, season: number) => {
-  const query = useQuery({
-    ...showSeasonEpisodesQuery({
-      slug,
-      season,
-    }),
-    staleTime: time.hours(1),
-  });
+  const query = useQuery(showSeasonEpisodesQuery({
+    slug,
+    season,
+  }));
 
   return {
     list: derived(query, ($query) => $query.data ?? []),

--- a/projects/client/src/lib/sections/lists/stores/useUpNextEpisodes.ts
+++ b/projects/client/src/lib/sections/lists/stores/useUpNextEpisodes.ts
@@ -2,7 +2,6 @@ import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { useQuery } from '$lib/features/query/useQuery';
 import { upNextQuery } from '$lib/requests/queries/sync/upNextQuery.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 const UP_NEXT_LIMIT = 100;
@@ -10,14 +9,10 @@ const UP_NEXT_LIMIT = 100;
 export const useUpNextEpisodes = () => {
   const { current: user } = useUser();
 
-  const query = useQuery({
-    ...upNextQuery({
-      limit: UP_NEXT_LIMIT,
-      sort: user().preferences.progress.sort,
-    }),
-    staleTime: time.minutes(5),
-    refetchOnWindowFocus: true,
-  });
+  const query = useQuery(upNextQuery({
+    limit: UP_NEXT_LIMIT,
+    sort: user().preferences.progress.sort,
+  }));
 
   return {
     list: derived(query, ($query) => $query.data?.entries ?? []),

--- a/projects/client/src/lib/sections/lists/trending/useTrendingList.ts
+++ b/projects/client/src/lib/sections/lists/trending/useTrendingList.ts
@@ -9,7 +9,6 @@ import {
   showTrendingQuery,
   type TrendingShow,
 } from '$lib/requests/queries/shows/showTrendingQuery.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
@@ -44,10 +43,7 @@ function typeToQuery(
 export function useTrendingList(
   { type, limit, page }: TrendingListStoreProps,
 ) {
-  const query = useQuery({
-    ...typeToQuery({ type, limit, page }),
-    staleTime: time.hours(1),
-  });
+  const query = useQuery(typeToQuery({ type, limit, page }));
 
   return {
     list: derived(query, ($query) => $query.data?.entries ?? []),

--- a/projects/client/src/lib/sections/lists/watchlist/useWatchlistList.ts
+++ b/projects/client/src/lib/sections/lists/watchlist/useWatchlistList.ts
@@ -10,7 +10,6 @@ import {
   type WatchlistShow,
 } from '$lib/requests/queries/users/showWatchlistQuery.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 export type WatchListParams = {
@@ -40,10 +39,7 @@ function typeToQuery(
 }
 
 export function useWatchlistList(params: WatchListStoreProps) {
-  const query = useQuery({
-    ...typeToQuery(params),
-    staleTime: time.hours(1),
-  });
+  const query = useQuery(typeToQuery(params));
   const list = derived(
     query,
     ($query) => ($query.data ?? []).map((item) => item.entry),

--- a/projects/client/src/lib/sections/navbar/components/search/useSearch.ts
+++ b/projects/client/src/lib/sections/navbar/components/search/useSearch.ts
@@ -7,7 +7,6 @@ import {
 } from '$lib/requests/queries/search/searchQuery.ts';
 import { useMedia, WellKnownMediaQuery } from '$lib/stores/css/useMedia.ts';
 import { debounce } from '$lib/utils/timing/debounce.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { CancelledError, useQueryClient } from '@tanstack/svelte-query';
 import { onDestroy } from 'svelte';
 import { derived, get, writable } from 'svelte/store';
@@ -39,12 +38,9 @@ export function useSearch() {
       return;
     }
 
-    const response = await client.fetchQuery({
-      ...searchQuery({
-        query,
-      }),
-      staleTime: time.minutes(5),
-    })
+    const response = await client.fetchQuery(searchQuery({
+      query,
+    }))
       .then((response) => ({
         items: response,
         reason: 'result',

--- a/projects/client/src/lib/sections/profile/stores/useHistory.ts
+++ b/projects/client/src/lib/sections/profile/stores/useHistory.ts
@@ -2,7 +2,6 @@ import { useQuery } from '$lib/features/query/useQuery';
 import { movieHistoryQuery } from '$lib/requests/queries/users/movieHistoryQuery.ts';
 import { showHistoryQuery } from '$lib/requests/queries/users/showHistoryQuery.ts';
 import { getPastMonthRange } from '$lib/utils/date/getPastMonthRange.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 // TODO: add fetchAllPages or something
@@ -14,15 +13,8 @@ export function useHistory() {
     ...getPastMonthRange(new Date()),
   };
 
-  const movies = useQuery({
-    ...movieHistoryQuery(params),
-    staleTime: time.days(1),
-  });
-
-  const shows = useQuery({
-    ...showHistoryQuery(params),
-    staleTime: time.days(1),
-  });
+  const movies = useQuery(movieHistoryQuery(params));
+  const shows = useQuery(showHistoryQuery(params));
 
   return {
     historyMovies: derived(movies, ($movies) => $movies.data),

--- a/projects/client/src/lib/stores/useShowProgress.ts
+++ b/projects/client/src/lib/stores/useShowProgress.ts
@@ -1,13 +1,9 @@
 import { useQuery } from '$lib/features/query/useQuery';
 import { showProgressQuery } from '$lib/requests/queries/shows/showProgressQuery.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 export function useShowProgress(slug: string) {
-  const progress = useQuery({
-    ...showProgressQuery({ slug }),
-    staleTime: time.days(1),
-  });
+  const progress = useQuery(showProgressQuery({ slug }));
 
   return {
     progress: derived(progress, ($progress) => $progress.data),

--- a/projects/client/src/lib/stores/useWatchNow.ts
+++ b/projects/client/src/lib/stores/useWatchNow.ts
@@ -1,16 +1,15 @@
 import { useAuth } from '$lib/features/auth/stores/useAuth.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { getLanguageAndRegion } from '$lib/features/i18n/index.ts';
+import { useQuery } from '$lib/features/query/useQuery.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { WatchNowServices } from '$lib/requests/models/WatchNowServices.ts';
 import { episodeWatchNowQuery } from '$lib/requests/queries/episode/episodeWatchNowQuery.ts';
 import { showWatchNowQuery } from '$lib/requests/queries/shows/showWatchNowQuery.ts';
 import { findFavoriteWatchNowService } from '$lib/stores/_internal/findFavoriteWatchNowService.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived, get, readable } from 'svelte/store';
 import { movieWatchNowQuery } from '../requests/queries/movies/movieWatchNowQuery.ts';
-import { useQuery } from '$lib/features/query/useQuery.ts';
 
 type WatchNowMediaType = MediaType | 'episode';
 
@@ -57,10 +56,7 @@ export function useWatchNow({ type, id }: WatchNowStoreProps) {
   const { watchNow: watchNowSettings } = current();
   const country = watchNowSettings.country ?? region;
 
-  const watchNow = useQuery({
-    ...typeToQuery(type, id, country),
-    staleTime: time.days(1),
-  });
+  const watchNow = useQuery(typeToQuery(type, id, country));
 
   return {
     watchNow: derived(

--- a/projects/client/src/lib/stores/useWatchNowSources.ts
+++ b/projects/client/src/lib/stores/useWatchNowSources.ts
@@ -11,10 +11,7 @@ export function useWatchNowSources() {
   const { watchNow: watchNowSettings } = current();
   const country = watchNowSettings.country ?? region;
 
-  const watchNowSources = useQuery({
-    ...watchNowSourcesQuery({}),
-    staleTime: Infinity,
-  });
+  const watchNowSources = useQuery(watchNowSourcesQuery({}));
 
   return {
     sources: derived(

--- a/projects/client/src/routes/movies/[slug]/useMovie.ts
+++ b/projects/client/src/routes/movies/[slug]/useMovie.ts
@@ -7,55 +7,34 @@ import { movieStatsQuery } from '$lib/requests/queries/movies/movieStatsQuery.ts
 import { movieStudiosQuery } from '$lib/requests/queries/movies/movieStudiosQuery.ts';
 import { movieSummaryQuery } from '$lib/requests/queries/movies/movieSummaryQuery.ts';
 import { movieWatchersQuery } from '$lib/requests/queries/movies/movieWatchersQuery.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 export function useMovie(slug: string) {
-  const movie = useQuery({
-    ...movieSummaryQuery({
-      slug,
-    }),
-    staleTime: time.days(1),
-  });
+  const movie = useQuery(movieSummaryQuery({
+    slug,
+  }));
 
-  const ratings = useQuery({
-    ...movieRatingQuery({
-      slug,
-    }),
-    staleTime: time.days(1),
-  });
+  const ratings = useQuery(movieRatingQuery({
+    slug,
+  }));
 
-  const stats = useQuery({
-    ...movieStatsQuery({
-      slug,
-    }),
-    staleTime: time.minutes(30),
-  });
+  const stats = useQuery(movieStatsQuery({
+    slug,
+  }));
 
-  const watchers = useQuery({
-    ...movieWatchersQuery({
-      slug,
-    }),
-    staleTime: time.minutes(5),
-  });
+  const watchers = useQuery(movieWatchersQuery({
+    slug,
+  }));
 
-  const studios = useQuery({
-    ...movieStudiosQuery({ slug }),
-    staleTime: time.days(1),
-  });
-
-  const crew = useQuery({
-    ...moviePeopleQuery({ slug }),
-    staleTime: time.days(1),
-  });
+  const studios = useQuery(movieStudiosQuery({ slug }));
+  const crew = useQuery(moviePeopleQuery({ slug }));
 
   const locale = languageTag();
 
   const isLocaleSkipped = locale === 'en';
-  const intl = isLocaleSkipped ? movie : useQuery({
-    ...movieIntlQuery({ slug, ...getLanguageAndRegion() }),
-    staleTime: time.days(7),
-  });
+  const intl = isLocaleSkipped
+    ? movie
+    : useQuery(movieIntlQuery({ slug, ...getLanguageAndRegion() }));
 
   const queries = [movie, ratings, stats, watchers, studios, crew, intl];
 

--- a/projects/client/src/routes/people/[slug]/usePerson.ts
+++ b/projects/client/src/routes/people/[slug]/usePerson.ts
@@ -1,15 +1,11 @@
 import { useQuery } from '$lib/features/query/useQuery';
 import { peopleSummaryQuery } from '$lib/requests/queries/people/peopleSummaryQuery';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 export function usePerson(slug: string) {
-  const person = useQuery({
-    ...peopleSummaryQuery({
-      slug,
-    }),
-    staleTime: time.days(1),
-  });
+  const person = useQuery(peopleSummaryQuery({
+    slug,
+  }));
 
   return {
     isLoading: derived(person, ($person) => $person.isPending),

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/useEpisode.ts
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/useEpisode.ts
@@ -8,7 +8,6 @@ import {
   episodeWatchersQuery,
 } from '$lib/requests/queries/episode/episodeWatchersQuery';
 import { showSeasonsQuery } from '$lib/requests/queries/shows/showSeasonsQuery';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 type UseEpisodeParams = {
@@ -20,38 +19,18 @@ type UseEpisodeParams = {
 export function useEpisode(
   params: UseEpisodeParams,
 ) {
-  const episode = useQuery({
-    ...episodeSummaryQuery(params),
-    staleTime: time.days(1),
-  });
-
-  const seasons = useQuery({
-    ...showSeasonsQuery(params),
-    staleTime: time.days(1),
-  });
-
-  const ratings = useQuery({
-    ...episodeRatingQuery(params),
-    staleTime: time.days(1),
-  });
-
-  const stats = useQuery({
-    ...episodeStatsQuery(params),
-    staleTime: time.minutes(30),
-  });
-
-  const watchers = useQuery({
-    ...episodeWatchersQuery(params),
-    staleTime: time.minutes(5),
-  });
+  const episode = useQuery(episodeSummaryQuery(params));
+  const seasons = useQuery(showSeasonsQuery(params));
+  const ratings = useQuery(episodeRatingQuery(params));
+  const stats = useQuery(episodeStatsQuery(params));
+  const watchers = useQuery(episodeWatchersQuery(params));
 
   const locale = languageTag();
 
   const isLocaleSkipped = locale === 'en';
-  const intl = isLocaleSkipped ? episode : useQuery({
-    ...episodeIntlQuery({ ...params, ...getLanguageAndRegion() }),
-    staleTime: time.days(7),
-  });
+  const intl = isLocaleSkipped
+    ? episode
+    : useQuery(episodeIntlQuery({ ...params, ...getLanguageAndRegion() }));
 
   const queries = [episode, seasons, ratings, stats, watchers, intl];
 

--- a/projects/client/src/routes/shows/[slug]/useShow.ts
+++ b/projects/client/src/routes/shows/[slug]/useShow.ts
@@ -2,22 +2,17 @@ import { getLanguageAndRegion, languageTag } from '$lib/features/i18n/index.ts';
 import { useQuery } from '$lib/features/query/useQuery';
 import { showIntlQuery } from '$lib/requests/queries/shows/showIntlQuery.ts';
 import { showSummaryQuery } from '$lib/requests/queries/shows/showSummaryQuery.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 export function useShow(slug: string) {
-  const show = useQuery({
-    ...showSummaryQuery({ slug }),
-    staleTime: time.days(1),
-  });
+  const show = useQuery(showSummaryQuery({ slug }));
 
   const locale = languageTag();
   const isLocaleSkipped = locale === 'en';
 
-  const intl = isLocaleSkipped ? show : useQuery({
-    ...showIntlQuery({ slug, ...getLanguageAndRegion() }),
-    staleTime: time.days(7),
-  });
+  const intl = isLocaleSkipped
+    ? show
+    : useQuery(showIntlQuery({ slug, ...getLanguageAndRegion() }));
 
   const queries = [
     show,

--- a/projects/client/src/routes/shows/[slug]/useShowDetails.ts
+++ b/projects/client/src/routes/shows/[slug]/useShowDetails.ts
@@ -5,39 +5,15 @@ import { showSeasonsQuery } from '$lib/requests/queries/shows/showSeasonsQuery.t
 import { showStatsQuery } from '$lib/requests/queries/shows/showStatsQuery.ts';
 import { showStudiosQuery } from '$lib/requests/queries/shows/showStudiosQuery.ts';
 import { showWatchersQuery } from '$lib/requests/queries/shows/showWatchersQuery.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { derived } from 'svelte/store';
 
 export function useShowDetails(slug: string) {
-  const ratings = useQuery({
-    ...showRatingQuery({ slug }),
-    staleTime: time.days(1),
-  });
-
-  const stats = useQuery({
-    ...showStatsQuery({ slug }),
-    staleTime: time.minutes(30),
-  });
-
-  const watchers = useQuery({
-    ...showWatchersQuery({ slug }),
-    staleTime: time.minutes(5),
-  });
-
-  const studios = useQuery({
-    ...showStudiosQuery({ slug }),
-    staleTime: time.days(1),
-  });
-
-  const crew = useQuery({
-    ...showPeopleQuery({ slug }),
-    staleTime: time.days(1),
-  });
-
-  const seasons = useQuery({
-    ...showSeasonsQuery({ slug }),
-    staleTime: time.days(1),
-  });
+  const ratings = useQuery(showRatingQuery({ slug }));
+  const seasons = useQuery(showSeasonsQuery({ slug }));
+  const studios = useQuery(showStudiosQuery({ slug }));
+  const crew = useQuery(showPeopleQuery({ slug }));
+  const stats = useQuery(showStatsQuery({ slug }));
+  const watchers = useQuery(showWatchersQuery({ slug }));
 
   const queries = [
     ratings,


### PR DESCRIPTION
## Query Definition Enhancement and Standardization

This pull request refines query definitions across the project, improving cache management and code consistency.

### Query Definition Updates

- Added a `ttl` (time-to-live) parameter to numerous query definitions. This parameter sets the duration for which cached data remains valid, ensuring data freshness and preventing unnecessary API calls.
- Included the `refetchOnWindowFocus` option in several query definitions. This option determines whether queries should be refetched when the window regains focus, providing users with the latest data upon returning to the application.

### Function and Type Enhancements

- Updated the `useUser` function to remove redundant `staleTime` settings, simplifying the code and relying on the `ttl` parameter for cache invalidation.
- Enhanced the `defineQuery` function to support the `ttl` and `refetchOnWindowFocus` parameters, centralizing the configuration of these options and promoting consistency across query definitions.

(These changes, like a meticulous librarian carefully cataloging and organizing a vast collection of books, enhance the efficiency and maintainability of the query definitions. The standardized use of `ttl` and `refetchOnWindowFocus` parameters ensures consistent cache management and data freshness throughout the application.)