### PR TITLE
feat(query): invalidate queries with associated invalidators only

### DIFF
--- a/projects/client/src/lib/features/auth/queries/currentUserWatchlistQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserWatchlistQuery.ts
@@ -91,7 +91,6 @@ export const currentUserWatchlistQuery = defineQuery({
       currentUserWatchlistedShowsRequest({ fetch }),
     ]),
   invalidations: [
-    InvalidateAction.Watchlisted('episode'),
     InvalidateAction.Watchlisted('show'),
     InvalidateAction.Watchlisted('movie'),
   ],

--- a/projects/client/src/lib/features/query/defineQuery.ts
+++ b/projects/client/src/lib/features/query/defineQuery.ts
@@ -34,9 +34,21 @@ type DefineQueryProps<
   refetchOnWindowFocus?: boolean;
 };
 
-export const QUERY_ID = 'query';
-export const SCHEMA_ID = 'schema';
-export const DEPENDENCY_ID = 'dependency';
+const QUERY_ID = 'query';
+const SCHEMA_ID = 'schema';
+const DEPENDENCY_ID = 'dependency';
+
+export function queryId(key: string) {
+  return `${QUERY_ID}:${key}`;
+}
+
+export function schemaId(key: string) {
+  return `${SCHEMA_ID}:${key}`;
+}
+
+export function dependencyId(key: Dependency) {
+  return `${DEPENDENCY_ID}:${key}`;
+}
 
 export function defineQuery<
   TInput,
@@ -52,10 +64,8 @@ export function defineQuery<
     ...params
   }: DefineQueryProps<TInput, TOutput, TRequestParams>,
 ) {
-  const key = `${QUERY_ID}:${params.key}`;
-  const hash = `${SCHEMA_ID}:${
-    monitor(zodToHash, `${params.key} hashing`)(schema)
-  }`;
+  const key = queryId(params.key);
+  const hash = schemaId(monitor(zodToHash, `${params.key} hashing`)(schema));
 
   return (
     requestParams: TRequestParams = {} as TRequestParams,
@@ -66,7 +76,7 @@ export function defineQuery<
 
     const dependencies = resolved
       .filter((dependency) => dependency != null)
-      .map((dependency) => `${DEPENDENCY_ID}:${dependency}`);
+      .map((dependency) => dependencyId(dependency));
 
     return {
       queryKey: [

--- a/projects/client/src/lib/features/query/useQuery.ts
+++ b/projects/client/src/lib/features/query/useQuery.ts
@@ -6,7 +6,7 @@ import {
   useQueryClient,
 } from '@tanstack/svelte-query';
 import { onMount } from 'svelte';
-import { QUERY_ID } from './defineQuery';
+import { queryId } from './defineQuery';
 
 const INVALIDATION_MAP = new Map<string, number>();
 
@@ -23,21 +23,21 @@ export function useQuery<
       return;
     }
 
-    const queryId = props.queryKey.find((key) =>
-      typeof key === 'string' && key.includes(`${QUERY_ID}:`)
+    const id = props.queryKey.find((key) =>
+      typeof key === 'string' && key.includes(queryId(''))
     ) as string | Nil;
 
-    if (queryId == null) {
+    if (id == null) {
       return;
     }
 
-    const isInvalidatedQueued = INVALIDATION_MAP.has(queryId);
+    const isInvalidatedQueued = INVALIDATION_MAP.has(id);
 
     if (isInvalidatedQueued) {
       return;
     }
 
-    INVALIDATION_MAP.set(queryId, Date.now());
+    INVALIDATION_MAP.set(id, Date.now());
 
     const timeoutId = setTimeout(() => {
       client.invalidateQueries({ queryKey: props.queryKey });

--- a/projects/client/src/lib/features/query/useQuery.ts
+++ b/projects/client/src/lib/features/query/useQuery.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import { invalidationId } from '$lib/requests/models/InvalidateAction';
 import { time } from '$lib/utils/timing/time';
 import {
   createQuery,
@@ -28,6 +29,14 @@ export function useQuery<
     ) as string | Nil;
 
     if (id == null) {
+      return;
+    }
+
+    const hasInvalidationMarker = props.queryKey.some((key) =>
+      typeof key === 'string' && key.includes(invalidationId(''))
+    );
+
+    if (!hasInvalidationMarker) {
       return;
     }
 


### PR DESCRIPTION
## Query and Invalidation Handling Refinements

This pull request focuses on improving the consistency and efficiency of query and invalidation handling within the client project.

With this change we'll once again have consistent behavior as with active sessions after first load since data without associated invalidators will stay cached.

### Improvements to Query ID Generation

- Introduced new utility functions (`queryId`, `schemaId`, `dependencyId`) to generate consistent and predictable IDs for queries, schemas, and dependencies. This standardization improves code readability and reduces the risk of errors caused by inconsistent naming conventions.

### Refactoring of Invalidation Actions

- Added an `INVALIDATION_ID` constant and refactored the `InvalidateAction` type to use the `buildInvalidationKey` function for generating invalidation keys. This change centralizes the logic for invalidation key generation, promoting consistency and maintainability.

### Updates to Query Usage

- Updated the `useQuery` function to utilize the new `queryId` and `invalidationId` functions for handling query keys and invalidation markers, ensuring consistency and alignment with the new ID generation approach.

### Removal of Unnecessary Invalidations

- Removed an unnecessary invalidation for 'episode' in the `currentUserWatchlistQuery`, optimizing the invalidation logic and preventing unnecessary cache refreshes.

(These changes, like a meticulous detective organizing their case files and evidence, enhance the clarity and efficiency of query and invalidation handling. The standardized ID generation, refactored invalidation actions, and optimized query usage contribute to a more robust and maintainable codebase.)