### PR TITLE
feat(summary): add vignette to watch now poster overlay

### DIFF
--- a/projects/client/src/lib/components/summary/SummaryPoster.svelte
+++ b/projects/client/src/lib/components/summary/SummaryPoster.svelte
@@ -51,7 +51,10 @@
 
   .trakt-summary-poster :global(img),
   .trakt-summary-poster-overlay {
+    overflow: hidden;
+
     border-radius: var(--border-radius-xxl);
+
     width: var(--ni-320);
     height: var(--ni-480);
   }
@@ -61,22 +64,25 @@
       align-self: stretch;
       box-shadow: 0px 7.673px 23.02px 0px rgba(0, 0, 0, 0.56);
       transition: var(--transition-increment) ease-in-out;
-      transition-property: filter border;
-      box-sizing: border-box;
+      transition-property: filter transform;
     }
   }
 
   .trakt-summary-poster-overlay {
     position: absolute;
+
     opacity: 0;
     transition: opacity var(--transition-increment) ease-in-out;
+
     pointer-events: none;
+
+    border: var(--ni-2) solid var(--color-foreground);
   }
 
   .has-active-overlay:hover {
     :global(img) {
       filter: saturate(30%);
-      border: var(--ni-2) solid var(--color-foreground);
+      transform: scale(1.01);
     }
 
     & + .trakt-summary-poster-overlay {

--- a/projects/client/src/lib/sections/summary/components/overlay/WatchNowOverlay.svelte
+++ b/projects/client/src/lib/sections/summary/components/overlay/WatchNowOverlay.svelte
@@ -38,6 +38,21 @@
     align-items: center;
     justify-content: center;
     position: relative;
+
+    &:before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, 1) 0%,
+        rgba(0, 0, 0, 0) 20%,
+        rgba(0, 0, 0, 0) 100%
+      );
+    }
   }
 
   .trakt-watch-now-source {


### PR DESCRIPTION
## 👀 Examples 👀
Before:
<img width="1098" alt="Screenshot 2025-01-27 at 12 42 10" src="https://github.com/user-attachments/assets/c7b373a8-9f0c-4138-a530-bf22bde4807b" />

After:
<img width="1098" alt="Screenshot 2025-01-27 at 12 56 35" src="https://github.com/user-attachments/assets/68766b46-7504-4df8-b161-65a9f72f30d6" />
