### PR TITLE
test(rating): use value awaiter to eliminate flakiness

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -58,6 +58,7 @@ module.exports = {
         'popular',
         'pwa',
         'query',
+        'rating',
         'readme',
         'recommended',
         'search',

--- a/projects/client/src/lib/sections/summary/components/rating/useRatings.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/useRatings.spec.ts
@@ -5,6 +5,7 @@ import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mappe
 import { MovieMatrixMappedMock } from '$mocks/data/summary/movies/matrix/MovieMatrixMappedMock';
 import { renderStore } from '$test/beds/store/renderStore';
 import { waitForEmission } from '$test/readable/waitForEmission';
+import { waitForValue } from '$test/readable/waitForValue';
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { useRatings } from './useRatings';
@@ -31,7 +32,7 @@ describe('useRatings', () => {
     );
 
     addRating(SimpleRating.Bad);
-    expect(await waitForEmission(isRating, 1)).toBe(true);
+    expect(get(isRating)).toBe(true);
   });
 
   it('should not indicate that rating is in progress', async () => {
@@ -53,7 +54,7 @@ describe('useRatings', () => {
       })
     );
 
-    const rating = await waitForEmission(currentRating, 2);
+    const rating = await waitForValue(currentRating, SimpleRating.Great);
     expect(rating).toBe('great');
   });
 


### PR DESCRIPTION
## Test Optimization and Commitlint Configuration Update

This pull request refines the testing approach for the `useRatings` component and updates the commitlint configuration for improved consistency.

### Configuration Update

- Added `rating` to the list of available categories in the `commitlint.config.js` file. This ensures that commit messages related to rating functionality adhere to the project's standardized naming conventions.

### Testing Improvements

- Replaced `waitForEmission` with more efficient methods in the `useRatings.spec.ts` test file:
    - Used `get` to directly check the `isRating` store value, simplifying the test and reducing reliance on asynchronous emissions.
    - Replaced `waitForEmission` with `waitForValue` to check the `currentRating` store value, improving test efficiency and reducing the likelihood of flaky tests.

(These changes, like a meticulous detective refining their investigative techniques, enhance the efficiency and reliability of the test suite. The updated commitlint configuration ensures consistency in commit messages, while the optimized testing methods contribute to a more robust and maintainable codebase.)