### PR TITLE
feat: watchlist view all

### DIFF
--- a/projects/api/src/contracts/users/index.ts
+++ b/projects/api/src/contracts/users/index.ts
@@ -101,7 +101,8 @@ export const users = builder.router({
       path: '/movies/:sort',
       pathParams: profileParamsSchema.merge(sortParamsSchema),
       method: 'GET',
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+      query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+        .merge(pageQuerySchema),
       responses: {
         200: watchlistedMoviesResponseSchema.array(),
       },
@@ -110,7 +111,8 @@ export const users = builder.router({
       path: '/shows/:sort',
       pathParams: profileParamsSchema.merge(sortParamsSchema),
       method: 'GET',
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+      query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+        .merge(pageQuerySchema),
       responses: {
         200: watchlistedShowsResponseSchema.array(),
       },

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -279,5 +279,9 @@
   "favorite_shows": "Lieblingsserien",
   "favorite_movies_empty": "Your favorite movies list is empty.",
   "favorite_shows_empty": "Your favorite shows list is empty.",
-  "stream_on": "Streamen auf"
+  "stream_on": "Streamen auf",
+  "your_watchlist_shows": "Deine Merkliste Serien",
+  "your_watchlist_movies": "Deine Merkliste Filme",
+  "view_all_watchlist_movies": "Alle Merkliste Filme ansehen",
+  "view_all_watchlist_shows": "Alle Merkliste Serien ansehen"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -279,5 +279,9 @@
   "favorite_shows": "Favorite Shows",
   "favorite_movies_empty": "Your favorite movies list is empty.",
   "favorite_shows_empty": "Your favorite shows list is empty.",
-  "stream_on": "Stream on"
+  "stream_on": "Stream on",
+  "your_watchlist_shows": "Your Watchlist Shows",
+  "your_watchlist_movies": "Your Watchlist Movies",
+  "view_all_watchlist_movies": "View all watchlist movies",
+  "view_all_watchlist_shows": "View all watchlist shows"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -279,5 +279,9 @@
   "favorite_shows": "Series favoritas",
   "favorite_movies_empty": "Tu lista de favoritos está vacía. ¡Es hora de encontrar algunas joyas!",
   "favorite_shows_empty": "Tu lista de favoritos está vacía. ¡Hora de descubrir nuevas series!",
-  "stream_on": "Ver en streaming"
+  "stream_on": "Ver en streaming",
+  "your_watchlist_shows": "Tus listas para ver",
+  "your_watchlist_movies": "Tus listas para ver",
+  "view_all_watchlist_movies": "Ver todos en lista",
+  "view_all_watchlist_shows": "Ver todos en lista"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -279,5 +279,9 @@
   "favorite_shows": "Series Favoritas",
   "favorite_movies_empty": "Tu lista de favoritos está vacía.",
   "favorite_shows_empty": "Tu lista de favoritos está vacía.",
-  "stream_on": "Ver en línea"
+  "stream_on": "Ver en línea",
+  "your_watchlist_shows": "Tu lista de 'a ver' series",
+  "your_watchlist_movies": "Tu lista de 'a ver' pelis",
+  "view_all_watchlist_movies": "Ver todas las pelis 'a ver'",
+  "view_all_watchlist_shows": "Ver todas las series 'a ver'"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -279,5 +279,9 @@
   "favorite_shows": "Séries préférées",
   "favorite_movies_empty": "Votre liste de favoris est vide.",
   "favorite_shows_empty": "Votre liste d'émissions favorites est vide.",
-  "stream_on": "En diffusion sur"
+  "stream_on": "En diffusion sur",
+  "your_watchlist_shows": "Vos éléments à voir (séries)",
+  "your_watchlist_movies": "Vos éléments à voir (films)",
+  "view_all_watchlist_movies": "Voir tous les films à voir",
+  "view_all_watchlist_shows": "Voir toutes les séries à voir"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -279,5 +279,9 @@
   "favorite_shows": "Séries favorites",
   "favorite_movies_empty": "Votre liste de favoris est vide.",
   "favorite_shows_empty": "Votre liste de séries préférées est vide.",
-  "stream_on": "En streaming sur"
+  "stream_on": "En streaming sur",
+  "your_watchlist_shows": "Vos listes à voir (séries)",
+  "your_watchlist_movies": "Vos listes à voir (films)",
+  "view_all_watchlist_movies": "Voir tous les films à voir",
+  "view_all_watchlist_shows": "Voir toutes les séries à voir"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -279,5 +279,9 @@
   "favorite_shows": "お気に入り作品",
   "favorite_movies_empty": "お気に入りの作品リストは空です。",
   "favorite_shows_empty": "お気に入りの番組リストは空です。",
-  "stream_on": "配信で見る"
+  "stream_on": "配信で見る",
+  "your_watchlist_shows": "視聴予定の作品",
+  "your_watchlist_movies": "視聴予定の作品",
+  "view_all_watchlist_movies": "視聴予定の作品をすべて見る",
+  "view_all_watchlist_shows": "視聴予定の作品をすべて見る"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -279,5 +279,9 @@
   "favorite_shows": "Favoriete series",
   "favorite_movies_empty": "Je lijst met favorieten is leeg.",
   "favorite_shows_empty": "Je favoriete series lijst is leeg.",
-  "stream_on": "Streamen op"
+  "stream_on": "Streamen op",
+  "your_watchlist_shows": "Jouw kijklijst series",
+  "your_watchlist_movies": "Jouw kijklijst films",
+  "view_all_watchlist_movies": "Bekijk alle films op kijklijst",
+  "view_all_watchlist_shows": "Bekijk alle series op kijklijst"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -279,5 +279,9 @@
   "favorite_shows": "Séries Favoritas",
   "favorite_movies_empty": "Sua lista de favoritos está vazia. Que tal adicionar um clássico?",
   "favorite_shows_empty": "Sua lista de séries favoritas está vazia. Hora de maratonar algo novo!",
-  "stream_on": "Assista em"
+  "stream_on": "Assista em",
+  "your_watchlist_shows": "Sua Lista para Ver",
+  "your_watchlist_movies": "Sua Lista para Ver",
+  "view_all_watchlist_movies": "Ver tudo para ver",
+  "view_all_watchlist_shows": "Ver tudo para ver"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -279,5 +279,9 @@
   "favorite_shows": "Seriale preferate",
   "favorite_movies_empty": "Your favorite movies list is empty.",
   "favorite_shows_empty": "Your favorite shows list is empty.",
-  "stream_on": "Vezi pe platforme"
+  "stream_on": "Vezi pe platforme",
+  "your_watchlist_shows": "Serialele din lista ta",
+  "your_watchlist_movies": "Filmele din lista ta",
+  "view_all_watchlist_movies": "Vezi toate filmele din lista",
+  "view_all_watchlist_shows": "Vezi toate serialele din listă"
 }

--- a/projects/client/src/lib/components/lists/grid-list/GridList.svelte
+++ b/projects/client/src/lib/components/lists/grid-list/GridList.svelte
@@ -1,21 +1,37 @@
 <script lang="ts" generics="T extends { id: unknown }">
+  import { onMount, type Snippet } from "svelte";
+  import { writable } from "svelte/store";
   import "../_internal/list.css";
   import ListHeader from "../_internal/ListHeader.svelte";
   import type { ListProps } from "../ListProps";
 
-  type PageListProps<T> = ListProps<T>;
+  type PageListProps<T> = ListProps<T> & {
+    empty?: Snippet;
+  };
 
-  const { items, title, item, actions }: PageListProps<T> = $props();
+  const { items, title, item, actions, empty }: PageListProps<T> = $props();
+
+  const isMounted = writable(false);
+
+  onMount(() => {
+    isMounted.set(true);
+  });
 </script>
 
 <section class="trakt-grid-list-container">
   <ListHeader {title} {actions} inset="all" />
 
-  <div class="trakt-list-item-container trakt-list-items">
-    {#each items as i (i.id)}
-      {@render item(i)}
-    {/each}
-  </div>
+  {#if items.length > 0}
+    <div class="trakt-list-item-container trakt-list-items">
+      {#each items as i (i.id)}
+        {@render item(i)}
+      {/each}
+    </div>
+  {:else if empty != null && $isMounted}
+    <div class="grid-list-empty-state">
+      {@render empty()}
+    </div>
+  {/if}
 </section>
 
 <style lang="scss">
@@ -40,5 +56,12 @@
     @include for-mobile {
       grid-template-columns: 1fr;
     }
+  }
+
+  .grid-list-empty-state {
+    display: flex;
+    justify-content: center;
+
+    padding: 0 var(--layout-distance-side);
   }
 </style>

--- a/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
+++ b/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
@@ -5,6 +5,7 @@ import {
   movieAnticipatedQuery,
 } from '$lib/requests/queries/movies/movieAnticipatedQuery.ts';
 import { showAnticipatedQuery } from '$lib/requests/queries/shows/showAnticipatedQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState';
 import { derived } from 'svelte/store';
 
 export type AnticipatedEntry = AnticipatedMovie;
@@ -37,7 +38,13 @@ export function useAnticipatedList(
 ) {
   const query = useQuery(typeToQuery(props));
 
+  const isLoading = derived(
+    query,
+    toLoadingState,
+  );
+
   return {
+    isLoading,
     list: derived(query, ($query) => $query.data?.entries ?? []),
     page: derived(
       query,

--- a/projects/client/src/lib/sections/lists/components/ViewAllButton.svelte
+++ b/projects/client/src/lib/sections/lists/components/ViewAllButton.svelte
@@ -6,14 +6,16 @@
   type ViewAllButtonProps = {
     href: string;
     label: string;
+    isDisabled: boolean;
   };
 
-  const { href, label }: ViewAllButtonProps = $props();
+  const { href, label, isDisabled }: ViewAllButtonProps = $props();
 </script>
 
 <Button
   {label}
   {href}
+  disabled={isDisabled || undefined}
   style="flat"
   variant="primary"
   color="purple"

--- a/projects/client/src/lib/sections/lists/drilldown/DrillableMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrillableMediaList.svelte
@@ -8,18 +8,20 @@
   type DrillableList<T> = DrillListProps<T> & {
     drilldownLabel: string;
     useList: MediaStore<T>;
+    emptyMessage?: string;
   };
 
   const {
     title,
     drilldownLabel,
+    emptyMessage,
     type,
     item,
     useList,
     urlBuilder,
   }: DrillableList<T> = $props();
 
-  const { list } = $derived(useList({ type }));
+  const { list, isLoading } = $derived(useList({ type }));
 </script>
 
 <SectionList
@@ -31,5 +33,13 @@
 >
   {#snippet actions()}
     <ViewAllButton href={urlBuilder({ type })} label={drilldownLabel} />
+  {/snippet}
+
+  {#snippet empty()}
+    {#if !$isLoading && emptyMessage}
+      <p class="small secondary">
+        {emptyMessage}
+      </p>
+    {/if}
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/lists/drilldown/DrillableMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrillableMediaList.svelte
@@ -22,6 +22,7 @@
   }: DrillableList<T> = $props();
 
   const { list, isLoading } = $derived(useList({ type }));
+  const isEmptyList = $derived(!$isLoading && $list.length === 0);
 </script>
 
 <SectionList
@@ -32,7 +33,11 @@
   --height-list={mediaListHeightResolver(type)}
 >
   {#snippet actions()}
-    <ViewAllButton href={urlBuilder({ type })} label={drilldownLabel} />
+    <ViewAllButton
+      href={urlBuilder({ type })}
+      label={drilldownLabel}
+      isDisabled={isEmptyList}
+    />
   {/snippet}
 
   {#snippet empty()}

--- a/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
@@ -9,16 +9,17 @@
 
   type DrilledMediaListProps = DrillListProps<T> & {
     useList: PaginatableStore<T>;
+    emptyMessage?: string;
   };
 
-  const { title, type, item, useList, urlBuilder }: DrilledMediaListProps =
+  const { title, type, item, useList, emptyMessage }: DrilledMediaListProps =
     $props();
 
   const current = $derived(
     parseInt(pageState.url.searchParams.get("page") ?? "1"),
   );
 
-  const { list, page } = $derived(
+  const { list, page, isLoading } = $derived(
     useList({
       type,
       page: current,
@@ -40,4 +41,12 @@
   items={$list}
   {item}
   --width-item={mediaCardWidthResolver(type)}
-/>
+>
+  {#snippet empty()}
+    {#if !$isLoading && emptyMessage}
+      <p class="small secondary">
+        {emptyMessage}
+      </p>
+    {/if}
+  {/snippet}
+</GridList>

--- a/projects/client/src/lib/sections/lists/drilldown/MediaStore.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaStore.ts
@@ -5,4 +5,5 @@ export type MediaStore<T> = (
   params: { type: MediaType; limit?: number },
 ) => {
   list: Readable<T[]>;
+  isLoading: Readable<boolean>;
 };

--- a/projects/client/src/lib/sections/lists/drilldown/PaginatableStore.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/PaginatableStore.ts
@@ -6,4 +6,5 @@ export type PaginatableStore<T> = (
 ) => {
   list: Readable<T[]>;
   page: Readable<{ total?: number }>;
+  isLoading: Readable<boolean>;
 };

--- a/projects/client/src/lib/sections/lists/popular/usePopularList.ts
+++ b/projects/client/src/lib/sections/lists/popular/usePopularList.ts
@@ -5,6 +5,7 @@ import {
   type PopularShow,
   showPopularQuery,
 } from '$lib/requests/queries/shows/showPopularQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { derived } from 'svelte/store';
 import type { MediaType } from '../../../requests/models/MediaType.ts';
 
@@ -38,7 +39,13 @@ export function usePopularList(
 ) {
   const query = useQuery(typeToQuery(props));
 
+  const isLoading = derived(
+    query,
+    toLoadingState,
+  );
+
   return {
+    isLoading,
     list: derived(query, ($query) => $query.data?.entries ?? []),
     page: derived(
       query,

--- a/projects/client/src/lib/sections/lists/recommended/toInMemoryPaginatable.spec.ts
+++ b/projects/client/src/lib/sections/lists/recommended/toInMemoryPaginatable.spec.ts
@@ -12,6 +12,7 @@ describe('toInMemoryPaginatable', () => {
 
     const mockStore = {
       list: readable(data),
+      isLoading: readable(false),
     };
 
     const paginatable = toInMemoryPaginatable({
@@ -45,6 +46,7 @@ describe('toInMemoryPaginatable', () => {
 
     const store = {
       list: readable(data),
+      isLoading: readable(false),
     };
 
     const paginatable = toInMemoryPaginatable({
@@ -70,6 +72,7 @@ describe('toInMemoryPaginatable', () => {
 
     const store = {
       list: readable(data),
+      isLoading: readable(false),
     };
 
     const paginatable = toInMemoryPaginatable({

--- a/projects/client/src/lib/sections/lists/recommended/toInMemoryPaginatable.ts
+++ b/projects/client/src/lib/sections/lists/recommended/toInMemoryPaginatable.ts
@@ -10,7 +10,7 @@ export const toInMemoryPaginatable = <T>(params: {
 }): PaginatableStore<T> => {
   const { total, type, useList } = params;
 
-  const { list: store } = useList({ type, limit: total });
+  const { list: store, isLoading } = useList({ type, limit: total });
 
   return ({ page, limit }) => {
     const from = (page - 1) * limit;
@@ -23,6 +23,7 @@ export const toInMemoryPaginatable = <T>(params: {
 
     return {
       list,
+      isLoading,
       page: readable({ page, total: Math.ceil(total / limit) }),
     };
   };

--- a/projects/client/src/lib/sections/lists/recommended/useRecommendedList.ts
+++ b/projects/client/src/lib/sections/lists/recommended/useRecommendedList.ts
@@ -8,6 +8,7 @@ import {
   type RecommendedShow,
   recommendedShowsQuery,
 } from '$lib/requests/queries/recommendations/recommendedShowsQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState';
 import { type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
@@ -40,8 +41,13 @@ export function useRecommendedList(
 ) {
   const query = useQuery(typeToQuery(props));
   const list = derived(query, ($query) => $query.data ?? []);
+  const isLoading = derived(
+    query,
+    toLoadingState,
+  );
 
   return {
     list,
+    isLoading,
   };
 }

--- a/projects/client/src/lib/sections/lists/trending/useTrendingList.ts
+++ b/projects/client/src/lib/sections/lists/trending/useTrendingList.ts
@@ -9,6 +9,7 @@ import {
   showTrendingQuery,
   type TrendingShow,
 } from '$lib/requests/queries/shows/showTrendingQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState';
 import { type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
@@ -44,8 +45,13 @@ export function useTrendingList(
   { type, limit, page }: TrendingListStoreProps,
 ) {
   const query = useQuery(typeToQuery({ type, limit, page }));
+  const isLoading = derived(
+    query,
+    toLoadingState,
+  );
 
   return {
+    isLoading,
     list: derived(query, ($query) => $query.data?.entries ?? []),
     page: derived(
       query,

--- a/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
@@ -1,30 +1,30 @@
 <script lang="ts">
   import type { MediaType } from "$lib/requests/models/MediaType";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import MediaCard from "../components/MediaCard.svelte";
-  import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
+  import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import { useWatchlistList } from "./useWatchlistList";
 
   type WatchlistListProps = {
     title: string;
     type: MediaType;
-    drilldownLabel: string;
     emptyMessage: string;
   };
 
-  const { title, type, emptyMessage, drilldownLabel }: WatchlistListProps =
-    $props();
+  const { title, type, emptyMessage }: WatchlistListProps = $props();
+  const isMobile = useMedia(WellKnownMediaQuery.mobile);
+  const style = $derived($isMobile ? "summary" : "cover");
 </script>
 
-<DrillableMediaList
+<DrilledMediaList
   {title}
-  {drilldownLabel}
   {type}
   {emptyMessage}
   useList={useWatchlistList}
   urlBuilder={UrlBuilder.watchlistPage}
 >
   {#snippet item(media)}
-    <MediaCard {type} {media} />
+    <MediaCard {type} {media} {style} />
   {/snippet}
-</DrillableMediaList>
+</DrilledMediaList>

--- a/projects/client/src/lib/sections/lists/watchlist/useComingSoon.ts
+++ b/projects/client/src/lib/sections/lists/watchlist/useComingSoon.ts
@@ -5,6 +5,9 @@ import {
 } from '$lib/sections/lists/watchlist/useWatchlistList';
 import { derived } from 'svelte/store';
 
+// TODO use drilledmedia list for this
+const COMING_SOON_LIMIT = 500;
+
 const IN_PROGRESS_STATUSES: MediaStatus[] = [
   'planned',
   'post production',
@@ -16,6 +19,7 @@ export function useComingSoon(type: MediaType) {
   const { list: watchlist, isLoading } = useWatchlistList({
     type,
     sort: 'unreleased',
+    limit: COMING_SOON_LIMIT,
   });
 
   const list = derived(

--- a/projects/client/src/lib/sections/lists/watchlist/useOutNow.ts
+++ b/projects/client/src/lib/sections/lists/watchlist/useOutNow.ts
@@ -2,10 +2,14 @@ import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { derived } from 'svelte/store';
 import { useWatchlistList } from './useWatchlistList.ts';
 
+// TODO use drilledmedia list for this
+const OUT_NOW_LIMIT = 500;
+
 export function useOutNow(type: MediaType) {
   const { list: watchlist, isLoading } = useWatchlistList({
     type,
     sort: 'released',
+    limit: OUT_NOW_LIMIT,
   });
 
   const list = derived(

--- a/projects/client/src/lib/sections/lists/watchlist/useWatchlistList.ts
+++ b/projects/client/src/lib/sections/lists/watchlist/useWatchlistList.ts
@@ -21,12 +21,16 @@ export type WatchlistMediaList = Array<WatchlistMediaItem>;
 
 export type WatchListStoreProps = {
   type: MediaType;
+  limit?: number;
+  page?: number;
 } & Partial<WatchListParams>;
 
 function typeToQuery(
-  { type, sort = 'rank' }: WatchListStoreProps,
+  { type, limit, page, sort = 'rank' }: WatchListStoreProps,
 ) {
-  const params: WatchListParams = {
+  const params = {
+    limit,
+    page,
     sort,
   };
 
@@ -42,8 +46,9 @@ export function useWatchlistList(params: WatchListStoreProps) {
   const query = useQuery(typeToQuery(params));
   const list = derived(
     query,
-    ($query) => ($query.data ?? []).map((item) => item.entry),
+    ($query) => ($query.data?.entries ?? []).map((item) => item.entry),
   );
+
   const isLoading = derived(
     query,
     toLoadingState,
@@ -52,5 +57,9 @@ export function useWatchlistList(params: WatchListStoreProps) {
   return {
     list,
     isLoading,
+    page: derived(
+      query,
+      ($query) => $query.data?.page ?? { page: 0, total: 0 },
+    ),
   };
 }

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -12,7 +12,16 @@ const mediaDrilldownFactory =
     return baseUrl + buildParamString({ page });
   };
 
+const categoryDrilldownFactory =
+  (category: string) => ({ type, page }: PaginatableMediaPageUrl) => {
+    const baseUrl = `/${category}/${type}s`;
+    return baseUrl + buildParamString({ page });
+  };
+
 export const UrlBuilder = {
+  watchlistPage(params: PaginatableMediaPageUrl) {
+    return categoryDrilldownFactory('watchlist')(params);
+  },
   trending(params: PaginatableMediaPageUrl) {
     return mediaDrilldownFactory('trending')(params);
   },

--- a/projects/client/src/routes/watchlist/+page.svelte
+++ b/projects/client/src/routes/watchlist/+page.svelte
@@ -16,12 +16,14 @@
 
   <WatchlistList
     title={m.watchlist_movies()}
+    drilldownLabel={m.view_all_watchlist_movies()}
     emptyMessage={m.watchlist_movies_empty()}
     type="movie"
   />
 
   <WatchlistList
     title={m.watchlist_shows()}
+    drilldownLabel={m.view_all_watchlist_shows()}
     emptyMessage={m.watchlist_shows_empty()}
     type="show"
   />

--- a/projects/client/src/routes/watchlist/movies/+page.svelte
+++ b/projects/client/src/routes/watchlist/movies/+page.svelte
@@ -1,0 +1,22 @@
+<script>
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+
+  import WatchlistPaginatedList from "$lib/sections/lists/watchlist/WatchlistPaginatedList.svelte";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+</script>
+
+<TraktPage
+  audience="authenticated"
+  image={DEFAULT_SHARE_MOVIE_COVER}
+  title={m.your_watchlist_movies()}
+>
+  <TraktPageCoverSetter />
+
+  <WatchlistPaginatedList
+    title={m.your_watchlist_movies()}
+    emptyMessage={m.watchlist_movies_empty()}
+    type="movie"
+  />
+</TraktPage>

--- a/projects/client/src/routes/watchlist/shows/+page.svelte
+++ b/projects/client/src/routes/watchlist/shows/+page.svelte
@@ -1,0 +1,23 @@
+<script>
+  import * as m from "$lib/features/i18n/messages";
+
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+
+  import WatchlistPaginatedList from "$lib/sections/lists/watchlist/WatchlistPaginatedList.svelte";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+</script>
+
+<TraktPage
+  audience="authenticated"
+  image={DEFAULT_SHARE_MOVIE_COVER}
+  title={m.your_watchlist_shows()}
+>
+  <TraktPageCoverSetter />
+
+  <WatchlistPaginatedList
+    title={m.your_watchlist_shows()}
+    emptyMessage={m.watchlist_shows_empty()}
+    type="show"
+  />
+</TraktPage>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds 'view all' support for the watch list page lists.
- For now adds basic support for empty list messages to the grid and drillable lists.
- We should also do this for `out now` and `coming soon`

## 👀 Examples 👀
<img width="1433" alt="Screenshot 2025-01-27 at 22 15 47" src="https://github.com/user-attachments/assets/c32dfe55-a66e-43e6-ae6e-6835f1602b3a" />

<img width="1433" alt="Screenshot 2025-01-27 at 22 15 51" src="https://github.com/user-attachments/assets/3f77199c-8b54-44b2-855b-c82a16b9e728" />

<img width="425" alt="Screenshot 2025-01-27 at 22 15 59" src="https://github.com/user-attachments/assets/c120392c-1c11-4f00-ba2c-11075697ed70" />

<img width="1433" alt="Screenshot 2025-01-27 at 22 15 23" src="https://github.com/user-attachments/assets/344092f1-3daf-459f-8668-7a683ba88223" />

<img width="1433" alt="Screenshot 2025-01-27 at 22 15 30" src="https://github.com/user-attachments/assets/ba694bf4-bd01-4e2d-9d58-d3e38664a84f" />

