### PR TITLE
fix(summary): sizing of service logo on poster overlay

### DIFF
--- a/projects/client/src/lib/components/media/watch-now/WatchNowServiceLogo.svelte
+++ b/projects/client/src/lib/components/media/watch-now/WatchNowServiceLogo.svelte
@@ -28,7 +28,10 @@
   .trakt-watch-now-service-logo {
     display: flex;
     align-items: center;
-    width: var(--ni-36);
-    height: auto;
+
+    :global(img) {
+      width: var(--ni-36);
+      height: auto;
+    }
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/overlay/WatchNowOverlay.svelte
+++ b/projects/client/src/lib/sections/summary/components/overlay/WatchNowOverlay.svelte
@@ -64,7 +64,7 @@
     text-shadow: var(--source-shadow);
     padding: var(--ni-8);
 
-    :global(.trakt-watch-now-service-logo) {
+    :global(.trakt-watch-now-service-logo img) {
       filter: drop-shadow(var(--source-shadow));
       height: var(--ni-40);
       width: auto;


### PR DESCRIPTION
## 🎶 Notes 🎶
Woopsie 😅

## 👀 Example 👀
Before:
<img width="357" alt="Screenshot 2025-01-29 at 14 53 21" src="https://github.com/user-attachments/assets/c3202d4b-1c45-4177-9b2d-8592f5bdb547" />

After:
<img width="357" alt="Screenshot 2025-01-29 at 14 52 33" src="https://github.com/user-attachments/assets/9cef1c3f-e53d-4dea-a31b-cf9c52fdedec" />
