### PR TITLE
feat: responsive media actions

### DIFF
--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -278,6 +278,10 @@
   "favorite_movies_empty": "Twoja lista ulubionych pozycji jest pusta.",
   "favorite_shows_empty": "Twoja lista ulubionych seriali jest pusta.",
   "stream_on": "Oglądaj na",
+  "your_watchlist_shows": "Twoje seriale na liście do obejrzenia",
+  "your_watchlist_movies": "Twoje filmy na liście do obejrzenia",
+  "view_all_watchlist_movies": "Zobacz wszystkie filmy z listy do obejrzenia",
+  "view_all_watchlist_shows": "Zobacz wszystkie seriale z listy do obejrzenia",
   "streaming": "Streaming",
   "on_demand": "Na życzenie"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -278,6 +278,10 @@
   "favorite_movies_empty": "Ваш список улюбленого кіно порожній.",
   "favorite_shows_empty": "Ваш список улюблених серіалів порожній.",
   "stream_on": "Дивись на",
+  "your_watchlist_shows": "Ваш список перегляду",
+  "your_watchlist_movies": "Ваш список перегляду",
+  "view_all_watchlist_movies": "Усі зі списку до перегляду",
+  "view_all_watchlist_shows": "Усі зі списку до перегляду",
   "streaming": "Онлайн",
   "on_demand": "На вимогу"
 }

--- a/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButtonProps.ts
@@ -6,6 +6,7 @@ export type MarkAsWatchedButtonProps = {
   isMarkingAsWatched: boolean;
   isWatched: boolean;
   style: 'action' | 'normal';
+  size: 'normal' | 'small';
   onWatch: () => void;
   onRemove: () => void;
 } & Omit<ButtonProps, 'children' | 'onclick' | 'label'>;

--- a/projects/client/src/lib/components/buttons/watchlist/WatchlistButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/watchlist/WatchlistButtonProps.ts
@@ -6,6 +6,7 @@ export type WatchlistButtonProps = {
   isWatchlistUpdating: boolean;
   isWatchlisted: boolean;
   type: 'action' | 'normal';
+  size: 'small' | 'normal';
   onAdd: () => void;
   onRemove: () => void;
 } & Omit<ButtonProps, 'children' | 'onclick' | 'label'>;

--- a/projects/client/src/lib/components/summary/RatingItem.svelte
+++ b/projects/client/src/lib/components/summary/RatingItem.svelte
@@ -29,12 +29,38 @@
   </div>
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .rating-item {
     display: flex;
 
     align-items: center;
     gap: var(--gap-xxs);
+
+    p {
+      transition: font-size calc(var(--transition-increment) * 2) ease-in-out;
+    }
+
+    :global(svg) {
+      transition: calc(var(--transition-increment) * 2) ease-in-out;
+      transition-property: width, height;
+    }
+
+    @include for-mobile {
+      :global(svg) {
+        height: var(--ni-12);
+        width: auto;
+      }
+
+      p.large {
+        font-size: var(--ni-12);
+      }
+
+      p.small {
+        font-size: var(--ni-10);
+      }
+    }
   }
 
   .rating-info {

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
@@ -10,10 +10,12 @@
     style: "normal" | "action";
     title: string;
     onAction?: (state: boolean) => void;
+    size?: "normal" | "small";
   } & MarkAsWatchedStoreProps;
 
   const {
     style = "action",
+    size = "normal",
     title,
     onAction,
     ...target
@@ -36,6 +38,7 @@
   <MarkAsWatchedButton
     {style}
     {title}
+    {size}
     isWatched={$isWatched}
     isMarkingAsWatched={$isMarkingAsWatched}
     onWatch={markAsWatched}

--- a/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
@@ -5,12 +5,14 @@
 
   type WatchlistActionProps = {
     style?: "action" | "normal";
+    size?: "small" | "normal";
     title: string;
     onAction?: (state: boolean) => void;
   } & WatchlistStoreProps;
 
   const {
     style = "action",
+    size = "normal",
     title,
     onAction,
     ...target
@@ -31,6 +33,7 @@
 <WatchlistButton
   type={style}
   {title}
+  {size}
   isWatchlisted={$isWatchlisted}
   isWatchlistUpdating={$isWatchlistUpdating}
   onAdd={addToWatchlist}

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -67,9 +67,15 @@
   });
 </script>
 
-{#snippet mediaActions()}
-  <WatchlistAction {...watchlistProps} />
-  <MarkAsWatchedAction {...markWasWatchedProps} />
+{#snippet mediaActions(device: "mobile" | "other" = "other")}
+  <WatchlistAction
+    {...watchlistProps}
+    style={device === "mobile" ? "action" : "normal"}
+  />
+  <MarkAsWatchedAction
+    {...markWasWatchedProps}
+    size={device === "mobile" ? "small" : "normal"}
+  />
 {/snippet}
 
 <CoverImageSetter src={media.cover.url.medium} {type} />
@@ -122,13 +128,19 @@
 
   <RenderFor audience="authenticated">
     <SummaryActions>
-      {#if type === "movie"}
-        <RateNow {type} {media} />
-      {/if}
-
-      <RenderFor device={["mobile", "tablet-sm"]} audience="authenticated">
+      <RenderFor device={["tablet-sm"]} audience="authenticated">
         {@render mediaActions()}
       </RenderFor>
+
+      <RenderFor device={["mobile"]} audience="authenticated">
+        {@render mediaActions("mobile")}
+      </RenderFor>
+
+      {#snippet contextualActions()}
+        {#if type === "movie"}
+          <RateNow {type} {media} />
+        {/if}
+      {/snippet}
     </SummaryActions>
   </RenderFor>
 </SummaryContainer>

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -57,7 +57,20 @@
   </div>
 {/if}
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-rate-now {
+    h6 {
+      transition: font-size calc(var(--transition-increment) * 2) ease-in-out;
+    }
+
+    @include for-mobile {
+      h6 {
+        font-size: var(--ni-12);
+      }
+    }
+  }
   .trakt-rate-now,
   .trakt-rate-actions {
     display: flex;

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryActions.svelte
@@ -1,9 +1,22 @@
 <script lang="ts">
-  const { children }: ChildrenProps = $props();
+  import type { Snippet } from "svelte";
+
+  const {
+    children,
+    contextualActions,
+  }: {
+    contextualActions?: Snippet;
+  } & ChildrenProps = $props();
 </script>
 
 <div class="trakt-summary-actions">
   {@render children()}
+
+  {#if contextualActions}
+    <div class="trakt-summary-contextual-actions">
+      {@render contextualActions()}
+    </div>
+  {/if}
 </div>
 
 <style lang="scss">
@@ -17,11 +30,21 @@
 
     @include for-tablet-sm {
       display: grid;
+      grid-template-columns: 1fr 1fr;
+
+      gap: var(--gap-xs);
     }
 
     @include for-mobile {
-      flex-flow: column;
-      padding: var(--ni-16);
+      gap: var(--gap-xs);
+    }
+  }
+
+  .trakt-summary-contextual-actions {
+    justify-self: end;
+
+    @include for-tablet-sm {
+      grid-column: span 2;
     }
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Final part to match what I had shown in the prototype earlier.
  - Media actions are now placed side by side on smaller sizes.
  - Rate now is placed below them if usable.
  - Ratings list is smaller on mobile sizes.
- Optimized so that even on an iPhone SE, the buttons fit good enough.
- From here on out, we can start fine tuning more.

## 👀 Examples 👀
<img width="752" alt="Screenshot 2025-01-29 at 18 58 14" src="https://github.com/user-attachments/assets/0716eed2-abe2-4f24-bdb7-09ea35083d99" />


<img width="371" alt="Screenshot 2025-01-29 at 18 53 38" src="https://github.com/user-attachments/assets/28c182b5-ff9e-4147-a0c4-661dcdcc6746" />
