### PR TITLE
fix: content spacing

### DIFF
--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -105,11 +105,11 @@
       }
 
       @include for-tablet-lg-and-below {
-        --content-gap: var(--gap-m);
+        --content-gap: var(--gap-l);
       }
 
       @include for-mobile {
-        --content-gap: var(--gap-xs);
+        --content-gap: var(--gap-m);
 
         &:first-child {
           margin-top: 0;

--- a/projects/client/src/lib/sections/summary/components/media/MediaDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaDetails.svelte
@@ -91,14 +91,12 @@
 <DetailsGrid title={m.details()}>
   {#each mediaDetails as { title, values }}
     {#if values && values.length > 0}
-      <div>
+      <CollapsableValues category={title} {values}>
         <p class="meta-info secondary">{title}</p>
-        <CollapsableValues category={title} {values}>
-          {#snippet value(value)}
-            <p class="small capitalize ellipsis">{value}</p>
-          {/snippet}
-        </CollapsableValues>
-      </div>
+        {#snippet value(value)}
+          <p class="small capitalize ellipsis">{value}</p>
+        {/snippet}
+      </CollapsableValues>
     {/if}
   {/each}
 </DetailsGrid>

--- a/projects/client/src/lib/sections/summary/components/media/_internal/CollapsableValues.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/_internal/CollapsableValues.svelte
@@ -12,9 +12,10 @@
     category: string;
     value: Snippet<[T]>;
     values: T[];
-  };
+  } & ChildrenProps;
 
-  const { category, values, value }: CollapsableValuesProps<T> = $props();
+  const { category, values, value, children }: CollapsableValuesProps<T> =
+    $props();
 
   const displayableValues = values.slice(0, MAX_ITEMS);
   const omittedValues = values.slice(MAX_ITEMS);
@@ -23,42 +24,52 @@
 </script>
 
 <div class="trakt-collapsable-values">
-  {#each displayableValues as v, index}
-    <div class="trakt-displayable-value">
-      {@render value(v)}
+  <div class="trakt-summary-details-grid-header">
+    {@render children()}
+  </div>
+  <div class="trakt-collapsable-values-content">
+    {#each displayableValues as v, index}
+      <div class="trakt-displayable-value">
+        {@render value(v)}
 
-      {#if omittedValues.length > 0 && index === MAX_ITEMS - 1}
-        <MoreButton
-          i18n={MoreButtonIntlProvider}
-          label="{m.expand_category({ category })}}"
-          count={omittedValues.length}
-          onExpand={() => expanded.set(true)}
-          onCollapse={() => expanded.set(false)}
-        />
-      {/if}
-    </div>
-  {/each}
+        {#if omittedValues.length > 0 && index === MAX_ITEMS - 1}
+          <MoreButton
+            i18n={MoreButtonIntlProvider}
+            label="{m.expand_category({ category })}}"
+            count={omittedValues.length}
+            onExpand={() => expanded.set(true)}
+            onCollapse={() => expanded.set(false)}
+          />
+        {/if}
+      </div>
+    {/each}
 
-  {#if omittedValues.length > 0}
-    <div hidden={!$expanded}>
-      <div class="trakt-omitted-values">
+    {#if omittedValues.length > 0}
+      <div
+        class="trakt-collapsable-values-content"
+        class:is-hidden={!$expanded}
+      >
         {#each omittedValues as v}
           <div class="trakt-displayable-value">
             {@render value(v)}
           </div>
         {/each}
       </div>
-    </div>
-  {/if}
+    {/if}
+  </div>
 </div>
 
 <style>
   .trakt-collapsable-values,
-  .trakt-omitted-values {
+  .trakt-collapsable-values-content {
     display: flex;
     flex-direction: column;
 
     gap: var(--gap-xxs);
+
+    &.is-hidden {
+      display: none;
+    }
   }
 
   .trakt-displayable-value {
@@ -66,5 +77,7 @@
     grid-template-columns: 1fr auto;
 
     gap: var(--gap-xxs);
+
+    min-height: var(--ni-18);
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/media/_internal/DetailsGrid.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/_internal/DetailsGrid.svelte
@@ -40,6 +40,10 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-m);
+
+    @include for-mobile {
+      gap: var(--gap-s);
+    }
   }
 
   .trakt-summary-details-grid-header {
@@ -78,7 +82,7 @@
 
     @include for-mobile {
       grid-template-columns: 1fr;
-      gap: var(--gap-xs);
+      gap: var(--gap-s);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/media/_internal/WatchNowCategoryServices.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/_internal/WatchNowCategoryServices.svelte
@@ -25,8 +25,8 @@
 </script>
 
 <div class="trakt-watch-now-category-services">
-  <p class="meta-info secondary">{title}</p>
   <CollapsableValues category="streaming" values={services}>
+    <p class="meta-info secondary">{title}</p>
     {#snippet value(service)}
       <Link href={service.link}>
         <p class="small ellipsis">


### PR DESCRIPTION
## 🎶 Notes 🎶

- Increases the content gap on smaller devices.
- Added some space between items in the summary details grid.

## 👀 Example 👀
Before / after:
<img width="449" alt="Screenshot 2025-01-31 at 07 38 23" src="https://github.com/user-attachments/assets/3b6b106b-b858-4654-a186-65cac8419b62" /> <img width="449" alt="Screenshot 2025-01-31 at 07 34 17" src="https://github.com/user-attachments/assets/28d55186-4dc4-4cc1-982d-5daf9c3bab55" />

Before / after:
<img width="449" alt="Screenshot 2025-01-31 at 07 38 19" src="https://github.com/user-attachments/assets/90be2ca3-68e3-49c7-9aee-b6f15722ec22" />
<img width="449" alt="Screenshot 2025-01-31 at 07 34 25" src="https://github.com/user-attachments/assets/d605b613-c5f9-4790-8122-9a5491287899" />
