### PR TITLE
feat(list): enable free scroll on mobile

### DIFF
--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -193,19 +193,35 @@
     & > :global(:not(svelte-css-wrapper)) {
       scroll-snap-align: start;
 
+      @include for-mobile() {
+        scroll-snap-align: unset;
+      }
+
       &:first-child,
       &:last-child {
         scroll-snap-align: end;
+
+        @include for-mobile() {
+          scroll-snap-align: unset;
+        }
       }
     }
 
     & > :global(svelte-css-wrapper > *) {
       scroll-snap-align: start;
+
+      @include for-mobile() {
+        scroll-snap-align: unset;
+      }
     }
 
     & > :global(svelte-css-wrapper:first-child > *),
     & > :global(svelte-css-wrapper:last-child > *) {
       scroll-snap-align: end;
+
+      @include for-mobile() {
+        scroll-snap-align: unset;
+      }
     }
   }
 </style>


### PR DESCRIPTION
## Mobile Scroll Snap Optimization

This pull request improves the responsiveness of the `ShadowList` component on mobile devices by adjusting the scroll snap behavior.

### Responsiveness Improvements

- Added `@include for-mobile()` media queries to unset `scroll-snap-align` for various elements within the `ShadowList` component. This change disables the scroll snap alignment on mobile screens, providing a smoother and more intuitive scrolling experience on touch devices.

(This adjustment, like a skilled tailor adjusting a garment for a better fit, ensures that the `ShadowList` component adapts seamlessly to different screen sizes. By disabling scroll snap alignment on mobile devices, we prioritize touch-friendly scrolling behavior, enhancing the user experience on smaller screens.)