### PR TITLE
feat(watchlist): default sort to added

### DIFF
--- a/projects/client/src/lib/sections/lists/watchlist/useWatchlistList.ts
+++ b/projects/client/src/lib/sections/lists/watchlist/useWatchlistList.ts
@@ -26,7 +26,7 @@ export type WatchListStoreProps = {
 } & Partial<WatchListParams>;
 
 function typeToQuery(
-  { type, limit, page, sort = 'rank' }: WatchListStoreProps,
+  { type, limit, page, sort = 'added' }: WatchListStoreProps,
 ) {
   const params = {
     limit,


### PR DESCRIPTION
## Watchlist Sorting Adjustment

This pull request modifies the default sorting behavior for watchlists to prioritize recently added items.

### Change to Default Sorting

- Changed the default `sort` parameter in the `typeToQuery` function within `useWatchlistList.ts` from `'rank'` to `'added'`. This change ensures that newly added items appear at the top of the watchlist, providing users with a clearer view of their recently added media.

(This minor adjustment, like a meticulous librarian reorganizing a bookshelf, prioritizes the display of recently added items in the watchlist. By defaulting to the `'added'` sort option, we ensure that users can easily find and access the media they've recently added, improving the overall user experience.)