### PR TITLE
fix(dropdown): scale without transform

### DIFF
--- a/projects/client/src/lib/components/dropdown/DropdownList.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownList.svelte
@@ -32,6 +32,7 @@
       onclick?.(ev);
     }}
     style="textured"
+    {size}
     {...props}
   >
     {@render children()}
@@ -71,11 +72,30 @@
     }
 
     &[data-size="small"] {
-      transform: scale(0.75);
-      margin: var(--ni-neg-32);
+      // TODO change back to transform scale when scaling is fixed
+      --small-padding: var(--ni-10);
+      padding: var(--small-padding);
+      margin: 0;
+
+      :global(li) {
+        padding: 0 var(--small-padding);
+        height: calc(var(--ni-16) + var(--small-padding) * 2);
+        width: calc(100% - var(--small-padding) * 4);
+      }
 
       :global(li p) {
-        font-size: var(--ni-16);
+        font-size: var(--ni-12);
+      }
+
+      .trakt-dropdown-list-icon {
+        :global(.trakt-dropdown-caret) {
+          width: var(--ni-12);
+          height: var(--ni-12);
+        }
+      }
+
+      .trakt-list .spacer {
+        height: calc(var(--ni-24) + var(--small-padding) * 2);
       }
     }
 

--- a/projects/client/src/lib/sections/navbar/ProfileButton.svelte
+++ b/projects/client/src/lib/sections/navbar/ProfileButton.svelte
@@ -59,8 +59,8 @@
   {#snippet icon()}
     <div class="profile-icon">
       <ProfileImage
-        --width="var(--ni-24)"
-        --height="var(--ni-24)"
+        --width="var(--ni-16)"
+        --height="var(--ni-16)"
         --border-width="var(--border-thickness-xs)"
       />
       <RenderFor


### PR DESCRIPTION
## 🎶 Notes 🎶

- Similar issue as with the button scaling.

## 👀 Examples 👀
Before/after:
<img width="292" alt="bef1" src="https://github.com/user-attachments/assets/bfb47509-a8bd-4916-9975-9fbf90914fb7" /> <img width="292" alt="Screenshot 2025-01-31 at 13 05 23" src="https://github.com/user-attachments/assets/89115788-86a7-4af4-a04b-4429be4785a0" />

Before/after:
<img width="292" alt="bef2" src="https://github.com/user-attachments/assets/63164c8f-bf5e-466a-8ab8-9b908646a6db" />  <img width="292" alt="Screenshot 2025-01-31 at 13 06 09" src="https://github.com/user-attachments/assets/d029d8ce-5553-45cf-b5d3-510a9e151c84" />
