### PR TITLE
refactor: switch to public image api

### DIFF
--- a/projects/api/src/contracts/_internal/response/episodeResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/episodeResponseSchema.ts
@@ -50,7 +50,7 @@ export const episodeResponseSchema = z.object({
     .optional(),
   ids: episodeIdsResponseSchema,
   /***
-   * Available if requesting extended `cloud9`.
+   * Available if requesting extended `images`.
    */
   images: z
     .object({ screenshot: z.array(z.string()) })

--- a/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
@@ -10,7 +10,7 @@ export const movieResponseSchema = z.object({
   year: z.number().optional(),
   ids: movieIdsResponseSchema,
   /***
-   * Available if requesting extended `cloud9`.
+   * Available if requesting extended `images`.
    */
   images: imagesResponseSchema.optional(),
 

--- a/projects/api/src/contracts/_internal/response/peopleResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/peopleResponseSchema.ts
@@ -31,7 +31,7 @@ const personSchema = z.object({
     tmdb: z.number().nullable(),
   }),
   /***
-   * Available if requesting extended `cloud9`.
+   * Available if requesting extended `images`.
    */
   images: headshotSchema.extend({
     fanart: z.array(z.string()),
@@ -42,7 +42,7 @@ export const castSchema = z.object({
   episode_count: z.number().optional(),
   person: personSchema,
   /***
-   * Available if requesting extended `cloud9`.
+   * Available if requesting extended `images`.
    */
   images: headshotSchema.optional(),
 }).merge(characterResponseSchema);
@@ -53,7 +53,7 @@ export const crewSchema = z.object({
   person: personSchema,
   episode_count: z.number().optional(),
   /***
-   * Available if requesting extended `cloud9`.
+   * Available if requesting extended `images`.
    */
   images: headshotSchema.optional(),
 });

--- a/projects/api/src/contracts/_internal/response/showResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showResponseSchema.ts
@@ -10,7 +10,7 @@ export const showResponseSchema = z.object({
   year: z.number().optional(),
   ids: showIdsResponseSchema,
   /***
-   * Available if requesting extended `cloud9`.
+   * Available if requesting extended `images`.
    */
   images: imagesResponseSchema.optional(),
   /**

--- a/projects/api/src/contracts/calendars/index.ts
+++ b/projects/api/src/contracts/calendars/index.ts
@@ -9,7 +9,7 @@ export const calendars = builder.router({
   shows: {
     method: 'GET',
     path: '/:target/shows/:start_date/:days',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     pathParams: calendarRequestParamsSchema,
     responses: {
       200: calendarShowListResponseSchema,
@@ -18,7 +18,7 @@ export const calendars = builder.router({
   newShows: {
     method: 'GET',
     path: '/:target/shows/new/:start_date/:days',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     pathParams: calendarRequestParamsSchema,
     responses: {
       200: calendarShowListResponseSchema,
@@ -27,7 +27,7 @@ export const calendars = builder.router({
   seasonPremieres: {
     method: 'GET',
     path: '/:target/shows/premieres/:start_date/:days',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     pathParams: calendarRequestParamsSchema,
     responses: {
       200: calendarShowListResponseSchema,
@@ -36,7 +36,7 @@ export const calendars = builder.router({
   finales: {
     method: 'GET',
     path: '/:target/shows/finales/:start_date/:days',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     pathParams: calendarRequestParamsSchema,
     responses: {
       200: calendarShowListResponseSchema,
@@ -45,7 +45,7 @@ export const calendars = builder.router({
   movies: {
     method: 'GET',
     path: '/:target/movies/:start_date/:days',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     pathParams: calendarRequestParamsSchema,
     responses: {
       200: movieResponseSchema.array(),
@@ -54,7 +54,7 @@ export const calendars = builder.router({
   dvdReleases: {
     method: 'GET',
     path: '/:target/dvd/:start_date/:days',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     pathParams: calendarRequestParamsSchema,
     responses: {
       200: movieResponseSchema.array(),

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -31,7 +31,7 @@ const ENTITY_LEVEL = builder.router({
   summary: {
     path: '',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     pathParams: idParamsSchema,
     responses: {
       200: movieResponseSchema,
@@ -65,7 +65,7 @@ const ENTITY_LEVEL = builder.router({
   related: {
     path: '/related',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     pathParams: idParamsSchema,
     responses: {
       200: movieResponseSchema.array(),
@@ -98,7 +98,7 @@ const ENTITY_LEVEL = builder.router({
   people: {
     path: '/people',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['cloud9']>(),
+    query: extendedQuerySchemaFactory<['images']>(),
     pathParams: idParamsSchema,
     responses: {
       200: peopleResponseSchema,
@@ -112,7 +112,7 @@ const GLOBAL_LEVEL = builder.router({
   trending: {
     path: '/trending',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+    query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(pageQuerySchema),
     responses: {
       200: movieTrendingResponseSchema.array(),
@@ -121,7 +121,7 @@ const GLOBAL_LEVEL = builder.router({
   anticipated: {
     path: '/anticipated',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+    query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(pageQuerySchema),
     responses: {
       200: movieAnticipatedResponseSchema.array(),
@@ -130,7 +130,7 @@ const GLOBAL_LEVEL = builder.router({
   popular: {
     path: '/popular',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+    query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(pageQuerySchema),
     responses: {
       200: movieResponseSchema.array(),

--- a/projects/api/src/contracts/people/_internal/response/peopleSummaryResponseSchema.ts
+++ b/projects/api/src/contracts/people/_internal/response/peopleSummaryResponseSchema.ts
@@ -51,7 +51,7 @@ export const peopleSummaryResponseSchema = z.object({
    */
   updated_at: z.string().optional(),
   /***
-   * Available if requesting extended `cloud9`.
+   * Available if requesting extended `images`.
    */
   images: z.object({
     headshot: z.array(z.string()),

--- a/projects/api/src/contracts/people/index.ts
+++ b/projects/api/src/contracts/people/index.ts
@@ -10,7 +10,7 @@ export const people = builder.router({
   summary: {
     path: '/',
     pathParams: idParamsSchema,
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     method: 'GET',
     responses: {
       200: peopleSummaryResponseSchema,
@@ -19,7 +19,7 @@ export const people = builder.router({
   movies: {
     path: '/movies',
     pathParams: idParamsSchema,
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     method: 'GET',
     responses: {
       200: peopleMovieCreditsResponseSchema,
@@ -28,7 +28,7 @@ export const people = builder.router({
   shows: {
     path: '/shows',
     pathParams: idParamsSchema,
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     method: 'GET',
     responses: {
       200: peopleShowCreditsResponseSchema,

--- a/projects/api/src/contracts/recommendations/index.ts
+++ b/projects/api/src/contracts/recommendations/index.ts
@@ -10,7 +10,7 @@ const movies = builder.router({
   recommend: {
     path: '/',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+    query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(recommendationsQuerySchema),
     responses: {
       200: recommendedMovieResponse,
@@ -30,7 +30,7 @@ const shows = builder.router({
   recommend: {
     path: '/',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+    query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(recommendationsQuerySchema),
     responses: {
       200: recommendedShowResponse,

--- a/projects/api/src/contracts/search/index.ts
+++ b/projects/api/src/contracts/search/index.ts
@@ -17,7 +17,7 @@ export const search = builder.router({
       ['movie', 'show']
     >(),
     query: searchQuerySchema.merge(
-      extendedQuerySchemaFactory<['full,cloud9']>(),
+      extendedQuerySchemaFactory<['full,images']>(),
     ),
     responses: {
       200: searchResultResponseSchema,

--- a/projects/api/src/contracts/shows/_internal/response/seasonsResponseSchema.ts
+++ b/projects/api/src/contracts/shows/_internal/response/seasonsResponseSchema.ts
@@ -44,7 +44,7 @@ export const seasonsResponseSchema = z.array(
      */
     network: z.string().optional(),
     /**
-     * Available if requesting extended `cloud9`.
+     * Available if requesting extended `images`.
      */
     images: z.object({
       poster: z.array(z.string()),

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -29,7 +29,7 @@ const ENTITY_LEVEL = builder.router({
   summary: {
     path: '',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     pathParams: idParamsSchema,
     responses: {
       200: showResponseSchema,
@@ -57,7 +57,7 @@ const ENTITY_LEVEL = builder.router({
       path: '/progress/watched',
       method: 'GET',
       pathParams: idParamsSchema,
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+      query: extendedQuerySchemaFactory<['full', 'images']>()
         .merge(showQueryParamsSchema)
         .merge(statsQuerySchema),
       responses: {
@@ -77,7 +77,7 @@ const ENTITY_LEVEL = builder.router({
     path: '/related',
     method: 'GET',
     pathParams: idParamsSchema,
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     responses: {
       200: showResponseSchema.array(),
     },
@@ -109,7 +109,7 @@ const ENTITY_LEVEL = builder.router({
   people: {
     path: '/people',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['cloud9']>(),
+    query: extendedQuerySchemaFactory<['images']>(),
     pathParams: idParamsSchema,
     responses: {
       200: peopleResponseSchema,
@@ -118,7 +118,7 @@ const ENTITY_LEVEL = builder.router({
   seasons: {
     path: '/seasons',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     pathParams: idParamsSchema,
     responses: {
       200: seasonsResponseSchema,
@@ -127,7 +127,7 @@ const ENTITY_LEVEL = builder.router({
   episodes: {
     path: '/seasons/:season',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
     pathParams: idParamsSchema
       .merge(seasonParamsSchema),
     responses: {
@@ -138,7 +138,7 @@ const ENTITY_LEVEL = builder.router({
     summary: {
       path: '/seasons/:season/episodes/:episode',
       method: 'GET',
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+      query: extendedQuerySchemaFactory<['full', 'images']>(),
       pathParams: idParamsSchema
         .merge(seasonParamsSchema)
         .merge(episodeParamsSchema),
@@ -197,7 +197,7 @@ const GLOBAL_LEVEL = builder.router({
   trending: {
     path: '/trending',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+    query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(pageQuerySchema),
     responses: {
       200: showTrendingResponseSchema.array(),
@@ -206,7 +206,7 @@ const GLOBAL_LEVEL = builder.router({
   anticipated: {
     path: '/anticipated',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+    query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(pageQuerySchema),
     responses: {
       200: showAnticipatedResponseSchema.array(),
@@ -215,7 +215,7 @@ const GLOBAL_LEVEL = builder.router({
   popular: {
     path: '/popular',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+    query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(pageQuerySchema),
     responses: {
       200: showResponseSchema.array(),

--- a/projects/api/src/contracts/sync/index.ts
+++ b/projects/api/src/contracts/sync/index.ts
@@ -19,7 +19,7 @@ const progress = builder.router({
   upNext: {
     method: 'GET',
     path: '/up_next',
-    query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+    query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(pageQuerySchema)
       .merge(sortQuerySchema)
       .merge(statsQuerySchema),

--- a/projects/api/src/contracts/users/index.ts
+++ b/projects/api/src/contracts/users/index.ts
@@ -66,7 +66,7 @@ export const users = builder.router({
       path: '/movies',
       method: 'GET',
       pathParams: profileParamsSchema,
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+      query: extendedQuerySchemaFactory<['full', 'images']>()
         .merge(dateRangeParamsSchema)
         .merge(pageQuerySchema),
       responses: {
@@ -76,7 +76,7 @@ export const users = builder.router({
     shows: {
       path: '/shows',
       method: 'GET',
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+      query: extendedQuerySchemaFactory<['full', 'images']>()
         .merge(dateRangeParamsSchema)
         .merge(pageQuerySchema),
       responses: {
@@ -86,7 +86,7 @@ export const users = builder.router({
     episodes: {
       path: '/episodes',
       method: 'GET',
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+      query: extendedQuerySchemaFactory<['full', 'images']>()
         .merge(dateRangeParamsSchema)
         .merge(pageQuerySchema),
       responses: {
@@ -101,7 +101,7 @@ export const users = builder.router({
       path: '/movies/:sort',
       pathParams: profileParamsSchema.merge(sortParamsSchema),
       method: 'GET',
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+      query: extendedQuerySchemaFactory<['full', 'images']>()
         .merge(pageQuerySchema),
       responses: {
         200: watchlistedMoviesResponseSchema.array(),
@@ -111,7 +111,7 @@ export const users = builder.router({
       path: '/shows/:sort',
       pathParams: profileParamsSchema.merge(sortParamsSchema),
       method: 'GET',
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>()
+      query: extendedQuerySchemaFactory<['full', 'images']>()
         .merge(pageQuerySchema),
       responses: {
         200: watchlistedShowsResponseSchema.array(),
@@ -125,7 +125,7 @@ export const users = builder.router({
       path: '/movies',
       pathParams: profileParamsSchema,
       method: 'GET',
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+      query: extendedQuerySchemaFactory<['full', 'images']>(),
       responses: {
         200: ratedMoviesResponseSchema.array(),
       },
@@ -134,7 +134,7 @@ export const users = builder.router({
       path: '/episodes',
       pathParams: profileParamsSchema,
       method: 'GET',
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+      query: extendedQuerySchemaFactory<['full', 'images']>(),
       responses: {
         200: ratedEpisodesResponseSchema.array(),
       },
@@ -147,7 +147,7 @@ export const users = builder.router({
       path: '/movies/:sort',
       pathParams: profileParamsSchema.merge(sortParamsSchema),
       method: 'GET',
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+      query: extendedQuerySchemaFactory<['full', 'images']>(),
       responses: {
         200: favoritedMoviesResponseSchema.array(),
       },
@@ -156,7 +156,7 @@ export const users = builder.router({
       path: '/shows/:sort',
       pathParams: profileParamsSchema.merge(sortParamsSchema),
       method: 'GET',
-      query: extendedQuerySchemaFactory<['full', 'cloud9']>(),
+      query: extendedQuerySchemaFactory<['full', 'images']>(),
       responses: {
         200: favoritedShowsResponseSchema.array(),
       },

--- a/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
@@ -26,7 +26,7 @@ const upcomingEpisodesRequest = (
     .calendars
     .shows({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
       params: {
         target: 'my',

--- a/projects/client/src/lib/requests/queries/episode/episodeSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeSummaryQuery.ts
@@ -23,7 +23,7 @@ const episodeSummaryRequest = (
         episode,
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
@@ -36,7 +36,7 @@ const movieAnticipatedRequest = (
     .movies
     .anticipated({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         page,
         limit,
       },

--- a/projects/client/src/lib/requests/queries/movies/movieFavoritesQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieFavoritesQuery.ts
@@ -21,7 +21,7 @@ const favoritedMoviesRequest = (
         sort: 'rank',
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/movies/moviePeopleQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePeopleQuery.ts
@@ -18,7 +18,7 @@ const moviePeopleRequest = (
         id: slug,
       },
       query: {
-        extended: 'cloud9',
+        extended: 'images',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
@@ -19,7 +19,7 @@ const moviePopularRequest = (
     .movies
     .popular({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         page,
         limit,
       },

--- a/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
@@ -16,7 +16,7 @@ const movieRelatedRequest = (
     .movies
     .related({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
       params: {
         id: slug,

--- a/projects/client/src/lib/requests/queries/movies/movieSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieSummaryQuery.ts
@@ -16,7 +16,7 @@ const movieSummaryRequest = (
         id: slug,
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
@@ -36,7 +36,7 @@ const movieTrendingRequest = (
     .movies
     .trending({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         page,
         limit,
       },

--- a/projects/client/src/lib/requests/queries/people/peopleMovieCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleMovieCreditsQuery.ts
@@ -16,7 +16,7 @@ const peopleMovieCreditsRequest = (
         id: slug,
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/people/peopleShowCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleShowCreditsQuery.ts
@@ -16,7 +16,7 @@ const peopleShowCreditsRequest = (
         id: slug,
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
@@ -19,7 +19,7 @@ const peopleSummaryRequest = (
         id: slug,
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
@@ -22,7 +22,7 @@ const recommendedMoviesRequest = (
     .movies
     .recommend({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         ignore_collected: true,
         ignore_watchlisted: true,
         limit,

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
@@ -27,7 +27,7 @@ const recommendedShowsRequest = (
     .shows
     .recommend({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         ignore_collected: true,
         ignore_watchlisted: true,
         limit,

--- a/projects/client/src/lib/requests/queries/search/searchQuery.ts
+++ b/projects/client/src/lib/requests/queries/search/searchQuery.ts
@@ -44,7 +44,7 @@ const searchRequest = ({ query, fetch }: SearchParams) =>
     .query({
       query: {
         query,
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
       params: {
         type: 'movie,show',

--- a/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
@@ -45,7 +45,7 @@ const showAnticipatedRequest = (
     .shows
     .anticipated({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         page,
         limit,
       },

--- a/projects/client/src/lib/requests/queries/shows/showFavoritesQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showFavoritesQuery.ts
@@ -21,7 +21,7 @@ const favoritedShowsRequest = (
         sort: 'rank',
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/shows/showPeopleQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showPeopleQuery.ts
@@ -18,7 +18,7 @@ const showPeopleRequest = (
         id: slug,
       },
       query: {
-        extended: 'cloud9',
+        extended: 'images',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
@@ -39,7 +39,7 @@ const showPopularRequest = (
     .shows
     .popular({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         page,
         limit,
       },

--- a/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
@@ -25,7 +25,7 @@ const showProgressRequest = (
         count_specials: false,
         specials: false,
         hidden: false,
-        extended: 'full,cloud9',
+        extended: 'full,images',
         include_stats: true,
       },
       params: {

--- a/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
@@ -28,7 +28,7 @@ const showRelatedRequest = ({ fetch, slug }: ShowRelatedParams) =>
     .shows
     .related({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
       params: {
         id: slug,

--- a/projects/client/src/lib/requests/queries/shows/showSeasonEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSeasonEpisodesQuery.ts
@@ -20,7 +20,7 @@ const showSeasonEpisodesRequest = (
         season,
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/shows/showSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSummaryQuery.ts
@@ -16,7 +16,7 @@ const showSummaryRequest = (
         id: slug,
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
@@ -42,7 +42,7 @@ const showTrendingRequest = (
     .shows
     .trending({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         page,
         limit,
       },

--- a/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
@@ -39,7 +39,7 @@ const upNextRequest = (params: UpNextParams = {}) => {
     .progress
     .upNext({
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         page,
         limit,
         include_stats: true,

--- a/projects/client/src/lib/requests/queries/users/episodeHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/episodeHistoryQuery.ts
@@ -38,7 +38,7 @@ function episodeHistoryRequest(
         id: 'me',
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         start_at: startDate.toISOString(),
         end_at: endDate.toISOString(),
         limit,

--- a/projects/client/src/lib/requests/queries/users/movieHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieHistoryQuery.ts
@@ -35,7 +35,7 @@ const movieHistoryRequest = (
         id: 'me',
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         start_at: startDate.toISOString(),
         end_at: endDate.toISOString(),
         limit,

--- a/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
@@ -32,7 +32,7 @@ const watchlistRequest = (
         sort,
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         page,
         limit,
       },

--- a/projects/client/src/lib/requests/queries/users/showHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showHistoryQuery.ts
@@ -38,7 +38,7 @@ const showHistoryRequest = (
         id: 'me',
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         start_at: startDate.toISOString(),
         end_at: endDate.toISOString(),
         limit,

--- a/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
@@ -32,7 +32,7 @@ const watchlistRequest = (
         sort,
       },
       query: {
-        extended: 'full,cloud9',
+        extended: 'full,images',
         page,
         limit,
       },


### PR DESCRIPTION
## Image Access and Contribution Enhancements

This pull request updates the API and documentation to reflect the newly public availability of images, making it easier for external contributors to work with the project.

### API Updates

- Updated the extended query parameter from `cloud9` to `images` in various schemas and router configurations across the API. This change standardizes the naming convention for extended query parameters related to images, improving consistency and readability.

### Documentation Updates

- Updated the README.md file to reflect the public availability of images. This change ensures that external contributors have accurate and up-to-date information about accessing image data, facilitating their contributions to the project.

(These changes, like a museum unveiling a new exhibit, make images readily accessible to the public and empower external contributors to enhance the visual aspects of the Trakt Lite experience. The standardized query parameter and updated documentation contribute to a more transparent and user-friendly development process.)