### PR TITLE
test(e2e): add steps to check media summary pages

### DIFF
--- a/projects/client/e2e/features/navigate.feature
+++ b/projects/client/e2e/features/navigate.feature
@@ -9,3 +9,9 @@ Feature: Basic navigation
 
     When I click on the "nav-bar-movies-button" button
     Then I should see "Movies" in the page title
+
+    When I view the show summary of "silo"
+    Then I should see the "summary-media-title" element on the page
+
+    When I view the movie summary of "heretic-2024"
+    Then I should see the "summary-media-title" element on the page

--- a/projects/client/e2e/models/TestId.ts
+++ b/projects/client/e2e/models/TestId.ts
@@ -8,4 +8,5 @@ export enum TestId {
   NavBarHomeButton = 'nav-bar-home-button',
   NavBarShowsButton = 'nav-bar-shows-button',
   NavBarMoviesButton = 'nav-bar-movies-button',
+  SummaryMediaTitle = 'summary-media-title',
 }

--- a/projects/client/e2e/support/navigate.steps.ts
+++ b/projects/client/e2e/support/navigate.steps.ts
@@ -1,6 +1,7 @@
 import { Then, When } from '@cucumber/cucumber';
 import { expect } from '@playwright/test';
 import { TestId } from '../models/TestId.ts';
+import { TestUrlBuilder } from '../utils/TestUrlBuilder.ts';
 import { TraktWorld } from '../world.ts';
 
 // TODO - figure out custom parameters
@@ -17,5 +18,27 @@ Then(
   'I should see {string} in the page title',
   async function (this: TraktWorld, title: string) {
     await expect(this.page).toHaveTitle(new RegExp(title));
+  },
+);
+
+When(
+  'I view the show summary of {string}',
+  async function (this: TraktWorld, slug: string) {
+    await this.page.goto(TestUrlBuilder.showSummary(slug));
+  },
+);
+
+When(
+  'I view the movie summary of {string}',
+  async function (this: TraktWorld, slug: string) {
+    await this.page.goto(TestUrlBuilder.movieSummary(slug));
+  },
+);
+
+Then(
+  'I should see the {string} element on the page',
+  async function (this: TraktWorld, testId: TestId) {
+    const element = this.page.getByTestId(testId);
+    await expect(element).toBeVisible();
   },
 );

--- a/projects/client/e2e/utils/TestUrlBuilder.ts
+++ b/projects/client/e2e/utils/TestUrlBuilder.ts
@@ -1,0 +1,22 @@
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
+import { prefixPathWithBaseUrl } from './prefixPathWithBaseUrl.ts';
+
+export function prefixBuilderPaths<
+  T extends Record<string, (arg: string) => string>,
+>(
+  builder: T,
+): { [K in keyof T]: (arg: string) => string } {
+  return Object.fromEntries(
+    Object.entries(builder).map(([key, fn]) => [
+      key,
+      (...args: Parameters<typeof fn>) => prefixPathWithBaseUrl(fn(...args)),
+    ]),
+  ) as { [K in keyof T]: (...args: Parameters<T[K]>) => string };
+}
+
+const builder = {
+  movieSummary: (slug: string) => UrlBuilder.movie(slug),
+  showSummary: (slug: string) => UrlBuilder.show(slug),
+};
+
+export const TestUrlBuilder = prefixBuilderPaths(builder);

--- a/projects/client/e2e/utils/prefixPathWithBaseUrl.ts
+++ b/projects/client/e2e/utils/prefixPathWithBaseUrl.ts
@@ -1,0 +1,10 @@
+import { E2E_BASE_URL } from '../constants/constants.ts';
+
+export function prefixPathWithBaseUrl(path: string) {
+  const cleanPath = path.startsWith('/') ? path.slice(1) : path;
+  const cleanBase = E2E_BASE_URL.endsWith('/')
+    ? E2E_BASE_URL.slice(0, -1)
+    : E2E_BASE_URL;
+
+  return `${cleanBase}/${cleanPath}`;
+}

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryTitle.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { TestId } from "$e2e/models/TestId";
+
   type MediaTitleProps = {
     title: string;
   };
@@ -6,7 +8,11 @@
   const { title }: MediaTitleProps = $props();
 </script>
 
-<h3 class:short-title={title.length < 15} class:long-title={title.length > 25}>
+<h3
+  class:short-title={title.length < 15}
+  class:long-title={title.length > 25}
+  data-testid={TestId.SummaryMediaTitle}
+>
   {title}
 </h3>
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds 2 simple scenarios to make sure the movie and show summary pages are visible.
- Kept everything in a single scenario to reduce overhead.

## 👀 Example 👀
Reduced the speed for dramatic purposes:
https://github.com/user-attachments/assets/3b5d2948-191a-4828-8ca8-b88dbad763dd

Still runs fast:
<img width="377" alt="Screenshot 2025-02-04 at 17 30 31" src="https://github.com/user-attachments/assets/0fdbc763-9366-4071-ae0d-b251a467a0c3" />
