### PR TITLE
docs(readme): remove image limitation remark

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ While public applications can be used, they might withhold some of their
 secrets. Think of it as a trial version of an ancient spellbook. Limitations
 include:
 
-- **Missing Image Links:** Alas, the visual delights of posters and banners will
-  remain shrouded in mystery.
 - **"Up Next" Dysfunction:** This powerful prophecy, revealing your future
   viewing pleasures, will be temporarily silenced.
 


### PR DESCRIPTION
Public applications have image access again, limitation remark is now stale.

This pull request includes a small change to the `README.md` file. The change removes the bullet point regarding missing image links from the list of limitations. 

Changes to documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-L70): Removed the bullet point about missing image links from the limitations section.