### PR TITLE
feat(up-next): switch to nitro endpoint

### DIFF
--- a/projects/api/src/contracts/sync/index.ts
+++ b/projects/api/src/contracts/sync/index.ts
@@ -17,14 +17,24 @@ import { watchlistResponseSchema } from './_internal/response/watchlistResponseS
 
 const progress = builder.router({
   upNext: {
-    method: 'GET',
-    path: '/up_next',
-    query: extendedQuerySchemaFactory<['full', 'images']>()
-      .merge(pageQuerySchema)
-      .merge(sortQuerySchema)
-      .merge(statsQuerySchema),
-    responses: {
-      200: upNextResponseSchema,
+    standard: {
+      method: 'GET',
+      path: '/up_next',
+      query: extendedQuerySchemaFactory<['full', 'images']>()
+        .merge(pageQuerySchema)
+        .merge(sortQuerySchema)
+        .merge(statsQuerySchema),
+      responses: {
+        200: upNextResponseSchema,
+      },
+    },
+    nitro: {
+      method: 'GET',
+      path: '/up_next_nitro',
+      query: pageQuerySchema,
+      responses: {
+        200: upNextResponseSchema,
+      },
     },
   },
 }, { pathPrefix: '/progress' });

--- a/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
@@ -37,7 +37,8 @@ const upNextRequest = (params: UpNextParams = {}) => {
   return api({ fetch })
     .sync
     .progress
-    .upNext({
+    .upNext
+    .standard({
       query: {
         extended: 'full,images',
         page,
@@ -55,7 +56,7 @@ const upNextRequest = (params: UpNextParams = {}) => {
     });
 };
 
-function mapUpNextResponse(item: UpNextResponse[0]): UpNextEntry {
+export function mapUpNextResponse(item: UpNextResponse[0]): UpNextEntry {
   const episode = item.progress.next_episode;
 
   return {

--- a/projects/client/src/lib/requests/queries/sync/upNextQueryNitro.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextQueryNitro.ts
@@ -1,0 +1,62 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import { EpisodeProgressEntrySchema } from '$lib/requests/models/EpisodeProgressEntry.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
+import { mapUpNextResponse } from '$lib/requests/queries/sync/upNextQuery.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { z } from 'zod';
+
+export const UpNextEntryNitroSchema = EpisodeProgressEntrySchema.merge(
+  z.object({
+    show: ShowEntrySchema,
+  }),
+);
+
+type UpNextParams = {
+  page?: number;
+  limit?: number;
+} & ApiParams;
+
+const upNextNitroRequest = (params: UpNextParams = {}) => {
+  const { fetch, page = 1, limit } = params;
+
+  return api({ fetch })
+    .sync
+    .progress
+    .upNext
+    .nitro({
+      query: {
+        page,
+        limit,
+      },
+    })
+    .then(({ status, body, headers }) => {
+      if (status !== 200) {
+        throw new Error('Failed to fetch up next');
+      }
+
+      return { body, headers };
+    });
+};
+
+export const upNextQueryNitro = defineQuery({
+  key: 'upNext',
+  invalidations: [
+    InvalidateAction.MarkAsWatched('show'),
+    InvalidateAction.MarkAsWatched('episode'),
+  ],
+  dependencies: (
+    params: UpNextParams,
+  ) => [params.page, params.limit],
+  request: upNextNitroRequest,
+  mapper: (response) => ({
+    entries: response.body.map(mapUpNextResponse),
+    page: extractPageMeta(response.headers),
+  }),
+  schema: PaginatableSchemaFactory(UpNextEntryNitroSchema),
+  ttl: time.minutes(30),
+  refetchOnWindowFocus: true,
+});

--- a/projects/client/src/lib/sections/lists/UpNextList.svelte
+++ b/projects/client/src/lib/sections/lists/UpNextList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
 
+  import { page } from "$app/state";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import type { UpNextEntry } from "$lib/requests/queries/sync/upNextQuery";
   import { onMount } from "svelte";
@@ -10,7 +11,11 @@
   import { useUpNextEpisodes } from "./stores/useUpNextEpisodes";
   import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
 
-  const { list: unstable, isLoading } = useUpNextEpisodes();
+  const type = $derived(
+    page.url.searchParams.get("up-next") === "nitro" ? "nitro" : "standard",
+  );
+
+  const { list: unstable, isLoading } = $derived(useUpNextEpisodes(type));
   const { list, set } = useStableArray<UpNextEntry>(
     (l, r) => l.show.id === r.show.id,
   );

--- a/projects/client/src/lib/sections/lists/stores/useUpNextEpisodes.ts
+++ b/projects/client/src/lib/sections/lists/stores/useUpNextEpisodes.ts
@@ -1,18 +1,21 @@
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { useQuery } from '$lib/features/query/useQuery.ts';
 import { upNextQuery } from '$lib/requests/queries/sync/upNextQuery.ts';
+import { upNextQueryNitro } from '$lib/requests/queries/sync/upNextQueryNitro.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { derived } from 'svelte/store';
 
 const UP_NEXT_LIMIT = 100;
 
-export const useUpNextEpisodes = () => {
+export const useUpNextEpisodes = (type: 'standard' | 'nitro') => {
   const { current: user } = useUser();
 
-  const query = useQuery(upNextQuery({
-    limit: UP_NEXT_LIMIT,
-    sort: user().preferences.progress.sort,
-  }));
+  const query = useQuery(
+    (type === 'standard' ? upNextQuery : upNextQueryNitro)({
+      limit: UP_NEXT_LIMIT,
+      sort: user().preferences.progress.sort,
+    }),
+  );
 
   return {
     list: derived(query, ($query) => $query.data?.entries ?? []),


### PR DESCRIPTION
## Up Next Performance Boost: Introducing the Nitro Endpoint

This pull request introduces a new, optimized "nitro" version of the "up next" endpoint and updates the client to utilize this enhanced functionality.

### API Changes

- Added `standard` and `nitro` endpoints to the `upNext` router in the API. This provides two versions of the "up next" endpoint: the standard version and the optimized "nitro" version.

### Client Changes

- Updated the `upNextRequest` function to use the `standard` endpoint and exported the `mapUpNextResponse` function for reusability.
- Created a new query file, `upNextQueryNitro.ts`, for the `nitro` endpoint, including the request function and query definition.
- Modified the `UpNextList.svelte` component to dynamically determine the type of endpoint to use based on a URL parameter, ensuring the appropriate query is used for fetching data.
- Updated the `useUpNextEpisodes` store to accept a `type` parameter and use the corresponding query for either the `standard` or `nitro` endpoint, providing flexibility in data fetching.

(This change, like a skilled mechanic souping up a classic car, introduces a "nitro" version of the "up next" endpoint, significantly boosting performance and efficiency. The updated client components seamlessly integrate with the new endpoint, providing users with a faster and more responsive experience when accessing their upcoming media.)

Test: http://localhost:5173/?up-next=nitro