### PR TITLE
feat(auth): enable passwordless auth flow

### DIFF
--- a/projects/client/src/lib/utils/url/buildOAuthLink.spec.ts
+++ b/projects/client/src/lib/utils/url/buildOAuthLink.spec.ts
@@ -6,7 +6,7 @@ describe('buildOAuthUrl', () => {
     const result = buildOAuthUrl('test-client-id', 'http://localhost:5173');
 
     expect(result).toBe(
-      'https://trakt.tv/oauth/authorize?client_id=test-client-id&redirect_uri=http://localhost:5173&response_type=code',
+      'https://trakt.tv/oauth/authorize?client_id=test-client-id&redirect_uri=http://localhost:5173&response_type=code&hide_email_form=true',
     );
   });
 
@@ -14,7 +14,7 @@ describe('buildOAuthUrl', () => {
     const result = buildOAuthUrl('test-client-id', 'https://my-app.com');
 
     expect(result).toBe(
-      'https://trakt.tv/oauth/authorize?client_id=test-client-id&redirect_uri=https://my-app.com&response_type=code',
+      'https://trakt.tv/oauth/authorize?client_id=test-client-id&redirect_uri=https://my-app.com&response_type=code&hide_email_form=true',
     );
   });
 });

--- a/projects/client/src/lib/utils/url/buildOAuthLink.ts
+++ b/projects/client/src/lib/utils/url/buildOAuthLink.ts
@@ -13,5 +13,5 @@ export function buildOAuthUrl(clientId: string, origin: string) {
       .replace('apiz.', ''),
   );
 
-  return `${env}/oauth/authorize?client_id=${clientId}&redirect_uri=${origin}&response_type=code`;
+  return `${env}/oauth/authorize?client_id=${clientId}&redirect_uri=${origin}&response_type=code&hide_email_form=true`;
 }


### PR DESCRIPTION
## OAuth URL Enhancement: Hiding the Email Form

This pull request modifies the OAuth authorization URL to include a new query parameter, `hide_email_form=true`, streamlining the authentication process.

### OAuth URL Enhancement

- Updated the `buildOAuthUrl` function to append the `hide_email_form=true` query parameter to the OAuth authorization URL. This change instructs the authentication provider to hide the email form during the authorization flow, simplifying the user experience and reducing potential confusion.

### Updates to Tests

- Updated the test cases for `buildOAuthUrl` to reflect the addition of the `hide_email_form=true` query parameter in the expected OAuth authorization URLs. This ensures that the function continues to generate correct URLs with the new parameter.

(This change, like a skilled stagehand removing an unnecessary prop from the set, streamlines the OAuth authentication flow by hiding the email form. This subtle adjustment improves the user experience by reducing clutter and potential confusion, guiding users through the authentication process with greater clarity and efficiency.)