### PR TITLE
Fix/card shadow

### DIFF
--- a/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
+++ b/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
@@ -66,9 +66,20 @@
 
     @include popup-button-style();
 
+    :global(svg) {
+      overflow: visible;
+      :global(circle) {
+        filter: drop-shadow(0px 0px 2px var(--purple-900));
+      }
+    }
+
     &:hover {
       background-color: var(--shade-10);
       color: var(--purple-900);
+
+      :global(svg circle) {
+        filter: none;
+      }
     }
   }
 

--- a/projects/client/src/lib/components/card/CardCover.svelte
+++ b/projects/client/src/lib/components/card/CardCover.svelte
@@ -60,27 +60,6 @@
     border-top-right-radius: var(--border-radius-m);
     overflow: hidden;
     position: relative;
-
-    &::before {
-      z-index: 2;
-      pointer-events: none;
-      content: "";
-
-      border-top-left-radius: var(--border-radius-m);
-      border-top-right-radius: var(--border-radius-m);
-
-      position: absolute;
-      top: 0;
-
-      width: 100%;
-      height: var(--ni-48);
-
-      background: linear-gradient(
-        to bottom,
-        color-mix(in srgb, var(--color-shadow) 70%, transparent 30%),
-        color-mix(in srgb, var(--color-shadow) 0%, transparent 100%)
-      );
-    }
   }
 
   .card-cover-loading {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adding a shadow to the entire button also looked strange; like there was a smudge at the top right of the card. Instead, added a shadow to the circles in the icon itself. cc: @anodpixels 

## 👀 Examples 👀
Before/after:
<img width="159" alt="before1" src="https://github.com/user-attachments/assets/16379753-34a6-44a1-ad81-4b087b722f91" /> <img width="159" alt="after1" src="https://github.com/user-attachments/assets/aee9ff1b-73a8-404f-a120-f9ee5ef1a2e4" />

Before/after:
<img width="159" alt="before2" src="https://github.com/user-attachments/assets/7fa61687-a5e2-4aa6-aede-d063298102f3" /> <img width="159" alt="after2" src="https://github.com/user-attachments/assets/fb173fae-7384-49d8-ac33-7cfb4bb3819e" />
