### PR TITLE
fix: shadow on svg element in safari

### DIFF
--- a/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
+++ b/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
@@ -17,7 +17,7 @@
   class="trakt-popup-menu-button"
   {...props}
 >
-  <MoreIcon />
+  <MoreIcon shadowColor="var(--purple-900)" />
 </button>
 
 {#if $isOpened}
@@ -65,13 +65,6 @@
     all: unset;
 
     @include popup-button-style();
-
-    :global(svg) {
-      overflow: visible;
-      :global(circle) {
-        filter: drop-shadow(0px 0px 2px var(--purple-900));
-      }
-    }
 
     &:hover {
       background-color: var(--shade-10);

--- a/projects/client/src/lib/components/icons/MoreIcon.svelte
+++ b/projects/client/src/lib/components/icons/MoreIcon.svelte
@@ -1,11 +1,43 @@
+<script lang="ts">
+  import { checksum } from "$lib/utils/string/checksum";
+
+  type MoreIconProps = {
+    shadowColor?: string;
+  };
+
+  const { shadowColor }: MoreIconProps = $props();
+
+  const filterId = $derived(
+    shadowColor ? `drop-shadow-${checksum(shadowColor)}` : undefined,
+  );
+</script>
+
+{#snippet circles(filterUrl: string = "")}
+  <circle cx="8" cy="2" r="2" fill="currentColor" filter={filterUrl} />
+  <circle cx="8" cy="8" r="2" fill="currentColor" filter={filterUrl} />
+  <circle cx="8" cy="14" r="2" fill="currentColor" filter={filterUrl} />
+{/snippet}
+
 <svg
   width="16"
   height="16"
   viewBox="0 0 16 16"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
+  overflow="visible"
 >
-  <circle cx="8" cy="2" r="2" fill="currentColor" />
-  <circle cx="8" cy="8" r="2" fill="currentColor" />
-  <circle cx="8" cy="14" r="2" fill="currentColor" />
+  {#if filterId}
+    <defs>
+      <!--
+        CSS drop shadow filter does not work on SVG elements in Safari,
+        so we use an SVG filter instead.
+      -->
+      <filter id={filterId} x="-100%" y="-100%" width="300%" height="300%">
+        <feDropShadow dx="0" dy="0" flood-color={shadowColor} />
+      </filter>
+    </defs>
+    {@render circles(`url(#${filterId})`)}
+  {:else}
+    {@render circles()}
+  {/if}
 </svg>


### PR DESCRIPTION
## 🎶 Notes 🎶
![2toadyex9ls81](https://github.com/user-attachments/assets/6dd9a241-11e0-445c-9b2e-2c7330e436de)

# 👀 Example 👀
Before / After:
<img width="166" alt="Screenshot 2025-02-08 at 23 48 01" src="https://github.com/user-attachments/assets/3d513cb7-85f0-4dba-96ee-5e3c0418a8f5" /> <img width="166" alt="Screenshot 2025-02-08 at 23 46 28" src="https://github.com/user-attachments/assets/289f436d-7480-41de-af98-ab957562637c" />
