### PR TITLE
Fix/portal underlay

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -58,6 +58,7 @@ module.exports = {
         'profile',
         'pr_gate',
         'popular',
+        'popup',
         'pwa',
         'query',
         'rating',

--- a/projects/client/src/lib/components/buttons/popup/_internal/constants.ts
+++ b/projects/client/src/lib/components/buttons/popup/_internal/constants.ts
@@ -1,0 +1,1 @@
+export const PORTAL_UNDERLAY_ID = 'trakt-portal-underlay';

--- a/projects/client/src/lib/components/buttons/popup/_internal/createUnderlay.spec.ts
+++ b/projects/client/src/lib/components/buttons/popup/_internal/createUnderlay.spec.ts
@@ -1,0 +1,21 @@
+import {
+  PORTAL_UNDERLAY_ID,
+} from '$lib/components/buttons/popup/_internal/constants.ts';
+import { createUnderlay } from '$lib/components/buttons/popup/_internal/createUnderlay.ts';
+import { describe, expect, it } from 'vitest';
+
+describe('util: createUnderlay', () => {
+  it('should create an underlay', () => {
+    const underlay = createUnderlay();
+
+    expect(underlay).toBeInstanceOf(HTMLDivElement);
+
+    expect(underlay.style.position).toEqual('fixed');
+    expect(underlay.style.top).toEqual('0px');
+    expect(underlay.style.left).toEqual('0px');
+    expect(underlay.style.width).toEqual('100%');
+    expect(underlay.style.height).toEqual('100%');
+
+    expect(underlay.id).toEqual(PORTAL_UNDERLAY_ID);
+  });
+});

--- a/projects/client/src/lib/components/buttons/popup/_internal/createUnderlay.ts
+++ b/projects/client/src/lib/components/buttons/popup/_internal/createUnderlay.ts
@@ -1,0 +1,19 @@
+import {
+  PORTAL_UNDERLAY_ID,
+} from '$lib/components/buttons/popup/_internal/constants.ts';
+
+export const createUnderlay = () => {
+  const underlay = document.createElement('div');
+
+  underlay.id = PORTAL_UNDERLAY_ID;
+
+  underlay.style.position = 'fixed';
+  underlay.style.top = '0';
+  underlay.style.left = '0';
+  underlay.style.width = '100%';
+  underlay.style.height = '100%';
+
+  underlay.style.zIndex = '777';
+
+  return underlay;
+};

--- a/projects/client/src/lib/components/buttons/popup/_internal/usePortal.ts
+++ b/projects/client/src/lib/components/buttons/popup/_internal/usePortal.ts
@@ -2,14 +2,23 @@ import { clickOutside } from '$lib/utils/actions/clickOutside.ts';
 import { onMount } from 'svelte';
 import { get, readable, writable } from 'svelte/store';
 import { bodyPortal } from './bodyPortal.ts';
+import { createUnderlay } from './createUnderlay.ts';
 
 export function usePortal() {
   let popupTarget: HTMLElement | null = null;
   let popupContainer: HTMLElement | null = null;
+  let underlay: HTMLDivElement | null = null;
 
   const isPopupOpen = writable(false);
-  const closeHandler = () => isPopupOpen.set(false);
-  const openHandler = () => isPopupOpen.set(true);
+  const closeHandler = () => {
+    underlay?.remove();
+    isPopupOpen.set(false);
+  };
+  const openHandler = () => {
+    underlay = createUnderlay();
+    document.body.appendChild(underlay);
+    isPopupOpen.set(true);
+  };
 
   const portalTrigger = (targetNode: HTMLElement) => {
     onMount(() => {
@@ -24,6 +33,7 @@ export function usePortal() {
         targetNode.removeEventListener('clickoutside', closeHandler);
         targetNode.removeEventListener('click', openHandler);
         popupContainer?.remove();
+        underlay?.remove();
       },
     };
   };

--- a/projects/client/src/lib/components/buttons/popup/_internal/usePortal.ts
+++ b/projects/client/src/lib/components/buttons/popup/_internal/usePortal.ts
@@ -1,5 +1,4 @@
 import { clickOutside } from '$lib/utils/actions/clickOutside.ts';
-import { GlobalEventBus } from '$lib/utils/events/GlobalEventBus.ts';
 import { onMount } from 'svelte';
 import { get, readable, writable } from 'svelte/store';
 import { bodyPortal } from './bodyPortal.ts';
@@ -20,23 +19,11 @@ export function usePortal() {
       targetNode.addEventListener('click', openHandler);
     });
 
-    const unregisterResize = GlobalEventBus.getInstance()
-      .register(
-        'resize',
-        () =>
-          requestAnimationFrame(() => {
-            if (get(isPopupOpen)) {
-              closeHandler();
-            }
-          }),
-      );
-
     return {
       destroy() {
         targetNode.removeEventListener('clickoutside', closeHandler);
         targetNode.removeEventListener('click', openHandler);
         popupContainer?.remove();
-        unregisterResize();
       },
     };
   };

--- a/projects/client/src/lib/utils/actions/clickOutside.spec.ts
+++ b/projects/client/src/lib/utils/actions/clickOutside.spec.ts
@@ -52,4 +52,28 @@ describe('clickOutside', () => {
 
     expect(eventFired).toBe(false);
   });
+
+  it('should dispatch on a window resize event ', () => {
+    let eventFired = false;
+    node.addEventListener('clickoutside', () => {
+      eventFired = true;
+    });
+
+    clickOutside(node);
+    globalThis.window.dispatchEvent(new Event('resize'));
+
+    expect(eventFired).toBe(true);
+  });
+
+  it('should dispatch on a window scroll event ', () => {
+    let eventFired = false;
+    node.addEventListener('clickoutside', () => {
+      eventFired = true;
+    });
+
+    clickOutside(node);
+    globalThis.window.dispatchEvent(new Event('scroll'));
+
+    expect(eventFired).toBe(true);
+  });
 });

--- a/projects/client/src/lib/utils/actions/clickOutside.ts
+++ b/projects/client/src/lib/utils/actions/clickOutside.ts
@@ -1,18 +1,26 @@
 import { GlobalEventBus } from '../events/GlobalEventBus.ts';
 
 export function clickOutside(node: HTMLElement) {
+  const dispatch = () => node.dispatchEvent(new CustomEvent('clickoutside'));
+
   function handleClick(e: MouseEvent) {
     if (!e.target) return;
     if (e.target instanceof Node && node.contains(e.target as Node)) return;
 
-    node.dispatchEvent(new CustomEvent('clickoutside'));
+    dispatch();
   }
 
-  const destroy = GlobalEventBus
-    .getInstance()
-    .register('click', handleClick);
+  const instance = GlobalEventBus.getInstance();
+
+  const destroyClick = instance.register('click', handleClick);
+  const destroyResize = instance.register('resize', dispatch);
+  const destroyScroll = instance.register('scroll', dispatch);
 
   return {
-    destroy,
+    destroy() {
+      destroyClick();
+      destroyResize();
+      destroyScroll();
+    },
   };
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Clickoutside action now also considers window scroll and resize as an outside click.
- Adds an underlay to the popup menu:
  - Prevents scrolling in lists when the menu is open.
  - Prevents actions when clicking outside to close it (see example).

## 👀 Examples 👀
Before:
https://github.com/user-attachments/assets/77500231-14b7-4e30-97cf-188dbf5b19f8

After:
https://github.com/user-attachments/assets/0b36e4df-d54d-4b0f-8859-bb3925252dca

