### PR TITLE
Feat/deleted users

### DIFF
--- a/projects/api/src/contracts/_internal/response/userProfileResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/userProfileResponseSchema.ts
@@ -3,6 +3,7 @@ import { z } from '../z.ts';
 export const profileResponseSchema = z.object({
   username: z.string(),
   private: z.boolean(),
+  deleted: z.boolean(),
   name: z.string(),
   vip: z.boolean(),
   vip_ep: z.boolean(),

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -282,5 +282,6 @@
   "popular_comments": "Beliebte Kommentare",
   "no_comments": "Noch keine Kommentare. Sei der/die Erste!",
   "review_by": "Review von",
-  "shout_by": "Shout von"
+  "shout_by": "Shout von",
+  "deleted_user": "Gelöscht"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -282,5 +282,6 @@
   "popular_comments": "Popular comments",
   "no_comments": "No comments yet.",
   "review_by": "Review by",
-  "shout_by": "Shout by"
+  "shout_by": "Shout by",
+  "deleted_user": "Deleted"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -282,5 +282,6 @@
   "popular_comments": "Comentarios populares",
   "no_comments": "Aún no hay comentarios.",
   "review_by": "Reseña de",
-  "shout_by": "Grito de"
+  "shout_by": "Grito de",
+  "deleted_user": "Eliminado"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -282,5 +282,6 @@
   "popular_comments": "Comentarios populares",
   "no_comments": "Aún no hay comentarios.",
   "review_by": "Reseña de",
-  "shout_by": "Grito de"
+  "shout_by": "Grito de",
+  "deleted_user": "Eliminado"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -282,5 +282,6 @@
   "popular_comments": "Commentaires populaires",
   "no_comments": "Aucun commentaire pour l'instant.",
   "review_by": "Critique par",
-  "shout_by": "Crié par"
+  "shout_by": "Crié par",
+  "deleted_user": "Supprimé"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -282,5 +282,6 @@
   "popular_comments": "Commentaires populaires",
   "no_comments": "Pas encore de commentaires.",
   "review_by": "Critique par",
-  "shout_by": "Crié par"
+  "shout_by": "Crié par",
+  "deleted_user": "Supprimé"
 }

--- a/projects/client/i18n/messages/it-it.json
+++ b/projects/client/i18n/messages/it-it.json
@@ -282,5 +282,6 @@
   "popular_comments": "Commenti popolari",
   "no_comments": "Nessun commento per ora.",
   "review_by": "Recensione di",
-  "shout_by": "Grido di"
+  "shout_by": "Grido di",
+  "deleted_user": "Eliminato"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -282,5 +282,6 @@
   "popular_comments": "人気のコメント",
   "no_comments": "まだコメントはありません。",
   "review_by": "レビュー:",
-  "shout_by": "シャウト:"
+  "shout_by": "シャウト:",
+  "deleted_user": "削除済み"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -282,5 +282,6 @@
   "popular_comments": "Populaire reacties",
   "no_comments": "Nog geen reacties.",
   "review_by": "Review door",
-  "shout_by": "Geschreeuwd door"
+  "shout_by": "Geschreeuwd door",
+  "deleted_user": "Verwijderd"
 }

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -282,5 +282,6 @@
   "popular_comments": "Popularne komentarze",
   "no_comments": "Jeszcze brak komentarzy.",
   "review_by": "Recenzja od",
-  "shout_by": "Krzyknął"
+  "shout_by": "Krzyknął",
+  "deleted_user": "Usunięto"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -282,5 +282,6 @@
   "popular_comments": "Comentários populares",
   "no_comments": "Sem comentários por enquanto. Seja o primeiro!",
   "review_by": "Crítica por",
-  "shout_by": "Grito por"
+  "shout_by": "Grito por",
+  "deleted_user": "Excluído"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -282,5 +282,6 @@
   "popular_comments": "Comentarii populare",
   "no_comments": "Încă nu sunt comentarii.",
   "review_by": "Recenzie de",
-  "shout_by": "Strigăt de"
+  "shout_by": "Strigăt de",
+  "deleted_user": "Șters"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -282,5 +282,6 @@
   "popular_comments": "Популярні коментарі",
   "no_comments": "Ще немає коментарів.",
   "review_by": "Огляд від",
-  "shout_by": "Вигук від"
+  "shout_by": "Вигук від",
+  "deleted_user": "Видалено"
 }

--- a/projects/client/src/lib/requests/_internal/mapToUserProfile.ts
+++ b/projects/client/src/lib/requests/_internal/mapToUserProfile.ts
@@ -8,6 +8,7 @@ export function mapToUserProfile(user: ProfileResponse): UserProfile {
     name: user.name,
     private: user.private,
     isVip: user.vip || user.vip_ep,
+    isDeleted: user.deleted,
     slug: user.ids.slug,
     avatar: {
       url: user.images?.avatar.full ?? DEFAULT_AVATAR,

--- a/projects/client/src/lib/requests/models/UserProfile.ts
+++ b/projects/client/src/lib/requests/models/UserProfile.ts
@@ -5,6 +5,7 @@ export const UserProfileSchema = z.object({
   name: z.string(),
   private: z.boolean(),
   isVip: z.boolean(),
+  isDeleted: z.boolean(),
   slug: z.string(),
   avatar: z.object({
     url: z.string(),

--- a/projects/client/src/lib/sections/summary/components/_internal/UserProfileLink.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/UserProfileLink.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
   import Link from "$lib/components/link/Link.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { UserProfile } from "$lib/requests/models/UserProfile";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
-  type UserProfileProps = {
-    slug: string;
-    name: string;
-  };
-
-  const { slug, name }: UserProfileProps = $props();
+  const { user }: { user: UserProfile } = $props();
 </script>
 
-<Link href={UrlBuilder.og.user(slug)} target="_blank">
-  <p class="secondary small ellipsis">
-    {name}
-  </p>
-</Link>
+{#if user.isDeleted}
+  <p class="secondary small trakt-deleted-user">{m.deleted_user()}</p>
+{:else}
+  <Link href={UrlBuilder.og.user(user.slug)} target="_blank">
+    <p class="secondary small ellipsis">
+      {user.username}
+    </p>
+  </Link>
+{/if}
+
+<style>
+  .trakt-deleted-user {
+    color: var(--shade-700);
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentHeader.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import VipBadge from "$lib/components/badge/VipBadge.svelte";
-  import RateIcon from "$lib/components/icons/RateIcon.svelte";
   import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaComment } from "$lib/requests/models/MediaComment";
@@ -17,14 +16,6 @@
       mapRatingToSimpleRating(comment.user.stats.rating),
   );
 </script>
-
-{#snippet icon()}
-  {#if commenterRating}
-    <div class="trakt-avatar-icon">
-      <RateIcon rating={commenterRating} />
-    </div>
-  {/if}
-{/snippet}
 
 <div class="trakt-comment-header" class:is-vip={comment.user.isVip}>
   <UserAvatar

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentHeader.svelte
@@ -35,7 +35,7 @@
       <p class="small secondary">
         {comment.isReview ? m.review_by() : m.shout_by()}
       </p>
-      <UserProfileLink slug={comment.user.slug} name={comment.user.username} />
+      <UserProfileLink user={comment.user} />
       {#if comment.user.isVip}
         <VipBadge />
       {/if}
@@ -78,7 +78,7 @@
   .trakt-comment-user {
     display: flex;
     align-items: center;
-    gap: var(--gap-xs);
+    gap: var(--gap-xxs);
 
     height: var(--ni-18);
   }

--- a/projects/client/src/lib/sections/summary/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/lists/_internal/ListHeader.svelte
@@ -15,7 +15,7 @@
     </p>
     <div class="list-credits">
       <p class="secondary small">{m.by()}</p>
-      <UserProfileLink slug={list.user.slug} name={list.user.username} />
+      <UserProfileLink user={list.user} />
     </div>
   </div>
 </div>

--- a/projects/client/src/mocks/data/summary/common/mapped/MediaWatchingMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/common/mapped/MediaWatchingMappedMock.ts
@@ -9,6 +9,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'Kim Kitsuragi',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'kimkitsuragi',
     'avatar': {
       'url': DEFAULT_AVATAR,
@@ -19,6 +20,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'Klaasje Amandou',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'klaasje',
     'avatar': {
       'url': DEFAULT_AVATAR,
@@ -29,6 +31,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'Cuno',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'cuno',
     'avatar': {
       'url': DEFAULT_AVATAR,
@@ -39,6 +42,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'Joyce Messier',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'joyce',
     'avatar': {
       'url': DEFAULT_AVATAR,
@@ -49,6 +53,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'Measurehead',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'measurehead',
     'avatar': {
       'url': DEFAULT_AVATAR,
@@ -59,6 +64,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'Lilian Carter',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'lilian',
     'avatar': {
       'url': DEFAULT_AVATAR,
@@ -69,6 +75,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'Titus Hardie',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'titus',
     'avatar': {
       'url': DEFAULT_AVATAR,
@@ -79,6 +86,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'Garte',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'garte',
     'avatar': {
       'url': DEFAULT_AVATAR,
@@ -89,6 +97,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'Evrart Claire',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'evrart',
     'avatar': {
       'url': DEFAULT_AVATAR,
@@ -99,6 +108,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'The Pale',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'thepale',
     'avatar': {
       'url': DEFAULT_AVATAR,
@@ -109,6 +119,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'Lena',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'lena',
     'avatar': {
       'url': DEFAULT_AVATAR,
@@ -119,6 +130,7 @@ export const MediaWatchingMappedMock: UserProfile[] = [
     'private': false,
     'name': 'Renee',
     'isVip': false,
+    'isDeleted': false,
     'slug': 'renee',
     'avatar': {
       'url': DEFAULT_AVATAR,

--- a/projects/client/src/mocks/data/summary/common/response/MediaWatchingResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/common/response/MediaWatchingResponseMock.ts
@@ -8,6 +8,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'Kim Kitsuragi',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'kimkitsuragi',
@@ -19,6 +20,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'Klaasje Amandou',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'klaasje',
@@ -30,6 +32,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'Cuno',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'cuno',
@@ -41,6 +44,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'Joyce Messier',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'joyce',
@@ -52,6 +56,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'Measurehead',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'measurehead',
@@ -63,6 +68,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'Lilian Carter',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'lilian',
@@ -74,6 +80,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'Titus Hardie',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'titus',
@@ -85,6 +92,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'Garte',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'garte',
@@ -96,6 +104,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'Evrart Claire',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'evrart',
@@ -107,6 +116,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'The Pale',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'thepale',
@@ -118,6 +128,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'Lena',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'lena',
@@ -129,6 +140,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'private': false,
     'name': 'Renee',
     'vip': false,
+    'deleted': false,
     'vip_ep': false,
     'ids': {
       'slug': 'renee',

--- a/projects/client/src/mocks/data/users/mapped/UserProfileHarryMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/UserProfileHarryMappedMock.ts
@@ -10,4 +10,5 @@ export const UserProfileHarryMappedMock: UserProfile = {
   },
   'private': false,
   'isVip': true,
+  'isDeleted': false,
 };

--- a/projects/client/src/mocks/data/users/response/UserProfileHarryResponseMock.ts
+++ b/projects/client/src/mocks/data/users/response/UserProfileHarryResponseMock.ts
@@ -3,6 +3,7 @@ import type { ProfileResponse } from '$lib/api.ts';
 export const UserProfileHarryResponseMock: ProfileResponse = {
   'username': 'harrier_dubois',
   'private': false,
+  'deleted': false,
   'name': 'Harry Du Bois',
   'vip': true,
   'vip_ep': false,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Now that we know if a user is deleted or not, we can mark it as such. They will be listed as `Deleted`.
- This will be visible in the comments and lists lists.
- I also experimented with a red label, but think that draws too much attention to it. See examples below.

## 👀 Examples 👀
Before:
<img width="515" alt="Screenshot 2025-02-12 at 15 34 35" src="https://github.com/user-attachments/assets/0f58357c-7587-4c87-84d0-014ee0e11d38" />

After:
<img width="515" alt="Screenshot 2025-02-12 at 15 44 23" src="https://github.com/user-attachments/assets/e2b5cc40-0c3d-4054-a17c-6cfded61770a" />

Example with red label:
<img width="515" alt="Screenshot 2025-02-12 at 15 42 20" src="https://github.com/user-attachments/assets/e6f111a8-e654-4949-9358-a0c3ef620d8c" />

