### PR TITLE
fix: increase gap for more button when text is clamped

### DIFF
--- a/projects/client/src/lib/components/text/ClampedText.svelte
+++ b/projects/client/src/lib/components/text/ClampedText.svelte
@@ -44,6 +44,8 @@
     display: flex;
     align-items: flex-end;
 
+    gap: var(--gap-xs);
+
     @include for-tablet-sm-and-below {
       flex-direction: column;
     }


### PR DESCRIPTION
## 👀 Examples 👀
Before:
<img width="551" alt="Screenshot 2025-02-13 at 16 14 09" src="https://github.com/user-attachments/assets/486cad1a-d6f6-4b8f-b777-ac5a8016d2ce" />

After:
<img width="551" alt="Screenshot 2025-02-13 at 16 14 37" src="https://github.com/user-attachments/assets/23f4c99f-39b4-4422-a8f1-fc65594f4c4d" />

Before:
<img width="989" alt="Screenshot 2025-02-13 at 16 13 59" src="https://github.com/user-attachments/assets/373d4e25-c8ef-402c-ad38-66cae7570e43" />

After:
<img width="999" alt="Screenshot 2025-02-13 at 16 18 12" src="https://github.com/user-attachments/assets/a9c994dc-d5c1-4ce9-845a-0f0fab5acd78" />
