### PR TITLE
fix(social): improve username readability on light covers

### DIFF
--- a/projects/client/src/lib/sections/lists/social/SocialActivityCard.svelte
+++ b/projects/client/src/lib/sections/lists/social/SocialActivityCard.svelte
@@ -42,7 +42,7 @@
     align-items: center;
 
     padding: 0 var(--ni-4);
-    backdrop-filter: blur(var(--ni-8));
+    backdrop-filter: blur(var(--ni-8)) contrast(0.6);
     border-radius: var(--border-radius-m);
     overflow: hidden;
   }


### PR DESCRIPTION
Before:

<img width="457" alt="image" src="https://github.com/user-attachments/assets/3da20cb6-ae56-46bd-a235-5874a88ce80f" />

After:

<img width="457" alt="image" src="https://github.com/user-attachments/assets/9ab1200b-5d45-4cfd-b69e-d042e40e8d4a" />
