### PR TITLE
fix(watched): do not use date range for recently watched items

### DIFF
--- a/projects/client/src/lib/requests/queries/users/episodeHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/episodeHistoryQuery.ts
@@ -12,9 +12,9 @@ import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 
 type EpisodeHistoryParams = {
-  startDate: Date;
-  endDate: Date;
   limit: number;
+  startDate?: Date;
+  endDate?: Date;
   page?: number;
 } & ApiParams;
 
@@ -39,8 +39,8 @@ function episodeHistoryRequest(
       },
       query: {
         extended: 'full,images',
-        start_at: startDate.toISOString(),
-        end_at: endDate.toISOString(),
+        start_at: startDate?.toISOString(),
+        end_at: endDate?.toISOString(),
         limit,
         page,
       },

--- a/projects/client/src/lib/requests/queries/users/movieHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieHistoryQuery.ts
@@ -10,9 +10,9 @@ import { z } from 'zod';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
 
 type MovieHistoryParams = {
-  startDate: Date;
-  endDate: Date;
   limit: number;
+  startDate?: Date;
+  endDate?: Date;
   page?: number;
 } & ApiParams;
 
@@ -36,8 +36,8 @@ const movieHistoryRequest = (
       },
       query: {
         extended: 'full,images',
-        start_at: startDate.toISOString(),
-        end_at: endDate.toISOString(),
+        start_at: startDate?.toISOString(),
+        end_at: endDate?.toISOString(),
         limit,
         page,
       },

--- a/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
@@ -3,17 +3,16 @@ import type { Paginatable } from '$lib/requests/models/Paginatable.ts';
 import {
   episodeHistoryQuery,
   type HistoryEpisode,
-} from '$lib/requests/queries/users/episodeHistoryQuery';
+} from '$lib/requests/queries/users/episodeHistoryQuery.ts';
 import {
   type HistoryMovie,
   movieHistoryQuery,
 } from '$lib/requests/queries/users/movieHistoryQuery.ts';
-import { getPastMonthRange } from '$lib/utils/date/getPastMonthRange.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import type { CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 
-const HISTORY_LIMIT = 1000;
+const HISTORY_LIMIT = 25;
 
 type RecentlyWatchedListStoreProps = {
   type: 'movie' | 'episode';
@@ -27,7 +26,6 @@ function typeToQuery(
   { type, limit, page }: RecentlyWatchedListStoreProps,
 ) {
   const params = {
-    ...getPastMonthRange(new Date()),
     limit: limit ?? HISTORY_LIMIT,
     page,
   };


### PR DESCRIPTION
## 🎶 Notes 🎶

- The recently watched lists will now show the last 25 items, the `view all` variants will show the last 100 items.