### PR TITLE
improve / card title and subtitle styling and ensure username does not overflow

### DIFF
--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -50,6 +50,22 @@
       &:global(:has(~ .trakt-card-footer-action:not(:empty)) > :nth-child(2)) {
         max-width: 80%;
       }
+
+      :global(.trakt-card-title) {
+        color: var(--color-text-primary);
+        margin: 0;
+        font-weight: 500;
+
+        :has(~ .trakt-card-subtitle) {
+          font-weight: 600;
+        }
+      }
+
+      :global(.trakt-card-subtitle) {
+        color: var(--color-text-secondary);
+        margin: 0;
+        font-weight: 500;
+      }
     }
 
     .trakt-card-footer-action {

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -111,7 +111,7 @@
 
     <CardFooter {action}>
       {#if isShowContext}
-        <p class="episode-card-title ellipsis">
+        <p class="trakt-card-title ellipsis">
           <Spoiler
             media={props.episode}
             show={props.show}
@@ -121,27 +121,27 @@
             {props.episode.title}
           </Spoiler>
         </p>
-        <p class="episode-card-subtitle ellipsis small">
+        <p class="trakt-card-subtitle ellipsis small">
           {props.episode.season}x{props.episode.number}
         </p>
       {/if}
 
       {#if props.variant === "activity"}
         <Link href={UrlBuilder.show(props.show.slug)}>
-          <p class="episode-card-title ellipsis">
+          <p class="trakt-card-title ellipsis">
             {props.episode.season}x{props.episode.number} - {props.show.title}
           </p>
         </Link>
-        <p class="episode-card-subtitle ellipsis small">
+        <p class="trakt-card-subtitle ellipsis small">
           {EpisodeIntlProvider.timestampText(props.date)}
         </p>
       {/if}
 
       {#if !isShowContext && !isActivity}
         <Link href={UrlBuilder.show(props.show.slug)}>
-          <p class="episode-card-title ellipsis">{props.show.title}</p>
+          <p class="trakt-card-title ellipsis">{props.show.title}</p>
         </Link>
-        <p class="episode-card-subtitle ellipsis small">
+        <p class="trakt-card-subtitle ellipsis small">
           {props.episode.season}x{props.episode.number}
           <Spoiler
             media={props.episode}
@@ -158,18 +158,6 @@
 {/if}
 
 <style>
-  .episode-card-title {
-    color: var(--color-text-primary);
-    margin: 0;
-    font-weight: 600;
-  }
-
-  .episode-card-subtitle {
-    color: var(--color-text-secondary);
-    margin: 0;
-    font-weight: 500;
-  }
-
   .show-progress-label {
     position: relative;
   }

--- a/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
@@ -80,14 +80,14 @@
   <CardFooter {action}>
     <Link href={UrlBuilder.media(type, media.slug)}>
       <p
-        class="media-title small ellipsis"
+        class="trakt-card-title small ellipsis"
         class:small={rest.variant !== "activity"}
       >
         {media.title}
       </p>
     </Link>
     {#if rest.variant === "activity"}
-      <p class="media-subtitle small ellipsis">
+      <p class="trakt-card-subtitle small ellipsis">
         {toHumanDate(new Date(), rest.date, getLocale())}
       </p>
     {/if}
@@ -111,23 +111,3 @@
     {@render content(media.thumb.url)}
   </ActivityCard>
 {/if}
-
-<style>
-  .media-title {
-    margin: 0;
-    padding: 0;
-
-    color: var(--color-text-secondary);
-
-    font-weight: 600;
-  }
-
-  .media-subtitle {
-    margin: 0;
-    padding: 0;
-
-    color: var(--color-text-secondary);
-
-    font-weight: 500;
-  }
-</style>

--- a/projects/client/src/lib/sections/lists/social/SocialActivityCard.svelte
+++ b/projects/client/src/lib/sections/lists/social/SocialActivityCard.svelte
@@ -37,6 +37,7 @@
 
 <style>
   .user-profile-badge {
+    max-width: calc(100% - var(--ni-32));
     display: flex;
     gap: var(--gap-xs);
     align-items: center;
@@ -45,5 +46,9 @@
     backdrop-filter: blur(var(--ni-8)) contrast(0.6);
     border-radius: var(--border-radius-m);
     overflow: hidden;
+
+    :global(.trakt-link) {
+      max-width: 75%;
+    }
   }
 </style>


### PR DESCRIPTION
## Card Component Styling Standardization

This pull request standardizes CSS class names and improves the styling for card components.  The primary changes involve renaming title and subtitle classes and updating their associated styles for consistency.

### Class Name Standardization:

* **`EpisodeCard.svelte`**: The class names `.episode-card-title` and `.episode-card-subtitle` have been renamed to `.trakt-card-title` and `.trakt-card-subtitle`, respectively.  All instances of these classes within the file have been updated to reflect the new names.
* **`MediaItemCard.svelte`**:  Similarly, `.media-title` and `.media-subtitle` have been renamed to `.trakt-card-title` and `.trakt-card-subtitle`.  The old styles associated with the previous class names have been removed.

### Styling Improvements:

* **`CardFooter.svelte`**: New styles have been added for `.trakt-card-title` and `.trakt-card-subtitle` within the `CardFooter` component.  These styles define consistent text color, margin, and font-weight for card titles and subtitles across the application.
* **`SocialActivityCard.svelte`**: Styles have been added for `.trakt-link` to set a maximum width and ensure proper alignment within the social activity card. This prevents links from overflowing and maintains a consistent layout.

(This update, like a detective meticulously organizing their files, brings greater consistency to the styling of card components.  The standardized class names make the CSS easier to understand and maintain, while the styling improvements ensure a more polished and professional look.  It's a step towards a more unified design language, where each card tells its story clearly and concisely.)