### PR TITLE
Feat / clickable directors & writers

### DIFF
--- a/projects/api/src/contracts/_internal/response/crewPositionResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/crewPositionResponseSchema.ts
@@ -1,0 +1,18 @@
+import { z } from '../z.ts';
+
+export const crewPositionResponseSchema = z.enum([
+  'acting',
+  'production',
+  'art',
+  'crew',
+  'costume & make-up',
+  'directing',
+  'writing',
+  'sound',
+  'camera',
+  'lighting',
+  'visual effects',
+  'editing',
+  'creator',
+  'created by',
+]);

--- a/projects/api/src/contracts/_internal/response/jobsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/jobsResponseSchema.ts
@@ -1,0 +1,7 @@
+import { z } from '../z.ts';
+import { jobResponseSchema } from './jobResponseSchema.ts';
+
+export const jobsResponseSchema = z.object({
+  job: z.string(),
+  jobs: z.array(jobResponseSchema),
+});

--- a/projects/api/src/contracts/_internal/response/peopleResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/peopleResponseSchema.ts
@@ -1,22 +1,7 @@
 import { z } from '../z.ts';
 import { characterResponseSchema } from './characterResponseSchema.ts';
-import { jobResponseSchema } from './jobResponseSchema.ts';
-
-const crewPositions = z.enum([
-  'production',
-  'art',
-  'crew',
-  'costume & make-up',
-  'directing',
-  'writing',
-  'sound',
-  'camera',
-  'lighting',
-  'visual effects',
-  'editing',
-  'creator',
-  'created by',
-]);
+import { crewPositionResponseSchema } from './crewPositionResponseSchema.ts';
+import { jobsResponseSchema } from './jobsResponseSchema.ts';
 
 const headshotSchema = z.object({
   headshot: z.array(z.string()),
@@ -48,20 +33,18 @@ export const castSchema = z.object({
 }).merge(characterResponseSchema);
 
 export const crewSchema = z.object({
-  job: z.string(),
-  jobs: z.array(jobResponseSchema),
   person: personSchema,
   episode_count: z.number().optional(),
   /***
    * Available if requesting extended `images`.
    */
   images: headshotSchema.optional(),
-});
+}).merge(jobsResponseSchema);
 
 export const peopleResponseSchema = z.object({
   cast: z.array(castSchema).optional(),
   crew: z.record(
-    crewPositions,
+    crewPositionResponseSchema,
     z.array(crewSchema),
   ).optional(),
 });

--- a/projects/api/src/contracts/enums/crewPositionSchema.ts
+++ b/projects/api/src/contracts/enums/crewPositionSchema.ts
@@ -1,0 +1,3 @@
+import { crewPositionResponseSchema } from '../_internal/response/crewPositionResponseSchema.ts';
+
+export const crewPositionSchema = crewPositionResponseSchema;

--- a/projects/api/src/contracts/enums/index.ts
+++ b/projects/api/src/contracts/enums/index.ts
@@ -1,3 +1,4 @@
+export * from './crewPositionSchema.ts';
 export * from './genreOptionSchema.ts';
 export * from './jobOptionSchema.ts';
 export * from './mediaStatusSchema.ts';

--- a/projects/api/src/contracts/people/_internal/response/peopleMovieCreditsResponseSchema.ts
+++ b/projects/api/src/contracts/people/_internal/response/peopleMovieCreditsResponseSchema.ts
@@ -1,4 +1,6 @@
 import { characterResponseSchema } from '../../../_internal/response/characterResponseSchema.ts';
+import { crewPositionResponseSchema } from '../../../_internal/response/crewPositionResponseSchema.ts';
+import { jobsResponseSchema } from '../../../_internal/response/jobsResponseSchema.ts';
 import { movieResponseSchema } from '../../../_internal/response/movieResponseSchema.ts';
 import { z } from '../../../_internal/z.ts';
 
@@ -7,5 +9,13 @@ export const peopleMovieCreditsResponseSchema = z.object({
     z.object({
       movie: movieResponseSchema,
     }).merge(characterResponseSchema),
+  ).optional(),
+  crew: z.record(
+    crewPositionResponseSchema,
+    z.array(
+      z.object({
+        movie: movieResponseSchema,
+      }).merge(jobsResponseSchema),
+    ),
   ).optional(),
 });

--- a/projects/api/src/contracts/people/_internal/response/peopleShowCreditsResponseSchema.ts
+++ b/projects/api/src/contracts/people/_internal/response/peopleShowCreditsResponseSchema.ts
@@ -1,4 +1,6 @@
 import { characterResponseSchema } from '../../../_internal/response/characterResponseSchema.ts';
+import { crewPositionResponseSchema } from '../../../_internal/response/crewPositionResponseSchema.ts';
+import { jobsResponseSchema } from '../../../_internal/response/jobsResponseSchema.ts';
 import { showResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
 import { z } from '../../../_internal/z.ts';
 
@@ -9,5 +11,14 @@ export const peopleShowCreditsResponseSchema = z.object({
       episode_count: z.number(),
       series_regular: z.boolean(),
     }).merge(characterResponseSchema),
+  ).optional(),
+  crew: z.record(
+    crewPositionResponseSchema,
+    z.array(
+      z.object({
+        show: showResponseSchema,
+        episode_count: z.number(),
+      }).merge(jobsResponseSchema),
+    ),
   ).optional(),
 });

--- a/projects/api/src/contracts/people/_internal/response/peopleSummaryResponseSchema.ts
+++ b/projects/api/src/contracts/people/_internal/response/peopleSummaryResponseSchema.ts
@@ -1,3 +1,4 @@
+import { crewPositionResponseSchema } from '../../../_internal/response/crewPositionResponseSchema.ts';
 import { z } from '../../../_internal/z.ts';
 
 export const peopleSummaryResponseSchema = z.object({
@@ -45,7 +46,7 @@ export const peopleSummaryResponseSchema = z.object({
   /***
    * Available if requesting extended `full`.
    */
-  known_for_department: z.string().optional(),
+  known_for_department: crewPositionResponseSchema.optional(),
   /***
    * Available if requesting extended `full`.
    */

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -285,5 +285,20 @@
   "shout_by": "Shout von",
   "deleted_user": "Gelöscht",
   "social_activity_title": "Soziale Aktivität",
-  "view_all_social_activity": "Alle Aktivitäten anzeigen"
+  "view_all_social_activity": "Alle Aktivitäten anzeigen",
+  "position_dropwdown_label": "Position",
+  "position_acting": "Schauspielerei",
+  "position_production": "Produktion",
+  "position_art": "Kunst",
+  "position_crew": "Team",
+  "position_costume___make_up": "Kostüm & Make-up",
+  "position_directing": "Regie",
+  "position_writing": "Drehbuch",
+  "position_sound": "Ton",
+  "position_camera": "Kamera",
+  "position_lighting": "Beleuchtung",
+  "position_visual_effects": "Visuelle Effekte",
+  "position_editing": "Schnitt",
+  "position_creator": "Schöpfer",
+  "position_created_by": "Erstellt von"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -285,5 +285,20 @@
   "shout_by": "Shout by",
   "deleted_user": "Deleted",
   "social_activity_title": "Social Activity",
-  "view_all_social_activity": "View all social activity"
+  "view_all_social_activity": "View all social activity",
+  "position_dropwdown_label": "Position",
+  "position_acting": "Acting",
+  "position_production": "Production",
+  "position_art": "Art",
+  "position_crew": "Crew",
+  "position_costume___make_up": "Costume & Make-Up",
+  "position_directing": "Directing",
+  "position_writing": "Writing",
+  "position_sound": "Sound",
+  "position_camera": "Camera",
+  "position_lighting": "Lighting",
+  "position_visual_effects": "Visual Effects",
+  "position_editing": "Editing",
+  "position_creator": "Creator",
+  "position_created_by": "Created By"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -285,5 +285,20 @@
   "shout_by": "Grito de",
   "deleted_user": "Eliminado",
   "social_activity_title": "Actividad Social",
-  "view_all_social_activity": "Ver toda la actividad social"
+  "view_all_social_activity": "Ver toda la actividad social",
+  "position_dropwdown_label": "Puesto",
+  "position_acting": "Actuación",
+  "position_production": "Producción",
+  "position_art": "Arte",
+  "position_crew": "Equipo",
+  "position_costume___make_up": "Vestuario y Maquillaje",
+  "position_directing": "Dirección",
+  "position_writing": "Escritura",
+  "position_sound": "Sonido",
+  "position_camera": "Cámara",
+  "position_lighting": "Iluminación",
+  "position_visual_effects": "Efectos Visuales",
+  "position_editing": "Edición",
+  "position_creator": "Creador",
+  "position_created_by": "Creado por"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -285,5 +285,20 @@
   "shout_by": "Grito de",
   "deleted_user": "Eliminado",
   "social_activity_title": "Actividad Social",
-  "view_all_social_activity": "Ver toda la actividad social"
+  "view_all_social_activity": "Ver toda la actividad social",
+  "position_dropwdown_label": "Puesto",
+  "position_acting": "Actuación",
+  "position_production": "Producción",
+  "position_art": "Arte",
+  "position_crew": "Equipo",
+  "position_costume___make_up": "Vestuario y Maquillaje",
+  "position_directing": "Dirección",
+  "position_writing": "Escritura",
+  "position_sound": "Sonido",
+  "position_camera": "Cámaras",
+  "position_lighting": "Iluminación",
+  "position_visual_effects": "Efectos Visuales",
+  "position_editing": "Edición",
+  "position_creator": "Creador",
+  "position_created_by": "Creado por"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -285,5 +285,20 @@
   "shout_by": "Crié par",
   "deleted_user": "Supprimé",
   "social_activity_title": "Activité Sociale",
-  "view_all_social_activity": "Voir toutes les activités sociales"
+  "view_all_social_activity": "Voir toutes les activités sociales",
+  "position_dropwdown_label": "Poste",
+  "position_acting": "Interprétation",
+  "position_production": "Production",
+  "position_art": "Art",
+  "position_crew": "Équipe",
+  "position_costume___make_up": "Costumes et maquillage",
+  "position_directing": "Réalisation",
+  "position_writing": "Scénarisation",
+  "position_sound": "Son",
+  "position_camera": "Caméra",
+  "position_lighting": "Éclairage",
+  "position_visual_effects": "Effets visuels",
+  "position_editing": "Montage",
+  "position_creator": "Créateur",
+  "position_created_by": "Créé par"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -285,5 +285,20 @@
   "shout_by": "Crié par",
   "deleted_user": "Supprimé",
   "social_activity_title": "Activité Sociale",
-  "view_all_social_activity": "Afficher toute l'activité sociale"
+  "view_all_social_activity": "Afficher toute l'activité sociale",
+  "position_dropwdown_label": "Position",
+  "position_acting": "Acteur",
+  "position_production": "Production",
+  "position_art": "Art",
+  "position_crew": "Équipe",
+  "position_costume___make_up": "Costumes & Maquillage",
+  "position_directing": "Réalisation",
+  "position_writing": "Écriture",
+  "position_sound": "Son",
+  "position_camera": "Caméra",
+  "position_lighting": "Éclairage",
+  "position_visual_effects": "Effets visuels",
+  "position_editing": "Montage",
+  "position_creator": "Créateur",
+  "position_created_by": "Créé par"
 }

--- a/projects/client/i18n/messages/it-it.json
+++ b/projects/client/i18n/messages/it-it.json
@@ -285,5 +285,20 @@
   "shout_by": "Grido di",
   "deleted_user": "Eliminato",
   "social_activity_title": "Attività Sociale",
-  "view_all_social_activity": "Visualizza tutte le attività social"
+  "view_all_social_activity": "Visualizza tutte le attività social",
+  "position_dropwdown_label": "Poziție",
+  "position_acting": "Recitazione",
+  "position_production": "Produzione",
+  "position_art": "Arte",
+  "position_crew": "Squadra",
+  "position_costume___make_up": "Costumi e Trucco",
+  "position_directing": "Regia",
+  "position_writing": "Scrittura",
+  "position_sound": "Suono",
+  "position_camera": "Fotocamera",
+  "position_lighting": "Illuminazione",
+  "position_visual_effects": "Effetti Vis.",
+  "position_editing": "Montaggio",
+  "position_creator": "Creatore",
+  "position_created_by": "Creato Da"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -285,5 +285,20 @@
   "shout_by": "シャウト:",
   "deleted_user": "削除済み",
   "social_activity_title": "ソーシャルアクティビティ",
-  "view_all_social_activity": "すべてのソーシャルアクティビティを表示"
+  "view_all_social_activity": "すべてのソーシャルアクティビティを表示",
+  "position_dropwdown_label": "役職",
+  "position_acting": "演技",
+  "position_production": "制作",
+  "position_art": "美術",
+  "position_crew": "スタッフ",
+  "position_costume___make_up": "衣装＆メイク",
+  "position_directing": "監督",
+  "position_writing": "脚本",
+  "position_sound": "音響",
+  "position_camera": "カメラ",
+  "position_lighting": "照明",
+  "position_visual_effects": "ビジュアルエフェクト",
+  "position_editing": "編集",
+  "position_creator": "クリエイター",
+  "position_created_by": "制作"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -285,5 +285,20 @@
   "shout_by": "Geschreeuwd door",
   "deleted_user": "Verwijderd",
   "social_activity_title": "Sociale Activiteit",
-  "view_all_social_activity": "Alle sociale activiteiten bekijken"
+  "view_all_social_activity": "Alle sociale activiteiten bekijken",
+  "position_dropwdown_label": "Functie",
+  "position_acting": "Acteren",
+  "position_production": "Productie",
+  "position_art": "Art",
+  "position_crew": "Crew",
+  "position_costume___make_up": "Kostuum & Make-up",
+  "position_directing": "Regisseren",
+  "position_writing": "Schrijven",
+  "position_sound": "Geluid",
+  "position_camera": "Camera",
+  "position_lighting": "Licht",
+  "position_visual_effects": "Visuele effecten",
+  "position_editing": "Montage",
+  "position_creator": "Creator",
+  "position_created_by": "Gemaakt door"
 }

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -285,5 +285,20 @@
   "shout_by": "Krzyknął",
   "deleted_user": "Usunięto",
   "social_activity_title": "Aktywność społeczna",
-  "view_all_social_activity": "Zobacz całą aktywność społeczną"
+  "view_all_social_activity": "Zobacz całą aktywność społeczną",
+  "position_dropwdown_label": "Pozycja",
+  "position_acting": "Aktorski",
+  "position_production": "Produkcja",
+  "position_art": "Sztuka",
+  "position_crew": "Załoga",
+  "position_costume___make_up": "Kostiumy i makijaż",
+  "position_directing": "Reżyseria",
+  "position_writing": "Scenariusz",
+  "position_sound": "Dźwięk",
+  "position_camera": "Kamera",
+  "position_lighting": "Oświetlenie",
+  "position_visual_effects": "Efekty wizualne",
+  "position_editing": "Montaż",
+  "position_creator": "Twórca",
+  "position_created_by": "Utworzony przez"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -285,5 +285,20 @@
   "shout_by": "Grito por",
   "deleted_user": "Excluído",
   "social_activity_title": "Atividade Social",
-  "view_all_social_activity": "Ver todas as atividades sociais"
+  "view_all_social_activity": "Ver todas as atividades sociais",
+  "position_dropwdown_label": "Cargo",
+  "position_acting": "Ator",
+  "position_production": "Produção",
+  "position_art": "Arte",
+  "position_crew": "Equipe",
+  "position_costume___make_up": "Figurinos e Maquiagem",
+  "position_directing": "Direção",
+  "position_writing": "Roteiro",
+  "position_sound": "Som",
+  "position_camera": "Câmera",
+  "position_lighting": "Iluminação",
+  "position_visual_effects": "Efeitos Visuais",
+  "position_editing": "Edição",
+  "position_creator": "Criador",
+  "position_created_by": "Criado por"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -285,5 +285,20 @@
   "shout_by": "Strigăt de",
   "deleted_user": "Șters",
   "social_activity_title": "Activitate Socială",
-  "view_all_social_activity": "Vezi toate activitățile sociale"
+  "view_all_social_activity": "Vezi toate activitățile sociale",
+  "position_dropwdown_label": "Funcție",
+  "position_acting": "Actor",
+  "position_production": "Producție",
+  "position_art": "Artă",
+  "position_crew": "Echipă",
+  "position_costume___make_up": "Costume și Machiaj",
+  "position_directing": "Regia",
+  "position_writing": "Scriere",
+  "position_sound": "Sunet",
+  "position_camera": "Cameră",
+  "position_lighting": "Iluminat",
+  "position_visual_effects": "Efecte Vizuale",
+  "position_editing": "Montaj",
+  "position_creator": "Creator",
+  "position_created_by": "Creat de"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -285,5 +285,20 @@
   "shout_by": "Вигук від",
   "deleted_user": "Видалено",
   "social_activity_title": "Соціальна активність",
-  "view_all_social_activity": "Переглянути всю соціальну активність"
+  "view_all_social_activity": "Переглянути всю соціальну активність",
+  "position_dropwdown_label": "Посада",
+  "position_acting": "Акторська гра",
+  "position_production": "Виробництво",
+  "position_art": "Образотворче мистецтво",
+  "position_crew": "Команда",
+  "position_costume___make_up": "Костюми та грим",
+  "position_directing": "Режисура",
+  "position_writing": "Написання",
+  "position_sound": "Звук",
+  "position_camera": "Камера",
+  "position_lighting": "Освітлення",
+  "position_visual_effects": "Візуальні ефекти",
+  "position_editing": "Монтаж",
+  "position_creator": "Створено",
+  "position_created_by": "Створено"
 }

--- a/projects/client/src/lib/components/lists/ListProps.ts
+++ b/projects/client/src/lib/components/lists/ListProps.ts
@@ -6,4 +6,5 @@ export type ListProps<T> = {
   items: T[];
   item: Snippet<[T]>;
   actions?: Snippet;
+  dynamicActions?: Snippet;
 };

--- a/projects/client/src/lib/components/lists/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/SectionList.svelte
@@ -19,6 +19,7 @@
     title,
     item,
     empty,
+    dynamicActions,
     actions: externalActions,
   }: SectionListProps<T> = $props();
 
@@ -58,6 +59,10 @@
 
 <ShadowList {id} {title} {items} {item} {empty} {scrollX} {scrollContainer}>
   {#snippet actions()}
+    {#if dynamicActions != null}
+      {@render dynamicActions()}
+    {/if}
+
     <RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>
       <ActionButton
         onclick={scrollToLeft}

--- a/projects/client/src/lib/requests/_internal/mapToMediaCredits.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaCredits.ts
@@ -1,0 +1,51 @@
+import type {
+  MovieResponse,
+  PeopleMovieCreditsResponse,
+  PeopleShowCreditsResponse,
+  ShowResponse,
+} from '$lib/api.ts';
+import { mapToMovieEntry } from '$lib/requests/_internal/mapToMovieEntry.ts';
+import { mapToShowEntry } from '$lib/requests/_internal/mapToShowEntry.ts';
+import type { CrewPosition } from '$lib/requests/models/CrewPosition.ts';
+import type { MediaCredits } from '$lib/requests/models/MediaCredits.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+
+type MediaCreditsResponse =
+  | PeopleMovieCreditsResponse
+  | PeopleShowCreditsResponse;
+
+type EntryResponse = {
+  movie: MovieResponse;
+} | {
+  show: ShowResponse;
+};
+
+function mapToMediaEntry(entryResponse: EntryResponse) {
+  if ('movie' in entryResponse) {
+    return mapToMovieEntry(entryResponse.movie);
+  }
+
+  return mapToShowEntry(entryResponse.show);
+}
+
+function mapToCrew(response: MediaCreditsResponse) {
+  const crewResponse = Object.entries<EntryResponse[]>(response.crew ?? {});
+
+  return crewResponse
+    .reduce((map, [position, entries]) => {
+      const mediaEntry = entries.map(mapToMediaEntry);
+      map.set(position as CrewPosition, mediaEntry);
+      return map;
+    }, new Map<CrewPosition, MediaEntry[]>());
+}
+
+export function mapToMediaCredits(
+  response: MediaCreditsResponse,
+): MediaCredits {
+  const castResponse = response.cast ?? [];
+
+  return {
+    cast: castResponse.map(mapToMediaEntry),
+    crew: mapToCrew(response),
+  };
+}

--- a/projects/client/src/lib/requests/_internal/mapToMediaCrew.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaCrew.ts
@@ -14,6 +14,7 @@ function toCrewMember(
   return ({
     jobs: crewResponse.jobs,
     name: crewResponse.person.name,
+    id: crewResponse.person.ids.slug,
   });
 }
 

--- a/projects/client/src/lib/requests/models/CrewPosition.ts
+++ b/projects/client/src/lib/requests/models/CrewPosition.ts
@@ -1,0 +1,4 @@
+import { crewPositionSchema } from '$lib/api.ts';
+import { z } from 'zod';
+
+export type CrewPosition = z.infer<typeof crewPositionSchema>;

--- a/projects/client/src/lib/requests/models/MediaCredits.ts
+++ b/projects/client/src/lib/requests/models/MediaCredits.ts
@@ -1,0 +1,15 @@
+import { crewPositionSchema } from '$lib/api.ts';
+import { MediaEntrySchema } from '$lib/requests/models/MediaEntry.ts';
+import { z } from 'zod';
+
+export const MediaCreditsSchema = z.object({
+  cast: z
+    .array(MediaEntrySchema),
+  crew: z
+    .map(
+      crewPositionSchema,
+      z.array(MediaEntrySchema),
+    ),
+});
+
+export type MediaCredits = z.infer<typeof MediaCreditsSchema>;

--- a/projects/client/src/lib/requests/models/MediaCrew.ts
+++ b/projects/client/src/lib/requests/models/MediaCrew.ts
@@ -7,6 +7,7 @@ export type Job = z.output<typeof JobSchema>;
 export const CrewMemberSchema = z.object({
   jobs: z.array(z.string()),
   name: z.string(),
+  id: z.string(),
 });
 export type CrewMember = z.infer<typeof CrewMemberSchema>;
 

--- a/projects/client/src/lib/requests/models/PersonSummary.ts
+++ b/projects/client/src/lib/requests/models/PersonSummary.ts
@@ -1,3 +1,4 @@
+import { crewPositionSchema } from '$lib/api.ts';
 import { z } from 'zod';
 import { HttpsUrlSchema } from './HttpsUrlSchema.ts';
 
@@ -6,5 +7,7 @@ export const PersonSummarySchema = z.object({
   biography: z.string(),
   headShotUrl: HttpsUrlSchema,
   slug: z.string(),
+  knownFor: crewPositionSchema.optional(),
 });
+
 export type PersonSummary = z.infer<typeof PersonSummarySchema>;

--- a/projects/client/src/lib/requests/queries/people/peopleMovieCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleMovieCreditsQuery.ts
@@ -1,8 +1,8 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
-import { mapToMovieEntry } from '$lib/requests/_internal/mapToMovieEntry.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
-import { MediaEntrySchema } from '$lib/requests/models/MediaEntry.ts';
+import { MediaCreditsSchema } from '$lib/requests/models/MediaCredits.ts';
 import { time } from '$lib/utils/timing/time.ts';
+import { mapToMediaCredits } from '../../_internal/mapToMediaCredits.ts';
 
 type PeopleMovieCreditsParams = { slug: string } & ApiParams;
 
@@ -24,7 +24,7 @@ const peopleMovieCreditsRequest = (
         throw new Error('Failed to fetch person movie credits');
       }
 
-      return response.body.cast ?? [];
+      return response.body;
     });
 
 export const peopleMovieCreditsQuery = defineQuery({
@@ -32,7 +32,7 @@ export const peopleMovieCreditsQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: peopleMovieCreditsRequest,
-  mapper: (response) => response.map(({ movie }) => mapToMovieEntry(movie)),
-  schema: MediaEntrySchema.array(),
+  mapper: mapToMediaCredits,
+  schema: MediaCreditsSchema,
   ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/people/peopleShowCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleShowCreditsQuery.ts
@@ -1,8 +1,8 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
-import { mapToShowEntry } from '$lib/requests/_internal/mapToShowEntry.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
-import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
+import { MediaCreditsSchema } from '$lib/requests/models/MediaCredits.ts';
 import { time } from '$lib/utils/timing/time.ts';
+import { mapToMediaCredits } from '../../_internal/mapToMediaCredits.ts';
 
 type PeopleShowCreditsParams = { slug: string } & ApiParams;
 
@@ -24,7 +24,7 @@ const peopleShowCreditsRequest = (
         throw new Error('Failed to fetch person show credits');
       }
 
-      return response.body.cast ?? [];
+      return response.body;
     });
 
 export const peopleShowCreditsQuery = defineQuery({
@@ -32,7 +32,7 @@ export const peopleShowCreditsQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: peopleShowCreditsRequest,
-  mapper: (response) => response.map(({ show }) => mapToShowEntry(show)),
-  schema: ShowEntrySchema.array(),
+  mapper: mapToMediaCredits,
+  schema: MediaCreditsSchema,
   ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
@@ -41,6 +41,7 @@ const mapPeopleResponseToPersonSummary = (
     slug: peopleSummaryResponse.ids.slug,
     name: peopleSummaryResponse.name,
     biography: peopleSummaryResponse.biography ?? '',
+    knownFor: peopleSummaryResponse.known_for_department,
     headShotUrl: prependHttps(
       headshotCandidate,
       MEDIA_POSTER_PLACEHOLDER,

--- a/projects/client/src/lib/sections/lists/CreditsList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsList.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import type { CrewPosition } from "$lib/requests/models/CrewPosition";
   import type { MediaCredits } from "$lib/requests/models/MediaCredits";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
+  import { toTranslatedValue } from "$lib/utils/formatting/string/toTranslatedValue";
+  import { writable } from "svelte/store";
   import MediaCard from "./components/MediaCard.svelte";
   import { useCreditsList } from "./stores/useCreditsList";
   import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
@@ -15,31 +21,66 @@
 
   const { title, type, person }: CreditsListProps = $props();
 
-  const { credits } = useCreditsList({
-    type,
-    slug: person.slug,
-  });
+  const currentPosition = writable<CrewPosition>(person.knownFor ?? "acting");
+
+  const { credits } = useCreditsList({ type, slug: person.slug });
 
   const getPositionList = (mediaCredits?: MediaCredits) => {
     if (!mediaCredits) return [];
 
-    if (!person.knownFor || person.knownFor === "acting") {
+    if ($currentPosition === "acting") {
       return mediaCredits.cast ?? [];
     }
 
-    return mediaCredits.crew?.get(person.knownFor) ?? [];
+    return mediaCredits.crew?.get($currentPosition) ?? [];
   };
 
+  const getAvailablePositions = (mediaCredits?: MediaCredits) => {
+    if (!mediaCredits) return [];
+
+    const positions = Array.from(mediaCredits.crew?.keys() ?? []);
+    if (mediaCredits.cast?.length) {
+      positions.unshift("acting");
+    }
+
+    return positions;
+  };
+
+  const positions = $derived(getAvailablePositions($credits));
   const list = $derived(getPositionList($credits));
 </script>
 
 <SectionList
-  id={`credits-list-${type}`}
+  id={`credits-list-${type}-${$currentPosition}`}
   items={list}
   {title}
   --height-list={mediaListHeightResolver(type)}
 >
   {#snippet item(media)}
     <MediaCard {type} {media} />
+  {/snippet}
+
+  {#snippet dynamicActions()}
+    <DropdownList
+      label={m.position_dropwdown_label()}
+      style="flat"
+      variant="primary"
+      color="blue"
+      text="capitalize"
+      size="small"
+      disabled={positions.length <= 1}
+    >
+      {toTranslatedValue("position", $currentPosition)}
+      {#snippet items()}
+        {#each positions as position}
+          <DropdownItem
+            color="blue"
+            onclick={() => currentPosition.set(position)}
+          >
+            {toTranslatedValue("position", position)}
+          </DropdownItem>
+        {/each}
+      {/snippet}
+    </DropdownList>
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/lists/CreditsList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsList.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import type { MediaCredits } from "$lib/requests/models/MediaCredits";
   import type { MediaType } from "$lib/requests/models/MediaType";
+  import type { PersonSummary } from "$lib/requests/models/PersonSummary";
   import MediaCard from "./components/MediaCard.svelte";
   import { useCreditsList } from "./stores/useCreditsList";
   import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
@@ -8,17 +10,32 @@
   type CreditsListProps = {
     title: string;
     type: MediaType;
-    slug: string;
+    person: PersonSummary;
   };
 
-  const { title, type, slug }: CreditsListProps = $props();
+  const { title, type, person }: CreditsListProps = $props();
 
-  const { list } = useCreditsList({ type, slug });
+  const { credits } = useCreditsList({
+    type,
+    slug: person.slug,
+  });
+
+  const getPositionList = (mediaCredits?: MediaCredits) => {
+    if (!mediaCredits) return [];
+
+    if (!person.knownFor || person.knownFor === "acting") {
+      return mediaCredits.cast ?? [];
+    }
+
+    return mediaCredits.crew?.get(person.knownFor) ?? [];
+  };
+
+  const list = $derived(getPositionList($credits));
 </script>
 
 <SectionList
   id={`credits-list-${type}`}
-  items={$list}
+  items={list}
   {title}
   --height-list={mediaListHeightResolver(type)}
 >

--- a/projects/client/src/lib/sections/lists/SeasonList.svelte
+++ b/projects/client/src/lib/sections/lists/SeasonList.svelte
@@ -50,16 +50,6 @@
     <EpisodeCard {episode} {show} variant="default" context="show" />
   {/snippet}
   {#snippet actions()}
-    <RenderFor audience="authenticated">
-      <MarkAsWatchedAction
-        style="action"
-        type="episode"
-        title={m.season_number_label({ number: $active.number })}
-        media={$list}
-        episode={$list}
-        {show}
-      />
-    </RenderFor>
     {#if seasons.length > 1}
       <DropdownList
         label="Seasons"
@@ -79,6 +69,16 @@
         {/snippet}
       </DropdownList>
     {/if}
+    <RenderFor audience="authenticated">
+      <MarkAsWatchedAction
+        style="action"
+        type="episode"
+        title={m.season_number_label({ number: $active.number })}
+        media={$list}
+        episode={$list}
+        {show}
+      />
+    </RenderFor>
   {/snippet}
 </ShadowList>
 

--- a/projects/client/src/lib/sections/lists/stores/useCreditsList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useCreditsList.ts
@@ -22,12 +22,12 @@ function typeToQuery(
   }
 }
 
-export function useCreditsList({ type, slug }: UseCreditsListProps) {
+export function useCreditsList(
+  { type, slug }: UseCreditsListProps,
+) {
   const query = useQuery(typeToQuery({ type, slug }));
 
-  const list = derived(query, ($query) => $query.data ?? []);
-
   return {
-    list,
+    credits: derived(query, ($query) => $query.data),
   };
 }

--- a/projects/client/src/lib/sections/summary/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/PeopleSummary.svelte
@@ -27,5 +27,5 @@
   <SummaryOverview title={person.name} overview={person.biography} />
 </SummaryContainer>
 
-<CreditsList title={m.movies()} type="movie" slug={person.slug} />
-<CreditsList title={m.shows()} type="show" slug={person.slug} />
+<CreditsList title={m.movies()} type="movie" {person} />
+<CreditsList title={m.shows()} type="show" {person} />

--- a/projects/client/src/lib/sections/summary/components/media/_internal/MediaDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/_internal/MediaDetails.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
 
+  import Link from "$lib/components/link/Link.svelte";
   import { GenreIntlProvider } from "$lib/components/summary/GenreIntlProvider";
   import { getLocale, languageTag } from "$lib/features/i18n/index.ts";
   import type { CrewMember } from "$lib/requests/models/MediaCrew";
@@ -9,12 +10,17 @@
   import { toCountryName } from "$lib/utils/formatting/intl/toCountryName";
   import { toLanguageName } from "$lib/utils/formatting/intl/toLanguageName";
   import { toTranslatedValue } from "$lib/utils/formatting/string/toTranslatedValue";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CollapsableValues from "./CollapsableValues.svelte";
   import DetailsGrid from "./DetailsGrid.svelte";
   import type { MediaDetailsProps } from "./MediaDetailsProps";
 
   const { media, studios, crew }: MediaDetailsProps = $props();
 
+  type MediaDetail = {
+    title: string;
+    values?: Array<string | { label: string; link: string }>;
+  };
   /*TODO:
     -Differentiate between Show and Movie
   */
@@ -28,7 +34,10 @@
 
   const toCrewMemberWithJob = (person: CrewMember) => {
     const jobs = person.jobs.map((job) => toTranslatedValue("job", job));
-    return `${person.name} (${jobs.join(", ")})`;
+    return {
+      label: `${person.name} (${jobs.join(", ")})`,
+      link: UrlBuilder.people(person.id),
+    };
   };
 
   const mainItemDetail = () => {
@@ -46,7 +55,7 @@
     };
   };
 
-  const mediaDetails = [
+  const mediaDetails: MediaDetail[] = [
     mainItemDetail(),
     {
       title: m.runtime(),
@@ -87,7 +96,13 @@
       <CollapsableValues category={title} {values}>
         <p class="meta-info secondary">{title}</p>
         {#snippet value(value)}
-          <p class="small capitalize ellipsis">{value}</p>
+          {#if typeof value === "object"}
+            <Link href={value.link}>
+              <p class="small capitalize ellipsis">{value.label}</p>
+            </Link>
+          {:else}
+            <p class="small capitalize ellipsis">{value}</p>
+          {/if}
         {/snippet}
       </CollapsableValues>
     {/if}

--- a/projects/client/src/lib/utils/string/toMessageKey.spec.ts
+++ b/projects/client/src/lib/utils/string/toMessageKey.spec.ts
@@ -14,6 +14,10 @@ describe('toMessageKey', () => {
     expect(toMessageKey('prefix', 'my-value')).toBe('prefix_my_value');
   });
 
+  it('should replace ampersands with an underscore', () => {
+    expect(toMessageKey('prefix', 'my&value')).toBe('prefix_my_value');
+  });
+
   it('should replace strip quotes and parenthesis', () => {
     expect(toMessageKey('prefix', "My Value ('or not')")).toBe(
       'prefix_my_value_or_not',

--- a/projects/client/src/lib/utils/string/toMessageKey.ts
+++ b/projects/client/src/lib/utils/string/toMessageKey.ts
@@ -1,7 +1,7 @@
 export function toMessageKey(prefix: string, value: string) {
   const valueKey = value
     .toLocaleLowerCase()
-    .replace(/[\s-]+/g, '_')
+    .replace(/[\s-&]+/g, '_')
     .replace(/['()]+/g, '');
 
   return `${prefix}_${valueKey}` as const;

--- a/projects/client/src/mocks/data/people/mapped/PersonFergusonMappedMock.ts
+++ b/projects/client/src/mocks/data/people/mapped/PersonFergusonMappedMock.ts
@@ -7,4 +7,5 @@ export const PersonFergusonMappedMock: PersonSummary = {
     'https://walter-r2.trakt.tv/images/people/000/447/271/headshots/thumb/d7e3e2fc64.jpg.webp',
   name: 'Rebecca Ferguson',
   slug: 'rebecca-ferguson',
+  knownFor: 'acting',
 };

--- a/projects/client/src/mocks/data/people/mapped/PersonFergusonShowCreditsMappedMock.ts
+++ b/projects/client/src/mocks/data/people/mapped/PersonFergusonShowCreditsMappedMock.ts
@@ -5,5 +5,12 @@ export const PersonFergusonShowCreditsMappedMock: MediaCredits = {
   'cast': [
     ShowSiloMappedMock,
   ],
-  'crew': new Map(),
+  'crew': new Map([
+    [
+      'production',
+      [
+        ShowSiloMappedMock,
+      ],
+    ],
+  ]),
 };

--- a/projects/client/src/mocks/data/people/mapped/PersonFergusonShowCreditsMappedMock.ts
+++ b/projects/client/src/mocks/data/people/mapped/PersonFergusonShowCreditsMappedMock.ts
@@ -1,6 +1,9 @@
-import type { ShowEntry } from '$lib/requests/models/ShowEntry.ts';
+import type { MediaCredits } from '$lib/requests/models/MediaCredits.ts';
 import { ShowSiloMappedMock } from '../../summary/shows/silo/mapped/ShowSiloMappedMock.ts';
 
-export const PersonFergusonShowCreditsMappedMock: ShowEntry[] = [
-  ShowSiloMappedMock,
-];
+export const PersonFergusonShowCreditsMappedMock: MediaCredits = {
+  'cast': [
+    ShowSiloMappedMock,
+  ],
+  'crew': new Map(),
+};

--- a/projects/client/src/mocks/data/people/mapped/PersonGrantMovieCreditsMappedMock.ts
+++ b/projects/client/src/mocks/data/people/mapped/PersonGrantMovieCreditsMappedMock.ts
@@ -1,6 +1,9 @@
-import type { MovieEntry } from '$lib/requests/models/MovieEntry.ts';
+import type { MediaCredits } from '$lib/requests/models/MediaCredits.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
 
-export const PersonGrantMovieCreditsMappedMock: MovieEntry[] = [
-  MovieHereticMappedMock,
-];
+export const PersonGrantMovieCreditsMappedMock: MediaCredits = {
+  'cast': [
+    MovieHereticMappedMock,
+  ],
+  'crew': new Map(),
+};

--- a/projects/client/src/mocks/data/people/response/PersonFergusonShowCreditsResponseMock.ts
+++ b/projects/client/src/mocks/data/people/response/PersonFergusonShowCreditsResponseMock.ts
@@ -14,4 +14,16 @@ export const PersonFergusonShowCreditsResponseMock: PeopleShowCreditsResponse =
         'show': ShowSiloResponseMock,
       },
     ],
+    'crew': {
+      'production': [
+        {
+          'job': 'Executive Producer',
+          'jobs': [
+            'Executive Producer',
+          ],
+          'episode_count': 20,
+          'show': ShowSiloResponseMock,
+        },
+      ],
+    },
   };

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticPeopleMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticPeopleMappedMock.ts
@@ -109,25 +109,40 @@ export const MovieHereticPeopleMappedMock: MediaCrew = {
   ],
   'directors': [
     {
-      'jobs': ['Director'],
+      'id': 'scott-beck',
+      'jobs': [
+        'Director',
+      ],
       'name': 'Scott Beck',
     },
     {
-      'jobs': ['First Assistant Director'],
+      'id': 'richard-cowan',
+      'jobs': [
+        'First Assistant Director',
+      ],
       'name': 'Richard Cowan',
     },
     {
-      'jobs': ['Director'],
+      'id': 'bryan-woods',
+      'jobs': [
+        'Director',
+      ],
       'name': 'Bryan Woods',
     },
   ],
   'writers': [
     {
-      'jobs': ['Writer'],
+      'id': 'scott-beck',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Scott Beck',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'bryan-woods',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Bryan Woods',
     },
   ],

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts
@@ -96,89 +96,152 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
   ],
   'directors': [
     {
-      'jobs': ['Script Supervisor'],
+      'id': 'rhiannon-preece-towey',
+      'jobs': [
+        'Script Supervisor',
+      ],
       'name': 'Rhiannon Preece-Towey',
     },
     {
-      'jobs': ['Director'],
+      'id': 'bert',
+      'jobs': [
+        'Director',
+      ],
       'name': 'Bert',
     },
     {
-      'jobs': ['Director'],
+      'id': 'michael-dinner',
+      'jobs': [
+        'Director',
+      ],
       'name': 'Michael Dinner',
     },
     {
-      'jobs': ['Director'],
+      'id': 'morten-tyldum',
+      'jobs': [
+        'Director',
+      ],
       'name': 'Morten Tyldum',
     },
     {
-      'jobs': ['Director'],
+      'id': 'adam-bernstein-5c662b3b-7930-4ca7-82a4-b0342f518e01',
+      'jobs': [
+        'Director',
+      ],
       'name': 'Adam Bernstein',
     },
     {
-      'jobs': ['Director'],
+      'id': 'david-semel',
+      'jobs': [
+        'Director',
+      ],
       'name': 'David Semel',
     },
     {
-      'jobs': ['Director'],
+      'id': 'bertie',
+      'jobs': [
+        'Director',
+      ],
       'name': 'Bertie',
     },
     {
-      'jobs': ['Director'],
+      'id': 'aric-avelino',
+      'jobs': [
+        'Director',
+      ],
       'name': 'Aric Avelino',
     },
   ],
   'writers': [
     {
-      'jobs': ['Book'],
+      'id': 'hugh-howey',
+      'jobs': [
+        'Book',
+      ],
       'name': 'Hugh Howey',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'graham-yost',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Graham Yost',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'cassie-pappas',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Cassie Pappas',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'jessica-blaire-c7557156-391c-48b4-b128-8f7ef2d2a94b',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Jessica Blaire',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'ingrid-escajeda',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Ingrid Escajeda',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'jeffery-wang',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Jeffery Wang',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'fred-golan',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Fred Golan',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'remi-aubuchon',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Remi Aubuchon',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'aric-avelino',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Aric Avelino',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'lekethia-dalcoe',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Lekethia Dalcoe',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'sal-calleros',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Sal Calleros',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'jenny-dearmitt',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Jenny DeArmitt',
     },
     {
-      'jobs': ['Writer'],
+      'id': 'katherine-disavino',
+      'jobs': [
+        'Writer',
+      ],
       'name': 'Katherine DiSavino',
     },
   ],


### PR DESCRIPTION
## 🎶 Notes 🎶

- Directors & writers on summary pages are now clickable.
- People summary pages now contain a dropdown per list to view different positions they worked at (e.g. `Directing`, `Writing`, `Acting`, etc.
- By default, the credits list will be for the position they're known for.
- Other changes:
  - `SectionList.svelte` can now have `dynamicActions`. These are actions with a dynamic size and will be placed before the scroll buttons to keep the scroll buttons at a stable location.
  - Switched the order of the actions on the season list.
- For now I left some small utils in `CreditsList.svelte`: I want to change the whole thing in a later PR -> uplift the requests to the `PeopleSummary` component, move the position dropdown below the poster or something, and add it as a search param so specific views can be shared.

## 👀 Examples 👀
<img width="1425" alt="Screenshot 2025-02-14 at 21 03 08" src="https://github.com/user-attachments/assets/6e80436d-264d-4229-9d35-46cc8cee80c7" />

<img width="1425" alt="Screenshot 2025-02-14 at 21 03 18" src="https://github.com/user-attachments/assets/30215cf4-7776-40fc-be50-de7a7b95267d" />

<img width="1425" alt="Screenshot 2025-02-14 at 21 03 49" src="https://github.com/user-attachments/assets/8860e916-6cf9-4797-ac14-612d23d657bd" />

Before / after:
<img width="1463" alt="Screenshot 2025-02-14 at 22 32 29" src="https://github.com/user-attachments/assets/dbdc31e5-cf5e-424c-8500-d2db18308c79" />

<img width="1463" alt="Screenshot 2025-02-14 at 22 32 03" src="https://github.com/user-attachments/assets/fa21843a-3f84-42be-bf3c-3bf54896087d" />

