### PR TITLE
fix: scrollbars in safari

### DIFF
--- a/projects/client/src/lib/components/dropdown/DropdownList.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownList.svelte
@@ -111,6 +111,7 @@
       }
 
       .trakt-list {
+        z-index: var(--layer-menu);
         opacity: 1;
       }
 

--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -185,10 +185,14 @@
   .shadow-list-horizontal-scroll {
     height: var(--height-list);
     display: flex;
-    overflow-x: auto;
+    overflow-x: hidden;
     scroll-snap-type: x proximity;
     transition: gap var(--transition-increment) ease-in-out;
     @include adaptive-gap(gap);
+
+    &:hover {
+      overflow-x: auto;
+    }
 
     & > :global(:not(svelte-css-wrapper)) {
       scroll-snap-align: start;

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -134,7 +134,6 @@
       );
       border-radius: var(--border-radius-xs);
       backdrop-filter: blur(var(--ni-4));
-      opacity: 0;
     }
 
     :global(:hover::-webkit-scrollbar-thumb) {


### PR DESCRIPTION
## 🎶 Notes 🎶
- Safari (╯°□°)╯︵ ┻━┻
- Scrollbars never became visible.
- Dropdowns were hidden under the section lists.

## 👀 Example 👀
I removed the `opacity:0`, which causes safari to be buggy when it comes to displaying hiding scrollbars. Example:
https://github.com/user-attachments/assets/4929838c-f989-484d-9904-095a4e9e7cf3

So for now, the overflow-x on the lists is set on a hover.

Dropdown fix:
Before/after:
<img width="769" alt="Screenshot 2025-02-15 at 16 27 22" src="https://github.com/user-attachments/assets/e65da3c4-7bca-4535-882d-b851848ded77" />

<img width="769" alt="Screenshot 2025-02-15 at 16 27 31" src="https://github.com/user-attachments/assets/a2b4726a-0048-41b1-bd4c-16f78af74a6f" />

