### PR TITLE
fix: initialize rendering with display none

### DIFF
--- a/projects/client/src/lib/guards/_internal/RenderForDevice.svelte
+++ b/projects/client/src/lib/guards/_internal/RenderForDevice.svelte
@@ -53,7 +53,11 @@
   @use "$style/scss/mixins/index" as *;
 
   trakt-render-for {
-    display: contents;
+    display: none;
+
+    &:not([class*="render-for-"]) {
+      display: contents !important;
+    }
   }
 
   .render-for-mobile {


### PR DESCRIPTION
## Device-Specific Rendering Improvement

This pull request modifies the `RenderForDevice.svelte` component to enhance its device-specific rendering logic. The primary change involves adjusting the CSS rule for `trakt-render-for` to improve how elements are displayed on different devices.

### Rendering Logic Update:

* **`RenderForDevice.svelte`**: The `trakt-render-for` CSS rule has been modified.  It now defaults to `display: none`, effectively hiding elements by default.  For elements that *do not* have classes prefixed with "render-for-", the rule is overridden with `display: contents!important`.  This ensures that only elements explicitly intended for specific devices are shown, improving the accuracy of device-specific rendering and preventing unintended display of content.

(This update, like a detective carefully examining a piece of evidence, refines the device-specific rendering logic for Trakt Lite. By defaulting to `display: none` and then selectively overriding it, we ensure that content is displayed correctly on the intended devices. This prevents visual glitches and contributes to a smoother and more consistent user experience across different platforms. It's a small change, perhaps, but it addresses a potentially significant issue and strengthens the reliability of our rendering system.)