### PR TITLE
feat(summary): add related shows on episode pages

### DIFF
--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -11,6 +11,7 @@
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { useStreamOn } from "$lib/stores/useStreamOn";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import RelatedList from "../lists/RelatedList.svelte";
   import type { EpisodeSummaryProps } from "./components/EpisodeSummaryProps";
   import MediaMetaInfo from "./components/media/MediaMetaInfo.svelte";
   import StreamOnOverlay from "./components/overlay/StreamOnOverlay.svelte";
@@ -109,3 +110,5 @@
 </SummaryContainer>
 
 <SeasonList {show} {seasons} />
+
+<RelatedList title={m.related_shows_title()} slug={show.slug} type="show" />


### PR DESCRIPTION
## Episode Summary Enhancement: Related Shows

This pull request enhances the episode summary section by integrating a related list component. This addition provides users with relevant recommendations and improves the overall viewing experience.

### Episode Summary Enhancement:

* **`RelatedList` Import**: The `RelatedList` component has been imported into the `EpisodeSummary.svelte` file. This component displays a list of related shows, offering viewers additional content recommendations based on the episode they are currently viewing.
* **`RelatedList` Integration**: The `RelatedList` component has been added to the episode summary section. This integration ensures that users can easily discover and explore related shows, enhancing their viewing experience and encouraging further content exploration within Trakt Lite.

(This update, like a detective uncovering hidden connections, enriches the episode summary with relevant recommendations.  The inclusion of the `RelatedList` component provides viewers with a seamless way to discover similar shows, expanding their viewing options and increasing engagement with Trakt Lite.  It's a small addition that adds significant value, making the platform a more comprehensive and enjoyable destination for media enthusiasts.)
