### PR TITLE
Feat/switch toggle

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -70,6 +70,7 @@ module.exports = {
         'social',
         'spoiler',
         'summary',
+        'toggle',
         'trending',
         'up-next',
         'upcoming',

--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -50,6 +50,10 @@ declare global {
     onerror?: (event: Event) => void;
   };
 
+  type HTMLInputElementProps = {
+    value?: string;
+  };
+
   type HTMLElementProps = {
     disabled?: boolean;
     'data-testid'?: string;
@@ -143,6 +147,14 @@ declare global {
     }
     & HTMLElementProps
     & ChildrenProps;
+
+  export type CheckboxProps =
+    & {
+      label: string;
+      checked?: boolean;
+    }
+    & HTMLInputElementProps
+    & HTMLElementProps;
 
   namespace App {
     // interface Error {}

--- a/projects/client/src/lib/components/icons/SwitchIcon.svelte
+++ b/projects/client/src/lib/components/icons/SwitchIcon.svelte
@@ -1,0 +1,13 @@
+<svg
+  width="8"
+  height="8"
+  viewBox="0 0 8 8"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M1.17157 1.17188L6.82842 6.82873"
+    stroke="currentColor"
+    stroke-width="2"
+  />
+</svg>

--- a/projects/client/src/lib/components/toggles/Switch.spec.ts
+++ b/projects/client/src/lib/components/toggles/Switch.spec.ts
@@ -1,0 +1,62 @@
+import Switch from './Switch.svelte';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import type { SwitchProps } from './SwitchProps.ts';
+
+describe('Switch', () => {
+  const defaultProps: SwitchProps = {
+    label: 'Test Switch',
+  };
+
+  it('should render a switch element', () => {
+    render(
+      Switch,
+      defaultProps,
+    );
+
+    const switchToggle = screen.getByRole('switch', { name: 'Test Switch' });
+    expect(switchToggle).toBeInTheDocument();
+  });
+
+  it('should render inner text', () => {
+    render(Switch, {
+      ...defaultProps,
+      innerText: 'Lite',
+    });
+
+    const subtitle = screen.getByText('Lite');
+
+    expect(subtitle).toBeInTheDocument();
+  });
+
+  it('should toggle', async () => {
+    render(Switch, defaultProps);
+
+    const switchToggle = screen.getByRole('switch');
+    expect(switchToggle).not.toBeChecked();
+
+    await fireEvent.click(switchToggle);
+    expect(switchToggle).toBeChecked();
+  });
+
+  it('should apply correct styles based on props', () => {
+    render(Switch, {
+      ...defaultProps,
+      color: 'red',
+    });
+
+    const switchToggle = screen.getByRole('switch');
+    expect(switchToggle).toHaveAttribute('data-color', 'red');
+  });
+
+  it('should set switch as disabled', () => {
+    render(Switch, {
+      ...defaultProps,
+      disabled: true,
+    });
+
+    const switchToggle = screen.getByRole('switch');
+    expect(switchToggle).toBeDisabled();
+  });
+});

--- a/projects/client/src/lib/components/toggles/Switch.svelte
+++ b/projects/client/src/lib/components/toggles/Switch.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+  import SwitchIcon from "../icons/SwitchIcon.svelte";
+  import type { SwitchProps } from "./SwitchProps";
+
+  const {
+    label,
+    innerText,
+    color = "purple",
+    ...props
+  }: SwitchProps = $props();
+</script>
+
+<label class="trakt-switch">
+  <input
+    type="checkbox"
+    role="switch"
+    data-color={color}
+    aria-label={label}
+    {...props}
+  />
+
+  <span class="trakt-switch-tick"><SwitchIcon /></span>
+  {#if innerText}
+    <span class="trakt-switch-text meta-info ellipsis">
+      {innerText}
+    </span>
+  {/if}
+</label>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index.scss" as *;
+
+  @mixin state-styles($background-color, $foreground-color) {
+    --color-foreground-switch: #{$background-color};
+    --color-background-switch: #{$foreground-color};
+
+    &:has(input:not([disabled]):checked) {
+      --color-foreground-switch: #{$foreground-color};
+      --color-background-switch: #{$background-color};
+    }
+
+    @include for-mouse {
+      &:hover:has(input:not([disabled])) {
+        --color-foreground-switch: #{$foreground-color};
+        --color-background-switch: #{$background-color};
+
+        &:has(input:checked) {
+          --color-foreground-switch: #{$background-color};
+          --color-background-switch: #{$foreground-color};
+        }
+      }
+    }
+  }
+
+  @mixin color-styles($color) {
+    &:has(input[data-color="#{$color}"]) {
+      $foreground-color: var(--color-switch-foreground-#{$color});
+      $background-color: var(--color-switch-background-#{$color});
+      --color-tick: var(--color-tick-#{$color});
+
+      @include state-styles($background-color, $foreground-color);
+    }
+  }
+
+  @keyframes direction-preview {
+    0% {
+      transform: rotate(initial);
+    }
+    50% {
+      transform: rotate(45deg);
+    }
+    100% {
+      transform: rotate(initial);
+    }
+  }
+
+  .trakt-switch {
+    --button-width: var(--ni-64);
+    --button-height: var(--ni-28);
+
+    --text-width: var(--ni-24);
+    --text-offset: var(--ni-10);
+
+    --tick-size: var(--ni-20);
+    --tick-offset: var(--ni-4);
+
+    all: unset;
+    cursor: pointer;
+
+    display: flex;
+    position: relative;
+    align-items: center;
+
+    min-width: var(--button-width);
+    max-width: var(--button-width);
+    width: var(--button-width);
+    height: var(--button-height);
+
+    box-shadow: var(--ni-0) var(--ni-4) var(--ni-4) var(--ni-0)
+      color-mix(in srgb, var(--shade-940) 24%, transparent 76%) inset;
+
+    box-sizing: border-box;
+    padding: var(--ni-4);
+    border-radius: var(--border-radius-l);
+
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: background-color, outline;
+
+    -webkit-tap-highlight-color: transparent;
+    background-color: var(--color-background-switch);
+
+    @each $color in "purple", "red", "blue", "orange", "default", "custom" {
+      @include color-styles($color);
+    }
+
+    &:has(input:active[disabled]) {
+      animation: jiggle-wiggle var(--animation-duration-jiggle-wiggle) infinite;
+    }
+
+    &:has(input[disabled]) {
+      --color-foreground-switch: var(--color-foreground-button-disabled);
+      --color-background-switch: var(--color-surface-button-disabled);
+      --color-tick: var(--color-foreground-button-disabled);
+
+      cursor: not-allowed;
+    }
+
+    @include for-mouse {
+      &:hover:has(input:not([disabled])) {
+        .trakt-switch-tick {
+          :global(svg) {
+            animation: direction-preview calc(var(--transition-increment) * 2)
+              ease-in;
+          }
+        }
+      }
+    }
+
+    input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    &:has(input:checked) {
+      .trakt-switch-text {
+        transform: translateX(0);
+      }
+
+      .trakt-switch-tick {
+        transform: translateX(
+          calc(var(--button-width) - var(--tick-size) - 2 * var(--tick-offset))
+        );
+
+        :global(svg) {
+          transform: rotate(90deg);
+        }
+      }
+    }
+
+    &:has(input:focus-visible) {
+      outline: var(--border-thickness-xs) solid var(--color-foreground-switch);
+    }
+
+    .trakt-switch-text {
+      user-select: none;
+      color: var(--color-foreground-switch);
+
+      transition: var(--transition-increment) ease-in-out;
+      transition-property: color, transform;
+
+      position: absolute;
+      left: var(--text-offset);
+      width: var(--text-width);
+
+      transform: translateX(
+        calc(var(--button-width) - var(--text-width) - 2 * var(--text-offset))
+      );
+    }
+
+    .trakt-switch-tick {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      position: absolute;
+      top: var(--tick-offset);
+      left: var(--tick-offset);
+
+      width: var(--tick-size);
+      height: var(--tick-size);
+
+      background: var(--color-tick);
+      color: var(--shade-10);
+      border-radius: 50%;
+
+      transition: transform var(--transition-increment) ease-in-out;
+
+      :global(svg) {
+        transition: transform var(--transition-increment) ease-in-out;
+      }
+
+      &::before {
+        content: "";
+
+        position: absolute;
+        top: 0;
+        left: 0;
+
+        width: 100%;
+        height: 100%;
+
+        border-radius: 50%;
+
+        box-shadow:
+          var(--ni-1) var(--ni-neg-2) var(--ni-4) var(--ni-0)
+            color-mix(in srgb, black 25%, transparent 75%) inset,
+          var(--ni-0) var(--ni-1) var(--ni-2) var(--ni-0)
+            color-mix(in srgb, white 44%, transparent 56%) inset,
+          var(--ni-0) var(--ni-2) var(--ni-8) var(--ni-0)
+            color-mix(in srgb, black 16%, transparent 84%);
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/toggles/SwitchProps.ts
+++ b/projects/client/src/lib/components/toggles/SwitchProps.ts
@@ -1,0 +1,4 @@
+export type SwitchProps = CheckboxProps & {
+  innerText?: string;
+  color?: 'purple' | 'red' | 'blue' | 'orange' | 'default' | 'custom';
+};

--- a/projects/client/src/routes/_design_system/toggles/+page.svelte
+++ b/projects/client/src/routes/_design_system/toggles/+page.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import Switch from "$lib/components/toggles/Switch.svelte";
+
+  const props = [
+    { color: "purple" as const, checked: true, innerText: "Lite" },
+    { color: "red" as const, checked: false },
+    { color: "blue" as const, checked: true },
+    { color: "orange" as const, checked: false },
+  ];
+</script>
+
+<main>
+  <h1>Toggles</h1>
+
+  <div class="toggle-display">
+    <section>
+      <h2 class="capitalize">Switches</h2>
+      {#each props as { color, checked, innerText }}
+        <Switch
+          {checked}
+          label={`This is the ${color} switch`}
+          {color}
+          {innerText}
+        />
+      {/each}
+      <Switch checked={true} label={`This is the disabled switch`} disabled />
+      <Switch label={`This is the disabled switch`} innerText="Lite" disabled />
+    </section>
+  </div>
+</main>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  main {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xl);
+    padding-top: var(--ni-32);
+    align-items: center;
+
+    @include for-tablet-sm-and-below {
+      .toggle-display {
+        flex-direction: column;
+        align-items: center;
+        gap: var(--gap-xl);
+      }
+    }
+
+    section {
+      display: flex;
+      flex-direction: column;
+      gap: var(--gap-m);
+      align-items: start;
+    }
+  }
+
+  .toggle-display {
+    display: flex;
+    justify-content: space-between;
+
+    width: 75%;
+  }
+</style>

--- a/projects/client/src/style/numeric-increments/index.css
+++ b/projects/client/src/style/numeric-increments/index.css
@@ -16,6 +16,7 @@
   --ni-20: 1.25rem;
   --ni-22: 1.375rem;
   --ni-24: 1.5rem;
+  --ni-28: 1.75rem;
   --ni-32: 2rem;
   --ni-36: 2.25rem;
   --ni-40: 2.5rem;
@@ -96,6 +97,7 @@
   --ni-neg-18: -1.125rem;
   --ni-neg-20: -1.25rem;
   --ni-neg-24: -1.5rem;
+  --ni-neg-28: -1.75rem;
   --ni-neg-32: -2rem;
   --ni-neg-36: -2.25rem;
   --ni-neg-40: -2.5rem;

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -80,4 +80,27 @@
   --color-background-orange: var(--orange-300);
   --color-foreground-orange: var(--orange-50);
   --color-background-orange-hover: var(--orange-700);
+
+  /**
+   * Toggle switches
+   */
+  --color-tick-purple: var(--purple-500);
+  --color-switch-foreground-purple: var(--purple-50);
+  --color-switch-background-purple: var(--purple-800);
+
+  --color-tick-red: var(--red-500);
+  --color-switch-foreground-red: var(--red-50);
+  --color-switch-background-red: var(--red-800);
+
+  --color-tick-blue: var(--blue-500);
+  --color-switch-foreground-blue: var(--blue-50);
+  --color-switch-background-blue: var(--blue-800);
+
+  --color-tick-default: var(--shade-500);
+  --color-switch-foreground-default: var(--shade-50);
+  --color-switch-background-default: var(--shade-800);
+
+  --color-tick-orange: var(--orange-500);
+  --color-switch-foreground-orange: var(--orange-50);
+  --color-switch-background-orange: var(--orange-800);
 }

--- a/projects/client/src/style/typography/index.css
+++ b/projects/client/src/style/typography/index.css
@@ -94,7 +94,10 @@ p {
   &.small {
     font-size: var(--ni-14);
   }
+}
 
+span,
+p {
   &.meta-info {
     font-size: var(--ni-10);
     font-style: normal;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds a switch toggle component
- Also added it to the design systems: http://localhost:5173/_design_system/buttons/toggles
- I played around a bit with an intl provider, but even with short `on`/`off` labels, certain translations will result in long values. We can revisit later, for now I opted to add an `innerText` property.

## 👀 Examples 👀
<img width="1400" alt="Screenshot 2025-02-17 at 20 11 50" src="https://github.com/user-attachments/assets/d12cf1ba-0ce2-4ad9-9500-8cf724faa5ee" />

https://github.com/user-attachments/assets/f8fb3002-fcdb-484b-ae2d-f03482f2d97d


