### PR TITLE
feat / allow user to mark as watched if item is watchlisted

### DIFF
--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import MarkAsWatchedButton from "$lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte";
   import { onMount } from "svelte";
+  import { useIsWatchlisted } from "../watchlist/useIsWatchlisted";
   import {
     type MarkAsWatchedStoreProps,
     useMarkAsWatched,
@@ -29,6 +30,8 @@
     isWatchable,
   } = $derived(useMarkAsWatched(target));
 
+  const { isWatchlisted } = $derived(useIsWatchlisted(target));
+
   onMount(() => {
     return isMarkingAsWatched.subscribe((value) => onAction?.(value));
   });
@@ -39,7 +42,7 @@
     {style}
     {title}
     {size}
-    isWatched={$isWatched}
+    isWatched={$isWatched && !$isWatchlisted}
     isMarkingAsWatched={$isMarkingAsWatched}
     onWatch={markAsWatched}
     onRemove={removeWatched}

--- a/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
   import WatchlistButton from "$lib/components/buttons/watchlist/WatchlistButton.svelte";
+  import type { MediaStoreProps } from "$lib/models/MediaStoreProps";
   import { onMount } from "svelte";
-  import { useWatchlist, type WatchlistStoreProps } from "./useWatchlist";
+  import { useWatchlist } from "./useWatchlist";
 
   type WatchlistActionProps = {
     style?: "action" | "normal" | "dropdown-item";
     size?: "small" | "normal";
     title: string;
     onAction?: (state: boolean) => void;
-  } & WatchlistStoreProps;
+  } & MediaStoreProps;
 
   const {
     style = "action",

--- a/projects/client/src/lib/sections/media-actions/watchlist/useIsWatchlisted.ts
+++ b/projects/client/src/lib/sections/media-actions/watchlist/useIsWatchlisted.ts
@@ -1,0 +1,33 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import { derived } from 'svelte/store';
+
+export type IsWatchlistedStoreProps = MediaStoreProps;
+
+export function useIsWatchlisted(props: IsWatchlistedStoreProps) {
+  const { type } = props;
+  const media = Array.isArray(props.media) ? props.media : [props.media];
+  const { watchlist } = useUser();
+
+  const isWatchlisted = derived(
+    watchlist,
+    ($watchlist) => {
+      if (!$watchlist) {
+        return false;
+      }
+
+      switch (type) {
+        case 'movie':
+          return media.every((m) => $watchlist.movies.has(m.id));
+        case 'show':
+          return media.every((m) => $watchlist.shows.has(m.id));
+        case 'episode':
+          return false;
+      }
+    },
+  );
+
+  return {
+    isWatchlisted,
+  };
+}

--- a/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.spec.ts
@@ -1,3 +1,4 @@
+import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { MovieMatrixMappedMock } from '$mocks/data/summary/movies/matrix/MovieMatrixMappedMock.ts';
@@ -7,7 +8,7 @@ import { renderStore } from '$test/beds/store/renderStore.ts';
 import { waitForEmission } from '$test/readable/waitForEmission.ts';
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
-import { useWatchlist, type WatchlistStoreProps } from './useWatchlist.ts';
+import { useWatchlist } from './useWatchlist.ts';
 
 vi.mock('$lib/stores/useInvalidator.ts');
 
@@ -22,7 +23,7 @@ describe('useWatchlist', () => {
     });
   });
 
-  const runCommonTests = (props: WatchlistStoreProps, invalidation: string) => {
+  const runCommonTests = (props: MediaStoreProps, invalidation: string) => {
     it('should NOT be updating watchlist when first requested', async () => {
       const { isWatchlistUpdating } = await renderStore(() =>
         useWatchlist(props)

--- a/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
+++ b/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
@@ -1,42 +1,29 @@
-import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
-import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { addToWatchlistRequest } from '$lib/requests/sync/addToWatchlistRequest.ts';
 import { removeFromWatchlistRequest } from '$lib/requests/sync/removeFromWatchlistRequest.ts';
 import { toWatchlistPayload } from '$lib/sections/media-actions/watchlist/toWatchlistPayload.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { derived, writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+import { useIsWatchlisted } from './useIsWatchlisted.ts';
 
-export type WatchlistStoreProps = {
-  type: MediaType;
-  media: { id: number };
-};
-
-export function useWatchlist({ type, media }: WatchlistStoreProps) {
+export function useWatchlist(props: MediaStoreProps) {
+  const { type } = props;
+  const media = Array.isArray(props.media) ? props.media : [props.media];
   const isWatchlistUpdating = writable(false);
-  const { watchlist } = useUser();
   const { invalidate } = useInvalidator();
+  const ids = media.map(({ id }) => id);
 
-  const isWatchlisted = derived(
-    watchlist,
-    ($watchlist) => {
-      if (!$watchlist) {
-        return false;
-      }
-
-      switch (type) {
-        case 'movie':
-          return $watchlist.movies.has(media.id);
-        case 'show':
-          return $watchlist.shows.has(media.id);
-      }
-    },
-  );
+  const { isWatchlisted } = useIsWatchlisted(props);
 
   const addToWatchlist = async () => {
+    if (type === 'episode') {
+      return;
+    }
+
     isWatchlistUpdating.set(true);
     await addToWatchlistRequest({
-      body: toWatchlistPayload(type, [media.id]),
+      body: toWatchlistPayload(type, ids),
     });
 
     await invalidate(InvalidateAction.Watchlisted(type));
@@ -45,9 +32,13 @@ export function useWatchlist({ type, media }: WatchlistStoreProps) {
   };
 
   const removeFromWatchlist = async () => {
+    if (type === 'episode') {
+      return;
+    }
+
     isWatchlistUpdating.set(true);
     await removeFromWatchlistRequest({
-      body: toWatchlistPayload(type, [media.id]),
+      body: toWatchlistPayload(type, ids),
     });
 
     await invalidate(InvalidateAction.Watchlisted(type));


### PR DESCRIPTION
## Watchlist Functionality and Code Refinement

This pull request introduces enhancements to the watchlist functionality in the media actions section and includes code refactoring for improved maintainability.

### Watchlist Functionality Enhancements:

* **`MarkAsWatchedAction.svelte`**: The `MarkAsWatchedAction.svelte` component now utilizes the new `useIsWatchlisted` utility function. This ensures that an item is not accidentally marked as watched if it is still on the user's watchlist, preventing unintended changes to their watch history.

* **`useIsWatchlisted.ts`**: A new utility function, `useIsWatchlisted`, has been added to determine if a media item is currently in the user's watchlist. This function provides a centralized and reusable way to check the watchlist status of media items.

### Codebase Simplification:

* **`useWatchlist.ts`**: The `useWatchlist` function has been refactored to use the new `useIsWatchlisted` utility. This refactoring removes redundant code and improves the function's readability and maintainability. Additionally, checks have been added to prevent watchlist updates for episodes, ensuring that the watchlist functionality operates as intended.

(This update, like a detective meticulously reviewing their case files, refines the watchlist functionality and improves the codebase. The new utility function and its integration into the media actions section provide a more robust and reliable way to manage watchlists, while the code refactoring simplifies the logic and enhances maintainability. It's a small but important step towards a more polished and user-friendly experience.)