### PR TITLE
feat(ds): update action button size to 40 globally and 32 within footer

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -95,7 +95,7 @@
   }
 
   .trakt-action-button {
-    --button-size: var(--ni-36);
+    --button-size: var(--ni-40);
 
     all: unset;
 
@@ -144,8 +144,8 @@
     }
 
     &[data-size="small"] {
-      scale: 0.7777777778;
-      margin: var(--ni-neg-4);
+      scale: 0.8;
+      margin: var(--ni-neg-8);
     }
 
     &[data-style="ghost"] {

--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -36,7 +36,7 @@
 
     .trakt-card-footer-information {
       width: 100%;
-      margin-top: var(--ni-neg-2);
+      margin-top: var(--ni-neg-4);
       overflow: hidden;
 
       display: flex;

--- a/projects/client/src/lib/components/icons/CaretLeftIcon.svelte
+++ b/projects/client/src/lib/components/icons/CaretLeftIcon.svelte
@@ -1,9 +1,9 @@
 <svg
-  width="13"
-  height="22"
-  viewBox="0 0 13 22"
+  width="16"
+  height="16"
+  viewBox="0 0 16 16"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <path d="M12 21L2 11L12 1" stroke="currentColor" stroke-width="2" />
+  <path d="M11 15L4 8L11 1" stroke="currentColor" stroke-width="2" />
 </svg>

--- a/projects/client/src/lib/components/icons/CaretRightIcon.svelte
+++ b/projects/client/src/lib/components/icons/CaretRightIcon.svelte
@@ -1,9 +1,9 @@
 <svg
-  width="13"
-  height="22"
-  viewBox="0 0 13 22"
+  width="16"
+  height="16"
+  viewBox="0 0 16 16"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <path d="M1 21L11 11L0.999999 1" stroke="currentColor" stroke-width="2" />
+  <path d="M5 15L12 8L5 1" stroke="currentColor" stroke-width="2" />
 </svg>


### PR DESCRIPTION
## Component Styling and Layout Refinements

This pull request introduces several styling and layout adjustments to button, card footer, and icon components within the `projects/client/src/lib/components` directory. The changes primarily focus on refining sizes, margins, and SVG dimensions to enhance visual consistency and overall appearance.

### Button Component Updates:

* **`ActionButton.svelte`**: The size of action buttons has been increased slightly from `var(--ni-36)` to `var(--ni-40)`. Additionally, the scale and margin for the small size variant have been adjusted to maintain visual balance and proportion.

### Card Footer Component Update:

* **`CardFooter.svelte`**: The margin-top value for the `trakt-card-footer-information` class has been updated from `var(--ni-neg-2)` to `var(--ni-neg-4)`. This minor adjustment refines the spacing within the card footer, improving the visual layout.

### Icon Component Updates:

* **`CaretLeftIcon.svelte` and `CaretRightIcon.svelte`**: The SVG dimensions and path for both the `CaretLeftIcon` and `CaretRightIcon` components have been modified. The width and height have been changed from `13x22` to `16x16`, and the path coordinates have been updated accordingly. This ensures that the icons are displayed with the correct proportions and align with the overall visual style.

(This update, like a meticulous artist refining their brushstrokes, focuses on the finer details of the Trakt Lite interface. The adjustments to button sizes, card footer margins, and icon dimensions enhance visual consistency and improve the overall aesthetic appeal. These subtle refinements contribute to a more polished and harmonious user experience.)

Before / After:

<img width="373" alt="image" src="https://github.com/user-attachments/assets/1a8ee812-e3c0-4870-86b4-31fdb7841f7d" /><img width="374" alt="image" src="https://github.com/user-attachments/assets/7b1c945d-4a42-4d50-b879-f017192f01d1" />
