### PR TITLE
fix(navbar): match card border radius

### DIFF
--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -130,7 +130,7 @@
     align-items: center;
     gap: var(--gap-l);
 
-    border-radius: var(--border-radius-l);
+    border-radius: var(--border-radius-m);
     transition: var(--transition-increment) cubic-bezier(0.4, 0, 0.2, 1);
     transition-property: background-color, box-shadow;
 


### PR DESCRIPTION
## ♪ Note ♪
Small visual fix; when navbar overlaps cards, the rounding will be the same. Example of my slight annoyance:
![image](https://github.com/user-attachments/assets/5237ae38-1cde-4a1e-9a5c-50786fa71a9c)

