### PR TITLE
Feat/official lists

### DIFF
--- a/projects/api/src/contracts/_internal/response/userProfileResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/userProfileResponseSchema.ts
@@ -1,14 +1,15 @@
 import { z } from '../z.ts';
 
+// FIXME: split up in user profile, and official user
 export const profileResponseSchema = z.object({
   username: z.string(),
   private: z.boolean(),
   deleted: z.boolean(),
-  name: z.string(),
+  name: z.string().nullable(),
   vip: z.boolean(),
   vip_ep: z.boolean(),
   ids: z.object({
-    slug: z.string(),
+    slug: z.string().nullable(),
     trakt: z.number(),
   }),
   /***

--- a/projects/api/src/contracts/lists/index.ts
+++ b/projects/api/src/contracts/lists/index.ts
@@ -4,10 +4,20 @@ import { idParamsSchema } from '../_internal/request/idParamsSchema.ts';
 import { pageQuerySchema } from '../_internal/request/pageQuerySchema.ts';
 import { listedMovieResponseSchema } from '../_internal/response/listedMovieResponseSchema.ts';
 import { listedShowResponseSchema } from '../_internal/response/listedShowResponseSchema.ts';
+import { listResponseSchema } from '../_internal/response/listResponseSchema.ts';
 import { z } from '../_internal/z.ts';
 import { searchTypeParamFactory } from '../search/_internal/request/searchTypeParamFactory.ts';
 
 export const lists = builder.router({
+  summary: {
+    path: '',
+    method: 'GET',
+    pathParams: idParamsSchema,
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
+    responses: {
+      200: listResponseSchema,
+    },
+  },
   items: {
     path: '/items/:type',
     method: 'GET',

--- a/projects/api/src/contracts/lists/index.ts
+++ b/projects/api/src/contracts/lists/index.ts
@@ -4,30 +4,26 @@ import { idParamsSchema } from '../_internal/request/idParamsSchema.ts';
 import { pageQuerySchema } from '../_internal/request/pageQuerySchema.ts';
 import { listedMovieResponseSchema } from '../_internal/response/listedMovieResponseSchema.ts';
 import { listedShowResponseSchema } from '../_internal/response/listedShowResponseSchema.ts';
+import { z } from '../_internal/z.ts';
+import { searchTypeParamFactory } from '../search/_internal/request/searchTypeParamFactory.ts';
 
 export const lists = builder.router({
-  items: builder.router({
-    movies: {
-      path: '/items/movies',
-      method: 'GET',
-      pathParams: idParamsSchema,
-      query: extendedQuerySchemaFactory<['full', 'images']>()
-        .merge(pageQuerySchema),
-      responses: {
-        200: listedMovieResponseSchema.array(),
-      },
+  items: {
+    path: '/items/:type',
+    method: 'GET',
+    pathParams: idParamsSchema
+      .merge(
+        searchTypeParamFactory<
+          ['movie', 'show']
+        >(),
+      ),
+    query: extendedQuerySchemaFactory<['full', 'images']>()
+      .merge(pageQuerySchema),
+    responses: {
+      200: z.union([listedMovieResponseSchema, listedShowResponseSchema])
+        .array(),
     },
-    shows: {
-      path: '/items/shows',
-      method: 'GET',
-      pathParams: idParamsSchema,
-      query: extendedQuerySchemaFactory<['full', 'images']>()
-        .merge(pageQuerySchema),
-      responses: {
-        200: listedShowResponseSchema.array(),
-      },
-    },
-  }),
+  },
 }, {
   pathPrefix: '/lists/:id',
 });

--- a/projects/client/src/lib/requests/_internal/mapToListItem.ts
+++ b/projects/client/src/lib/requests/_internal/mapToListItem.ts
@@ -35,3 +35,11 @@ export function mapToMovieListItem(
     entry: mapToMovieEntry(listedMovieResponse.movie),
   };
 }
+
+export function mapToListItem(
+  listedItem: ListedMovieResponse | ListedShowResponse,
+) {
+  return listedItem.type === 'movie'
+    ? mapToMovieListItem(listedItem)
+    : mapToShowListItem(listedItem);
+}

--- a/projects/client/src/lib/requests/models/UserProfile.ts
+++ b/projects/client/src/lib/requests/models/UserProfile.ts
@@ -2,11 +2,11 @@ import z from 'zod';
 
 export const UserProfileSchema = z.object({
   username: z.string(),
-  name: z.string(),
+  name: z.string().nullable(),
   private: z.boolean(),
   isVip: z.boolean(),
   isDeleted: z.boolean(),
-  slug: z.string(),
+  slug: z.string().nullable(),
   avatar: z.object({
     url: z.string(),
   }),

--- a/projects/client/src/lib/requests/queries/lists/listItemsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/lists/listItemsQuery.spec.ts
@@ -1,0 +1,58 @@
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { ListedMoviesMappedMock } from '$mocks/data/lists/mapped/ListedMoviesMappedMock.ts';
+import { ListedShowsMappedMock } from '$mocks/data/lists/mapped/ListedShowsMappedMock.ts';
+import { HereticListsMappedMock } from '$mocks/data/summary/movies/heretic/mapped/HereticListsMappedMock.ts';
+import { SiloListsMappedMock } from '$mocks/data/summary/shows/silo/mapped/SiloListsMappedMock.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { createQuery } from '@tanstack/svelte-query';
+import { describe, expect, it } from 'vitest';
+import { listItemsQuery } from './listItemsQuery.ts';
+
+describe('listItemsQuery', () => {
+  it('should query list items', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          listItemsQuery({
+            listId: `${assertDefined(SiloListsMappedMock.at(0)).id}`,
+          }),
+        ),
+      mapper: (response) => response?.data?.entries,
+    });
+
+    expect(result).to.deep.equal([
+      ...ListedShowsMappedMock,
+      ...ListedMoviesMappedMock,
+    ]);
+  });
+
+  it('should query show list items', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          listItemsQuery({
+            listId: `${assertDefined(SiloListsMappedMock.at(0)).id}`,
+            type: 'show',
+          }),
+        ),
+      mapper: (response) => response?.data?.entries,
+    });
+
+    expect(result).to.deep.equal(ListedShowsMappedMock);
+  });
+
+  it('should query movie list items', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          listItemsQuery({
+            listId: `${assertDefined(HereticListsMappedMock.at(0)).id}`,
+            type: 'movie',
+          }),
+        ),
+      mapper: (response) => response?.data?.entries,
+    });
+
+    expect(result).to.deep.equal(ListedMoviesMappedMock);
+  });
+});

--- a/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
@@ -12,9 +12,8 @@ import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 
-type UserListItemsParams =
+type ListItemsParams =
   & {
-    userId: string;
     listId: string;
     page?: number;
     limit?: number;
@@ -30,25 +29,20 @@ const ListedItemSchema = ListItemSchemaFactory(
   z.union([MovieEntrySchema, ListedShowEntrySchema]),
 );
 
-export type ListedItem = z.infer<typeof ListedItemSchema>;
-
 const userListItemsRequest = (
   {
     fetch,
-    userId,
     listId,
     limit = DEFAULT_PAGE_SIZE,
     page = 1,
     type = 'movie,show',
-  }: UserListItemsParams,
+  }: ListItemsParams,
 ) =>
   api({ fetch })
-    .users
     .lists
     .items({
       params: {
-        id: userId,
-        list_id: listId,
+        id: listId,
         type,
       },
       query: {
@@ -59,19 +53,18 @@ const userListItemsRequest = (
     })
     .then((response) => {
       if (response.status !== 200) {
-        throw new Error('Failed to fetch user list items');
+        throw new Error('Failed to fetch list items');
       }
 
       return response;
     });
 
-export const userListItemsQuery = defineQuery({
-  key: 'userListItems',
+export const listItemsQuery = defineQuery({
+  key: 'listItems',
   invalidations: [],
   dependencies: (
     params,
   ) => [
-    params.userId,
     params.listId,
     params.limit,
     params.page,

--- a/projects/client/src/lib/requests/queries/lists/listSummaryQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/lists/listSummaryQuery.spec.ts
@@ -1,0 +1,22 @@
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { SiloListsMappedMock } from '$mocks/data/summary/shows/silo/mapped/SiloListsMappedMock.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { createQuery } from '@tanstack/svelte-query';
+import { describe, expect, it } from 'vitest';
+import { listSummaryQuery } from './listSummaryQuery.ts';
+
+describe('listSummaryQuery', () => {
+  it('should query user list summary', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          listSummaryQuery({
+            listId: `${assertDefined(SiloListsMappedMock.at(0)).id}`,
+          }),
+        ),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(SiloListsMappedMock.at(0));
+  });
+});

--- a/projects/client/src/lib/requests/queries/lists/listSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/lists/listSummaryQuery.ts
@@ -4,23 +4,21 @@ import { time } from '$lib/utils/timing/time.ts';
 import { mapToMediaListSummary } from '../../_internal/mapToMediaListSummary.ts';
 import { MediaListSummarySchema } from '../../models/MediaListSummary.ts';
 
-type ListSummaryParams = { userId: string; listId: string } & ApiParams;
+type ListSummaryParams = { listId: string } & ApiParams;
 
 const listSummaryRequest = (
-  { fetch, userId, listId }: ListSummaryParams,
+  { fetch, listId }: ListSummaryParams,
 ) =>
   api({ fetch })
-    .users
     .lists
     .summary({
       params: {
-        id: userId,
-        list_id: listId,
+        id: listId,
       },
     })
     .then((response) => {
       if (response.status !== 200) {
-        throw new Error('Failed to fetch list summary');
+        throw new Error('Failed to get list summary');
       }
 
       return response.body;
@@ -29,7 +27,7 @@ const listSummaryRequest = (
 export const listSummaryQuery = defineQuery({
   key: 'listSummary',
   invalidations: [],
-  dependencies: (params) => [params.userId, params.listId],
+  dependencies: (params) => [params.listId],
   request: listSummaryRequest,
   mapper: mapToMediaListSummary,
   schema: MediaListSummarySchema,

--- a/projects/client/src/lib/requests/queries/movies/movieListsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieListsQuery.spec.ts
@@ -1,3 +1,4 @@
+import { OfficialListsMappedMock } from '$mocks/data/lists/mapped/OfficialListsMappedMock.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
 import { createQuery } from '@tanstack/svelte-query';
@@ -16,5 +17,21 @@ describe('movieListsQuery', () => {
     });
 
     expect(result).to.deep.equal(HereticListsMappedMock);
+  });
+
+  it('should query for official lists that contain Heretic (2024)', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          movieListsQuery({
+            slug: MovieHereticMappedMock.slug,
+            limit: 10,
+            type: 'official',
+          }),
+        ),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(OfficialListsMappedMock);
   });
 });

--- a/projects/client/src/lib/requests/queries/movies/movieListsQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieListsQuery.ts
@@ -4,17 +4,21 @@ import { time } from '$lib/utils/timing/time.ts';
 import { mapToMediaListSummary } from '../../_internal/mapToMediaListSummary.ts';
 import { MediaListSummarySchema } from '../../models/MediaListSummary.ts';
 
-type MovieListsParams = { slug: string; limit: number } & ApiParams;
+type MovieListsParams = {
+  slug: string;
+  limit: number;
+  type?: 'official' | 'personal';
+} & ApiParams;
 
 const movieListsRequest = (
-  { fetch, slug, limit }: MovieListsParams,
+  { fetch, slug, limit, type }: MovieListsParams,
 ) =>
   api({ fetch })
     .movies
     .lists({
       params: {
         id: slug,
-        type: 'all',
+        type: type ?? 'personal',
         sort: 'popular',
       },
       query: {
@@ -33,7 +37,7 @@ const movieListsRequest = (
 export const movieListsQuery = defineQuery({
   key: 'movieLists',
   invalidations: [],
-  dependencies: (params) => [params.slug, params.limit],
+  dependencies: (params) => [params.slug, params.limit, params.type],
   request: movieListsRequest,
   mapper: (data) => data.map(mapToMediaListSummary),
   schema: MediaListSummarySchema.array(),

--- a/projects/client/src/lib/requests/queries/shows/showListsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/shows/showListsQuery.spec.ts
@@ -1,3 +1,4 @@
+import { OfficialListsMappedMock } from '$mocks/data/lists/mapped/OfficialListsMappedMock.ts';
 import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
 import { createQuery } from '@tanstack/svelte-query';
@@ -16,5 +17,21 @@ describe('showListsQuery', () => {
     });
 
     expect(result).to.deep.equal(SiloListsMappedMock);
+  });
+
+  it('should query for official lists that contain Silo (2023)', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          showListsQuery({
+            slug: ShowSiloMappedMock.slug,
+            limit: 10,
+            type: 'official',
+          }),
+        ),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(OfficialListsMappedMock);
   });
 });

--- a/projects/client/src/lib/requests/queries/shows/showListsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showListsQuery.ts
@@ -4,17 +4,21 @@ import { time } from '$lib/utils/timing/time.ts';
 import { mapToMediaListSummary } from '../../_internal/mapToMediaListSummary.ts';
 import { MediaListSummarySchema } from '../../models/MediaListSummary.ts';
 
-type ShowListsParams = { slug: string; limit: number } & ApiParams;
+type ShowListsParams = {
+  slug: string;
+  limit: number;
+  type?: 'official' | 'personal';
+} & ApiParams;
 
 const showListsRequest = (
-  { fetch, slug, limit }: ShowListsParams,
+  { fetch, slug, limit, type }: ShowListsParams,
 ) =>
   api({ fetch })
     .shows
     .lists({
       params: {
         id: slug,
-        type: 'all',
+        type: type ?? 'personal',
         sort: 'popular',
       },
       query: {
@@ -33,7 +37,7 @@ const showListsRequest = (
 export const showListsQuery = defineQuery({
   key: 'showLists',
   invalidations: [],
-  dependencies: (params) => [params.slug],
+  dependencies: (params) => [params.slug, params.limit, params.type],
   request: showListsRequest,
   mapper: (data) => data.map(mapToMediaListSummary),
   schema: MediaListSummarySchema.array(),

--- a/projects/client/src/lib/requests/queries/users/userListItemsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/userListItemsQuery.spec.ts
@@ -15,7 +15,7 @@ describe('userListItemsQuery', () => {
       factory: () =>
         createQuery(
           userListItemsQuery({
-            userId: UserProfileHarryMappedMock.slug,
+            userId: assertDefined(UserProfileHarryMappedMock.slug),
             listId: assertDefined(SiloListsMappedMock.at(0)).slug,
           }),
         ),
@@ -33,7 +33,7 @@ describe('userListItemsQuery', () => {
       factory: () =>
         createQuery(
           userListItemsQuery({
-            userId: UserProfileHarryMappedMock.slug,
+            userId: assertDefined(UserProfileHarryMappedMock.slug),
             listId: assertDefined(SiloListsMappedMock.at(0)).slug,
             type: 'show',
           }),
@@ -49,7 +49,7 @@ describe('userListItemsQuery', () => {
       factory: () =>
         createQuery(
           userListItemsQuery({
-            userId: UserProfileHarryMappedMock.slug,
+            userId: assertDefined(UserProfileHarryMappedMock.slug),
             listId: assertDefined(HereticListsMappedMock.at(0)).slug,
             type: 'movie',
           }),

--- a/projects/client/src/lib/requests/queries/users/userListItemsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/userListItemsQuery.spec.ts
@@ -7,14 +7,14 @@ import { UserProfileHarryMappedMock } from '$mocks/data/users/mapped/UserProfile
 import { runQuery } from '$test/beds/query/runQuery.ts';
 import { createQuery } from '@tanstack/svelte-query';
 import { describe, expect, it } from 'vitest';
-import { listItemsQuery } from './listItemsQuery.ts';
+import { userListItemsQuery } from './userListItemsQuery.ts';
 
-describe('listItemsQuery', () => {
+describe('userListItemsQuery', () => {
   it('should query list items', async () => {
     const result = await runQuery({
       factory: () =>
         createQuery(
-          listItemsQuery({
+          userListItemsQuery({
             userId: UserProfileHarryMappedMock.slug,
             listId: assertDefined(SiloListsMappedMock.at(0)).slug,
           }),
@@ -32,7 +32,7 @@ describe('listItemsQuery', () => {
     const result = await runQuery({
       factory: () =>
         createQuery(
-          listItemsQuery({
+          userListItemsQuery({
             userId: UserProfileHarryMappedMock.slug,
             listId: assertDefined(SiloListsMappedMock.at(0)).slug,
             type: 'show',
@@ -48,7 +48,7 @@ describe('listItemsQuery', () => {
     const result = await runQuery({
       factory: () =>
         createQuery(
-          listItemsQuery({
+          userListItemsQuery({
             userId: UserProfileHarryMappedMock.slug,
             listId: assertDefined(HereticListsMappedMock.at(0)).slug,
             type: 'movie',

--- a/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
@@ -16,7 +16,7 @@ import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 
-type ListItemsParams =
+type UserListItemsParams =
   & {
     userId: string;
     listId: string;
@@ -44,7 +44,7 @@ function mapToListItem(
     : mapToShowListItem(listedItem);
 }
 
-const listItemsRequest = (
+const userListItemsRequest = (
   {
     fetch,
     userId,
@@ -52,7 +52,7 @@ const listItemsRequest = (
     limit = DEFAULT_PAGE_SIZE,
     page = 1,
     type = 'movie,show',
-  }: ListItemsParams,
+  }: UserListItemsParams,
 ) =>
   api({ fetch })
     .users
@@ -77,8 +77,8 @@ const listItemsRequest = (
       return response;
     });
 
-export const listItemsQuery = defineQuery({
-  key: 'listItems',
+export const userListItemsQuery = defineQuery({
+  key: 'userListItems',
   invalidations: [],
   dependencies: (
     params,
@@ -89,7 +89,7 @@ export const listItemsQuery = defineQuery({
     params.page,
     params.type,
   ],
-  request: listItemsRequest,
+  request: userListItemsRequest,
   mapper: (response) => ({
     entries: response.body.map(mapToListItem),
     page: extractPageMeta(response.headers),

--- a/projects/client/src/lib/requests/queries/users/userListSummaryQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/userListSummaryQuery.spec.ts
@@ -12,7 +12,7 @@ describe('userListSummaryQuery', () => {
       factory: () =>
         createQuery(
           userListSummaryQuery({
-            userId: UserProfileHarryMappedMock.slug,
+            userId: assertDefined(UserProfileHarryMappedMock.slug),
             listId: assertDefined(SiloListsMappedMock.at(0)).slug,
           }),
         ),

--- a/projects/client/src/lib/requests/queries/users/userListSummaryQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/userListSummaryQuery.spec.ts
@@ -4,14 +4,14 @@ import { UserProfileHarryMappedMock } from '$mocks/data/users/mapped/UserProfile
 import { runQuery } from '$test/beds/query/runQuery.ts';
 import { createQuery } from '@tanstack/svelte-query';
 import { describe, expect, it } from 'vitest';
-import { listSummaryQuery } from './listSummaryQuery.ts';
+import { userListSummaryQuery } from './userListSummaryQuery.ts';
 
-describe('listSummaryQuery', () => {
-  it('should query list summary', async () => {
+describe('userListSummaryQuery', () => {
+  it('should query user list summary', async () => {
     const result = await runQuery({
       factory: () =>
         createQuery(
-          listSummaryQuery({
+          userListSummaryQuery({
             userId: UserProfileHarryMappedMock.slug,
             listId: assertDefined(SiloListsMappedMock.at(0)).slug,
           }),

--- a/projects/client/src/lib/requests/queries/users/userListSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListSummaryQuery.ts
@@ -1,0 +1,37 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { mapToMediaListSummary } from '../../_internal/mapToMediaListSummary.ts';
+import { MediaListSummarySchema } from '../../models/MediaListSummary.ts';
+
+type UserListSummaryParams = { userId: string; listId: string } & ApiParams;
+
+const userListSummaryRequest = (
+  { fetch, userId, listId }: UserListSummaryParams,
+) =>
+  api({ fetch })
+    .users
+    .lists
+    .summary({
+      params: {
+        id: userId,
+        list_id: listId,
+      },
+    })
+    .then((response) => {
+      if (response.status !== 200) {
+        throw new Error('Failed to fetch list summary');
+      }
+
+      return response.body;
+    });
+
+export const userListSummaryQuery = defineQuery({
+  key: 'userListSummary',
+  invalidations: [],
+  dependencies: (params) => [params.userId, params.listId],
+  request: userListSummaryRequest,
+  mapper: mapToMediaListSummary,
+  schema: MediaListSummarySchema,
+  ttl: time.minutes(30),
+});

--- a/projects/client/src/lib/sections/lists/components/UserProfileLink.svelte
+++ b/projects/client/src/lib/sections/lists/components/UserProfileLink.svelte
@@ -2,19 +2,42 @@
   import Link from "$lib/components/link/Link.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { UserProfile } from "$lib/requests/models/UserProfile";
+  import { assertDefined } from "$lib/utils/assert/assertDefined";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
   const { user }: { user: UserProfile } = $props();
+
+  const displayType = $derived.by(() => {
+    if (user.isDeleted) {
+      return "deleted";
+    }
+
+    if (user.slug) {
+      return "linkable";
+    }
+
+    return "plain";
+  });
 </script>
 
-{#if user.isDeleted}
+{#snippet username()}
+  <p class="secondary small ellipsis">
+    {user.username}
+  </p>
+{/snippet}
+
+{#if displayType === "deleted"}
   <p class="secondary small trakt-deleted-user">{m.deleted_user()}</p>
-{:else}
-  <Link href={UrlBuilder.og.user(user.slug)} target="_blank">
-    <p class="secondary small ellipsis">
-      {user.username}
-    </p>
+{/if}
+
+{#if displayType === "linkable"}
+  <Link href={UrlBuilder.og.user(assertDefined(user.slug))} target="_blank">
+    {@render username()}
   </Link>
+{/if}
+
+{#if displayType === "plain"}
+  {@render username()}
 {/if}
 
 <style>

--- a/projects/client/src/lib/sections/lists/components/list-summary/ListPreview.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/ListPreview.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import { useListItems } from "$lib/sections/lists/components/list-summary/_internal/useListItems.ts";
+  import MediaCard from "$lib/sections/lists/components/MediaCard.svelte";
+  import { mediaListHeightResolver } from "$lib/sections/lists/utils/mediaListHeightResolver.ts";
+  import ViewAllButton from "../ViewAllButton.svelte";
+  import { getListUrl } from "./_internal/getListUrl";
+
+  const { list, type }: { list: MediaListSummary; type: MediaType } = $props();
+
+  const { items, isLoading } = useListItems({ list, type });
+  const isEmptyList = $derived(!$isLoading && $items.length === 0);
+</script>
+
+<!-- FIXME switch to drillable list when support is added -->
+<SectionList
+  id={`top-list-${type}-${list.id}`}
+  items={$items}
+  title={list.name}
+  --height-list={mediaListHeightResolver(type)}
+>
+  {#snippet actions()}
+    <ViewAllButton
+      href={getListUrl(list, type)}
+      label={m.view_all()}
+      isDisabled={isEmptyList}
+    />
+  {/snippet}
+  {#snippet item(media)}
+    <MediaCard {type} media={media.entry} />
+  {/snippet}
+</SectionList>

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListHeader.svelte
@@ -5,7 +5,7 @@
   import type { MediaType } from "$lib/requests/models/MediaType";
   import UserAvatar from "$lib/sections/lists/components/UserAvatar.svelte";
   import UserProfileLink from "$lib/sections/lists/components/UserProfileLink.svelte";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { getListUrl } from "./getListUrl";
 
   const { list, type }: { list: MediaListSummary; type?: MediaType } = $props();
 </script>
@@ -14,7 +14,7 @@
   <UserAvatar user={list.user} />
 
   <div class="list-name-and-creator">
-    <Link href={UrlBuilder.users(list.user.slug).lists(list.slug, type)}>
+    <Link href={getListUrl(list, type)}>
       <p class="secondary bold ellipsis">
         {list.name}
       </p>

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
@@ -4,20 +4,16 @@
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
   import type { MediaType } from "$lib/requests/models/MediaType.ts";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+  import { getListUrl } from "./getListUrl.ts";
   import { useListItems } from "./useListItems.ts";
 
   const { list, type }: { list: MediaListSummary; type?: MediaType } = $props();
 
-  const { items } = useListItems({
-    userId: list.user.slug,
-    listId: list.slug,
-    type,
-  });
+  const { items } = useListItems({ list, type });
 </script>
 
 {#if $items}
-  <Link href={UrlBuilder.users(list.user.slug).lists(list.slug, type)}>
+  <Link href={getListUrl(list, type)}>
     <div class="trakt-list-posters" style="--poster-count: {$items.length}">
       {#each $items as item, index}
         <div class="poster-wrapper" style="--poster-index: {index}">

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/getListUrl.ts
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/getListUrl.ts
@@ -1,0 +1,11 @@
+import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
+
+export function getListUrl(list: MediaListSummary, type?: MediaType) {
+  if (list.user.slug) {
+    return UrlBuilder.users(list.user.slug).lists(list.slug, type);
+  }
+
+  return UrlBuilder.lists.official(list.id, type);
+}

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/useListItems.ts
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/useListItems.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '$lib/features/query/useQuery.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 
-import { listItemsQuery } from '$lib/requests/queries/users/listItemsQuery.ts';
+import { userListItemsQuery } from '$lib/requests/queries/users/listItemsQuery.ts';
 import { derived } from 'svelte/store';
 
 const PREVIEW_LIMIT = 8;
@@ -17,7 +17,7 @@ export function useListItems({
   listId,
   type,
 }: UseListItemsProps) {
-  const items = useQuery(listItemsQuery({
+  const items = useQuery(userListItemsQuery({
     userId,
     listId,
     type,

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/useListItems.ts
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/useListItems.ts
@@ -1,30 +1,50 @@
 import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
-
-import { userListItemsQuery } from '$lib/requests/queries/users/listItemsQuery.ts';
+import { listItemsQuery } from '$lib/requests/queries/lists/listItemsQuery.ts';
+import { userListItemsQuery } from '$lib/requests/queries/users/userListItemsQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { derived } from 'svelte/store';
 
 const PREVIEW_LIMIT = 8;
 
 type UseListItemsProps = {
-  userId: string;
-  listId: string;
+  list: MediaListSummary;
   type?: MediaType;
 };
 
-export function useListItems({
-  userId,
-  listId,
-  type,
-}: UseListItemsProps) {
-  const items = useQuery(userListItemsQuery({
-    userId,
-    listId,
+function listToQuery(
+  { list, type }: UseListItemsProps,
+) {
+  const commonParams = {
     type,
     limit: PREVIEW_LIMIT,
-  }));
+  };
+
+  if (list.user.slug) {
+    return userListItemsQuery({
+      ...commonParams,
+      userId: list.user.slug,
+      listId: list.slug,
+    });
+  }
+
+  return listItemsQuery({
+    ...commonParams,
+    listId: `${list.id}`,
+  });
+}
+
+export function useListItems(props: UseListItemsProps) {
+  const items = useQuery(listToQuery(props));
+
+  const isLoading = derived(
+    items,
+    toLoadingState,
+  );
 
   return {
+    isLoading,
     items: derived(items, ($list) => $list.data?.entries ?? []),
   };
 }

--- a/projects/client/src/lib/sections/lists/official/OfficialList.svelte
+++ b/projects/client/src/lib/sections/lists/official/OfficialList.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import GridList from "$lib/components/lists/grid-list/GridList.svelte";
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import MediaCard from "../components/MediaCard.svelte";
+  import { useOfficialList } from "./useOfficialList";
+
+  type OfficialListProps = {
+    title: string;
+    listId: string;
+    type?: MediaType;
+  };
+
+  const { title, listId, type }: OfficialListProps = $props();
+
+  const { list } = $derived(useOfficialList({ listId, type }));
+  const isMobile = useMedia(WellKnownMediaQuery.mobile);
+  const style = $derived($isMobile ? "summary" : "cover");
+</script>
+
+<!-- TODO use drilled media list & fetch rest on scroll -->
+<GridList
+  id={`official-list-${listId}`}
+  {title}
+  items={$list}
+  --width-item="var(--width-poster-card)"
+>
+  {#snippet item(media)}
+    <MediaCard type={media.type} {media} {style} />
+  {/snippet}
+</GridList>

--- a/projects/client/src/lib/sections/lists/official/useOfficialList.ts
+++ b/projects/client/src/lib/sections/lists/official/useOfficialList.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import { listItemsQuery } from '$lib/requests/queries/lists/listItemsQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { derived } from 'svelte/store';
+
+const LIST_LIMIT = 100;
+
+type OfficialListItemsProps = {
+  listId: string;
+  limit?: number;
+  page?: number;
+  type?: MediaType;
+};
+
+export function useOfficialList(props: OfficialListItemsProps) {
+  const query = useQuery(listItemsQuery({
+    ...props,
+    limit: props.limit ?? LIST_LIMIT,
+  }));
+
+  const list = derived(
+    query,
+    ($query) => ($query.data?.entries ?? []).map((item) => item.entry),
+  );
+
+  const isLoading = derived(
+    query,
+    toLoadingState,
+  );
+
+  return {
+    list,
+    isLoading,
+    page: derived(
+      query,
+      ($query) => $query.data?.page ?? { page: 0, total: 0 },
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/lists/user/UserList.svelte
+++ b/projects/client/src/lib/sections/lists/user/UserList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
   import type { MediaType } from "$lib/requests/models/MediaType";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import MediaCard from "../components/MediaCard.svelte";
   import { useUserList } from "./useUserList";
 
@@ -14,6 +15,8 @@
   const { title, userId, listId, type }: UserListProps = $props();
 
   const { list } = $derived(useUserList({ userId, listId, type }));
+  const isMobile = useMedia(WellKnownMediaQuery.mobile);
+  const style = $derived($isMobile ? "summary" : "cover");
 </script>
 
 <!-- TODO use drilled media list & fetch rest on scroll -->
@@ -24,6 +27,6 @@
   --width-item="var(--width-poster-card)"
 >
   {#snippet item(media)}
-    <MediaCard type={media.type} {media} />
+    <MediaCard type={media.type} {media} {style} />
   {/snippet}
 </GridList>

--- a/projects/client/src/lib/sections/lists/user/useUserList.ts
+++ b/projects/client/src/lib/sections/lists/user/useUserList.ts
@@ -3,7 +3,7 @@ import { useQuery } from '$lib/features/query/useQuery.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { derived } from 'svelte/store';
-import { listItemsQuery } from '../../../requests/queries/users/listItemsQuery.ts';
+import { userListItemsQuery } from '../../../requests/queries/users/userListItemsQuery.ts';
 
 const LIST_LIMIT = 100;
 
@@ -16,7 +16,7 @@ type UseListItemsProps = {
 };
 
 export function useUserList(props: UseListItemsProps) {
-  const query = useQuery(listItemsQuery({
+  const query = useQuery(userListItemsQuery({
     ...props,
     limit: props.limit ?? LIST_LIMIT,
   }));

--- a/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
+++ b/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
@@ -3,10 +3,10 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaType } from "$lib/requests/models/MediaType";
+  import ListPreview from "../../../lists/components/list-summary/ListPreview.svelte";
   import ListSummaryCard from "../../../lists/components/list-summary/ListSummaryCard.svelte";
+  import { MAX_LISTS } from "./_internal/constants.ts";
   import { useListSummary } from "./useListSummary.ts";
-
-  const MAX_MOBILE_LISTS = 3;
 
   const {
     slug,
@@ -15,13 +15,21 @@
   }: { slug: string; type: MediaType; title: string } = $props();
 
   // Due to slow performance, we fetch the lists here instead of useMovie/useShow
-  const { isLoading, lists } = useListSummary({ slug, type });
+  const { isLoading, personalLists, officialLists } = useListSummary({
+    slug,
+    type,
+  });
+
+  const lists = $derived(
+    [...$officialLists, ...$personalLists].slice(0, MAX_LISTS),
+  );
+  const topList = $derived(lists.at(0));
 </script>
 
 <RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>
   <SectionList
     id={`popular-lists-list`}
-    items={$lists}
+    items={lists}
     title={m.popular_lists()}
     --height-list="var(--height-lists-list)"
   >
@@ -38,37 +46,7 @@
 </RenderFor>
 
 <RenderFor audience="all" device={["mobile"]}>
-  <div class="vertical-list-container">
-    <h4>{m.popular_lists()}</h4>
-    <div class="vertical-list-items">
-      {#each $lists.slice(0, MAX_MOBILE_LISTS) as list}
-        <ListSummaryCard {list} {type} />
-      {/each}
-    </div>
-  </div>
+  {#if topList}
+    <ListPreview list={topList} {type} />
+  {/if}
 </RenderFor>
-
-<style>
-  .vertical-list-container {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-m);
-
-    padding: 0 var(--layout-distance-side);
-
-    h4 {
-      font-size: var(--ni-24);
-    }
-  }
-
-  .vertical-list-items {
-    display: flex;
-    flex-direction: column;
-
-    gap: var(--gap-xs);
-
-    :global(.trakt-card) {
-      --width-card: calc(100vw - 2 * var(--layout-distance-side));
-    }
-  }
-</style>

--- a/projects/client/src/lib/sections/summary/components/lists/_internal/constants.ts
+++ b/projects/client/src/lib/sections/summary/components/lists/_internal/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_LISTS = 10;

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -76,6 +76,10 @@ export const UrlBuilder = {
         ? `/users/${id}/lists/${slug}?type=${type}`
         : `/users/${id}/lists/${slug}`,
   }),
+  lists: {
+    official: (id: number, type?: MediaType) =>
+      `/lists/official/${id}?type=${type}`,
+  },
   app: {
     android: () => 'https://trakt.tv/a/trakt-android',
     ios: () => 'https://trakt.tv/a/trakt-ios',

--- a/projects/client/src/mocks/data/lists/mapped/ListedMoviesMappedMock.ts
+++ b/projects/client/src/mocks/data/lists/mapped/ListedMoviesMappedMock.ts
@@ -1,4 +1,4 @@
-import type { ListedItem } from '$lib/requests/queries/users/listItemsQuery.ts';
+import type { ListedItem } from '$lib/requests/queries/users/userListItemsQuery.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
 
 export const ListedMoviesMappedMock: ListedItem[] = [

--- a/projects/client/src/mocks/data/lists/mapped/ListedShowsMappedMock.ts
+++ b/projects/client/src/mocks/data/lists/mapped/ListedShowsMappedMock.ts
@@ -1,4 +1,4 @@
-import type { ListedItem } from '$lib/requests/queries/users/listItemsQuery.ts';
+import type { ListedItem } from '$lib/requests/queries/users/userListItemsQuery.ts';
 import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
 
 export const ListedShowsMappedMock: ListedItem[] = [

--- a/projects/client/src/mocks/data/lists/mapped/OfficialListsMappedMock.ts
+++ b/projects/client/src/mocks/data/lists/mapped/OfficialListsMappedMock.ts
@@ -1,0 +1,22 @@
+import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
+
+export const OfficialListsMappedMock: MediaListSummary[] = [
+  {
+    'description': 'This is super official',
+    'id': 1234,
+    'name': 'Official list',
+    'slug': 'official-list',
+    'user': {
+      'username': 'Trakt',
+      'avatar': {
+        'url':
+          'https://trakt.tv/assets/logos/logomark.circle.gradient-cb51d322e6bc3be6370499c6b61a906f8ef49c42a75e5e6d71aaeab2c6689061.svg',
+      },
+      'name': null,
+      'slug': null,
+      'private': false,
+      'isVip': false,
+      'isDeleted': false,
+    },
+  },
+];

--- a/projects/client/src/mocks/data/lists/response/OfficialListsResponseMock.ts
+++ b/projects/client/src/mocks/data/lists/response/OfficialListsResponseMock.ts
@@ -1,0 +1,42 @@
+import type { ListResponse } from '$lib/api.ts';
+
+export const OfficialListsResponseMock: ListResponse[] = [
+  {
+    'name': 'Official list',
+    'description': 'This is super official',
+    'privacy': 'public',
+    'share_link': 'https://trakt.tv/lists/1234',
+    'type': 'official',
+    'display_numbers': false,
+    'allow_comments': true,
+    'sort_by': 'added',
+    'sort_how': 'asc',
+    'created_at': '2018-07-29T10:16:22.000Z',
+    'updated_at': '2025-02-09T21:39:59.000Z',
+    'item_count': 2,
+    'comment_count': 5,
+    'likes': 4161,
+    'ids': {
+      'trakt': 1234,
+      'slug': 'official-list',
+    },
+    'user': {
+      'username': 'Trakt',
+      'private': false,
+      'deleted': false,
+      'name': null,
+      'vip': false,
+      'vip_ep': false,
+      'ids': {
+        'slug': null,
+        'trakt': 0,
+      },
+      'images': {
+        'avatar': {
+          'full':
+            'https://trakt.tv/assets/logos/logomark.circle.gradient-cb51d322e6bc3be6370499c6b61a906f8ef49c42a75e5e6d71aaeab2c6689061.svg',
+        },
+      },
+    },
+  },
+];

--- a/projects/client/src/mocks/handlers/lists.ts
+++ b/projects/client/src/mocks/handlers/lists.ts
@@ -1,0 +1,44 @@
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { ListedMoviesResponseMock } from '$mocks/data/lists/response/ListedMoviesResponseMock.ts';
+import { ListedShowsResponseMock } from '$mocks/data/lists/response/ListedShowsResponseMock.ts';
+import { HereticListsResponseMock } from '$mocks/data/summary/movies/heretic/response/HereticListsResponseMock.ts';
+import { SiloListsResponseMock } from '$mocks/data/summary/shows/silo/response/SiloListsResponseMock.ts';
+import { http, HttpResponse } from 'msw';
+
+export const lists = [
+  http.get(
+    `http://localhost/lists/${
+      assertDefined(SiloListsResponseMock.at(0)).ids.trakt
+    }`,
+    () => {
+      return HttpResponse.json(SiloListsResponseMock[0]);
+    },
+  ),
+  http.get(
+    `http://localhost/lists/${
+      assertDefined(SiloListsResponseMock.at(0)).ids.trakt
+    }/items/movie,show*`,
+    () => {
+      return HttpResponse.json([
+        ...ListedShowsResponseMock,
+        ...ListedMoviesResponseMock,
+      ]);
+    },
+  ),
+  http.get(
+    `http://localhost/lists/${
+      assertDefined(SiloListsResponseMock.at(0)).ids.trakt
+    }/items/show*`,
+    () => {
+      return HttpResponse.json(ListedShowsResponseMock);
+    },
+  ),
+  http.get(
+    `http://localhost/lists/${
+      assertDefined(HereticListsResponseMock.at(0)).ids.trakt
+    }/items/movie*`,
+    () => {
+      return HttpResponse.json(ListedMoviesResponseMock);
+    },
+  ),
+];

--- a/projects/client/src/mocks/handlers/movies.ts
+++ b/projects/client/src/mocks/handlers/movies.ts
@@ -89,7 +89,7 @@ export const movies = [
     },
   ),
   http.get(
-    `http://localhost/movies/${MovieHereticResponseMock.ids.slug}/lists/all/popular*`,
+    `http://localhost/movies/${MovieHereticResponseMock.ids.slug}/lists/personal/popular*`,
     () => {
       return HttpResponse.json(HereticListsResponseMock);
     },

--- a/projects/client/src/mocks/handlers/movies.ts
+++ b/projects/client/src/mocks/handlers/movies.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw';
 
+import { OfficialListsResponseMock } from '$mocks/data/lists/response/OfficialListsResponseMock.ts';
 import { MovieHereticCommentsResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticCommentsResponseMock.ts';
 import { MoviesAnticipatedResponseMock } from '../data/movies/response/MoviesAnticipatedResponseMock.ts';
 import { MoviesPopularResponseMock } from '../data/movies/response/MoviesPopularResponseMock.ts';
@@ -92,6 +93,12 @@ export const movies = [
     `http://localhost/movies/${MovieHereticResponseMock.ids.slug}/lists/personal/popular*`,
     () => {
       return HttpResponse.json(HereticListsResponseMock);
+    },
+  ),
+  http.get(
+    `http://localhost/movies/${MovieHereticResponseMock.ids.slug}/lists/official/popular*`,
+    () => {
+      return HttpResponse.json(OfficialListsResponseMock);
     },
   ),
   http.get(

--- a/projects/client/src/mocks/handlers/shows.ts
+++ b/projects/client/src/mocks/handlers/shows.ts
@@ -156,7 +156,7 @@ export const shows = [
     },
   ),
   http.get(
-    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/lists/all/popular*`,
+    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/lists/personal/popular*`,
     () => {
       return HttpResponse.json(SiloListsResponseMock);
     },

--- a/projects/client/src/mocks/handlers/shows.ts
+++ b/projects/client/src/mocks/handlers/shows.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { OfficialListsResponseMock } from '$mocks/data/lists/response/OfficialListsResponseMock.ts';
 import { EpisodeSiloCommentsResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloCommentsResponseMock.ts';
 import { ShowSiloCommentsResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloCommentsResponseMock.ts';
 import { ShowsAnticipatedResponseMock } from '../data/shows/response/ShowsAnticipatedResponseMock.ts';
@@ -159,6 +160,12 @@ export const shows = [
     `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/lists/personal/popular*`,
     () => {
       return HttpResponse.json(SiloListsResponseMock);
+    },
+  ),
+  http.get(
+    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/lists/official/popular*`,
+    () => {
+      return HttpResponse.json(OfficialListsResponseMock);
     },
   ),
   http.get(

--- a/projects/client/src/mocks/server.ts
+++ b/projects/client/src/mocks/server.ts
@@ -2,6 +2,7 @@ import { setupServer } from 'msw/node';
 import { auth } from './handlers/auth.ts';
 import { calendars } from './handlers/calendars.ts';
 import { episodes } from './handlers/episodes.ts';
+import { lists } from './handlers/lists.ts';
 import { movies } from './handlers/movies.ts';
 import { people } from './handlers/people.ts';
 import { recommendations } from './handlers/recommendations.ts';
@@ -23,6 +24,7 @@ const handlers = [
   ...recommendations,
   ...calendars,
   ...search,
+  ...lists,
 ];
 
 export const server = setupServer(...handlers);

--- a/projects/client/src/routes/lists/official/[id]/+page.svelte
+++ b/projects/client/src/routes/lists/official/[id]/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import OfficialList from "$lib/sections/lists/official/OfficialList.svelte";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { mapToMediaType } from "../../../users/[user]/lists/[list]/_internal/mapToMediaType";
+  import { useListSummary } from "./useListSummary";
+
+  const type = $derived(mapToMediaType(page.url.searchParams));
+
+  const { list } = useListSummary({
+    listId: page.params.id,
+  });
+
+  const listName = $derived($list?.name ?? "");
+</script>
+
+<TraktPage audience="all" image={DEFAULT_SHARE_COVER} title={listName}>
+  <TraktPageCoverSetter />
+
+  <OfficialList title={listName} listId={page.params.id} {type} />
+</TraktPage>

--- a/projects/client/src/routes/lists/official/[id]/useListSummary.ts
+++ b/projects/client/src/routes/lists/official/[id]/useListSummary.ts
@@ -1,15 +1,14 @@
 import { useQuery } from '$lib/features/query/useQuery.ts';
 
+import { listSummaryQuery } from '$lib/requests/queries/lists/listSummaryQuery.ts';
 import { derived } from 'svelte/store';
-import { userListSummaryQuery } from '../../../../../lib/requests/queries/users/userListSummaryQuery.ts';
 
 type UseListSummaryProps = {
-  userId: string;
   listId: string;
 };
 
 export function useListSummary(props: UseListSummaryProps) {
-  const query = useQuery(userListSummaryQuery(props));
+  const query = useQuery(listSummaryQuery(props));
 
   return {
     list: derived(query, ($query) => $query.data),

--- a/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
@@ -5,9 +5,9 @@
   import UserList from "$lib/sections/lists/user/UserList.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
   import { mapToMediaType } from "./_internal/mapToMediaType";
-  import { useListSummary } from "./useListSummary";
+  import { userListSummary } from "./userListSummary.ts";
 
-  const { list } = useListSummary({
+  const { list } = userListSummary({
     userId: page.params.user,
     listId: page.params.list,
   });

--- a/projects/client/src/routes/users/[user]/lists/[list]/userListSummary.ts
+++ b/projects/client/src/routes/users/[user]/lists/[list]/userListSummary.ts
@@ -1,14 +1,14 @@
 import { useQuery } from '$lib/features/query/useQuery.ts';
 
+import { userListSummaryQuery } from '$lib/requests/queries/users/userListSummaryQuery.ts';
 import { derived } from 'svelte/store';
-import { userListSummaryQuery } from '../../../../../lib/requests/queries/users/userListSummaryQuery.ts';
 
-type UseListSummaryProps = {
+type UseUserListSummaryProps = {
   userId: string;
   listId: string;
 };
 
-export function useListSummary(props: UseListSummaryProps) {
+export function userListSummary(props: UseUserListSummaryProps) {
   const query = useQuery(userListSummaryQuery(props));
 
   return {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds official lists to summary pages, will append with popular personal lists.
- On mobile it will show the list contents of the top list.
- Will get follow-ups:
  - Create a separate model for the Trakt user.
  - DrillableMediaList will need some changes so we can use Drillable/Drilled lists for all lists.

## 👀 Examples 👀
<img width="1289" alt="Screenshot 2025-02-20 at 21 02 57" src="https://github.com/user-attachments/assets/f4a292c3-5a73-4c60-9dac-d88d8ea0f2e0" />

<img width="405" alt="Screenshot 2025-02-20 at 21 03 25" src="https://github.com/user-attachments/assets/596c4789-2f63-4763-925e-abece08ca003" />

<img width="1289" alt="Screenshot 2025-02-20 at 21 03 11" src="https://github.com/user-attachments/assets/af798ad7-e226-4605-b5fc-0baf2331ad07" />
