### PR TITLE
Feat/personal preview

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToMediaListSummary.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaListSummary.ts
@@ -11,5 +11,6 @@ export function mapToMediaListSummary(
     name: listResponse.name,
     description: listResponse.description,
     user: mapToUserProfile(listResponse.user),
+    count: listResponse.item_count,
   };
 }

--- a/projects/client/src/lib/requests/models/MediaListSummary.ts
+++ b/projects/client/src/lib/requests/models/MediaListSummary.ts
@@ -7,6 +7,7 @@ export const MediaListSummarySchema = z.object({
   name: z.string(),
   description: z.string(),
   user: UserProfileSchema,
+  count: z.number(),
 });
 
 export type MediaListSummary = z.infer<typeof MediaListSummarySchema>;

--- a/projects/client/src/lib/sections/lists/components/list-summary/ListPreview.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/ListPreview.svelte
@@ -9,7 +9,7 @@
   import ViewAllButton from "../ViewAllButton.svelte";
   import { getListUrl } from "./_internal/getListUrl";
 
-  const { list, type }: { list: MediaListSummary; type: MediaType } = $props();
+  const { list, type }: { list: MediaListSummary; type?: MediaType } = $props();
 
   const { items, isLoading } = useListItems({ list, type });
   const isEmptyList = $derived(!$isLoading && $items.length === 0);
@@ -30,6 +30,6 @@
     />
   {/snippet}
   {#snippet item(media)}
-    <MediaCard {type} media={media.entry} />
+    <MediaCard type={media.entry.type} media={media.entry} />
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
@@ -7,9 +7,10 @@
   import { getListUrl } from "./getListUrl.ts";
   import { useListItems } from "./useListItems.ts";
 
+  const POSTER_LIMIT = 8;
   const { list, type }: { list: MediaListSummary; type?: MediaType } = $props();
 
-  const { items } = useListItems({ list, type });
+  const { items } = useListItems({ list, type, limit: POSTER_LIMIT });
 </script>
 
 {#if $items}

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/useListItems.ts
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/useListItems.ts
@@ -6,19 +6,20 @@ import { userListItemsQuery } from '$lib/requests/queries/users/userListItemsQue
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { derived } from 'svelte/store';
 
-const PREVIEW_LIMIT = 8;
+const PREVIEW_LIMIT = 25;
 
 type UseListItemsProps = {
   list: MediaListSummary;
+  limit?: number;
   type?: MediaType;
 };
 
 function listToQuery(
-  { list, type }: UseListItemsProps,
+  { list, type, limit }: UseListItemsProps,
 ) {
   const commonParams = {
     type,
-    limit: PREVIEW_LIMIT,
+    limit: limit ?? PREVIEW_LIMIT,
   };
 
   if (list.user.slug) {

--- a/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
+++ b/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
@@ -1,25 +1,39 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import ListPreview from "../components/list-summary/ListPreview.svelte";
   import ListSummaryCard from "../components/list-summary/ListSummaryCard.svelte";
   import type { PersonalListType } from "./models/PersonalListType.ts";
   import { usePersonalListsSummary } from "./usePersonalListsSummary.ts";
 
-  const { type }: { type: PersonalListType } = $props();
+  const {
+    type,
+    variant,
+  }: { type: PersonalListType; variant: "summary" | "preview" } = $props();
 
   const { lists, isLoading } = usePersonalListsSummary({ type });
 </script>
 
 <!-- TODO unhide when lists are actionable -->
 {#if !$isLoading && $lists.length > 0}
-  <SectionList
-    id={`personal-lists-${type}-list`}
-    items={$lists}
-    title={type === "personal" ? m.personal_lists() : m.collaborations()}
-    --height-list="var(--height-lists-list)"
-  >
-    {#snippet item(list)}
-      <ListSummaryCard {list} />
-    {/snippet}
-  </SectionList>
+  {#if variant === "preview"}
+    {#each $lists as list}
+      {#if list.count > 0}
+        <ListPreview {list} />
+      {/if}
+    {/each}
+  {/if}
+
+  {#if variant === "summary"}
+    <SectionList
+      id={`personal-lists-${type}-list`}
+      items={$lists}
+      title={type === "personal" ? m.personal_lists() : m.collaborations()}
+      --height-list="var(--height-lists-list)"
+    >
+      {#snippet item(list)}
+        <ListSummaryCard {list} />
+      {/snippet}
+    </SectionList>
+  {/if}
 {/if}

--- a/projects/client/src/lib/sections/profile/Profile.svelte
+++ b/projects/client/src/lib/sections/profile/Profile.svelte
@@ -33,5 +33,5 @@
   title={m.recently_watched()}
 />
 
-<PersonalLists type="personal" />
-<PersonalLists type="collaboration" />
+<PersonalLists type="personal" variant="preview" />
+<PersonalLists type="collaboration" variant="summary" />

--- a/projects/client/src/mocks/data/lists/mapped/OfficialListsMappedMock.ts
+++ b/projects/client/src/mocks/data/lists/mapped/OfficialListsMappedMock.ts
@@ -6,6 +6,7 @@ export const OfficialListsMappedMock: MediaListSummary[] = [
     'id': 1234,
     'name': 'Official list',
     'slug': 'official-list',
+    'count': 2,
     'user': {
       'username': 'Trakt',
       'avatar': {

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/HereticListsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/HereticListsMappedMock.ts
@@ -8,5 +8,6 @@ export const HereticListsMappedMock: MediaListSummary[] = [
     'name': 'Heretics only',
     'slug': 'heretics-only',
     'user': UserProfileHarryMappedMock,
+    'count': 1,
   },
 ];

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/SiloListsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/SiloListsMappedMock.ts
@@ -8,5 +8,6 @@ export const SiloListsMappedMock: MediaListSummary[] = [
     'name': 'Silos',
     'slug': 'silos',
     'user': UserProfileHarryMappedMock,
+    'count': 1,
   },
 ];

--- a/projects/client/src/mocks/data/users/mapped/CollaborationListsMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/CollaborationListsMappedMock.ts
@@ -8,5 +8,6 @@ export const CollaborationListsMappedMock: MediaListSummary[] = [
     'name': 'Our collaborative list',
     'slug': 'our-list',
     'user': UserProfileHarryMappedMock,
+    'count': 1,
   },
 ];

--- a/projects/client/src/mocks/data/users/mapped/PersonalListsMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/PersonalListsMappedMock.ts
@@ -8,5 +8,6 @@ export const PersonalListsMappedMock: MediaListSummary[] = [
     'name': 'My personal list',
     'slug': 'my-personal-list',
     'user': UserProfileHarryMappedMock,
+    'count': 1,
   },
 ];


### PR DESCRIPTION
## 🎶 Notes 🎶

- On the profile page, personal lists are shown as a preview instead of a summary.
- Collaboration lists are kept as a summary for now; will need a different approach to mark them appropriately.

## 👀 Example 👀
<img width="1294" alt="Screenshot 2025-02-21 at 08 35 48" src="https://github.com/user-attachments/assets/eac78451-a54d-4c92-9777-3dbaa8f28736" />
