### PR TITLE
fix(safari): navigation retriggering randomly

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -65,6 +65,7 @@ module.exports = {
         'rating',
         'readme',
         'recommended',
+        'safari',
         'search',
         'show',
         'social',

--- a/projects/client/src/lib/components/dropdown/DropdownItem.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { mobileAppleDeviceTriggerHack } from "$lib/utils/actions/mobileAppleDeviceTriggerHack";
   import { triggerWithKeyboard } from "$lib/utils/actions/triggerWithKeyboard";
   import type { Snippet } from "svelte";
   import Link from "../link/Link.svelte";
@@ -38,7 +37,6 @@
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <li
   use:triggerWithKeyboard
-  use:mobileAppleDeviceTriggerHack
   tabindex={tabIndex}
   data-color={color}
   data-style={style}

--- a/projects/client/src/lib/components/link/Link.svelte
+++ b/projects/client/src/lib/components/link/Link.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { useActiveLink } from "$lib/stores/useActiveLink";
-  import { mobileAppleDeviceTriggerHack } from "$lib/utils/actions/mobileAppleDeviceTriggerHack";
   import { triggerWithKeyboard } from "$lib/utils/actions/triggerWithKeyboard";
 
   const {
@@ -9,7 +8,6 @@
     target,
     color = "default",
     focusable = true,
-    retrigger = true,
     noscroll,
     ...props
   }: ChildrenProps &
@@ -17,7 +15,6 @@
     HTMLElementProps & {
       color?: "default" | "classic" | "inherit";
       focusable?: boolean;
-      retrigger?: boolean;
     } = $props();
 
   const { isActive } = $derived(useActiveLink(href));
@@ -27,7 +24,6 @@
   <a
     {href}
     {target}
-    use:mobileAppleDeviceTriggerHack={retrigger}
     use:triggerWithKeyboard
     data-sveltekit-keepfocus
     data-sveltekit-noscroll={noscroll}

--- a/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
+++ b/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
@@ -62,7 +62,7 @@
   {#if $results.length > 0}
     <div class="trakt-search-results" use:clearOnClick>
       {#each $results as result}
-        <MediaSummaryItem media={result} retrigger={false} type={result.type} />
+        <MediaSummaryItem media={result} type={result.type} />
       {/each}
     </div>
   {/if}

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummaryItem.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummaryItem.svelte
@@ -19,24 +19,18 @@
     media,
     tags,
     badges,
-    retrigger = true,
     ...rest
   }: {
     tags?: Snippet<[MediaInput["media"]]>;
     action?: Snippet;
     badges?: Snippet;
-    retrigger?: boolean;
   } & MediaItemVariant<MediaInput["media"]> = $props();
 
   const variant = $derived(rest.variant ?? "poster");
   const MAX_GENRE_COUNT = $derived(variant === "poster" ? 2 : 1);
 </script>
 
-<Link
-  href={UrlBuilder.media(media.type, media.slug)}
-  {retrigger}
-  color="inherit"
->
+<Link href={UrlBuilder.media(media.type, media.slug)} color="inherit">
   <div class="trakt-summary-item" data-variant={variant}>
     <div class="trakt-summary-item-image">
       {#if badges}

--- a/projects/client/src/lib/utils/actions/mobileAppleDeviceTriggerHack.spec.ts
+++ b/projects/client/src/lib/utils/actions/mobileAppleDeviceTriggerHack.spec.ts
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mobileAppleDeviceTriggerHack } from './mobileAppleDeviceTriggerHack.ts';
 
@@ -6,11 +7,11 @@ describe('mobileAppleDeviceTriggerHack', () => {
     vi.resetAllMocks();
   });
 
-  it('should trigger click for mobile apple touch events', () => {
+  it('should trigger click for mobile apple touch events', async () => {
     const platformSpy = vi.spyOn(globalThis.navigator, 'platform', 'get');
     platformSpy.mockReturnValue('iPhone');
 
-    const node = document.createElement('button');
+    const node = document.createElement('a');
     let clickCount = 0;
     node.addEventListener('click', () => clickCount++);
 
@@ -23,16 +24,16 @@ describe('mobileAppleDeviceTriggerHack', () => {
 
     node.dispatchEvent(touchEvent);
 
-    expect(clickCount).toBe(1);
+    await waitFor(() => expect(clickCount).toBe(1));
 
     action.destroy();
   });
 
-  it('should not trigger click for mobile apple devices using a mouse', () => {
+  it('should not trigger click for mobile apple devices using a mouse', async () => {
     const platformSpy = vi.spyOn(globalThis.navigator, 'platform', 'get');
     platformSpy.mockReturnValue('iPhone');
 
-    const node = document.createElement('button');
+    const node = document.createElement('a');
     let clickCount = 0;
     node.addEventListener('click', () => clickCount++);
 
@@ -45,13 +46,13 @@ describe('mobileAppleDeviceTriggerHack', () => {
 
     node.dispatchEvent(touchEvent);
 
-    expect(clickCount).toBe(0);
+    await waitFor(() => expect(clickCount).toBe(0));
 
     action.destroy();
   });
 
-  it('should NOT trigger click for other devices', () => {
-    const node = document.createElement('button');
+  it('should NOT trigger click for other devices', async () => {
+    const node = document.createElement('a');
     let clickCount = 0;
     node.addEventListener('click', () => clickCount++);
 
@@ -64,13 +65,13 @@ describe('mobileAppleDeviceTriggerHack', () => {
 
     node.dispatchEvent(mouseEvent);
 
-    expect(clickCount).toBe(0);
+    await waitFor(() => expect(clickCount).toBe(0));
 
     action.destroy();
   });
 
-  it('should cleanup listeners on destroy', () => {
-    const node = document.createElement('button');
+  it('should cleanup listeners on destroy', async () => {
+    const node = document.createElement('a');
     let clickCount = 0;
 
     const action = mobileAppleDeviceTriggerHack(node);
@@ -85,11 +86,11 @@ describe('mobileAppleDeviceTriggerHack', () => {
 
     node.dispatchEvent(touchEvent);
 
-    expect(clickCount).toBe(0);
+    await waitFor(() => expect(clickCount).toBe(0));
   });
 
-  it('should NOT trigger click for non-HTMLElement targets', () => {
-    const node = document.createElement('button');
+  it('should NOT trigger click for non-HTMLElement targets', async () => {
+    const node = document.createElement('a');
     let clickCount = 0;
     node.addEventListener('click', () => clickCount++);
 
@@ -103,7 +104,7 @@ describe('mobileAppleDeviceTriggerHack', () => {
 
     node.dispatchEvent(touchEvent);
 
-    expect(clickCount).toBe(0);
+    await waitFor(() => expect(clickCount).toBe(0));
 
     action.destroy();
   });


### PR DESCRIPTION
## Code Cleanup and Mobile Safari Handling

This pull request streamlines the codebase and improves the handling of mobile Apple devices, particularly addressing issues related to Safari.

### Codebase Simplification:

* **`retrigger` Property Removal**: The `retrigger` property has been removed from several components, including `DropdownItem.svelte`, `Link.svelte`, `SearchInput.svelte`, and `MediaSummaryItem.svelte`. This removal simplifies the code and reduces unnecessary complexity.

### Mobile Apple Device Handling:

* **`mobileAppleDeviceTriggerHack` Update**: The `mobileAppleDeviceTriggerHack` function has been updated to specifically target `HTMLAnchorElement` instead of the more general `HTMLElement`. This change improves the precision of the function and ensures that it only affects anchor elements. Additionally, a navigation check using `beforeNavigate` has been added to ensure that touch events are handled correctly, addressing issues that specifically arise on mobile Safari browsers.

### Configuration Updates:

* **`commitlint.config.js` Update**: A new entry, `safari`, has been added to the `commitlint.config.js` file to include it in the list of valid scopes. This addition improves the organization of commit messages and allows for better tracking of changes related to Safari.

(This update, like a detective meticulously refining their investigative techniques, removes unnecessary elements and improves the precision of the Trakt Lite codebase. The removal of the `retrigger` property streamlines the code, while the targeted update to the `mobileAppleDeviceTriggerHack` function ensures that touch events are handled correctly on mobile Safari browsers. The addition of 'safari' to the commitlint configuration further improves the organization and tracking of code changes. It's a collection of refinements that contribute to a cleaner, more robust, and user-friendly application, especially for those unfortunate souls forced to use Safari.)