### PR TITLE
fix(search): search width in non floating navbar

### DIFF
--- a/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
+++ b/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
@@ -82,6 +82,11 @@
 
   :global(.trakt-navbar-scroll) {
     .trakt-search {
+      --mobile-search-focus-width: calc(
+        100dvw - var(--layout-distance-side) * 2 - var(--navbar-side-padding) *
+          2
+      );
+
       .trakt-search-input {
         background: color-mix(in srgb, var(--shade-940) 90%, transparent 10%);
       }
@@ -90,9 +95,7 @@
 
   .trakt-search {
     --search-input-width: clamp(var(--ni-80), 100%, var(--ni-320));
-    --mobile-search-focus-width: calc(
-      100dvw - var(--layout-distance-side) * 2 - var(--navbar-side-padding) * 2
-    );
+    --mobile-search-focus-width: calc(100dvw - var(--layout-distance-side) * 2);
     --search-icon-size: var(--ni-24);
 
     display: flex;


### PR DESCRIPTION
## 👀 Example 👀
Before:
<img width="419" alt="Screenshot 2025-02-22 at 13 27 36" src="https://github.com/user-attachments/assets/b064200d-8978-4e5a-9cd9-824035754dda" />

After:
<img width="419" alt="Screenshot 2025-02-22 at 13 27 45" src="https://github.com/user-attachments/assets/a3b9f805-c5b5-492c-9228-a77d3f7511e0" />
