### PR TITLE
fix(list): ellipse list headers

### DIFF
--- a/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
@@ -72,6 +72,7 @@
       display: flex;
       align-items: center;
       gap: var(--gap-s);
+      min-width: 0;
 
       :global(.trakt-preview-badge) {
         // To visually align the badge with the title


### PR DESCRIPTION
## 👀 Example 👀
Before:
<img width="454" alt="Screenshot 2025-02-22 at 13 31 13" src="https://github.com/user-attachments/assets/c7e60a43-a46a-432f-8bca-98bb4aeb717c" />

After:
<img width="454" alt="Screenshot 2025-02-22 at 13 30 58" src="https://github.com/user-attachments/assets/e4a57976-74cc-468b-9929-2b555960dc80" />
