### PR TITLE
fix(summary): responsiveness of episode summary actions

### DIFF
--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -43,7 +43,7 @@
   const showTitle = $derived(showIntl.title ?? show.title);
 </script>
 
-{#snippet mediaActions()}
+{#snippet mediaActions(size: "small" | "normal" = "normal")}
   <MarkAsWatchedAction
     style="normal"
     {type}
@@ -51,6 +51,7 @@
     media={episode}
     {episode}
     {show}
+    {size}
   />
 {/snippet}
 
@@ -112,10 +113,16 @@
 
   <RenderFor audience="authenticated">
     <SummaryActions>
-      <RateNow type="episode" media={episode} {episode} {show} />
+      {#snippet contextualActions()}
+        <RateNow type="episode" media={episode} {episode} {show} />
+      {/snippet}
 
-      <RenderFor device={["mobile", "tablet-sm"]} audience="authenticated">
+      <RenderFor device={["tablet-sm"]} audience="authenticated">
         {@render mediaActions()}
+      </RenderFor>
+
+      <RenderFor device={["mobile"]} audience="authenticated">
+        {@render mediaActions("small")}
       </RenderFor>
     </SummaryActions>
   </RenderFor>

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryActions.svelte
@@ -10,8 +10,9 @@
 </script>
 
 <div class="trakt-summary-actions">
-  {@render children()}
-
+  <div class="trakt-summary-main-actions">
+    {@render children()}
+  </div>
   {#if contextualActions}
     <div class="trakt-summary-contextual-actions">
       {@render contextualActions()}
@@ -24,27 +25,28 @@
 
   .trakt-summary-actions {
     display: flex;
-    gap: var(--gap-m);
-    justify-content: flex-end;
-    flex-wrap: wrap;
+    flex-direction: column;
 
-    @include for-tablet-sm {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-
-      gap: var(--gap-xs);
-    }
-
-    @include for-mobile {
+    @include for-tablet-sm-and-below {
       gap: var(--gap-xs);
     }
   }
 
-  .trakt-summary-contextual-actions {
-    justify-self: end;
+  .trakt-summary-main-actions {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: var(--gap-xs);
 
     @include for-tablet-sm {
-      grid-column: span 2;
+      :global(.trakt-button) {
+        flex-basis: calc(50% - var(--gap-xs) / 2);
+      }
     }
+  }
+
+  .trakt-summary-contextual-actions {
+    display: flex;
+    justify-content: flex-end;
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- The episode summary actions now match the media summary actions.
- Ideally we do a follow up on this. The `SummaryActions` component makes assumptions it shouldn't make:
  - Either on consumer side the actions are already placed in their own container and sized properly.
  - Or we omit the design where on large tablets the `watchlist` and `mark as watched` buttons are sized 50/50.

## 👀 Examples 👀
Before:
<img width="733" alt="Screenshot 2025-02-23 at 21 50 46" src="https://github.com/user-attachments/assets/270e47c7-7b05-4be9-91f3-74ec944e3d5f" />

<img width="371" alt="Screenshot 2025-02-23 at 21 50 55" src="https://github.com/user-attachments/assets/6c1fa143-5ed6-4634-b786-3e8b8c317f79" />

After:
<img width="713" alt="Screenshot 2025-02-23 at 21 57 40" src="https://github.com/user-attachments/assets/3ba2fa14-072d-45be-8a6d-6fdad428aced" />

<img width="369" alt="Screenshot 2025-02-23 at 21 50 25" src="https://github.com/user-attachments/assets/cc6dd25c-b180-44bd-a793-2dff2d65ee5c" />

