### PR TITLE
feat(popup): increase tappable area for touch input

### DIFF
--- a/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
+++ b/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
@@ -63,6 +63,7 @@
 
   .trakt-popup-menu-button {
     all: unset;
+    position: relative;
 
     @include popup-button-style();
 
@@ -72,6 +73,19 @@
 
       :global(svg circle) {
         filter: none;
+      }
+    }
+    @include for-touch {
+      &::after {
+        position: absolute;
+        content: "";
+        width: 175%;
+        height: 175%;
+        border-radius: 50%;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        z-index: -1;
       }
     }
   }


### PR DESCRIPTION
## Popup Menu Styling Enhancements

This pull request refines the styling of the `PopupMenu` component to improve positioning and enhance the touch experience.

### Styling Improvements:

* **Relative Positioning**: The `.trakt-popup-menu-button` class now includes `position: relative`. This ensures that any child elements within the button are positioned correctly relative to the button itself, preventing unexpected overlaps or misalignments.
* **Touch Target Enhancement**: A new `for-touch` style has been added to the component. This style introduces a pseudo-element that increases the touch target area for the popup menu button, making it easier to interact with on touch devices. The pseudo-element is absolutely positioned, centered using CSS transforms, and scaled to 175% of the original element's size, providing a larger and more comfortable touch target.

(This update, like a detective meticulously adjusting their tools for optimal use, refines the `PopupMenu` component for improved usability and accessibility. The relative positioning ensures proper layout and prevents visual glitches, while the touch target enhancement makes the component easier to interact with on touch devices. These subtle but important changes contribute to a more polished and user-friendly experience.)

<img width="416" alt="image" src="https://github.com/user-attachments/assets/b0d97f17-67d8-47ec-95c3-f9215f971cf2" />
