### PR TITLE
Refactor/lists

### DIFF
--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import AnticipatedListItem from "./AnticipatedListItem.svelte";
   import { useAnticipatedList } from "./useAnticipatedList";
@@ -22,7 +21,6 @@
   {title}
   {type}
   useList={useAnticipatedList}
-  urlBuilder={UrlBuilder.anticipated}
 >
   {#snippet item(media)}
     <AnticipatedListItem {type} {media} {style} />

--- a/projects/client/src/lib/sections/lists/components/list-summary/ListPreview.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/ListPreview.svelte
@@ -1,35 +1,28 @@
 <script lang="ts">
-  import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useListItems } from "$lib/sections/lists/components/list-summary/_internal/useListItems.ts";
-  import MediaCard from "$lib/sections/lists/components/MediaCard.svelte";
-  import { mediaListHeightResolver } from "$lib/sections/lists/utils/mediaListHeightResolver.ts";
-  import ViewAllButton from "../ViewAllButton.svelte";
+  import DrillableMediaList from "../../drilldown/DrillableMediaList.svelte";
+  import { mediaListHeightResolver } from "../../utils/mediaListHeightResolver";
+  import MediaCard from "../MediaCard.svelte";
   import { getListUrl } from "./_internal/getListUrl";
 
   const { list, type }: { list: MediaListSummary; type?: MediaType } = $props();
-
-  const { items, isLoading } = $derived(useListItems({ list, type }));
-  const isEmptyList = $derived(!$isLoading && $items.length === 0);
+  $inspect(type);
 </script>
 
-<!-- FIXME switch to drillable list when support is added -->
-<SectionList
+<DrillableMediaList
+  {type}
   id={`top-list-${type}-${list.id}`}
-  items={$items}
+  drilldownLabel={m.view_all()}
+  useList={(params) => useListItems({ list, ...params })}
+  urlBuilder={() => getListUrl(list, type)}
   title={list.name}
   --height-list={mediaListHeightResolver(type)}
 >
-  {#snippet actions()}
-    <ViewAllButton
-      href={getListUrl(list, type)}
-      label={m.view_all()}
-      isDisabled={isEmptyList}
-    />
-  {/snippet}
   {#snippet item(media)}
     <MediaCard type={media.entry.type} media={media.entry} />
   {/snippet}
-</SectionList>
+</DrillableMediaList>

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
@@ -10,7 +10,7 @@
   const POSTER_LIMIT = 8;
   const { list, type }: { list: MediaListSummary; type?: MediaType } = $props();
 
-  const { items } = useListItems({ list, type, limit: POSTER_LIMIT });
+  const { list: items } = useListItems({ list, type, limit: POSTER_LIMIT });
 </script>
 
 {#if $items}

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/useListItems.ts
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/useListItems.ts
@@ -12,13 +12,15 @@ type UseListItemsProps = {
   list: MediaListSummary;
   limit?: number;
   type?: MediaType;
+  page?: number;
 };
 
 function listToQuery(
-  { list, type, limit }: UseListItemsProps,
+  { list, type, limit, page }: UseListItemsProps,
 ) {
   const commonParams = {
     type,
+    page,
     limit: limit ?? PREVIEW_LIMIT,
   };
 
@@ -37,15 +39,19 @@ function listToQuery(
 }
 
 export function useListItems(props: UseListItemsProps) {
-  const items = useQuery(listToQuery(props));
+  const query = useQuery(listToQuery(props));
 
   const isLoading = derived(
-    items,
+    query,
     toLoadingState,
   );
 
   return {
     isLoading,
-    items: derived(items, ($list) => $list.data?.entries ?? []),
+    list: derived(query, ($query) => $query.data?.entries ?? []),
+    page: derived(
+      query,
+      ($query) => $query.data?.page ?? { page: 0, total: 0 },
+    ),
   };
 }

--- a/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
@@ -8,7 +8,7 @@
   import type { DrillListProps } from "./DrillListProps";
   import type { PaginatableStore } from "./PaginatableStore";
 
-  type DrilledMediaListProps = DrillListProps<T, M> & {
+  type DrilledMediaListProps = Omit<DrillListProps<T, M>, "urlBuilder"> & {
     useList: PaginatableStore<T, M>;
     empty?: Snippet;
     badge?: Snippet;

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import { useRecentlyWatchedList } from "../stores/useRecentlyWatchedList";
   import RecentlyWatchedItem from "./RecentlyWatchedItem.svelte";
@@ -23,7 +22,6 @@
       type: "all",
       limit,
     })}
-  urlBuilder={UrlBuilder.history.all}
 >
   {#snippet item(media)}
     <RecentlyWatchedItem {media} {style} />

--- a/projects/client/src/lib/sections/lists/official/OfficialListPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/official/OfficialListPaginatedList.svelte
@@ -1,31 +1,28 @@
 <script lang="ts">
   import Preview from "$lib/components/badge/Preview.svelte";
-  import GridList from "$lib/components/lists/grid-list/GridList.svelte";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import MediaCard from "../components/MediaCard.svelte";
-  import { useUserList } from "./useUserList";
+  import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
+  import { useOfficialList } from "./useOfficialList";
 
-  type UserListProps = {
+  type OfficialListProps = {
     title: string;
-    userId: string;
     listId: string;
     type?: MediaType;
   };
 
-  const { title, userId, listId, type }: UserListProps = $props();
+  const { title, listId, type }: OfficialListProps = $props();
 
-  const { list } = $derived(useUserList({ userId, listId, type }));
   const isMobile = useMedia(WellKnownMediaQuery.mobile);
   const style = $derived($isMobile ? "summary" : "cover");
 </script>
 
-<!-- TODO use drilled media list & fetch rest on scroll -->
-<GridList
-  id={`userlist-list-${userId}-${listId}`}
+<DrilledMediaList
+  id={`official-list-${listId}`}
   {title}
-  items={$list}
-  --width-item="var(--width-poster-card)"
+  {type}
+  useList={(params) => useOfficialList({ listId, ...params })}
 >
   {#snippet item(media)}
     <MediaCard type={media.type} {media} {style} />
@@ -34,4 +31,4 @@
   {#snippet badge()}
     <Preview />
   {/snippet}
-</GridList>
+</DrilledMediaList>

--- a/projects/client/src/lib/sections/lists/popular/PopularPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/popular/PopularPaginatedList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import PopularListItem from "./PopularListItem.svelte";
   import { usePopularList } from "./usePopularList";
@@ -22,7 +21,6 @@
   {title}
   {type}
   useList={usePopularList}
-  urlBuilder={UrlBuilder.popular}
 >
   {#snippet item(media)}
     <PopularListItem {type} {media} {style} />

--- a/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
@@ -1,7 +1,6 @@
 <script>
   import * as m from "$lib/features/i18n/messages.ts";
 
-  import { useUser } from "$lib/features/auth/stores/useUser";
   import DrilledMediaList from "$lib/sections/lists/drilldown/DrilledMediaList.svelte";
   import EpisodeProgressItem from "$lib/sections/lists/progress/EpisodeProgressItem.svelte";
   import UpNextLabSwitch from "$lib/sections/lists/progress/UpNextLabSwitch.svelte";
@@ -10,13 +9,11 @@
   import { useUpNextList } from "$lib/sections/lists/progress/useUpNextList";
   import { useStablePaginated } from "$lib/sections/lists/stores/useStablePaginated";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
   const { type } = useUpNextExperiment();
 
   const { list: hidden } = $derived(useHiddenShows());
 
-  const { user } = useUser();
   const isMobile = useMedia(WellKnownMediaQuery.mobile);
 
   const style = $derived($isMobile ? "summary" : "cover");
@@ -32,7 +29,6 @@
       useList: (params) => useUpNextList({ type: $type, limit: params.limit }),
       compareFn: (l, r) => l.show.id === r.show.id,
     })}
-  urlBuilder={() => UrlBuilder.progress($user?.slug ?? "")}
   title={m.up_next_title()}
 >
   {#snippet badge()}

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
@@ -2,7 +2,6 @@
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { RECOMMENDED_UPPER_LIMIT } from "$lib/utils/constants";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import RecommendedListItem from "./RecommendedListItem.svelte";
   import { toInMemoryPaginatable } from "./toInMemoryPaginatable";
@@ -31,7 +30,6 @@
   {title}
   {type}
   useList={useInMemoryRecommendedList}
-  urlBuilder={UrlBuilder.recommended}
 >
   {#snippet item(media)}
     <RecommendedListItem {type} {media} {style} />

--- a/projects/client/src/lib/sections/lists/social/SocialActivityPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/social/SocialActivityPaginatedList.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import SocialActivityItem from "./SocialActivityItem.svelte";
   import { useSocialActivityList } from "./useSocialActivityList";
@@ -20,7 +19,6 @@
   {title}
   type="episode"
   useList={useSocialActivityList}
-  urlBuilder={UrlBuilder.recommended}
 >
   {#snippet item(media)}
     <SocialActivityItem activity={media} {style} />

--- a/projects/client/src/lib/sections/lists/trending/TrendingPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingPaginatedList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import TrendingListItem from "./TrendingListItem.svelte";
   import { useTrendingList } from "./useTrendingList";
@@ -22,7 +21,6 @@
   {title}
   {type}
   useList={useTrendingList}
-  urlBuilder={UrlBuilder.trending}
 >
   {#snippet item(media)}
     <TrendingListItem {type} {media} {style} />

--- a/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
@@ -1,30 +1,29 @@
 <script lang="ts">
   import Preview from "$lib/components/badge/Preview.svelte";
-  import GridList from "$lib/components/lists/grid-list/GridList.svelte";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import MediaCard from "../components/MediaCard.svelte";
-  import { useOfficialList } from "./useOfficialList";
+  import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
+  import { useUserList } from "./useUserList";
 
-  type OfficialListProps = {
+  type UserListProps = {
     title: string;
+    userId: string;
     listId: string;
     type?: MediaType;
   };
 
-  const { title, listId, type }: OfficialListProps = $props();
+  const { title, userId, listId, type }: UserListProps = $props();
 
-  const { list } = $derived(useOfficialList({ listId, type }));
   const isMobile = useMedia(WellKnownMediaQuery.mobile);
   const style = $derived($isMobile ? "summary" : "cover");
 </script>
 
-<!-- TODO use drilled media list & fetch rest on scroll -->
-<GridList
-  id={`official-list-${listId}`}
+<DrilledMediaList
+  id={`userlist-list-${userId}-${listId}`}
   {title}
-  items={$list}
-  --width-item="var(--width-poster-card)"
+  {type}
+  useList={(params) => useUserList({ userId, listId, ...params })}
 >
   {#snippet item(media)}
     <MediaCard type={media.type} {media} {style} />
@@ -33,4 +32,4 @@
   {#snippet badge()}
     <Preview />
   {/snippet}
-</GridList>
+</DrilledMediaList>

--- a/projects/client/src/lib/sections/lists/utils/mediaCardWidthResolver.ts
+++ b/projects/client/src/lib/sections/lists/utils/mediaCardWidthResolver.ts
@@ -4,10 +4,9 @@ export function mediaCardWidthResolver<M = MediaType>(
   type: M,
 ) {
   switch (type) {
-    case 'movie':
-    case 'show':
-      return 'var(--width-poster-card)';
     case 'episode':
       return 'var(--width-episode-card)';
+    default:
+      return 'var(--width-poster-card)';
   }
 }

--- a/projects/client/src/lib/sections/lists/utils/mediaListHeightResolver.ts
+++ b/projects/client/src/lib/sections/lists/utils/mediaListHeightResolver.ts
@@ -4,12 +4,11 @@ export function mediaListHeightResolver<M = MediaType>(
   type: M,
 ) {
   switch (type) {
-    case 'movie':
-    case 'show':
-      return 'var(--height-poster-list)';
     case 'episode':
       return 'var(--height-episode-list)';
     case 'person':
       return 'var(--height-person-list)';
+    default:
+      return 'var(--height-poster-list)';
   }
 }

--- a/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import MediaCard from "../components/MediaCard.svelte";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import EmptyWatchlist from "./EmptyWatchlist.svelte";
@@ -20,13 +19,7 @@
   const useList = $derived.by(() => statusToStore(status));
 </script>
 
-<DrilledMediaList
-  id="view-all-watchlist-${type}"
-  {title}
-  {type}
-  {useList}
-  urlBuilder={UrlBuilder.watchlistPage}
->
+<DrilledMediaList id="view-all-watchlist-${type}" {title} {type} {useList}>
   {#snippet item(media)}
     <MediaCard {type} {media} {style} />
   {/snippet}

--- a/projects/client/src/routes/lists/official/[id]/+page.svelte
+++ b/projects/client/src/routes/lists/official/[id]/+page.svelte
@@ -2,7 +2,7 @@
   import { page } from "$app/state";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
-  import OfficialList from "$lib/sections/lists/official/OfficialList.svelte";
+  import OfficialListPaginatedList from "$lib/sections/lists/official/OfficialListPaginatedList.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
   import { mapToMediaType } from "../../../users/[user]/lists/[list]/_internal/mapToMediaType";
   import { useListSummary } from "./useListSummary";
@@ -21,5 +21,5 @@
 <TraktPage audience="all" image={DEFAULT_SHARE_COVER} title={listName}>
   <TraktPageCoverSetter />
 
-  <OfficialList title={listName} listId={page.params.id} {type} />
+  <OfficialListPaginatedList title={listName} listId={page.params.id} {type} />
 </TraktPage>

--- a/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
@@ -2,7 +2,7 @@
   import { page } from "$app/state";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
-  import UserList from "$lib/sections/lists/user/UserList.svelte";
+  import UserListPaginatedList from "$lib/sections/lists/user/UserListPaginatedList.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
   import { mapToMediaType } from "./_internal/mapToMediaType";
   import { userListSummary } from "./userListSummary.ts";
@@ -21,7 +21,7 @@
 <TraktPage audience="all" image={DEFAULT_SHARE_COVER} title={listName}>
   <TraktPageCoverSetter />
 
-  <UserList
+  <UserListPaginatedList
     title={listName}
     userId={page.params.user}
     listId={page.params.list}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Removes unused urlbuilder from drilled media lists.
- Adds defaults to some size resolvers.
- Uses drillable/drilled lists for personal and official lists.
- Note: might get a follow up, I think I can merge the drilled personal and official lists 🤔 