### PR TITLE
fix(rating): ignore vote count if there is no rating

### DIFF
--- a/projects/client/src/lib/components/summary/RatingItem.svelte
+++ b/projects/client/src/lib/components/summary/RatingItem.svelte
@@ -3,16 +3,15 @@
   import Link from "../link/Link.svelte";
 
   type RatingItemProps = {
-    rating: Snippet;
+    rating?: string | number;
     superscript: Snippet;
-    voteCount: number;
     url?: string | Nil;
   } & ChildrenProps;
 
-  const { children, rating, superscript, voteCount, url }: RatingItemProps =
-    $props();
+  const { children, rating, superscript, url }: RatingItemProps = $props();
 
-  const ratingLink = $derived(voteCount > 0 ? url : undefined);
+  const hasValidRating = $derived(rating !== undefined);
+  const ratingLink = $derived(hasValidRating ? url : undefined);
 </script>
 
 <rating>
@@ -21,13 +20,13 @@
       {@render children()}
       <div class="rating-info">
         <p class="large bold">
-          {#if voteCount === 0}
+          {#if !hasValidRating}
             -
           {:else}
-            {@render rating()}
+            {rating}
           {/if}
         </p>
-        {#if voteCount > 0}
+        {#if hasValidRating}
           <p class="small bold uppercase secondary vote-count">
             {@render superscript()}
           </p>

--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -30,33 +30,24 @@
 </script>
 
 <div class="trakt-summary-ratings">
-  <RatingItem voteCount={trakt.votes}>
+  <RatingItem rating={toPercentage(trakt.rating, languageTag())}>
     <RatingIcon style={toVotesBasedRating(trakt.votes)} />
-    {#snippet rating()}
-      {toPercentage(trakt.rating, languageTag())}
-    {/snippet}
     {#snippet superscript()}
       {i18n.voteText(trakt.votes)}
     {/snippet}
   </RatingItem>
 
-  <RatingItem voteCount={imdb.votes} url={imdb.url}>
-    <IMDBIcon style={toVotesBasedRating(imdb.votes)} />
-    {#snippet rating()}
-      {imdb.rating}
-    {/snippet}
+  <RatingItem rating={imdb?.rating} url={imdb?.url}>
+    <IMDBIcon style={toVotesBasedRating(imdb?.votes)} />
     {#snippet superscript()}
-      {i18n.voteText(imdb.votes)}
+      {i18n.voteText(imdb?.votes ?? 0)}
     {/snippet}
   </RatingItem>
 
-  <RatingItem voteCount={rotten.critic} url={rotten.url}>
-    <RottenIcon style={toRottenTomatoRating(rotten.critic)} />
-    {#snippet rating()}
-      {rotten.critic}
-    {/snippet}
+  <RatingItem rating={rotten?.critic} url={rotten?.url}>
+    <RottenIcon style={toRottenTomatoRating(rotten?.critic)} />
     {#snippet superscript()}
-      {toRottenTomatoRating(rotten.critic)}
+      {toRottenTomatoRating(rotten?.critic ?? 0)}
     {/snippet}
   </RatingItem>
 </div>

--- a/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.spec.ts
+++ b/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.spec.ts
@@ -13,10 +13,6 @@ describe('getDisplayableRatings', () => {
       votes: 3,
       distribution: {},
     },
-    tmdb: {
-      rating: 8,
-      votes: 12,
-    },
     rotten: {
       critic: 90,
       audience: 10,
@@ -24,9 +20,6 @@ describe('getDisplayableRatings', () => {
     imdb: {
       rating: 3,
       votes: 5,
-    },
-    metacritic: {
-      rating: 9,
     },
   };
 

--- a/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.ts
+++ b/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.ts
@@ -11,14 +11,8 @@ export const EMPTY_RATINGS = Object.freeze({
     votes: 0,
     distribution: {},
   },
-  rotten: {
-    critic: 0,
-    audience: 0,
-  },
-  imdb: {
-    rating: 0,
-    votes: 0,
-  },
+  rotten: undefined,
+  imdb: undefined,
 });
 
 export function getDisplayableRatings({

--- a/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.ts
+++ b/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.ts
@@ -11,10 +11,6 @@ export const EMPTY_RATINGS = Object.freeze({
     votes: 0,
     distribution: {},
   },
-  tmdb: {
-    rating: 0,
-    votes: 0,
-  },
   rotten: {
     critic: 0,
     audience: 0,
@@ -22,9 +18,6 @@ export const EMPTY_RATINGS = Object.freeze({
   imdb: {
     rating: 0,
     votes: 0,
-  },
-  metacritic: {
-    rating: 0,
   },
 });
 

--- a/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
@@ -19,11 +19,6 @@ export function mapToMediaRating(
       votes: ratings.trakt.votes,
       distribution: ratings.trakt.distribution,
     },
-    tmdb: {
-      rating: (ratings.tmdb?.rating ?? 0) / 10,
-      votes: ratings.tmdb?.votes ?? 0,
-      url: forceHttps(ratings.tmdb?.link),
-    },
     rotten: {
       critic: ratings.rotten_tomatoes?.rating ?? 0,
       audience: ratings.rotten_tomatoes?.user_rating ?? 0,
@@ -33,10 +28,6 @@ export function mapToMediaRating(
       rating: ratings.imdb?.rating ?? 0,
       votes: ratings.imdb?.votes ?? 0,
       url: forceHttps(ratings.imdb?.link),
-    },
-    metacritic: {
-      rating: ratings.metascore?.rating ?? 0,
-      url: forceHttps(ratings.metascore?.link),
     },
   };
 }

--- a/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
@@ -7,21 +7,39 @@ type RatingResponse = MovieRatingsResponse | ShowRatingsResponse;
 export function mapToMediaRating(
   ratings: RatingResponse,
 ): MediaRating {
+  const mapImdbRating = () => {
+    const { imdb } = ratings;
+    if (!imdb?.rating || !imdb?.votes) {
+      return;
+    }
+
+    return {
+      rating: imdb.rating,
+      votes: imdb.votes,
+      url: prependHttps(imdb.link),
+    };
+  };
+
+  const mapRottenRating = () => {
+    const { rotten_tomatoes: rotten } = ratings;
+    if (!rotten?.rating) {
+      return;
+    }
+
+    return {
+      critic: rotten.rating,
+      audience: rotten.user_rating,
+      url: prependHttps(rotten.link),
+    };
+  };
+
   return {
     trakt: {
       rating: ratings.trakt.rating / 10,
       votes: ratings.trakt.votes,
       distribution: ratings.trakt.distribution,
     },
-    rotten: {
-      critic: ratings.rotten_tomatoes?.rating ?? 0,
-      audience: ratings.rotten_tomatoes?.user_rating ?? 0,
-      url: prependHttps(ratings.rotten_tomatoes?.link),
-    },
-    imdb: {
-      rating: ratings.imdb?.rating ?? 0,
-      votes: ratings.imdb?.votes ?? 0,
-      url: prependHttps(ratings.imdb?.link),
-    },
+    imdb: mapImdbRating(),
+    rotten: mapRottenRating(),
   };
 }

--- a/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
@@ -4,12 +4,6 @@ import type { MediaRating } from '../models/MediaRating.ts';
 
 type RatingResponse = MovieRatingsResponse | ShowRatingsResponse;
 
-// FIXME: remove when server always returns https
-function forceHttps(url: string | Nil): HttpsUrl | Nil {
-  const strippedUrl = url?.replace(/^(http:\/\/)/, '');
-  return prependHttps(strippedUrl);
-}
-
 export function mapToMediaRating(
   ratings: RatingResponse,
 ): MediaRating {
@@ -22,12 +16,12 @@ export function mapToMediaRating(
     rotten: {
       critic: ratings.rotten_tomatoes?.rating ?? 0,
       audience: ratings.rotten_tomatoes?.user_rating ?? 0,
-      url: forceHttps(ratings.rotten_tomatoes?.link),
+      url: prependHttps(ratings.rotten_tomatoes?.link),
     },
     imdb: {
       rating: ratings.imdb?.rating ?? 0,
       votes: ratings.imdb?.votes ?? 0,
-      url: forceHttps(ratings.imdb?.link),
+      url: prependHttps(ratings.imdb?.link),
     },
   };
 }

--- a/projects/client/src/lib/requests/models/MediaRating.ts
+++ b/projects/client/src/lib/requests/models/MediaRating.ts
@@ -12,14 +12,14 @@ export const MediaRatingSchema = z.object({
   }),
   rotten: z.object({
     critic: z.number(),
-    audience: z.number(),
+    audience: z.number().nullable(),
     url: HttpsUrlSchema.nullish(),
-  }),
+  }).optional(),
   imdb: z.object({
     rating: z.number(),
     votes: z.number(),
     url: HttpsUrlSchema.nullish(),
-  }),
+  }).optional(),
 });
 
 export type MediaRating = z.infer<typeof MediaRatingSchema>;

--- a/projects/client/src/lib/requests/models/MediaRating.ts
+++ b/projects/client/src/lib/requests/models/MediaRating.ts
@@ -10,11 +10,6 @@ export const MediaRatingSchema = z.object({
       z.number(),
     ),
   }),
-  tmdb: z.object({
-    rating: z.number(),
-    votes: z.number(),
-    url: HttpsUrlSchema.nullish(),
-  }),
   rotten: z.object({
     critic: z.number(),
     audience: z.number(),
@@ -23,10 +18,6 @@ export const MediaRatingSchema = z.object({
   imdb: z.object({
     rating: z.number(),
     votes: z.number(),
-    url: HttpsUrlSchema.nullish(),
-  }),
-  metacritic: z.object({
-    rating: z.number(),
     url: HttpsUrlSchema.nullish(),
   }),
 });

--- a/projects/client/src/lib/utils/formatting/number/toRottenTomatoRating.spec.ts
+++ b/projects/client/src/lib/utils/formatting/number/toRottenTomatoRating.spec.ts
@@ -6,6 +6,10 @@ describe('toRottenTomatoRating', () => {
     expect(toRottenTomatoRating(0)).toBe('unrated');
   });
 
+  it('should return "unrated" when there is no rating', () => {
+    expect(toRottenTomatoRating()).toBe('unrated');
+  });
+
   it('should return "rotten" when rating is less than 60', () => {
     expect(toRottenTomatoRating(59)).toBe('rotten');
     expect(toRottenTomatoRating(1)).toBe('rotten');

--- a/projects/client/src/lib/utils/formatting/number/toRottenTomatoRating.ts
+++ b/projects/client/src/lib/utils/formatting/number/toRottenTomatoRating.ts
@@ -1,9 +1,9 @@
 export type RottenTomatoRating = 'rotten' | 'fresh' | 'unrated';
 
 export function toRottenTomatoRating(
-  rating: number,
+  rating?: number,
 ): 'rotten' | 'fresh' | 'unrated' {
-  if (rating === 0) {
+  if (!rating) {
     return 'unrated';
   }
 

--- a/projects/client/src/lib/utils/formatting/number/toVotesBasedRating.spec.ts
+++ b/projects/client/src/lib/utils/formatting/number/toVotesBasedRating.spec.ts
@@ -6,6 +6,10 @@ describe('toVotesBasedRating', () => {
     expect(toVotesBasedRating(0)).toBe('unrated');
   });
 
+  it('should return "unrated" when there are no votes', () => {
+    expect(toVotesBasedRating()).toBe('unrated');
+  });
+
   it('should return "rated" when votes is greater than 0', () => {
     expect(toVotesBasedRating(1)).toBe('rated');
     expect(toVotesBasedRating(100)).toBe('rated');

--- a/projects/client/src/lib/utils/formatting/number/toVotesBasedRating.ts
+++ b/projects/client/src/lib/utils/formatting/number/toVotesBasedRating.ts
@@ -1,7 +1,7 @@
 export type VotesBasedRating = 'unrated' | 'rated';
 
-export function toVotesBasedRating(votes: number): VotesBasedRating {
-  if (votes === 0) {
+export function toVotesBasedRating(votes?: number): VotesBasedRating {
+  if (!votes) {
     return 'unrated';
   }
 

--- a/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloRatingsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloRatingsMappedMock.ts
@@ -17,11 +17,6 @@ export const EpisodeSiloRatingsMappedMock: MediaRating = {
       '10': 1130,
     },
   },
-  'tmdb': {
-    'rating': 0.82,
-    'votes': 1181,
-    'url': 'https://www.themoviedb.org/tv/125988/season/1/episode/1',
-  },
   'rotten': {
     'critic': 92,
     'audience': 64,
@@ -31,9 +26,5 @@ export const EpisodeSiloRatingsMappedMock: MediaRating = {
     'rating': 8.1,
     'votes': 144574,
     'url': 'https://www.imdb.com/title/tt14693272',
-  },
-  'metacritic': {
-    'rating': 0,
-    'url': 'https://www.imdb.com/title/tt14693272/criticreviews',
   },
 };

--- a/projects/client/src/mocks/data/summary/episodes/silo/response/EpisodeSiloRatingsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/response/EpisodeSiloRatingsResponseMock.ts
@@ -25,11 +25,11 @@ export const EpisodeSiloRatingsResponseMock: ShowRatingsResponse = {
   'imdb': {
     'rating': 8.1,
     'votes': 144574,
-    'link': 'http://www.imdb.com/title/tt14693272',
+    'link': 'https://www.imdb.com/title/tt14693272',
   },
   'metascore': {
     'rating': null,
-    'link': 'http://www.imdb.com/title/tt14693272/criticreviews',
+    'link': 'https://www.imdb.com/title/tt14693272/criticreviews',
   },
   'rotten_tomatoes': {
     'rating': 92,

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticRatingsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticRatingsMappedMock.ts
@@ -17,11 +17,6 @@ export const MovieHereticRatingsMappedMock: MediaRating = {
       '10': 262,
     },
   },
-  'tmdb': {
-    'rating': 0.714,
-    'votes': 563,
-    'url': 'https://www.themoviedb.org/movie/1138194',
-  },
   'rotten': {
     'critic': 0,
     'audience': 0,
@@ -31,9 +26,5 @@ export const MovieHereticRatingsMappedMock: MediaRating = {
     'rating': 7.1,
     'votes': 49905,
     'url': 'https://www.imdb.com/title/tt28015403',
-  },
-  'metacritic': {
-    'rating': 71,
-    'url': 'https://www.imdb.com/title/tt28015403/criticreviews',
   },
 };

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticRatingsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticRatingsMappedMock.ts
@@ -17,11 +17,7 @@ export const MovieHereticRatingsMappedMock: MediaRating = {
       '10': 262,
     },
   },
-  'rotten': {
-    'critic': 0,
-    'audience': 0,
-    'url': 'https://www.rottentomatoes.com/m/heretic_2023',
-  },
+  'rotten': undefined,
   'imdb': {
     'rating': 7.1,
     'votes': 49905,

--- a/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticRatingsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticRatingsResponseMock.ts
@@ -29,11 +29,11 @@ export const MovieHereticRatingsResponseMock: MovieRatingsResponse = {
   },
   'metascore': {
     'rating': 71,
-    'link': 'http://www.imdb.com/title/tt28015403/criticreviews',
+    'link': 'https://www.imdb.com/title/tt28015403/criticreviews',
   },
   'rotten_tomatoes': {
     'rating': 0,
     'user_rating': 0,
-    'link': 'http://www.rottentomatoes.com/m/heretic_2023',
+    'link': 'https://www.rottentomatoes.com/m/heretic_2023',
   },
 };

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloRatingsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloRatingsMappedMock.ts
@@ -17,11 +17,6 @@ export const ShowSiloRatingsMappedMock: MediaRating = {
       '10': 1130,
     },
   },
-  'tmdb': {
-    'rating': 0.82,
-    'votes': 1181,
-    'url': 'https://www.themoviedb.org/tv/125988',
-  },
   'rotten': {
     'critic': 92,
     'audience': 64,
@@ -31,9 +26,5 @@ export const ShowSiloRatingsMappedMock: MediaRating = {
     'rating': 8.1,
     'votes': 144574,
     'url': 'https://www.imdb.com/title/tt14688458',
-  },
-  'metacritic': {
-    'rating': 0,
-    'url': 'https://www.imdb.com/title/tt14688458/criticreviews',
   },
 };

--- a/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloRatingsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloRatingsResponseMock.ts
@@ -25,15 +25,15 @@ export const ShowSiloRatingsResponseMock: ShowRatingsResponse = {
   'imdb': {
     'rating': 8.1,
     'votes': 144574,
-    'link': 'http://www.imdb.com/title/tt14688458',
+    'link': 'https://www.imdb.com/title/tt14688458',
   },
   'metascore': {
     'rating': null,
-    'link': 'http://www.imdb.com/title/tt14688458/criticreviews',
+    'link': 'https://www.imdb.com/title/tt14688458/criticreviews',
   },
   'rotten_tomatoes': {
     'rating': 92,
     'user_rating': 64,
-    'link': 'http://www.rottentomatoes.com/tv/silo',
+    'link': 'https://www.rottentomatoes.com/tv/silo',
   },
 };


### PR DESCRIPTION
## ♩ Note ♩

- Apparently we can have empty ratings, but still have vote counts.

## 👀 Example 👀
Before:
<img width="1171" alt="Screenshot 2025-02-26 at 21 33 46" src="https://github.com/user-attachments/assets/411c68bc-1e1d-4102-9921-3eec4c755ea0" />

After:
<img width="1171" alt="Screenshot 2025-02-26 at 21 32 37" src="https://github.com/user-attachments/assets/69c76b25-ba56-4baf-851c-bdbf8fd31c03" />
