### PR TITLE
Fix/list scroll pos

### DIFF
--- a/projects/client/src/lib/components/lists/_internal/useScrollHistoryAction.ts
+++ b/projects/client/src/lib/components/lists/_internal/useScrollHistoryAction.ts
@@ -1,27 +1,27 @@
-import { onMount } from 'svelte';
 import { writable } from 'svelte/store';
 import { useScrollHistory } from './useScrollHistory.ts';
 
+type DestroyCallback = () => void;
+
 export function useScrollHistoryAction(
-  id: string,
   type: 'horizontal' | 'vertical' = 'horizontal',
 ) {
   const { readScrollState, writeScrollState, event } = useScrollHistory();
 
-  const scrollPosition = writable(0);
+  function scrollHistory(container: HTMLElement, id: string) {
+    let destroyRestore: DestroyCallback | undefined;
+    let destroySnapshot: DestroyCallback | undefined;
 
-  onMount(() => {
-    return event.on('restore', () => {
-      scrollPosition.set(readScrollState(id));
-    });
-  });
+    const scrollPosition = writable(0);
 
-  function scrollHistory(container: HTMLElement) {
-    const handleSnapshot = () => {
+    const handleRestore = (restoreId: string) =>
+      scrollPosition.set(readScrollState(restoreId));
+
+    const handleSnapshot = (snapshotId: string) => {
       const position = type === 'horizontal'
         ? container.scrollLeft
         : container.scrollTop;
-      writeScrollState(id, position);
+      writeScrollState(snapshotId, position);
     };
 
     const updateScrollPosition = (position: number) => {
@@ -29,10 +29,30 @@ export function useScrollHistoryAction(
       container[scrollProp] = position;
     };
 
-    onMount(() => event.on('snapshot', handleSnapshot));
+    const resetHandlers = (handleId: string) => {
+      destroyRestore?.();
+      destroySnapshot?.();
+
+      destroyRestore = event.on('restore', () => handleRestore(handleId));
+      destroySnapshot = event.on('snapshot', () => handleSnapshot(handleId));
+    };
+
+    resetHandlers(id);
+
+    const ubSubscribeScrollPosition = scrollPosition.subscribe(
+      updateScrollPosition,
+    );
 
     return {
-      destroy: scrollPosition.subscribe(updateScrollPosition),
+      update: (updatedId: string) => {
+        resetHandlers(updatedId);
+      },
+      destroy: () => {
+        destroyRestore?.();
+        destroySnapshot?.();
+
+        ubSubscribeScrollPosition();
+      },
     };
   }
 

--- a/projects/client/src/lib/components/lists/section-list/ListScrollHistoryProvider.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ListScrollHistoryProvider.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { afterNavigate, beforeNavigate } from "$app/navigation";
+  import { debounce } from "$lib/utils/timing/debounce";
+  import { time } from "$lib/utils/timing/time";
   import { useScrollHistory } from "../_internal/useScrollHistory";
 
   const { children }: ChildrenProps = $props();
@@ -17,7 +19,11 @@
     const isHistoryNavigation =
       nav.type === "popstate" && nav.willUnload === false;
 
-    isHistoryNavigation && event.emit("restore", undefined);
+    // FIXME: see if we can do this without the debounce
+    debounce(
+      () => isHistoryNavigation && event.emit("restore", undefined),
+      time.fps(30),
+    )();
   });
 </script>
 

--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -43,7 +43,7 @@
   const isVisible = writable(false);
   const isMounted = writable(false);
 
-  const { scrollHistory } = useScrollHistoryAction(id, "horizontal");
+  const { scrollHistory } = useScrollHistoryAction("horizontal");
 
   onMount(() => {
     isMounted.set(true);
@@ -67,7 +67,7 @@
         <div
           bind:this={$scrollContainer}
           use:scrollTracking={scrollX}
-          use:scrollHistory
+          use:scrollHistory={id}
           class="trakt-list-item-container shadow-list-horizontal-scroll"
         >
           {#each items as i (i.id)}

--- a/projects/client/src/lib/sections/lists/CastList.svelte
+++ b/projects/client/src/lib/sections/lists/CastList.svelte
@@ -7,13 +7,14 @@
   type CastListProps = {
     title: string;
     cast: CastMember[];
+    slug: string;
   };
 
-  const { title, cast }: CastListProps = $props();
+  const { title, cast, slug }: CastListProps = $props();
 </script>
 
 <SectionList
-  id={`cast-list`}
+  id={`cast-list-${slug}`}
   items={cast}
   {title}
   --height-list={mediaListHeightResolver("person")}

--- a/projects/client/src/lib/sections/lists/CreditsList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsList.svelte
@@ -52,7 +52,7 @@
 </script>
 
 <SectionList
-  id={`credits-list-${type}-${$currentPosition}`}
+  id={`credits-list-${person.slug}-${type}-${$currentPosition}`}
   items={list}
   {title}
   --height-list={mediaListHeightResolver(type)}

--- a/projects/client/src/lib/sections/lists/user/UserList.svelte
+++ b/projects/client/src/lib/sections/lists/user/UserList.svelte
@@ -14,7 +14,7 @@
 
 <DrillableMediaList
   {type}
-  id={`top-list-${type}-${list.id}`}
+  id={`user-list-${type}-${list.id}`}
   drilldownLabel={m.view_all()}
   useList={(params) => useListItems({ list, ...params })}
   urlBuilder={() => getListUrl(list, type)}

--- a/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
@@ -27,7 +27,7 @@
 </script>
 
 <DrilledMediaList
-  id={`userlist-list-${listCacheId}`}
+  id={`user-paginated-list-${listCacheId}`}
   {title}
   {type}
   useList={(params) => useListItems({ list, ...params })}

--- a/projects/client/src/lib/sections/lists/watchlist/WatchList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchList.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <DrillableMediaList
-  id="watch-list-{type}"
+  id="watch-list-{type}-{status}"
   {title}
   {drilldownLabel}
   {type}

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -141,7 +141,7 @@
   {/if}
 </SummaryContainer>
 
-<CastList title={m.actors()} cast={crew.cast} />
+<CastList title={m.actors()} cast={crew.cast} slug={show.slug} />
 
 <SeasonList {show} {seasons} />
 

--- a/projects/client/src/lib/sections/summary/MovieSummary.svelte
+++ b/projects/client/src/lib/sections/summary/MovieSummary.svelte
@@ -40,7 +40,7 @@
   type="movie"
 />
 
-<CastList title={m.actors()} cast={crew.cast} />
+<CastList title={m.actors()} cast={crew.cast} slug={media.slug} />
 
 <Comments {media} type="movie" />
 

--- a/projects/client/src/lib/sections/summary/ShowSummary.svelte
+++ b/projects/client/src/lib/sections/summary/ShowSummary.svelte
@@ -61,7 +61,7 @@
   {/snippet}
 </MediaSummary>
 
-<CastList title={m.actors()} cast={crew.cast} />
+<CastList title={m.actors()} cast={crew.cast} slug={media.slug} />
 
 <SeasonList show={media} {seasons} />
 

--- a/projects/client/src/lib/sections/summary/components/comments/Comments.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/Comments.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <SectionList
-  id={`cast-list`}
+  id={`comments-list-${media.slug}`}
   items={topLevelComments}
   title={m.popular_comments()}
   --height-list="var(--height-comments-list)"

--- a/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
+++ b/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
@@ -31,7 +31,7 @@
 
 <RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>
   <SectionList
-    id={`popular-lists-list`}
+    id={`popular-lists-list-${slug}`}
     items={lists}
     title={m.popular_lists()}
     --height-list="var(--height-lists-list)"


### PR DESCRIPTION
## 🎶 Notes 🎶

- Changes some list id's to be more verbose.
- Fixes the scroll history provider and action to always restore all lists on a page using correct id's.
  - Left a FIXME in there; ideally we get rid of the debounce, but would probably need a different approach. Maybe something like: we keep track of restores for a page; if a list on that page is being mounted/updated, it checks if that page had a restore 🤔 

## 👀 Example 👀

https://github.com/user-attachments/assets/c6aeee43-af0f-44b1-9de0-141b6554c26d

