### PR TITLE
refactor / extract pagination query list store and make pagination params mandatory

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -67,6 +67,7 @@ module.exports = {
         'query',
         'rating',
         'readme',
+        'related',
         'recommended',
         'safari',
         'search',

--- a/deno.json
+++ b/deno.json
@@ -37,6 +37,7 @@
     "strictFunctionTypes": true,
     "strictPropertyInitialization": true,
     "strictBindCallApply": true,
-    "strict": true
+    "strict": true,
+    "verbatimModuleSyntax": true
   }
 }

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -70,7 +70,8 @@ const ENTITY_LEVEL = builder.router({
   related: {
     path: '/related',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>()
+      .merge(pageQuerySchema),
     pathParams: idParamsSchema,
     responses: {
       200: movieResponseSchema.array(),

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -175,7 +175,8 @@ const ENTITY_LEVEL = builder.router({
     path: '/related',
     method: 'GET',
     pathParams: idParamsSchema,
-    query: extendedQuerySchemaFactory<['full', 'images']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>()
+      .merge(pageQuerySchema),
     responses: {
       200: showResponseSchema.array(),
     },

--- a/projects/client/src/lib/requests/models/LimitParams.ts
+++ b/projects/client/src/lib/requests/models/LimitParams.ts
@@ -1,0 +1,3 @@
+export type LimitParams = {
+  limit: number;
+};

--- a/projects/client/src/lib/requests/models/PaginationParams.ts
+++ b/projects/client/src/lib/requests/models/PaginationParams.ts
@@ -1,0 +1,5 @@
+import type { LimitParams } from '$lib/requests/models/LimitParams.ts';
+
+export type PaginationParams = {
+  page: number;
+} & LimitParams;

--- a/projects/client/src/lib/requests/queries/lists/listItemsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/lists/listItemsQuery.spec.ts
@@ -8,6 +8,11 @@ import { createQuery } from '@tanstack/svelte-query';
 import { describe, expect, it } from 'vitest';
 import { listItemsQuery } from './listItemsQuery.ts';
 
+const PAGINATION_PARAMS = {
+  limit: 10,
+  page: 1,
+};
+
 describe('listItemsQuery', () => {
   it('should query list items', async () => {
     const result = await runQuery({
@@ -15,6 +20,7 @@ describe('listItemsQuery', () => {
         createQuery(
           listItemsQuery({
             listId: `${assertDefined(SiloListsMappedMock.at(0)).id}`,
+            ...PAGINATION_PARAMS,
           }),
         ),
       mapper: (response) => response?.data?.entries,
@@ -33,6 +39,7 @@ describe('listItemsQuery', () => {
           listItemsQuery({
             listId: `${assertDefined(SiloListsMappedMock.at(0)).id}`,
             type: 'show',
+            ...PAGINATION_PARAMS,
           }),
         ),
       mapper: (response) => response?.data?.entries,
@@ -48,6 +55,7 @@ describe('listItemsQuery', () => {
           listItemsQuery({
             listId: `${assertDefined(HereticListsMappedMock.at(0)).id}`,
             type: 'movie',
+            ...PAGINATION_PARAMS,
           }),
         ),
       mapper: (response) => response?.data?.entries,

--- a/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
@@ -7,18 +7,17 @@ import { ListItemSchemaFactory } from '$lib/requests/models/ListItem.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { MovieEntrySchema } from '$lib/requests/models/MovieEntry.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 
 type ListItemsParams =
   & {
     listId: string;
-    page?: number;
-    limit?: number;
     type?: MediaType | 'movie,show';
   }
+  & PaginationParams
   & ApiParams;
 
 const ListedShowEntrySchema = ShowEntrySchema.merge(
@@ -33,8 +32,8 @@ const userListItemsRequest = (
   {
     fetch,
     listId,
-    limit = DEFAULT_PAGE_SIZE,
-    page = 1,
+    limit,
+    page,
     type = 'movie,show',
   }: ListItemsParams,
 ) =>

--- a/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
@@ -4,7 +4,7 @@ import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
@@ -15,10 +15,7 @@ export const AnticipatedMovieSchema = MovieEntrySchema.extend({
 });
 export type AnticipatedMovie = z.infer<typeof AnticipatedMovieSchema>;
 
-type MovieAnticipatedParams = {
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type MovieAnticipatedParams = PaginationParams & ApiParams;
 
 function mapToAnticipatedMovie({
   list_count,
@@ -31,7 +28,7 @@ function mapToAnticipatedMovie({
 }
 
 const movieAnticipatedRequest = (
-  { fetch, limit = DEFAULT_PAGE_SIZE, page = 1 }: MovieAnticipatedParams,
+  { fetch, limit, page }: MovieAnticipatedParams,
 ) =>
   api({ fetch })
     .movies

--- a/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
@@ -3,18 +3,15 @@ import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
 
-type MoviePopularParams = {
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type MoviePopularParams = PaginationParams & ApiParams;
 
 const moviePopularRequest = (
-  { fetch, limit = DEFAULT_PAGE_SIZE, page = 1 }: MoviePopularParams,
+  { fetch, limit, page }: MoviePopularParams,
 ) =>
   api({ fetch })
     .movies

--- a/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.spec.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
 import { MovieHereticRelatedMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticRelatedMappedMock.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
@@ -5,12 +6,22 @@ import { createQuery } from '@tanstack/svelte-query';
 import { describe, expect, it } from 'vitest';
 import { movieRelatedQuery } from './movieRelatedQuery.ts';
 
+const PAGINATION_PARAMS = {
+  limit: DEFAULT_PAGE_SIZE,
+  page: 1,
+};
+
 describe('movieRelatedQuery', () => {
   it('should query related for Heretic (2024)', async () => {
     const result = await runQuery({
       factory: () =>
-        createQuery(movieRelatedQuery({ slug: MovieHereticMappedMock.slug })),
-      mapper: (response) => response?.data,
+        createQuery(
+          movieRelatedQuery({
+            slug: MovieHereticMappedMock.slug,
+            ...PAGINATION_PARAMS,
+          }),
+        ),
+      mapper: (response) => response?.data?.entries,
     });
 
     expect(result).to.deep.equal(MovieHereticRelatedMappedMock);

--- a/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
@@ -2,19 +2,20 @@ import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
 
-type MovieRelatedParams = {
-  slug: string;
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type MovieRelatedParams =
+  & {
+    slug: string;
+  }
+  & PaginationParams
+  & ApiParams;
 
 const movieRelatedRequest = (
-  { fetch, slug, limit = DEFAULT_PAGE_SIZE, page = 1 }: MovieRelatedParams,
+  { fetch, slug, limit, page }: MovieRelatedParams,
 ) =>
   api({ fetch })
     .movies

--- a/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
@@ -1,22 +1,28 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import { z } from 'zod';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
 
 type MovieRelatedParams = {
   slug: string;
+  page?: number;
+  limit?: number;
 } & ApiParams;
 
 const movieRelatedRequest = (
-  { fetch, slug }: MovieRelatedParams,
+  { fetch, slug, limit = DEFAULT_PAGE_SIZE, page = 1 }: MovieRelatedParams,
 ) =>
   api({ fetch })
     .movies
     .related({
       query: {
         extended: 'full,images',
+        limit,
+        page,
       },
       params: {
         id: slug,
@@ -27,15 +33,18 @@ const movieRelatedRequest = (
         throw new Error('Failed to fetch related movies');
       }
 
-      return response.body;
+      return response;
     });
 
 export const movieRelatedQuery = defineQuery({
   key: 'movieRelated',
   invalidations: [],
-  dependencies: (params) => [params.slug],
+  dependencies: (params) => [params.slug, params.page, params.limit],
   request: movieRelatedRequest,
-  mapper: (response) => response.map(mapToMovieEntry),
-  schema: z.array(MovieEntrySchema),
+  mapper: (response) => ({
+    entries: response.body.map(mapToMovieEntry),
+    page: extractPageMeta(response.headers),
+  }),
+  schema: PaginatableSchemaFactory(MovieEntrySchema),
   ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
@@ -4,7 +4,7 @@ import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
@@ -15,10 +15,7 @@ export const TrendingMovieSchema = MovieEntrySchema.extend({
 });
 export type TrendingMovie = z.infer<typeof TrendingMovieSchema>;
 
-type MovieTrendingParams = {
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type MovieTrendingParams = PaginationParams & ApiParams;
 
 function mapToTrendingMovie({
   watchers,
@@ -31,7 +28,7 @@ function mapToTrendingMovie({
 }
 
 const movieTrendingRequest = (
-  { fetch, limit = DEFAULT_PAGE_SIZE, page = 1 }: MovieTrendingParams,
+  { fetch, limit, page }: MovieTrendingParams,
 ) =>
   api({ fetch })
     .movies

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
@@ -1,7 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { LimitParams } from '$lib/requests/models/LimitParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { z } from 'zod';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
@@ -10,12 +10,10 @@ import { MovieEntrySchema } from '../../models/MovieEntry.ts';
 export const RecommendedMovieSchema = MovieEntrySchema;
 export type RecommendedMovie = z.infer<typeof RecommendedMovieSchema>;
 
-type RecommendedMoviesParams = {
-  limit?: number;
-} & ApiParams;
+type RecommendedMoviesParams = LimitParams & ApiParams;
 
 const recommendedMoviesRequest = (
-  { fetch, limit = DEFAULT_PAGE_SIZE }: RecommendedMoviesParams,
+  { fetch, limit }: RecommendedMoviesParams,
 ) =>
   api({ fetch })
     .recommendations

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
@@ -4,7 +4,7 @@ import { mapToEpisodeCount } from '$lib/requests/_internal/mapToEpisodeCount.ts'
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { LimitParams } from '$lib/requests/models/LimitParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapToShowEntry } from '../../_internal/mapToShowEntry.ts';
@@ -13,12 +13,10 @@ import { MediaEntrySchema } from '../../models/MediaEntry.ts';
 export const RecommendedShowSchema = MediaEntrySchema.merge(EpisodeCountSchema);
 export type RecommendedShow = z.infer<typeof RecommendedShowSchema>;
 
-type RecommendedShowsParams = {
-  limit?: number;
-} & ApiParams;
+type RecommendedShowsParams = LimitParams & ApiParams;
 
 const recommendedShowsRequest = (
-  { fetch, limit = DEFAULT_PAGE_SIZE }: RecommendedShowsParams,
+  { fetch, limit }: RecommendedShowsParams,
 ) =>
   api({ fetch })
     .recommendations

--- a/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
@@ -5,7 +5,7 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapToShowEntry } from '../../_internal/mapToShowEntry.ts';
@@ -18,10 +18,7 @@ export const AnticipatedShowSchema = ShowEntrySchema
   });
 export type AnticipatedShow = z.infer<typeof AnticipatedShowSchema>;
 
-type ShowAnticipatedParams = {
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type ShowAnticipatedParams = PaginationParams & ApiParams;
 
 function mapToAnticipatedShow({
   list_count,
@@ -40,7 +37,7 @@ function mapToAnticipatedShow({
 }
 
 const showAnticipatedRequest = (
-  { fetch, limit = DEFAULT_PAGE_SIZE, page = 1 }: ShowAnticipatedParams,
+  { fetch, limit, page }: ShowAnticipatedParams,
 ) =>
   api({ fetch })
     .shows

--- a/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
@@ -5,7 +5,7 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapToShowEntry } from '../../_internal/mapToShowEntry.ts';
@@ -16,10 +16,7 @@ export const PopularShowSchema = ShowEntrySchema.merge(
 );
 export type PopularShow = z.infer<typeof PopularShowSchema>;
 
-type ShowPopularParams = {
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type ShowPopularParams = PaginationParams & ApiParams;
 
 function mapToPopularShow(show: ShowResponse): PopularShow {
   const { aired_episodes } = show;
@@ -34,7 +31,7 @@ function mapToPopularShow(show: ShowResponse): PopularShow {
 }
 
 const showPopularRequest = (
-  { fetch, limit = DEFAULT_PAGE_SIZE, page = 1 }: ShowPopularParams,
+  { fetch, limit, page }: ShowPopularParams,
 ) =>
   api({ fetch })
     .shows

--- a/projects/client/src/lib/requests/queries/shows/showRelatedQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRelatedQuery.spec.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
 import { ShowSiloRelatedMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloRelatedMappedMock.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
@@ -5,12 +6,22 @@ import { createQuery } from '@tanstack/svelte-query';
 import { describe, expect, it } from 'vitest';
 import { showRelatedQuery } from './showRelatedQuery.ts';
 
+const PAGINATION_PARAMS = {
+  limit: DEFAULT_PAGE_SIZE,
+  page: 1,
+};
+
 describe('showRelatedQuery', () => {
   it('should query related for Silo (2023)', async () => {
     const result = await runQuery({
       factory: () =>
-        createQuery(showRelatedQuery({ slug: ShowSiloMappedMock.slug })),
-      mapper: (response) => response?.data,
+        createQuery(
+          showRelatedQuery({
+            slug: ShowSiloMappedMock.slug,
+            ...PAGINATION_PARAMS,
+          }),
+        ),
+      mapper: (response) => response?.data?.entries,
     });
 
     expect(result).to.deep.equal(ShowSiloRelatedMappedMock);

--- a/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
@@ -1,8 +1,11 @@
 import { type ShowResponse } from '$lib/api.ts';
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { mapToEpisodeCount } from '$lib/requests/_internal/mapToEpisodeCount.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
+import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { z } from 'zod';
 import { mapToShowEntry } from '../../_internal/mapToShowEntry.ts';
@@ -10,6 +13,8 @@ import { ShowEntrySchema } from '../../models/ShowEntry.ts';
 
 type ShowRelatedParams = {
   slug: string;
+  page?: number;
+  limit?: number;
 } & ApiParams;
 
 const RelatedShowSchema = ShowEntrySchema.merge(EpisodeCountSchema);
@@ -22,12 +27,16 @@ function mapToRelatedShow(show: ShowResponse) {
   };
 }
 
-const showRelatedRequest = ({ fetch, slug }: ShowRelatedParams) =>
+const showRelatedRequest = (
+  { fetch, slug, limit = DEFAULT_PAGE_SIZE, page = 1 }: ShowRelatedParams,
+) =>
   api({ fetch })
     .shows
     .related({
       query: {
         extended: 'full,images',
+        limit,
+        page,
       },
       params: {
         id: slug,
@@ -38,15 +47,18 @@ const showRelatedRequest = ({ fetch, slug }: ShowRelatedParams) =>
         throw new Error('Failed to fetch related shows');
       }
 
-      return response.body;
+      return response;
     });
 
 export const showRelatedQuery = defineQuery({
   key: 'showRelated',
   invalidations: [],
-  dependencies: (params) => [params.slug],
+  dependencies: (params) => [params.slug, params.page, params.limit],
   request: showRelatedRequest,
-  mapper: (body) => body.map(mapToRelatedShow),
-  schema: RelatedShowSchema.array(),
+  mapper: (response) => ({
+    entries: response.body.map(mapToRelatedShow),
+    page: extractPageMeta(response.headers),
+  }),
+  schema: PaginatableSchemaFactory(RelatedShowSchema),
   ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
@@ -5,17 +5,18 @@ import { mapToEpisodeCount } from '$lib/requests/_internal/mapToEpisodeCount.ts'
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { z } from 'zod';
 import { mapToShowEntry } from '../../_internal/mapToShowEntry.ts';
 import { ShowEntrySchema } from '../../models/ShowEntry.ts';
 
-type ShowRelatedParams = {
-  slug: string;
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type ShowRelatedParams =
+  & {
+    slug: string;
+  }
+  & PaginationParams
+  & ApiParams;
 
 const RelatedShowSchema = ShowEntrySchema.merge(EpisodeCountSchema);
 export type RelatedShow = z.infer<typeof RelatedShowSchema>;
@@ -28,7 +29,7 @@ function mapToRelatedShow(show: ShowResponse) {
 }
 
 const showRelatedRequest = (
-  { fetch, slug, limit = DEFAULT_PAGE_SIZE, page = 1 }: ShowRelatedParams,
+  { fetch, slug, limit, page }: ShowRelatedParams,
 ) =>
   api({ fetch })
     .shows

--- a/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
@@ -5,7 +5,7 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapToEpisodeCount } from '../../_internal/mapToEpisodeCount.ts';
@@ -19,10 +19,7 @@ export const TrendingShowSchema = ShowEntrySchema
   });
 export type TrendingShow = z.infer<typeof TrendingShowSchema>;
 
-type ShowTrendingParams = {
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type ShowTrendingParams = PaginationParams & ApiParams;
 
 function mapToTrendingShow({
   watchers,
@@ -36,7 +33,7 @@ function mapToTrendingShow({
 }
 
 const showTrendingRequest = (
-  { fetch, limit = DEFAULT_PAGE_SIZE, page = 1 }: ShowTrendingParams,
+  { fetch, limit, page }: ShowTrendingParams,
 ) =>
   api({ fetch })
     .shows

--- a/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
@@ -4,9 +4,9 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeProgressEntrySchema } from '$lib/requests/models/EpisodeProgressEntry.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
 import { mapUpNextResponse } from '$lib/requests/queries/sync/upNextQuery.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 
@@ -16,13 +16,10 @@ export const UpNextEntryNitroSchema = EpisodeProgressEntrySchema.merge(
   }),
 );
 
-type UpNextParams = {
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type UpNextParams = PaginationParams & ApiParams;
 
-const upNextNitroRequest = (params: UpNextParams = {}) => {
-  const { fetch, page = 1, limit = DEFAULT_PAGE_SIZE } = params;
+const upNextNitroRequest = (params: UpNextParams) => {
+  const { fetch, limit, page } = params;
 
   return api({ fetch })
     .sync

--- a/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
@@ -7,8 +7,8 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeProgressEntrySchema } from '$lib/requests/models/EpisodeProgressEntry.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 
@@ -17,17 +17,18 @@ export const UpNextEntrySchema = EpisodeProgressEntrySchema.merge(z.object({
 }));
 export type UpNextEntry = z.infer<typeof UpNextEntrySchema>;
 
-type UpNextParams = {
-  page?: number;
-  limit?: number;
-  sort?: {
-    by?: string;
-    direction?: SortDirection;
-  };
-} & ApiParams;
+type UpNextParams =
+  & {
+    sort?: {
+      by?: string;
+      direction?: SortDirection;
+    };
+  }
+  & PaginationParams
+  & ApiParams;
 
-const upNextRequest = (params: UpNextParams = {}) => {
-  const { fetch, page = 1, limit = DEFAULT_PAGE_SIZE, sort } = params;
+const upNextRequest = (params: UpNextParams) => {
+  const { fetch, limit, page, sort } = params;
   const sortQuery = sort?.by && sort?.direction
     ? {
       sort_by: sort.by,

--- a/projects/client/src/lib/requests/queries/users/hiddenShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/hiddenShowsQuery.ts
@@ -9,12 +9,10 @@ import {
 } from '$lib/requests/models/HiddenShow.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 
-type HiddenShowsParams = {
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type HiddenShowsParams = PaginationParams & ApiParams;
 
 function mapToHiddenShowItem(item: HiddenShowItemResponse): HiddenShow {
   return {

--- a/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
@@ -6,22 +6,23 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { ListItemSchemaFactory } from '$lib/requests/models/ListItem.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
 
-type MovieWatchlistParams = {
-  sort: SortType;
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type MovieWatchlistParams =
+  & {
+    sort: SortType;
+  }
+  & PaginationParams
+  & ApiParams;
 
 export const WatchlistMovieSchema = ListItemSchemaFactory(MovieEntrySchema);
 export type WatchlistMovie = z.infer<typeof WatchlistMovieSchema>;
 
 const watchlistRequest = (
-  { fetch, sort, limit = DEFAULT_PAGE_SIZE, page = 1 }: MovieWatchlistParams,
+  { fetch, sort, limit, page }: MovieWatchlistParams,
 ) =>
   api({ fetch })
     .users

--- a/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
@@ -7,16 +7,17 @@ import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { ListItemSchemaFactory } from '$lib/requests/models/ListItem.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { ShowEntrySchema } from '../../models/ShowEntry.ts';
 
-type ShowWatchlistParams = {
-  sort: SortType;
-  page?: number;
-  limit?: number;
-} & ApiParams;
+type ShowWatchlistParams =
+  & {
+    sort: SortType;
+  }
+  & PaginationParams
+  & ApiParams;
 
 export const WatchlistShowEntrySchema = ShowEntrySchema.merge(
   EpisodeCountSchema,
@@ -28,7 +29,7 @@ export const WatchlistShowSchema = ListItemSchemaFactory(
 export type WatchlistShow = z.infer<typeof WatchlistShowSchema>;
 
 const watchlistRequest = (
-  { fetch, sort, limit = DEFAULT_PAGE_SIZE, page = 1 }: ShowWatchlistParams,
+  { fetch, sort, limit, page }: ShowWatchlistParams,
 ) =>
   api({ fetch })
     .users

--- a/projects/client/src/lib/requests/queries/users/socialActivityQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/socialActivityQuery.ts
@@ -7,14 +7,14 @@ import { mapToShowEntry } from '$lib/requests/_internal/mapToShowEntry.ts';
 import { mapToUserProfile } from '$lib/requests/_internal/mapToUserProfile.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import {
   type SocialActivity,
   SocialActivitySchema,
 } from '$lib/requests/models/SocialActivity.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
 
-type SocialActivityParams = { limit?: number; page?: number } & ApiParams;
+type SocialActivityParams = PaginationParams & ApiParams;
 
 function mapToSocialActivity(
   response: SocialActivityResponse,
@@ -43,7 +43,7 @@ function mapToSocialActivity(
 }
 
 const socialActivityRequest = (
-  { fetch, limit = DEFAULT_PAGE_SIZE, page }: SocialActivityParams,
+  { fetch, limit, page }: SocialActivityParams,
 ) =>
   api({ fetch })
     .users

--- a/projects/client/src/lib/requests/queries/users/userListItemsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/userListItemsQuery.spec.ts
@@ -1,4 +1,5 @@
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { ListedMoviesMappedMock } from '$mocks/data/lists/mapped/ListedMoviesMappedMock.ts';
 import { ListedShowsMappedMock } from '$mocks/data/lists/mapped/ListedShowsMappedMock.ts';
 import { HereticListsMappedMock } from '$mocks/data/summary/movies/heretic/mapped/HereticListsMappedMock.ts';
@@ -9,6 +10,11 @@ import { createQuery } from '@tanstack/svelte-query';
 import { describe, expect, it } from 'vitest';
 import { userListItemsQuery } from './userListItemsQuery.ts';
 
+const PAGINATION_PARAMS = {
+  limit: DEFAULT_PAGE_SIZE,
+  page: 1,
+};
+
 describe('userListItemsQuery', () => {
   it('should query list items', async () => {
     const result = await runQuery({
@@ -17,6 +23,7 @@ describe('userListItemsQuery', () => {
           userListItemsQuery({
             userId: assertDefined(UserProfileHarryMappedMock.slug),
             listId: assertDefined(SiloListsMappedMock.at(0)).slug,
+            ...PAGINATION_PARAMS,
           }),
         ),
       mapper: (response) => response?.data?.entries,
@@ -36,6 +43,7 @@ describe('userListItemsQuery', () => {
             userId: assertDefined(UserProfileHarryMappedMock.slug),
             listId: assertDefined(SiloListsMappedMock.at(0)).slug,
             type: 'show',
+            ...PAGINATION_PARAMS,
           }),
         ),
       mapper: (response) => response?.data?.entries,
@@ -52,6 +60,7 @@ describe('userListItemsQuery', () => {
             userId: assertDefined(UserProfileHarryMappedMock.slug),
             listId: assertDefined(HereticListsMappedMock.at(0)).slug,
             type: 'movie',
+            ...PAGINATION_PARAMS,
           }),
         ),
       mapper: (response) => response?.data?.entries,

--- a/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
@@ -7,8 +7,8 @@ import { ListItemSchemaFactory } from '$lib/requests/models/ListItem.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { MovieEntrySchema } from '$lib/requests/models/MovieEntry.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
-import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 
@@ -16,10 +16,9 @@ type UserListItemsParams =
   & {
     userId: string;
     listId: string;
-    page?: number;
-    limit?: number;
     type?: MediaType | 'movie,show';
   }
+  & PaginationParams
   & ApiParams;
 
 const ListedShowEntrySchema = ShowEntrySchema.merge(
@@ -37,8 +36,8 @@ const userListItemsRequest = (
     fetch,
     userId,
     listId,
-    limit = DEFAULT_PAGE_SIZE,
-    page = 1,
+    limit,
+    page,
     type = 'movie,show',
   }: UserListItemsParams,
 ) =>

--- a/projects/client/src/lib/sections/lists/RelatedList.svelte
+++ b/projects/client/src/lib/sections/lists/RelatedList.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import MediaList from "$lib/sections/lists/drilldown/MediaList.svelte";
+
   import type { MediaType } from "$lib/requests/models/MediaType";
   import MediaCard from "./components/MediaCard.svelte";
   import { useRelatedList } from "./stores/useRelatedList";
-  import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
 
   type RelatedListProps = {
     title: string;
@@ -12,17 +12,15 @@
   };
 
   const { title, type, slug }: RelatedListProps = $props();
-
-  const { list } = $derived(useRelatedList({ type, slug }));
 </script>
 
-<SectionList
+<MediaList
   id={`related-list-${type}-${slug}`}
-  items={$list}
+  useList={(params) => useRelatedList({ ...params, slug })}
+  {type}
   {title}
-  --height-list={mediaListHeightResolver(type)}
 >
   {#snippet item(media)}
     <MediaCard {type} {media} />
   {/snippet}
-</SectionList>
+</MediaList>

--- a/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
+++ b/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
@@ -1,21 +1,18 @@
-import { useQuery } from '$lib/features/query/useQuery.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import {
   type AnticipatedMovie,
   movieAnticipatedQuery,
 } from '$lib/requests/queries/movies/movieAnticipatedQuery.ts';
 import { showAnticipatedQuery } from '$lib/requests/queries/shows/showAnticipatedQuery.ts';
-import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
-import { derived } from 'svelte/store';
+import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
 
 export type AnticipatedEntry = AnticipatedMovie;
 export type AnticipatedMediaList = Array<AnticipatedEntry>;
 
 type AnticipatedListStoreProps = {
   type: MediaType;
-  limit?: number;
-  page?: number;
-};
+} & PaginationParams;
 
 function typeToQuery(
   { type, limit, page }: AnticipatedListStoreProps,
@@ -36,19 +33,5 @@ function typeToQuery(
 export function useAnticipatedList(
   props: AnticipatedListStoreProps,
 ) {
-  const query = useQuery(typeToQuery(props));
-
-  const isLoading = derived(
-    query,
-    toLoadingState,
-  );
-
-  return {
-    isLoading,
-    list: derived(query, ($query) => $query.data?.entries ?? []),
-    page: derived(
-      query,
-      ($query) => $query.data?.page ?? { page: 0, total: 0 },
-    ),
-  };
+  return usePaginatedListQuery(typeToQuery(props));
 }

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
@@ -10,7 +10,12 @@
   const POSTER_LIMIT = 8;
   const { list, type }: { list: MediaListSummary; type?: MediaType } = $props();
 
-  const { list: items } = useListItems({ list, type, limit: POSTER_LIMIT });
+  const { list: items } = useListItems({
+    list,
+    type,
+    limit: POSTER_LIMIT,
+    page: 1,
+  });
 </script>
 
 {#if $items}

--- a/projects/client/src/lib/sections/lists/drilldown/DrillListProps.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/DrillListProps.ts
@@ -1,10 +1,5 @@
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
-import type { Snippet } from 'svelte';
 
-export type DrillListProps<T, M = MediaType> = {
-  id: string;
-  title: string;
-  type: M;
-  item: Snippet<[T]>;
+export type DrillListProps<M = MediaType> = {
   urlBuilder: (params: { type: M } & Record<string, unknown>) => string;
 };

--- a/projects/client/src/lib/sections/lists/drilldown/DrillableMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrillableMediaList.svelte
@@ -1,53 +1,27 @@
 <script lang="ts" generics="T extends { id: unknown }, M">
-  import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import type { Snippet } from "svelte";
   import ViewAllButton from "../components/ViewAllButton.svelte";
-  import { mediaListHeightResolver } from "../utils/mediaListHeightResolver";
   import type { DrillListProps } from "./DrillListProps";
-  import type { MediaStore } from "./MediaStore";
+  import MediaList from "./MediaList.svelte";
+  import type { MediaListProps } from "./MediaListProps";
 
-  type DrillableList<T, M> = DrillListProps<T, M> & {
-    drilldownLabel: string;
-    useList: MediaStore<T, M>;
-    empty?: Snippet;
-    badge?: Snippet;
-  };
+  type DrillableList<T, M> = MediaListProps<T, M> &
+    DrillListProps<M> & {
+      drilldownLabel: string;
+      empty?: Snippet;
+      badge?: Snippet;
+    };
 
-  const {
-    id,
-    title,
-    drilldownLabel,
-    empty: externalEmpty,
-    badge,
-    type,
-    item,
-    useList,
-    urlBuilder,
-  }: DrillableList<T, M> = $props();
-
-  const { list, isLoading } = $derived(useList({ type }));
-  const isEmptyList = $derived(!$isLoading && $list.length === 0);
+  const { drilldownLabel, urlBuilder, ...props }: DrillableList<T, M> =
+    $props();
 </script>
 
-<SectionList
-  {id}
-  items={$list}
-  {badge}
-  {item}
-  {title}
-  --height-list={mediaListHeightResolver(type)}
->
-  {#snippet actions()}
+<MediaList {...props}>
+  {#snippet actions(items, type)}
     <ViewAllButton
       href={urlBuilder({ type })}
       label={drilldownLabel}
-      isDisabled={isEmptyList}
+      isDisabled={items.length === 0}
     />
   {/snippet}
-
-  {#snippet empty()}
-    {#if !$isLoading}
-      {@render externalEmpty?.()}
-    {/if}
-  {/snippet}
-</SectionList>
+</MediaList>

--- a/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
@@ -5,10 +5,10 @@
   import type { Snippet } from "svelte";
   import { writable } from "svelte/store";
   import { mediaCardWidthResolver } from "../utils/mediaCardWidthResolver";
-  import type { DrillListProps } from "./DrillListProps";
+  import type { MediaListProps } from "./MediaListProps";
   import type { PaginatableStore } from "./PaginatableStore";
 
-  type DrilledMediaListProps = Omit<DrillListProps<T, M>, "urlBuilder"> & {
+  type DrilledMediaListProps = Omit<MediaListProps<T, M>, "useList"> & {
     useList: PaginatableStore<T, M>;
     empty?: Snippet;
     badge?: Snippet;

--- a/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
@@ -2,26 +2,18 @@
   import { page as pageState } from "$app/state";
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
   import { DEFAULT_DRILL_SIZE, PAGE_UPPER_LIMIT } from "$lib/utils/constants";
-  import type { Snippet } from "svelte";
   import { writable } from "svelte/store";
   import { mediaCardWidthResolver } from "../utils/mediaCardWidthResolver";
   import type { MediaListProps } from "./MediaListProps";
-  import type { PaginatableStore } from "./PaginatableStore";
 
-  type DrilledMediaListProps = Omit<MediaListProps<T, M>, "useList"> & {
-    useList: PaginatableStore<T, M>;
-    empty?: Snippet;
-    badge?: Snippet;
-  };
+  type DrilledMediaListProps = MediaListProps<T, M>;
 
   const {
-    id,
-    title,
     type,
     empty: externalEmpty,
-    badge,
-    item,
     useList,
+    actions: _,
+    ...props
   }: DrilledMediaListProps = $props();
 
   const current = $derived(
@@ -45,14 +37,7 @@
   });
 </script>
 
-<GridList
-  {id}
-  {title}
-  {badge}
-  items={$list}
-  {item}
-  --width-item={mediaCardWidthResolver(type)}
->
+<GridList {...props} items={$list} --width-item={mediaCardWidthResolver(type)}>
   {#snippet empty()}
     {#if !$isLoading}
       {@render externalEmpty?.()}

--- a/projects/client/src/lib/sections/lists/drilldown/LimitStore.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/LimitStore.ts
@@ -1,8 +1,8 @@
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { Readable } from 'svelte/store';
 
-export type MediaStore<T, M = MediaType> = (
-  params: { type: M; limit?: number },
+export type LimitStore<T, M = MediaType> = (
+  params: { type: M; limit: number },
 ) => {
   list: Readable<T[]>;
   isLoading: Readable<boolean>;

--- a/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" generics="T extends { id: unknown }, M">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import { DEFAULT_PAGE_SIZE } from "$lib/utils/constants";
   import { mediaListHeightResolver } from "../utils/mediaListHeightResolver";
   import type { MediaListProps } from "./MediaListProps";
 
@@ -14,7 +15,9 @@
     useList,
   }: MediaListProps<T, M> = $props();
 
-  const { list, isLoading } = $derived(useList({ type }));
+  const { list, isLoading } = $derived(
+    useList({ type, page: 1, limit: DEFAULT_PAGE_SIZE }),
+  );
 </script>
 
 {#snippet actions()}

--- a/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
@@ -1,0 +1,40 @@
+<script lang="ts" generics="T extends { id: unknown }, M">
+  import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import { mediaListHeightResolver } from "../utils/mediaListHeightResolver";
+  import type { MediaListProps } from "./MediaListProps";
+
+  const {
+    id,
+    title,
+    empty: externalEmpty,
+    badge,
+    type,
+    item,
+    actions: externalActions,
+    useList,
+  }: MediaListProps<T, M> = $props();
+
+  const { list, isLoading } = $derived(useList({ type }));
+</script>
+
+{#snippet actions()}
+  {#if externalActions}
+    {@render externalActions($list, type)}
+  {/if}
+{/snippet}
+
+<SectionList
+  {id}
+  items={$list}
+  {badge}
+  {item}
+  {title}
+  actions={externalActions ? actions : undefined}
+  --height-list={mediaListHeightResolver(type)}
+>
+  {#snippet empty()}
+    {#if !$isLoading}
+      {@render externalEmpty?.()}
+    {/if}
+  {/snippet}
+</SectionList>

--- a/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
@@ -1,0 +1,13 @@
+import type { MediaStore } from '$lib/sections/lists/drilldown/MediaStore.ts';
+import type { Snippet } from 'svelte';
+
+export type MediaListProps<T, M> = {
+  id: string;
+  title: string;
+  type: M;
+  item: Snippet<[T]>;
+  useList: MediaStore<T, M>;
+  actions?: Snippet<[T[], M]>;
+  empty?: Snippet;
+  badge?: Snippet;
+};

--- a/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
@@ -1,4 +1,4 @@
-import type { MediaStore } from '$lib/sections/lists/drilldown/MediaStore.ts';
+import type { PaginatableStore } from '$lib/sections/lists/drilldown/PaginatableStore.ts';
 import type { Snippet } from 'svelte';
 
 export type MediaListProps<T, M> = {
@@ -6,7 +6,7 @@ export type MediaListProps<T, M> = {
   title: string;
   type: M;
   item: Snippet<[T]>;
-  useList: MediaStore<T, M>;
+  useList: PaginatableStore<T, M>;
   actions?: Snippet<[T[], M]>;
   empty?: Snippet;
   badge?: Snippet;

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedList.svelte
@@ -17,10 +17,11 @@
   {title}
   {drilldownLabel}
   type="episode"
-  useList={({ limit }) =>
+  useList={({ limit, page }) =>
     useRecentlyWatchedList({
       type: "all",
       limit,
+      page,
     })}
   urlBuilder={UrlBuilder.history.all}
 >

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
@@ -17,10 +17,11 @@
   id="view-all-recently-watched-list"
   {title}
   type="episode"
-  useList={({ limit }) =>
+  useList={({ limit, page }) =>
     useRecentlyWatchedList({
       type: "all",
       limit,
+      page,
     })}
 >
   {#snippet item(media)}

--- a/projects/client/src/lib/sections/lists/popular/usePopularList.ts
+++ b/projects/client/src/lib/sections/lists/popular/usePopularList.ts
@@ -1,22 +1,19 @@
-import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { type MovieEntry } from '$lib/requests/models/MovieEntry.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { moviePopularQuery } from '$lib/requests/queries/movies/moviePopularQuery.ts';
 import {
   type PopularShow,
   showPopularQuery,
 } from '$lib/requests/queries/shows/showPopularQuery.ts';
-import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
-import { derived } from 'svelte/store';
-import type { MediaType } from '../../../requests/models/MediaType.ts';
+import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
 
 export type PopularEntry = PopularShow | MovieEntry;
 export type PopularMediaList = Array<PopularEntry>;
 
 type PopularListStoreProps = {
   type: MediaType;
-  limit?: number;
-  page?: number;
-};
+} & PaginationParams;
 
 function typeToQuery(
   { type, limit, page }: PopularListStoreProps,
@@ -37,19 +34,5 @@ function typeToQuery(
 export function usePopularList(
   props: PopularListStoreProps,
 ) {
-  const query = useQuery(typeToQuery(props));
-
-  const isLoading = derived(
-    query,
-    toLoadingState,
-  );
-
-  return {
-    isLoading,
-    list: derived(query, ($query) => $query.data?.entries ?? []),
-    page: derived(
-      query,
-      ($query) => $query.data?.page ?? { page: 0, total: 0 },
-    ),
-  };
+  return usePaginatedListQuery(typeToQuery(props));
 }

--- a/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
@@ -26,7 +26,8 @@
     useStablePaginated({
       ...params,
       type: "episode",
-      useList: (params) => useUpNextList({ type: $type, limit: params.limit }),
+      useList: (params) =>
+        useUpNextList({ type: $type, limit: params.limit, page: params.page }),
       compareFn: (l, r) => l.show.id === r.show.id,
     })}
   title={m.up_next_title()}

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
-  import { RECOMMENDED_UPPER_LIMIT } from "$lib/utils/constants";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import RecommendedListItem from "./RecommendedListItem.svelte";
-  import { toInMemoryPaginatable } from "./toInMemoryPaginatable";
   import { useRecommendedList } from "./useRecommendedList";
 
   type RecommendedListProps = {
@@ -13,13 +11,6 @@
   };
 
   const { title, type }: RecommendedListProps = $props();
-  const useInMemoryRecommendedList = $derived(
-    toInMemoryPaginatable({
-      useList: useRecommendedList,
-      total: RECOMMENDED_UPPER_LIMIT,
-      type,
-    }),
-  );
 
   const isMobile = useMedia(WellKnownMediaQuery.mobile);
   const style = $derived($isMobile ? "summary" : "cover");
@@ -29,7 +20,7 @@
   id="view-all-recommended-${type}"
   {title}
   {type}
-  useList={useInMemoryRecommendedList}
+  useList={useRecommendedList}
 >
   {#snippet item(media)}
     <RecommendedListItem {type} {media} {style} />

--- a/projects/client/src/lib/sections/lists/recommended/toInMemoryPaginatable.ts
+++ b/projects/client/src/lib/sections/lists/recommended/toInMemoryPaginatable.ts
@@ -1,10 +1,10 @@
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { derived, readable } from 'svelte/store';
-import type { MediaStore } from '../drilldown/MediaStore.ts';
+import type { LimitStore } from '../drilldown/LimitStore.ts';
 import type { PaginatableStore } from '../drilldown/PaginatableStore.ts';
 
 export const toInMemoryPaginatable = <T>(params: {
-  useList: MediaStore<T>;
+  useList: LimitStore<T>;
   type: MediaType;
   total: number;
 }): PaginatableStore<T> => {

--- a/projects/client/src/lib/sections/lists/social/SocialActivityList.svelte
+++ b/projects/client/src/lib/sections/lists/social/SocialActivityList.svelte
@@ -6,7 +6,8 @@
   import SocialActivityItem from "./SocialActivityItem.svelte";
   import { useSocialActivityList } from "./useSocialActivityList";
 
-  const { list, isLoading } = useSocialActivityList({});
+  /** once we have a proper social hub we should encourage people to find other users to follow, aka: empty placeholder */
+  const { list, isLoading } = useSocialActivityList({ limit: 1, page: 1 });
 
   const hasSocialActivity = $derived(!$isLoading && $list.length > 0);
 </script>

--- a/projects/client/src/lib/sections/lists/social/useSocialActivityList.ts
+++ b/projects/client/src/lib/sections/lists/social/useSocialActivityList.ts
@@ -1,32 +1,22 @@
-import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { socialActivityQuery } from '$lib/requests/queries/users/socialActivityQuery.ts';
-import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
-import { derived } from 'svelte/store';
+import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
 
-type SocialActivityListProps = {
-  limit?: number;
-  page?: number;
-};
+type SocialActivityListProps = PaginationParams;
 
-export function useSocialActivityList(props: SocialActivityListProps) {
-  const query = useQuery(
-    socialActivityQuery(props),
-  );
-
-  const isLoading = derived(
-    query,
-    toLoadingState,
-  );
-
-  const list = derived(query, ($query) => $query.data?.entries ?? []);
-  const page = derived(
-    query,
-    ($query) => $query.data?.page ?? { page: 0, total: 0 },
-  );
-
-  return {
-    list,
+function typeToQuery(
+  { limit, page }: SocialActivityListProps,
+) {
+  const params = {
+    limit,
     page,
-    isLoading,
   };
+
+  return socialActivityQuery(params);
+}
+
+export function useSocialActivityList(
+  props: SocialActivityListProps,
+) {
+  return usePaginatedListQuery(typeToQuery(props));
 }

--- a/projects/client/src/lib/sections/lists/stores/usePaginatedListQuery.ts
+++ b/projects/client/src/lib/sections/lists/stores/usePaginatedListQuery.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { Paginatable } from '$lib/requests/models/Paginatable.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { type CreateQueryOptions } from '@tanstack/svelte-query';
+import { derived } from 'svelte/store';
+
+export function usePaginatedListQuery<
+  TOutput,
+  TError extends Error,
+>(
+  props: CreateQueryOptions<Paginatable<TOutput>, TError>,
+) {
+  const query = useQuery(props);
+
+  const isLoading = derived(query, toLoadingState);
+
+  const list = derived(query, ($query) => $query.data?.entries ?? []);
+
+  const page = derived(
+    query,
+    ($query) => $query.data?.page ?? { page: 0, total: 0 },
+  );
+
+  return { list, page, isLoading };
+}

--- a/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
@@ -1,24 +1,19 @@
-import { useQuery } from '$lib/features/query/useQuery.ts';
 import type { Paginatable } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { activityHistoryQuery } from '$lib/requests/queries/users/activityHistoryQuery.ts';
-import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
-import type { CreateQueryOptions } from '@tanstack/svelte-query';
-import { derived } from 'svelte/store';
 import {
   type EpisodeActivityHistory,
   episodeActivityHistoryQuery,
-} from '../../../requests/queries/users/episodeActivityHistoryQuery.ts';
+} from '$lib/requests/queries/users/episodeActivityHistoryQuery.ts';
 import {
   type MovieActivityHistory,
   movieActivityHistoryQuery,
-} from '../../../requests/queries/users/movieActivityHistoryQuery.ts';
+} from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
+import type { CreateQueryOptions } from '@tanstack/svelte-query';
 
-const HISTORY_LIMIT = 25;
-
-type RecentlyWatchedListStoreProps = {
+type RecentlyWatchedListStoreProps = PaginationParams & {
   type: 'movie' | 'episode' | 'all';
-  limit?: number;
-  page?: number;
 };
 
 export type HistoryEntry = MovieActivityHistory | EpisodeActivityHistory;
@@ -27,7 +22,7 @@ function typeToQuery(
   { type, limit, page }: RecentlyWatchedListStoreProps,
 ) {
   const params = {
-    limit: limit ?? HISTORY_LIMIT,
+    limit,
     page,
   };
 
@@ -50,21 +45,5 @@ function typeToQuery(
 export function useRecentlyWatchedList(
   params: RecentlyWatchedListStoreProps,
 ) {
-  const query = useQuery(typeToQuery(params));
-  const isLoading = derived(
-    query,
-    toLoadingState,
-  );
-
-  return {
-    isLoading,
-    list: derived(
-      query,
-      ($query) => $query.data?.entries ?? [],
-    ),
-    page: derived(
-      query,
-      ($query) => $query.data?.page ?? { page: 0, total: 0 },
-    ),
-  };
+  return usePaginatedListQuery(typeToQuery(params));
 }

--- a/projects/client/src/lib/sections/lists/stores/useRelatedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRelatedList.ts
@@ -5,6 +5,7 @@ import {
   type RelatedShow,
   showRelatedQuery,
 } from '$lib/requests/queries/shows/showRelatedQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { type CreateQueryOptions } from '@tanstack/svelte-query';
 import { derived } from 'svelte/store';
 import type { MediaType } from '../../../requests/models/MediaType.ts';
@@ -38,5 +39,9 @@ export function useRelatedList(
 
   return {
     list,
+    isLoading: derived(
+      query,
+      toLoadingState,
+    ),
   };
 }

--- a/projects/client/src/lib/sections/lists/stores/useRelatedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRelatedList.ts
@@ -1,30 +1,27 @@
-import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { type MovieEntry } from '$lib/requests/models/MovieEntry.ts';
 import type { Paginatable } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { movieRelatedQuery } from '$lib/requests/queries/movies/movieRelatedQuery.ts';
 import {
   type RelatedShow,
   showRelatedQuery,
 } from '$lib/requests/queries/shows/showRelatedQuery.ts';
-import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
 import { type CreateQueryOptions } from '@tanstack/svelte-query';
-import { derived } from 'svelte/store';
-import type { MediaType } from '../../../requests/models/MediaType.ts';
 
 export type RelatedEntry = RelatedShow | MovieEntry;
 export type RelatedMediaList = Paginatable<RelatedEntry>;
 
-type PopularListStoreProps = {
+type RelatedListStoreProps = PaginationParams & {
   type: MediaType;
   slug: string;
 };
 
 function typeToQuery(
-  { type, slug }: PopularListStoreProps,
+  params: RelatedListStoreProps,
 ) {
-  const params = { slug };
-
-  switch (type) {
+  switch (params.type) {
     case 'movie':
       return movieRelatedQuery(params) as CreateQueryOptions<RelatedMediaList>;
     case 'show':
@@ -33,21 +30,7 @@ function typeToQuery(
 }
 
 export function useRelatedList(
-  { type, slug }: PopularListStoreProps,
+  props: RelatedListStoreProps,
 ) {
-  const query = useQuery(typeToQuery({ type, slug }));
-  const list = derived(query, ($query) => $query.data?.entries ?? []);
-  const page = derived(
-    query,
-    ($query) => $query.data?.page ?? { page: 0, total: 0 },
-  );
-
-  return {
-    list,
-    page,
-    isLoading: derived(
-      query,
-      toLoadingState,
-    ),
-  };
+  return usePaginatedListQuery(typeToQuery(props));
 }

--- a/projects/client/src/lib/sections/lists/stores/useRelatedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRelatedList.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '$lib/features/query/useQuery.ts';
 import { type MovieEntry } from '$lib/requests/models/MovieEntry.ts';
+import type { Paginatable } from '$lib/requests/models/Paginatable.ts';
 import { movieRelatedQuery } from '$lib/requests/queries/movies/movieRelatedQuery.ts';
 import {
   type RelatedShow,
@@ -11,7 +12,7 @@ import { derived } from 'svelte/store';
 import type { MediaType } from '../../../requests/models/MediaType.ts';
 
 export type RelatedEntry = RelatedShow | MovieEntry;
-export type RelatedMediaList = Array<RelatedEntry>;
+export type RelatedMediaList = Paginatable<RelatedEntry>;
 
 type PopularListStoreProps = {
   type: MediaType;
@@ -35,10 +36,15 @@ export function useRelatedList(
   { type, slug }: PopularListStoreProps,
 ) {
   const query = useQuery(typeToQuery({ type, slug }));
-  const list = derived(query, ($query) => $query.data ?? []);
+  const list = derived(query, ($query) => $query.data?.entries ?? []);
+  const page = derived(
+    query,
+    ($query) => $query.data?.page ?? { page: 0, total: 0 },
+  );
 
   return {
     list,
+    page,
     isLoading: derived(
       query,
       toLoadingState,

--- a/projects/client/src/lib/sections/lists/user/useListItems.ts
+++ b/projects/client/src/lib/sections/lists/user/useListItems.ts
@@ -1,10 +1,9 @@
-import { useQuery } from '$lib/features/query/useQuery.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { listItemsQuery } from '$lib/requests/queries/lists/listItemsQuery.ts';
 import { userListItemsQuery } from '$lib/requests/queries/users/userListItemsQuery.ts';
+import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
-import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
-import { derived } from 'svelte/store';
 
 const LIST_LIMIT = 25;
 
@@ -16,11 +15,9 @@ export type ListParams = {
   id?: number;
 };
 
-type UseListItemsProps = {
+type UseListItemsProps = PaginationParams & {
   list: ListParams;
-  limit?: number;
   type?: MediaType;
-  page?: number;
 };
 
 // FIXME: remove when official lists are sluggable
@@ -62,19 +59,5 @@ function listToQuery(
 }
 
 export function useListItems(props: UseListItemsProps) {
-  const query = useQuery(listToQuery(props));
-
-  const isLoading = derived(
-    query,
-    toLoadingState,
-  );
-
-  return {
-    isLoading,
-    list: derived(query, ($query) => $query.data?.entries ?? []),
-    page: derived(
-      query,
-      ($query) => $query.data?.page ?? { page: 0, total: 0 },
-    ),
-  };
+  return usePaginatedListQuery(listToQuery(props));
 }

--- a/projects/client/src/lib/utils/constants.ts
+++ b/projects/client/src/lib/utils/constants.ts
@@ -51,7 +51,7 @@ export const NOOP_FN = () => {
   // noop
 };
 
-export const DEFAULT_PAGE_SIZE = 15;
+export const DEFAULT_PAGE_SIZE = 25;
 export const DEFAULT_DRILL_SIZE = 100;
-export const RECOMMENDED_UPPER_LIMIT = 100;
+export const RECOMMENDED_UPPER_LIMIT = DEFAULT_DRILL_SIZE;
 export const PAGE_UPPER_LIMIT = 3;

--- a/projects/client/src/routes/_design_system/assets/+page.svelte
+++ b/projects/client/src/routes/_design_system/assets/+page.svelte
@@ -31,12 +31,14 @@
     useTrendingList({
       type,
       limit,
+      page: 1,
     }),
   );
   const { list: popularMedia } = $derived(
     usePopularList({
       type,
       limit,
+      page: 1,
     }),
   );
 


### PR DESCRIPTION
NOTE: also updated the default page size to 25, seems like a better chunk to serve.

Future: Default page size could be adaptive based on consumer (Eg; 25 on desktop, 15 tablet, 5 on mobile). Although this is a bit overkill so not tackling it now.