### PR TITLE
fix(navbar): mobile navbar without labels

### DIFF
--- a/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
@@ -4,7 +4,6 @@
   import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
   import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
-  import * as m from "$lib/features/i18n/messages";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 </script>
@@ -13,21 +12,18 @@
   <Link href={UrlBuilder.home()}>
     <div class="trakt-mobile-navbar-link">
       <HomeIcon />
-      <p class="meta-info ellipsis">{m.navbar_link_home()}</p>
     </div>
   </Link>
 
   <Link href={UrlBuilder.shows()}>
     <div class="trakt-mobile-navbar-link">
       <ShowIcon />
-      <p class="meta-info ellipsis">{m.navbar_link_shows()}</p>
     </div>
   </Link>
 
   <Link href={UrlBuilder.movies()}>
     <div class="trakt-mobile-navbar-link">
       <MovieIcon />
-      <p class="meta-info ellipsis">{m.navbar_link_movies()}</p>
     </div>
   </Link>
 
@@ -35,7 +31,6 @@
     <Link href={UrlBuilder.watchlist()}>
       <div class="trakt-mobile-navbar-link">
         <WatchlistIcon />
-        <p class="meta-info ellipsis">{m.navbar_link_watchlist()}</p>
       </div>
     </Link>
   </RenderFor>
@@ -76,11 +71,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--gap-xxs);
-
-    .ellipsis {
-      max-width: 100%;
-    }
+    justify-content: center;
   }
 
   :global(.trakt-link.trakt-link-active) {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes https://github.com/trakt/trakt-lite/issues/289
- Removes the labels from the mobile navbar
  - We'll not have to worry about making sure translations would always fit.
  - These buttons are clear enough; if not:
    - Pages load quite fast, after a single tap users know what the button does.
    - If the icons aren't clear enough, we can improve on that also.

## 👀 Example 👀
Before:
<img width="372" alt="Screenshot 2025-03-03 at 13 24 12" src="https://github.com/user-attachments/assets/9ee83799-2a05-45f3-aa0c-40e9d47c64dc" />

After:
<img width="372" alt="Screenshot 2025-03-03 at 13 24 37" src="https://github.com/user-attachments/assets/e689025d-75e2-4bac-90bd-6008da5abb41" />

