### PR TITLE
feat(up-next): enable nitro by default

### DIFF
--- a/projects/client/src/lib/sections/lists/progress/useUpNextExperiment.ts
+++ b/projects/client/src/lib/sections/lists/progress/useUpNextExperiment.ts
@@ -8,15 +8,16 @@ import { derived, get, writable } from 'svelte/store';
 
 export type UpNextType = 'standard' | 'nitro';
 
-const UP_NEXT_STORAGE_KEY = 'up-next-type';
+const DEFAULT_UP_NEXT_TYPE: UpNextType = 'nitro';
+const UP_NEXT_STORAGE_KEY = 'up-next-type-v2';
 
 function getCachedUpNextType(): UpNextType {
   if (!browser) {
-    return 'standard';
+    return DEFAULT_UP_NEXT_TYPE;
   }
 
   const stored = localStorage.getItem(UP_NEXT_STORAGE_KEY);
-  return stored ? JSON.parse(stored) : 'standard';
+  return stored ? JSON.parse(stored) : DEFAULT_UP_NEXT_TYPE;
 }
 
 function saveCachedUpNextType(type: UpNextType) {
@@ -45,6 +46,11 @@ function updateCachedUpNextType(
   );
 }
 
+const UP_NEXT_TOGGLE_TYPE_MAP = {
+  standard: 'nitro',
+  nitro: 'standard',
+} as const;
+
 export function useUpNextExperiment() {
   const type = writable(getCachedUpNextType());
   const { track } = useTrack(AnalyticsEvent.NitroExperiment);
@@ -56,7 +62,7 @@ export function useUpNextExperiment() {
     enabled: derived(type, ($type) => $type === 'nitro'),
     toggle: () => {
       const oldType = get(type);
-      const newType = oldType === 'standard' ? 'nitro' : 'standard';
+      const newType = UP_NEXT_TOGGLE_TYPE_MAP[oldType];
 
       track({ type: newType });
       /**


### PR DESCRIPTION
## Up Next Feature Refinement: Constants and Type Toggling

This pull request refines the handling of the "Up Next" feature in the `useUpNextExperiment.ts` file by introducing constants and simplifying the type toggling logic.

### Key Changes:

* **Constants for Default Value and Storage Key**:
    * `DEFAULT_UP_NEXT_TYPE`: A new constant, `DEFAULT_UP_NEXT_TYPE`, has been introduced with the value 'nitro' to represent the default type for the "Up Next" feature.
    * `UP_NEXT_STORAGE_KEY`: The storage key for the "Up Next" type has been updated to 'up-next-type-v2' to distinguish it from previous versions.

* **Simplified Type Toggling**:
    * `UP_NEXT_TOGGLE_TYPE_MAP`: A new constant, `UP_NEXT_TOGGLE_TYPE_MAP`, has been added to map between 'standard' and 'nitro' types, simplifying the toggling logic.
    * `toggle` Function Update: The `toggle` function now utilizes the `UP_NEXT_TOGGLE_TYPE_MAP` to determine the new type when toggling between 'standard' and 'nitro', making the code more concise and readable.

(This update, like a meticulous detective refining their investigative tools, improves the clarity and efficiency of the "Up Next" feature's code. The introduction of constants for the default type and storage key enhances readability and maintainability, while the simplified type toggling logic makes the code more concise and easier to understand. These refinements contribute to a more robust and well-organized codebase.)