### PR TITLE
fix: remove strange action delegation

### DIFF
--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
@@ -2,7 +2,6 @@
   import * as m from "$lib/features/i18n/messages";
 
   import MarkAsWatchedButton from "$lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte";
-  import { onMount } from "svelte";
   import { attachWarning } from "../_internal/attachWarning";
   import { useIsWatchlisted } from "../watchlist/useIsWatchlisted";
   import {
@@ -14,7 +13,6 @@
     style: "normal" | "action" | "dropdown-item";
     title: string;
     isRewatching?: boolean;
-    onAction?: (state: boolean) => void;
     size?: "normal" | "small";
   } & MarkAsWatchedStoreProps;
 
@@ -23,7 +21,6 @@
     size = "normal",
     title,
     isRewatching,
-    onAction,
     ...target
   }: MarkAsWatchedActionProps = $props();
 
@@ -62,10 +59,6 @@
   const onRemoveHandler = $derived(
     attachWarning(removeWatched, m.remove_from_watched_warning({ title })),
   );
-
-  onMount(() => {
-    return isMarkingAsWatched.subscribe((value) => onAction?.(value));
-  });
 </script>
 
 {#if isWatchable}

--- a/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
@@ -3,7 +3,6 @@
 
   import WatchlistButton from "$lib/components/buttons/watchlist/WatchlistButton.svelte";
   import type { MediaStoreProps } from "$lib/models/MediaStoreProps";
-  import { onMount } from "svelte";
   import { attachWarning } from "../_internal/attachWarning";
   import { useWatchlist } from "./useWatchlist";
 
@@ -11,14 +10,12 @@
     style?: "action" | "normal" | "dropdown-item";
     size?: "small" | "normal";
     title: string;
-    onAction?: (state: boolean) => void;
   } & MediaStoreProps;
 
   const {
     style = "action",
     size = "normal",
     title,
-    onAction,
     ...target
   }: WatchlistActionProps = $props();
 
@@ -35,10 +32,6 @@
       m.remove_from_watchlist_warning({ title }),
     ),
   );
-
-  onMount(() => {
-    return isWatchlistUpdating.subscribe((value) => onAction?.(value));
-  });
 </script>
 
 <WatchlistButton


### PR DESCRIPTION
## Component Simplification: Removing Unused Code and Subscriptions

This pull request streamlines the `MarkAsWatchedAction.svelte` and `WatchlistAction.svelte` components by removing unused imports, properties, and unnecessary `onMount` subscriptions.

### Code Simplification:

* **`MarkAsWatchedAction.svelte`**:
    * The `onMount` import and the `onAction` property have been removed, as they were not being used in the component.
    * The `onMount` subscription, which previously called `onAction` when `isMarkingAsWatched` changed, has been eliminated. This simplification removes unnecessary code and improves the component's efficiency.

* **`WatchlistAction.svelte`**:
    * Similar to the `MarkAsWatchedAction` component, the `onMount` import, `onAction` property, and the corresponding `onMount` subscription have been removed. This cleanup streamlines the code and removes unnecessary complexity.

(This update, like a detective discarding irrelevant clues, removes unnecessary elements from the `MarkAsWatchedAction` and `WatchlistAction` components. This streamlining improves code readability and maintainability, making the components more efficient and easier to understand. These changes contribute to a cleaner and more optimized codebase.)