### PR TITLE
Fix/better trending numbers

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "npm:@cucumber/cucumber@^11.2.0": "11.2.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.0.2_@cucumber+messages@27.0.2",
     "npm:@google/generative-ai@0.21": "0.21.0",
     "npm:@inlang/paraglide-sveltekit@~0.15.5": "0.15.5_@sveltejs+kit@2.17.1__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.19.9____acorn@8.14.0___vite@6.1.0____sass-embedded@1.83.4___sass-embedded@1.83.4__svelte@5.19.9___acorn@8.14.0__vite@6.1.0___sass-embedded@1.83.4__sass-embedded@1.83.4_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.19.9___acorn@8.14.0__vite@6.1.0___sass-embedded@1.83.4__sass-embedded@1.83.4_svelte@5.19.9__acorn@8.14.0_vite@6.1.0__sass-embedded@1.83.4_sass-embedded@1.83.4",
-    "npm:@jsr/trakt__api@0.1": "0.1.0_zod@3.24.1",
+    "npm:@jsr/trakt__api@~0.1.1": "0.1.1_zod@3.24.1",
     "npm:@playwright/test@^1.50.1": "1.50.1",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.19.9__acorn@8.14.0",
     "npm:@sveltejs/adapter-auto@4": "4.0.0_@sveltejs+kit@2.17.1__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.19.9____acorn@8.14.0___vite@6.1.0____sass-embedded@1.83.4___sass-embedded@1.83.4__svelte@5.19.9___acorn@8.14.0__vite@6.1.0___sass-embedded@1.83.4__sass-embedded@1.83.4_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.19.9___acorn@8.14.0__vite@6.1.0___sass-embedded@1.83.4__sass-embedded@1.83.4_svelte@5.19.9__acorn@8.14.0_vite@6.1.0__sass-embedded@1.83.4_sass-embedded@1.83.4",
@@ -2082,8 +2082,8 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.1.0_zod@3.24.1": {
-      "integrity": "sha512-LiXQiKnk4zcuJlJLV+QE4bs9VE7P7E+LWnqs2H7OmU8CPOoGwQiyWl3Q4p7Gyg/WhqJcLPfrPsIoNSvZ/yuCWA==",
+    "@jsr/trakt__api@0.1.1_zod@3.24.1": {
+      "integrity": "sha512-0eIe7NPUK4/bVp6Tk0qAXu38UAAgHmM7g2oUmqdHwLD491pE7O1qdlVL/7lyi1q3YyuM7fxcqq1zm0ybuzqA/A==",
       "dependencies": [
         "@ts-rest/core",
         "zod"
@@ -6898,7 +6898,7 @@
             "npm:@cucumber/cucumber@^11.2.0",
             "npm:@google/generative-ai@0.21",
             "npm:@inlang/paraglide-sveltekit@~0.15.5",
-            "npm:@jsr/trakt__api@0.1",
+            "npm:@jsr/trakt__api@~0.1.1",
             "npm:@playwright/test@^1.50.1",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@sveltejs/adapter-auto@4",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -61,7 +61,7 @@
     "@tanstack/svelte-query": "^5.66.0",
     "@tanstack/svelte-query-devtools": "^5.66.0",
     "@tanstack/svelte-query-persist-client": "^5.66.0",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.1.0",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.1.1",
     "@ts-rest/core": "^3.51.0",
     "date-fns": "^4.1.0",
     "firebase": "^11.3.0",

--- a/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
@@ -5,7 +5,7 @@ import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import type { MovieTrendingResponse } from '@trakt/api';
+import type { MovieWatchedResponse } from '@trakt/api';
 import { z } from 'zod';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
@@ -18,9 +18,9 @@ export type TrendingMovie = z.infer<typeof TrendingMovieSchema>;
 type MovieTrendingParams = PaginationParams & ApiParams;
 
 function mapToTrendingMovie({
-  watchers,
+  watcher_count: watchers,
   movie,
-}: MovieTrendingResponse): TrendingMovie {
+}: MovieWatchedResponse): TrendingMovie {
   return {
     watchers,
     ...mapToMovieEntry(movie),
@@ -30,9 +30,13 @@ function mapToTrendingMovie({
 const movieTrendingRequest = (
   { fetch, limit, page }: MovieTrendingParams,
 ) =>
+  // FIXME: switch back to trending query when stats are fixed
   api({ fetch })
     .movies
-    .trending({
+    .watched({
+      params: {
+        period: 'daily',
+      },
       query: {
         extended: 'full,images',
         ignore_collected: true,

--- a/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
@@ -6,7 +6,7 @@ import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import type { ShowTrendingResponse } from '@trakt/api';
+import type { ShowWatchedResponse } from '@trakt/api';
 import { z } from 'zod';
 import { mapToEpisodeCount } from '../../_internal/mapToEpisodeCount.ts';
 import { mapToShowEntry } from '../../_internal/mapToShowEntry.ts';
@@ -22,9 +22,9 @@ export type TrendingShow = z.infer<typeof TrendingShowSchema>;
 type ShowTrendingParams = PaginationParams & ApiParams;
 
 function mapToTrendingShow({
-  watchers,
+  watcher_count: watchers,
   show,
-}: ShowTrendingResponse): TrendingShow {
+}: ShowWatchedResponse): TrendingShow {
   return {
     watchers,
     ...mapToEpisodeCount(show),
@@ -35,9 +35,13 @@ function mapToTrendingShow({
 const showTrendingRequest = (
   { fetch, limit, page }: ShowTrendingParams,
 ) =>
+  // FIXME: switch back to trending query when stats are fixed
   api({ fetch })
     .shows
-    .trending({
+    .watched({
+      params: {
+        period: 'daily',
+      },
       query: {
         extended: 'full,images',
         ignore_collected: true,

--- a/projects/client/src/mocks/data/movies/response/MoviesWatchedResponseMock.ts
+++ b/projects/client/src/mocks/data/movies/response/MoviesWatchedResponseMock.ts
@@ -1,0 +1,18 @@
+import { MovieHereticResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticResponseMock.ts';
+import { MovieMatrixResponseMock } from '$mocks/data/summary/movies/matrix/MovieMatrixResponseMock.ts';
+import type { MovieWatchedResponse } from '@trakt/api';
+
+export const MoviesWatchedResponseMock: MovieWatchedResponse[] = [
+  {
+    watcher_count: 127434,
+    play_count: 1,
+    collected_count: 1,
+    movie: MovieHereticResponseMock,
+  },
+  {
+    watcher_count: 12,
+    play_count: 12,
+    collected_count: 12,
+    movie: MovieMatrixResponseMock,
+  },
+];

--- a/projects/client/src/mocks/data/shows/response/ShowsWatchedResponseMock.ts
+++ b/projects/client/src/mocks/data/shows/response/ShowsWatchedResponseMock.ts
@@ -1,0 +1,20 @@
+import { ShowDevsResponseMock } from '$mocks/data/summary/shows/devs/ShowDevsResponseMock.ts';
+import { ShowSiloResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloResponseMock.ts';
+import type { ShowWatchedResponse } from '@trakt/api';
+
+export const ShowsWatchedResponseMock: ShowWatchedResponse[] = [
+  {
+    watcher_count: 127434,
+    play_count: 1,
+    collected_count: 1,
+    collector_count: 1,
+    show: ShowSiloResponseMock,
+  },
+  {
+    watcher_count: 12,
+    play_count: 12,
+    collected_count: 13,
+    collector_count: 14,
+    show: ShowDevsResponseMock,
+  },
+];

--- a/projects/client/src/mocks/handlers/movies.ts
+++ b/projects/client/src/mocks/handlers/movies.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
 import { OfficialListsResponseMock } from '$mocks/data/lists/response/OfficialListsResponseMock.ts';
+import { MoviesWatchedResponseMock } from '$mocks/data/movies/response/MoviesWatchedResponseMock.ts';
 import { MovieHereticCommentsResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticCommentsResponseMock.ts';
 import { MoviesAnticipatedResponseMock } from '../data/movies/response/MoviesAnticipatedResponseMock.ts';
 import { MoviesPopularResponseMock } from '../data/movies/response/MoviesPopularResponseMock.ts';
@@ -69,6 +70,12 @@ export const movies = [
     'http://localhost/movies/trending*',
     () => {
       return HttpResponse.json(MoviesTrendingResponseMock);
+    },
+  ),
+  http.get(
+    'http://localhost/movies/watched/daily*',
+    () => {
+      return HttpResponse.json(MoviesWatchedResponseMock);
     },
   ),
   http.get(

--- a/projects/client/src/mocks/handlers/shows.ts
+++ b/projects/client/src/mocks/handlers/shows.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from 'msw';
 
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { OfficialListsResponseMock } from '$mocks/data/lists/response/OfficialListsResponseMock.ts';
+import { ShowsWatchedResponseMock } from '$mocks/data/shows/response/ShowsWatchedResponseMock.ts';
 import { EpisodeSiloCommentsResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloCommentsResponseMock.ts';
 import { EpisodeSiloPeopleResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloPeopleResponseMock.ts';
 import { EpisodeSiloWatchNowResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloWatchNowResponseMock.ts';
@@ -150,6 +151,12 @@ export const shows = [
     'http://localhost/shows/trending*',
     () => {
       return HttpResponse.json(ShowsTrendingResponseMock);
+    },
+  ),
+  http.get(
+    'http://localhost/shows/watched/daily*',
+    () => {
+      return HttpResponse.json(ShowsWatchedResponseMock);
     },
   ),
   http.get(


### PR DESCRIPTION
## 🎶 Notes 🎶

- Temporarily use the `watched` endpoint to have nicer stats in the Trending lists.
- Tried to keep the changes minimal so we can easily switch back.

## 👀 Examples 👀
Before:
<img width="761" alt="Screenshot 2025-03-04 at 23 34 33" src="https://github.com/user-attachments/assets/a915da62-6e66-4938-84a9-bdb70479d3ee" />

After:
<img width="761" alt="Screenshot 2025-03-04 at 23 25 03" src="https://github.com/user-attachments/assets/ee9b9829-6f63-4e5b-980a-a79b0398fe7d" />

Durations seem comparable to other lists:
<img width="761" alt="image" src="https://github.com/user-attachments/assets/539d10eb-9928-4e02-84f4-b40a40dcbc62" />
