### PR TITLE
chore(e2e): strip headless from user agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
               - 'projects/client/src/**'
               - 'projects/client/i18n/**'
               - 'projects/client/static/**'
+              - 'projects/client/e2e/**'
               - 'projects/client/package.json'
               - 'projects/client/deno.json'
               - 'projects/client/svelte.config.js'

--- a/projects/client/e2e/world.ts
+++ b/projects/client/e2e/world.ts
@@ -17,6 +17,12 @@ export class TraktWorld extends World {
     this._context = await this._browser.newContext();
     this._page = await this._context.newPage();
 
+    const userAgent = await this._page.evaluate(() => navigator.userAgent);
+    const headlessUserAgent = userAgent.replace(/headless/gi, '');
+    await this._context.setExtraHTTPHeaders({
+      'user-agent': headlessUserAgent,
+    });
+
     await this._page.goto(E2E_BASE_URL);
   }
 


### PR DESCRIPTION
## ♪ Note ♪
Always use the headless version of user agents in E2E tests.