### PR TITLE
Update de-de.json

### DIFF
--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -60,7 +60,7 @@
   "genre_science_fiction": "Science Fiction",
   "remove_from_watchlist": "Von der Wunschliste entfernen",
   "remove_from_watchlist_label": "Entferne {title} von deiner Wunschliste",
-  "watch_the_trailer": "Anhänger ansehen",
+  "watch_the_trailer": "Trailer ansehen",
   "search_placeholder": "Bereit zum Entdecken?",
   "join_trakt_button": "Trakt beitreten",
   "join_trakt_button_label": "Tritt trakt.tv bei, um den Überblick über deine Inhalte zu behalten",


### PR DESCRIPTION
"watch_the_trailer": "Anhänger ansehen", to "watch_the_trailer": "Trailer ansehen",

watch_the_trailer: "Anhänger ansehen" has been replaced with "Trailer ansehen" as it is more commonly used this way (rather than a direct translation).
