### PR TITLE
Feat/underlined buttons

### DIFF
--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -44,7 +44,8 @@
   <div class="button-label">
     <p
       class="ellipsis"
-      class:small={subtitle != null}
+      class:small={subtitle != null || style === "underlined"}
+      class:bold={style === "underlined"}
       class:capitalize={text === "capitalize"}
     >
       {@render children()}
@@ -178,12 +179,33 @@
 
     transition: var(--transition-increment) ease-in-out;
     transition-property: box-shadow, outline, padding, transform, color,
-      background;
+      background, text-decoration;
+
+    &:not([data-style="underlined"]) p:not(.meta-info) {
+      font-size: 1rem;
+      font-style: normal;
+      font-weight: 700;
+    }
+
+    p:not(.meta-info) {
+      text-transform: uppercase;
+    }
 
     &.trakt-button-link {
       &[data-style="ghost"] {
         &.trakt-link-active {
           color: var(--color-background-button);
+        }
+      }
+
+      &[data-style="underlined"] {
+        &.trakt-link-active {
+          text-decoration-color: color-mix(
+            in srgb,
+            var(--color-background-button) 80%,
+            white 20%
+          );
+          text-decoration-line: underline;
         }
       }
     }
@@ -318,7 +340,7 @@
       background: transparent;
 
       &:not([data-variant="secondary"]) {
-        color: color(var(--color-foreground));
+        color: var(--color-foreground);
       }
 
       &[disabled] {
@@ -395,6 +417,38 @@
     &[data-style="flat"] {
       &:active:not([disabled]) {
         transform: scale(calc(var(--scale-factor-button) * 0.97));
+      }
+    }
+
+    &[data-style="underlined"] {
+      --underline-offset: var(--ni-4);
+      --line-thickness: var(--ni-2);
+
+      background: transparent;
+      text-decoration-color: transparent;
+      color: var(--color-foreground);
+
+      text-underline-offset: var(--underline-offset);
+      text-decoration-thickness: var(--line-thickness);
+      line-height: calc(100% + var(--underline-offset) + var(--line-thickness));
+
+      &[disabled] {
+        color: var(--color-foreground-button-disabled);
+      }
+
+      @include for-mouse {
+        &:hover:not([disabled]) {
+          text-decoration-line: underline;
+          text-decoration-color: var(--color-foreground);
+
+          &:not(.trakt-link-active) {
+            color: color-mix(
+              in srgb,
+              var(--color-foreground-button) 80%,
+              white 20%
+            );
+          }
+        }
       }
     }
   }

--- a/projects/client/src/lib/components/buttons/TraktButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/TraktButtonProps.ts
@@ -3,7 +3,7 @@ import type { Snippet } from 'svelte';
 export type TraktButtonProps = ButtonProps & {
   color?: 'purple' | 'red' | 'blue' | 'orange' | 'default' | 'custom';
   variant?: 'primary' | 'secondary';
-  style?: 'textured' | 'flat' | 'ghost';
+  style?: 'textured' | 'flat' | 'ghost' | 'underlined';
   icon?: Snippet;
   subtitle?: Snippet;
   size?: 'normal' | 'small' | 'tag';

--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -82,7 +82,7 @@
         <Button
           href={UrlBuilder.home()}
           label={m.navbar_link_home_label()}
-          style="ghost"
+          style="underlined"
           variant="primary"
           color="purple"
           data-testid={TestId.NavBarHomeButton}
@@ -92,7 +92,7 @@
         <Button
           href={UrlBuilder.shows()}
           label={m.navbar_link_shows_label()}
-          style="ghost"
+          style="underlined"
           variant="primary"
           color="purple"
           data-testid={TestId.NavBarShowsButton}
@@ -102,7 +102,7 @@
         <Button
           href={UrlBuilder.movies()}
           label={m.navbar_link_movies_label()}
-          style="ghost"
+          style="underlined"
           variant="primary"
           color="purple"
           data-testid={TestId.NavBarMoviesButton}
@@ -114,7 +114,7 @@
         <Button
           href={UrlBuilder.watchlist()}
           label={m.navbar_link_watchlist_label()}
-          style="ghost"
+          style="underlined"
           variant="primary"
           color="purple"
         >
@@ -187,20 +187,6 @@
       gap: var(--gap-xs);
       align-items: center;
       justify-content: end;
-
-      /** 
-      * Navbar links have custom design,
-      * to accommodate the custom cover background
-      * so we need to override the button styles
-      */
-      :global(.trakt-button.trakt-link-active[data-style="ghost"]) {
-        background: color-mix(
-          in srgb,
-          var(--color-background-button) 70%,
-          transparent 30%
-        );
-        color: var(--color-foreground-button);
-      }
     }
   }
 
@@ -212,6 +198,23 @@
     backdrop-filter: blur(8px);
 
     color: var(--color-foreground-navbar);
+
+    /** 
+      * Navbar links have custom design,
+      * to accommodate the scrolled navbar
+      * we need to override the button styles
+      */
+    :global(.trakt-button[data-style="underlined"]) {
+      color: var(--color-foreground-navbar);
+    }
+
+    @include for-mouse {
+      :global(.trakt-button[data-style="underlined"]) {
+        &:hover:not([disabled]) {
+          text-decoration-color: var(--color-foreground-navbar);
+        }
+      }
+    }
 
     &.trakt-navbar {
       width: calc(100dvw - 2 * var(--layout-distance-side));

--- a/projects/client/src/routes/_design_system/buttons/+page.svelte
+++ b/projects/client/src/routes/_design_system/buttons/+page.svelte
@@ -7,7 +7,12 @@
 
   import type { TraktButtonProps } from "$lib/components/buttons/TraktButtonProps";
 
-  const styles: TraktButtonProps["style"][] = ["textured", "flat", "ghost"];
+  const styles: TraktButtonProps["style"][] = [
+    "textured",
+    "flat",
+    "ghost",
+    "underlined",
+  ];
   const colors: TraktButtonProps["color"][] = [
     "purple",
     "red",

--- a/projects/client/src/style/typography/index.css
+++ b/projects/client/src/style/typography/index.css
@@ -117,13 +117,6 @@ p {
   white-space: nowrap;
 }
 
-.trakt-button p:not(.meta-info) {
-  font-size: 1rem;
-  font-style: normal;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
 p,
 span,
 h1,


### PR DESCRIPTION
## ⚠️ Draft ⚠️
@anodpixels:

- With certain page backgrounds, the non active button is slightly less readable since the button itself no longer has a background. See examples below. Is this good enough to start with?
- By default, only buttons that can have an active state will show the colored underline. Non active, and regular buttons will fall back to the slightly grayer font color. The color will be shown on a hover. See video example below. These do seem a bit like disable ghost buttons now though. Not sure if we should fix this right this moment, since we only have use for the ones that can have an active state.
- You can check out this branch if you want to play around with it first.

## 🎶 Notes 🎶

- Adds an underlined style to the button component.
- Works best when used with links.

## 👀 Examples 👀
<img width="1086" alt="Screenshot 2025-03-13 at 15 30 42" src="https://github.com/user-attachments/assets/102136c7-4c5c-4958-9679-5101d6d6f9d4" />

<img width="1086" alt="Screenshot 2025-03-13 at 15 30 46" src="https://github.com/user-attachments/assets/a522eabb-8e8e-4f30-b6c8-f564ed67dfb8" />

<img width="1086" alt="Screenshot 2025-03-13 at 15 30 51" src="https://github.com/user-attachments/assets/ff2d59f9-63f7-4bf9-8b09-c5a753e28b68" />

https://github.com/user-attachments/assets/1b8a2c67-22ba-4a47-9f9b-13efa58a5f47

