### PR TITLE
feat(navbar): new search input design

### DIFF
--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Von der Wunschliste entfernen",
   "remove_from_watchlist_label": "Entferne {title} von deiner Wunschliste",
   "watch_the_trailer": "Trailer ansehen",
-  "search_placeholder": "Bereit zum Entdecken?",
+  "search_placeholder": "Suche nach Serien & Filmen...",
   "join_trakt_button": "Trakt beitreten",
   "join_trakt_button_label": "Tritt trakt.tv bei, um den Überblick über deine Inhalte zu behalten",
   "copyright_notice": "Alle Rechte vorbehalten.",

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Remove from Watchlist",
   "remove_from_watchlist_label": "Remove {title} from your Watchlist",
   "watch_the_trailer": "Watch Trailer",
-  "search_placeholder": "Ready to explore?",
+  "search_placeholder": "Search shows & movies...",
   "join_trakt_button": "Join Trakt",
   "join_trakt_button_label": "Join trakt.tv to keep track of what you're watching",
   "copyright_notice": "All rights reserved.",

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Quitar de la lista",
   "remove_from_watchlist_label": "Quitar {title} de tu lista",
   "watch_the_trailer": "Ver tráiler",
-  "search_placeholder": "¿Preparado para explorar?",
+  "search_placeholder": "Buscar series y películas...",
   "join_trakt_button": "Únete a Trakt",
   "join_trakt_button_label": "Únete a trakt.tv para seguir tu visionado",
   "copyright_notice": "Todos los derechos reservados.",

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Quitar de la Lista",
   "remove_from_watchlist_label": "Quitar {title} de tu Lista",
   "watch_the_trailer": "Mira el tráiler",
-  "search_placeholder": "¿Listo para explorar?",
+  "search_placeholder": "Busca series y pelis...",
   "join_trakt_button": "Únete a Trakt",
   "join_trakt_button_label": "Únete a trakt.tv para seguir tu contenido",
   "copyright_notice": "Todos los derechos reservados.",

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Retirer de la liste",
   "remove_from_watchlist_label": "Retirer {title} de votre liste de visionnement",
   "watch_the_trailer": "Regarder la bande-annonce",
-  "search_placeholder": "Prêt à explorer?",
+  "search_placeholder": "Rechercher séries & films...",
   "join_trakt_button": "Rejoindre Trakt",
   "join_trakt_button_label": "Rejoignez trakt.tv pour suivre vos visionnements",
   "copyright_notice": "Tous droits réservés.",

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Supprimer de la liste",
   "remove_from_watchlist_label": "Retirer {title} de votre liste de visionnage",
   "watch_the_trailer": "Regarder la bande-annonce",
-  "search_placeholder": "Prêt à explorer ?",
+  "search_placeholder": "Rechercher séries & films...",
   "join_trakt_button": "Rejoindre Trakt",
   "join_trakt_button_label": "Rejoignez trakt.tv pour suivre vos visionnages",
   "copyright_notice": "Tous droits réservés.",

--- a/projects/client/i18n/messages/it-it.json
+++ b/projects/client/i18n/messages/it-it.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Rimuovi dalla Watchlist",
   "remove_from_watchlist_label": "Rimuovi {title} dalla tua Watchlist",
   "watch_the_trailer": "Guarda il trailer",
-  "search_placeholder": "Pronto ad esplorare?",
+  "search_placeholder": "Cerca serie e film...",
   "join_trakt_button": "Iscriviti a Trakt",
   "join_trakt_button_label": "Iscriviti a trakt.tv per tenere traccia di ciò che stai guardando",
   "copyright_notice": "Tutti i diritti riservati.",

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "視聴リストから削除",
   "remove_from_watchlist_label": "{title} を視聴リストから削除",
   "watch_the_trailer": "予告編を見る",
-  "search_placeholder": "探したい作品は？",
+  "search_placeholder": "番組や映像作品を検索...",
   "join_trakt_button": "Traktに参加",
   "join_trakt_button_label": "trakt.tvに参加して視聴状況を記録しましょう",
   "copyright_notice": "全著作権所有。",

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Van Watchlist verwijderen",
   "remove_from_watchlist_label": "{title} van je Watchlist verwijderen",
   "watch_the_trailer": "Trailer bekijken",
-  "search_placeholder": "Klaar om te ontdekken?",
+  "search_placeholder": "Zoek series & films...",
   "join_trakt_button": "Doe mee met Trakt",
   "join_trakt_button_label": "Doe mee met trakt.tv om bij te houden wat je bekijkt",
   "copyright_notice": "Alle rechten voorbehouden.",

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Usuń z listy do obejrzenia",
   "remove_from_watchlist_label": "Usuń {title} z listy do obejrzenia",
   "watch_the_trailer": "Zobacz zwiastun",
-  "search_placeholder": "Gotowy na poszukiwania?",
+  "search_placeholder": "Szukaj seriali i filmów...",
   "join_trakt_button": "Dołącz do Trakt",
   "join_trakt_button_label": "Dołącz do trakt.tv, by śledzić co oglądasz",
   "copyright_notice": "Wszystkie prawa zastrzeżone.",

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Remover da Lista Para Assistir",
   "remove_from_watchlist_label": "Remover {title} da sua Lista Para Assistir",
   "watch_the_trailer": "Assista ao Trailer",
-  "search_placeholder": "Pronto para explorar?",
+  "search_placeholder": "Busque séries e filmes...",
   "join_trakt_button": "Junte-se ao Trakt",
   "join_trakt_button_label": "Junte-se ao trakt.tv para acompanhar o que você assiste",
   "copyright_notice": "Todos os direitos reservados.",

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Șterge din vizionate",
   "remove_from_watchlist_label": "Șterge {title} din lista ta de vizionat",
   "watch_the_trailer": "Urmărește Trailerul",
-  "search_placeholder": "Gata să explorezi?",
+  "search_placeholder": "Caută seriale & filme...",
   "join_trakt_button": "Alătură-te Trakt",
   "join_trakt_button_label": "Alătură-te trakt.tv pentru a urmări ce urmărești",
   "copyright_notice": "Toate drepturile rezervate.",

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -62,7 +62,7 @@
   "remove_from_watchlist": "Прибрати з перегляду",
   "remove_from_watchlist_label": "Прибрати {title} зі списку перегляду",
   "watch_the_trailer": "Переглянути трейлер",
-  "search_placeholder": "Готові дослідити?",
+  "search_placeholder": "Пошук серіалів та фільмів...",
   "join_trakt_button": "Приєднатися до Trakt",
   "join_trakt_button_label": "Приєднайтеся до trakt.tv, щоб відстежувати те, що ви дивитеся",
   "copyright_notice": "Всі права захищені.",

--- a/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
+++ b/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
@@ -89,14 +89,22 @@
 
       .trakt-search-input {
         background: color-mix(in srgb, var(--shade-940) 90%, transparent 10%);
+        outline: var(--border-thickness-xs) solid var(--shade-700);
+
+        @include for-mobile {
+          &:not(:focus-within) {
+            opacity: 0;
+          }
+        }
       }
     }
   }
 
   .trakt-search {
-    --search-input-width: clamp(var(--ni-80), 100%, var(--ni-320));
+    --search-input-width: clamp(var(--ni-80), 100%, var(--ni-480));
     --mobile-search-focus-width: calc(100dvw - var(--layout-distance-side) * 2);
     --search-icon-size: var(--ni-24);
+    --search-icon-offset: calc(var(--search-icon-size) / 2);
 
     display: flex;
     height: var(--ni-48);
@@ -114,8 +122,8 @@
 
       position: absolute;
       z-index: calc(var(--layer-top) + var(--layer-overlay));
-      top: calc(var(--search-icon-size) / 2);
-      left: calc(var(--search-icon-size) / 2);
+      top: var(--search-icon-offset);
+      left: var(--search-icon-offset);
     }
 
     .trakt-search-input {
@@ -123,11 +131,12 @@
       height: 100%;
       width: 100%;
       padding: var(--ni-8) var(--ni-16);
-      padding-left: calc(var(--search-icon-size) + var(--ni-16));
+      padding-left: calc(
+        var(--search-icon-size) + var(--search-icon-offset) + var(--ni-16)
+      );
       box-sizing: border-box;
 
       border-radius: var(--border-radius-s);
-      outline: var(--border-thickness-xs) solid var(--shade-700);
       background: color-mix(
         in srgb,
         var(--color-background) 75%,
@@ -150,6 +159,10 @@
           outline: none;
           opacity: 0.75;
         }
+      }
+
+      &:placeholder-shown {
+        text-overflow: ellipsis;
       }
 
       &:focus-within {


### PR DESCRIPTION
## ⚠️ Draft ⚠️
Pending design checks:
- Use a max width after all; search can get too big on desktop otherwise.
- Use a background for the search icon on non-scrolled mobile view.

## 🎶 Notes 🎶

- Updated design for search input.
- New placeholder text
- Ellipsed placeholder text
- Desktop:
  - Increased max width
  - Only show outline when scrolled
- Mobile:
  - Should look the same in non-scrolled version
  - When scrolled, background is removed

## 👀 Examples 👀

before/after:
<img width="1439" alt="Screenshot 2025-03-14 at 21 00 42" src="https://github.com/user-attachments/assets/c697008d-975d-45da-992d-6b0378e1332f" />

<img width="1439" alt="Screenshot 2025-03-14 at 21 00 46" src="https://github.com/user-attachments/assets/b035c5fb-8939-439d-81ac-65c795cb25d3" />

before/after:
<img width="1439" alt="Screenshot 2025-03-14 at 21 00 54" src="https://github.com/user-attachments/assets/7423fd2b-8503-407b-b33e-4d6eab613437" />

<img width="1439" alt="Screenshot 2025-03-14 at 21 00 59" src="https://github.com/user-attachments/assets/e4b9f670-1cb4-4533-ae07-5480e3c11427" />

before/after:
<img width="427" alt="Screenshot 2025-03-14 at 21 01 55" src="https://github.com/user-attachments/assets/39dc66b0-7740-4e14-b71f-4077fc887a92" />

<img width="427" alt="Screenshot 2025-03-14 at 21 02 00" src="https://github.com/user-attachments/assets/e0480a8d-9654-4742-8a93-fd386bc7aea2" />

before/after:
<img width="498" alt="Screenshot 2025-03-14 at 21 17 06" src="https://github.com/user-attachments/assets/7a16df7c-7829-45c4-ae40-118f29e6b972" />

<img width="498" alt="Screenshot 2025-03-14 at 21 17 11" src="https://github.com/user-attachments/assets/63620052-a99e-48ce-bd2e-54fd46d09096" />
