### PR TITLE
Fix/no auth queries

### DIFF
--- a/projects/client/src/lib/sections/lists/history/MediaWatchHistoryList.svelte
+++ b/projects/client/src/lib/sections/lists/history/MediaWatchHistoryList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import type { MediaType } from "$lib/requests/models/MediaType";
@@ -16,23 +17,25 @@
   const { title, type, media }: RecentlyWatchedListProps = $props();
 </script>
 
-<MediaList
-  id="media-watch-history-list-{type}-{media.id}"
-  {title}
-  type="episode"
-  useList={({ limit, page }) =>
-    useRecentlyWatchedList({
-      type,
-      limit,
-      page,
-      id: media.id,
-    })}
->
-  {#snippet item(media)}
-    <RecentlyWatchedItem {media} />
-  {/snippet}
+<RenderFor audience="authenticated">
+  <MediaList
+    id="media-watch-history-list-{type}-{media.id}"
+    {title}
+    type="episode"
+    useList={({ limit, page }) =>
+      useRecentlyWatchedList({
+        type,
+        limit,
+        page,
+        id: media.id,
+      })}
+  >
+    {#snippet item(media)}
+      <RecentlyWatchedItem {media} />
+    {/snippet}
 
-  {#snippet empty()}
-    <p>{m.empty_media_history_label({ title: media.title })}</p>
-  {/snippet}
-</MediaList>
+    {#snippet empty()}
+      <p>{m.empty_media_history_label({ title: media.title })}</p>
+    {/snippet}
+  </MediaList>
+</RenderFor>


### PR DESCRIPTION
## 🎶 Notes 🎶

- ~Do not request user data if we know the user is not signed in~
- Do not show the watched history list if we know the user is not signed in

## 👀 Examples 👀

**~Before/after~**:
<img width="420" alt="Screenshot 2025-03-17 at 19 00 56" src="https://github.com/user-attachments/assets/7f6333e5-2ceb-48f7-8efb-d5a377d38e4e" />

<img width="420" alt="Screenshot 2025-03-17 at 19 05 13" src="https://github.com/user-attachments/assets/ca02694a-c9e7-48c2-9a22-26c2485c7e5b" />

**Before**:
<img width="1168" alt="Screenshot 2025-03-17 at 19 08 37" src="https://github.com/user-attachments/assets/2059a387-f182-4153-99e6-fbf4d9cfe1ec" />

And after 3 failed requests it would show:
<img width="1168" alt="Screenshot 2025-03-17 at 19 08 45" src="https://github.com/user-attachments/assets/d89e8907-5f50-4954-a266-2047392fa827" />

**After**:
<img width="1168" alt="Screenshot 2025-03-17 at 19 08 16" src="https://github.com/user-attachments/assets/7a1d00af-ea1f-4bfe-9fa4-8e1ac7ea7f08" />
