### PR TITLE
fix: gradients in chrome

### DIFF
--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -62,19 +62,11 @@
       background: linear-gradient(
         180deg,
         color-mix(in srgb, var(--color-background) 64%, transparent 36%) 0%,
-        color-mix(in srgb, var(--color-background) 65%, transparent 35%) 5%,
-        color-mix(in srgb, var(--color-background) 66%, transparent 34%) 9%,
         color-mix(in srgb, var(--color-background) 67%, transparent 33%) 13%,
-        color-mix(in srgb, var(--color-background) 68%, transparent 32%) 17%,
-        color-mix(in srgb, var(--color-background) 69%, transparent 31%) 20%,
         color-mix(in srgb, var(--color-background) 70%, transparent 30%) 25%,
-        color-mix(in srgb, var(--color-background) 72%, transparent 28%) 29%,
         color-mix(in srgb, var(--color-background) 74%, transparent 26%) 34%,
-        color-mix(in srgb, var(--color-background) 77%, transparent 23%) 40%,
         color-mix(in srgb, var(--color-background) 79%, transparent 21%) 46%,
-        color-mix(in srgb, var(--color-background) 83%, transparent 17%) 55%,
         color-mix(in srgb, var(--color-background) 86%, transparent 14%) 64%,
-        color-mix(in srgb, var(--color-background) 90%, transparent 10%) 74%,
         color-mix(in srgb, var(--color-background) 95%, transparent 5%) 85%,
         var(--color-background) 100%
       );

--- a/projects/client/src/lib/components/background/TraktCoverImage.svelte
+++ b/projects/client/src/lib/components/background/TraktCoverImage.svelte
@@ -46,19 +46,11 @@
         background: linear-gradient(
           180deg,
           color-mix(in srgb, var(--color-background) 48%, transparent 52%) 0%,
-          color-mix(in srgb, var(--color-background) 49%, transparent 51%) 5%,
-          color-mix(in srgb, var(--color-background) 50%, transparent 50%) 9%,
           color-mix(in srgb, var(--color-background) 51%, transparent 49%) 13%,
-          color-mix(in srgb, var(--color-background) 53%, transparent 47%) 17%,
-          color-mix(in srgb, var(--color-background) 55%, transparent 45%) 20%,
           color-mix(in srgb, var(--color-background) 57%, transparent 43%) 25%,
-          color-mix(in srgb, var(--color-background) 59%, transparent 41%) 29%,
           color-mix(in srgb, var(--color-background) 62%, transparent 38%) 34%,
-          color-mix(in srgb, var(--color-background) 66%, transparent 34%) 40%,
           color-mix(in srgb, var(--color-background) 70%, transparent 30%) 46%,
-          color-mix(in srgb, var(--color-background) 75%, transparent 25%) 55%,
           color-mix(in srgb, var(--color-background) 80%, transparent 20%) 64%,
-          color-mix(in srgb, var(--color-background) 85%, transparent 15%) 74%,
           color-mix(in srgb, var(--color-background) 95%, transparent 5%) 85%,
           var(--color-background) 100%
         );

--- a/projects/client/src/lib/components/card/CardCover.svelte
+++ b/projects/client/src/lib/components/card/CardCover.svelte
@@ -116,29 +116,15 @@
       background: linear-gradient(
         180deg,
         transparent 0%,
-        color-mix(in srgb, var(--color-card-background) 2%, transparent 98%) 5%,
-        color-mix(in srgb, var(--color-card-background) 4%, transparent 96%) 9%,
         color-mix(in srgb, var(--color-card-background) 7%, transparent 93%) 13%,
-        color-mix(in srgb, var(--color-card-background) 10%, transparent 90%)
-          17%,
-        color-mix(in srgb, var(--color-card-background) 14%, transparent 86%)
-          20%,
         color-mix(in srgb, var(--color-card-background) 18%, transparent 82%)
           24%,
-        color-mix(in srgb, var(--color-card-background) 23%, transparent 77%)
-          29%,
         color-mix(in srgb, var(--color-card-background) 29%, transparent 71%)
           34%,
-        color-mix(in srgb, var(--color-card-background) 35%, transparent 65%)
-          40%,
         color-mix(in srgb, var(--color-card-background) 43%, transparent 57%)
           46%,
-        color-mix(in srgb, var(--color-card-background) 52%, transparent 48%)
-          54%,
         color-mix(in srgb, var(--color-card-background) 62%, transparent 38%)
           63%,
-        color-mix(in srgb, var(--color-card-background) 73%, transparent 27%)
-          74%,
         color-mix(in srgb, var(--color-card-background) 86%, transparent 14%)
           86%,
         var(--color-card-background) 100%

--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -154,19 +154,11 @@
       background: linear-gradient(
         var(--list-shadow-direction),
         transparent 0%,
-        color-mix(in srgb, var(--color-background) 2%, transparent 98%) 5%,
-        color-mix(in srgb, var(--color-background) 4%, transparent 96%) 9%,
         color-mix(in srgb, var(--color-background) 7%, transparent 93%) 13%,
-        color-mix(in srgb, var(--color-background) 10%, transparent 90%) 17%,
-        color-mix(in srgb, var(--color-background) 14%, transparent 86%) 20%,
         color-mix(in srgb, var(--color-background) 18%, transparent 82%) 24%,
-        color-mix(in srgb, var(--color-background) 23%, transparent 77%) 29%,
         color-mix(in srgb, var(--color-background) 29%, transparent 71%) 34%,
-        color-mix(in srgb, var(--color-background) 35%, transparent 65%) 40%,
         color-mix(in srgb, var(--color-background) 43%, transparent 57%) 46%,
-        color-mix(in srgb, var(--color-background) 52%, transparent 48%) 54%,
         color-mix(in srgb, var(--color-background) 62%, transparent 38%) 63%,
-        color-mix(in srgb, var(--color-background) 73%, transparent 27%) 74%,
         color-mix(in srgb, var(--color-background) 86%, transparent 14%) 86%,
         var(--color-background) 100%
       );

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -188,19 +188,11 @@
     background: linear-gradient(
       0deg,
       transparent 0%,
-      color-mix(in srgb, var(--color-background) 2%, transparent 98%) 5%,
-      color-mix(in srgb, var(--color-background) 4%, transparent 96%) 9%,
       color-mix(in srgb, var(--color-background) 7%, transparent 93%) 13%,
-      color-mix(in srgb, var(--color-background) 10%, transparent 90%) 17%,
-      color-mix(in srgb, var(--color-background) 14%, transparent 86%) 20%,
       color-mix(in srgb, var(--color-background) 18%, transparent 82%) 24%,
-      color-mix(in srgb, var(--color-background) 23%, transparent 77%) 29%,
       color-mix(in srgb, var(--color-background) 29%, transparent 71%) 34%,
-      color-mix(in srgb, var(--color-background) 35%, transparent 65%) 40%,
       color-mix(in srgb, var(--color-background) 43%, transparent 57%) 46%,
-      color-mix(in srgb, var(--color-background) 52%, transparent 48%) 54%,
       color-mix(in srgb, var(--color-background) 62%, transparent 38%) 63%,
-      color-mix(in srgb, var(--color-background) 73%, transparent 27%) 74%,
       color-mix(in srgb, var(--color-background) 86%, transparent 14%) 86%,
       var(--color-background) 100%
     );


### PR DESCRIPTION
## 🎶 Notes 🎶

- Latest Chrome on macOS seems to have broken gradients.
- More than 8 stop colors breaks the gradients. For now, I'm switching to use at most 8 stops.
- I reproduced it in codepen and reported it.

## 👀 Example 👀
Before:
<img width="880" alt="Screenshot 2025-03-18 at 19 02 34" src="https://github.com/user-attachments/assets/a9a74e43-e23c-4f08-8402-5579201215dc" />

After:
<img width="880" alt="Screenshot 2025-03-18 at 19 02 26" src="https://github.com/user-attachments/assets/9afcb186-6c06-4f78-b3b1-35fedf95e2fd" />
