### PR TITLE
Feat/centered scroll list

### DIFF
--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -13,6 +13,7 @@
     empty?: Snippet;
     scrollContainer?: Writable<HTMLDivElement>;
     scrollX?: Writable<{ left: number; right: number }>;
+    variant?: "normal" | "centered";
   };
 
   const {
@@ -25,6 +26,7 @@
     actions,
     badge,
     empty,
+    variant = "normal",
   }: SectionListProps<T> = $props();
   const sideDistance = useVarToPixels("var(--layout-distance-side)");
   const windowShadowWidth = useVarToPixels("var(--ni-64)");
@@ -68,7 +70,9 @@
           bind:this={$scrollContainer}
           use:scrollTracking={scrollX}
           use:scrollHistory={id}
-          class="trakt-list-item-container shadow-list-horizontal-scroll"
+          class="trakt-list-item-container"
+          class:shadow-list-horizontal-scroll-centered={variant === "centered"}
+          class:shadow-list-horizontal-scroll={variant === "normal"}
         >
           {#each items as i (i.id)}
             {@render item(i)}
@@ -172,13 +176,17 @@
     }
   }
 
+  .shadow-list-horizontal-scroll-centered,
   .shadow-list-horizontal-scroll {
     height: var(--height-list);
     display: flex;
     overflow-x: auto;
-    scroll-snap-type: x proximity;
     transition: gap var(--transition-increment) ease-in-out;
     @include adaptive-gap(gap);
+  }
+
+  .shadow-list-horizontal-scroll {
+    scroll-snap-type: x proximity;
 
     & > :global(:not(svelte-css-wrapper)) {
       scroll-snap-align: start;
@@ -212,6 +220,19 @@
       @include for-mobile() {
         scroll-snap-align: unset;
       }
+    }
+  }
+
+  .shadow-list-horizontal-scroll-centered {
+    --center-offset: calc(50% - var(--item-width) / 2);
+
+    scroll-snap-type: x mandatory;
+    padding-left: var(--center-offset);
+    padding-right: var(--center-offset);
+
+    & > :global(:not(svelte-css-wrapper)),
+    & > :global(svelte-css-wrapper > *) {
+      scroll-snap-align: center;
     }
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentList.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentList.svelte
@@ -1,0 +1,81 @@
+<script lang="ts" generics="T extends { id: unknown }">
+  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import CaretLeftIcon from "$lib/components/icons/CaretLeftIcon.svelte";
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
+  import type { ListProps } from "$lib/components/lists/ListProps";
+  import ShadowList from "$lib/components/lists/section-list/ShadowList.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
+  import { writable } from "svelte/store";
+
+  type CommentListProps<T> = Omit<
+    ListProps<T>,
+    "actions" | "dynamicActions" | "badge"
+  >;
+
+  const { id, items, title, item }: CommentListProps<T> = $props();
+
+  const scrollContainer = writable<HTMLDivElement>();
+  const scrollX = writable({ left: 0, right: 0 });
+
+  const itemWidth = useVarToPixels("var(--width-comment-thread-card)", false);
+
+  function scrollToLeft() {
+    const left = Math.max(0, $scrollContainer.scrollLeft - $itemWidth);
+
+    $scrollContainer.scrollTo({
+      left,
+      behavior: "smooth",
+    });
+  }
+
+  function scrollToRight() {
+    const maxScrollLeft =
+      $scrollContainer.scrollWidth - $scrollContainer.clientWidth;
+
+    const left = Math.min(
+      maxScrollLeft,
+      $scrollContainer.scrollLeft + $itemWidth,
+    );
+
+    $scrollContainer.scrollTo({
+      left,
+      behavior: "smooth",
+    });
+  }
+
+  const isLeftScrollDisabled = $derived($scrollX.left <= 0);
+  const isRightScrollDisabled = $derived($scrollX.right <= 0);
+</script>
+
+<ShadowList
+  {id}
+  {title}
+  {items}
+  {item}
+  {scrollX}
+  {scrollContainer}
+  variant="centered"
+  --item-width="var(--width-comment-thread-card)"
+>
+  {#snippet actions()}
+    <RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>
+      <ActionButton
+        onclick={scrollToLeft}
+        label={`Scroll ${title} to the left`}
+        color="purple"
+        disabled={isLeftScrollDisabled}
+      >
+        <CaretLeftIcon />
+      </ActionButton>
+      <ActionButton
+        onclick={scrollToRight}
+        label={`Scroll ${title} to the right`}
+        color="purple"
+        disabled={isRightScrollDisabled}
+      >
+        <CaretRightIcon />
+      </ActionButton>
+    </RenderFor>
+  {/snippet}
+</ShadowList>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentThreadCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentThreadCard.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <Card
-  --width-card="min(var(--width-comment-thread-card), 85vw)"
+  --width-card="var(--width-comment-thread-card)"
   --height-card="min(var(--height-comment-thread-card), 65vh)"
 >
   <div class="trakt-comment-thread-container">

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentsDialog.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentsDialog.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import Dialog from "$lib/components/dialogs/Dialog.svelte";
-  import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import type { CommentsProps } from "$lib/sections/summary/components/comments/CommentsProps";
   import { onMount } from "svelte";
   import { writable, type Writable } from "svelte/store";
+  import CommentList from "./CommentList.svelte";
   import CommentThreadCard from "./CommentThreadCard.svelte";
   import { useComments } from "./useComments";
 
@@ -32,7 +32,8 @@
 
   function scrollIntoView(node: HTMLElement, isSourceComment: boolean) {
     const update = (isSourceComment: boolean) => {
-      isSourceComment && node.scrollIntoView({ behavior: "smooth" });
+      isSourceComment &&
+        node.scrollIntoView({ behavior: "instant", inline: "center" });
     };
 
     onMount(() => update(isSourceComment));
@@ -42,8 +43,7 @@
 
 <Dialog title="Comments" {dialog}>
   <div class="trakt-comment-threads">
-    <!-- FIXME: replace with centered list -->
-    <SectionList
+    <CommentList
       id={`comment-threads-list-${media.slug}`}
       items={topLevelComments}
       title=""
@@ -54,7 +54,7 @@
           <CommentThreadCard {comment} {media} />
         </comment-thread>
       {/snippet}
-    </SectionList>
+    </CommentList>
   </div>
 </Dialog>
 

--- a/projects/client/src/lib/stores/css/useVarToPixels.ts
+++ b/projects/client/src/lib/stores/css/useVarToPixels.ts
@@ -36,23 +36,12 @@ function calculate(value: string) {
   return pixelMeasurementDiv.getBoundingClientRect().width;
 }
 
-const STABLE = [
-  'px',
-  'pt',
-  'cm',
-  'mm',
-  'in',
-  'pc',
-];
-
-export function useVarToPixels(variable: string) {
+export function useVarToPixels(variable: string, isStable = true) {
   const value = writable(0);
 
   if (!browser) return value;
 
   value.set(calculate(variable));
-
-  const isStable = STABLE.some((unit) => variable.includes(unit));
 
   if (isStable) return value;
 

--- a/projects/client/src/style/layout/index.css
+++ b/projects/client/src/style/layout/index.css
@@ -33,7 +33,7 @@
   --width-comment-card: var(--ni-480);
   --height-comment-card: var(--ni-228);
 
-  --width-comment-thread-card: var(--width-comment-card);
+  --width-comment-thread-card: min(var(--width-comment-card), 85vw);
   --height-comment-thread-card: var(--ni-480);
 
   /**


### PR DESCRIPTION
## 🎶 Notes 🎶

- Comment threads are now centered in the dialog.
- Scrolling is snapped to center.
- Buttons scroll items one by one.
- The source comment is scrolled to instantly now.
- `useVarToPixels` is now stable by default, non-stableness can be opted in via a param.
  - Most use cases required it to be stable, but they were css variables that don't directly contain units.
  - Detection could also result into false positives. For example, in case of `mm`, variable `--comment-width` would be falsely detected as being stable.

## 👀 Examples 👀

https://github.com/user-attachments/assets/aab8a7fc-25d6-4280-9820-97bf39f629fb


https://github.com/user-attachments/assets/4972fc6e-ebe1-4817-9e49-450e5fdba67f

