### PR TITLE
Fix/comment likes

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "npm:@cucumber/cucumber@^11.2.0": "11.2.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.0.2_@cucumber+messages@27.0.2",
     "npm:@google/generative-ai@0.21": "0.21.0",
     "npm:@inlang/paraglide-sveltekit@~0.15.5": "0.15.5_@sveltejs+kit@2.17.1__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.19.9____acorn@8.14.0___vite@6.1.0____sass-embedded@1.83.4___sass-embedded@1.83.4__svelte@5.19.9___acorn@8.14.0__vite@6.1.0___sass-embedded@1.83.4__sass-embedded@1.83.4_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.19.9___acorn@8.14.0__vite@6.1.0___sass-embedded@1.83.4__sass-embedded@1.83.4_svelte@5.19.9__acorn@8.14.0_vite@6.1.0__sass-embedded@1.83.4_sass-embedded@1.83.4",
-    "npm:@jsr/trakt__api@~0.1.6": "0.1.6_zod@3.24.1",
+    "npm:@jsr/trakt__api@~0.1.9": "0.1.9_zod@3.24.1",
     "npm:@playwright/test@^1.50.1": "1.50.1",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.19.9__acorn@8.14.0",
     "npm:@sveltejs/adapter-auto@4": "4.0.0_@sveltejs+kit@2.17.1__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.19.9____acorn@8.14.0___vite@6.1.0____sass-embedded@1.83.4___sass-embedded@1.83.4__svelte@5.19.9___acorn@8.14.0__vite@6.1.0___sass-embedded@1.83.4__sass-embedded@1.83.4_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.19.9___acorn@8.14.0__vite@6.1.0___sass-embedded@1.83.4__sass-embedded@1.83.4_svelte@5.19.9__acorn@8.14.0_vite@6.1.0__sass-embedded@1.83.4_sass-embedded@1.83.4",
@@ -2082,8 +2082,8 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.1.6_zod@3.24.1": {
-      "integrity": "sha512-LZperzKEddHOSZEG5pTMmFZlQ9Jrh7BS/Mi42MtmRP0s0CazYyWfsINAS22EV9AqcXhJrNxvj9dBib8UIvVCIw==",
+    "@jsr/trakt__api@0.1.9_zod@3.24.1": {
+      "integrity": "sha512-HvOVfiYiEg3NSh5faoaL0AsUkGeZZxKr2wr9jYVpC+1Rdk2S32iyI/q8szLMUxgpQzOOMsm0YDeTQNVpHMenWw==",
       "dependencies": [
         "@ts-rest/core",
         "zod"
@@ -6898,7 +6898,7 @@
             "npm:@cucumber/cucumber@^11.2.0",
             "npm:@google/generative-ai@0.21",
             "npm:@inlang/paraglide-sveltekit@~0.15.5",
-            "npm:@jsr/trakt__api@~0.1.6",
+            "npm:@jsr/trakt__api@~0.1.9",
             "npm:@playwright/test@^1.50.1",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@sveltejs/adapter-auto@4",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -61,7 +61,7 @@
     "@tanstack/svelte-query": "^5.66.0",
     "@tanstack/svelte-query-devtools": "^5.66.0",
     "@tanstack/svelte-query-persist-client": "^5.66.0",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.1.6",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.1.9",
     "@ts-rest/core": "^3.51.0",
     "date-fns": "^4.1.0",
     "firebase": "^11.3.0",

--- a/projects/client/src/lib/components/dialogs/Dialog.svelte
+++ b/projects/client/src/lib/components/dialogs/Dialog.svelte
@@ -3,6 +3,7 @@
   import CloseIcon from "$lib/components/icons/CloseIcon.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import { writable, type Writable } from "svelte/store";
+  import { setDialogState } from "./_internal/setDialogState";
 
   type DialogProps = {
     title: string;
@@ -12,7 +13,7 @@
   const { title, children, dialog = writable() }: DialogProps = $props();
 </script>
 
-<dialog bind:this={$dialog}>
+<dialog bind:this={$dialog} use:setDialogState>
   <div class="trakt-dialog-header">
     <h5 class="secondary">{title}</h5>
     <ActionButton

--- a/projects/client/src/lib/components/dialogs/Dialog.svelte
+++ b/projects/client/src/lib/components/dialogs/Dialog.svelte
@@ -84,6 +84,7 @@
     box-sizing: border-box;
 
     margin: var(--ni-12) var(--layout-distance-side);
+    margin-top: calc(var(--ni-12) + env(safe-area-inset-top));
     padding: 0 var(--navbar-side-padding);
   }
 

--- a/projects/client/src/lib/components/dialogs/_internal/setDialogState.ts
+++ b/projects/client/src/lib/components/dialogs/_internal/setDialogState.ts
@@ -1,0 +1,32 @@
+import { onMount } from 'svelte';
+
+/*
+  Safari on iOS can sometimes be slow to update the layout when a dialog is opened.
+  So, checking the dialog[open] attribute does not consistently work.
+  Instead, we can use a MutationObserver to watch for changes to the open attribute.
+*/
+export function setDialogState(dialog: HTMLDialogElement) {
+  const setState = () =>
+    globalThis.document.body.classList.toggle('dialog-open', dialog.open);
+
+  // A mutation observer is used since a dialog has no open/show event
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.attributeName !== 'open') {
+        return;
+      }
+
+      setState();
+    });
+  });
+
+  observer.observe(dialog, { attributes: true });
+
+  onMount(setState);
+
+  return {
+    destroy() {
+      observer.disconnect();
+    },
+  };
+}

--- a/projects/client/src/lib/features/auth/queries/currentUserLikesQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserLikesQuery.ts
@@ -5,9 +5,6 @@ import type { LikedItemResponse } from '@trakt/api';
 import { z } from 'zod';
 import { api, type ApiParams } from '../../../requests/api.ts';
 
-// FIXME: remove this when we have min & all query params
-const LIKES_LIMIT = 35000;
-
 const UserLikeSchema = z.object({
   type: z.enum(['comment', 'list']),
   id: z.number(),
@@ -18,9 +15,7 @@ export type UserLike = z.infer<typeof UserLikeSchema>;
 function mapRatedItemResponse(response: LikedItemResponse): UserLike {
   return {
     type: response.type,
-    id: response.type === 'comment'
-      ? response.comment.id
-      : response.list.ids.trakt,
+    id: response.type === 'comment' ? response.comment.id : response.list.id,
   };
 }
 
@@ -32,7 +27,8 @@ const currentUserCommentLikesRequest = ({ fetch }: ApiParams) =>
         type: 'comments',
       },
       query: {
-        limit: LIKES_LIMIT,
+        limit: 'all',
+        extended: 'min',
       },
     })
     .then((response) => {

--- a/projects/client/src/lib/requests/queries/episode/episodeCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeCommentsQuery.ts
@@ -1,6 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapToMediaComment } from '$lib/requests/_internal/mapToMediaComment.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { MediaCommentSchema } from '$lib/requests/models/MediaComment.ts';
 import { time } from '$lib/utils/timing/time.ts';
 
@@ -37,7 +38,7 @@ const showCommentsRequest = (
 
 export const episodeCommentsQuery = defineQuery({
   key: 'episodeComments',
-  invalidations: [],
+  invalidations: [InvalidateAction.Like],
   dependencies: (params) => [params.slug, params.season, params.episode],
   request: showCommentsRequest,
   mapper: (data) => data.map(mapToMediaComment),

--- a/projects/client/src/lib/requests/queries/movies/movieCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieCommentsQuery.ts
@@ -1,6 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapToMediaComment } from '$lib/requests/_internal/mapToMediaComment.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { MediaCommentSchema } from '$lib/requests/models/MediaComment.ts';
 import { time } from '$lib/utils/timing/time.ts';
 
@@ -32,7 +33,7 @@ const movieCommentsRequest = (
 
 export const movieCommentsQuery = defineQuery({
   key: 'movieComments',
-  invalidations: [],
+  invalidations: [InvalidateAction.Like],
   dependencies: (params) => [params.slug],
   request: movieCommentsRequest,
   mapper: (data) => data.map(mapToMediaComment),

--- a/projects/client/src/lib/requests/queries/shows/showCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showCommentsQuery.ts
@@ -1,6 +1,7 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { mapToMediaComment } from '$lib/requests/_internal/mapToMediaComment.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { MediaCommentSchema } from '$lib/requests/models/MediaComment.ts';
 import { time } from '$lib/utils/timing/time.ts';
 
@@ -32,7 +33,7 @@ const showCommentsRequest = (
 
 export const showCommentsQuery = defineQuery({
   key: 'showComments',
-  invalidations: [],
+  invalidations: [InvalidateAction.Like],
   dependencies: (params) => [params.slug],
   request: showCommentsRequest,
   mapper: (data) => data.map(mapToMediaComment),

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/useComments.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/useComments.ts
@@ -3,12 +3,14 @@ import type { MediaComment } from '$lib/requests/models/MediaComment.ts';
 import { episodeCommentsQuery } from '$lib/requests/queries/episode/episodeCommentsQuery.ts';
 import { movieCommentsQuery } from '$lib/requests/queries/movies/movieCommentsQuery.ts';
 import { showCommentsQuery } from '$lib/requests/queries/shows/showCommentsQuery.ts';
+import { useStableArray } from '$lib/sections/lists/stores/useStableArray.ts';
 import type {
   EpisodeCommentProps,
   MediaCommentProps,
 } from '$lib/sections/summary/components/comments/CommentsProps.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { type CreateQueryOptions } from '@tanstack/svelte-query';
+import { onMount } from 'svelte';
 import { derived } from 'svelte/store';
 
 type UseCommentsProps = {
@@ -46,8 +48,13 @@ export function useComments(props: UseCommentsProps) {
     toLoadingState,
   );
 
+  const unstable = derived(query, ($query) => $query.data ?? []);
+  const { list, set } = useStableArray<MediaComment>((l, r) => l.id === r.id);
+
+  onMount(() => unstable.subscribe(set));
+
   return {
     isLoading,
-    comments: derived(query, ($query) => $query.data ?? []),
+    comments: list,
   };
 }

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -73,7 +73,8 @@
       font-family: "Spline Sans", Arial, sans-serif;
     }
 
-    body:has(dialog[open]) {
+    body:has(dialog[open]),
+    body:has(.dialog-open) {
       overflow: hidden;
     }
   </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Get all user likes and request minimal response
- Invalidate comments on like
  - We should do a follow up where can update a single comment instead of invalidating on media level.
- And some ios fixes:
  - Safari on iOS had some issues reliably detecting if a browser was open.
  - Place the dialog header in a safe space. This was an issue in the PWA on iOS. 

## 👀 Example 👀
Before/after:
<img width="980" alt="Screenshot 2025-03-20 at 15 10 42" src="https://github.com/user-attachments/assets/77d36012-f98a-44ab-b592-825ced200cb3" />

<img width="980" alt="Screenshot 2025-03-20 at 15 11 30" src="https://github.com/user-attachments/assets/5940f351-0d70-4f88-bfe8-65d31861c0a7" />

Issue with the header:
![IMG_3483](https://github.com/user-attachments/assets/41eae05a-6e90-4e90-ac94-daf97f350ede)

