### PR TITLE
fix(summary): meta tags overflow

### DIFF
--- a/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
@@ -109,6 +109,7 @@
   .trakt-meta-tags {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
 
     gap: var(--gap-xs);
   }


### PR DESCRIPTION
## ♪ Note ♪

- Could overflow in some languages

## 👀 Example 👀

Before:
<img width="370" alt="Screenshot 2025-03-25 at 16 37 26" src="https://github.com/user-attachments/assets/52eaf4f9-f042-41f1-b494-bb46f94cac66" />

After:
<img width="370" alt="Screenshot 2025-03-25 at 16 37 15" src="https://github.com/user-attachments/assets/209874b5-040d-4509-bf1f-4c4f5e16c131" />
