### PR TITLE
Fix/ep coalesce

### DIFF
--- a/projects/client/src/lib/requests/_internal/coalesceEpisodes.spec.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceEpisodes.spec.ts
@@ -1,38 +1,147 @@
-import { EpisodeComputedType } from '$lib/requests/models/EpisodeType.ts';
+import {
+  EpisodeComputedType,
+  EpisodeFinaleType,
+  EpisodePremiereType,
+} from '$lib/requests/models/EpisodeType.ts';
 import { describe, expect, it } from 'vitest';
 import type { UpcomingEpisodeEntry } from '../queries/calendars/upcomingEpisodesQuery.ts';
 import { coalesceEpisodes } from './coalesceEpisodes.ts';
 
 describe('coalesceEpisodes', () => {
-  it('should coalesce season premiere and finale into full season', () => {
-    const show = { id: 1, title: 'Test Show' };
-    const episodes = [
-      {
-        show,
-        season: 1,
-        episode: 1,
-        type: 'season_premiere',
-        airDate: new Date('2024-01-01'),
-      } as unknown as UpcomingEpisodeEntry,
-      {
-        show,
-        season: 1,
-        episode: 10,
-        type: 'season_finale',
-        airDate: new Date('2024-03-01'),
-      } as unknown as UpcomingEpisodeEntry,
-    ];
+  const runCommonTests = (
+    premiereType: EpisodePremiereType,
+    finaleType: EpisodeFinaleType,
+  ) => {
+    it('should coalesce season premiere and finale into full season', () => {
+      const show = { id: 1, title: 'Test Show' };
+      const episodes = [
+        {
+          show,
+          season: 1,
+          episode: 1,
+          type: premiereType,
+          airDate: new Date('2024-01-01'),
+        } as unknown as UpcomingEpisodeEntry,
+        {
+          show,
+          season: 1,
+          episode: 10,
+          type: finaleType,
+          airDate: new Date('2024-03-01'),
+        } as unknown as UpcomingEpisodeEntry,
+      ];
 
-    const result = coalesceEpisodes(episodes);
+      const result = coalesceEpisodes(episodes);
 
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
-      ...episodes[0],
-      type: EpisodeComputedType.full_season,
-      season: 1,
-      show,
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        ...episodes[0],
+        type: EpisodeComputedType.full_season,
+        season: 1,
+        show,
+      });
     });
-  });
+
+    it('should not coalesce if there is no season finale', () => {
+      const show = { id: 1, title: 'Test Show' };
+      const episodes = [
+        {
+          show,
+          season: 1,
+          episode: 1,
+          type: premiereType,
+          airDate: new Date('2024-01-01'),
+        } as unknown as UpcomingEpisodeEntry,
+        {
+          show,
+          season: 1,
+          episode: 2,
+          type: 'regular',
+          airDate: new Date('2024-03-01'),
+        } as unknown as UpcomingEpisodeEntry,
+      ];
+
+      const result = coalesceEpisodes(episodes);
+
+      expect(result).toEqual(episodes);
+    });
+
+    it('should not coalesce if one episode from multiple shows', () => {
+      const show1 = { id: 1, title: 'Test Show 1' };
+      const show2 = { id: 2, title: 'Test Show 2' };
+      const episodes = [
+        {
+          show: show1,
+          season: 1,
+          episode: 1,
+          type: premiereType,
+          airDate: new Date('2024-01-01'),
+        } as unknown as UpcomingEpisodeEntry,
+        {
+          show: show2,
+          season: 1,
+          episode: 10,
+          type: finaleType,
+          airDate: new Date('2024-03-01'),
+        } as unknown as UpcomingEpisodeEntry,
+      ];
+
+      const result = coalesceEpisodes(episodes);
+
+      expect(result).toEqual(episodes);
+    });
+
+    it('should coalesce multiple shows if they fulfill the criteria', () => {
+      const show1 = { id: 1, title: 'Test Show 1' };
+      const show2 = { id: 2, title: 'Test Show 2' };
+      const episodes = [
+        {
+          show: show1,
+          season: 1,
+          episode: 1,
+          type: premiereType,
+          airDate: new Date('2024-01-01'),
+        } as unknown as UpcomingEpisodeEntry,
+        {
+          show: show2,
+          season: 1,
+          episode: 1,
+          type: premiereType,
+          airDate: new Date('2024-01-01'),
+        } as unknown as UpcomingEpisodeEntry,
+        {
+          show: show1,
+          season: 1,
+          episode: 10,
+          type: finaleType,
+          airDate: new Date('2024-03-01'),
+        } as unknown as UpcomingEpisodeEntry,
+        {
+          show: show2,
+          season: 1,
+          episode: 10,
+          type: finaleType,
+          airDate: new Date('2024-03-01'),
+        } as unknown as UpcomingEpisodeEntry,
+      ];
+
+      const result = coalesceEpisodes(episodes);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        ...episodes[0],
+        type: EpisodeComputedType.full_season,
+        season: 1,
+        show: show1,
+      });
+      expect(result[1]).toEqual({
+        ...episodes[1],
+        type: EpisodeComputedType.full_season,
+        season: 1,
+        show: show2,
+      });
+    });
+  };
 
   it('should not coalesce regular episodes', () => {
     const show = { id: 1, title: 'Test Show' };
@@ -84,127 +193,19 @@ describe('coalesceEpisodes', () => {
     expect(result[1].airDate).toEqual(new Date('2024-01-08'));
   });
 
-  it('should not coalesce if there is no season finale', () => {
-    const show = { id: 1, title: 'Test Show' };
-    const episodes = [
-      {
-        show,
-        season: 1,
-        episode: 1,
-        type: 'season_premiere',
-        airDate: new Date('2024-01-01'),
-      } as unknown as UpcomingEpisodeEntry,
-      {
-        show,
-        season: 1,
-        episode: 2,
-        type: 'regular',
-        airDate: new Date('2024-03-01'),
-      } as unknown as UpcomingEpisodeEntry,
-    ];
-
-    const result = coalesceEpisodes(episodes);
-
-    expect(result).toEqual(episodes);
+  describe('coalesce: season premiere and season finale', () => {
+    runCommonTests('season_premiere', 'season_finale');
   });
 
-  it('should not coalesce if there is no season premiere', () => {
-    const show = { id: 1, title: 'Test Show' };
-    const episodes = [
-      {
-        show,
-        season: 1,
-        episode: 9,
-        type: 'regular',
-        airDate: new Date('2024-01-01'),
-      } as unknown as UpcomingEpisodeEntry,
-      {
-        show,
-        season: 1,
-        episode: 10,
-        type: 'season_finale',
-        airDate: new Date('2024-03-01'),
-      } as unknown as UpcomingEpisodeEntry,
-    ];
-
-    const result = coalesceEpisodes(episodes);
-
-    expect(result).toEqual(episodes);
+  describe('coalesce: season premiere and series finale', () => {
+    runCommonTests('season_premiere', 'series_finale');
   });
 
-  it('should not coalesce if one episode from multiple shows', () => {
-    const show1 = { id: 1, title: 'Test Show 1' };
-    const show2 = { id: 2, title: 'Test Show 2' };
-    const episodes = [
-      {
-        show: show1,
-        season: 1,
-        episode: 1,
-        type: 'season_premiere',
-        airDate: new Date('2024-01-01'),
-      } as unknown as UpcomingEpisodeEntry,
-      {
-        show: show2,
-        season: 1,
-        episode: 10,
-        type: 'season_finale',
-        airDate: new Date('2024-03-01'),
-      } as unknown as UpcomingEpisodeEntry,
-    ];
-
-    const result = coalesceEpisodes(episodes);
-
-    expect(result).toEqual(episodes);
+  describe('coalesce: series premiere and series finale', () => {
+    runCommonTests('series_premiere', 'series_finale');
   });
 
-  it('should coalesce multiple shows if they fulfill the criteria', () => {
-    const show1 = { id: 1, title: 'Test Show 1' };
-    const show2 = { id: 2, title: 'Test Show 2' };
-    const episodes = [
-      {
-        show: show1,
-        season: 1,
-        episode: 1,
-        type: 'season_premiere',
-        airDate: new Date('2024-01-01'),
-      } as unknown as UpcomingEpisodeEntry,
-      {
-        show: show2,
-        season: 1,
-        episode: 1,
-        type: 'season_premiere',
-        airDate: new Date('2024-01-01'),
-      } as unknown as UpcomingEpisodeEntry,
-      {
-        show: show1,
-        season: 1,
-        episode: 10,
-        type: 'season_finale',
-        airDate: new Date('2024-03-01'),
-      } as unknown as UpcomingEpisodeEntry,
-      {
-        show: show2,
-        season: 1,
-        episode: 10,
-        type: 'season_finale',
-        airDate: new Date('2024-03-01'),
-      } as unknown as UpcomingEpisodeEntry,
-    ];
-
-    const result = coalesceEpisodes(episodes);
-
-    expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({
-      ...episodes[0],
-      type: EpisodeComputedType.full_season,
-      season: 1,
-      show: show1,
-    });
-    expect(result[1]).toEqual({
-      ...episodes[1],
-      type: EpisodeComputedType.full_season,
-      season: 1,
-      show: show2,
-    });
+  describe('coalesce: series premiere and season finale', () => {
+    runCommonTests('series_premiere', 'season_finale');
   });
 });

--- a/projects/client/src/lib/requests/_internal/coalesceEpisodes.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceEpisodes.ts
@@ -28,9 +28,11 @@ export function coalesceEpisodes(episodes: UpcomingEpisodeEntry[]) {
     { episodes, show, season },
   ) => {
     const hasSeasonPremiere = episodes.some((ep) =>
-      ep.type === 'season_premiere'
+      ['season_premiere', 'series_premiere'].includes(ep.type)
     );
-    const hasSeasonFinale = episodes.some((ep) => ep.type === 'season_finale');
+    const hasSeasonFinale = episodes.some((ep) =>
+      ['season_finale', 'series_finale'].includes(ep.type)
+    );
 
     if (hasSeasonPremiere && hasSeasonFinale) {
       return [{


### PR DESCRIPTION
## ♪ Note ♪

- Coalescing episodes did not happen when series premieres/finales were involved.

## 👀 Examples 👀

Before:
<img width="1157" alt="Screenshot 2025-03-28 at 21 14 37" src="https://github.com/user-attachments/assets/6dcaad62-714c-4208-a082-006c1a54085b" />

After:
<img width="1157" alt="Screenshot 2025-03-28 at 21 15 49" src="https://github.com/user-attachments/assets/6dce0a04-c9b7-4b16-9c8a-8520aac4ad21" />

