### PR TITLE
Feat/error boundary

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -46,6 +46,7 @@ module.exports = {
         'dropdown',
         'e2e',
         'episode',
+        'errors',
         'favorite',
         'formatter',
         'footer',

--- a/projects/client/i18n/messages/bg-bg.json
+++ b/projects/client/i18n/messages/bg-bg.json
@@ -352,5 +352,9 @@
   "original_title": "Оригинално Заглавие",
   "view_all_comments": "Виж всички коментари",
   "remove_from_list": "Премахни от списъка",
-  "remove_from_list_label": "Премахни {title} от списъка"
+  "remove_from_list_label": "Премахни {title} от списъка",
+  "error_page_service_title": "Услугата Trakt е недостъпна",
+  "error_page_service_message": "Връзката... отсъства. Като забравен спомен.",
+  "error_page_service_status": "Състояние на услугата Trakt",
+  "retry": "Опитай отново"
 }

--- a/projects/client/i18n/messages/da-dk.json
+++ b/projects/client/i18n/messages/da-dk.json
@@ -352,5 +352,9 @@
   "original_title": "Original Titel",
   "view_all_comments": "Se alle kommentarer",
   "remove_from_list": "Fjern fra listen",
-  "remove_from_list_label": "Fjern {title} fra listen"
+  "remove_from_list_label": "Fjern {title} fra listen",
+  "error_page_service_title": "Trakt tjeneste utilgængelig",
+  "error_page_service_message": "Forbindelsen er... fraværende. Som en glemt erindring.",
+  "error_page_service_status": "Trakt tjeneste status",
+  "retry": "Prøv igen"
 }

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -352,5 +352,9 @@
   "original_title": "Originaltitel",
   "view_all_comments": "Alle Kommentare anzeigen",
   "remove_from_list": "Remove from list",
-  "remove_from_list_label": "Remove {title} from list"
+  "remove_from_list_label": "Remove {title} from list",
+  "error_page_service_title": "Trakt-Dienst nicht erreichbar",
+  "error_page_service_message": "Die Verbindung ist... abwesend. Wie eine vergessene Erinnerung.",
+  "error_page_service_status": "Trakt-Dienststatus",
+  "retry": "Erneut versuchen"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -352,5 +352,9 @@
   "original_title": "Original Title",
   "view_all_comments": "View all comments",
   "remove_from_list": "Remove from list",
-  "remove_from_list_label": "Remove {title} from list"
+  "remove_from_list_label": "Remove {title} from list",
+  "error_page_service_title": "Trakt service unreachable",
+  "error_page_service_message": "The connection is... absent. Like a forgotten memory.",
+  "error_page_service_status": "Trakt service status",
+  "retry": "Retry"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -352,5 +352,9 @@
   "original_title": "Título original",
   "view_all_comments": "Ver todos los comentarios",
   "remove_from_list": "Eliminar de la lista",
-  "remove_from_list_label": "Eliminar {title} de la lista"
+  "remove_from_list_label": "Eliminar {title} de la lista",
+  "error_page_service_title": "Servicio Trakt inaccesible",
+  "error_page_service_message": "La conexión… ausente. Como un recuerdo olvidado.",
+  "error_page_service_status": "Estado del servicio Trakt",
+  "retry": "Reintentar"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -352,5 +352,9 @@
   "original_title": "Título original",
   "view_all_comments": "Ver todos los comentarios",
   "remove_from_list": "Eliminar de la lista",
-  "remove_from_list_label": "Eliminar {title} de la lista"
+  "remove_from_list_label": "Eliminar {title} de la lista",
+  "error_page_service_title": "Servicio Trakt inaccesible",
+  "error_page_service_message": "La conexión... ausente. Como un recuerdo olvidado.",
+  "error_page_service_status": "Estado del servicio Trakt",
+  "retry": "Reintentar"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -352,5 +352,9 @@
   "original_title": "Titre original",
   "view_all_comments": "Voir tous les commentaires",
   "remove_from_list": "Retirer de la liste",
-  "remove_from_list_label": "Retirer {title} de la liste"
+  "remove_from_list_label": "Retirer {title} de la liste",
+  "error_page_service_title": "Trakt service unreachable",
+  "error_page_service_message": "The connection is... absent. Like a forgotten memory.",
+  "error_page_service_status": "Trakt service status",
+  "retry": "Retry"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -352,5 +352,9 @@
   "original_title": "Titre original",
   "view_all_comments": "Voir tous les commentaires",
   "remove_from_list": "Retirer de la liste",
-  "remove_from_list_label": "Retirer {title} de la liste"
+  "remove_from_list_label": "Retirer {title} de la liste",
+  "error_page_service_title": "Service Trakt inaccessible",
+  "error_page_service_message": "La connexion est... absente. Tel un souvenir oublié.",
+  "error_page_service_status": "État du service Trakt",
+  "retry": "Réessayer"
 }

--- a/projects/client/i18n/messages/it-it.json
+++ b/projects/client/i18n/messages/it-it.json
@@ -352,5 +352,9 @@
   "original_title": "Titolo Originale",
   "view_all_comments": "Vedi tutti i commenti",
   "remove_from_list": "Rimuovi dalla lista",
-  "remove_from_list_label": "Rimuovi {title} dalla lista"
+  "remove_from_list_label": "Rimuovi {title} dalla lista",
+  "error_page_service_title": "Servizio Trakt irraggiungibile",
+  "error_page_service_message": "La connessione è... assente. Come un ricordo svanito.",
+  "error_page_service_status": "Stato del servizio Trakt",
+  "retry": "Riprova"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -352,5 +352,9 @@
   "original_title": "原題",
   "view_all_comments": "すべてのコメントを表示",
   "remove_from_list": "Remove from list",
-  "remove_from_list_label": "Remove {title} from list"
+  "remove_from_list_label": "Remove {title} from list",
+  "error_page_service_title": "Traktサービスに接続できません",
+  "error_page_service_message": "接続が…ありません。まるで忘れられた記憶のように。",
+  "error_page_service_status": "Traktサービスの状態",
+  "retry": "再試行"
 }

--- a/projects/client/i18n/messages/nb-no.json
+++ b/projects/client/i18n/messages/nb-no.json
@@ -352,5 +352,9 @@
   "original_title": "Originaltittel",
   "view_all_comments": "Se alle kommentarer",
   "remove_from_list": "Fjern fra liste",
-  "remove_from_list_label": "Fjern {title} fra listen"
+  "remove_from_list_label": "Fjern {title} fra listen",
+  "error_page_service_title": "Trakt-tjenesten er utilgjengelig",
+  "error_page_service_message": "Tilkoblingen er... fraværende. Som et glemt minne.",
+  "error_page_service_status": "Trakt-tjenestens status",
+  "retry": "Prøv igjen"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -352,5 +352,9 @@
   "original_title": "Originele titel",
   "view_all_comments": "Bekijk alle reacties",
   "remove_from_list": "Verwijder van lijst",
-  "remove_from_list_label": "Verwijder {title} van de lijst"
+  "remove_from_list_label": "Verwijder {title} van de lijst",
+  "error_page_service_title": "Trakt-dienst onbereikbaar",
+  "error_page_service_message": "De verbinding is... afwezig. Als een vergeten herinnering.",
+  "error_page_service_status": "Trakt-dienststatus",
+  "retry": "Opnieuw proberen"
 }

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -352,5 +352,9 @@
   "original_title": "Tytuł oryginalny",
   "view_all_comments": "Zobacz wszystkie komentarze",
   "remove_from_list": "Usuń z listy",
-  "remove_from_list_label": "Usuń {title} z listy"
+  "remove_from_list_label": "Usuń {title} z listy",
+  "error_page_service_title": "Usługa Trakt niedostępna",
+  "error_page_service_message": "Połączenie... nie istnieje. Niczym zapomniana scena.",
+  "error_page_service_status": "Status usługi Trakt",
+  "retry": "Spróbuj ponownie"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -352,5 +352,9 @@
   "original_title": "Título Original",
   "view_all_comments": "Ver todos os comentários",
   "remove_from_list": "Remover da lista",
-  "remove_from_list_label": "Remover {title} da lista"
+  "remove_from_list_label": "Remover {title} da lista",
+  "error_page_service_title": "Serviço Trakt inacessível",
+  "error_page_service_message": "A conexão está... ausente. Como uma memória esquecida.",
+  "error_page_service_status": "Status do serviço Trakt",
+  "retry": "Tentar novamente"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -352,5 +352,9 @@
   "original_title": "Titlu original",
   "view_all_comments": "Vezi toate comentariile",
   "remove_from_list": "Elimină din listă",
-  "remove_from_list_label": "Elimină {title} din listă"
+  "remove_from_list_label": "Elimină {title} din listă",
+  "error_page_service_title": "Serviciul Trakt inaccesibil",
+  "error_page_service_message": "Conexiunea... lipsește. Ca o amintire uitată.",
+  "error_page_service_status": "Starea serviciului Trakt",
+  "retry": "Reîncearcă"
 }

--- a/projects/client/i18n/messages/sv-se.json
+++ b/projects/client/i18n/messages/sv-se.json
@@ -352,5 +352,9 @@
   "original_title": "Originaltitel",
   "view_all_comments": "Visa alla kommentarer",
   "remove_from_list": "Ta bort från listan",
-  "remove_from_list_label": "Ta bort {title} från listan"
+  "remove_from_list_label": "Ta bort {title} från listan",
+  "error_page_service_title": "Trakt-tjänsten ej tillgänglig",
+  "error_page_service_message": "Anslutningen är... borta. Som ett bortglömt minne.",
+  "error_page_service_status": "Trakt-tjänstens status",
+  "retry": "Försök igen"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -352,5 +352,9 @@
   "original_title": "Оригінальна назва",
   "view_all_comments": "Переглянути всі коментарі",
   "remove_from_list": "Видалити зі списку",
-  "remove_from_list_label": "Видалити {title} зі списку"
+  "remove_from_list_label": "Видалити {title} зі списку",
+  "error_page_service_title": "Сервіс Trakt недоступний",
+  "error_page_service_message": "З'єднання... відсутнє. Як спогад, що забули.",
+  "error_page_service_status": "Статус сервісу Trakt",
+  "retry": "Спробувати знову"
 }

--- a/projects/client/src/lib/features/auth/queries/currentUserLikesQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserLikesQuery.ts
@@ -1,6 +1,5 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
-import { error } from '$lib/utils/console/print.ts';
 import type { LikedItemResponse } from '@trakt/api';
 import { z } from 'zod';
 import { api, type ApiParams } from '../../../requests/api.ts';
@@ -30,14 +29,6 @@ const currentUserCommentLikesRequest = ({ fetch }: ApiParams) =>
         limit: 'all',
         extended: 'min',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        error('Error fetching user liked comments', response);
-        throw new Error('Error fetching user liked comments.');
-      }
-
-      return response.body;
     });
 
 export const currentUserLikesQuery = defineQuery({
@@ -45,7 +36,7 @@ export const currentUserLikesQuery = defineQuery({
   request: () => currentUserCommentLikesRequest({ fetch }),
   invalidations: [InvalidateAction.Like],
   dependencies: [],
-  mapper: (response) => response.map(mapRatedItemResponse),
+  mapper: (response) => response.body.map(mapRatedItemResponse),
   schema: UserLikeSchema.array(),
   ttl: Infinity,
 });

--- a/projects/client/src/lib/features/auth/queries/currentUserSettingsQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserSettingsQuery.ts
@@ -4,7 +4,6 @@ import {
   permissionSchema,
 } from '$lib/requests/models/Permission.ts';
 import { UserNameSchema } from '$lib/requests/models/UserName.ts';
-import { error } from '$lib/utils/console/print.ts';
 import { DEFAULT_COVER } from '$lib/utils/constants.ts';
 import { toUserName } from '$lib/utils/formatting/string/toUserName.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
@@ -122,17 +121,6 @@ const currentUserRequest = ({ fetch }: ApiParams) =>
       query: {
         extended: 'browsing',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        error('Error fetching current user', response);
-        /**
-         * TODO: define error handling strategy/system
-         */
-        throw new Error('Error fetching current user.');
-      }
-
-      return response.body;
     });
 
 export const currentUserQueryKey = ['userSettings'] as const;
@@ -141,7 +129,7 @@ export const currentUserSettingsQuery = defineQuery({
   invalidations: [],
   dependencies: [],
   request: currentUserRequest,
-  mapper: mapUserSettingsResponse,
+  mapper: (response) => mapUserSettingsResponse(response.body),
   schema: UserSettingsSchema,
   ttl: Infinity,
 });

--- a/projects/client/src/lib/features/auth/queries/currentUserWatchlistQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserWatchlistQuery.ts
@@ -1,7 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { toMap } from '$lib/utils/array/toMap.ts';
-import { error } from '$lib/utils/console/print.ts';
 import type { ListedMovieResponse, ListedShowResponse } from '@trakt/api';
 import { z } from 'zod';
 import { api, type ApiParams } from '../../../requests/api.ts';
@@ -34,13 +33,6 @@ const currentUserWatchlistedMoviesRequest = ({ fetch }: ApiParams) =>
         id: 'me',
         sort: 'rank',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        error('Error fetching user movie watchlist', response);
-        throw new Error('Error fetching user movie watchlist.');
-      }
-      return response.body;
     });
 
 const WatchlistedShowSchema = WatchlistedMediaSchema;
@@ -65,13 +57,6 @@ const currentUserWatchlistedShowsRequest = ({ fetch }: ApiParams) =>
         id: 'me',
         sort: 'rank',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        error('Error fetching user show watchlist', response);
-        throw new Error('Error fetching user show watchlist.');
-      }
-      return response.body;
     });
 
 const UserWatchlistSchema = z.object({
@@ -92,9 +77,17 @@ export const currentUserWatchlistQuery = defineQuery({
     InvalidateAction.Watchlisted('movie'),
   ],
   dependencies: [],
-  mapper: ([movies, shows]) => ({
-    movies: toMap(movies, mapWatchlistedMovieResponse, (entry) => entry.id),
-    shows: toMap(shows, mapWatchlistedShowResponse, (entry) => entry.id),
+  mapper: ([moviesResponse, showsResponse]) => ({
+    movies: toMap(
+      moviesResponse.body,
+      mapWatchlistedMovieResponse,
+      (entry) => entry.id,
+    ),
+    shows: toMap(
+      showsResponse.body,
+      mapWatchlistedShowResponse,
+      (entry) => entry.id,
+    ),
   }),
   schema: UserWatchlistSchema,
   ttl: Infinity,

--- a/projects/client/src/lib/features/errors/ErrorProvider.svelte
+++ b/projects/client/src/lib/features/errors/ErrorProvider.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { afterNavigate } from "$app/navigation";
+  import ErrorServicePage from "$lib/pages/errors/ErrorServicePage.svelte";
+  import { onMount } from "svelte";
+  import { writable } from "svelte/store";
+  import { mapToWellKnownError } from "./_internal/mapToWellKnownError";
+  import { FETCH_ERROR_EVENT } from "./constants";
+  import { WellKnownError } from "./models/WellKnownErrors";
+
+  const { children }: ChildrenProps = $props();
+  const fetchError = writable<WellKnownError | undefined>(undefined);
+
+  onMount(() => {
+    const handler = (event: Event) => {
+      const errorEvent = event as CustomEvent<number>;
+      fetchError.set(mapToWellKnownError(errorEvent.detail));
+    };
+
+    globalThis.window.addEventListener(FETCH_ERROR_EVENT, handler);
+
+    return () => {
+      globalThis.window.removeEventListener(FETCH_ERROR_EVENT, handler);
+    };
+  });
+
+  afterNavigate((_) => fetchError.set(undefined));
+</script>
+
+{#if $fetchError === WellKnownError.ServerError}
+  <ErrorServicePage />
+{/if}
+
+{#if !$fetchError}
+  {@render children()}
+{/if}

--- a/projects/client/src/lib/features/errors/_internal/mapToWellKnownError.ts
+++ b/projects/client/src/lib/features/errors/_internal/mapToWellKnownError.ts
@@ -1,0 +1,13 @@
+import { WellKnownError } from '../models/WellKnownErrors.ts';
+
+export function mapToWellKnownError(
+  statusCode: number,
+): WellKnownError | undefined {
+  switch (statusCode) {
+    case 502:
+    case 503:
+      return WellKnownError.ServerError;
+    default:
+      return;
+  }
+}

--- a/projects/client/src/lib/features/errors/constants.ts
+++ b/projects/client/src/lib/features/errors/constants.ts
@@ -1,0 +1,1 @@
+export const FETCH_ERROR_EVENT = 'query-fetch-error';

--- a/projects/client/src/lib/features/errors/models/WellKnownErrors.ts
+++ b/projects/client/src/lib/features/errors/models/WellKnownErrors.ts
@@ -1,0 +1,3 @@
+export enum WellKnownError {
+  ServerError = 'ServerError',
+}

--- a/projects/client/src/lib/features/query/_internal/isSuccessResponse.spec.ts
+++ b/projects/client/src/lib/features/query/_internal/isSuccessResponse.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isSuccessResponse } from './isSuccessResponse.ts';
+
+describe('isSuccessResponse', () => {
+  it('should return true for single successful response', () => {
+    const response = { status: 200, data: 'test' };
+    expect(isSuccessResponse(response)).toBe(true);
+  });
+
+  it('should return true for array of successful responses', () => {
+    const responses = [
+      { status: 200, data: 'test1' },
+      { status: 200, data: 'test2' },
+    ];
+    expect(isSuccessResponse(responses)).toBe(true);
+  });
+
+  it('should return false for single failed response', () => {
+    const response = { status: 404, error: 'Not found' };
+    expect(isSuccessResponse(response)).toBe(false);
+  });
+
+  it('should return false if any response in array fails', () => {
+    const responses = [
+      { status: 200, data: 'test1' },
+      { status: 404, error: 'Not found' },
+      { status: 200, data: 'test3' },
+    ];
+    expect(isSuccessResponse(responses)).toBe(false);
+  });
+});

--- a/projects/client/src/lib/features/query/_internal/isSuccessResponse.ts
+++ b/projects/client/src/lib/features/query/_internal/isSuccessResponse.ts
@@ -1,0 +1,12 @@
+import type {
+  RequestResponse,
+  SuccessResponse,
+} from '../models/ResponseDefinitions.ts';
+
+export function isSuccessResponse<TInput>(
+  response: RequestResponse<TInput>,
+): response is SuccessResponse<TInput> {
+  return Array.isArray(response)
+    ? response.every((item) => item?.status === 200)
+    : response.status === 200;
+}

--- a/projects/client/src/lib/features/query/models/DefineQueryProps.ts
+++ b/projects/client/src/lib/features/query/models/DefineQueryProps.ts
@@ -1,0 +1,22 @@
+import type { ApiParams } from '$lib/requests/api.ts';
+import type { InvalidateActionOptions } from '$lib/requests/models/InvalidateAction.ts';
+import { type ZodType } from 'zod';
+import type { Dependency } from './Dependency.ts';
+import type { MapperDefinition } from './MapperDefinition.ts';
+import type { RequestDefinition } from './RequestDefinition.ts';
+
+export type DefineQueryProps<
+  TInput,
+  TOutput extends ZodType,
+  TRequestParams extends ApiParams,
+> = {
+  key: string;
+  invalidations: InvalidateActionOptions[];
+  dependencies: Dependency[] | ((params: TRequestParams) => Dependency[]);
+  request: RequestDefinition<TInput, TRequestParams>;
+  mapper: MapperDefinition<TInput, TOutput, TRequestParams>;
+  schema: TOutput;
+  ttl: number | Nil;
+  refetchOnWindowFocus?: boolean;
+  retry?: number;
+};

--- a/projects/client/src/lib/features/query/models/Dependency.ts
+++ b/projects/client/src/lib/features/query/models/Dependency.ts
@@ -1,0 +1,1 @@
+export type Dependency = number | string | Date | Nil;

--- a/projects/client/src/lib/features/query/models/MapperDefinition.ts
+++ b/projects/client/src/lib/features/query/models/MapperDefinition.ts
@@ -1,0 +1,12 @@
+import type { ApiParams } from '$lib/requests/api.ts';
+import { type z, type ZodType } from 'zod';
+import type { SuccessResponse } from './ResponseDefinitions.ts';
+
+export type MapperDefinition<
+  TInput,
+  TOutput extends ZodType,
+  TRequestParams extends ApiParams,
+> = (
+  response: SuccessResponse<TInput>,
+  params: TRequestParams,
+) => z.infer<TOutput>;

--- a/projects/client/src/lib/features/query/models/RequestDefinition.ts
+++ b/projects/client/src/lib/features/query/models/RequestDefinition.ts
@@ -1,0 +1,6 @@
+import type { ApiParams } from '$lib/requests/api.ts';
+import type { RequestResponse } from './ResponseDefinitions.ts';
+
+export type RequestDefinition<TInput, TRequestParams extends ApiParams> = (
+  { fetch }: TRequestParams,
+) => Promise<RequestResponse<TInput>>;

--- a/projects/client/src/lib/features/query/models/ResponseDefinitions.ts
+++ b/projects/client/src/lib/features/query/models/ResponseDefinitions.ts
@@ -1,0 +1,6 @@
+export type InputWithStatus<TInput, TStatus> = TInput extends
+  readonly [...infer U] ? { [K in keyof U]: U[K] & { status: TStatus } }
+  : TInput & { status: TStatus };
+
+export type RequestResponse<TInput> = InputWithStatus<TInput, number>;
+export type SuccessResponse<TInput> = InputWithStatus<TInput, 200>;

--- a/projects/client/src/lib/pages/errors/ErrorPage.svelte
+++ b/projects/client/src/lib/pages/errors/ErrorPage.svelte
@@ -19,7 +19,9 @@
   {/if}
 </main>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .error-page {
     height: 100%;
 
@@ -28,5 +30,27 @@
     align-items: center;
     justify-content: center;
     gap: var(--gap-l);
+
+    text-align: center;
+
+    padding: var(--layout-distance-side);
+
+    h1 {
+      transition: var(--transition-increment) ease-in-out;
+      transition-property: font-size, letter-spacing;
+    }
+
+    @include for-tablet-sm-and-below {
+      h1 {
+        font-size: var(--ni-48);
+      }
+    }
+
+    @include for-mobile {
+      h1 {
+        font-size: var(--ni-24);
+        letter-spacing: 0;
+      }
+    }
   }
 </style>

--- a/projects/client/src/lib/pages/errors/ErrorServicePage.svelte
+++ b/projects/client/src/lib/pages/errors/ErrorServicePage.svelte
@@ -1,0 +1,24 @@
+<script>
+  import Button from "$lib/components/buttons/Button.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import ErrorPage from "./ErrorPage.svelte";
+</script>
+
+<ErrorPage
+  title={m.error_page_service_title()}
+  message={m.error_page_service_message()}
+>
+  <Link href={UrlBuilder.og.status()} color="classic">
+    {m.error_page_service_status()}
+  </Link>
+  <Button
+    variant="primary"
+    color="purple"
+    onclick={() => window.location.reload()}
+    label={m.retry()}
+  >
+    {m.retry()}
+  </Button>
+</ErrorPage>

--- a/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
@@ -33,12 +33,6 @@ const upcomingEpisodesRequest = (
         start_date: startDate,
         days,
       },
-    })
-    .then(({ status, body }) => {
-      if (status !== 200) {
-        throw new Error('Failed to fetch calendar');
-      }
-      return body;
     });
 
 export const upcomingEpisodesQuery = defineQuery({
@@ -47,7 +41,7 @@ export const upcomingEpisodesQuery = defineQuery({
   dependencies: (params) => [params.startDate, params.days],
   request: upcomingEpisodesRequest,
   mapper: (response) => {
-    const episodes = response.map((item) => ({
+    const episodes = response.body.map((item) => ({
       show: mapToShowEntry(item.show),
       ...mapToEpisodeEntry(item.episode),
     }));

--- a/projects/client/src/lib/requests/queries/comments/commentRepliesQuery.ts
+++ b/projects/client/src/lib/requests/queries/comments/commentRepliesQuery.ts
@@ -33,13 +33,6 @@ const userCommentRepliesRequest = (
         page,
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch comment replies');
-      }
-
-      return response;
     });
 
 export const commentRepliesQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/episode/episodeCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeCommentsQuery.ts
@@ -30,13 +30,6 @@ const showCommentsRequest = (
         extended: 'images',
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch episode comments');
-      }
-
-      return response.body;
     });
 
 export const episodeCommentsQuery = defineQuery({
@@ -46,7 +39,7 @@ export const episodeCommentsQuery = defineQuery({
     params,
   ) => [params.slug, params.season, params.episode, params.limit],
   request: showCommentsRequest,
-  mapper: (data) => data.map(mapToMediaComment),
+  mapper: (response) => response.body.map(mapToMediaComment),
   schema: MediaCommentSchema.array(),
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/episode/episodeIntlQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeIntlQuery.ts
@@ -45,13 +45,6 @@ const episodeIntlRequest = (
         episode,
         language,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch episode intl');
-      }
-
-      return response.body;
     });
 
 export const episodeIntlQuery = defineQuery({
@@ -65,8 +58,8 @@ export const episodeIntlQuery = defineQuery({
     params.region,
   ],
   request: episodeIntlRequest,
-  mapper: (body, { language, region }) =>
-    body
+  mapper: (response, { language, region }) =>
+    response.body
       .filter((translation) =>
         translation.language === language &&
         translation.country === region

--- a/projects/client/src/lib/requests/queries/episode/episodePeopleQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodePeopleQuery.ts
@@ -23,13 +23,6 @@ const episodePeopleRequest = (
       query: {
         extended: 'images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch episode people');
-      }
-
-      return response.body;
     });
 
 export const episodePeopleQuery = defineQuery({
@@ -37,7 +30,7 @@ export const episodePeopleQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug, params.season, params.episode],
   request: episodePeopleRequest,
-  mapper: (body) => mapToMediaCrew(body),
+  mapper: (response) => mapToMediaCrew(response.body),
   schema: MediaCrewSchema,
   ttl: time.days(30),
 });

--- a/projects/client/src/lib/requests/queries/episode/episodeRatingQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeRatingQuery.ts
@@ -25,13 +25,6 @@ const episodeRatingRequest = (
       query: {
         extended: 'all',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch episode ratings');
-      }
-
-      return response.body;
     });
 
 export const episodeRatingQuery = defineQuery({
@@ -39,7 +32,7 @@ export const episodeRatingQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug, params.season, params.episode],
   request: episodeRatingRequest,
-  mapper: mapToMediaRating,
+  mapper: (response) => mapToMediaRating(response.body),
   schema: MediaRatingSchema,
   ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/episode/episodeStatsQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeStatsQuery.ts
@@ -22,13 +22,6 @@ const episodeStatsRequest = (
         season,
         episode,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch episode stats');
-      }
-
-      return response.body;
     });
 
 export const episodeStatsQuery = defineQuery({
@@ -36,7 +29,7 @@ export const episodeStatsQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug, params.season, params.episode],
   request: episodeStatsRequest,
-  mapper: mapToEpisodeStats,
+  mapper: (response) => mapToEpisodeStats(response.body),
   schema: EpisodeStatsSchema,
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/episode/episodeSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeSummaryQuery.ts
@@ -25,13 +25,6 @@ const episodeSummaryRequest = (
       query: {
         extended: 'full,images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch episode summary');
-      }
-
-      return response.body;
     });
 
 export const episodeSummaryQuery = defineQuery({
@@ -39,7 +32,7 @@ export const episodeSummaryQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug, params.season, params.episode],
   request: episodeSummaryRequest,
-  mapper: mapToEpisodeEntry,
+  mapper: (response) => mapToEpisodeEntry(response.body),
   schema: EpisodeEntrySchema,
   ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/episode/episodeWatchersQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeWatchersQuery.ts
@@ -20,20 +20,13 @@ export function episodeWatchersRequest(
         season,
         episode,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch active episode watchers');
-      }
-
-      return response.body;
     });
 }
 
 export const episodeWatchersQuery = defineQuery({
   key: 'episodeWatchers',
   request: episodeWatchersRequest,
-  mapper: (users) => users.map(mapToUserProfile),
+  mapper: (response) => response.body.map(mapToUserProfile),
   dependencies: (params) => [params.slug, params.season, params.episode],
   invalidations: [],
   schema: UserProfileSchema.array(),

--- a/projects/client/src/lib/requests/queries/episode/streamEpisodeQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/streamEpisodeQuery.ts
@@ -24,13 +24,6 @@ const streamEpisodeRequest = (
         episode,
         country,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch episode streaming services');
-      }
-
-      return response.body;
     });
 
 export const streamEpisodeQuery = defineQuery({
@@ -41,7 +34,7 @@ export const streamEpisodeQuery = defineQuery({
   ) => [params.slug, params.season, params.episode, params.country],
   request: streamEpisodeRequest,
   mapper: (response, params) =>
-    mapToStreamingServices(response, params.country),
+    mapToStreamingServices(response.body, params.country),
   schema: StreamingServiceOptionsSchema,
   ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
@@ -49,13 +49,6 @@ const userListItemsRequest = (
         page,
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch list items');
-      }
-
-      return response;
     });
 
 export const listItemsQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/lists/listSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/lists/listSummaryQuery.ts
@@ -15,13 +15,6 @@ const listSummaryRequest = (
       params: {
         id: listId,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to get list summary');
-      }
-
-      return response.body;
     });
 
 export const listSummaryQuery = defineQuery({
@@ -29,7 +22,7 @@ export const listSummaryQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.listId],
   request: listSummaryRequest,
-  mapper: mapToMediaListSummary,
+  mapper: (response) => mapToMediaListSummary(response.body),
   schema: MediaListSummarySchema,
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
@@ -41,13 +41,6 @@ const movieAnticipatedRequest = (
         page,
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch anticipated movies');
-      }
-
-      return response;
     });
 
 export const movieAnticipatedQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/movies/movieCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieCommentsQuery.ts
@@ -24,13 +24,6 @@ const movieCommentsRequest = (
         extended: 'images',
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch movie comments');
-      }
-
-      return response.body;
     });
 
 export const movieCommentsQuery = defineQuery({
@@ -38,7 +31,7 @@ export const movieCommentsQuery = defineQuery({
   invalidations: [InvalidateAction.Like],
   dependencies: (params) => [params.slug, params.limit],
   request: movieCommentsRequest,
-  mapper: (data) => data.map(mapToMediaComment),
+  mapper: (response) => response.body.map(mapToMediaComment),
   schema: MediaCommentSchema.array(),
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieIntlQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieIntlQuery.ts
@@ -36,13 +36,6 @@ const movieIntlRequest = (
         id: slug,
         language,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch movie intl');
-      }
-
-      return response.body;
     });
 
 export const movieIntlQuery = defineQuery({
@@ -54,8 +47,8 @@ export const movieIntlQuery = defineQuery({
     params.region,
   ],
   request: movieIntlRequest,
-  mapper: (body, { language, region }) =>
-    body
+  mapper: (response, { language, region }) =>
+    response.body
       .filter((translation) =>
         translation.language === language &&
         translation.country === region

--- a/projects/client/src/lib/requests/queries/movies/movieListsQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieListsQuery.ts
@@ -25,13 +25,6 @@ const movieListsRequest = (
         extended: 'images',
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch movie lists');
-      }
-
-      return response.body;
     });
 
 export const movieListsQuery = defineQuery({
@@ -39,7 +32,7 @@ export const movieListsQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug, params.limit, params.type],
   request: movieListsRequest,
-  mapper: (data) => data.map(mapToMediaListSummary),
+  mapper: (response) => response.body.map(mapToMediaListSummary),
   schema: MediaListSummarySchema.array(),
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/movies/moviePeopleQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePeopleQuery.ts
@@ -20,13 +20,6 @@ const moviePeopleRequest = (
       query: {
         extended: 'images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch movie people');
-      }
-
-      return response.body;
     });
 
 export const moviePeopleQuery = defineQuery({
@@ -34,7 +27,7 @@ export const moviePeopleQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: moviePeopleRequest,
-  mapper: (body) => mapToMediaCrew(body),
+  mapper: (response) => mapToMediaCrew(response.body),
   schema: MediaCrewSchema,
   ttl: time.days(30),
 });

--- a/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
@@ -24,13 +24,6 @@ const moviePopularRequest = (
         page,
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch popular movies');
-      }
-
-      return response;
     });
 
 export const moviePopularQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/movies/movieRatingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieRatingQuery.ts
@@ -18,13 +18,6 @@ const movieRatingRequest = (
       query: {
         extended: 'all',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch movie rating');
-      }
-
-      return response.body;
     });
 
 export const movieRatingQuery = defineQuery({
@@ -32,7 +25,7 @@ export const movieRatingQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: movieRatingRequest,
-  mapper: mapToMediaRating,
+  mapper: (response) => mapToMediaRating(response.body),
   schema: MediaRatingSchema,
   ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
@@ -28,13 +28,6 @@ const movieRelatedRequest = (
       params: {
         id: slug,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch related movies');
-      }
-
-      return response;
     });
 
 export const movieRelatedQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/movies/movieStatsQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieStatsQuery.ts
@@ -17,13 +17,6 @@ const movieStatsRequest = (
       params: {
         id: slug,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch movie stats');
-      }
-
-      return response.body;
     });
 
 export const movieStatsQuery = defineQuery({
@@ -31,7 +24,7 @@ export const movieStatsQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: movieStatsRequest,
-  mapper: mapToMediaStats,
+  mapper: (response) => mapToMediaStats(response.body),
   schema: MediaStatsSchema,
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieStudiosQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieStudiosQuery.ts
@@ -17,13 +17,6 @@ const movieStudiosRequest = (
       params: {
         id: slug,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch movie studios');
-      }
-
-      return response.body;
     });
 
 export const movieStudiosQuery = defineQuery({
@@ -31,7 +24,7 @@ export const movieStudiosQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: movieStudiosRequest,
-  mapper: (body) => body.map(mapToMediaStudio),
+  mapper: (response) => response.body.map(mapToMediaStudio),
   schema: MediaStudioSchema.array(),
   ttl: time.days(30),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieSummaryQuery.ts
@@ -18,13 +18,6 @@ const movieSummaryRequest = (
       query: {
         extended: 'full,images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch movie summary');
-      }
-
-      return response.body;
     });
 
 export const movieSummaryQuery = defineQuery({
@@ -32,7 +25,7 @@ export const movieSummaryQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: movieSummaryRequest,
-  mapper: mapToMovieEntry,
+  mapper: (response) => mapToMovieEntry(response.body),
   schema: MediaEntrySchema,
   ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
@@ -41,13 +41,6 @@ const movieTrendingRequest = (
         page,
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch trending movies');
-      }
-
-      return response;
     });
 
 export const movieTrendingQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/movies/movieWatchersQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieWatchersQuery.ts
@@ -15,20 +15,13 @@ export function movieWatchersRequest(
       params: {
         id: slug,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch active movie watchers');
-      }
-
-      return response.body;
     });
 }
 
 export const movieWatchersQuery = defineQuery({
   key: 'movieWatchers',
   request: movieWatchersRequest,
-  mapper: (users) => users.map(mapToUserProfile),
+  mapper: (response) => response.body.map(mapToUserProfile),
   dependencies: (params) => [params.slug],
   invalidations: [],
   schema: UserProfileSchema.array(),

--- a/projects/client/src/lib/requests/queries/movies/streamMovieQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/streamMovieQuery.ts
@@ -19,13 +19,6 @@ const streamMovieRequest = (
         id: slug,
         country,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch movie streaming services');
-      }
-
-      return response.body;
     });
 
 export const streamMovieQuery = defineQuery({
@@ -34,7 +27,7 @@ export const streamMovieQuery = defineQuery({
   dependencies: (params) => [params.slug, params.country],
   request: streamMovieRequest,
   mapper: (response, params) =>
-    mapToStreamingServices(response, params.country),
+    mapToStreamingServices(response.body, params.country),
   schema: StreamingServiceOptionsSchema,
   ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/people/peopleMovieCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleMovieCreditsQuery.ts
@@ -18,13 +18,6 @@ const peopleMovieCreditsRequest = (
       query: {
         extended: 'full,images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch person movie credits');
-      }
-
-      return response.body;
     });
 
 export const peopleMovieCreditsQuery = defineQuery({
@@ -32,7 +25,7 @@ export const peopleMovieCreditsQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: peopleMovieCreditsRequest,
-  mapper: mapToMediaCredits,
+  mapper: (response) => mapToMediaCredits(response.body),
   schema: MediaCreditsSchema,
   ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/people/peopleShowCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleShowCreditsQuery.ts
@@ -18,13 +18,6 @@ const peopleShowCreditsRequest = (
       query: {
         extended: 'full,images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch person show credits');
-      }
-
-      return response.body;
     });
 
 export const peopleShowCreditsQuery = defineQuery({
@@ -32,7 +25,7 @@ export const peopleShowCreditsQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: peopleShowCreditsRequest,
-  mapper: mapToMediaCredits,
+  mapper: (response) => mapToMediaCredits(response.body),
   schema: MediaCreditsSchema,
   ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/peopleSummaryQuery.ts
@@ -21,13 +21,6 @@ const peopleSummaryRequest = (
       query: {
         extended: 'full,images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch person summary');
-      }
-
-      return response.body;
     });
 
 const mapPeopleResponseToPersonSummary = (
@@ -54,7 +47,7 @@ export const peopleSummaryQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: peopleSummaryRequest,
-  mapper: mapPeopleResponseToPersonSummary,
+  mapper: (response) => mapPeopleResponseToPersonSummary(response.body),
   schema: PersonSummarySchema,
   ttl: time.days(30),
 });

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
@@ -26,18 +26,6 @@ const recommendedMoviesRequest = (
         ignore_watched: true,
         limit,
       },
-    })
-    .then(({ status, body }) => {
-      if (status !== 200) {
-        throw new Error(
-          [
-            'The digital projector sputters and dies.',
-            'The recommended movies remain trapped in the celluloid void.',
-          ].join(' '),
-        );
-      }
-
-      return body;
     });
 
 export const recommendedMoviesQuery = defineQuery({
@@ -48,7 +36,7 @@ export const recommendedMoviesQuery = defineQuery({
   ],
   dependencies: (params) => [params.limit],
   request: recommendedMoviesRequest,
-  mapper: (body) => body.map(mapToMovieEntry),
+  mapper: (response) => response.body.map(mapToMovieEntry),
   schema: RecommendedMovieSchema.array(),
   ttl: time.hours(24),
 });

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
@@ -29,15 +29,6 @@ const recommendedShowsRequest = (
         ignore_watched: true,
         limit,
       },
-    })
-    .then(({ status, body }) => {
-      if (status !== 200) {
-        throw new Error(
-          'The recommended shows, like elusive phantoms, refuse to materialize.',
-        );
-      }
-
-      return body;
     });
 
 export const recommendedShowsQuery = defineQuery({
@@ -49,8 +40,8 @@ export const recommendedShowsQuery = defineQuery({
   ],
   dependencies: (params) => [params.limit],
   request: recommendedShowsRequest,
-  mapper: (body) =>
-    body.map((show: RecommendedShowResponse[0]) => ({
+  mapper: (response) =>
+    response.body.map((show: RecommendedShowResponse[0]) => ({
       ...mapToShowEntry(show),
       ...mapToEpisodeCount(show),
     })),

--- a/projects/client/src/lib/requests/queries/search/searchQuery.ts
+++ b/projects/client/src/lib/requests/queries/search/searchQuery.ts
@@ -49,12 +49,6 @@ const searchRequest = ({ query, fetch }: SearchParams) =>
       params: {
         type: 'movie,show',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to search');
-      }
-      return response.body;
     });
 
 export const searchQuery = defineQuery({
@@ -62,8 +56,8 @@ export const searchQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.query.toLowerCase().trim()],
   request: searchRequest,
-  mapper: (results) =>
-    results
+  mapper: (response) =>
+    response.body
       .map(mapToSearchResultEntry)
       .filter((value) => !isGarbage(value)),
   schema: MediaEntrySchema.array(),

--- a/projects/client/src/lib/requests/queries/services/streamingSourcesQuery.ts
+++ b/projects/client/src/lib/requests/queries/services/streamingSourcesQuery.ts
@@ -38,24 +38,17 @@ const streamingSourcesRequest = (
 ) =>
   api({ fetch })
     .watchnow
-    .sources()
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch streaming sources');
-      }
-
-      return response.body;
-    });
+    .sources();
 
 export const streamingSourcesQuery = defineQuery({
   key: 'streamingSources',
   invalidations: [],
   dependencies: () => [],
   request: streamingSourcesRequest,
-  mapper: (body) =>
-    toMap(body, (response) => {
-      const countryCode = extractCountryCode(response);
-      const countrySources = response[countryCode];
+  mapper: (response) =>
+    toMap(response.body, (data) => {
+      const countryCode = extractCountryCode(data);
+      const countrySources = data[countryCode];
 
       return countrySources?.map(mapStreamingSourceResponse) ?? [];
     }, (_, entry) => extractCountryCode(entry)),

--- a/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
@@ -50,13 +50,6 @@ const showAnticipatedRequest = (
         page,
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch anticipated shows');
-      }
-
-      return response;
     });
 
 export const showAnticipatedQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/shows/showCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showCommentsQuery.ts
@@ -24,13 +24,6 @@ const showCommentsRequest = (
         extended: 'images',
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch show comments');
-      }
-
-      return response.body;
     });
 
 export const showCommentsQuery = defineQuery({
@@ -38,7 +31,7 @@ export const showCommentsQuery = defineQuery({
   invalidations: [InvalidateAction.Like],
   dependencies: (params) => [params.slug, params.limit],
   request: showCommentsRequest,
-  mapper: (data) => data.map(mapToMediaComment),
+  mapper: (response) => response.body.map(mapToMediaComment),
   schema: MediaCommentSchema.array(),
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/shows/showIntlQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showIntlQuery.ts
@@ -36,13 +36,6 @@ const showIntlRequest = (
         id: slug,
         language,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch show intl');
-      }
-
-      return response.body;
     });
 
 export const showIntlQuery = defineQuery({
@@ -54,8 +47,8 @@ export const showIntlQuery = defineQuery({
     params.region,
   ],
   request: showIntlRequest,
-  mapper: (body, { language, region }) =>
-    body
+  mapper: (response, { language, region }) =>
+    response.body
       .filter((translation) =>
         translation.language === language &&
         translation.country === region

--- a/projects/client/src/lib/requests/queries/shows/showListsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showListsQuery.ts
@@ -25,13 +25,6 @@ const showListsRequest = (
         extended: 'images',
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch show lists');
-      }
-
-      return response.body;
     });
 
 export const showListsQuery = defineQuery({
@@ -39,7 +32,7 @@ export const showListsQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug, params.limit, params.type],
   request: showListsRequest,
-  mapper: (data) => data.map(mapToMediaListSummary),
+  mapper: (response) => response.body.map(mapToMediaListSummary),
   schema: MediaListSummarySchema.array(),
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/shows/showPeopleQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showPeopleQuery.ts
@@ -20,13 +20,6 @@ const showPeopleRequest = (
       query: {
         extended: 'images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch show people');
-      }
-
-      return response.body;
     });
 
 export const showPeopleQuery = defineQuery({
@@ -34,7 +27,7 @@ export const showPeopleQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: showPeopleRequest,
-  mapper: (body) => mapToMediaCrew(body),
+  mapper: (response) => mapToMediaCrew(response.body),
   schema: MediaCrewSchema,
   ttl: time.days(30),
 });

--- a/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
@@ -44,13 +44,6 @@ const showPopularRequest = (
         page,
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch popular shows');
-      }
-
-      return response;
     });
 
 export const showPopularQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
@@ -3,7 +3,7 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import {
   type EpisodeProgressEntry,
   EpisodeProgressEntrySchema,
-} from '$lib/requests/models/EpisodeProgressEntry';
+} from '$lib/requests/models/EpisodeProgressEntry.ts';
 import {
   type EpisodeType,
   EpisodeUnknownType,
@@ -31,13 +31,6 @@ const showProgressRequest = (
       params: {
         id: slug,
       },
-    })
-    .then(({ status, body }) => {
-      if (status !== 200) {
-        throw new Error('Failed to fetch show progress');
-      }
-
-      return body;
     });
 
 function mapShowProgressResponse(
@@ -75,7 +68,7 @@ export const showProgressQuery = defineQuery({
   ],
   dependencies: (params) => [params.slug],
   request: showProgressRequest,
-  mapper: mapShowProgressResponse,
+  mapper: (response) => mapShowProgressResponse(response.body),
   schema: EpisodeProgressEntrySchema,
   ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showRatingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRatingQuery.ts
@@ -20,13 +20,6 @@ const showRatingRequest = (
       query: {
         extended: 'all',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch show rating');
-      }
-
-      return response.body;
     });
 
 export const showRatingQuery = defineQuery({
@@ -34,7 +27,7 @@ export const showRatingQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: showRatingRequest,
-  mapper: mapToMediaRating,
+  mapper: (response) => mapToMediaRating(response.body),
   schema: MediaRatingSchema,
   ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
@@ -42,13 +42,6 @@ const showRelatedRequest = (
       params: {
         id: slug,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch related shows');
-      }
-
-      return response;
     });
 
 export const showRelatedQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/shows/showSeasonEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSeasonEpisodesQuery.ts
@@ -22,13 +22,6 @@ const showSeasonEpisodesRequest = (
       query: {
         extended: 'full,images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch up season episodes');
-      }
-
-      return response.body;
     });
 
 export const showSeasonEpisodesQuery = defineQuery({
@@ -36,7 +29,7 @@ export const showSeasonEpisodesQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug, params.season],
   request: showSeasonEpisodesRequest,
-  mapper: (body) => body.map(mapToEpisodeEntry),
+  mapper: (response) => response.body.map(mapToEpisodeEntry),
   schema: EpisodeEntrySchema.array(),
   ttl: time.hours(6),
 });

--- a/projects/client/src/lib/requests/queries/shows/showSeasonsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSeasonsQuery.ts
@@ -21,13 +21,6 @@ const showSeasonsRequest = (
       query: {
         extended: 'full',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch seasons');
-      }
-
-      return response.body;
     });
 
 const mapSeasonResponseToSeason = (item: SeasonsResponse[0]): Season => ({
@@ -44,7 +37,7 @@ export const showSeasonsQuery = defineQuery({
   dependencies: (params) => [params.slug],
   request: showSeasonsRequest,
   mapper: (response) =>
-    response
+    response.body
       .map(mapSeasonResponseToSeason)
       .filter((season) => season.episodes.count > 0 && season.number !== 0),
   schema: z.array(SeasonSchema),

--- a/projects/client/src/lib/requests/queries/shows/showStatsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showStatsQuery.ts
@@ -17,13 +17,6 @@ const showStatsRequest = (
       params: {
         id: slug,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch show stats');
-      }
-
-      return response.body;
     });
 
 export const showStatsQuery = defineQuery({
@@ -31,7 +24,7 @@ export const showStatsQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: showStatsRequest,
-  mapper: mapToMediaStats,
+  mapper: (response) => mapToMediaStats(response.body),
   schema: MediaStatsSchema,
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/shows/showStudiosQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showStudiosQuery.ts
@@ -17,13 +17,6 @@ const showStudiosRequest = (
       params: {
         id: slug,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch show studios');
-      }
-
-      return response.body;
     });
 
 export const showStudiosQuery = defineQuery({
@@ -31,7 +24,7 @@ export const showStudiosQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: showStudiosRequest,
-  mapper: (body) => body.map(mapToMediaStudio),
+  mapper: (response) => response.body.map(mapToMediaStudio),
   schema: MediaStudioSchema.array(),
   ttl: time.days(30),
 });

--- a/projects/client/src/lib/requests/queries/shows/showSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSummaryQuery.ts
@@ -18,13 +18,6 @@ const showSummaryRequest = (
       query: {
         extended: 'full,images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch show summary');
-      }
-
-      return response.body;
     });
 
 export const showSummaryQuery = defineQuery({
@@ -32,7 +25,7 @@ export const showSummaryQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: showSummaryRequest,
-  mapper: mapToShowEntry,
+  mapper: (response) => mapToShowEntry(response.body),
   schema: MediaEntrySchema,
   ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
@@ -46,13 +46,6 @@ const showTrendingRequest = (
         page,
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch trending shows');
-      }
-
-      return response;
     });
 
 export const showTrendingQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/shows/showWatchersQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showWatchersQuery.ts
@@ -15,20 +15,13 @@ export function showWatchersRequest(
       params: {
         id: slug,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch active show watchers');
-      }
-
-      return response.body;
     });
 }
 
 export const showWatchersQuery = defineQuery({
   key: 'showWatchers',
   request: showWatchersRequest,
-  mapper: (users) => users.map(mapToUserProfile),
+  mapper: (response) => response.body.map(mapToUserProfile),
   dependencies: (params) => [params.slug],
   invalidations: [],
   schema: UserProfileSchema.array(),

--- a/projects/client/src/lib/requests/queries/shows/streamShowQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/streamShowQuery.ts
@@ -19,13 +19,6 @@ const showWatchNowRequest = (
         id: slug,
         country,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch show streaming services');
-      }
-
-      return response.body;
     });
 
 export const streamShowQuery = defineQuery({
@@ -34,7 +27,7 @@ export const streamShowQuery = defineQuery({
   dependencies: (params) => [params.slug, params.country],
   request: showWatchNowRequest,
   mapper: (response, params) =>
-    mapToStreamingServices(response, params.country),
+    mapToStreamingServices(response.body, params.country),
   schema: StreamingServiceOptionsSchema,
   ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
@@ -30,13 +30,6 @@ const upNextNitroRequest = (params: UpNextParams) => {
         page,
         limit,
       },
-    })
-    .then(({ status, body, headers }) => {
-      if (status !== 200) {
-        throw new Error('Failed to fetch up next');
-      }
-
-      return { body, headers };
     });
 };
 

--- a/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
@@ -48,13 +48,6 @@ const upNextRequest = (params: UpNextParams) => {
         include_stats: true,
         ...sortQuery,
       },
-    })
-    .then(({ status, body, headers }) => {
-      if (status !== 200) {
-        throw new Error('Failed to fetch up next');
-      }
-
-      return { body, headers };
     });
 };
 

--- a/projects/client/src/lib/requests/queries/users/activityHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/activityHistoryQuery.ts
@@ -46,13 +46,6 @@ function activityHistoryRequest(
         limit,
         page,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch episodes history');
-      }
-
-      return response;
     });
 }
 

--- a/projects/client/src/lib/requests/queries/users/collaborationListsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/collaborationListsQuery.ts
@@ -19,13 +19,6 @@ const collaborationListsRequest = (
       query: {
         extended: 'images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch user collaboration lists');
-      }
-
-      return response.body;
     });
 
 export const collaborationListsQuery = defineQuery({
@@ -33,7 +26,7 @@ export const collaborationListsQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: collaborationListsRequest,
-  mapper: (data) => data.map(mapToMediaListSummary),
+  mapper: (response) => response.body.map(mapToMediaListSummary),
   schema: MediaListSummarySchema.array(),
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/users/episodeActivityHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/episodeActivityHistoryQuery.ts
@@ -43,7 +43,7 @@ function episodeActivityHistoryRequest(
     page,
   };
 
-  const request = id
+  return id
     ? api({ fetch }).users.history.episode({
       params: { id: slug, item_id: `${id}` },
       query: queryParams,
@@ -52,14 +52,6 @@ function episodeActivityHistoryRequest(
       params: { id: slug },
       query: queryParams,
     });
-
-  return request.then((response) => {
-    if (response.status !== 200) {
-      throw new Error('Failed to fetch episodes history');
-    }
-
-    return response;
-  });
 }
 
 export function mapToEpisodeActivityHistory(

--- a/projects/client/src/lib/requests/queries/users/hiddenShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/hiddenShowsQuery.ts
@@ -34,13 +34,6 @@ const hiddenShowsRequest = (
         limit,
         type: 'show',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch hidden shows');
-      }
-
-      return response;
     });
 
 export const hiddenShowsQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/users/movieActivityHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieActivityHistoryQuery.ts
@@ -38,7 +38,7 @@ const movieActivityHistoryRequest = (
     page,
   };
 
-  const request = id
+  return id
     ? api({ fetch }).users.history.movie({
       params: { id: slug, item_id: `${id}` },
       query: queryParams,
@@ -47,14 +47,6 @@ const movieActivityHistoryRequest = (
       params: { id: slug },
       query: queryParams,
     });
-
-  return request.then((response) => {
-    if (response.status !== 200) {
-      throw new Error('Failed to fetch movies history');
-    }
-
-    return response;
-  });
 };
 
 export const mapToMovieActivityHistory = (

--- a/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
@@ -37,13 +37,6 @@ const watchlistRequest = (
         page,
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch movies watchlist');
-      }
-
-      return response;
     });
 
 export const movieWatchlistQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/users/personalListsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/personalListsQuery.ts
@@ -19,13 +19,6 @@ const personalListsRequest = (
       query: {
         extended: 'images',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch user lists');
-      }
-
-      return response.body;
     });
 
 export const personalListsQuery = defineQuery({
@@ -33,7 +26,7 @@ export const personalListsQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: personalListsRequest,
-  mapper: (data) => data.map(mapToMediaListSummary),
+  mapper: (response) => response.body.map(mapToMediaListSummary),
   schema: MediaListSummarySchema.array(),
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/users/showActivityHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showActivityHistoryQuery.ts
@@ -36,7 +36,7 @@ const showHistoryRequest = (
     page,
   };
 
-  const request = id
+  return id
     ? api({ fetch }).users.history.show({
       params: { id: slug, item_id: `${id}` },
       query: queryParams,
@@ -45,14 +45,6 @@ const showHistoryRequest = (
       params: { id: slug },
       query: queryParams,
     });
-
-  return request.then((response) => {
-    if (response.status !== 200) {
-      throw new Error('Failed to fetch shows history');
-    }
-
-    return response;
-  });
 };
 
 const mapToShowActivityHistory = (

--- a/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
@@ -44,13 +44,6 @@ const watchlistRequest = (
         page,
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch shows watchlist');
-      }
-
-      return response;
     });
 
 export const showWatchlistQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/users/socialActivityQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/socialActivityQuery.ts
@@ -57,13 +57,6 @@ const socialActivityRequest = (
         limit,
         page,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to social activities');
-      }
-
-      return response;
     });
 
 export const socialActivityQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
@@ -57,13 +57,6 @@ const userListItemsRequest = (
         page,
         limit,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch user list items');
-      }
-
-      return response;
     });
 
 export const userListItemsQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/users/userListSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListSummaryQuery.ts
@@ -18,13 +18,6 @@ const userListSummaryRequest = (
         id: userId,
         list_id: listId,
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch list summary');
-      }
-
-      return response.body;
     });
 
 export const userListSummaryQuery = defineQuery({
@@ -32,7 +25,7 @@ export const userListSummaryQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.userId, params.listId],
   request: userListSummaryRequest,
-  mapper: mapToMediaListSummary,
+  mapper: (response) => mapToMediaListSummary(response.body),
   schema: MediaListSummarySchema,
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/users/userProfileQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userProfileQuery.ts
@@ -18,13 +18,6 @@ const userProfileRequest = (
       query: {
         extended: 'full,vip',
       },
-    })
-    .then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Failed to fetch user profile');
-      }
-
-      return response.body;
     });
 
 export const userProfileQuery = defineQuery({
@@ -32,7 +25,7 @@ export const userProfileQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: userProfileRequest,
-  mapper: mapToUserProfile,
+  mapper: (response) => mapToUserProfile(response.body),
   schema: UserProfileSchema,
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -93,5 +93,6 @@ export const UrlBuilder = {
       `https://trakt.tv/users/${slug}/year/${year}`,
     getVip: () => 'https://trakt.tv/vip',
     site: () => 'https://trakt.tv',
+    status: () => 'https://status.trakt.tv',
   },
 };

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
   import AuthProvider from "$lib/features/auth/components/AuthProvider.svelte";
   import AutoSigninProvider from "$lib/features/auto-signin/AutoSigninProvider.svelte";
   import { DeploymentEndpoint } from "$lib/features/deployment/DeploymentEndpoint.js";
+  import ErrorProvider from "$lib/features/errors/ErrorProvider.svelte";
   import LocaleProvider from "$lib/features/i18n/components/LocaleProvider.svelte";
   import QueryClientProvider from "$lib/features/query/QueryClientProvider.svelte";
   import ThemeProvider from "$lib/features/theme/components/ThemeProvider.svelte";
@@ -80,42 +81,44 @@
   </style>
 </svelte:head>
 
-<QueryClientProvider client={data.queryClient}>
-  <AuthProvider isAuthorized={data.auth.isAuthorized} url={data.auth.url}>
-    <AnalyticsProvider>
-      <AutoSigninProvider>
-        <LocaleProvider>
-          <CoverProvider>
-            <CoverImage />
+<ErrorProvider>
+  <QueryClientProvider client={data.queryClient}>
+    <AuthProvider isAuthorized={data.auth.isAuthorized} url={data.auth.url}>
+      <AnalyticsProvider>
+        <AutoSigninProvider>
+          <LocaleProvider>
+            <CoverProvider>
+              <CoverImage />
 
-            <ThemeProvider theme={data.theme}>
-              <ListScrollHistoryProvider>
-                <div class="trakt-layout-wrapper">
-                  <Navbar />
-                  <div class="trakt-layout-content">
-                    {@render children()}
+              <ThemeProvider theme={data.theme}>
+                <ListScrollHistoryProvider>
+                  <div class="trakt-layout-wrapper">
+                    <Navbar />
+                    <div class="trakt-layout-content">
+                      {@render children()}
+                    </div>
+                    <Footer />
                   </div>
-                  <Footer />
-                </div>
-                <RenderFor audience="all" device={["mobile", "tablet-sm"]}>
-                  <MobileNavbar />
-                </RenderFor>
-                <SvelteQueryDevtools
-                  buttonPosition="bottom-left"
-                  styleNonce="opacity: 0.5"
-                />
-              </ListScrollHistoryProvider>
-            </ThemeProvider>
-          </CoverProvider>
-        </LocaleProvider>
+                  <RenderFor audience="all" device={["mobile", "tablet-sm"]}>
+                    <MobileNavbar />
+                  </RenderFor>
+                  <SvelteQueryDevtools
+                    buttonPosition="bottom-left"
+                    styleNonce="opacity: 0.5"
+                  />
+                </ListScrollHistoryProvider>
+              </ThemeProvider>
+            </CoverProvider>
+          </LocaleProvider>
 
-        {#key page.url.pathname}
-          <PageView />
-        {/key}
-      </AutoSigninProvider>
-    </AnalyticsProvider>
-  </AuthProvider>
-</QueryClientProvider>
+          {#key page.url.pathname}
+            <PageView />
+          {/key}
+        </AutoSigninProvider>
+      </AnalyticsProvider>
+    </AuthProvider>
+  </QueryClientProvider>
+</ErrorProvider>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds a first version for an error boundary.
- Refactors defineQuery; mappers now always get a valid response, all status code checking is now done in one place in defineQuery.
- This is a basic version ~~that requires opt-in usage on a query basis~~.
  - I left a fixme in there ~~to properly detect errors~~. Ideally we use the events on window.
- Approach reasoning:
  - Since these are well known errors, they are thrown on a first encounter, circumventing any retries. Depending on results irl, we can revisit.
  - `502` & `503` are mapped to a `WellKnownError.ServerError`
  - The provider ~~has an error context with can be set by children~~ listens to fetch error events and shows an error page in case of server errors.
  - Caught cases:
    - ~~Error on prefetch: uses it as an initial value for the provider. This should cover all authenticated users.~~
    - ~~To cover unauthenticated users, the `useUser`, `useTrendingItems`, `useTrendingList` can also detect well known errors.~~

## 👀 Examples 👀
<img width="1271" alt="Screenshot 2025-03-31 at 19 12 30" src="https://github.com/user-attachments/assets/175cebc7-3c76-42ad-956c-b562d553b22e" />

<img width="368" alt="Screenshot 2025-04-02 at 20 58 22" src="https://github.com/user-attachments/assets/cea06105-616d-4de2-86fc-e9c3ae1a5cc5" />

