### PR TITLE
Feat/Top streaming picks

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "npm:@cucumber/cucumber@^11.2.0": "11.2.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.0.2_@cucumber+messages@27.0.2",
     "npm:@google/generative-ai@0.24": "0.24.0",
     "npm:@inlang/paraglide-sveltekit@~0.16.1": "0.16.1_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
-    "npm:@jsr/trakt__api@~0.1.12": "0.1.12_zod@3.24.1",
+    "npm:@jsr/trakt__api@~0.1.13": "0.1.13_zod@3.24.1",
     "npm:@playwright/test@^1.51.1": "1.51.1",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.25.3__acorn@8.14.1",
     "npm:@sveltejs/adapter-auto@5": "5.0.0_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
@@ -2161,8 +2161,8 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.1.12_zod@3.24.1": {
-      "integrity": "sha512-sVDOXP2Fv8J/cJTNOCtwx3kZFEGZWMFiSmWWVHQUbH3PPhUFPrM7UkeAM4t26NP8dBx7lakjglKQ0b0dPengYw==",
+    "@jsr/trakt__api@0.1.13_zod@3.24.1": {
+      "integrity": "sha512-do5Gd/p4tMiAszHIeWpbQo/yxiHuBib3Zm73/lbsMiaRp7cKrb7natckebqAaGdHViORNPhl4YIdhflnqe/w2g==",
       "dependencies": [
         "@ts-rest/core",
         "zod@3.24.1"
@@ -7001,7 +7001,7 @@
             "npm:@cucumber/cucumber@^11.2.0",
             "npm:@google/generative-ai@0.24",
             "npm:@inlang/paraglide-sveltekit@~0.16.1",
-            "npm:@jsr/trakt__api@~0.1.12",
+            "npm:@jsr/trakt__api@~0.1.13",
             "npm:@playwright/test@^1.51.1",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@sveltejs/adapter-auto@5",

--- a/projects/client/i18n/messages/bg-bg.json
+++ b/projects/client/i18n/messages/bg-bg.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Услугата Trakt е недостъпна",
   "error_page_service_message": "Връзката... отсъства. Като забравен спомен.",
   "error_page_service_status": "Състояние на услугата Trakt",
-  "retry": "Опитай отново"
+  "retry": "Опитай отново",
+  "streaming_picks": "Топ предложения",
+  "view_all_streaming_movie_picks": "Виж всички топ предложения (филми)",
+  "view_all_streaming_show_picks": "Виж всички топ предложения (сериали)",
+  "streaming_movie_picks": "Топ предложения (филми)",
+  "streaming_show_picks": "Топ предложения (сериали)"
 }

--- a/projects/client/i18n/messages/da-dk.json
+++ b/projects/client/i18n/messages/da-dk.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Trakt tjeneste utilgængelig",
   "error_page_service_message": "Forbindelsen er... fraværende. Som en glemt erindring.",
   "error_page_service_status": "Trakt tjeneste status",
-  "retry": "Prøv igen"
+  "retry": "Prøv igen",
+  "streaming_picks": "Top streamingvalg",
+  "view_all_streaming_movie_picks": "Se alle top streaming filmvalg",
+  "view_all_streaming_show_picks": "Se alle top streaming serievalg",
+  "streaming_movie_picks": "Top streaming filmvalg",
+  "streaming_show_picks": "Top streaming serievalg"
 }

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Trakt-Dienst nicht erreichbar",
   "error_page_service_message": "Die Verbindung ist... abwesend. Wie eine vergessene Erinnerung.",
   "error_page_service_status": "Trakt-Dienststatus",
-  "retry": "Erneut versuchen"
+  "retry": "Erneut versuchen",
+  "streaming_picks": "Top streaming picks",
+  "view_all_streaming_movie_picks": "View all top streaming movie picks",
+  "view_all_streaming_show_picks": "View all top streaming show picks",
+  "streaming_movie_picks": "Top streaming movie picks",
+  "streaming_show_picks": "Top streaming show picks"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Trakt service unreachable",
   "error_page_service_message": "The connection is... absent. Like a forgotten memory.",
   "error_page_service_status": "Trakt service status",
-  "retry": "Retry"
+  "retry": "Retry",
+  "streaming_picks": "Top streaming picks",
+  "view_all_streaming_movie_picks": "View all top streaming movie picks",
+  "view_all_streaming_show_picks": "View all top streaming show picks",
+  "streaming_movie_picks": "Top streaming movie picks",
+  "streaming_show_picks": "Top streaming show picks"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Servicio Trakt inaccesible",
   "error_page_service_message": "La conexión… ausente. Como un recuerdo olvidado.",
   "error_page_service_status": "Estado del servicio Trakt",
-  "retry": "Reintentar"
+  "retry": "Reintentar",
+  "streaming_picks": "Lo mejor del streaming",
+  "view_all_streaming_movie_picks": "Ver todas las recomendaciones de películas en streaming",
+  "view_all_streaming_show_picks": "Ver todas las recomendaciones de series en streaming",
+  "streaming_movie_picks": "Recomendaciones de películas en streaming",
+  "streaming_show_picks": "Recomendaciones de series en streaming"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Servicio Trakt inaccesible",
   "error_page_service_message": "La conexión... ausente. Como un recuerdo olvidado.",
   "error_page_service_status": "Estado del servicio Trakt",
-  "retry": "Reintentar"
+  "retry": "Reintentar",
+  "streaming_picks": "Lo mejor para streaming",
+  "view_all_streaming_movie_picks": "Ver lo mejor del cine en streaming",
+  "view_all_streaming_show_picks": "Ver lo mejor de TV en streaming",
+  "streaming_movie_picks": "Lo mejor del cine en streaming",
+  "streaming_show_picks": "Lo mejor de TV en streaming"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Trakt service unreachable",
   "error_page_service_message": "The connection is... absent. Like a forgotten memory.",
   "error_page_service_status": "Trakt service status",
-  "retry": "Retry"
+  "retry": "Retry",
+  "streaming_picks": "Top streaming picks",
+  "view_all_streaming_movie_picks": "View all top streaming movie picks",
+  "view_all_streaming_show_picks": "View all top streaming show picks",
+  "streaming_movie_picks": "Top streaming movie picks",
+  "streaming_show_picks": "Top streaming show picks"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Service Trakt inaccessible",
   "error_page_service_message": "La connexion est... absente. Tel un souvenir oublié.",
   "error_page_service_status": "État du service Trakt",
-  "retry": "Réessayer"
+  "retry": "Réessayer",
+  "streaming_picks": "Meilleurs choix en streaming",
+  "view_all_streaming_movie_picks": "Voir tous les meilleurs choix de films en streaming",
+  "view_all_streaming_show_picks": "Voir tous les meilleurs choix de séries en streaming",
+  "streaming_movie_picks": "Meilleurs films en streaming",
+  "streaming_show_picks": "Meilleures séries en streaming"
 }

--- a/projects/client/i18n/messages/it-it.json
+++ b/projects/client/i18n/messages/it-it.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Servizio Trakt irraggiungibile",
   "error_page_service_message": "La connessione è... assente. Come un ricordo svanito.",
   "error_page_service_status": "Stato del servizio Trakt",
-  "retry": "Riprova"
+  "retry": "Riprova",
+  "streaming_picks": "Scelte streaming",
+  "view_all_streaming_movie_picks": "Vedi tutte le scelte streaming",
+  "view_all_streaming_show_picks": "Vedi tutte le scelte serie streaming",
+  "streaming_movie_picks": "Scelte film streaming",
+  "streaming_show_picks": "Scelte serie streaming"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Traktサービスに接続できません",
   "error_page_service_message": "接続が…ありません。まるで忘れられた記憶のように。",
   "error_page_service_status": "Traktサービスの状態",
-  "retry": "再試行"
+  "retry": "再試行",
+  "streaming_picks": "注目のストリーミング作品",
+  "view_all_streaming_movie_picks": "トップストリーミング作品をすべて見る",
+  "view_all_streaming_show_picks": "トップストリーミング番組をすべて見る",
+  "streaming_movie_picks": "注目のストリーミング作品",
+  "streaming_show_picks": "注目のストリーミング番組"
 }

--- a/projects/client/i18n/messages/nb-no.json
+++ b/projects/client/i18n/messages/nb-no.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Trakt-tjenesten er utilgjengelig",
   "error_page_service_message": "Tilkoblingen er... fraværende. Som et glemt minne.",
   "error_page_service_status": "Trakt-tjenestens status",
-  "retry": "Prøv igjen"
+  "retry": "Prøv igjen",
+  "streaming_picks": "De beste strømmetipsene",
+  "view_all_streaming_movie_picks": "Se alle topp strømmefilmtips",
+  "view_all_streaming_show_picks": "Se alle topp strømmetv-serietips",
+  "streaming_movie_picks": "De beste filmtipsene for strømming",
+  "streaming_show_picks": "De beste serietipsene for strømming"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Trakt-dienst onbereikbaar",
   "error_page_service_message": "De verbinding is... afwezig. Als een vergeten herinnering.",
   "error_page_service_status": "Trakt-dienststatus",
-  "retry": "Opnieuw proberen"
+  "retry": "Opnieuw proberen",
+  "streaming_picks": "Top streamingkeuzes",
+  "view_all_streaming_movie_picks": "Bekijk alle top streaming filmkeuzes",
+  "view_all_streaming_show_picks": "Bekijk alle top streaming seriekeuzes",
+  "streaming_movie_picks": "Top streaming filmkeuzes",
+  "streaming_show_picks": "Top streaming seriekeuzes"
 }

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Usługa Trakt niedostępna",
   "error_page_service_message": "Połączenie... nie istnieje. Niczym zapomniana scena.",
   "error_page_service_status": "Status usługi Trakt",
-  "retry": "Spróbuj ponownie"
+  "retry": "Spróbuj ponownie",
+  "streaming_picks": "Najlepsze wybory streamingowe",
+  "view_all_streaming_movie_picks": "Zobacz wszystkie najlepsze wybory filmowe",
+  "view_all_streaming_show_picks": "Zobacz wszystkie najlepsze serialowe wybory",
+  "streaming_movie_picks": "Najlepsze filmowe wybory streamingowe",
+  "streaming_show_picks": "Najlepsze serialowe wybory streamingowe"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Serviço Trakt inacessível",
   "error_page_service_message": "A conexão está... ausente. Como uma memória esquecida.",
   "error_page_service_status": "Status do serviço Trakt",
-  "retry": "Tentar novamente"
+  "retry": "Tentar novamente",
+  "streaming_picks": "Melhores do streaming",
+  "view_all_streaming_movie_picks": "Ver todas as melhores indicações de filmes no streaming",
+  "view_all_streaming_show_picks": "Ver todas as melhores indicações de séries no streaming",
+  "streaming_movie_picks": "Melhores filmes no streaming",
+  "streaming_show_picks": "Melhores séries no streaming"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Serviciul Trakt inaccesibil",
   "error_page_service_message": "Conexiunea... lipsește. Ca o amintire uitată.",
   "error_page_service_status": "Starea serviciului Trakt",
-  "retry": "Reîncearcă"
+  "retry": "Reîncearcă",
+  "streaming_picks": "Recomandări streaming",
+  "view_all_streaming_movie_picks": "Vezi toate recomandările de filme pe streaming",
+  "view_all_streaming_show_picks": "Vezi toate recomandările de seriale pe streaming",
+  "streaming_movie_picks": "Recomandări de filme pe streaming",
+  "streaming_show_picks": "Recomandări de seriale pe streaming"
 }

--- a/projects/client/i18n/messages/sv-se.json
+++ b/projects/client/i18n/messages/sv-se.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Trakt-tjänsten ej tillgänglig",
   "error_page_service_message": "Anslutningen är... borta. Som ett bortglömt minne.",
   "error_page_service_status": "Trakt-tjänstens status",
-  "retry": "Försök igen"
+  "retry": "Försök igen",
+  "streaming_picks": "Toppval för streaming",
+  "view_all_streaming_movie_picks": "Se alla toppval för streaming",
+  "view_all_streaming_show_picks": "Se alla toppval för serier på streaming",
+  "streaming_movie_picks": "Toppval för filmer på streaming",
+  "streaming_show_picks": "Toppval för serier på streaming"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -356,5 +356,10 @@
   "error_page_service_title": "Сервіс Trakt недоступний",
   "error_page_service_message": "З'єднання... відсутнє. Як спогад, що забули.",
   "error_page_service_status": "Статус сервісу Trakt",
-  "retry": "Спробувати знову"
+  "retry": "Спробувати знову",
+  "streaming_picks": "Найкращі стрімінгові добірки",
+  "view_all_streaming_movie_picks": "Переглянути всі найкращі стрімінгові добірки фільмів",
+  "view_all_streaming_show_picks": "Переглянути всі найкращі стрімінгові добірки серіалів",
+  "streaming_movie_picks": "Найкращі стрімінгові добірки фільмів",
+  "streaming_show_picks": "Найкращі стрімінгові добірки серіалів"
 }

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -61,7 +61,7 @@
     "@tanstack/svelte-query": "^5.69.0",
     "@tanstack/svelte-query-devtools": "^5.69.0",
     "@tanstack/svelte-query-persist-client": "^5.69.0",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.1.12",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.1.13",
     "@ts-rest/core": "^3.52.1",
     "date-fns": "^4.1.0",
     "firebase": "^11.5.0",

--- a/projects/client/src/lib/components/icons/TrendIcon.svelte
+++ b/projects/client/src/lib/components/icons/TrendIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  const { direction }: { direction: "up" | "down" } = $props();
+
+  const path = $derived(
+    direction === "down"
+      ? "M1.5 4.5L8.5 11.5L15.5 4.5"
+      : "M15.5 11.5L8.5 4.5L1.5 11.5",
+  );
+</script>
+
+<svg
+  width="16"
+  height="16"
+  viewBox="0 0 16 16"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path d={path} stroke="currentColor" stroke-width="2" />
+</svg>

--- a/projects/client/src/lib/components/media/tags/TagIntl.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntl.ts
@@ -7,4 +7,5 @@ export type TagIntl = {
   tbaLabel: () => string;
   toAnticipatedCount: (count: number) => string;
   watchCountLabel: (isShow: boolean) => string;
+  trendLabel: (delta: number) => string;
 };

--- a/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
@@ -21,4 +21,6 @@ export const TagIntlProvider: TagIntl = {
     m.anticipated_count({ count: toHumanNumber(count, languageTag()) }),
   watchCountLabel: (isShow) =>
     isShow ? m.watched_episodes_count_label() : m.watch_count_label(),
+  trendLabel: (delta) =>
+    delta ? toHumanNumber(Math.abs(delta), languageTag()) : '—',
 };

--- a/projects/client/src/lib/components/media/tags/TrendTag.svelte
+++ b/projects/client/src/lib/components/media/tags/TrendTag.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import TrendIcon from "$lib/components/icons/TrendIcon.svelte";
+  import StemTag from "$lib/components/tags/StemTag.svelte";
+  import type { TagIntl } from "./TagIntl";
+
+  const { delta, i18n }: { delta: number; i18n: TagIntl } = $props();
+
+  const trendDirection = $derived.by(() => {
+    if (delta === 0) {
+      return "neutral";
+    }
+
+    return delta > 0 ? "up" : "down";
+  });
+</script>
+
+<StemTag
+  --color-background-stem-tag="var(--color-background-trend-{trendDirection}-background-tag)"
+  --color-text-stem-tag="var(--color-text-trend-tag)"
+>
+  <div class="trend-tag-container">
+    {#if trendDirection !== "neutral"}
+      <TrendIcon direction={trendDirection} />
+    {/if}
+
+    {i18n.trendLabel(delta)}
+  </div>
+</StemTag>
+
+<style>
+  .trend-tag-container {
+    display: flex;
+    align-items: center;
+
+    gap: var(--gap-xxs);
+
+    :global(svg) {
+      width: var(--ni-10);
+      height: var(--ni-10);
+    }
+  }
+</style>

--- a/projects/client/src/lib/requests/queries/movies/movieStreamingQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieStreamingQuery.spec.ts
@@ -1,0 +1,19 @@
+import { MoviesStreamingMappedMock } from '$mocks/data/movies/mapped/MoviesStreamingMappedMock.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { createQuery } from '@tanstack/svelte-query';
+import { describe, expect, it } from 'vitest';
+import { movieStreamingQuery } from './movieStreamingQuery.ts';
+
+describe('movieStreamingQuery', () => {
+  it('should query trending streaming movies', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          movieStreamingQuery(),
+        ),
+      mapper: (response) => response?.data?.entries,
+    });
+
+    expect(result).to.deep.equal(MoviesStreamingMappedMock);
+  });
+});

--- a/projects/client/src/lib/requests/queries/movies/movieStreamingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieStreamingQuery.ts
@@ -1,0 +1,67 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import type { MovieStreamingResponse } from '@trakt/api';
+import { z } from 'zod';
+import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
+import { MovieEntrySchema } from '../../models/MovieEntry.ts';
+
+export const StreamingMovieSchema = MovieEntrySchema.extend({
+  rank: z.number(),
+  delta: z.number(),
+});
+export type StreamingMovie = z.infer<typeof StreamingMovieSchema>;
+
+type MovieStreamingParams = PaginationParams & ApiParams;
+
+function mapToStreamingMovie({
+  rank,
+  delta,
+  movie,
+}: MovieStreamingResponse): StreamingMovie {
+  return {
+    rank,
+    delta: delta ?? 0,
+    ...mapToMovieEntry(movie),
+  };
+}
+
+const movieStreamingRequest = (
+  { fetch, limit, page }: MovieStreamingParams,
+) =>
+  api({ fetch })
+    .movies
+    .streaming({
+      params: {
+        period: 'daily',
+      },
+      query: {
+        extended: 'full,images',
+        watchnow: 'favorites',
+        ignore_collected: true,
+        ignore_watchlisted: true,
+        ignore_watched: true,
+        page,
+        limit,
+      },
+    });
+
+export const movieStreamingQuery = defineQuery({
+  key: 'movieStreaming',
+  invalidations: [
+    InvalidateAction.Watchlisted('movie'),
+    InvalidateAction.MarkAsWatched('movie'),
+  ],
+  dependencies: (params) => [params.limit, params.page],
+  request: movieStreamingRequest,
+  mapper: (response) => ({
+    entries: response.body.map(mapToStreamingMovie),
+    page: extractPageMeta(response.headers),
+  }),
+  schema: PaginatableSchemaFactory(StreamingMovieSchema),
+  ttl: time.hours(1),
+});

--- a/projects/client/src/lib/requests/queries/shows/showStreamingQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/shows/showStreamingQuery.spec.ts
@@ -1,0 +1,19 @@
+import { ShowsStreamingMappedMock } from '$mocks/data/shows/mapped/ShowsStreamingMappedMock.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { createQuery } from '@tanstack/svelte-query';
+import { describe, expect, it } from 'vitest';
+import { showStreamingQuery } from './showStreamingQuery.ts';
+
+describe('showStreamingQuery', () => {
+  it('should query for trending streaming shows', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          showStreamingQuery(),
+        ),
+      mapper: (response) => response?.data?.entries,
+    });
+
+    expect(result).to.deep.equal(ShowsStreamingMappedMock);
+  });
+});

--- a/projects/client/src/lib/requests/queries/shows/showStreamingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showStreamingQuery.ts
@@ -1,0 +1,67 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import type { ShowStreamingResponse } from '@trakt/api';
+import { z } from 'zod';
+import { mapToShowEntry } from '../../_internal/mapToShowEntry.ts';
+
+export const StreamingShowSchema = ShowEntrySchema.extend({
+  rank: z.number(),
+  delta: z.number(),
+});
+export type StreamingShow = z.infer<typeof StreamingShowSchema>;
+
+type ShowStreamingParams = PaginationParams & ApiParams;
+
+function mapToStreamingShow({
+  rank,
+  delta,
+  show,
+}: ShowStreamingResponse): StreamingShow {
+  return {
+    rank,
+    delta: delta ?? 0,
+    ...mapToShowEntry(show),
+  };
+}
+
+const showStreamingRequest = (
+  { fetch, limit, page }: ShowStreamingParams,
+) =>
+  api({ fetch })
+    .shows
+    .streaming({
+      params: {
+        period: 'daily',
+      },
+      query: {
+        extended: 'full,images',
+        watchnow: 'favorites',
+        ignore_collected: true,
+        ignore_watchlisted: true,
+        ignore_watched: true,
+        page,
+        limit,
+      },
+    });
+
+export const showStreamingQuery = defineQuery({
+  key: 'showStreaming',
+  invalidations: [
+    InvalidateAction.Watchlisted('show'),
+    InvalidateAction.MarkAsWatched('show'),
+  ],
+  dependencies: (params) => [params.limit, params.page],
+  request: showStreamingRequest,
+  mapper: (response) => ({
+    entries: response.body.map(mapToStreamingShow),
+    page: extractPageMeta(response.headers),
+  }),
+  schema: PaginatableSchemaFactory(StreamingShowSchema),
+  ttl: time.hours(1),
+});

--- a/projects/client/src/lib/sections/lists/streaming/StreamingList.svelte
+++ b/projects/client/src/lib/sections/lists/streaming/StreamingList.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
+  import StreamingListItem from "./StreamingListItem.svelte";
+  import { useStreamingList } from "./useStreamingList";
+
+  type TrendingListProps = {
+    title: string;
+    drilldownLabel: string;
+    type: MediaType;
+  };
+
+  const { title, drilldownLabel, type }: TrendingListProps = $props();
+</script>
+
+<DrillableMediaList
+  id="streaming-list-{type}"
+  {title}
+  {drilldownLabel}
+  {type}
+  useList={useStreamingList}
+  urlBuilder={UrlBuilder.streaming}
+>
+  {#snippet item(media)}
+    <StreamingListItem {type} {media} />
+  {/snippet}
+</DrillableMediaList>

--- a/projects/client/src/lib/sections/lists/streaming/StreamingListItem.svelte
+++ b/projects/client/src/lib/sections/lists/streaming/StreamingListItem.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
+  import TrendTag from "$lib/components/media/tags/TrendTag.svelte";
+  import MediaCard from "../components/MediaCard.svelte";
+  import type { MediaCardProps } from "../components/MediaCardProps";
+  import type { StreamingEntry } from "./useStreamingList";
+
+  const { type, media, style }: MediaCardProps<StreamingEntry> = $props();
+</script>
+
+{#snippet tags()}
+  <TrendTag i18n={TagIntlProvider} delta={media.delta} />
+{/snippet}
+
+<MediaCard {type} {media} {tags} {style} />

--- a/projects/client/src/lib/sections/lists/streaming/StreamingPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/streaming/StreamingPaginatedList.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
+  import StreamingListItem from "./StreamingListItem.svelte";
+  import { useStreamingList } from "./useStreamingList";
+
+  type StreamingListProps = {
+    title: string;
+    type: MediaType;
+  };
+
+  const { title, type }: StreamingListProps = $props();
+
+  const isMobile = useMedia(WellKnownMediaQuery.mobile);
+  const style = $derived($isMobile ? "summary" : "cover");
+</script>
+
+<DrilledMediaList
+  id="view-all-streaming-${type}"
+  {title}
+  {type}
+  useList={useStreamingList}
+>
+  {#snippet item(media)}
+    <StreamingListItem {type} {media} {style} />
+  {/snippet}
+</DrilledMediaList>

--- a/projects/client/src/lib/sections/lists/streaming/useStreamingList.ts
+++ b/projects/client/src/lib/sections/lists/streaming/useStreamingList.ts
@@ -1,0 +1,41 @@
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import type { Paginatable } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import {
+  movieStreamingQuery,
+  type StreamingMovie,
+} from '$lib/requests/queries/movies/movieStreamingQuery.ts';
+import {
+  showStreamingQuery,
+  type StreamingShow,
+} from '$lib/requests/queries/shows/showStreamingQuery.ts';
+import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
+import { type CreateQueryOptions } from '@tanstack/svelte-query';
+
+export type StreamingEntry = StreamingMovie | StreamingShow;
+export type StreamingMediaList = Paginatable<StreamingEntry>;
+
+type StreamingListStoreProps = PaginationParams & {
+  type: MediaType;
+};
+
+function typeToQuery(
+  params: StreamingListStoreProps,
+) {
+  switch (params.type) {
+    case 'movie':
+      return movieStreamingQuery(params) as CreateQueryOptions<
+        StreamingMediaList
+      >;
+    case 'show':
+      return showStreamingQuery(params) as CreateQueryOptions<
+        StreamingMediaList
+      >;
+  }
+}
+
+export function useStreamingList(
+  props: StreamingListStoreProps,
+) {
+  return usePaginatedListQuery(typeToQuery(props));
+}

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -36,6 +36,9 @@ export const UrlBuilder = {
   trending(params: PaginatableMediaPageUrl) {
     return mediaDrilldownFactory('trending')(params);
   },
+  streaming(params: PaginatableMediaPageUrl) {
+    return mediaDrilldownFactory('streaming')(params);
+  },
   recommended(params: PaginatableMediaPageUrl) {
     return mediaDrilldownFactory('recommended')(params);
   },

--- a/projects/client/src/mocks/data/movies/mapped/MoviesStreamingMappedMock.ts
+++ b/projects/client/src/mocks/data/movies/mapped/MoviesStreamingMappedMock.ts
@@ -1,0 +1,16 @@
+import type { StreamingMovie } from '$lib/requests/queries/movies/movieStreamingQuery.ts';
+import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
+import { MovieMatrixMappedMock } from '$mocks/data/summary/movies/matrix/MovieMatrixMappedMock.ts';
+
+export const MoviesStreamingMappedMock: StreamingMovie[] = [
+  {
+    rank: 1,
+    delta: 5,
+    ...MovieHereticMappedMock,
+  },
+  {
+    rank: 13,
+    delta: -4,
+    ...MovieMatrixMappedMock,
+  },
+];

--- a/projects/client/src/mocks/data/movies/response/MoviesStreamingResponseMock.ts
+++ b/projects/client/src/mocks/data/movies/response/MoviesStreamingResponseMock.ts
@@ -1,0 +1,16 @@
+import { MovieHereticResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticResponseMock.ts';
+import { MovieMatrixResponseMock } from '$mocks/data/summary/movies/matrix/MovieMatrixResponseMock.ts';
+import type { MovieStreamingResponse } from '@trakt/api';
+
+export const MoviesStreamingResponseMock: MovieStreamingResponse[] = [
+  {
+    rank: 1,
+    delta: 5,
+    movie: MovieHereticResponseMock,
+  },
+  {
+    rank: 13,
+    delta: -4,
+    movie: MovieMatrixResponseMock,
+  },
+];

--- a/projects/client/src/mocks/data/shows/mapped/ShowsStreamingMappedMock.ts
+++ b/projects/client/src/mocks/data/shows/mapped/ShowsStreamingMappedMock.ts
@@ -1,0 +1,16 @@
+import type { StreamingShow } from '$lib/requests/queries/shows/showStreamingQuery.ts';
+import { ShowDevsMappedMock } from '$mocks/data/summary/shows/devs/ShowDevsMappedMock.ts';
+import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
+
+export const ShowsStreamingMappedMock: StreamingShow[] = [
+  {
+    rank: 42,
+    delta: 1337,
+    ...ShowSiloMappedMock,
+  },
+  {
+    rank: 180,
+    delta: 0,
+    ...ShowDevsMappedMock,
+  },
+];

--- a/projects/client/src/mocks/data/shows/response/ShowsStreamingResponseMock.ts
+++ b/projects/client/src/mocks/data/shows/response/ShowsStreamingResponseMock.ts
@@ -1,0 +1,16 @@
+import { ShowDevsResponseMock } from '$mocks/data/summary/shows/devs/ShowDevsResponseMock.ts';
+import { ShowSiloResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloResponseMock.ts';
+import type { ShowStreamingResponse } from '@trakt/api';
+
+export const ShowsStreamingResponseMock: ShowStreamingResponse[] = [
+  {
+    rank: 42,
+    delta: 1337,
+    show: ShowSiloResponseMock,
+  },
+  {
+    rank: 180,
+    delta: 0,
+    show: ShowDevsResponseMock,
+  },
+];

--- a/projects/client/src/mocks/handlers/movies.ts
+++ b/projects/client/src/mocks/handlers/movies.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
 import { OfficialListsResponseMock } from '$mocks/data/lists/response/OfficialListsResponseMock.ts';
+import { MoviesStreamingResponseMock } from '$mocks/data/movies/response/MoviesStreamingResponseMock.ts';
 import { MovieHereticCommentsResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticCommentsResponseMock.ts';
 import { MoviesAnticipatedResponseMock } from '../data/movies/response/MoviesAnticipatedResponseMock.ts';
 import { MoviesPopularResponseMock } from '../data/movies/response/MoviesPopularResponseMock.ts';
@@ -69,6 +70,12 @@ export const movies = [
     'http://localhost/movies/trending*',
     () => {
       return HttpResponse.json(MoviesTrendingResponseMock);
+    },
+  ),
+  http.get(
+    'http://localhost/movies/streaming*',
+    () => {
+      return HttpResponse.json(MoviesStreamingResponseMock);
     },
   ),
   http.get(

--- a/projects/client/src/mocks/handlers/shows.ts
+++ b/projects/client/src/mocks/handlers/shows.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from 'msw';
 
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { OfficialListsResponseMock } from '$mocks/data/lists/response/OfficialListsResponseMock.ts';
+import { ShowsStreamingResponseMock } from '$mocks/data/shows/response/ShowsStreamingResponseMock.ts';
 import { EpisodeSiloCommentsResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloCommentsResponseMock.ts';
 import { EpisodeSiloPeopleResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloPeopleResponseMock.ts';
 import { EpisodeSiloWatchNowResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloWatchNowResponseMock.ts';
@@ -150,6 +151,12 @@ export const shows = [
     'http://localhost/shows/trending*',
     () => {
       return HttpResponse.json(ShowsTrendingResponseMock);
+    },
+  ),
+  http.get(
+    'http://localhost/shows/streaming*',
+    () => {
+      return HttpResponse.json(ShowsStreamingResponseMock);
     },
   ),
   http.get(

--- a/projects/client/src/routes/movies/+page.svelte
+++ b/projects/client/src/routes/movies/+page.svelte
@@ -6,6 +6,7 @@
   import AnticipatedList from "$lib/sections/lists/anticipated/AnticipatedList.svelte";
   import PopularList from "$lib/sections/lists/popular/PopularList.svelte";
   import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
+  import StreamingList from "$lib/sections/lists/streaming/StreamingList.svelte";
   import TrendingList from "$lib/sections/lists/trending/TrendingList.svelte";
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
 
@@ -28,6 +29,11 @@
     <RecommendedList
       drilldownLabel={m.view_all_recommended_movies()}
       title={m.recommendations()}
+      {type}
+    />
+    <StreamingList
+      title={m.streaming_picks()}
+      drilldownLabel={m.view_all_streaming_movie_picks()}
       {type}
     />
   </RenderFor>

--- a/projects/client/src/routes/movies/streaming/+page.svelte
+++ b/projects/client/src/routes/movies/streaming/+page.svelte
@@ -1,0 +1,18 @@
+<script>
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import StreamingPaginatedList from "$lib/sections/lists/streaming/StreamingPaginatedList.svelte";
+
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+</script>
+
+<TraktPage
+  audience="authenticated"
+  image={DEFAULT_SHARE_MOVIE_COVER}
+  title={m.streaming_movie_picks()}
+>
+  <TraktPageCoverSetter />
+
+  <StreamingPaginatedList title={m.streaming_movie_picks()} type="movie" />
+</TraktPage>

--- a/projects/client/src/routes/shows/+page.svelte
+++ b/projects/client/src/routes/shows/+page.svelte
@@ -6,6 +6,7 @@
   import AnticipatedList from "$lib/sections/lists/anticipated/AnticipatedList.svelte";
   import PopularList from "$lib/sections/lists/popular/PopularList.svelte";
   import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
+  import StreamingList from "$lib/sections/lists/streaming/StreamingList.svelte";
   import TrendingList from "$lib/sections/lists/trending/TrendingList.svelte";
 
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
@@ -29,6 +30,11 @@
     <RecommendedList
       title={m.recommendations()}
       drilldownLabel={m.view_all_recommended_shows()}
+      {type}
+    />
+    <StreamingList
+      title={m.streaming_picks()}
+      drilldownLabel={m.view_all_streaming_show_picks()}
       {type}
     />
   </RenderFor>

--- a/projects/client/src/routes/shows/streaming/+page.svelte
+++ b/projects/client/src/routes/shows/streaming/+page.svelte
@@ -1,0 +1,18 @@
+<script>
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import StreamingPaginatedList from "$lib/sections/lists/streaming/StreamingPaginatedList.svelte";
+
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
+</script>
+
+<TraktPage
+  audience="authenticated"
+  image={DEFAULT_SHARE_SHOW_COVER}
+  title={m.streaming_show_picks()}
+>
+  <TraktPageCoverSetter />
+
+  <StreamingPaginatedList title={m.streaming_show_picks()} type="show" />
+</TraktPage>

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -58,6 +58,11 @@
   --color-text-watch-count-tag: var(--shade-10);
   --color-background-watch-count-tag: var(--purple-500);
 
+  --color-text-trend-tag: var(--shade-10);
+  --color-background-trend-neutral-background-tag: var(--shade-500);
+  --color-background-trend-down-background-tag: var(--red-700);
+  --color-background-trend-up-background-tag: var(--green-700);
+
   --color-border-avatar: var(--shade-50);
   --color-border-vip-avatar: var(--red-500);
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds `top streaming picks` to the shows and movies pages.
  - Didn't want to re-use the word `trending` in the title, since we already use it for our own lists.
- Currently works best if users have set favorite services.
  - Might need a follow-up for cases where users haven't set any.
- Didn't want to use the same tags on all lists, so this also adds a `TrendTag`.
  - It is a very barebone tag. If it leads to too much unclarity, it's an easy change to remove it.

## 👀 Examples 👀
<img width="1367" alt="Screenshot 2025-04-07 at 19 50 42" src="https://github.com/user-attachments/assets/61065346-c981-4eb1-94dc-65d8007815c3" />

<img width="1367" alt="Screenshot 2025-04-07 at 19 50 50" src="https://github.com/user-attachments/assets/c992949a-4c0e-478e-a2a2-24625f011964" />
