### PR TITLE
fix(auth): refresh on wrong token

### DIFF
--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
@@ -1,5 +1,17 @@
 import { getToken } from '$lib/features/auth/token/index.ts';
+
 import { error } from '$lib/utils/console/print.ts';
+
+const RELOAD_STATE_KEY = 'has-reloaded';
+
+function handle401(token: string | Nil) {
+  if (!token || sessionStorage.getItem(RELOAD_STATE_KEY)) {
+    return;
+  }
+
+  sessionStorage.setItem(RELOAD_STATE_KEY, 'true');
+  globalThis.window.location.reload();
+}
 
 export function createAuthenticatedFetch<
   T extends typeof fetch,
@@ -24,7 +36,16 @@ export function createAuthenticatedFetch<
           ...modifiedInit,
           headers,
         } as Parameters<T>[1],
-      );
+      ).then((response) => {
+        if (response.status === 401) {
+          handle401(token);
+          return Promise.reject(new Error('Unauthorized request'));
+        }
+
+        return response;
+      }).finally(() => {
+        sessionStorage.removeItem(RELOAD_STATE_KEY);
+      });
     } catch (e) {
       error('Fetch interceptor error:', e);
       return baseFetch(input, init);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Quick fix for cases where client does not have the correct token.
- Refreshes if there's a 401 while there is a token.
  - Just in case something goes wrong after the refresh, the refresh is only done once. This mechanism is reset after the first non-401.

## 👀 Example 👀
<img width="769" alt="Screenshot 2025-04-09 at 13 37 27" src="https://github.com/user-attachments/assets/abd793b5-fa13-4a32-bd61-e53b1371b774" />
