### PR TITLE
Feat/list action

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "npm:@cucumber/cucumber@^11.2.0": "11.2.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.0.2_@cucumber+messages@27.0.2",
     "npm:@google/generative-ai@0.24": "0.24.0",
     "npm:@inlang/paraglide-sveltekit@~0.16.1": "0.16.1_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
-    "npm:@jsr/trakt__api@~0.1.14": "0.1.14_zod@3.24.1",
+    "npm:@jsr/trakt__api@~0.1.15": "0.1.15_zod@3.24.1",
     "npm:@playwright/test@^1.51.1": "1.51.1",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.25.3__acorn@8.14.1",
     "npm:@sveltejs/adapter-auto@5": "5.0.0_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
@@ -2161,8 +2161,8 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.1.14_zod@3.24.1": {
-      "integrity": "sha512-3qeF8SY8LLEdaobK/tWrhUutjuN28iCSOYdbHrVx5/AAxPJoPdJBkxDfv2Yca1PYEdoA2vmXWQ7dV/36IQYf+w==",
+    "@jsr/trakt__api@0.1.15_zod@3.24.1": {
+      "integrity": "sha512-amCsrp1GmTpAukq9+0/R66uTrw57C3oA4o7r6AgSbT5BRwnPMJCbw+5EvU7Ytm9dIK+rdn1jsZzNcCP2Q0chmQ==",
       "dependencies": [
         "@ts-rest/core",
         "zod@3.24.1"
@@ -7001,7 +7001,7 @@
             "npm:@cucumber/cucumber@^11.2.0",
             "npm:@google/generative-ai@0.24",
             "npm:@inlang/paraglide-sveltekit@~0.16.1",
-            "npm:@jsr/trakt__api@~0.1.14",
+            "npm:@jsr/trakt__api@~0.1.15",
             "npm:@playwright/test@^1.51.1",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@sveltejs/adapter-auto@5",

--- a/projects/client/i18n/messages/bg-bg.json
+++ b/projects/client/i18n/messages/bg-bg.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Топ предложения (сериали)",
   "community_voice": "Гласът на общността",
   "the_good": "Доброто",
-  "the_bad": "Лошото"
+  "the_bad": "Лошото",
+  "add_to_list": "Добави в списък",
+  "listed": "В списъка",
+  "add_remove_from_lists": "Добави или премахни {title} от списъци",
+  "add_to_personal_list": "Добави в {list}",
+  "add_to_personal_list_label": "Добави {title} в {list}",
+  "remove_from_personal_list": "Премахни от {list}",
+  "remove_from_personal_list_label": "Премахни {title} от {list}",
+  "remove_from_personal_list_warning": "Сигурни ли сте, че искате да премахнете {title} от {list}?"
 }

--- a/projects/client/i18n/messages/da-dk.json
+++ b/projects/client/i18n/messages/da-dk.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Top streaming serievalg",
   "community_voice": "Fællesskabets stemme",
   "the_good": "Det gode",
-  "the_bad": "Det dårlige"
+  "the_bad": "Det dårlige",
+  "add_to_list": "Tilføj til liste",
+  "listed": "Tilføjet",
+  "add_remove_from_lists": "Tilføj eller fjern {title} fra lister",
+  "add_to_personal_list": "Tilføj til {list}",
+  "add_to_personal_list_label": "Tilføj {title} til {list}",
+  "remove_from_personal_list": "Fjern fra {list}",
+  "remove_from_personal_list_label": "Fjern {title} fra {list}",
+  "remove_from_personal_list_warning": "Er du sikker på, at du vil fjerne {title} fra {list}?"
 }

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Top streaming show picks",
   "community_voice": "Community Voice",
   "the_good": "Das Gute",
-  "the_bad": "Das Schlechte"
+  "the_bad": "Das Schlechte",
+  "add_to_list": "Zur Liste",
+  "listed": "Gelistet",
+  "add_remove_from_lists": "{title} zu Listen hinzufügen oder entfernen",
+  "add_to_personal_list": "Zu {list} hinzufügen",
+  "add_to_personal_list_label": "{title} zu {list} hinzufügen",
+  "remove_from_personal_list": "Von {list} entfernen",
+  "remove_from_personal_list_label": "{title} von {list} entfernen",
+  "remove_from_personal_list_warning": "Möchtest du {title} wirklich von {list} entfernen?"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Top streaming show picks",
   "community_voice": "Community Voice",
   "the_good": "The good",
-  "the_bad": "The bad"
+  "the_bad": "The bad",
+  "add_to_list": "Add to list",
+  "listed": "Listed",
+  "add_remove_from_lists": "Add or remove {title} from lists",
+  "add_to_personal_list": "Add to {list}",
+  "add_to_personal_list_label": "Add {title} to {list}",
+  "remove_from_personal_list": "Remove from {list}",
+  "remove_from_personal_list_label": "Remove {title} from {list}",
+  "remove_from_personal_list_warning": "Are you sure you want to remove {title} from {list}?"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Recomendaciones de series en streaming",
   "community_voice": "Voz de la comunidad",
   "the_good": "Lo bueno",
-  "the_bad": "Lo malo"
+  "the_bad": "Lo malo",
+  "add_to_list": "Añadir a la lista",
+  "listed": "En lista",
+  "add_remove_from_lists": "Añadir o quitar {title} de las listas",
+  "add_to_personal_list": "Añadir a {list}",
+  "add_to_personal_list_label": "Añadir {title} a {list}",
+  "remove_from_personal_list": "Quitar de {list}",
+  "remove_from_personal_list_label": "Quitar {title} de {list}",
+  "remove_from_personal_list_warning": "¿Seguro que quieres quitar {title} de {list}?"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Lo mejor de TV en streaming",
   "community_voice": "Voz de la comunidad",
   "the_good": "Lo bueno",
-  "the_bad": "Lo malo"
+  "the_bad": "Lo malo",
+  "add_to_list": "Añadir a la lista",
+  "listed": "En lista",
+  "add_remove_from_lists": "Añadir o quitar {title} de listas",
+  "add_to_personal_list": "Añadir a {list}",
+  "add_to_personal_list_label": "Añadir {title} a {list}",
+  "remove_from_personal_list": "Quitar de {list}",
+  "remove_from_personal_list_label": "Quitar {title} de {list}",
+  "remove_from_personal_list_warning": "¿Seguro que quieres quitar {title} de {list}?"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Top streaming show picks",
   "community_voice": "Voix de la communauté",
   "the_good": "Le bon",
-  "the_bad": "Le mauvais"
+  "the_bad": "Le mauvais",
+  "add_to_list": "Ajouter à la liste",
+  "listed": "Listé",
+  "add_remove_from_lists": "Ajouter ou retirer {title} des listes",
+  "add_to_personal_list": "Ajouter à {list}",
+  "add_to_personal_list_label": "Ajouter {title} à {list}",
+  "remove_from_personal_list": "Retirer de {list}",
+  "remove_from_personal_list_label": "Retirer {title} de {list}",
+  "remove_from_personal_list_warning": "Êtes-vous sûr de vouloir retirer {title} de {list}?"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Meilleures séries en streaming",
   "community_voice": "La voix de la communauté",
   "the_good": "Le bon",
-  "the_bad": "Le mauvais"
+  "the_bad": "Le mauvais",
+  "add_to_list": "Ajouter à la liste",
+  "listed": "Listé",
+  "add_remove_from_lists": "Ajouter ou retirer {title} des listes",
+  "add_to_personal_list": "Ajouter à {list}",
+  "add_to_personal_list_label": "Ajouter {title} à {list}",
+  "remove_from_personal_list": "Retirer de {list}",
+  "remove_from_personal_list_label": "Retirer {title} de {list}",
+  "remove_from_personal_list_warning": "Êtes-vous sûr de vouloir retirer {title} de {list} ?"
 }

--- a/projects/client/i18n/messages/it-it.json
+++ b/projects/client/i18n/messages/it-it.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Scelte serie streaming",
   "community_voice": "Voce della Community",
   "the_good": "Il bello",
-  "the_bad": "Il brutto"
+  "the_bad": "Il brutto",
+  "add_to_list": "Aggiungi a lista",
+  "listed": "In lista",
+  "add_remove_from_lists": "Aggiungi o rimuovi {title} dalle liste",
+  "add_to_personal_list": "Aggiungi a {list}",
+  "add_to_personal_list_label": "Aggiungi {title} a {list}",
+  "remove_from_personal_list": "Rimuovi da {list}",
+  "remove_from_personal_list_label": "Rimuovi {title} da {list}",
+  "remove_from_personal_list_warning": "Sei sicuro di voler rimuovere {title} da {list}?"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "注目のストリーミング番組",
   "community_voice": "コミュニティの声",
   "the_good": "良い点",
-  "the_bad": "悪い点"
+  "the_bad": "悪い点",
+  "add_to_list": "リストに追加",
+  "listed": "登録済み",
+  "add_remove_from_lists": "{title} をリストに追加または削除",
+  "add_to_personal_list": "{list} に追加",
+  "add_to_personal_list_label": "{title} を {list} に追加",
+  "remove_from_personal_list": "{list} から削除",
+  "remove_from_personal_list_label": "{title} を {list} から削除",
+  "remove_from_personal_list_warning": "{title} を {list} から削除してもよろしいですか？"
 }

--- a/projects/client/i18n/messages/nb-no.json
+++ b/projects/client/i18n/messages/nb-no.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "De beste serietipsene for strømming",
   "community_voice": "Felleskapsstemme",
   "the_good": "Det gode",
-  "the_bad": "Det dårlige"
+  "the_bad": "Det dårlige",
+  "add_to_list": "Legg til i liste",
+  "listed": "Listet",
+  "add_remove_from_lists": "Legg til eller fjern {title} fra lister",
+  "add_to_personal_list": "Legg til i {list}",
+  "add_to_personal_list_label": "Legg til {title} i {list}",
+  "remove_from_personal_list": "Fjern fra {list}",
+  "remove_from_personal_list_label": "Fjern {title} fra {list}",
+  "remove_from_personal_list_warning": "Er du sikker på at du vil fjerne {title} fra {list}?"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Top streaming seriekeuzes",
   "community_voice": "De stem van de gemeenschap",
   "the_good": "Het goede",
-  "the_bad": "Het slechte"
+  "the_bad": "Het slechte",
+  "add_to_list": "Toevoegen aan lijst",
+  "listed": "In lijst",
+  "add_remove_from_lists": "{title} toevoegen of verwijderen van lijsten",
+  "add_to_personal_list": "Toevoegen aan {list}",
+  "add_to_personal_list_label": "Voeg {title} toe aan {list}",
+  "remove_from_personal_list": "Verwijderen uit {list}",
+  "remove_from_personal_list_label": "Verwijder {title} uit {list}",
+  "remove_from_personal_list_warning": "Weet je zeker dat je {title} wilt verwijderen van {list}?"
 }

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Najlepsze serialowe wybory streamingowe",
   "community_voice": "Głos Społeczności",
   "the_good": "Same plusy!",
-  "the_bad": "Same minusy!"
+  "the_bad": "Same minusy!",
+  "add_to_list": "Dodaj do listy",
+  "listed": "Na liście",
+  "add_remove_from_lists": "Dodaj lub usuń {title} z list",
+  "add_to_personal_list": "Dodaj do {list}",
+  "add_to_personal_list_label": "Dodaj {title} do {list}",
+  "remove_from_personal_list": "Usuń z {list}",
+  "remove_from_personal_list_label": "Usuń {title} z {list}",
+  "remove_from_personal_list_warning": "Na pewno chcesz usunąć {title} z {list}?"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Melhores séries no streaming",
   "community_voice": "Voz da Comunidade",
   "the_good": "O bom",
-  "the_bad": "O ruim"
+  "the_bad": "O ruim",
+  "add_to_list": "Adicionar à lista",
+  "listed": "Listado",
+  "add_remove_from_lists": "Adicionar ou remover {title} das listas",
+  "add_to_personal_list": "Adicionar à {list}",
+  "add_to_personal_list_label": "Adicionar {title} à {list}",
+  "remove_from_personal_list": "Remover da {list}",
+  "remove_from_personal_list_label": "Remover {title} da {list}",
+  "remove_from_personal_list_warning": "Tem certeza que deseja remover {title} da {list}?"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Recomandări de seriale pe streaming",
   "community_voice": "Vocea comunității",
   "the_good": "Aspecte pozitive",
-  "the_bad": "Aspecte negative"
+  "the_bad": "Aspecte negative",
+  "add_to_list": "Adaugă în listă",
+  "listed": "Listat",
+  "add_remove_from_lists": "Adaugă sau elimină {title} din liste",
+  "add_to_personal_list": "Adaugă la {list}",
+  "add_to_personal_list_label": "Adaugă {title} la {list}",
+  "remove_from_personal_list": "Elimină din {list}",
+  "remove_from_personal_list_label": "Elimină {title} din {list}",
+  "remove_from_personal_list_warning": "Sigur vrei să elimini {title} din {list}?"
 }

--- a/projects/client/i18n/messages/sv-se.json
+++ b/projects/client/i18n/messages/sv-se.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Toppval för serier på streaming",
   "community_voice": "Känslan i gemenskapen",
   "the_good": "Det bra",
-  "the_bad": "Det dåliga"
+  "the_bad": "Det dåliga",
+  "add_to_list": "Lägg till i lista",
+  "listed": "Listad",
+  "add_remove_from_lists": "Lägg till eller ta bort {title} från listor",
+  "add_to_personal_list": "Lägg till i {list}",
+  "add_to_personal_list_label": "Lägg till {title} i {list}",
+  "remove_from_personal_list": "Ta bort från {list}",
+  "remove_from_personal_list_label": "Ta bort {title} från {list}",
+  "remove_from_personal_list_warning": "Är du säker på att du vill ta bort {title} från {list}?"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -364,5 +364,13 @@
   "streaming_show_picks": "Найкращі стрімінгові добірки серіалів",
   "community_voice": "Голос спільноти",
   "the_good": "Плюси",
-  "the_bad": "Мінуси"
+  "the_bad": "Мінуси",
+  "add_to_list": "Додати до списку",
+  "listed": "В списку",
+  "add_remove_from_lists": "Додати або видалити {title} зі списків",
+  "add_to_personal_list": "Додати до {list}",
+  "add_to_personal_list_label": "Додати {title} до {list}",
+  "remove_from_personal_list": "Видалити з {list}",
+  "remove_from_personal_list_label": "Видалити {title} з {list}",
+  "remove_from_personal_list_warning": "Ви впевнені, що хочете видалити {title} з {list}?"
 }

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -61,7 +61,7 @@
     "@tanstack/svelte-query": "^5.69.0",
     "@tanstack/svelte-query-devtools": "^5.69.0",
     "@tanstack/svelte-query-persist-client": "^5.69.0",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.1.14",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.1.15",
     "@ts-rest/core": "^3.52.1",
     "date-fns": "^4.1.0",
     "firebase": "^11.5.0",

--- a/projects/client/src/lib/features/auth/queries/currentUserSettingsQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserSettingsQuery.ts
@@ -48,6 +48,12 @@ export const UserSettingsSchema = z.object({
     showOnlyFavorites: z.boolean().optional(),
   }),
   permissions: permissionSchema.array(),
+  limits: z.object({
+    lists: z.object({
+      limit: z.number(),
+      itemLimit: z.number(),
+    }),
+  }),
 });
 
 export type UserSettings = z.infer<typeof UserSettingsSchema>;
@@ -111,6 +117,12 @@ function mapUserSettingsResponse(response: SettingsResponse): UserSettings {
     permissions: Object.entries(response.permissions)
       .filter(([_, value]) => value)
       .map(([key]) => PERMISSIONS_MAP[key as keyof typeof PERMISSIONS_MAP]),
+    limits: {
+      lists: {
+        limit: response.limits?.list.count ?? 0,
+        itemLimit: response.limits?.list.item_count ?? 0,
+      },
+    },
   };
 }
 

--- a/projects/client/src/lib/requests/queries/users/addToListRequest.ts
+++ b/projects/client/src/lib/requests/queries/users/addToListRequest.ts
@@ -1,0 +1,25 @@
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import type { WatchlistRequest } from '@trakt/api';
+
+type AddToListParams = {
+  body: WatchlistRequest;
+  listId: string;
+  userId?: string | Nil;
+} & ApiParams;
+
+export function addToListRequest(
+  { body, fetch, listId, userId }: AddToListParams,
+): Promise<boolean> {
+  return api({ fetch })
+    .users
+    .lists
+    .list
+    .add({
+      params: {
+        id: userId ?? 'me',
+        list_id: listId,
+      },
+      body,
+    })
+    .then(({ status }) => status === 201);
+}

--- a/projects/client/src/lib/requests/queries/users/removeFromListRequest.ts
+++ b/projects/client/src/lib/requests/queries/users/removeFromListRequest.ts
@@ -4,10 +4,11 @@ import type { WatchlistRequest } from '@trakt/api';
 type RemoveFromListParams = {
   body: WatchlistRequest;
   listId: string;
+  userId?: string | Nil;
 } & ApiParams;
 
 export function removeFromListRequest(
-  { body, fetch, listId }: RemoveFromListParams,
+  { body, fetch, listId, userId }: RemoveFromListParams,
 ): Promise<boolean> {
   return api({ fetch })
     .users
@@ -15,7 +16,7 @@ export function removeFromListRequest(
     .list
     .remove({
       params: {
-        id: 'me',
+        id: userId ?? 'me',
         list_id: listId,
       },
       body,

--- a/projects/client/src/lib/requests/queries/users/userListAllItemsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/userListAllItemsQuery.spec.ts
@@ -1,0 +1,26 @@
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { AllListedShowsMappedMock } from '$mocks/data/lists/mapped/AllListedShowsMappedMock.ts';
+import { SiloListsMappedMock } from '$mocks/data/summary/shows/silo/mapped/SiloListsMappedMock.ts';
+import { UserProfileHarryMappedMock } from '$mocks/data/users/mapped/UserProfileHarryMappedMock.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { createQuery } from '@tanstack/svelte-query';
+import { describe, expect, it } from 'vitest';
+import { userListAllItemsQuery } from './userListAllItemsQuery.ts';
+
+describe('userListAllItemsQuery', () => {
+  it('should query all show list items', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          userListAllItemsQuery({
+            userId: assertDefined(UserProfileHarryMappedMock.slug),
+            listId: assertDefined(SiloListsMappedMock.at(0)).slug,
+            type: 'show',
+          }),
+        ),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(AllListedShowsMappedMock);
+  });
+});

--- a/projects/client/src/lib/requests/queries/users/userListAllItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListAllItemsQuery.ts
@@ -1,0 +1,71 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { mapToListItem } from '$lib/requests/_internal/mapToListItem.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { ListItemSchemaFactory } from '$lib/requests/models/ListItem.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import { MovieEntrySchema } from '$lib/requests/models/MovieEntry.ts';
+import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { z } from 'zod';
+
+type UserListAllItemsParams =
+  & {
+    userId: string;
+    listId: string;
+    type: MediaType;
+  }
+  & ApiParams;
+
+const ListedShowEntrySchema = ShowEntrySchema.merge(
+  EpisodeCountSchema,
+);
+
+const ListedItemSchema = ListItemSchemaFactory(
+  z.union([MovieEntrySchema, ListedShowEntrySchema]),
+);
+
+export type ListedItem = z.infer<typeof ListedItemSchema>;
+
+const userListAllItemsRequest = (
+  {
+    fetch,
+    userId,
+    listId,
+    type,
+  }: UserListAllItemsParams,
+) =>
+  api({ fetch })
+    .users
+    .lists
+    .list
+    .items({
+      params: {
+        id: userId,
+        list_id: listId,
+        type,
+      },
+      query: {
+        limit: 'all',
+      },
+    });
+
+export const userListAllItemsQuery = defineQuery({
+  key: 'userListAllItems',
+  invalidations: [
+    InvalidateAction.Listed('movie'),
+    InvalidateAction.Listed('show'),
+  ],
+  dependencies: (
+    params,
+  ) => [
+    params.userId,
+    params.listId,
+    params.type,
+  ],
+  request: userListAllItemsRequest,
+  mapper: (response) => response.body.map(mapToListItem),
+  schema: ListedItemSchema.array(),
+  ttl: time.minutes(30),
+});

--- a/projects/client/src/lib/sections/media-actions/watchlist/WatchListActionProps.ts
+++ b/projects/client/src/lib/sections/media-actions/watchlist/WatchListActionProps.ts
@@ -1,7 +1,9 @@
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import type { Writable } from 'svelte/store';
 
 export type WatchlistActionProps = {
   style?: 'action' | 'normal' | 'dropdown-item';
   size?: 'small' | 'normal';
   title: string;
+  isUpdating?: Writable<boolean>;
 } & MediaStoreProps;

--- a/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
@@ -2,6 +2,7 @@
   import * as m from "$lib/features/i18n/messages";
 
   import WatchlistButton from "$lib/components/buttons/watchlist/WatchlistButton.svelte";
+  import { onMount } from "svelte";
   import { attachWarning } from "../_internal/attachWarning";
   import { useWatchlist } from "./useWatchlist";
   import type { WatchlistActionProps } from "./WatchListActionProps";
@@ -10,6 +11,7 @@
     style = "action",
     size = "normal",
     title,
+    isUpdating,
     ...target
   }: WatchlistActionProps = $props();
 
@@ -19,6 +21,20 @@
     isWatchlisted,
     removeFromWatchlist,
   } = $derived(useWatchlist(target));
+
+  onMount(() => {
+    if (!isUpdating) {
+      return;
+    }
+
+    const unsubscribe = isWatchlistUpdating.subscribe((value) => {
+      isUpdating.set(value);
+    });
+
+    return {
+      destroy: unsubscribe,
+    };
+  });
 
   const onRemoveHandler = $derived(
     attachWarning(

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/ListDropdown.svelte
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/ListDropdown.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+  import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
+  import { writable } from "svelte/store";
+  import ListDropdownButton from "./_internal/ListDropdownButton.svelte";
+  import ListDropdownItem from "./_internal/ListDropdownItem.svelte";
+  import { useIsOnAnyList } from "./_internal/useIsOnAnyList";
+  import type { ListDropdownProps } from "./ListDropdownProps";
+  import { useAllPersonalLists } from "./useAllPersonalLists";
+
+  const { style, title, ...target }: ListDropdownProps = $props();
+
+  // FIXME: replace this when we store states in session storage
+  const isUpdating = writable(false);
+  const { lists, isLoading } = useAllPersonalLists();
+
+  const { isListed } = $derived(
+    useIsOnAnyList({
+      lists: $lists,
+      ...target,
+    }),
+  );
+
+  const isDisabled = $derived($isLoading || $isUpdating);
+</script>
+
+<ListDropdownButton
+  {style}
+  title={m.add_remove_from_lists({ title })}
+  isListed={$isListed}
+  disabled={isDisabled}
+>
+  {#snippet items()}
+    <WatchlistAction style="dropdown-item" {title} {isUpdating} {...target} />
+
+    {#each $lists as list}
+      <ListDropdownItem {title} {list} {isUpdating} {...target} />
+    {/each}
+  {/snippet}
+</ListDropdownButton>

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/ListDropdownProps.ts
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/ListDropdownProps.ts
@@ -1,0 +1,6 @@
+import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+
+export type ListDropdownProps = MediaStoreProps & {
+  style?: 'normal' | 'action';
+  title: string;
+};

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownButton.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
+  import WatchlistIcon from "$lib/components/icons/WatchlistIcon.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import type { ListDropdownButtonProps } from "./ListDropdownButtonProps";
+
+  const {
+    title,
+    items: externalItems,
+    style = "normal",
+    isListed,
+    ...props
+  }: ListDropdownButtonProps = $props();
+
+  const size = $derived(style === "action" ? "small" : "normal");
+  const state = $derived(isListed ? "added" : "missing");
+  const variant = $derived(isListed ? "primary" : "secondary");
+  const text = $derived(isListed ? m.listed() : m.add_to_list());
+</script>
+
+<list-dropdown>
+  <DropdownList
+    label={title}
+    {variant}
+    text="capitalize"
+    color="blue"
+    style="flat"
+    {size}
+    {...props}
+  >
+    {#if style === "normal"}
+      {text}
+    {/if}
+
+    {#snippet icon()}
+      {#if style === "action"}
+        <WatchlistIcon size="small" {state} />
+      {/if}
+    {/snippet}
+
+    {#snippet items()}
+      {@render externalItems()}
+    {/snippet}
+  </DropdownList>
+</list-dropdown>
+
+<style>
+  list-dropdown {
+    :global(.trakt-list) {
+      min-width: var(--ni-220);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownButtonProps.ts
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownButtonProps.ts
@@ -1,0 +1,8 @@
+import type { Snippet } from 'svelte';
+
+export type ListDropdownButtonProps = {
+  title: string;
+  items: Snippet;
+  isListed: boolean;
+  style?: 'normal' | 'action';
+} & Omit<ButtonProps, 'children' | 'onclick' | 'label'>;

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItem.svelte
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItem.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { useDangerButton } from "$lib/components/buttons/_internal/useDangerButton";
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import WatchlistIcon from "$lib/components/icons/WatchlistIcon.svelte";
+  import { useUser } from "$lib/features/auth/stores/useUser";
+  import * as m from "$lib/features/i18n/messages";
+  import type { MediaStoreProps } from "$lib/models/MediaStoreProps";
+  import { attachWarning } from "$lib/sections/media-actions/_internal/attachWarning";
+  import { onMount } from "svelte";
+  import { ListDropdownItemIntlProvider } from "./ListDropdownItemIntlProvider";
+  import type { ListDropdownItemProps } from "./ListDropdownItemProps";
+  import { useList } from "./useList";
+
+  const {
+    title,
+    list,
+    isUpdating,
+    i18n = ListDropdownItemIntlProvider,
+    ...target
+  }: ListDropdownItemProps & MediaStoreProps = $props();
+
+  const { current } = useUser();
+
+  const { addToList, removeFromList, isListUpdating, isListed, itemCount } =
+    $derived(
+      useList({
+        list,
+        ...target,
+      }),
+    );
+
+  const isBelowLimit = $derived($itemCount < current().limits.lists.itemLimit);
+
+  onMount(() => {
+    const unsubscribe = isListUpdating.subscribe((value) => {
+      isUpdating.set(value);
+    });
+
+    return {
+      destroy: unsubscribe,
+    };
+  });
+
+  const onRemoveHandler = $derived(
+    attachWarning(
+      removeFromList,
+      m.remove_from_personal_list_warning({ list: list.name, title }),
+    ),
+  );
+  const handler = $derived($isListed ? onRemoveHandler : addToList);
+  const { color, variant, ...events } = $derived(
+    useDangerButton({ isActive: $isListed, color: "blue" }),
+  );
+  const state = $derived($isListed ? "added" : "missing");
+
+  const itemProps: Omit<ButtonProps, "children"> = $derived({
+    style: "flat",
+    label: i18n.label({ isListed: $isListed, listName: list.name, title }),
+    color: $color,
+    variant: $variant,
+    onclick: handler,
+    disabled: $isListUpdating || !isBelowLimit,
+    ...events,
+  });
+</script>
+
+<DropdownItem {...itemProps}>
+  {i18n.text({ isListed: $isListed, listName: list.name, title })}
+
+  {#snippet icon()}
+    <WatchlistIcon size="small" {state} />
+  {/snippet}
+</DropdownItem>

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItemIntl.ts
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItemIntl.ts
@@ -1,0 +1,10 @@
+export type ListDropdownItemMeta = {
+  isListed: boolean;
+  title: string;
+  listName: string;
+};
+
+export type ListDropdownItemIntl = {
+  label: (meta: ListDropdownItemMeta) => string;
+  text: (meta: ListDropdownItemMeta) => string;
+};

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItemIntlProvider.ts
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItemIntlProvider.ts
@@ -1,0 +1,16 @@
+import * as m from '$lib/features/i18n/messages.ts';
+import type {
+  ListDropdownItemIntl,
+  ListDropdownItemMeta,
+} from './ListDropdownItemIntl.ts';
+
+export const ListDropdownItemIntlProvider: ListDropdownItemIntl = {
+  label: ({ title, isListed, listName }: ListDropdownItemMeta) =>
+    isListed
+      ? m.remove_from_personal_list_label({ list: listName, title })
+      : m.add_to_personal_list_label({ list: listName, title }),
+  text: ({ isListed, listName }: ListDropdownItemMeta) =>
+    isListed
+      ? m.remove_from_personal_list({ list: listName })
+      : m.add_to_personal_list({ list: listName }),
+};

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItemProps.ts
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItemProps.ts
@@ -1,0 +1,10 @@
+import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
+import type { ListDropdownItemIntl } from '$lib/sections/summary/components/list-dropdown/_internal/ListDropdownItemIntl.ts';
+import type { Writable } from 'svelte/store';
+
+export type ListDropdownItemProps = {
+  title: string;
+  list: MediaListSummary;
+  isUpdating: Writable<boolean>;
+  i18n?: ListDropdownItemIntl;
+} & Omit<ButtonProps, 'children' | 'onclick' | 'label'>;

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/useIsListed.ts
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/useIsListed.ts
@@ -1,0 +1,45 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
+import { userListAllItemsQuery } from '$lib/requests/queries/users/userListAllItemsQuery.ts';
+
+import { derived, readable } from 'svelte/store';
+
+type UseIsListedProps = { list: MediaListSummary } & MediaStoreProps;
+
+export function useIsListed(props: UseIsListedProps) {
+  if (props.type === 'episode') {
+    return { isListed: readable(false), itemCount: readable(0) };
+  }
+
+  const { type } = props;
+  const media = Array.isArray(props.media) ? props.media : [props.media];
+
+  const response = useQuery(userListAllItemsQuery({
+    type: props.type,
+    userId: props.list.user.slug ?? 'me',
+    listId: props.list.slug,
+  }));
+
+  const isListed = derived(
+    response,
+    ($response) => {
+      if (!$response.data) {
+        return false;
+      }
+
+      switch (type) {
+        case 'movie':
+        case 'show':
+          return media.every((m) =>
+            $response.data.some((item) => item.entry.id === m.id)
+          );
+      }
+    },
+  );
+
+  return {
+    isListed,
+    itemCount: derived(response, ($response) => $response.data?.length ?? 0),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/useIsOnAnyList.ts
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/useIsOnAnyList.ts
@@ -1,0 +1,28 @@
+import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
+import { useWatchlist } from '$lib/sections/media-actions/watchlist/useWatchlist.ts';
+import { derived } from 'svelte/store';
+import { useList } from './useList.ts';
+
+type UseListCountProps = {
+  lists: MediaListSummary[];
+} & MediaStoreProps;
+
+// FIXME: replace with new list check endpoint when available
+export function useIsOnAnyList({ lists, ...target }: UseListCountProps) {
+  const { isWatchlisted } = useWatchlist(target);
+
+  const personalLists = lists
+    .map((list) => useList({ list, ...target }))
+    .map(({ isListed }) => isListed);
+
+  return {
+    isListed: derived(
+      [isWatchlisted, ...personalLists],
+      ([$isWatchlisted, ...$personalLists]) => {
+        const listCount = $personalLists.filter(Boolean).length;
+        return $isWatchlisted || listCount > 0;
+      },
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/useList.ts
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/useList.ts
@@ -1,0 +1,72 @@
+import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
+import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
+import { addToListRequest } from '$lib/requests/queries/users/addToListRequest.ts';
+import { removeFromListRequest } from '$lib/requests/queries/users/removeFromListRequest.ts';
+import {
+  toBulkPayload,
+} from '$lib/sections/media-actions/_internal/toBulkPayload.ts';
+import { useInvalidator } from '$lib/stores/useInvalidator.ts';
+import { writable } from 'svelte/store';
+import { useIsListed } from './useIsListed.ts';
+
+type UseListProps = { list: MediaListSummary } & MediaStoreProps;
+
+export function useList(props: UseListProps) {
+  const { type } = props;
+  const media = Array.isArray(props.media) ? props.media : [props.media];
+  const isListUpdating = writable(false);
+  const { invalidate } = useInvalidator();
+
+  const { isListed, itemCount } = useIsListed(props);
+
+  const { track } = useTrack(AnalyticsEvent.List);
+  const ids = media.map(({ id }) => id);
+  const body = toBulkPayload(type, ids);
+
+  const addToList = async () => {
+    if (type === 'episode') {
+      return;
+    }
+
+    isListUpdating.set(true);
+    track({ action: 'add' });
+
+    await addToListRequest({
+      listId: props.list.slug,
+      userId: props.list.user.slug,
+      body,
+    });
+    await invalidate(InvalidateAction.Listed(type));
+
+    isListUpdating.set(false);
+  };
+
+  const removeFromList = async () => {
+    if (type === 'episode') {
+      return;
+    }
+
+    isListUpdating.set(true);
+    track({ action: 'remove' });
+
+    await removeFromListRequest({
+      listId: props.list.slug,
+      userId: props.list.user.slug,
+      body,
+    });
+    await invalidate(InvalidateAction.Listed(type));
+
+    isListUpdating.set(false);
+  };
+
+  return {
+    addToList,
+    removeFromList,
+    isListUpdating,
+    isListed,
+    itemCount,
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/useAllPersonalLists.ts
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/useAllPersonalLists.ts
@@ -1,0 +1,28 @@
+import { usePersonalListsSummary } from '$lib/sections/lists/user/usePersonalListsSummary.ts';
+import { derived } from 'svelte/store';
+
+export function useAllPersonalLists() {
+  const { lists, isLoading } = usePersonalListsSummary({
+    type: 'personal',
+  });
+
+  const { lists: collaborationLists, isLoading: isLoadingCollaborations } =
+    usePersonalListsSummary({
+      type: 'collaboration',
+    });
+
+  return {
+    isLoading: derived(
+      [isLoading, isLoadingCollaborations],
+      ([$isLoading, $isLoadingCollaborations]) => {
+        return $isLoading || $isLoadingCollaborations;
+      },
+    ),
+    lists: derived(
+      [lists, collaborationLists],
+      ([$lists, $collaborativeLists]) => {
+        return [...$lists, ...$collaborativeLists];
+      },
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -20,6 +20,9 @@
   import type { Snippet } from "svelte";
   import MediaDetails from "../details/MediaDetails.svelte";
   import MediaStreamingServices from "../details/MediaStreamingServices.svelte";
+  import ListDropdown from "../list-dropdown/ListDropdown.svelte";
+  import type { ListDropdownProps } from "../list-dropdown/ListDropdownProps";
+  import { useAllPersonalLists } from "../list-dropdown/useAllPersonalLists";
   import MediaMetaInfo from "../media/MediaMetaInfo.svelte";
   import StreamOnOverlay from "../overlay/StreamOnOverlay.svelte";
   import TrailerOverlay from "../overlay/TrailerOverlay.svelte";
@@ -54,27 +57,35 @@
   const title = $derived(intl.title ?? media.title);
   const { watchCount } = useWatchCount({ media, type });
 
-  const watchlistProps = $derived<WatchlistActionProps>({
+  const commonProps = $derived({
     style: "normal" as const,
     title,
     type,
     media,
   });
 
+  const { lists } = useAllPersonalLists();
+
+  const watchlistProps = $derived<WatchlistActionProps>(commonProps);
+  const listProps = $derived<ListDropdownProps>(commonProps);
   const markAsWatchedProps = $derived<MarkAsWatchedActionProps>({
-    style: "normal" as const,
-    title,
-    type,
-    media,
+    ...commonProps,
     allowRewatch: $watchCount > 0,
   });
 </script>
 
 {#snippet mediaActions(device: "mobile" | "other" = "other")}
-  <WatchlistAction
-    {...watchlistProps}
-    style={device === "mobile" ? "action" : "normal"}
-  />
+  {#if $lists.length === 0}
+    <WatchlistAction
+      {...watchlistProps}
+      style={device === "mobile" ? "action" : "normal"}
+    />
+  {:else}
+    <ListDropdown
+      {...listProps}
+      style={device === "mobile" ? "action" : "normal"}
+    />
+  {/if}
   <MarkAsWatchedAction
     {...markAsWatchedProps}
     size={device === "mobile" ? "small" : "normal"}

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -16,6 +16,7 @@
   import type { MarkAsWatchedActionProps } from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedActionProps";
   import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import type { WatchlistActionProps } from "$lib/sections/media-actions/watchlist/WatchListActionProps";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { useWatchCount } from "$lib/stores/useWatchCount";
   import type { Snippet } from "svelte";
   import MediaDetails from "../details/MediaDetails.svelte";
@@ -54,11 +55,13 @@
     crew: MediaCrew;
   } = $props();
 
+  const isMobile = useMedia(WellKnownMediaQuery.mobile);
+
   const title = $derived(intl.title ?? media.title);
   const { watchCount } = useWatchCount({ media, type });
 
   const commonProps = $derived({
-    style: "normal" as const,
+    style: $isMobile ? ("action" as const) : ("normal" as const),
     title,
     type,
     media,
@@ -70,26 +73,19 @@
   const listProps = $derived<ListDropdownProps>(commonProps);
   const markAsWatchedProps = $derived<MarkAsWatchedActionProps>({
     ...commonProps,
+    style: "normal",
+    size: $isMobile ? "small" : "normal",
     allowRewatch: $watchCount > 0,
   });
 </script>
 
-{#snippet mediaActions(device: "mobile" | "other" = "other")}
+{#snippet mediaActions()}
   {#if $lists.length === 0}
-    <WatchlistAction
-      {...watchlistProps}
-      style={device === "mobile" ? "action" : "normal"}
-    />
+    <WatchlistAction {...watchlistProps} />
   {:else}
-    <ListDropdown
-      {...listProps}
-      style={device === "mobile" ? "action" : "normal"}
-    />
+    <ListDropdown {...listProps} />
   {/if}
-  <MarkAsWatchedAction
-    {...markAsWatchedProps}
-    size={device === "mobile" ? "small" : "normal"}
-  />
+  <MarkAsWatchedAction {...markAsWatchedProps} />
 {/snippet}
 
 <CoverImageSetter src={media.cover.url.medium} {type} />
@@ -156,12 +152,8 @@
 
   <RenderFor audience="authenticated">
     <SummaryActions>
-      <RenderFor device={["tablet-sm"]} audience="authenticated">
+      <RenderFor device={["tablet-sm", "mobile"]} audience="authenticated">
         {@render mediaActions()}
-      </RenderFor>
-
-      <RenderFor device={["mobile"]} audience="authenticated">
-        {@render mediaActions("mobile")}
       </RenderFor>
 
       {#snippet contextualActions()}

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryActions.svelte
@@ -39,7 +39,8 @@
     gap: var(--gap-xs);
 
     @include for-tablet-sm {
-      :global(.trakt-button) {
+      :global(.trakt-button),
+      :global(.trakt-dropdown-wrapper) {
         flex-basis: calc(50% - var(--gap-xs) / 2);
       }
     }

--- a/projects/client/src/mocks/data/lists/mapped/AllListedShowsMappedMock.ts
+++ b/projects/client/src/mocks/data/lists/mapped/AllListedShowsMappedMock.ts
@@ -1,0 +1,18 @@
+import type { ListedItem } from '$lib/requests/queries/users/userListItemsQuery.ts';
+import { ShowSiloMinimalMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMinimalMappedMock.ts';
+
+export const AllListedShowsMappedMock: ListedItem[] = [
+  {
+    'entry': {
+      ...ShowSiloMinimalMappedMock,
+      'episode': {
+        'count': 20,
+      },
+    },
+    'id': 1234,
+    'listedAt': new Date('2024-12-27T21:34:14.000Z'),
+    'notes': null,
+    'rank': 1,
+    'type': 'show',
+  },
+];

--- a/projects/client/src/mocks/data/lists/response/AllListedShowsResponseMock.ts
+++ b/projects/client/src/mocks/data/lists/response/AllListedShowsResponseMock.ts
@@ -1,0 +1,13 @@
+import { ShowSiloMinimalResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloMinimalResponseMock.ts';
+import type { ListedShowResponse } from '@trakt/api';
+
+export const AllListedShowsResponseMock: ListedShowResponse[] = [
+  {
+    'rank': 1,
+    'id': 1234,
+    'listed_at': '2024-12-27T21:34:14.000Z',
+    'notes': null,
+    'type': 'show',
+    'show': ShowSiloMinimalResponseMock,
+  },
+];

--- a/projects/client/src/mocks/data/lists/response/OfficialListsResponseMock.ts
+++ b/projects/client/src/mocks/data/lists/response/OfficialListsResponseMock.ts
@@ -27,6 +27,7 @@ export const OfficialListsResponseMock: ListResponse[] = [
       'name': null,
       'vip': false,
       'vip_ep': false,
+      'director': false,
       'ids': {
         'slug': null,
         'trakt': 0,

--- a/projects/client/src/mocks/data/summary/common/response/MediaWatchingResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/common/response/MediaWatchingResponseMock.ts
@@ -10,6 +10,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'kimkitsuragi',
       'trakt': 486292,
@@ -22,6 +23,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'klaasje',
       'trakt': 248249,
@@ -34,6 +36,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'cuno',
       'trakt': 4436692,
@@ -46,6 +49,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'joyce',
       'trakt': 793369,
@@ -58,6 +62,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'measurehead',
       'trakt': 12530721,
@@ -70,6 +75,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'lilian',
       'trakt': 13407874,
@@ -82,6 +88,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'titus',
       'trakt': 11467318,
@@ -94,6 +101,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'garte',
       'trakt': 1986881,
@@ -106,6 +114,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'evrart',
       'trakt': 14194266,
@@ -118,6 +127,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'thepale',
       'trakt': 13670159,
@@ -130,6 +140,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'lena',
       'trakt': 10084587,
@@ -142,6 +153,7 @@ export const MediaWatchingResponseMock: ProfileResponse[] = [
     'vip': false,
     'deleted': false,
     'vip_ep': false,
+    'director': false,
     'ids': {
       'slug': 'renee',
       'trakt': 2419555,

--- a/projects/client/src/mocks/data/users/mapped/ExtendedUserSettingsMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/ExtendedUserSettingsMappedMock.ts
@@ -37,4 +37,10 @@ export const ExtendedUserMappedMock: UserSettings = {
   },
   'genres': [],
   'permissions': ['comment', 'like', 'follow'],
+  'limits': {
+    'lists': {
+      'limit': 100,
+      'itemLimit': 1000,
+    },
+  },
 };

--- a/projects/client/src/mocks/data/users/response/ExtendedUserSettingsResponseMock.ts
+++ b/projects/client/src/mocks/data/users/response/ExtendedUserSettingsResponseMock.ts
@@ -7,6 +7,7 @@ export const ExtendedUsersResponseMock: SettingsResponse = {
     'name': 'Harry Du Bois',
     'vip': true,
     'vip_ep': true,
+    'director': false,
     'ids': {
       'slug': 'tequila_sunset',
       'trakt': 41152,

--- a/projects/client/src/mocks/data/users/response/ExtendedUserSettingsResponseMock.ts
+++ b/projects/client/src/mocks/data/users/response/ExtendedUserSettingsResponseMock.ts
@@ -130,4 +130,16 @@ export const ExtendedUsersResponseMock: SettingsResponse = {
       'only_favorites': true,
     },
   },
+  'limits': {
+    'list': {
+      'count': 100,
+      'item_count': 1000,
+    },
+    'favorites': {
+      'item_count': 100,
+    },
+    'watchlist': {
+      'item_count': 100,
+    },
+  },
 };

--- a/projects/client/src/mocks/data/users/response/UserProfileHarryResponseMock.ts
+++ b/projects/client/src/mocks/data/users/response/UserProfileHarryResponseMock.ts
@@ -7,6 +7,7 @@ export const UserProfileHarryResponseMock: ProfileResponse = {
   'name': 'Harry Du Bois',
   'vip': true,
   'vip_ep': false,
+  'director': false,
   'ids': {
     'slug': 'harry_du_bois',
     'trakt': 41152,

--- a/projects/client/src/mocks/handlers/users.ts
+++ b/projects/client/src/mocks/handlers/users.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { AllListedShowsResponseMock } from '$mocks/data/lists/response/AllListedShowsResponseMock.ts';
 import { ListedMoviesResponseMock } from '$mocks/data/lists/response/ListedMoviesResponseMock.ts';
 import { ListedShowsResponseMock } from '$mocks/data/lists/response/ListedShowsResponseMock.ts';
 import { HereticListsMappedMock } from '$mocks/data/summary/movies/heretic/mapped/HereticListsMappedMock.ts';
@@ -101,8 +102,15 @@ export const users = [
     `http://localhost/users/${UserProfileHarryMappedMock.slug}/lists/${
       assertDefined(SiloListsMappedMock.at(0)).slug
     }/items/show*`,
-    () => {
-      return HttpResponse.json(ListedShowsResponseMock);
+    (response) => {
+      const { searchParams } = new URL(response.request.url);
+      const limit = searchParams.get('limit');
+
+      const responseMock = limit === 'all'
+        ? AllListedShowsResponseMock
+        : ListedShowsResponseMock;
+
+      return HttpResponse.json(responseMock);
     },
   ),
   http.get(


### PR DESCRIPTION
## 🎶 Notes 🎶

- Makes it possible for users to add movies/shows to personal lists (on summary pages).
  - For now it's an internal component. When/if we ever have use of this in other places/forms, we can extract it and make it a media-action component.
- The dropdown is only shown if a user has lists, otherwise the `add to watchlist` button is shown.
- Follows the existing layout, i.e. will be placed at where the `add to watchlist` button is.
- Deviates a bit from the design (cc @anodpixels)
  - I followed youtube a bit more; i.e. not adding to watchlist by default. It is really strange that it always toggles the watchlisted state if I just want to add it to a list.
  - We can do a follow-up here and change it later. Maybe a separate action after all? Dialog with checkboxes? etc/

## 👀 Examples 👀

https://github.com/user-attachments/assets/48c43cec-008f-4e57-b97e-dc4b7632602f

<img width="373" alt="Screenshot 2025-04-10 at 10 43 14" src="https://github.com/user-attachments/assets/7bf28386-741a-4244-9854-42320ccbdd4f" />

When there are no lists:
<img width="1224" alt="Screenshot 2025-04-10 at 10 36 49" src="https://github.com/user-attachments/assets/8c2d52ab-c1a2-4673-a6d7-58e84b6c194e" />

