### PR TITLE
fix(auth): check token expiry in favor of using session storage

### DIFF
--- a/projects/client/src/lib/features/auth/token/index.ts
+++ b/projects/client/src/lib/features/auth/token/index.ts
@@ -1,13 +1,25 @@
-const token: {
+type Token = {
   value: string | Nil;
-} = {
+  expiresAt: number | Nil;
+};
+
+const token: Token = {
   value: null,
+  expiresAt: null,
 };
 
 export function getToken() {
-  return token.value;
+  return { ...token };
 }
 
-export function setToken(value: string | Nil) {
+export function setToken(newToken: Token | Nil) {
+  if (!newToken) {
+    token.value = null;
+    token.expiresAt = null;
+    return;
+  }
+
+  const { value, expiresAt } = newToken;
+  token.expiresAt = expiresAt;
   token.value = value;
 }

--- a/projects/client/src/routes/+layout.server.ts
+++ b/projects/client/src/routes/+layout.server.ts
@@ -16,6 +16,7 @@ export const load: LayoutServerLoad = (
       url: buildOAuthUrl(TRAKT_CLIENT_ID, requestUrl.origin),
       isAuthorized: isAuthorized(locals),
       token: null as string | Nil,
+      expiresAt: null as number | Nil,
     },
     isBot: isBotAgent(request.headers.get('user-agent')),
   };
@@ -27,5 +28,6 @@ export const load: LayoutServerLoad = (
   }
 
   defaultResponse.auth.token = locals.auth.token.access;
+  defaultResponse.auth.expiresAt = locals.auth.expiresAt;
   return defaultResponse;
 };

--- a/projects/client/src/routes/+layout.ts
+++ b/projects/client/src/routes/+layout.ts
@@ -17,7 +17,7 @@ export const load: LayoutLoad = async ({ data, fetch }) => {
     },
   });
 
-  setToken(data.auth.token);
+  setToken({ value: data.auth.token, expiresAt: data.auth.expiresAt });
 
   if (data.auth.isAuthorized) {
     await queryClient.prefetchQuery(currentUserSettingsQuery({ fetch }));


### PR DESCRIPTION
## ♪ Note ♪

- Replaces the session storage check with checking the actual token expiry date