### PR TITLE
Feat/dpad navigation

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -60,6 +60,7 @@ module.exports = {
         'movie',
         'msw',
         'navbar',
+        'navigation',
         'out-now',
         'profile',
         'pr_gate',

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -20,6 +20,7 @@
     subtitle,
     size = "normal",
     text = "uppercase",
+    navigationType,
     ...props
   }: TraktButtonProps | TraktButtonAnchorProps = $props();
 
@@ -69,6 +70,7 @@
     data-style={style}
     data-color={color}
     data-size={size}
+    data-dpad-navigation={navigationType}
     {...props}
   >
     {@render contents()}
@@ -85,6 +87,7 @@
     data-style={style}
     data-color={color}
     data-size={size}
+    data-dpad-navigation={navigationType}
     {...props}
   >
     {@render contents()}

--- a/projects/client/src/lib/components/buttons/TraktButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/TraktButtonProps.ts
@@ -1,3 +1,4 @@
+import type { DpadNavigationType } from '$lib/features/navigation/models/DpadNavigationType.ts';
 import type { Snippet } from 'svelte';
 
 export type TraktButtonProps = ButtonProps & {
@@ -8,4 +9,5 @@ export type TraktButtonProps = ButtonProps & {
   subtitle?: Snippet;
   size?: 'normal' | 'small' | 'tag';
   text?: 'capitalize' | 'uppercase';
+  navigationType?: DpadNavigationType;
 };

--- a/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte
+++ b/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import MarkAsWatchedIcon from "../../icons/MarkAsWatchedIcon.svelte";
   import ActionButton from "../ActionButton.svelte";
   import Button from "../Button.svelte";
@@ -38,7 +39,7 @@
 </script>
 
 {#if style === "normal"}
-  <Button {...commonProps} {...props}>
+  <Button {...commonProps} {...props} navigationType={DpadNavigationType.Item}>
     {i18n.text({ title, isWatched, isRewatching })}
     {#snippet icon()}
       <MarkAsWatchedIcon {state} size="small" />

--- a/projects/client/src/lib/components/buttons/streaming-service/StreamingServiceButton.svelte
+++ b/projects/client/src/lib/components/buttons/streaming-service/StreamingServiceButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import PlayIcon from "$lib/components/icons/PlayIcon.svelte";
   import { StreamingServiceLogoIntlProvider } from "$lib/components/media/streaming-service/StreamingServiceLogoIntlProvider";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import StreamingServiceLogo from "../../media/streaming-service/StreamingServiceLogo.svelte";
   import Button from "../Button.svelte";
   import { StreamingServiceButtonIntlProvider } from "./StreamingServiceButtonIntlProvider";
@@ -20,6 +21,7 @@
     variant: "primary",
     href: service.link,
     target: "_blank",
+    navigationType: DpadNavigationType.Item,
   });
 
   /**

--- a/projects/client/src/lib/components/link/Link.svelte
+++ b/projects/client/src/lib/components/link/Link.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import { useActiveLink } from "$lib/stores/useActiveLink";
   import { mobileAppleDeviceTriggerHack } from "$lib/utils/actions/mobileAppleDeviceTriggerHack";
   import { triggerWithKeyboard } from "$lib/utils/actions/triggerWithKeyboard";
@@ -11,12 +12,14 @@
     focusable = true,
     noscroll,
     label,
+    navigationType,
     ...props
   }: ChildrenProps &
     HTMLAnchorProps &
     HTMLElementProps & {
       color?: "default" | "classic" | "inherit";
       focusable?: boolean;
+      navigationType?: DpadNavigationType;
     } = $props();
 
   const { isActive } = $derived(useActiveLink(href));
@@ -35,6 +38,7 @@
     aria-label={label}
     class="trakt-link"
     class:trakt-link-active={$isActive}
+    data-dpad-navigation={navigationType}
     {...props}
   >
     {@render children?.()}

--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts" generics="T extends { id: unknown }">
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
   import { whenInViewport } from "$lib/utils/actions/whenInViewport";
   import { onMount, type Snippet } from "svelte";
@@ -73,6 +74,7 @@
           class="trakt-list-item-container"
           class:shadow-list-horizontal-scroll-centered={variant === "centered"}
           class:shadow-list-horizontal-scroll={variant === "normal"}
+          data-dpad-navigation={DpadNavigationType.List}
         >
           {#each items as i (i.id)}
             {@render item(i)}

--- a/projects/client/src/lib/features/navigation/NavigationProvider.svelte
+++ b/projects/client/src/lib/features/navigation/NavigationProvider.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { useNavigation } from "./useNavigation";
+
+  const { children }: ChildrenProps = $props();
+
+  const { controller, redirect } = useNavigation();
+
+  onMount(() => {
+    if (!controller) {
+      return;
+    }
+
+    redirect();
+  });
+</script>
+
+{#if controller}
+  <div use:controller>
+    {@render children()}
+  </div>
+{:else}
+  {@render children()}
+{/if}

--- a/projects/client/src/lib/features/navigation/_internal/dpadController.ts
+++ b/projects/client/src/lib/features/navigation/_internal/dpadController.ts
@@ -1,0 +1,40 @@
+import { GlobalEventBus } from '$lib/utils/events/GlobalEventBus.ts';
+import { onMount } from 'svelte';
+import { focusSomething } from './focusSomething.ts';
+import { handleItemNavigation } from './handleItemNavigation.ts';
+import { handleListNavigation } from './handleListNavigation.ts';
+
+const handler = (ev: KeyboardEvent) => {
+  switch (ev.key) {
+    case 'ArrowLeft':
+    case 'ArrowUp':
+    case 'ArrowDown':
+    case 'ArrowRight':
+      focusSomething();
+      ev.preventDefault();
+      break;
+  }
+
+  switch (ev.key) {
+    case 'ArrowLeft':
+    case 'ArrowRight':
+      handleItemNavigation(ev.key);
+      break;
+    case 'ArrowUp':
+    case 'ArrowDown':
+      handleListNavigation(ev.key);
+      break;
+  }
+};
+
+export function dpadController(_: HTMLElement) {
+  onMount(() => {
+    focusSomething();
+
+    const destroy = GlobalEventBus.getInstance().register('keydown', handler);
+
+    return {
+      destroy,
+    };
+  });
+}

--- a/projects/client/src/lib/features/navigation/_internal/focusAndScrollIntoView.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/focusAndScrollIntoView.spec.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { focusAndScrollIntoView } from './focusAndScrollIntoView.ts';
+
+describe('focusAndScrollIntoView', () => {
+  let mockElement: HTMLButtonElement;
+
+  beforeEach(() => {
+    mockElement = document.createElement('button');
+    mockElement.focus = vi.fn();
+    mockElement.scrollIntoView = vi.fn();
+
+    document.body.appendChild(mockElement);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('should focus and scroll to the element when valid HTMLElement is provided', () => {
+    focusAndScrollIntoView(mockElement);
+
+    expect(mockElement.focus).toHaveBeenCalledTimes(1);
+    expect(mockElement.scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(mockElement.scrollIntoView).toHaveBeenCalledWith({
+      block: 'center',
+      inline: 'center',
+    });
+  });
+
+  it('should do nothing when null is provided', () => {
+    focusAndScrollIntoView(null);
+
+    expect(mockElement.focus).not.toHaveBeenCalled();
+    expect(mockElement.scrollIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/projects/client/src/lib/features/navigation/_internal/focusAndScrollIntoView.ts
+++ b/projects/client/src/lib/features/navigation/_internal/focusAndScrollIntoView.ts
@@ -1,0 +1,10 @@
+export const focusAndScrollIntoView = (element?: Element | null) => {
+  if (!element) return;
+  if (!(element instanceof HTMLElement)) return;
+
+  element.focus();
+  element.scrollIntoView({
+    block: 'center',
+    inline: 'center',
+  });
+};

--- a/projects/client/src/lib/features/navigation/_internal/focusSomething.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/focusSomething.spec.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DpadNavigationType } from '../models/DpadNavigationType.ts';
+import { focusSomething } from './focusSomething.ts';
+
+describe('focusSomething', () => {
+  let element: HTMLButtonElement;
+
+  beforeEach(() => {
+    element = document.createElement('button');
+    element.scrollIntoView = vi.fn();
+    element.setAttribute('data-dpad-navigation', DpadNavigationType.Item);
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('should focus the first navigable element when no element is focused', () => {
+    document.body.focus();
+    expect(document.activeElement).toBe(document.body);
+
+    focusSomething();
+
+    expect(document.activeElement).toBe(element);
+  });
+
+  it('should not focus anything if an element is already focused', () => {
+    const otherElement = document.createElement('button');
+    document.body.appendChild(otherElement);
+    otherElement.focus();
+
+    focusSomething();
+
+    expect(document.activeElement).toBe(otherElement);
+
+    document.body.removeChild(otherElement);
+  });
+
+  it('should do nothing when no navigable element is found', () => {
+    document.body.removeChild(element);
+    document.body.focus();
+
+    focusSomething();
+
+    expect(document.activeElement).toBe(document.body);
+  });
+});

--- a/projects/client/src/lib/features/navigation/_internal/focusSomething.ts
+++ b/projects/client/src/lib/features/navigation/_internal/focusSomething.ts
@@ -1,0 +1,14 @@
+import { DpadNavigationType } from '../models/DpadNavigationType.ts';
+import { focusAndScrollIntoView } from './focusAndScrollIntoView.ts';
+
+export function focusSomething() {
+  if (document.activeElement && document.activeElement !== document.body) {
+    return;
+  }
+
+  const firstNavigableElement = document.querySelector(
+    `[data-dpad-navigation="${DpadNavigationType.Item}"]`,
+  );
+
+  focusAndScrollIntoView(firstNavigableElement);
+}

--- a/projects/client/src/lib/features/navigation/_internal/getAllUsableLists.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getAllUsableLists.spec.ts
@@ -1,0 +1,32 @@
+import { createList } from '$lib/features/navigation/_internal/test/createList.ts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DpadNavigationType } from '../models/DpadNavigationType.ts';
+import { getAllUsableLists } from './getAllUsableLists.ts';
+
+describe('getAllUsableLists', () => {
+  let list: HTMLElement;
+
+  beforeEach(() => {
+    list = createList(true);
+    document.body.appendChild(list);
+  });
+
+  afterEach(() => {
+    list.remove();
+  });
+
+  it('should not get lists without any items in them', () => {
+    const lists = getAllUsableLists();
+
+    expect(lists).toHaveLength(0);
+  });
+
+  it('should get lists with items in them', () => {
+    const item = document.createElement('button');
+    item.setAttribute('data-dpad-navigation', DpadNavigationType.Item);
+    list.appendChild(item);
+
+    const lists = getAllUsableLists();
+    expect(lists).toEqual([list]);
+  });
+});

--- a/projects/client/src/lib/features/navigation/_internal/getAllUsableLists.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getAllUsableLists.ts
@@ -1,0 +1,13 @@
+import { DpadNavigationType } from '$lib/features/navigation/models/DpadNavigationType.ts';
+
+export function getAllUsableLists() {
+  const lists = Array.from(
+    document.querySelectorAll(
+      `[data-dpad-navigation="${DpadNavigationType.List}"]`,
+    ),
+  );
+
+  return lists.filter((list) =>
+    list.querySelector(`[data-dpad-navigation="${DpadNavigationType.Item}"]`)
+  );
+}

--- a/projects/client/src/lib/features/navigation/_internal/getNavigationState.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getNavigationState.spec.ts
@@ -1,0 +1,50 @@
+import { createList } from '$lib/features/navigation/_internal/test/createList.ts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getNavigationState } from './getNavigationState.ts';
+
+describe('getNavigationState', () => {
+  let lists: HTMLElement[];
+
+  beforeEach(() => {
+    lists = [createList(), createList()];
+    lists.forEach((list) => {
+      document.body.appendChild(list);
+    });
+  });
+
+  afterEach(() => {
+    lists.forEach((list) => {
+      list.remove();
+    });
+  });
+
+  it('should focus something if no active element exists', () => {
+    getNavigationState();
+
+    expect(document.activeElement).not.toBe(document.body);
+  });
+
+  it('should return the correct navigation state', () => {
+    const item = lists[0]?.childNodes[1] as HTMLElement;
+    item.focus();
+
+    const result = getNavigationState();
+
+    expect(result.focusedIndex).toBe(1);
+    expect(result.currentListIndex).toBe(0);
+    expect(result.items.length).toBe(3);
+    expect(result.lists.length).toBe(2);
+  });
+
+  it('should return the correct navigation state within another list', () => {
+    const item = lists[1]?.childNodes[0] as HTMLElement;
+    item.focus();
+
+    const result = getNavigationState();
+
+    expect(result.focusedIndex).toBe(0);
+    expect(result.currentListIndex).toBe(1);
+    expect(result.items.length).toBe(3);
+    expect(result.lists.length).toBe(2);
+  });
+});

--- a/projects/client/src/lib/features/navigation/_internal/getNavigationState.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getNavigationState.ts
@@ -1,0 +1,31 @@
+import { focusSomething } from '$lib/features/navigation/_internal/focusSomething.ts';
+import { getAllUsableLists } from '$lib/features/navigation/_internal/getAllUsableLists.ts';
+import { getSelectableItems } from '$lib/features/navigation/_internal/getSelectableItems.ts';
+import { DpadNavigationType } from '$lib/features/navigation/models/DpadNavigationType.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+
+export function getNavigationState() {
+  focusSomething();
+
+  const currentItem = assertDefined(
+    document.activeElement,
+    'No focusable item was found',
+  );
+
+  const currentList = assertDefined(
+    currentItem.closest(
+      `[data-dpad-navigation="${DpadNavigationType.List}"]`,
+    ),
+    'No current list was found',
+  );
+
+  const items = getSelectableItems(currentList);
+  const lists = getAllUsableLists();
+
+  return {
+    items,
+    lists,
+    focusedIndex: items.indexOf(currentItem),
+    currentListIndex: lists.indexOf(currentList),
+  };
+}

--- a/projects/client/src/lib/features/navigation/_internal/getNextIndex.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getNextIndex.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getNextIndex } from './getNextIndex.ts';
+
+describe('getNextIndex', () => {
+  it('should return the next index when moving forward', () => {
+    expect(getNextIndex(0, 5, true)).toBe(1);
+    expect(getNextIndex(2, 5, true)).toBe(3);
+  });
+
+  it('should not exceed the maximum index when moving forward', () => {
+    expect(getNextIndex(4, 5, true)).toBe(4);
+  });
+
+  it('should return the previous index when moving backward', () => {
+    expect(getNextIndex(4, 5, false)).toBe(3);
+    expect(getNextIndex(2, 5, false)).toBe(1);
+  });
+
+  it('should not go below zero when moving backward', () => {
+    expect(getNextIndex(0, 5, false)).toBe(0);
+  });
+});

--- a/projects/client/src/lib/features/navigation/_internal/getNextIndex.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getNextIndex.ts
@@ -1,0 +1,9 @@
+export const getNextIndex = (
+  current: number,
+  length: number,
+  isForward: boolean,
+) => {
+  return isForward
+    ? Math.min(current + 1, length - 1)
+    : Math.max(current - 1, 0);
+};

--- a/projects/client/src/lib/features/navigation/_internal/getSelectableItems.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getSelectableItems.spec.ts
@@ -1,0 +1,34 @@
+import { createList } from '$lib/features/navigation/_internal/test/createList.ts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DpadNavigationType } from '../models/DpadNavigationType.ts';
+import { getSelectableItems } from './getSelectableItems.ts';
+
+describe('getSelectableItems', () => {
+  let list: HTMLElement;
+
+  beforeEach(() => {
+    list = createList(true);
+  });
+
+  afterEach(() => {
+    list.remove();
+  });
+
+  it('should not return elements that are not navigate-able', () => {
+    const notAnItem = document.createElement('div');
+    list.appendChild(notAnItem);
+
+    const items = getSelectableItems(list);
+
+    expect(items).toHaveLength(0);
+  });
+
+  it('should get the items in a list', () => {
+    const item = document.createElement('button');
+    item.setAttribute('data-dpad-navigation', DpadNavigationType.Item);
+    list.appendChild(item);
+
+    const items = getSelectableItems(list);
+    expect(items).toEqual([item]);
+  });
+});

--- a/projects/client/src/lib/features/navigation/_internal/getSelectableItems.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getSelectableItems.ts
@@ -1,0 +1,9 @@
+import { DpadNavigationType } from '../models/DpadNavigationType.ts';
+
+export const getSelectableItems = (list: Element) => {
+  return Array.from(
+    list.querySelectorAll(
+      `[data-dpad-navigation="${DpadNavigationType.Item}"]`,
+    ),
+  );
+};

--- a/projects/client/src/lib/features/navigation/_internal/handleItemNavigation.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/handleItemNavigation.spec.ts
@@ -1,0 +1,49 @@
+import { createList } from '$lib/features/navigation/_internal/test/createList.ts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { handleItemNavigation } from './handleItemNavigation.ts';
+
+describe('handleItemNavigation', () => {
+  let list: HTMLElement;
+
+  beforeEach(() => {
+    list = createList();
+
+    document.body.appendChild(list);
+  });
+
+  afterEach(() => {
+    list.remove();
+  });
+
+  it('should navigate to next item with ArrowRight', () => {
+    (list.childNodes[1] as HTMLElement).focus();
+
+    handleItemNavigation('ArrowRight');
+
+    expect(document.activeElement).toBe(list.childNodes[2]);
+  });
+
+  it('should navigate to previous item with ArrowLeft', () => {
+    (list.childNodes[1] as HTMLElement).focus();
+
+    handleItemNavigation('ArrowLeft');
+
+    expect(document.activeElement).toBe(list.childNodes[0]);
+  });
+
+  it('should keep focus at the end', () => {
+    (list.childNodes[2] as HTMLElement).focus();
+
+    handleItemNavigation('ArrowRight');
+
+    expect(document.activeElement).toBe(list.childNodes[2]);
+  });
+
+  it('should keep focus at the start', () => {
+    (list.childNodes[0] as HTMLElement).focus();
+
+    handleItemNavigation('ArrowLeft');
+
+    expect(document.activeElement).toBe(list.childNodes[0]);
+  });
+});

--- a/projects/client/src/lib/features/navigation/_internal/handleItemNavigation.ts
+++ b/projects/client/src/lib/features/navigation/_internal/handleItemNavigation.ts
@@ -1,0 +1,15 @@
+import { focusAndScrollIntoView } from './focusAndScrollIntoView.ts';
+import { getNavigationState } from './getNavigationState.ts';
+import { getNextIndex } from './getNextIndex.ts';
+
+export const handleItemNavigation = (key: 'ArrowLeft' | 'ArrowRight') => {
+  const { items, focusedIndex } = getNavigationState();
+
+  const newIndex = getNextIndex(
+    focusedIndex,
+    items.length,
+    key === 'ArrowRight',
+  );
+
+  focusAndScrollIntoView(items.at(newIndex));
+};

--- a/projects/client/src/lib/features/navigation/_internal/handleListNavigation.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/handleListNavigation.spec.ts
@@ -1,0 +1,52 @@
+import { createList } from '$lib/features/navigation/_internal/test/createList.ts';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { handleListNavigation } from './handleListNavigation.ts';
+
+describe('handleListNavigation', () => {
+  let lists: HTMLElement[];
+
+  beforeEach(() => {
+    lists = [createList(), createList(), createList()];
+    lists.forEach((list) => {
+      document.body.appendChild(list);
+    });
+  });
+
+  afterEach(() => {
+    lists.forEach((list) => {
+      list.remove();
+    });
+  });
+
+  it('should navigate to next list item with ArrowDown', () => {
+    (lists[1]?.childNodes[0] as HTMLElement).focus();
+
+    handleListNavigation('ArrowDown');
+
+    expect(document.activeElement).toBe(lists[2]?.childNodes[0]);
+  });
+
+  it('should navigate to previous list item with ArrowUp', () => {
+    (lists[1]?.childNodes[0] as HTMLElement).focus();
+
+    handleListNavigation('ArrowUp');
+
+    expect(document.activeElement).toBe(lists[0]?.childNodes[0]);
+  });
+
+  it('should keep focus at the end', () => {
+    (lists[2]?.childNodes[0] as HTMLElement).focus();
+
+    handleListNavigation('ArrowDown');
+
+    expect(document.activeElement).toBe(lists[2]?.childNodes[0]);
+  });
+
+  it('should keep focus at the start', () => {
+    (lists[0]?.childNodes[0] as HTMLElement).focus();
+
+    handleListNavigation('ArrowUp');
+
+    expect(document.activeElement).toBe(lists[0]?.childNodes[0]);
+  });
+});

--- a/projects/client/src/lib/features/navigation/_internal/handleListNavigation.ts
+++ b/projects/client/src/lib/features/navigation/_internal/handleListNavigation.ts
@@ -1,0 +1,20 @@
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { focusAndScrollIntoView } from './focusAndScrollIntoView.ts';
+import { getNavigationState } from './getNavigationState.ts';
+import { getNextIndex } from './getNextIndex.ts';
+import { getSelectableItems } from './getSelectableItems.ts';
+
+export const handleListNavigation = (key: 'ArrowUp' | 'ArrowDown') => {
+  const { lists, currentListIndex } = getNavigationState();
+
+  const newListIndex = getNextIndex(
+    currentListIndex,
+    lists.length,
+    key === 'ArrowDown',
+  );
+
+  const targetList = assertDefined(lists[newListIndex], 'No list found');
+  const targetItems = getSelectableItems(targetList);
+
+  focusAndScrollIntoView(targetItems.at(0));
+};

--- a/projects/client/src/lib/features/navigation/_internal/test/createItem.ts
+++ b/projects/client/src/lib/features/navigation/_internal/test/createItem.ts
@@ -1,0 +1,9 @@
+import { DpadNavigationType } from '$lib/features/navigation/models/DpadNavigationType.ts';
+import { vi } from 'vitest';
+
+export function createItem() {
+  const item = document.createElement('button');
+  item.setAttribute('data-dpad-navigation', DpadNavigationType.Item);
+  item.scrollIntoView = vi.fn();
+  return item;
+}

--- a/projects/client/src/lib/features/navigation/_internal/test/createList.ts
+++ b/projects/client/src/lib/features/navigation/_internal/test/createList.ts
@@ -1,0 +1,17 @@
+import { createItem } from '$lib/features/navigation/_internal/test/createItem.ts';
+import { DpadNavigationType } from '$lib/features/navigation/models/DpadNavigationType.ts';
+
+function addItemsToList(list: HTMLDivElement) {
+  list.appendChild(createItem());
+  list.appendChild(createItem());
+  list.appendChild(createItem());
+}
+
+export function createList(isEmpty = false) {
+  const list = document.createElement('div');
+  list.setAttribute('data-dpad-navigation', DpadNavigationType.List);
+
+  !isEmpty && addItemsToList(list);
+
+  return list;
+}

--- a/projects/client/src/lib/features/navigation/models/DpadNavigationType.ts
+++ b/projects/client/src/lib/features/navigation/models/DpadNavigationType.ts
@@ -1,0 +1,4 @@
+export enum DpadNavigationType {
+  Item = 'item',
+  List = 'list',
+}

--- a/projects/client/src/lib/features/navigation/useNavigation.ts
+++ b/projects/client/src/lib/features/navigation/useNavigation.ts
@@ -1,0 +1,34 @@
+import { goto } from '$app/navigation';
+import { page } from '$app/state';
+import { dpadController } from '$lib/features/navigation/_internal/dpadController.ts';
+
+const PARAM_NAME = 'navigation';
+const DPAD_REF = 'd-pad';
+
+type NavigationType = 'default' | 'dpad';
+type Controller = (node: HTMLElement) => void;
+
+const navigationControllers: Record<NavigationType, Controller | undefined> = {
+  'default': undefined,
+  'dpad': dpadController,
+};
+
+export function useNavigation() {
+  const ref = page.url.searchParams.get(PARAM_NAME);
+  const navigationType: NavigationType = ref === DPAD_REF ? 'dpad' : 'default';
+
+  const redirect = () => {
+    const url = new URL(page.url);
+    url.searchParams.delete(PARAM_NAME);
+
+    goto(url, {
+      replaceState: true,
+      keepFocus: true,
+    });
+  };
+
+  return {
+    controller: navigationControllers[navigationType],
+    redirect,
+  };
+}

--- a/projects/client/src/lib/sections/lists/components/CastMemberCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/CastMemberCard.svelte
@@ -3,6 +3,7 @@
   import Link from "$lib/components/link/Link.svelte";
   import PersonCard from "$lib/components/people/card/PersonCard.svelte";
   import * as m from "$lib/features/i18n/messages";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import type { CastMember } from "$lib/requests/models/MediaCrew";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
@@ -14,7 +15,11 @@
 </script>
 
 <trakt-cast-member>
-  <Link focusable={false} href={UrlBuilder.people(castMember.id)}>
+  <Link
+    focusable={false}
+    href={UrlBuilder.people(castMember.id)}
+    navigationType={DpadNavigationType.Item}
+  >
     <div class="trakt-cast-member">
       <PersonCard>
         <CardCover
@@ -31,11 +36,17 @@
   </Link>
 </trakt-cast-member>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   trakt-cast-member {
+    position: relative;
+
     :global(.trakt-link) {
       text-decoration: none;
     }
+
+    @include focused-item-style(var(--height-person-card));
   }
 
   .trakt-cast-member-footer {

--- a/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
@@ -7,6 +7,7 @@
   import { EpisodeIntlProvider } from "$lib/components/episode/EpisodeIntlProvider";
   import Link from "$lib/components/link/Link.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage";
   import { EPISODE_COVER_PLACEHOLDER } from "$lib/utils/constants";
@@ -36,63 +37,74 @@
   --height-card="var(--height-episode-card)"
   --height-card-cover="var(--height-episode-card-cover)"
 >
-  {#if popupActions}
-    <CardActionBar>
-      {#snippet actions()}
-        <PopupMenu label={m.media_popup_label({ title: episode.title })}>
-          {#snippet items()}
-            {@render popupActions()}
-          {/snippet}
-        </PopupMenu>
-      {/snippet}
-    </CardActionBar>
-  {/if}
-
-  <Link
-    focusable={false}
-    href={UrlBuilder.episode(show.slug, episode.season, episode.number)}
-  >
-    <CardCover
-      src={$src ?? EPISODE_COVER_PLACEHOLDER}
-      alt={`${show.title} - ${episode.title}`}
-      {badges}
-      {tags}
-    />
-  </Link>
-
-  <CardFooter {action}>
-    {#if isShowContext}
-      <p class="trakt-card-title ellipsis">
-        <Spoiler media={episode} {show} {episode} type="episode">
-          {episode.title}
-        </Spoiler>
-      </p>
-      <p class="trakt-card-subtitle ellipsis small">
-        {episode.season}x{episode.number}
-      </p>
+  <trakt-episode-card-content>
+    {#if popupActions}
+      <CardActionBar>
+        {#snippet actions()}
+          <PopupMenu label={m.media_popup_label({ title: episode.title })}>
+            {#snippet items()}
+              {@render popupActions()}
+            {/snippet}
+          </PopupMenu>
+        {/snippet}
+      </CardActionBar>
     {/if}
 
-    {#if rest.variant === "activity"}
-      <Link href={UrlBuilder.show(show.slug)}>
+    <Link
+      focusable={false}
+      href={UrlBuilder.episode(show.slug, episode.season, episode.number)}
+      navigationType={DpadNavigationType.Item}
+    >
+      <CardCover
+        src={$src ?? EPISODE_COVER_PLACEHOLDER}
+        alt={`${show.title} - ${episode.title}`}
+        {badges}
+        {tags}
+      />
+    </Link>
+
+    <CardFooter {action}>
+      {#if isShowContext}
         <p class="trakt-card-title ellipsis">
-          {episode.season}x{episode.number} - {show.title}
+          <Spoiler media={episode} {show} {episode} type="episode">
+            {episode.title}
+          </Spoiler>
         </p>
-      </Link>
-      <p class="trakt-card-subtitle ellipsis small">
-        {EpisodeIntlProvider.timestampText(rest.date)}
-      </p>
-    {/if}
+        <p class="trakt-card-subtitle ellipsis small">
+          {episode.season}x{episode.number}
+        </p>
+      {/if}
 
-    {#if !isShowContext && !isActivity}
-      <Link href={UrlBuilder.show(show.slug)}>
-        <p class="trakt-card-title ellipsis">{show.title}</p>
-      </Link>
-      <p class="trakt-card-subtitle ellipsis small">
-        {episode.season}x{episode.number}
-        <Spoiler media={episode} {show} {episode} type="episode">
-          - {episode.title}
-        </Spoiler>
-      </p>
-    {/if}
-  </CardFooter>
+      {#if rest.variant === "activity"}
+        <Link href={UrlBuilder.show(show.slug)}>
+          <p class="trakt-card-title ellipsis">
+            {episode.season}x{episode.number} - {show.title}
+          </p>
+        </Link>
+        <p class="trakt-card-subtitle ellipsis small">
+          {EpisodeIntlProvider.timestampText(rest.date)}
+        </p>
+      {/if}
+
+      {#if !isShowContext && !isActivity}
+        <Link href={UrlBuilder.show(show.slug)}>
+          <p class="trakt-card-title ellipsis">{show.title}</p>
+        </Link>
+        <p class="trakt-card-subtitle ellipsis small">
+          {episode.season}x{episode.number}
+          <Spoiler media={episode} {show} {episode} type="episode">
+            - {episode.title}
+          </Spoiler>
+        </p>
+      {/if}
+    </CardFooter>
+  </trakt-episode-card-content>
 </Card>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  trakt-episode-card-content {
+    @include focused-item-style(var(--height-card-cover));
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
@@ -13,6 +13,7 @@
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import { toHumanDate } from "$lib/utils/formatting/date/toHumanDate";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CardActionBar from "../../../components/card/CardActionBar.svelte";
@@ -46,52 +47,58 @@
 {/snippet}
 
 {#snippet content(mediaCoverImageUrl: string)}
-  {#if popupActions}
-    <CardActionBar>
-      {#snippet actions()}
-        <PopupMenu label={m.media_popup_label({ title: media.title })}>
-          {#snippet items()}
-            {@render popupActions()}
-          {/snippet}
-        </PopupMenu>
-      {/snippet}
-    </CardActionBar>
-  {/if}
-
-  <Link focusable={false} href={UrlBuilder.media(type, media.slug)}>
-    <CardCover
-      src={mediaCoverImageUrl}
-      alt={m.media_poster({ title: media.title })}
-    >
-      {#snippet badges()}
-        {@render externalBadges?.()}
-      {/snippet}
-
-      {#snippet tags()}
-        {#if externalTags}
-          {@render externalTags()}
-        {:else}
-          {@render defaultTags(media)}
-        {/if}
-      {/snippet}
-    </CardCover>
-  </Link>
-
-  <CardFooter {action}>
-    <Link href={UrlBuilder.media(type, media.slug)}>
-      <p
-        class="trakt-card-title small ellipsis"
-        class:small={rest.variant !== "activity"}
-      >
-        {media.title}
-      </p>
-    </Link>
-    {#if rest.variant === "activity"}
-      <p class="trakt-card-subtitle small ellipsis">
-        {toHumanDate(new Date(), rest.date, getLocale())}
-      </p>
+  <trakt-media-card-content>
+    {#if popupActions}
+      <CardActionBar>
+        {#snippet actions()}
+          <PopupMenu label={m.media_popup_label({ title: media.title })}>
+            {#snippet items()}
+              {@render popupActions()}
+            {/snippet}
+          </PopupMenu>
+        {/snippet}
+      </CardActionBar>
     {/if}
-  </CardFooter>
+
+    <Link
+      focusable={false}
+      href={UrlBuilder.media(type, media.slug)}
+      navigationType={DpadNavigationType.Item}
+    >
+      <CardCover
+        src={mediaCoverImageUrl}
+        alt={m.media_poster({ title: media.title })}
+      >
+        {#snippet badges()}
+          {@render externalBadges?.()}
+        {/snippet}
+
+        {#snippet tags()}
+          {#if externalTags}
+            {@render externalTags()}
+          {:else}
+            {@render defaultTags(media)}
+          {/if}
+        {/snippet}
+      </CardCover>
+    </Link>
+
+    <CardFooter {action}>
+      <Link href={UrlBuilder.media(type, media.slug)}>
+        <p
+          class="trakt-card-title small ellipsis"
+          class:small={rest.variant !== "activity"}
+        >
+          {media.title}
+        </p>
+      </Link>
+      {#if rest.variant === "activity"}
+        <p class="trakt-card-subtitle small ellipsis">
+          {toHumanDate(new Date(), rest.date, getLocale())}
+        </p>
+      {/if}
+    </CardFooter>
+  </trakt-media-card-content>
 {/snippet}
 
 {#if variant === "poster"}
@@ -111,3 +118,11 @@
     {@render content(media.thumb.url)}
   </ActivityCard>
 {/if}
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  trakt-media-card-content {
+    @include focused-item-style(var(--height-card-cover));
+  }
+</style>

--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -8,6 +8,7 @@
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
   import * as m from "$lib/features/i18n/messages";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { GlobalEventBus } from "$lib/utils/events/GlobalEventBus";
   import { navigateToTraktOg } from "$lib/utils/url/navigateToTraktOg";
@@ -45,7 +46,11 @@
 {/snippet}
 
 <header>
-  <nav class="trakt-navbar" class:trakt-navbar-scroll={isScrolled}>
+  <nav
+    class="trakt-navbar"
+    class:trakt-navbar-scroll={isScrolled}
+    data-dpad-navigation={DpadNavigationType.List}
+  >
     <RenderFor
       audience="authenticated"
       device={["tablet-sm", "tablet-lg", "desktop"]}
@@ -86,6 +91,7 @@
           variant="primary"
           color="purple"
           data-testid={TestId.NavBarHomeButton}
+          navigationType={DpadNavigationType.Item}
         >
           {m.navbar_link_home()}
         </Button>
@@ -96,6 +102,7 @@
           variant="primary"
           color="purple"
           data-testid={TestId.NavBarShowsButton}
+          navigationType={DpadNavigationType.Item}
         >
           {m.navbar_link_shows()}
         </Button>
@@ -106,6 +113,7 @@
           variant="primary"
           color="purple"
           data-testid={TestId.NavBarMoviesButton}
+          navigationType={DpadNavigationType.Item}
         >
           {m.navbar_link_movies()}
         </Button>
@@ -117,6 +125,7 @@
           style="underlined"
           variant="primary"
           color="purple"
+          navigationType={DpadNavigationType.Item}
         >
           {m.navbar_link_watchlist()}
         </Button>

--- a/projects/client/src/lib/sections/navbar/components/JoinTraktButton.svelte
+++ b/projects/client/src/lib/sections/navbar/components/JoinTraktButton.svelte
@@ -2,6 +2,7 @@
   import Button from "$lib/components/buttons/Button.svelte";
   import { useAuth } from "$lib/features/auth/stores/useAuth";
   import * as m from "$lib/features/i18n/messages";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
 
   const { url } = useAuth();
 </script>
@@ -13,6 +14,7 @@
   size="small"
   color="purple"
   variant="primary"
+  navigationType={DpadNavigationType.Item}
 >
   {m.join_trakt_button()}
 </Button>

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import type { Snippet } from "svelte";
 
   type SummaryContainerProps = {
@@ -15,7 +16,10 @@
   }: SummaryContainerProps = $props();
 </script>
 
-<div class="trakt-summary-container">
+<div
+  class="trakt-summary-container"
+  data-dpad-navigation={DpadNavigationType.List}
+>
   {#if poster}
     <div class="trakt-summary-poster">
       {@render poster()}

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
   import { DeploymentEndpoint } from "$lib/features/deployment/DeploymentEndpoint.js";
   import ErrorProvider from "$lib/features/errors/ErrorProvider.svelte";
   import LocaleProvider from "$lib/features/i18n/components/LocaleProvider.svelte";
+  import NavigationProvider from "$lib/features/navigation/NavigationProvider.svelte";
   import QueryClientProvider from "$lib/features/query/QueryClientProvider.svelte";
   import ThemeProvider from "$lib/features/theme/components/ThemeProvider.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
@@ -87,28 +88,30 @@
       <AnalyticsProvider>
         <AutoSigninProvider>
           <LocaleProvider>
-            <CoverProvider>
-              <CoverImage />
+            <NavigationProvider>
+              <CoverProvider>
+                <CoverImage />
 
-              <ThemeProvider theme={data.theme}>
-                <ListScrollHistoryProvider>
-                  <div class="trakt-layout-wrapper">
-                    <Navbar />
-                    <div class="trakt-layout-content">
-                      {@render children()}
+                <ThemeProvider theme={data.theme}>
+                  <ListScrollHistoryProvider>
+                    <div class="trakt-layout-wrapper">
+                      <Navbar />
+                      <div class="trakt-layout-content">
+                        {@render children()}
+                      </div>
+                      <Footer />
                     </div>
-                    <Footer />
-                  </div>
-                  <RenderFor audience="all" device={["mobile", "tablet-sm"]}>
-                    <MobileNavbar />
-                  </RenderFor>
-                  <SvelteQueryDevtools
-                    buttonPosition="bottom-left"
-                    styleNonce="opacity: 0.5"
-                  />
-                </ListScrollHistoryProvider>
-              </ThemeProvider>
-            </CoverProvider>
+                    <RenderFor audience="all" device={["mobile", "tablet-sm"]}>
+                      <MobileNavbar />
+                    </RenderFor>
+                    <SvelteQueryDevtools
+                      buttonPosition="bottom-left"
+                      styleNonce="opacity: 0.5"
+                    />
+                  </ListScrollHistoryProvider>
+                </ThemeProvider>
+              </CoverProvider>
+            </NavigationProvider>
           </LocaleProvider>
 
           {#key page.url.pathname}

--- a/projects/client/src/style/scss/mixins/index.scss
+++ b/projects/client/src/style/scss/mixins/index.scss
@@ -78,3 +78,20 @@
     }
   }
 }
+
+@mixin focused-item-style($height) {
+  &:has(:global(.trakt-link:focus-visible)) {
+    &:after {
+      content: "";
+      width: 100%;
+      height: $height;
+      position: absolute;
+      top: 0;
+      left: 0;
+      border: var(--border-thickness-s) solid var(--color-link-active);
+      border-radius: var(--border-radius-m);
+      box-sizing: border-box;
+      z-index: var(--layer-raised);
+    }
+  }
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds a first version of the dpad navigator.
  - Can be enabled by using `?navigation=d-pad`
- Media/episode/people/mark-as-watched/stream elements are enabled for navigation.
- Quick implementation of denoting focused items; we should account for this when adding the new designs.
- Will need follow-ups:
  - `whenInViewport` needs to be modified so users can navigate to off-screen elements.
  - Hide elements that are not navigate-able

## 👀 Example 👀

https://github.com/user-attachments/assets/cf0a8035-b3af-4e61-a4a3-998d3b419cd0

