### PR TITLE
feat / expose recommended watch_window param to enable fine-tuning 

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "npm:@cucumber/cucumber@^11.2.0": "11.2.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.0.2_@cucumber+messages@27.0.2",
     "npm:@google/generative-ai@0.24": "0.24.0",
     "npm:@inlang/paraglide-sveltekit@~0.16.1": "0.16.1_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
-    "npm:@jsr/trakt__api@~0.1.15": "0.1.15_zod@3.24.1",
+    "npm:@jsr/trakt__api@~0.1.17": "0.1.17_zod@3.24.1",
     "npm:@playwright/test@^1.51.1": "1.51.1",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.25.3__acorn@8.14.1",
     "npm:@sveltejs/adapter-auto@5": "5.0.0_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
@@ -937,9 +937,9 @@
       "dependencies": [
         "@cucumber/ci-environment",
         "@cucumber/cucumber-expressions",
-        "@cucumber/gherkin@30.0.4",
         "@cucumber/gherkin-streams",
         "@cucumber/gherkin-utils",
+        "@cucumber/gherkin@30.0.4",
         "@cucumber/html-formatter",
         "@cucumber/junit-xml-formatter",
         "@cucumber/message-streams",
@@ -2112,12 +2112,12 @@
     "@isaacs/cliui@8.0.2": {
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dependencies": [
-        "string-width@5.1.2",
         "string-width-cjs@npm:string-width@4.2.3",
-        "strip-ansi@7.1.0",
+        "string-width@5.1.2",
         "strip-ansi-cjs@npm:strip-ansi@6.0.1",
-        "wrap-ansi@8.1.0",
-        "wrap-ansi-cjs@npm:wrap-ansi@7.0.0"
+        "strip-ansi@7.1.0",
+        "wrap-ansi-cjs@npm:wrap-ansi@7.0.0",
+        "wrap-ansi@8.1.0"
       ]
     },
     "@istanbuljs/schema@0.1.3": {
@@ -2161,8 +2161,8 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.1.15_zod@3.24.1": {
-      "integrity": "sha512-amCsrp1GmTpAukq9+0/R66uTrw57C3oA4o7r6AgSbT5BRwnPMJCbw+5EvU7Ytm9dIK+rdn1jsZzNcCP2Q0chmQ==",
+    "@jsr/trakt__api@0.1.17_zod@3.24.1": {
+      "integrity": "sha512-IcpV08rxWs4PUmGMYtTHtoIvZ1pp56mtmLncAbywmldlKcU/oVqCqLsNMVdNwoN8pz8KSPJans40/APluH2T7A==",
       "dependencies": [
         "@ts-rest/core",
         "zod@3.24.1"
@@ -3742,15 +3742,15 @@
     "esbuild@0.17.19": {
       "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
       "dependencies": [
-        "@esbuild/android-arm@0.17.19",
         "@esbuild/android-arm64@0.17.19",
+        "@esbuild/android-arm@0.17.19",
         "@esbuild/android-x64@0.17.19",
         "@esbuild/darwin-arm64@0.17.19",
         "@esbuild/darwin-x64@0.17.19",
         "@esbuild/freebsd-arm64@0.17.19",
         "@esbuild/freebsd-x64@0.17.19",
-        "@esbuild/linux-arm@0.17.19",
         "@esbuild/linux-arm64@0.17.19",
+        "@esbuild/linux-arm@0.17.19",
         "@esbuild/linux-ia32@0.17.19",
         "@esbuild/linux-loong64@0.17.19",
         "@esbuild/linux-mips64el@0.17.19",
@@ -3770,15 +3770,15 @@
       "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
       "dependencies": [
         "@esbuild/aix-ppc64@0.24.2",
-        "@esbuild/android-arm@0.24.2",
         "@esbuild/android-arm64@0.24.2",
+        "@esbuild/android-arm@0.24.2",
         "@esbuild/android-x64@0.24.2",
         "@esbuild/darwin-arm64@0.24.2",
         "@esbuild/darwin-x64@0.24.2",
         "@esbuild/freebsd-arm64@0.24.2",
         "@esbuild/freebsd-x64@0.24.2",
-        "@esbuild/linux-arm@0.24.2",
         "@esbuild/linux-arm64@0.24.2",
+        "@esbuild/linux-arm@0.24.2",
         "@esbuild/linux-ia32@0.24.2",
         "@esbuild/linux-loong64@0.24.2",
         "@esbuild/linux-mips64el@0.24.2",
@@ -3800,15 +3800,15 @@
       "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
       "dependencies": [
         "@esbuild/aix-ppc64@0.25.1",
-        "@esbuild/android-arm@0.25.1",
         "@esbuild/android-arm64@0.25.1",
+        "@esbuild/android-arm@0.25.1",
         "@esbuild/android-x64@0.25.1",
         "@esbuild/darwin-arm64@0.25.1",
         "@esbuild/darwin-x64@0.25.1",
         "@esbuild/freebsd-arm64@0.25.1",
         "@esbuild/freebsd-x64@0.25.1",
-        "@esbuild/linux-arm@0.25.1",
         "@esbuild/linux-arm64@0.25.1",
+        "@esbuild/linux-arm@0.25.1",
         "@esbuild/linux-ia32@0.25.1",
         "@esbuild/linux-loong64@0.25.1",
         "@esbuild/linux-mips64el@0.25.1",
@@ -3926,16 +3926,16 @@
     "espree@10.3.0_acorn@8.14.1": {
       "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dependencies": [
-        "acorn@8.14.1",
         "acorn-jsx",
+        "acorn@8.14.1",
         "eslint-visitor-keys@4.2.0"
       ]
     },
     "espree@9.6.1_acorn@8.14.1": {
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dependencies": [
-        "acorn@8.14.1",
         "acorn-jsx",
+        "acorn@8.14.1",
         "eslint-visitor-keys@3.4.3"
       ]
     },
@@ -4113,7 +4113,7 @@
     "flowbite-datepicker@1.3.2": {
       "integrity": "sha512-6Nfm0MCVX3mpaR7YSCjmEO2GO8CDt6CX8ZpQnGdeu03WUCWtEPQ/uy0PUiNtIJjJZWnX0Cm3H55MOhbD1g+E/g==",
       "dependencies": [
-        "@rollup/plugin-node-resolve@15.3.1",
+        "@rollup/plugin-node-resolve@15.3.1_rollup@2.79.2",
         "flowbite@2.5.2"
       ]
     },
@@ -4990,8 +4990,8 @@
       "integrity": "sha512-c9QPrgBUFzjL4pYvW6GIUw+NqeYlZGVHASKJqjIXB1WVsl14nYfpfHphYK8tluKaBqwA9NFyO5dC2zatJkC/mA==",
       "dependencies": [
         "@cspotcode/source-map-support",
-        "acorn@8.14.0",
         "acorn-walk",
+        "acorn@8.14.0",
         "exit-hook",
         "glob-to-regexp",
         "stoppable",
@@ -6079,7 +6079,7 @@
       "dependencies": [
         "@jridgewell/trace-mapping@0.3.25",
         "chokidar",
-        "fdir@6.4.3",
+        "fdir@6.4.3_picomatch@4.0.2",
         "picocolors",
         "sade",
         "svelte",
@@ -7001,7 +7001,7 @@
             "npm:@cucumber/cucumber@^11.2.0",
             "npm:@google/generative-ai@0.24",
             "npm:@inlang/paraglide-sveltekit@~0.16.1",
-            "npm:@jsr/trakt__api@~0.1.15",
+            "npm:@jsr/trakt__api@~0.1.17",
             "npm:@playwright/test@^1.51.1",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@sveltejs/adapter-auto@5",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -61,7 +61,7 @@
     "@tanstack/svelte-query": "^5.69.0",
     "@tanstack/svelte-query-devtools": "^5.69.0",
     "@tanstack/svelte-query-persist-client": "^5.69.0",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.1.15",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.1.17",
     "@ts-rest/core": "^3.52.1",
     "date-fns": "^4.1.0",
     "firebase": "^11.5.0",

--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -35,6 +35,10 @@ declare global {
 
   type HttpsUrl = `https://${string}`;
 
+  type DeepPartial<T> = {
+    [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : Partial<T[P]>;
+  };
+
   type ChildrenProps = {
     children: import('svelte').Snippet;
   };

--- a/projects/client/src/lib/features/filters/useFilter.ts
+++ b/projects/client/src/lib/features/filters/useFilter.ts
@@ -40,7 +40,7 @@ export function useFilter() {
     },
     filterMap: derived(filter, ($filter) => {
       if (!$filter?.value) {
-        return;
+        return {};
       }
 
       return {

--- a/projects/client/src/lib/requests/models/FilterParams.ts
+++ b/projects/client/src/lib/requests/models/FilterParams.ts
@@ -1,4 +1,4 @@
-export type FilterParams = Partial<{
+export type FilterParams = DeepPartial<{
   filter: {
     /*
       FIXME:
@@ -6,5 +6,6 @@ export type FilterParams = Partial<{
       -update defineQuery to deal with object dependencies
     */
     genres: string;
+    watch_window: number;
   };
 }>;

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
@@ -36,7 +36,9 @@ export const recommendedMoviesQuery = defineQuery({
     InvalidateAction.Watchlisted('movie'),
     InvalidateAction.MarkAsWatched('movie'),
   ],
-  dependencies: (params) => [params.limit, params.filter?.genres],
+  dependencies: (
+    params,
+  ) => [params.limit, params.filter?.genres, params.filter?.watch_window],
   request: recommendedMoviesRequest,
   mapper: (response) => response.body.map(mapToMovieEntry),
   schema: RecommendedMovieSchema.array(),

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
@@ -40,7 +40,9 @@ export const recommendedShowsQuery = defineQuery({
     InvalidateAction.Watchlisted('show'),
     InvalidateAction.MarkAsWatched('episode'),
   ],
-  dependencies: (params) => [params.limit, params.filter?.genres],
+  dependencies: (
+    params,
+  ) => [params.limit, params.filter?.genres, params.filter?.watch_window],
   request: recommendedShowsRequest,
   mapper: (response) =>
     response.body.map((show: RecommendedShowResponse[0]) => ({

--- a/projects/client/src/lib/sections/lists/drilldown/DrillableMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrillableMediaList.svelte
@@ -19,7 +19,7 @@
 <MediaList {...props}>
   {#snippet actions(items, type)}
     <ViewAllButton
-      href={urlBuilder({ type })}
+      href={urlBuilder({ type, ...props.filter })}
       label={drilldownLabel}
       isDisabled={items.length === 0}
     />

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedList.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import { useFilter } from "$lib/features/filters/useFilter";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
+  import { extractWatchWindowParam } from "./extractWatchWindowParam";
   import RecommendedListItem from "./RecommendedListItem.svelte";
   import { useRecommendedList } from "./useRecommendedList";
 
@@ -21,7 +23,10 @@
   {title}
   {drilldownLabel}
   {type}
-  filter={$filterMap}
+  filter={{
+    ...$filterMap,
+    ...extractWatchWindowParam(page.url.searchParams),
+  }}
   useList={useRecommendedList}
   urlBuilder={UrlBuilder.recommended}
 >

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import { useFilter } from "$lib/features/filters/useFilter";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
+  import { extractWatchWindowParam } from "./extractWatchWindowParam";
   import RecommendedListItem from "./RecommendedListItem.svelte";
   import { useRecommendedList } from "./useRecommendedList";
 
@@ -22,7 +24,10 @@
   id="view-all-recommended-${type}"
   {title}
   {type}
-  filter={$filterMap}
+  filter={{
+    ...$filterMap,
+    ...extractWatchWindowParam(page.url.searchParams),
+  }}
   useList={useRecommendedList}
 >
   {#snippet item(media)}

--- a/projects/client/src/lib/sections/lists/recommended/extractWatchWindowParam.ts
+++ b/projects/client/src/lib/sections/lists/recommended/extractWatchWindowParam.ts
@@ -1,0 +1,10 @@
+import { RECOMMENDED_DEFAULT_WATCH_WINDOW } from '$lib/utils/constants.ts';
+
+export function extractWatchWindowParam(params: URLSearchParams) {
+  return {
+    watch_window: parseInt(
+      params.get('watch_window') ?? RECOMMENDED_DEFAULT_WATCH_WINDOW.toString(),
+      10,
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/lists/recommended/useRecommendedList.ts
+++ b/projects/client/src/lib/sections/lists/recommended/useRecommendedList.ts
@@ -60,8 +60,15 @@ function useLimitRecommendedList(
     toLoadingState,
   );
 
-  const listKey = props.filter
-    ? `${props.type}-${props.filter.genres}`
+  const filters = props.filter ?? {};
+  const hasFilters = Object.keys(filters).length > 0;
+
+  const listKey = hasFilters
+    ? `${props.type}-${
+      Object.entries(filters)
+        .map(([key, value]) => `${key}-${value}`)
+        .join('-')
+    }`
     : props.type;
 
   const { list, set } = useDailyOrderedArray<RecommendedEntry>({

--- a/projects/client/src/lib/utils/constants.ts
+++ b/projects/client/src/lib/utils/constants.ts
@@ -55,3 +55,8 @@ export const DEFAULT_PAGE_SIZE = 25;
 export const DEFAULT_DRILL_SIZE = 100;
 export const RECOMMENDED_UPPER_LIMIT = DEFAULT_DRILL_SIZE;
 export const PAGE_UPPER_LIMIT = 3;
+/**
+ * This is the default we also have server-side.
+ * We expose it to tinker around and fine-tune the default value.
+ */
+export const RECOMMENDED_DEFAULT_WATCH_WINDOW = 25;

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -1,55 +1,70 @@
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { buildParamString } from './buildParamString.ts';
 
-type PaginatableMediaPageUrl = {
+type TypeParams = {
   type: MediaType | 'episode';
-  page?: number;
 };
 
+type WellKnownQueryParams = {
+  page?: number;
+  watch_window?: number;
+};
+
+type UrlBuilderParams = TypeParams & WellKnownQueryParams;
+
+function sanitizeParams(
+  params: WellKnownQueryParams,
+): WellKnownQueryParams {
+  return {
+    page: params.page,
+    watch_window: params.watch_window,
+  };
+}
+
 const mediaDrilldownFactory =
-  (category: string) => ({ type, page }: PaginatableMediaPageUrl) => {
+  (category: string) => ({ type, ...params }: UrlBuilderParams) => {
     const baseUrl = `/${type}s/${category}`;
-    return baseUrl + buildParamString({ page });
+    return baseUrl + buildParamString(sanitizeParams(params));
   };
 
 const categoryDrilldownFactory =
-  (category: string) => ({ type, page }: PaginatableMediaPageUrl) => {
+  (category: string) => ({ type, page }: UrlBuilderParams) => {
     const baseUrl = `/${category}/${type}s`;
     return baseUrl + buildParamString({ page });
   };
 
 export const UrlBuilder = {
   history: {
-    category: (params: PaginatableMediaPageUrl) => {
+    category: (params: UrlBuilderParams) => {
       return categoryDrilldownFactory('history')(params);
     },
-    all: ({ page }: PaginatableMediaPageUrl) => {
+    all: ({ page }: UrlBuilderParams) => {
       return `/history${buildParamString({ page })}`;
     },
   },
-  watched: (params: PaginatableMediaPageUrl) => {
+  watched: (params: UrlBuilderParams) => {
     return categoryDrilldownFactory('watched')(params);
   },
-  watchlistPage(params: PaginatableMediaPageUrl) {
+  watchlistPage(params: UrlBuilderParams) {
     return categoryDrilldownFactory('watchlist')(params);
   },
-  trending(params: PaginatableMediaPageUrl) {
+  trending(params: UrlBuilderParams) {
     return mediaDrilldownFactory('trending')(params);
   },
-  streaming(params: PaginatableMediaPageUrl) {
+  streaming(params: UrlBuilderParams) {
     return mediaDrilldownFactory('streaming')(params);
   },
-  recommended(params: PaginatableMediaPageUrl) {
+  recommended(params: UrlBuilderParams) {
     return mediaDrilldownFactory('recommended')(params);
   },
-  anticipated(params: PaginatableMediaPageUrl) {
+  anticipated(params: UrlBuilderParams) {
     return mediaDrilldownFactory('anticipated')(params);
   },
-  popular(params: PaginatableMediaPageUrl) {
+  popular(params: UrlBuilderParams) {
     return mediaDrilldownFactory('popular')(params);
   },
   social: {
-    activity: (_: PaginatableMediaPageUrl) => {
+    activity: (_: UrlBuilderParams) => {
       return '/social/activity';
     },
   },


### PR DESCRIPTION
##   Filter and Recommended List Enhancements

This pull request introduces several changes to enhance the filter functionality and improve the handling of recommended lists. Key improvements include dependency updates, modified filter parameters, and better handling of the watch window parameter.

###   Filter Functionality Improvements:

* **`useFilter.ts` Refinement**: The `filterMap`'s return value in `useFilter.ts` now defaults to an empty object instead of `undefined` when the filter value is absent. This seemingly small change can prevent some unexpected null pointer exceptions down the line. It's like finding a tiny crack in the wall before the whole building collapses, eh?
* **`FilterParams` Evolution**: The `FilterParams` type definition has been updated to use `DeepPartial` for greater flexibility. Plus, the `watch_window` parameter has been added, giving users a bit more temporal control over their recommendations.

###   Watch Window Parameter Mastery:

* **Recommended List Integration**: Both `RecommendedList.svelte` and `RecommendedPaginatedList.svelte` now wield the power of `extractWatchWindowParam` to properly include the `watch_window` parameter in their filter logic. This ensures that the recommendations respect the user's chosen timeframe.
* **`extractWatchWindowParam.ts` Genesis**: A brand new function, `extractWatchWindowParam.ts`, has been born to specifically handle the extraction of the `watch_window` parameter from those pesky URL search params.

###   Dependency and Query Updates:

* **`@trakt/api` Upgrade**: The `@trakt/api` dependency has been bumped up from 0.1.15 to 0.1.17. Keeping those libraries fresh, like a good pair of shoes.
* **Query Dependency Augmentation**: Both `recommendedMoviesQuery.ts` and `recommendedShowsQuery.ts` now correctly list `watch_window` among their dependencies. This is crucial for proper reactivity!

###   URL Builder Polish:

* **`UrlBuilder.ts` Refinement**: The `UrlBuilder` has been tweaked to gracefully incorporate the `watch_window` parameter into the generated URLs for recommendations.

(This pull request, much like a well-executed investigation, ties up loose ends and strengthens the foundations of Trakt Lite. The filter and parameter handling is more robust, the dependencies are up-to-date, and the URL construction is more precise. All these changes work together to create a smoother, more reliable experience for the user. And that, my friends, is what it's all about.)