### PR TITLE
Feat/profile button

### DIFF
--- a/projects/client/i18n/messages/bg-bg.json
+++ b/projects/client/i18n/messages/bg-bg.json
@@ -92,7 +92,6 @@
   "plays": "{number} гледания",
   "lists": "списъци",
   "profile": "Профил",
-  "user_menu_toggle_label": "Потребителско меню",
   "logout": "Излез",
   "unreleased_movies_title": "Очаквай скоро",
   "tba_label": "Предстои информация",

--- a/projects/client/i18n/messages/da-dk.json
+++ b/projects/client/i18n/messages/da-dk.json
@@ -92,7 +92,6 @@
   "plays": "{number} afspilninger",
   "lists": "Lister",
   "profile": "Profil",
-  "user_menu_toggle_label": "Brugermenu",
   "logout": "Log ud",
   "unreleased_movies_title": "Kommer snart",
   "tba_label": "TBA",

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -92,7 +92,6 @@
   "plays": "{number} Wiedergaben",
   "lists": "Listen",
   "profile": "Profil",
-  "user_menu_toggle_label": "Benutzermenü",
   "logout": "Abmelden",
   "unreleased_movies_title": "Demnächst verfügbar",
   "tba_label": "Noch nicht bekannt",

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -92,7 +92,6 @@
   "plays": "{number} plays",
   "lists": "Lists",
   "profile": "Profile",
-  "user_menu_toggle_label": "User Menu",
   "logout": "Logout",
   "unreleased_movies_title": "Coming Soon",
   "tba_label": "TBA",

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -92,7 +92,6 @@
   "plays": "{number} reproducciones",
   "lists": "Listas",
   "profile": "Perfil",
-  "user_menu_toggle_label": "Menú de Usuario",
   "logout": "Cerrar sesión",
   "unreleased_movies_title": "Próximamente",
   "tba_label": "Pendiente",

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -92,7 +92,6 @@
   "plays": "{number} reproducciones",
   "lists": "Listas",
   "profile": "Perfil",
-  "user_menu_toggle_label": "Menú de Usuario",
   "logout": "Cerrar sesión",
   "unreleased_movies_title": "Próximamente",
   "tba_label": "Pendiente",

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -92,7 +92,6 @@
   "plays": "{number} visionnements",
   "lists": "Listes",
   "profile": "Profil",
-  "user_menu_toggle_label": "Menu Utilisateur",
   "logout": "Déconnexion",
   "unreleased_movies_title": "Bientôt disponible",
   "tba_label": "À venir",

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -92,7 +92,6 @@
   "plays": "{number} visionnages",
   "lists": "Listes",
   "profile": "Profil",
-  "user_menu_toggle_label": "Menu Utilisateur",
   "logout": "Déconnexion",
   "unreleased_movies_title": "Bientôt disponible",
   "tba_label": "À venir",

--- a/projects/client/i18n/messages/it-it.json
+++ b/projects/client/i18n/messages/it-it.json
@@ -92,7 +92,6 @@
   "plays": "{number} riproduzioni",
   "lists": "Liste",
   "profile": "Profilo",
-  "user_menu_toggle_label": "Menu utente",
   "logout": "Esci",
   "unreleased_movies_title": "Prossimamente",
   "tba_label": "Da annunciare",

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -92,7 +92,6 @@
   "plays": "{number} 回再生",
   "lists": "リスト",
   "profile": "プロフィール",
-  "user_menu_toggle_label": "ユーザーメニュー",
   "logout": "ログアウト",
   "unreleased_movies_title": "もうすぐ公開",
   "tba_label": "未定",

--- a/projects/client/i18n/messages/nb-no.json
+++ b/projects/client/i18n/messages/nb-no.json
@@ -92,7 +92,6 @@
   "plays": "{number} visninger",
   "lists": "Lister",
   "profile": "Profil",
-  "user_menu_toggle_label": "Brukermeny",
   "logout": "Logg ut",
   "unreleased_movies_title": "Kommer Snart",
   "tba_label": "TBA",

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -92,7 +92,6 @@
   "plays": "{number} keer bekeken",
   "lists": "Lijsten",
   "profile": "Profiel",
-  "user_menu_toggle_label": "Gebruikersmenu",
   "logout": "Uitloggen",
   "unreleased_movies_title": "Komende",
   "tba_label": "Nog niet bekend",

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -92,7 +92,6 @@
   "plays": "{number} odtworzeń",
   "lists": "Listy",
   "profile": "Profil",
-  "user_menu_toggle_label": "Menu użytkownika",
   "logout": "Wyloguj się",
   "unreleased_movies_title": "Wkrótce",
   "tba_label": "Nieogłoszono czasu premiery",

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -92,7 +92,6 @@
   "plays": "{number} reproduções",
   "lists": "Listas",
   "profile": "Perfil",
-  "user_menu_toggle_label": "Menu do Usuário",
   "logout": "Sair",
   "unreleased_movies_title": "Em Breve",
   "tba_label": "Ainda por vir",

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -92,7 +92,6 @@
   "plays": "{number} vizionări",
   "lists": "Liste",
   "profile": "Profil",
-  "user_menu_toggle_label": "Meniu Utilizator",
   "logout": "Deconectare",
   "unreleased_movies_title": "Viitoarele premiere",
   "tba_label": "Va urma",

--- a/projects/client/i18n/messages/sv-se.json
+++ b/projects/client/i18n/messages/sv-se.json
@@ -92,7 +92,6 @@
   "plays": "{number} visningar",
   "lists": "Listor",
   "profile": "Profil",
-  "user_menu_toggle_label": "Användarmeny",
   "logout": "Logga ut",
   "unreleased_movies_title": "Kommer snart",
   "tba_label": "TBA",

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -92,7 +92,6 @@
   "plays": "{number} переглядів",
   "lists": "Списки",
   "profile": "Профіль",
-  "user_menu_toggle_label": "Меню користувача",
   "logout": "Вийти",
   "unreleased_movies_title": "Скоро з'явиться",
   "tba_label": "Наразі невідомо",

--- a/projects/client/src/lib/sections/footer/components/FooterContent.svelte
+++ b/projects/client/src/lib/sections/footer/components/FooterContent.svelte
@@ -1,20 +1,37 @@
-<script>
+<script lang="ts">
+  import { page } from "$app/state";
   import LocalePicker from "$lib/features/i18n/components/LocalePicker.svelte";
   import ThemePicker from "$lib/features/theme/components/ThemePicker.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CopyRight from "./CopyRight.svelte";
   import ExternalLinks from "./ExternalLinks.svelte";
-
   import FooterBar from "./FooterBar.svelte";
   import FooterLogo from "./FooterLogo.svelte";
+  import LogoutButton from "./LogoutButton.svelte";
+
+  const isOnProfile = $derived(page.route.id === UrlBuilder.profile.me());
 </script>
 
 <div class="trakt-footer-content">
   <RenderFor device={["tablet-lg", "desktop"]} audience="all">
     <FooterBar>
       <FooterLogo />
+      {#if isOnProfile}
+        <LogoutButton size="small" />
+      {/if}
     </FooterBar>
   </RenderFor>
+
+  {#if isOnProfile}
+    <RenderFor device={["tablet-sm", "mobile"]} audience="authenticated">
+      <div class="trakt-footer-logout">
+        <FooterBar>
+          <LogoutButton size="tag" />
+        </FooterBar>
+      </div>
+    </RenderFor>
+  {/if}
 
   <FooterBar>
     <!-- TODO: different layout for smaller (or different component for only theme/lang pickers) -->
@@ -44,5 +61,11 @@
     display: flex;
     justify-content: center;
     align-items: center;
+  }
+
+  .trakt-footer-logout {
+    :global(.trakt-footer-bar) {
+      justify-content: flex-end;
+    }
   }
 </style>

--- a/projects/client/src/lib/sections/footer/components/LogoutButton.svelte
+++ b/projects/client/src/lib/sections/footer/components/LogoutButton.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import Button from "$lib/components/buttons/Button.svelte";
+  import { useAuth } from "$lib/features/auth/stores/useAuth";
+  import * as m from "$lib/features/i18n/messages.ts";
+
+  const { size }: { size: "small" | "tag" } = $props();
+
+  const { logout } = useAuth();
+</script>
+
+<Button
+  {size}
+  onclick={logout}
+  label={m.logout()}
+  color="red"
+  style="flat"
+  variant="secondary"
+>
+  {m.logout()}
+</Button>

--- a/projects/client/src/lib/sections/navbar/ProfileButton.svelte
+++ b/projects/client/src/lib/sections/navbar/ProfileButton.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
-  import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
-  import { useAuth } from "$lib/features/auth/stores/useAuth";
+  import Button from "$lib/components/buttons/Button.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
-  import * as m from "$lib/features/i18n/messages";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import ProfileImage from "../profile-banner/ProfileImage.svelte";
@@ -11,7 +10,6 @@
   import VipBadge from "./components/VIPBadge.svelte";
 
   const { user } = useUser();
-  const { logout } = useAuth();
   const isVip = $derived(!!$user?.isVip);
   const color = $derived(isVip ? "red" : "purple");
   const style = $derived(isVip ? "textured" : "flat");
@@ -21,13 +19,13 @@
   <GetVIPLink />
 {/if}
 
-<DropdownList
-  label={m.user_menu_toggle_label()}
-  variant="primary"
-  text="capitalize"
+<Button
   size="small"
-  {style}
+  href={UrlBuilder.profile.me()}
+  label={m.user_profile_label()}
   {color}
+  {style}
+  navigationType={DpadNavigationType.Item}
 >
   <RenderFor audience="authenticated" device={["desktop"]}>
     {$user?.name?.first}
@@ -51,15 +49,7 @@
       </RenderFor>
     </div>
   {/snippet}
-  {#snippet items()}
-    <DropdownItem href={UrlBuilder.profile.me()}>
-      {m.profile()}
-    </DropdownItem>
-    <DropdownItem color="red" onclick={logout}>
-      {m.logout()}
-    </DropdownItem>
-  {/snippet}
-</DropdownList>
+</Button>
 
 <style>
   :global(.trakt-navbar .trakt-profile-button) {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Changes the profile dropdown list into a button.
- Moves the logout button to the footer (only on your profile page).
  - Not 100% happy about this location; when/if we have a `settings` block I'd rather move it there.

## 👀 Examples 👀
<img width="954" alt="Screenshot 2025-04-15 at 10 42 03" src="https://github.com/user-attachments/assets/e9b6c272-58d1-4857-9612-aef150fc216f" />

<img width="360" alt="Screenshot 2025-04-15 at 10 51 32" src="https://github.com/user-attachments/assets/5c57ea0b-1c74-43a9-949f-e7d10052fa5e" />
