### PR TITLE
Fix/button labels

### DIFF
--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -158,7 +158,7 @@
     display: flex;
     align-items: center;
     gap: var(--gap-m);
-    min-width: var(--ni-48);
+    min-width: var(--ni-40);
     padding: var(--ni-16);
     flex-shrink: 0;
     cursor: pointer;

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -158,7 +158,7 @@
     display: flex;
     align-items: center;
     gap: var(--gap-m);
-    min-width: var(--ni-40);
+    min-width: var(--ni-48);
     padding: var(--ni-16);
     flex-shrink: 0;
     cursor: pointer;
@@ -175,10 +175,6 @@
     transition-property:
       box-shadow, outline, padding, transform, color, background,
       text-decoration;
-
-    .button-label:has(p:empty) {
-      display: none;
-    }
 
     &:not([data-style="underlined"]) p:not(.meta-info) {
       font-size: 1rem;

--- a/projects/client/src/lib/components/dropdown/DropdownList.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownList.svelte
@@ -24,6 +24,7 @@
   use:portalTrigger
   use:observeWidth
   data-size={size}
+  class:has-external-icon={_icon != null}
 >
   <Button style="textured" {size} {...props}>
     {@render children()}
@@ -61,6 +62,15 @@
 
     :global(.trakt-button) {
       flex-grow: 1;
+    }
+
+    &.has-external-icon {
+      @include for-mobile {
+        :global(.trakt-button .button-label),
+        :global(.trakt-button .trakt-dropdown-caret) {
+          display: none;
+        }
+      }
     }
 
     &[data-size="small"] {

--- a/projects/client/src/lib/guards/RenderFor.svelte
+++ b/projects/client/src/lib/guards/RenderFor.svelte
@@ -22,15 +22,21 @@
         {@render children()}
       </RenderForInput>
     </RenderForDevice>
-  {:else if device && !input}
+  {/if}
+
+  {#if device && !input}
     <RenderForDevice {device}>
       {@render children()}
     </RenderForDevice>
-  {:else if input && !device}
+  {/if}
+
+  {#if input && !device}
     <RenderForInput {input}>
       {@render children()}
     </RenderForInput>
-  {:else if !device && !input}
+  {/if}
+
+  {#if !device && !input}
     {@render children()}
   {/if}
 </RenderForAudience>

--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -204,10 +204,10 @@
     }
 
     @include for-mobile {
-      gap: var(--gap-s);
+      gap: var(--gap-xs);
 
       .trakt-navbar-content {
-        gap: var(--gap-s);
+        gap: var(--gap-xs);
       }
     }
   }

--- a/projects/client/src/lib/sections/navbar/ProfileButton.svelte
+++ b/projects/client/src/lib/sections/navbar/ProfileButton.svelte
@@ -14,39 +14,51 @@
   const style = $derived(isVip ? "textured" : "flat");
 </script>
 
-<Button
-  size="small"
-  href={UrlBuilder.profile.me()}
-  label={m.user_profile_label()}
-  {color}
-  {style}
-  navigationType={DpadNavigationType.Item}
->
-  <RenderFor audience="authenticated" device={["desktop"]}>
-    {$user?.name?.first}
-  </RenderFor>
-  {#snippet icon()}
-    <div class="profile-icon">
-      <ProfileImage
-        --width="var(--ni-16)"
-        --height="var(--ni-16)"
-        --border-width="var(--border-thickness-xs)"
-        name={$user?.name?.first ?? ""}
-        src={$user?.avatar?.url ?? ""}
-      />
-      <RenderFor
-        audience="authenticated"
-        device={["tablet-sm", "tablet-lg", "desktop"]}
-      >
-        {#if isVip}
-          <VipBadge />
-        {/if}
-      </RenderFor>
-    </div>
-  {/snippet}
-</Button>
+<trakt-profile-button>
+  <Button
+    size="small"
+    href={UrlBuilder.profile.me()}
+    label={m.user_profile_label()}
+    {color}
+    {style}
+    navigationType={DpadNavigationType.Item}
+  >
+    <RenderFor audience="authenticated">
+      {$user?.name?.first}
+    </RenderFor>
+    {#snippet icon()}
+      <div class="profile-icon">
+        <ProfileImage
+          --width="var(--ni-16)"
+          --height="var(--ni-16)"
+          --border-width="var(--border-thickness-xs)"
+          name={$user?.name?.first ?? ""}
+          src={$user?.avatar?.url ?? ""}
+        />
+        <RenderFor
+          audience="authenticated"
+          device={["tablet-sm", "tablet-lg", "desktop"]}
+        >
+          {#if isVip}
+            <VipBadge />
+          {/if}
+        </RenderFor>
+      </div>
+    {/snippet}
+  </Button>
+</trakt-profile-button>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  trakt-profile-button {
+    @include for-mobile {
+      :global(.button-label) {
+        display: none;
+      }
+    }
+  }
+
   .profile-icon {
     display: flex;
     align-items: center;

--- a/projects/client/src/lib/sections/navbar/ProfileButton.svelte
+++ b/projects/client/src/lib/sections/navbar/ProfileButton.svelte
@@ -47,17 +47,6 @@
 </Button>
 
 <style>
-  :global(.trakt-navbar .trakt-profile-button) {
-    display: flex;
-    align-items: center;
-    gap: var(--gap-xs);
-  }
-
-  :global(.trakt-navbar .trakt-profile-button .profile-image) {
-    width: var(--ni-32);
-    height: var(--ni-32);
-  }
-
   .profile-icon {
     display: flex;
     align-items: center;

--- a/projects/client/src/lib/sections/navbar/components/filter/FilterButton.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/FilterButton.svelte
@@ -4,7 +4,6 @@
   import FilterIcon from "$lib/components/icons/FilterIcon.svelte";
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
 
   const { filter, setFilter } = useFilter();
 
@@ -27,9 +26,7 @@
     style="flat"
     {color}
   >
-    <RenderFor audience="authenticated" device={["desktop"]}>
-      {currentLabel}
-    </RenderFor>
+    {currentLabel}
     {#snippet icon()}
       <FilterIcon {state} />
     {/snippet}

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownButton.svelte
@@ -28,9 +28,7 @@
     {size}
     {...props}
   >
-    {#if style === "normal"}
-      {text}
-    {/if}
+    {text}
 
     {#snippet icon()}
       {#if style === "action"}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes spacing in the navbar on mobile; all gaps are now the same size.
- Fixes hiding button labels without having to rely on renderfor hacks.
  - This fixes the size jump on load.
- Dropdowns with icons will now hide the label & caret automatically on mobile.

## 👀 Example 👀

https://github.com/user-attachments/assets/10705ab9-1ff8-4a83-a852-64e7172f0f66

