### PR TITLE
feat(ds): integrate hotjar for UX guys

### DIFF
--- a/projects/client/src/app.html
+++ b/projects/client/src/app.html
@@ -13,15 +13,37 @@
       http-equiv="Content-Security-Policy"
       content="
         default-src 'self';
-        img-src 'self' data: https://*.trakt.tv https://trakt.tv https://secure.gravatar.com https://i2.wp.com/;
-        script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.trakt.tv https://*.googletagmanager.com;
-        script-src-elem 'self' 'unsafe-inline' https://*.googletagmanager.com https://*.cloudflareinsights.com https://*.trakt.tv/;
-        connect-src 'self' https://*.jsdelivr.net https://*.googleapis.com https://*.gstatic.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.trakt.tv https://*.posthog.com;
+        img-src 'self' data: https://*.trakt.tv https://trakt.tv https://secure.gravatar.com https://i2.wp.com/ https://*.contentsquare.net;
+        script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.trakt.tv https://*.googletagmanager.com https://*.contentsquare.net;
+        script-src-elem 'self' 'unsafe-inline' https://*.googletagmanager.com https://*.cloudflareinsights.com https://*.trakt.tv/ https://*.contentsquare.net https://static.hj.contentsquare.net;
+        worker-src 'self' blob:;
+        connect-src 'self' https://*.jsdelivr.net https://*.googleapis.com https://*.gstatic.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.trakt.tv https://*.posthog.com https://*.contentsquare.net https://*.hotjar.com https://*.hotjar.io wss://*.hotjar.com;
         font-src 'self' data: https://fonts.gstatic.com http://fonts.gstatic.com;
         style-src 'self' 'unsafe-inline' https://*.googleapis.com https://*.jsdelivr.net https://*.trakt.tv;
         style-src-elem 'self' 'unsafe-inline' https://*.googleapis.com https://*.jsdelivr.net https://*.trakt.tv;
+        frame-src 'self' https://*.hotjar.com;
       "
     >
+    <!-- HOTJAR -->
+    <script>
+      (function (c, s, q, u, a, r, e) {
+        c.hj = c.hj || function () {
+          (c.hj.q = c.hj.q || []).push(arguments);
+        };
+        c._hjSettings = { hjid: a };
+        r = s.getElementsByTagName('head')[0];
+        e = s.createElement('script');
+        e.async = true;
+        e.src = q + c._hjSettings.hjid + u;
+        r.appendChild(e);
+      })(
+        window,
+        document,
+        'https://static.hj.contentsquare.net/c/csq-',
+        '.js',
+        6374269,
+      );
+    </script>
     <!-- PWA -->
     <link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest">
     <script src="%sveltekit.assets%/register-install.js?v=%cache.timestamp%">


### PR DESCRIPTION
##   CSP Hardening and User Behavior Observation

This pull request fortifies the application's defenses with Content Security Policy (CSP) updates and introduces Hotjar analytics to gain insights into user behavior.

###   Content Security Policy Updates:

* **`script-src` and `script-src-elem` Fortification**: The `script-src` and `script-src-elem` directives have been updated to permit scripts from `https://*.contentsquare.net` and `https://static.hj.contentsquare.net`. We're opening the gates, but only to trusted allies.
* **`connect-src` Expansion**: The `connect-src` directive has been broadened to include `https://*.contentsquare.net`, `https://*.hotjar.com`, and `https://*.hotjar.io`, specifically for those elusive WebSocket connections. We need to hear what they're saying, you know?
* **`frame-src` Authorization**: The `frame-src` directive now allows frames from `https://*.hotjar.com`. We're letting them in, but we're keeping a close eye.

###   Hotjar Analytics Integration:

* **User Behavior Surveillance**: A script has been added to integrate Hotjar for user behavior analytics. The Hotjar ID, `6374269`, has been embedded within. We're watching their every move, not in a creepy way, but for science!

(This pull request is a two-pronged attack on both security and understanding. The CSP updates are like reinforcing the walls of a fortress, ensuring that only authorized scripts and connections can enter. The Hotjar integration, on the other hand, is like setting up surveillance cameras, allowing us to observe user behavior and gather valuable data. It's a delicate balance between protection and curiosity, a dance between security and insight.)