### PR TITLE
feat(android-tv): add callback for streamon deep links

### DIFF
--- a/projects/android-tv/.idea/misc.xml
+++ b/projects/android-tv/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="1">
+      <item index="0" class="java.lang.String" itemvalue="android.webkit.JavascriptInterface" />
+    </list>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />

--- a/projects/android-tv/app/src/main/java/tv/trakt/app/MainActivity.kt
+++ b/projects/android-tv/app/src/main/java/tv/trakt/app/MainActivity.kt
@@ -21,6 +21,7 @@ class MainActivity : ComponentActivity() {
         }
 
         webView.webViewClient = WebViewClient()
+        webView.addJavascriptInterface(StreamOnInterface(this), "StreamOnAndroid")
 
         webView.loadUrl(getBaseUrl())
 

--- a/projects/android-tv/app/src/main/java/tv/trakt/app/WebAppInterface.kt
+++ b/projects/android-tv/app/src/main/java/tv/trakt/app/WebAppInterface.kt
@@ -1,0 +1,31 @@
+package tv.trakt.app
+
+import android.app.AlertDialog
+import android.content.Intent
+import android.webkit.JavascriptInterface
+import androidx.annotation.Keep
+import androidx.core.net.toUri
+
+// FIXME: theming/styling for anything that triggers a native element
+class StreamOnInterface(private val activity: MainActivity) {
+
+    @Keep
+    @JavascriptInterface
+    fun open(source:String, deepLink: String) {
+        try {
+            val intent = Intent(Intent.ACTION_VIEW, deepLink.toUri())
+            activity.startActivity(intent)
+        } catch (e: Exception) {
+            activity.runOnUiThread {
+                AlertDialog.Builder(activity)
+                    .setTitle("Failed to open service")
+                    .setMessage("Could not open $source. Please make sure it's installed.")
+                    .setPositiveButton("OK") { dialog, _ ->
+                        dialog.dismiss()
+                    }
+                    .setCancelable(true)
+                    .show()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds basic support for opening deep links in the android wrapper.
- This is very basic support :P We should later on style the dialog properly.

## 👀 Example 👀

Usage in Lite would be like:
````
StreamOnAndroid.open(
      "Netflix",
      "nflx://www.netflix.com/watch/81131575?source=topshelf",
    );
````

Test with an available and unavailable app:

https://github.com/user-attachments/assets/bae3e1d7-013d-4911-b46d-0130a7b44785

https://github.com/user-attachments/assets/06597f68-935a-44f1-9810-077e414c2286


