### PR TITLE
fix / improve card readability and align actors

### DIFF
--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -51,7 +51,7 @@
 
       display: flex;
       flex-direction: column;
-      gap: var(--gap-xxs);
+      gap: var(--gap-micro);
 
       :global(.trakt-card-tag) {
         display: flex;
@@ -61,7 +61,7 @@
         color: var(--color-text-primary);
         margin: 0;
         font-weight: 500;
-        font-size: var(--ni-11);
+        font-size: var(--ni-12);
 
         :global(:has(~ .trakt-card-subtitle)) {
           font-weight: 600;
@@ -72,7 +72,7 @@
         color: var(--color-text-secondary);
         margin: 0;
         font-weight: 500;
-        font-size: var(--ni-11);
+        font-size: var(--ni-12);
       }
     }
   }

--- a/projects/client/src/lib/sections/lists/components/CastMemberCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/CastMemberCard.svelte
@@ -28,8 +28,12 @@
         style="flat"
       />
       <CardFooter>
-        <p class="secondary ellipsis actor-name">{castMember.name}</p>
-        <p class="small secondary ellipsis">{castMember.characterName}</p>
+        <p class="trakt-card-title ellipsis">
+          {castMember.name}
+        </p>
+        <p class="trakt-card-subtitle ellipsis">
+          {castMember.characterName}
+        </p>
       </CardFooter>
     </PersonCard>
   </Link>
@@ -44,9 +48,5 @@
     :global(.trakt-link) {
       text-decoration: none;
     }
-  }
-
-  .actor-name {
-    font-weight: 700;
   }
 </style>

--- a/projects/client/src/style/layout/index.css
+++ b/projects/client/src/style/layout/index.css
@@ -35,7 +35,6 @@
   );
   --height-person-list: calc(
     var(--height-person-card) + var(--layout-scrollbar-width)
-      + var(--layout-footer-less-padding)
   );
   --height-poster-list: calc(
     var(--height-poster-card) + var(--layout-scrollbar-width)

--- a/projects/client/src/style/sizing/index.css
+++ b/projects/client/src/style/sizing/index.css
@@ -19,6 +19,7 @@
   --gap-s: var(--ni-12);
   --gap-xs: var(--ni-8);
   --gap-xxs: var(--ni-4);
+  --gap-micro: var(--ni-2);
 
   --dialog-height: 100dvh;
 }


### PR DESCRIPTION
##   Card Component Polishing

This pull request focuses on enhancing the consistency and readability of card components in the client project.

###   Styling Updates:

* **`CardFooter.svelte`**:
    * The `gap` property has been adjusted to use the newly introduced `--gap-micro` variable. This is a subtle shift, but it's all about those small details, isn't it?
    * Font sizes for primary and secondary text elements have been bumped up from `var(--ni-11)` to `var(--ni-12)`. A touch of clarity, making those words easier to read, like a sharp image in a blurry world.

* **`index.css` (Sizing)**:
    * A new spacing variable, `--gap-micro`, has been added with a value of `var(--ni-2)`. This gives us finer-grained control over layout spacing, allowing for more precise adjustments.

###   Component Structure Updates:

* **`CastMemberCard.svelte`**:
    * Custom class names `actor-name` and `small secondary` have been replaced with the standardized `trakt-card-title` and `trakt-card-subtitle` classes. This is about bringing order to chaos, establishing a common language across components.
    * Unused styles for `.actor-name` have been removed. Like clearing out a cluttered room, getting rid of the things we don't need.

###   Cleanup:

* **`index

Before / After:

<img width="350" alt="image" src="https://github.com/user-attachments/assets/b2727441-3095-49e4-84dc-3a8b905747d9" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/5a9485b6-9f00-4735-ba32-9147ce805055" />

<img width="350" alt="image" src="https://github.com/user-attachments/assets/65c9e284-9864-4766-b7ed-3740a99887c9" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/cdbc7d72-2afd-464c-bb4e-19fba195d1bc" />

