### PR TITLE
fix(auth): only use host header for the redirect uri

### DIFF
--- a/projects/client/src/lib/features/auth/handle.ts
+++ b/projects/client/src/lib/features/auth/handle.ts
@@ -26,9 +26,7 @@ export const handle: Handle = async ({ event, resolve }) => {
   };
 
   const getReferrer = () =>
-    event.request.headers.get('referer') ??
-      prependHttpOrHttps(event.request.headers.get('host')) ??
-      '';
+    prependHttpOrHttps(event.request.headers.get('host')) ?? '';
 
   const isLogout = event.url.pathname.startsWith(AuthEndpoint.Logout);
 


### PR DESCRIPTION
## ♪ Note ♪

- Always use the host for the redirect uri on exchange & refresh.