### PR TITLE
feat / episode improvements

### DIFF
--- a/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
@@ -12,6 +12,7 @@
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage";
+  import { EpisodeComputedType } from "$lib/requests/models/EpisodeType";
   import { EPISODE_COVER_PLACEHOLDER } from "$lib/utils/constants";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { EpisodeCardProps } from "./EpisodeCardProps";
@@ -89,9 +90,19 @@
     {/if}
 
     {#if !isShowContext && !isActivity}
-      <Link href={UrlBuilder.show(show.slug)}>
-        <p class="trakt-card-title ellipsis">{show.title}</p>
-      </Link>
+      {#if episode.type === EpisodeComputedType.full_season}
+        <Link href={UrlBuilder.show(show.slug)}>
+          <p class="trakt-card-title uppercase ellipsis">
+            {m.season_number_label({
+              number: episode.season.toString().padStart(2, "0"),
+            })}
+          </p>
+        </Link>
+      {:else}
+        <Link href={UrlBuilder.show(show.slug)}>
+          <p class="trakt-card-title ellipsis">{show.title}</p>
+        </Link>
+      {/if}
       <p class="trakt-card-subtitle ellipsis small">
         {episode.season}x{episode.number}
         <Spoiler media={episode} {show} {episode} type="episode">

--- a/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
@@ -6,6 +6,7 @@
   import { EpisodeIntlProvider } from "$lib/components/episode/EpisodeIntlProvider";
   import Link from "$lib/components/link/Link.svelte";
   import LandscapeCard from "$lib/components/media/card/LandscapeCard.svelte";
+  import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
   import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -36,7 +37,15 @@
 </script>
 
 {#snippet activityTag()}
-  <DurationTag i18n={TagIntlProvider} runtime={episode.runtime} />
+  {#if rest.variant === "upcoming"}
+    <AirDateTag
+      i18n={TagIntlProvider}
+      airDate={episode.airDate}
+      year={episode.year}
+    />
+  {:else}
+    <DurationTag i18n={TagIntlProvider} runtime={episode.runtime} />
+  {/if}
 {/snippet}
 
 <LandscapeCard>


### PR DESCRIPTION
This pull request introduces updates to the `EpisodeItemCard.svelte` component, enhancing its functionality and improving its user interface. The changes primarily focus on adding conditional rendering for episode-specific details and incorporating a new tag component.

### Enhancements to EpisodeItemCard functionality:

* **Added `AirDateTag` for upcoming episodes:** Introduced a new `AirDateTag` component that displays the air date for episodes with the `upcoming` variant. For other variants, the existing `DurationTag` is used. (`projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte`, [[1]](diffhunk://#diff-b8fd52c4c90d3cacc2bdf192bf88420bd53bd362301d3684dc31595485738dcaR9-R16) [[2]](diffhunk://#diff-b8fd52c4c90d3cacc2bdf192bf88420bd53bd362301d3684dc31595485738dcaR40-R48)

* **Conditional rendering for episode title based on type:** Added logic to display the season number for episodes of type `full_season` using a link. For other episode types, the show's title is displayed as before. (`projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte`, [projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelteR102-R114](diffhunk://#diff-b8fd52c4c90d3cacc2bdf192bf88420bd53bd362301d3684dc31595485738dcaR102-R114))