### PR TITLE
Feat/deep links

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "npm:@cucumber/cucumber@^11.2.0": "11.2.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.0.2_@cucumber+messages@27.0.2",
     "npm:@google/generative-ai@0.24": "0.24.0",
     "npm:@inlang/paraglide-sveltekit@~0.16.1": "0.16.1_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
-    "npm:@jsr/trakt__api@~0.1.17": "0.1.17_zod@3.24.1",
+    "npm:@jsr/trakt__api@~0.1.19": "0.1.19_zod@3.24.1",
     "npm:@playwright/test@^1.51.1": "1.51.1",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.25.3__acorn@8.14.1",
     "npm:@sveltejs/adapter-auto@5": "5.0.0_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
@@ -937,9 +937,9 @@
       "dependencies": [
         "@cucumber/ci-environment",
         "@cucumber/cucumber-expressions",
+        "@cucumber/gherkin@30.0.4",
         "@cucumber/gherkin-streams",
         "@cucumber/gherkin-utils",
-        "@cucumber/gherkin@30.0.4",
         "@cucumber/html-formatter",
         "@cucumber/junit-xml-formatter",
         "@cucumber/message-streams",
@@ -2112,12 +2112,12 @@
     "@isaacs/cliui@8.0.2": {
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dependencies": [
-        "string-width-cjs@npm:string-width@4.2.3",
         "string-width@5.1.2",
-        "strip-ansi-cjs@npm:strip-ansi@6.0.1",
+        "string-width-cjs@npm:string-width@4.2.3",
         "strip-ansi@7.1.0",
-        "wrap-ansi-cjs@npm:wrap-ansi@7.0.0",
-        "wrap-ansi@8.1.0"
+        "strip-ansi-cjs@npm:strip-ansi@6.0.1",
+        "wrap-ansi@8.1.0",
+        "wrap-ansi-cjs@npm:wrap-ansi@7.0.0"
       ]
     },
     "@istanbuljs/schema@0.1.3": {
@@ -2161,8 +2161,8 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.1.17_zod@3.24.1": {
-      "integrity": "sha512-IcpV08rxWs4PUmGMYtTHtoIvZ1pp56mtmLncAbywmldlKcU/oVqCqLsNMVdNwoN8pz8KSPJans40/APluH2T7A==",
+    "@jsr/trakt__api@0.1.19_zod@3.24.1": {
+      "integrity": "sha512-Gj2ixCVxdaYEhh7KmZlqhTPNBpfFtKBURH4SpS3A0UQbYdYj63P1nPVdZaEdsLWJmydDpeKA/Gp0FQLyvvGKvQ==",
       "dependencies": [
         "@ts-rest/core",
         "zod@3.24.1"
@@ -3742,15 +3742,15 @@
     "esbuild@0.17.19": {
       "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
       "dependencies": [
-        "@esbuild/android-arm64@0.17.19",
         "@esbuild/android-arm@0.17.19",
+        "@esbuild/android-arm64@0.17.19",
         "@esbuild/android-x64@0.17.19",
         "@esbuild/darwin-arm64@0.17.19",
         "@esbuild/darwin-x64@0.17.19",
         "@esbuild/freebsd-arm64@0.17.19",
         "@esbuild/freebsd-x64@0.17.19",
-        "@esbuild/linux-arm64@0.17.19",
         "@esbuild/linux-arm@0.17.19",
+        "@esbuild/linux-arm64@0.17.19",
         "@esbuild/linux-ia32@0.17.19",
         "@esbuild/linux-loong64@0.17.19",
         "@esbuild/linux-mips64el@0.17.19",
@@ -3770,15 +3770,15 @@
       "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
       "dependencies": [
         "@esbuild/aix-ppc64@0.24.2",
-        "@esbuild/android-arm64@0.24.2",
         "@esbuild/android-arm@0.24.2",
+        "@esbuild/android-arm64@0.24.2",
         "@esbuild/android-x64@0.24.2",
         "@esbuild/darwin-arm64@0.24.2",
         "@esbuild/darwin-x64@0.24.2",
         "@esbuild/freebsd-arm64@0.24.2",
         "@esbuild/freebsd-x64@0.24.2",
-        "@esbuild/linux-arm64@0.24.2",
         "@esbuild/linux-arm@0.24.2",
+        "@esbuild/linux-arm64@0.24.2",
         "@esbuild/linux-ia32@0.24.2",
         "@esbuild/linux-loong64@0.24.2",
         "@esbuild/linux-mips64el@0.24.2",
@@ -3800,15 +3800,15 @@
       "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
       "dependencies": [
         "@esbuild/aix-ppc64@0.25.1",
-        "@esbuild/android-arm64@0.25.1",
         "@esbuild/android-arm@0.25.1",
+        "@esbuild/android-arm64@0.25.1",
         "@esbuild/android-x64@0.25.1",
         "@esbuild/darwin-arm64@0.25.1",
         "@esbuild/darwin-x64@0.25.1",
         "@esbuild/freebsd-arm64@0.25.1",
         "@esbuild/freebsd-x64@0.25.1",
-        "@esbuild/linux-arm64@0.25.1",
         "@esbuild/linux-arm@0.25.1",
+        "@esbuild/linux-arm64@0.25.1",
         "@esbuild/linux-ia32@0.25.1",
         "@esbuild/linux-loong64@0.25.1",
         "@esbuild/linux-mips64el@0.25.1",
@@ -3926,16 +3926,16 @@
     "espree@10.3.0_acorn@8.14.1": {
       "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dependencies": [
-        "acorn-jsx",
         "acorn@8.14.1",
+        "acorn-jsx",
         "eslint-visitor-keys@4.2.0"
       ]
     },
     "espree@9.6.1_acorn@8.14.1": {
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dependencies": [
-        "acorn-jsx",
         "acorn@8.14.1",
+        "acorn-jsx",
         "eslint-visitor-keys@3.4.3"
       ]
     },
@@ -4990,8 +4990,8 @@
       "integrity": "sha512-c9QPrgBUFzjL4pYvW6GIUw+NqeYlZGVHASKJqjIXB1WVsl14nYfpfHphYK8tluKaBqwA9NFyO5dC2zatJkC/mA==",
       "dependencies": [
         "@cspotcode/source-map-support",
-        "acorn-walk",
         "acorn@8.14.0",
+        "acorn-walk",
         "exit-hook",
         "glob-to-regexp",
         "stoppable",
@@ -7001,7 +7001,7 @@
             "npm:@cucumber/cucumber@^11.2.0",
             "npm:@google/generative-ai@0.24",
             "npm:@inlang/paraglide-sveltekit@~0.16.1",
-            "npm:@jsr/trakt__api@~0.1.17",
+            "npm:@jsr/trakt__api@~0.1.19",
             "npm:@playwright/test@^1.51.1",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@sveltejs/adapter-auto@5",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -61,7 +61,7 @@
     "@tanstack/svelte-query": "^5.69.0",
     "@tanstack/svelte-query-devtools": "^5.69.0",
     "@tanstack/svelte-query-persist-client": "^5.69.0",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.1.17",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.1.19",
     "@ts-rest/core": "^3.52.1",
     "date-fns": "^4.1.0",
     "firebase": "^11.5.0",

--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -186,6 +186,12 @@ declare global {
       'onclickoutside'?: (ev: CustomEvent) => void;
     }
   }
+
+  interface StreamOnAndroid {
+    open: (name: string, url: string) => void;
+  }
+
+  const StreamOnAndroid: StreamOnAndroid | Nil;
 }
 
 export {};

--- a/projects/client/src/lib/components/buttons/streaming-service/StreamingServiceButton.svelte
+++ b/projects/client/src/lib/components/buttons/streaming-service/StreamingServiceButton.svelte
@@ -4,6 +4,7 @@
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import StreamingServiceLogo from "../../media/streaming-service/StreamingServiceLogo.svelte";
   import Button from "../Button.svelte";
+  import { useStreamOnHandler } from "./_internal/useStreamOnHandler";
   import { StreamingServiceButtonIntlProvider } from "./StreamingServiceButtonIntlProvider";
   import type { StreamingServiceButtonProps } from "./StreamingServiceButtonProps";
 
@@ -19,10 +20,11 @@
     label: i18n.title(mediaTitle),
     color: "purple",
     variant: "primary",
-    href: service.link,
     target: "_blank",
     navigationType: DpadNavigationType.Item,
   });
+
+  const handler = $derived(useStreamOnHandler(service));
 
   /**
    * TODO: @seferturan
@@ -34,7 +36,7 @@
 
 {#if style === "normal"}
   <div class="trakt-streaming-service-button">
-    <Button {...commonProps} {...props} size="small">
+    <Button {...commonProps} {...props} {...handler} size="small">
       {i18n.streamOn()}
       {#snippet icon()}
         <StreamingServiceLogo
@@ -49,7 +51,7 @@
 
 {#if style === "logo"}
   <div class="trakt-streaming-service-button">
-    <Button {...commonProps} {...props} size="small">
+    <Button {...commonProps} {...props} {...handler} size="small">
       <StreamingServiceLogo
         source={service.source}
         i18n={StreamingServiceLogoIntlProvider}

--- a/projects/client/src/lib/components/buttons/streaming-service/_internal/useStreamOnHandler.spec.ts
+++ b/projects/client/src/lib/components/buttons/streaming-service/_internal/useStreamOnHandler.spec.ts
@@ -1,0 +1,67 @@
+import { useStreamOnHandler } from '$lib/components/buttons/streaming-service/_internal/useStreamOnHandler.ts';
+import type { StreamNow } from '$lib/requests/models/StreamingServiceOptions.ts';
+import { renderStore } from '$test/beds/store/renderStore.ts';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('useStreamOnHandler', () => {
+  const service: StreamNow = {
+    link: 'https://www.netflix.com/',
+    source: 'netflix',
+    is4k: false,
+    type: 'streaming',
+  };
+
+  const mockStreamOnAndroid = {
+    open: vi.fn(),
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should return href when deepLinkHandler is not available', async () => {
+    const handler = await renderStore(() => useStreamOnHandler(service));
+
+    const href = 'href' in handler ? handler.href : '';
+    expect(href).to.equal(service.link);
+  });
+
+  it('should return href when there is no deep link', async () => {
+    vi.stubGlobal('StreamOnAndroid', mockStreamOnAndroid);
+    const handler = await renderStore(() => useStreamOnHandler(service));
+
+    const href = 'href' in handler ? handler.href : '';
+    expect(href).to.equal(service.link);
+  });
+
+  it('should return the deep link handler', async () => {
+    vi.stubGlobal('StreamOnAndroid', mockStreamOnAndroid);
+    const handler = await renderStore(() =>
+      useStreamOnHandler({
+        ...service,
+        deepLink: 'nflx://www.netflix.com/',
+      })
+    );
+
+    const onclick = 'onclick' in handler ? handler.onclick : null;
+    expect(onclick).toBeDefined();
+  });
+
+  it('should call the deep link handler with the correct link', async () => {
+    vi.stubGlobal('StreamOnAndroid', mockStreamOnAndroid);
+    const handler = await renderStore(() =>
+      useStreamOnHandler({
+        ...service,
+        deepLink: 'nflx://www.netflix.com/',
+      })
+    );
+
+    const onclick = 'onclick' in handler ? handler.onclick : null;
+    onclick?.();
+    expect(mockStreamOnAndroid.open).toHaveBeenCalledWith(
+      'netflix',
+      'nflx://www.netflix.com/',
+    );
+  });
+});

--- a/projects/client/src/lib/components/buttons/streaming-service/_internal/useStreamOnHandler.ts
+++ b/projects/client/src/lib/components/buttons/streaming-service/_internal/useStreamOnHandler.ts
@@ -1,0 +1,39 @@
+import { getDeepLinkHandler } from '$lib/features/deep-link/getDeepLinkHandler.ts';
+import type { StreamNow } from '$lib/requests/models/StreamingServiceOptions.ts';
+import { useStreamingServices } from '$lib/stores/useStreamingServices.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { derived, get } from 'svelte/store';
+
+type StreamOnHandler = {
+  href: HttpsUrl;
+} | {
+  onclick: () => void;
+};
+
+export function useStreamOnHandler(service: StreamNow): StreamOnHandler {
+  const deepLinkHandler = getDeepLinkHandler();
+  if (!deepLinkHandler || !service.deepLink) {
+    return {
+      href: service.link,
+    };
+  }
+
+  const { sources } = useStreamingServices();
+  const source = derived(
+    sources,
+    ($sources) => $sources.find((s) => s.source === service.source),
+  );
+
+  const handler = () => {
+    const sourceName = get(source)?.name ?? service.source;
+
+    deepLinkHandler.open(
+      sourceName,
+      assertDefined(service.deepLink, 'Deep link is required'),
+    );
+  };
+
+  return {
+    onclick: handler,
+  };
+}

--- a/projects/client/src/lib/features/deep-link/getDeepLinkHandler.ts
+++ b/projects/client/src/lib/features/deep-link/getDeepLinkHandler.ts
@@ -1,0 +1,10 @@
+type DeepLinkHandler = {
+  open: (sourceName: string, deepLink: string) => void;
+};
+
+export function getDeepLinkHandler(): DeepLinkHandler | null {
+  const hasStreamOnAndroid = typeof StreamOnAndroid !== 'undefined' &&
+    StreamOnAndroid;
+
+  return hasStreamOnAndroid ? StreamOnAndroid : null;
+}

--- a/projects/client/src/lib/features/deep-link/getDeepLinkHandlers.spec.ts
+++ b/projects/client/src/lib/features/deep-link/getDeepLinkHandlers.spec.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getDeepLinkHandler } from './getDeepLinkHandler.ts';
+
+describe('getDeepLinkHandler', () => {
+  const mockStreamOnAndroid = {
+    open: vi.fn(),
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should return null when StreamOnAndroid is not available', () => {
+    const handler = getDeepLinkHandler();
+    expect(handler).toBeNull();
+  });
+
+  it('should return StreamOnAndroid when it is available', () => {
+    vi.stubGlobal('StreamOnAndroid', mockStreamOnAndroid);
+    const handler = getDeepLinkHandler();
+    expect(handler).toBe(mockStreamOnAndroid);
+  });
+
+  it('should return null when StreamOnAndroid is falsy', () => {
+    vi.stubGlobal('StreamOnAndroid', null);
+    const handler = getDeepLinkHandler();
+    expect(handler).toBeNull();
+  });
+
+  it('should call open method with correct parameters when available', () => {
+    vi.stubGlobal('StreamOnAndroid', mockStreamOnAndroid);
+    const handler = getDeepLinkHandler();
+
+    handler?.open('testSource', 'deeplink://test');
+    expect(mockStreamOnAndroid.open).toHaveBeenCalledWith(
+      'testSource',
+      'deeplink://test',
+    );
+  });
+});

--- a/projects/client/src/lib/requests/_internal/mapToStreamingServices.ts
+++ b/projects/client/src/lib/requests/_internal/mapToStreamingServices.ts
@@ -13,6 +13,7 @@ function mapToStreamNow(
   return {
     type: 'streaming',
     link: prependHttps(serviceResponse.link),
+    deepLink: serviceResponse.link_tvos,
     source: serviceResponse.source,
     is4k: serviceResponse.uhd,
   };
@@ -32,6 +33,7 @@ function mapToStreamOnDemand(
   return {
     type: 'on-demand',
     link: prependHttps(serviceResponse.link),
+    deepLink: serviceResponse.link_tvos,
     source: serviceResponse.source,
     is4k: serviceResponse.uhd,
     currency: serviceResponse.currency,

--- a/projects/client/src/lib/requests/models/StreamingServiceOptions.ts
+++ b/projects/client/src/lib/requests/models/StreamingServiceOptions.ts
@@ -3,6 +3,7 @@ import { HttpsUrlSchema } from './HttpsUrlSchema.ts';
 
 export const StreamingSubscriptionSchema = z.object({
   link: HttpsUrlSchema,
+  deepLink: z.string().nullish(),
   source: z.string(),
   is4k: z.boolean(),
   type: z.literal('streaming'),
@@ -13,6 +14,7 @@ export type StreamNow = z.infer<
 
 export const OnDemandStreamingSchema = z.object({
   link: HttpsUrlSchema,
+  deepLink: z.string().nullish(),
   source: z.string(),
   is4k: z.boolean(),
   type: z.literal('on-demand'),

--- a/projects/client/src/lib/requests/queries/episode/streamEpisodeQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/streamEpisodeQuery.ts
@@ -24,6 +24,9 @@ const streamEpisodeRequest = (
         episode,
         country,
       },
+      query: {
+        links: 'tvos',
+      },
     });
 
 export const streamEpisodeQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/movies/streamMovieQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/streamMovieQuery.ts
@@ -19,6 +19,9 @@ const streamMovieRequest = (
         id: slug,
         country,
       },
+      query: {
+        links: 'tvos',
+      },
     });
 
 export const streamMovieQuery = defineQuery({

--- a/projects/client/src/lib/requests/queries/shows/streamShowQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/streamShowQuery.ts
@@ -19,6 +19,9 @@ const showWatchNowRequest = (
         id: slug,
         country,
       },
+      query: {
+        links: 'tvos',
+      },
     });
 
 export const streamShowQuery = defineQuery({

--- a/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloStreamingServiceOptionsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloStreamingServiceOptionsMappedMock.ts
@@ -7,12 +7,14 @@ export const EpisodeSiloStreamingServiceOptionsMappedMock:
       {
         'is4k': true,
         'link': 'https://trakt.tv/watchnow/194270962',
+        'deepLink': undefined,
         'source': 'apple_tv_plus',
         'type': 'streaming',
       },
       {
         'is4k': true,
         'link': 'https://trakt.tv/watchnow/181597412',
+        'deepLink': undefined,
         'source': 'apple_tv_plus_amazon_channel',
         'type': 'streaming',
       },

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticWatchNowMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticWatchNowMappedMock.ts
@@ -6,6 +6,7 @@ export const MovieHereticWatchedNowMappedMock: StreamingServiceOptions = {
       'currency': 'usd',
       'is4k': true,
       'link': 'https://trakt.tv/watchnow/189110873',
+      'deepLink': undefined,
       'prices': {
         'purchase': 24.99,
         'rent': 19.99,
@@ -17,6 +18,7 @@ export const MovieHereticWatchedNowMappedMock: StreamingServiceOptions = {
       'currency': 'usd',
       'is4k': true,
       'link': 'https://trakt.tv/watchnow/189802504',
+      'deepLink': undefined,
       'prices': {
         'purchase': 19.99,
         'rent': 19.99,
@@ -28,6 +30,7 @@ export const MovieHereticWatchedNowMappedMock: StreamingServiceOptions = {
       'currency': 'usd',
       'is4k': true,
       'link': 'https://trakt.tv/watchnow/183946473',
+      'deepLink': undefined,
       'prices': {
         'purchase': 19.99,
         'rent': 19.99,
@@ -39,6 +42,7 @@ export const MovieHereticWatchedNowMappedMock: StreamingServiceOptions = {
       'currency': 'usd',
       'is4k': false,
       'link': 'https://trakt.tv/watchnow/189673385',
+      'deepLink': undefined,
       'prices': {
         'purchase': 24.99,
         'rent': 19.99,
@@ -50,6 +54,7 @@ export const MovieHereticWatchedNowMappedMock: StreamingServiceOptions = {
       'currency': 'usd',
       'is4k': true,
       'link': 'https://trakt.tv/watchnow/189110875',
+      'deepLink': undefined,
       'prices': {
         'purchase': 19.99,
         'rent': 19.99,
@@ -61,6 +66,7 @@ export const MovieHereticWatchedNowMappedMock: StreamingServiceOptions = {
       'currency': 'usd',
       'is4k': false,
       'link': 'https://trakt.tv/watchnow/189673386',
+      'deepLink': undefined,
       'prices': {
         'purchase': 24.99,
         'rent': 19.99,

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloStreamingServiceOptionsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloStreamingServiceOptionsMappedMock.ts
@@ -7,12 +7,14 @@ export const ShowSiloStreamingServiceOptionsMappedMock:
       {
         'is4k': true,
         'link': 'https://trakt.tv/watchnow/194269876',
+        'deepLink': undefined,
         'source': 'apple_tv_plus',
         'type': 'streaming',
       },
       {
         'is4k': true,
         'link': 'https://trakt.tv/watchnow/181342180',
+        'deepLink': undefined,
         'source': 'apple_tv_plus_amazon_channel',
         'type': 'streaming',
       },


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds initial version for supporting deep links.
- Can be generalized further to also use in the poster overlays. For now:
  - This is separate from detecting if we're on TV. When in the future we add a wrapper for phones, it should be a matter of adding the right handler and all other code can stay the same.
  - If there is a deep link handler, only services with a deep link are considered.

## 👀 Examples 👀
On desktop, it still uses the regular links (ignore the error, my pihole blocks these 😅):

https://github.com/user-attachments/assets/616c9455-eb1e-4ae2-9ac4-40451106b545

On Android TV it uses the callback (still has the dev env sign in issue, so to test I added a stream now button in the header):

https://github.com/user-attachments/assets/eed756d7-5ce2-42b6-9809-65a38095ac49


