### PR TITLE
fix(summary): less clamped external ratings

### DIFF
--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -56,6 +56,6 @@
   .trakt-summary-ratings {
     display: flex;
     align-items: center;
-    gap: var(--gap-xs);
+    gap: var(--gap-m);
   }
 </style>


### PR DESCRIPTION
## ♪ Note ♪

- @kevincador had a good remark; external ratings are quite close to each other. I.e. the gap between external ratings and the inner gap between logo/rating is the same. Especially annoying when there is no rating. This increases the distance between ratings.

## 👀 Examples 👀
Before:
<img width="932" alt="Screenshot 2025-04-17 at 16 12 11" src="https://github.com/user-attachments/assets/aeb5ea08-2958-420d-82e7-b948a8a02cd3" />

After:
<img width="932" alt="Screenshot 2025-04-17 at 16 14 17" src="https://github.com/user-attachments/assets/c365dbda-0ace-482f-ae41-3122cef885b9" />
