### PR TITLE
Fix/android tv

### DIFF
--- a/projects/android-tv/app/build.gradle.kts
+++ b/projects/android-tv/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "tv.trakt.app"
         minSdk = 21
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "0.1"
     }
 
     buildTypes {

--- a/projects/android-tv/app/src/main/AndroidManifest.xml
+++ b/projects/android-tv/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         android:required="false" />
     <uses-feature
         android:name="android.software.leanback"
-        android:required="false" />
+        android:required="true" />
 
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Some changes that were required while doing an internal test release.
  - version code set to `2`. Apparently even though my initial test error out and was never deployed, it still sees `1` as already having been used.
  - the "0.1" is just a visual label, we can change that to whatever when we do an actual beta release.
  - leanback feature is mandatory.