### PR TITLE
fix(search): remove broken hover effect in search results

### DIFF
--- a/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
+++ b/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
@@ -301,24 +301,6 @@
       backdrop-filter: blur(var(--ni-8));
       border-radius: var(--border-radius-l);
       box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-
-      :global(a.trakt-link) {
-        text-decoration: none;
-        transition: background-color var(--transition-increment) ease-in-out;
-
-        @include for-mouse {
-          &:hover,
-          &:focus-visible {
-            background: var(--purple-900);
-            color: var(--shade-10);
-            border-radius: var(--border-radius-m);
-          }
-        }
-
-        &:active {
-          background: var(--purple-700);
-        }
-      }
     }
   }
 </style>


### PR DESCRIPTION
## ♪ Note ♪

- Remove old hover styling

## 👀 Examples 👀
Ignore the non-pointer cursor, side effect of recording.

Before:

https://github.com/user-attachments/assets/7b671e22-3a9a-4305-a51a-5f6996fbccd8

After:

https://github.com/user-attachments/assets/a6efc78b-3258-48b4-a764-17e5cf818047

