### PR TITLE
Feat/dpad ux

### DIFF
--- a/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte
+++ b/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte
@@ -39,12 +39,18 @@
 </script>
 
 {#if style === "normal"}
-  <Button {...commonProps} {...props} navigationType={DpadNavigationType.Item}>
-    {i18n.text({ title, isWatched, isRewatching })}
-    {#snippet icon()}
-      <MarkAsWatchedIcon {state} size="small" />
-    {/snippet}
-  </Button>
+  <div data-dpad-navigation={DpadNavigationType.List} style="display: contents">
+    <Button
+      {...commonProps}
+      {...props}
+      navigationType={DpadNavigationType.Item}
+    >
+      {i18n.text({ title, isWatched, isRewatching })}
+      {#snippet icon()}
+        <MarkAsWatchedIcon {state} size="small" />
+      {/snippet}
+    </Button>
+  </div>
 {/if}
 
 {#if style === "action"}

--- a/projects/client/src/lib/components/buttons/streaming-service/StreamingServiceButton.svelte
+++ b/projects/client/src/lib/components/buttons/streaming-service/StreamingServiceButton.svelte
@@ -13,6 +13,7 @@
     service,
     style,
     i18n = StreamingServiceButtonIntlProvider,
+    size = "small",
     ...props
   }: StreamingServiceButtonProps = $props();
 
@@ -35,8 +36,11 @@
 </script>
 
 {#if style === "normal"}
-  <div class="trakt-streaming-service-button">
-    <Button {...commonProps} {...props} {...handler} size="small">
+  <div
+    class="trakt-streaming-service-button"
+    data-dpad-navigation={DpadNavigationType.List}
+  >
+    <Button {...commonProps} {...props} {...handler} {size}>
       {i18n.streamOn()}
       {#snippet icon()}
         <StreamingServiceLogo
@@ -51,7 +55,7 @@
 
 {#if style === "logo"}
   <div class="trakt-streaming-service-button">
-    <Button {...commonProps} {...props} {...handler} size="small">
+    <Button {...commonProps} {...props} {...handler} {size}>
       <StreamingServiceLogo
         source={service.source}
         i18n={StreamingServiceLogoIntlProvider}

--- a/projects/client/src/lib/components/buttons/streaming-service/StreamingServiceButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/streaming-service/StreamingServiceButtonProps.ts
@@ -6,4 +6,5 @@ export type StreamingServiceButtonProps = {
   service: StreamNow;
   style: 'logo' | 'normal';
   i18n?: StreamingServiceButtonIntl;
+  size?: 'small' | 'normal';
 } & Omit<ButtonProps, 'children' | 'onclick' | 'label'>;

--- a/projects/client/src/lib/components/card/CardActionBar.svelte
+++ b/projects/client/src/lib/components/card/CardActionBar.svelte
@@ -5,7 +5,7 @@
   const { actions }: { actions: Snippet } = $props();
 </script>
 
-<RenderFor audience="authenticated">
+<RenderFor audience="authenticated" navigation="default">
   <div class="trakt-card-action-bar">
     {@render actions()}
   </div>

--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { CardFooterProps } from "./CardFooterProps";
 
   const { children, action, tag }: CardFooterProps = $props();
@@ -16,9 +17,11 @@
   {/if}
 
   {#if action}
-    <div class="trakt-card-footer-action">
-      {@render action()}
-    </div>
+    <RenderFor audience="all" navigation="default">
+      <div class="trakt-card-footer-action">
+        {@render action()}
+      </div>
+    </RenderFor>
   {/if}
 </div>
 

--- a/projects/client/src/lib/components/link/Link.svelte
+++ b/projects/client/src/lib/components/link/Link.svelte
@@ -67,6 +67,10 @@
     text-underline-offset: var(--ni-2);
     text-decoration-thickness: var(--ni-2);
 
+    :global(.trakt-card-cover) {
+      transition: transform var(--transition-increment) ease-in-out;
+    }
+
     &:focus-visible {
       outline: none;
       position: relative;
@@ -83,6 +87,11 @@
         outline-offset: calc(-1 * var(--border-thickness-s));
 
         transition: border-radius var(--transition-increment) ease-in-out;
+      }
+
+      :global(.trakt-card-cover) {
+        transform: scale(0.9);
+        transform-origin: center;
       }
     }
 

--- a/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { Snippet } from "svelte";
   import ListTitle from "./ListTitle.svelte";
 
@@ -27,9 +28,11 @@
     {/if}
   </div>
   {#if actions != null}
-    <div class="trakt-list-actions">
-      {@render actions()}
-    </div>
+    <RenderFor audience="all" navigation="default">
+      <div class="trakt-list-actions">
+        {@render actions()}
+      </div>
+    </RenderFor>
   {/if}
 </div>
 

--- a/projects/client/src/lib/components/summary/SummaryPoster.svelte
+++ b/projects/client/src/lib/components/summary/SummaryPoster.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { Snippet } from "svelte";
   import Link from "../link/Link.svelte";
 
@@ -32,9 +33,11 @@
   </div>
 
   {#if activeOverlay}
-    <div class="trakt-summary-poster-overlay">
-      {@render activeOverlay()}
-    </div>
+    <RenderFor audience="all" navigation="default">
+      <div class="trakt-summary-poster-overlay">
+        {@render activeOverlay()}
+      </div>
+    </RenderFor>
   {/if}
 
   {@render actions?.()}

--- a/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
+++ b/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
@@ -5,6 +5,7 @@
     type AvailableLocale,
     availableLocales,
   } from "$lib/features/i18n/index.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import { WorkerMessage } from "$worker/WorkerMessage";
   import { workerRequest } from "$worker/workerRequest";
   import { LocaleEndpoint } from "../LocaleEndpoint";
@@ -80,7 +81,10 @@
       d="M480-80q-82 0-155-31.5t-127.5-86Q143-252 111.5-325T80-480q0-83 31.5-155.5t86-127Q252-817 325-848.5T480-880q83 0 155.5 31.5t127 86q54.5 54.5 86 127T880-480q0 82-31.5 155t-86 127.5q-54.5 54.5-127 86T480-80Zm0-82q26-36 45-75t31-83H404q12 44 31 83t45 75Zm-104-16q-18-33-31.5-68.5T322-320H204q29 50 72.5 87t99.5 55Zm208 0q56-18 99.5-55t72.5-87H638q-9 38-22.5 73.5T584-178ZM170-400h136q-3-20-4.5-39.5T300-480q0-21 1.5-40.5T306-560H170q-5 20-7.5 39.5T160-480q0 21 2.5 40.5T170-400Zm216 0h188q3-20 4.5-39.5T580-480q0-21-1.5-40.5T574-560H386q-3 20-4.5 39.5T380-480q0 21 1.5 40.5T386-400Zm268 0h136q5-20 7.5-39.5T800-480q0-21-2.5-40.5T790-560H654q3 20 4.5 39.5T660-480q0 21-1.5 40.5T654-400Zm-16-240h118q-29-50-72.5-87T584-782q18 33 31.5 68.5T638-640Zm-234 0h152q-12-44-31-83t-45-75q-26 36-45 75t-31 83Zm-200 0h118q9-38 22.5-73.5T376-782q-56 18-99.5 55T204-640Z"
     />
   </svg>
-  <select onchange={(ev) => submitLocale(ev.currentTarget.value)}>
+  <select
+    onchange={(ev) => submitLocale(ev.currentTarget.value)}
+    data-dpad-navigation={DpadNavigationType.Item}
+  >
     {#each availableLocales as option}
       <option
         selected={$locale === option}
@@ -102,6 +106,10 @@
     width: var(--ni-48);
     height: var(--ni-48);
     border-radius: 50%;
+
+    &:has(select:focus-visible) {
+      outline: var(--border-thickness-xs) solid var(--purple-500);
+    }
 
     .locale-icon {
       /** Scale 90% to visually compensate */

--- a/projects/client/src/lib/features/navigation/NavigationProvider.svelte
+++ b/projects/client/src/lib/features/navigation/NavigationProvider.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { DeviceType } from "$lib/models/DeviceType";
   import { onMount } from "svelte";
-  import { useNavigation } from "./useNavigation";
+  import { initializeNavigation } from "./useNavigation";
 
   type NavigationProviderProps = {
     device: DeviceType;
@@ -9,7 +9,7 @@
 
   const { children, device }: NavigationProviderProps = $props();
 
-  const { controller, redirect } = $derived(useNavigation(device));
+  const { controller, redirect } = $derived(initializeNavigation(device));
 
   onMount(() => {
     if (!controller) {

--- a/projects/client/src/lib/features/navigation/useNavigation.ts
+++ b/projects/client/src/lib/features/navigation/useNavigation.ts
@@ -2,22 +2,34 @@ import { goto } from '$app/navigation';
 import { page } from '$app/state';
 import { dpadController } from '$lib/features/navigation/_internal/dpadController.ts';
 import type { DeviceType } from '$lib/models/DeviceType.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { getContext, setContext } from 'svelte';
+import { get, type Readable, readable } from 'svelte/store';
 
+const NAVIGATION_CONTEXT_KEY = Symbol('navigation');
 const PARAM_NAME = 'navigation';
 const DPAD_REF = 'd-pad';
 
 type NavigationType = 'default' | 'dpad';
 type Controller = (node: HTMLElement) => void;
+type NavigationContextData = Readable<NavigationType>;
 
 const navigationControllers: Record<NavigationType, Controller | undefined> = {
   'default': undefined,
   'dpad': dpadController,
 };
 
-export function useNavigation(device: DeviceType) {
+export function initializeNavigation(device: DeviceType) {
   const ref = page.url.searchParams.get(PARAM_NAME);
   const hasDpadNavigation = device === 'tv' || ref === DPAD_REF;
-  const navigationType: NavigationType = hasDpadNavigation ? 'dpad' : 'default';
+  const navigationType = hasDpadNavigation ? 'dpad' : 'default';
+
+  const navigation =
+    getContext<NavigationContextData>(NAVIGATION_CONTEXT_KEY) ??
+      setContext<NavigationContextData>(
+        NAVIGATION_CONTEXT_KEY,
+        readable(navigationType),
+      );
 
   const redirect = () => {
     if (!page.url.searchParams.get(PARAM_NAME)) {
@@ -34,7 +46,16 @@ export function useNavigation(device: DeviceType) {
   };
 
   return {
-    controller: navigationControllers[navigationType],
+    controller: navigationControllers[get(navigation)],
     redirect,
+  };
+}
+
+export function useNavigation() {
+  return {
+    navigation: assertDefined<Readable<NavigationType>>(
+      getContext<NavigationContextData>(NAVIGATION_CONTEXT_KEY),
+      'Navigation can only be used within the NavigationProvider context.',
+    ),
   };
 }

--- a/projects/client/src/lib/features/theme/components/ThemePicker.svelte
+++ b/projects/client/src/lib/features/theme/components/ThemePicker.svelte
@@ -12,6 +12,7 @@
   import AutoMode from "./SystemMode.svelte";
 
   import * as m from "$lib/features/i18n/messages";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
 
   const { set, theme } = useTheme();
   const { track } = useTrack(AnalyticsEvent.Theme);
@@ -50,7 +51,10 @@
       <LightMode />
     {/if}
   </div>
-  <select onchange={(ev) => submitTheme(ev.currentTarget.value as Theme)}>
+  <select
+    onchange={(ev) => submitTheme(ev.currentTarget.value as Theme)}
+    data-dpad-navigation={DpadNavigationType.Item}
+  >
     {#each availableThemes as option}
       <option
         selected={$theme === option}
@@ -71,6 +75,10 @@
     width: var(--ni-48);
     height: var(--ni-48);
     border-radius: 50%;
+
+    &:has(select:focus-visible) {
+      outline: var(--border-thickness-xs) solid var(--purple-500);
+    }
 
     .theme-icon {
       width: calc(var(--ni-32) * 0.9);

--- a/projects/client/src/lib/guards/RenderFor.svelte
+++ b/projects/client/src/lib/guards/RenderFor.svelte
@@ -1,21 +1,29 @@
 <script lang="ts">
   import type { DeviceProps } from "./_internal/DeviceProps";
   import type { InputProps } from "./_internal/InputProps";
+  import type { NavigationProps } from "./_internal/NavigationProps";
   import RenderForAudience from "./_internal/RenderForAudience.svelte";
   import RenderForDevice from "./_internal/RenderForDevice.svelte";
   import RenderForInput from "./_internal/RenderForInput.svelte";
+  import RenderForNavigation from "./_internal/RenderForNavigation.svelte";
 
   type RenderForProps =
-    | (ChildrenProps & AudienceProps & DeviceProps & InputProps)
+    | (ChildrenProps &
+        AudienceProps &
+        DeviceProps &
+        InputProps &
+        NavigationProps)
     | (ChildrenProps &
         Partial<DeviceProps> &
         Partial<InputProps> &
+        Partial<NavigationProps> &
         AudienceProps);
 
-  const { children, audience, device, input }: RenderForProps = $props();
+  const { children, audience, device, input, navigation }: RenderForProps =
+    $props();
 </script>
 
-<RenderForAudience {audience}>
+{#snippet guardedContent()}
   {#if device && input}
     <RenderForDevice {device}>
       <RenderForInput {input}>
@@ -38,5 +46,15 @@
 
   {#if !device && !input}
     {@render children()}
+  {/if}
+{/snippet}
+
+<RenderForAudience {audience}>
+  {#if navigation}
+    <RenderForNavigation {navigation}>
+      {@render guardedContent()}
+    </RenderForNavigation>
+  {:else}
+    {@render guardedContent()}
   {/if}
 </RenderForAudience>

--- a/projects/client/src/lib/guards/_internal/NavigationProps.ts
+++ b/projects/client/src/lib/guards/_internal/NavigationProps.ts
@@ -1,0 +1,3 @@
+export type NavigationProps = {
+  navigation: 'all' | 'default' | 'dpad';
+};

--- a/projects/client/src/lib/guards/_internal/RenderForNavigation.svelte
+++ b/projects/client/src/lib/guards/_internal/RenderForNavigation.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { useNavigation } from "$lib/features/navigation/useNavigation";
+  import type { NavigationProps } from "./NavigationProps";
+
+  const { children, navigation }: ChildrenProps & NavigationProps = $props();
+
+  const { navigation: navigationContext } = useNavigation();
+
+  const isAvailableForNavigation = $derived(
+    navigation === "all" || navigation === $navigationContext,
+  );
+</script>
+
+{#if isAvailableForNavigation}
+  {@render children()}
+{/if}

--- a/projects/client/src/lib/sections/footer/components/FooterBar.svelte
+++ b/projects/client/src/lib/sections/footer/components/FooterBar.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
+
   const { children }: ChildrenProps = $props();
 </script>
 
-<div class="trakt-footer-bar">
+<div class="trakt-footer-bar" data-dpad-navigation={DpadNavigationType.List}>
   {@render children?.()}
 </div>
 

--- a/projects/client/src/lib/sections/footer/components/FooterContent.svelte
+++ b/projects/client/src/lib/sections/footer/components/FooterContent.svelte
@@ -43,7 +43,9 @@
       <ThemePicker />
     </div>
     <div class="trakt-footer-right">
-      <ExternalLinks />
+      <RenderFor audience="all" navigation="default">
+        <ExternalLinks />
+      </RenderFor>
     </div>
   </FooterBar>
 </div>

--- a/projects/client/src/lib/sections/footer/components/LogoutButton.svelte
+++ b/projects/client/src/lib/sections/footer/components/LogoutButton.svelte
@@ -2,6 +2,7 @@
   import Button from "$lib/components/buttons/Button.svelte";
   import { useAuth } from "$lib/features/auth/stores/useAuth";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
 
   const { size }: { size: "small" | "tag" } = $props();
 
@@ -15,6 +16,7 @@
   color="red"
   style="flat"
   variant="secondary"
+  navigationType={DpadNavigationType.Item}
 >
   {m.logout()}
 </Button>

--- a/projects/client/src/lib/sections/lists/progress/UpNextList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextList.svelte
@@ -2,6 +2,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
 
   import { useUser } from "$lib/features/auth/stores/useUser";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import { DEFAULT_PAGE_SIZE } from "$lib/utils/constants";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
@@ -37,7 +38,9 @@
   --height-list={mediaListHeightResolver("episode")}
 >
   {#snippet badge()}
-    <UpNextLabSwitch />
+    <RenderFor audience="authenticated" navigation="default">
+      <UpNextLabSwitch />
+    </RenderFor>
   {/snippet}
   {#snippet item(episode)}
     <EpisodeProgressItem

--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -76,13 +76,18 @@
       <RenderFor
         audience="authenticated"
         device={["tablet-sm", "tablet-lg", "desktop"]}
+        navigation="default"
       >
         {@render traktSwitch()}
       </RenderFor>
-      <RenderFor audience="authenticated">
+      <RenderFor audience="authenticated" navigation="default">
         <SearchInput />
       </RenderFor>
-      <RenderFor audience="authenticated" device={["mobile"]}>
+      <RenderFor
+        audience="authenticated"
+        device={["mobile"]}
+        navigation="default"
+      >
         {@render traktSwitch()}
       </RenderFor>
     </div>
@@ -142,7 +147,9 @@
         {#if !isVip}
           <GetVIPLink />
         {/if}
-        <FilterButton />
+        <RenderFor audience="authenticated" navigation="default">
+          <FilterButton />
+        </RenderFor>
         <ProfileButton />
       </RenderFor>
     </div>

--- a/projects/client/src/lib/sections/profile/Profile.svelte
+++ b/projects/client/src/lib/sections/profile/Profile.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import RecentlyWatchedList from "../lists/history/RecentlyWatchedList.svelte";
   import PersonalLists from "../lists/user/PersonalLists.svelte";
   import ProfilePageBanner from "../profile-banner/ProfilePageBanner.svelte";
@@ -23,7 +24,9 @@
   <ProfileAbout about={profile.about} />
 
   {#snippet contextualContent()}
-    <YearToDateLink isVip={profile.isVip} {slug} />
+    <RenderFor audience="all" navigation="default">
+      <YearToDateLink isVip={profile.isVip} {slug} />
+    </RenderFor>
   {/snippet}
 </ProfileContainer>
 

--- a/projects/client/src/lib/sections/summary/components/comments/Comments.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/Comments.svelte
@@ -3,6 +3,7 @@
   import Button from "$lib/components/buttons/Button.svelte";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import CommentCard from "$lib/sections/summary/components/comments/_internal/CommentCard.svelte";
   import { writable } from "svelte/store";
   import CommentsDialog from "./_internal/dialog/CommentsDialog.svelte";
@@ -28,38 +29,40 @@
   };
 </script>
 
-<SectionList
-  id={`comments-list-${media.slug}`}
-  items={$comments}
-  title={m.popular_comments()}
-  --height-list="var(--height-comments-list)"
->
-  {#snippet item(comment)}
-    <CommentCard {comment} {media} {onDrilldown} />
-  {/snippet}
+<RenderFor audience="all" navigation="default">
+  <SectionList
+    id={`comments-list-${media.slug}`}
+    items={$comments}
+    title={m.popular_comments()}
+    --height-list="var(--height-comments-list)"
+  >
+    {#snippet item(comment)}
+      <CommentCard {comment} {media} {onDrilldown} />
+    {/snippet}
 
-  {#snippet empty()}
-    {#if !$isLoading}
-      <p class="small">{m.no_comments()}</p>
-    {/if}
-  {/snippet}
+    {#snippet empty()}
+      {#if !$isLoading}
+        <p class="small">{m.no_comments()}</p>
+      {/if}
+    {/snippet}
 
-  {#snippet badge()}
-    <Preview />
-  {/snippet}
+    {#snippet badge()}
+      <Preview />
+    {/snippet}
 
-  {#snippet actions()}
-    <Button
-      label={m.view_all_comments()}
-      onclick={() => onDrilldown()}
-      style="flat"
-      variant="primary"
-      color="purple"
-      size="small"
-    >
-      {m.view_all()}
-    </Button>
-  {/snippet}
-</SectionList>
+    {#snippet actions()}
+      <Button
+        label={m.view_all_comments()}
+        onclick={() => onDrilldown()}
+        style="flat"
+        variant="primary"
+        color="purple"
+        size="small"
+      >
+        {m.view_all()}
+      </Button>
+    {/snippet}
+  </SectionList>
 
-<CommentsDialog source={$drilldownSource} {dialog} {media} {...props} />
+  <CommentsDialog source={$drilldownSource} {dialog} {media} {...props} />
+</RenderFor>

--- a/projects/client/src/lib/sections/summary/components/details/MediaDetails.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/details/MediaDetails.spec.ts
@@ -8,7 +8,8 @@ import { MovieHereticStudiosMappedMock } from '$mocks/data/summary/movies/hereti
 import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
 import { ShowSiloPeopleMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts';
 import { ShowSiloStudiosMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloStudiosMappedMock.ts';
-import { render, screen } from '@testing-library/svelte';
+import { renderComponent } from '$test/beds/component/renderComponent.ts';
+import { screen } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
 import MediaDetails from './MediaDetails.svelte';
 import type { MediaDetailsProps } from './MediaDetailsProps.ts';
@@ -16,7 +17,7 @@ import type { MediaDetailsProps } from './MediaDetailsProps.ts';
 describe('MediaDetails', () => {
   const mediaTests = (props: MediaDetailsProps & { type: MediaType }) => {
     it('should display the media details sections', () => {
-      render(
+      renderComponent(
         MediaDetails,
         { props },
       );
@@ -42,7 +43,7 @@ describe('MediaDetails', () => {
       const nextYear = new Date();
       nextYear.setFullYear(nextYear.getFullYear() + 1);
 
-      render(
+      renderComponent(
         MediaDetails,
         {
           props: {
@@ -60,7 +61,7 @@ describe('MediaDetails', () => {
     });
 
     it('should show the status if there is no known year for an item', () => {
-      render(
+      renderComponent(
         MediaDetails,
         {
           props: {
@@ -82,7 +83,7 @@ describe('MediaDetails', () => {
     });
 
     it('should hide undefined values', () => {
-      render(
+      renderComponent(
         MediaDetails,
         {
           props: {
@@ -100,7 +101,7 @@ describe('MediaDetails', () => {
     });
 
     it('should not show the original title if it is equal to the title', () => {
-      render(
+      renderComponent(
         MediaDetails,
         {
           props: {
@@ -118,7 +119,7 @@ describe('MediaDetails', () => {
     });
 
     it('should show the original title if it differs from the title', () => {
-      render(
+      renderComponent(
         MediaDetails,
         {
           props: {
@@ -147,7 +148,7 @@ describe('MediaDetails', () => {
     mediaTests(defaultProps);
 
     it('should display the director instead of creator', () => {
-      render(
+      renderComponent(
         MediaDetails,
         { props: defaultProps },
       );
@@ -171,7 +172,7 @@ describe('MediaDetails', () => {
     mediaTests(defaultProps);
 
     it('should display the creator instead of director', () => {
-      render(
+      renderComponent(
         MediaDetails,
         {
           props: defaultProps,
@@ -194,7 +195,7 @@ describe('MediaDetails', () => {
     };
 
     it('should display the episode details', () => {
-      render(
+      renderComponent(
         MediaDetails,
         {
           props: defaultProps,
@@ -216,7 +217,7 @@ describe('MediaDetails', () => {
       const nextYear = new Date();
       nextYear.setFullYear(nextYear.getFullYear() + 1);
 
-      render(
+      renderComponent(
         MediaDetails,
         {
           props: {

--- a/projects/client/src/lib/sections/summary/components/details/_internal/CollapsableValues.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/CollapsableValues.svelte
@@ -3,6 +3,7 @@
 
   import MoreButton from "$lib/components/buttons/more/MoreButton.svelte";
   import { MoreButtonIntlProvider } from "$lib/components/buttons/more/MoreButtonIntlProvider";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { Snippet } from "svelte";
   import { writable } from "svelte/store";
 
@@ -33,13 +34,15 @@
         {@render value(v)}
 
         {#if omittedValues.length > 0 && index === MAX_ITEMS - 1}
-          <MoreButton
-            i18n={MoreButtonIntlProvider}
-            label="{m.expand_category({ category })}}"
-            count={omittedValues.length}
-            onExpand={() => expanded.set(true)}
-            onCollapse={() => expanded.set(false)}
-          />
+          <RenderFor audience="all" navigation="default">
+            <MoreButton
+              i18n={MoreButtonIntlProvider}
+              label="{m.expand_category({ category })}}"
+              count={omittedValues.length}
+              onExpand={() => expanded.set(true)}
+              onCollapse={() => expanded.set(false)}
+            />
+          </RenderFor>
         {/if}
       </div>
     {/each}

--- a/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
+++ b/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
@@ -29,7 +29,11 @@
   const topList = $derived(lists.at(0));
 </script>
 
-<RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>
+<RenderFor
+  audience="all"
+  device={["tablet-sm", "tablet-lg", "desktop"]}
+  navigation="default"
+>
   <SectionList
     id={`popular-lists-list-${slug}`}
     items={lists}
@@ -56,7 +60,7 @@
   </SectionList>
 </RenderFor>
 
-<RenderFor audience="all" device={["mobile"]}>
+<RenderFor audience="all" device={["mobile"]} navigation="default">
   {#if topList}
     <UserList list={topList} {type} />
   {/if}

--- a/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
@@ -69,14 +69,22 @@
   </div>
   <div class="trakt-summary-watch-container">
     {#if streamOn?.preferred}
-      <RenderFor device={["tablet-lg", "desktop"]} audience="all">
+      <RenderFor
+        device={["tablet-lg", "desktop"]}
+        audience="all"
+        navigation="default"
+      >
         <StreamingServiceButton
           mediaTitle={media.title}
           service={streamOn.preferred}
           style="normal"
         />
       </RenderFor>
-      <RenderFor device={["tablet-sm", "mobile"]} audience="all">
+      <RenderFor
+        device={["tablet-sm", "mobile"]}
+        audience="all"
+        navigation="default"
+      >
         <StreamingServiceButton
           mediaTitle={media.title}
           service={streamOn.preferred}

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -3,6 +3,7 @@
 
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
   import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
+  import StreamingServiceButton from "$lib/components/buttons/streaming-service/StreamingServiceButton.svelte";
   import GenreList from "$lib/components/summary/GenreList.svelte";
   import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
@@ -80,11 +81,23 @@
 </script>
 
 {#snippet mediaActions()}
-  {#if $lists.length === 0}
-    <WatchlistAction {...watchlistProps} />
-  {:else}
-    <ListDropdown {...listProps} />
-  {/if}
+  <RenderFor audience="authenticated" navigation="default">
+    {#if $lists.length === 0}
+      <WatchlistAction {...watchlistProps} />
+    {:else}
+      <ListDropdown {...listProps} />
+    {/if}
+  </RenderFor>
+  <RenderFor audience="authenticated" navigation="dpad">
+    {#if streamOn?.preferred}
+      <StreamingServiceButton
+        mediaTitle={media.title}
+        service={streamOn.preferred}
+        style="normal"
+        size="normal"
+      />
+    {/if}
+  </RenderFor>
   <MarkAsWatchedAction {...markAsWatchedProps} />
 {/snippet}
 
@@ -167,9 +180,11 @@
   <MediaDetails {media} {studios} {crew} {type} />
 
   {#if streamOn}
-    <MediaStreamingServices
-      services={streamOn.services}
-      preferred={streamOn.preferred}
-    />
+    <RenderFor audience="authenticated" navigation="default">
+      <MediaStreamingServices
+        services={streamOn.services}
+        preferred={streamOn.preferred}
+      />
+    </RenderFor>
   {/if}
 </SummaryContainer>

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import type { Snippet } from "svelte";
 
   type SummaryContainerProps = {
@@ -16,10 +15,7 @@
   }: SummaryContainerProps = $props();
 </script>
 
-<div
-  class="trakt-summary-container"
-  data-dpad-navigation={DpadNavigationType.List}
->
+<div class="trakt-summary-container">
   {#if poster}
     <div class="trakt-summary-poster">
       {@render poster()}

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { Snippet } from "svelte";
 
   const {
@@ -9,9 +10,11 @@
 
 <div class="trakt-summary-header">
   {#if headerActions}
-    <div class="trakt-summary-action-header">
-      {@render headerActions()}
-    </div>
+    <RenderFor audience="all" navigation="default">
+      <div class="trakt-summary-action-header">
+        {@render headerActions()}
+      </div>
+    </RenderFor>
   {/if}
   <div class="trakt-summary-header-children">
     {@render children()}

--- a/projects/client/test/beds/_internal/TestProvider.svelte
+++ b/projects/client/test/beds/_internal/TestProvider.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import AnalyticsProvider from "$lib/features/analytics/AnalyticsProvider.svelte";
   import AuthProvider from "$lib/features/auth/components/AuthProvider.svelte";
+  import NavigationProvider from "$lib/features/navigation/NavigationProvider.svelte";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
   import type { Snippet } from "svelte";
   import { isAuthorized } from "./isAuthorized.ts";
@@ -11,8 +12,10 @@
 <!-- TODO: add more providers here as we expand test suite -->
 <AuthProvider isAuthorized={$isAuthorized} url="http://localhost:3000">
   <QueryClientProvider client={new QueryClient()}>
-    <AnalyticsProvider>
-      {@render children()}
-    </AnalyticsProvider>
+    <NavigationProvider device="unknown">
+      <AnalyticsProvider>
+        {@render children()}
+      </AnalyticsProvider>
+    </NavigationProvider>
   </QueryClientProvider>
 </AuthProvider>

--- a/projects/client/test/beds/component/ComponentTestBed.svelte
+++ b/projects/client/test/beds/component/ComponentTestBed.svelte
@@ -1,0 +1,9 @@
+<script>
+  import TestProvider from "../_internal/TestProvider.svelte";
+
+  const input = $props();
+</script>
+
+<TestProvider>
+  <input.component {...input.props} />
+</TestProvider>

--- a/projects/client/test/beds/component/renderComponent.ts
+++ b/projects/client/test/beds/component/renderComponent.ts
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/svelte';
+import type { Component } from 'svelte';
+import ComponentTestBed from './ComponentTestBed.svelte';
+
+type RenderComponentProps<T extends Record<string, unknown>> = {
+  props: T;
+};
+
+export function renderComponent<T extends Record<string, unknown>>(
+  component: Component<T>,
+  { props }: RenderComponentProps<T>,
+) {
+  return render(ComponentTestBed, {
+    props: { component, props },
+  });
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Pt.1 of some changes to improve d-pad navigation.
  - Unusable elements are hidden.
  - Placed the stream-on button below the poster when d-pad navigation is enabled.
  - Small tweak to focused cards to make it more clear that it is focused.
  - Footer action can now also be reached.

## 👀 Examples 👀

Before:
<img width="1348" alt="Screenshot 2025-04-22 at 08 47 20" src="https://github.com/user-attachments/assets/9fa65b4c-2be6-48f9-93f9-782c7b28c653" />

<img width="1348" alt="Screenshot 2025-04-22 at 08 48 33" src="https://github.com/user-attachments/assets/722e1f79-eb36-44b8-a3d5-1e04542cf30a" />

<img width="1348" alt="Screenshot 2025-04-22 at 08 48 37" src="https://github.com/user-attachments/assets/e77a8720-bcac-4d74-bd97-6d294dcc6bc6" />

After:
<img width="1349" alt="Screenshot 2025-04-22 at 08 53 15" src="https://github.com/user-attachments/assets/39b40fb1-5423-4833-8681-a50792c99626" />

<img width="1348" alt="Screenshot 2025-04-22 at 08 48 49" src="https://github.com/user-attachments/assets/3678c772-eb7a-402f-a228-e65260010540" />

<img width="1348" alt="Screenshot 2025-04-22 at 08 49 56" src="https://github.com/user-attachments/assets/77acb733-5a44-4946-ae25-869787f1ddbf" />

<img width="169" alt="Screenshot 2025-04-22 at 08 50 16" src="https://github.com/user-attachments/assets/55c34542-5a42-4ac5-99a1-8ea66d4a4810" />

<img width="178" alt="Screenshot 2025-04-22 at 08 50 27" src="https://github.com/user-attachments/assets/9a7d588c-c384-49b9-b1af-c1a7360eba63" />

