### PR TITLE
refactor / cleanup card restyling aftermath

### DIFF
--- a/projects/client/src/lib/components/card/CardCover.svelte
+++ b/projects/client/src/lib/components/card/CardCover.svelte
@@ -8,8 +8,8 @@
   const {
     src,
     alt,
-    badges,
-    tags,
+    badge,
+    tag,
     isLoading,
     title,
     style = "gradient",
@@ -32,14 +32,14 @@
   class:trakt-card-cover-loading={isImagePending || isLoading}
   class:trakt-card-cover-placeholder={PLACEHOLDERS.includes(src)}
 >
-  {#if badges}
-    <div class="trakt-card-cover-badges">
-      {@render badges()}
+  {#if badge}
+    <div class="trakt-card-cover-badge">
+      {@render badge()}
     </div>
   {/if}
-  {#if tags}
-    <div class="trakt-card-cover-tags">
-      {@render tags()}
+  {#if tag}
+    <div class="trakt-card-cover-tag">
+      {@render tag()}
     </div>
   {/if}
   <div class="trakt-card-cover-image" class:has-gradient={style === "gradient"}>
@@ -70,8 +70,8 @@
       }
     }
 
-    .trakt-card-cover-badges,
-    .trakt-card-cover-tags {
+    .trakt-card-cover-badge,
+    .trakt-card-cover-tag {
       z-index: var(--layer-raised);
 
       position: absolute;
@@ -84,12 +84,12 @@
       box-sizing: border-box;
     }
 
-    .trakt-card-cover-badges {
+    .trakt-card-cover-badge {
       top: 0;
       left: 0;
     }
 
-    .trakt-card-cover-tags {
+    .trakt-card-cover-tag {
       bottom: 0;
       left: 0;
 

--- a/projects/client/src/lib/components/card/CardCoverProps.ts
+++ b/projects/client/src/lib/components/card/CardCoverProps.ts
@@ -4,8 +4,8 @@ export type CardCoverProps = {
   src: string;
   alt: string;
   title: string;
-  badges?: Snippet;
-  tags?: Snippet;
+  badge?: Snippet;
+  tag?: Snippet;
   isLoading?: boolean;
   style?: 'flat' | 'gradient';
 };

--- a/projects/client/src/lib/sections/landing/components/TrendingItems.svelte
+++ b/projects/client/src/lib/sections/landing/components/TrendingItems.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import MediaCard from "$lib/sections/lists/components/MediaCard.svelte";
+  import DefaultMediaItem from "$lib/sections/lists/components/DefaultMediaItem.svelte";
   import { useTrendingItems } from "../useTrendingItems";
   import Phones from "./Phones.svelte";
 
@@ -9,7 +9,7 @@
 <div class="trakt-landing-preview">
   <div class="trakt-landing-media-wrapper">
     {#each $shows as show}
-      <MediaCard type="show" media={show} />
+      <DefaultMediaItem type="show" media={show} />
     {/each}
   </div>
   <div class="trakt-landing-phones">
@@ -17,10 +17,10 @@
   </div>
   <div class="trakt-landing-media-wrapper">
     {#if $show}
-      <MediaCard type="show" media={$show} />
+      <DefaultMediaItem type="show" media={$show} />
     {/if}
     {#if $movie}
-      <MediaCard type="movie" media={$movie} />
+      <DefaultMediaItem type="movie" media={$movie} />
     {/if}
   </div>
 </div>

--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import AnticipatedTag from "$lib/components/media/tags/AnticipatedTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
-  import MediaCard from "../components/MediaCard.svelte";
+  import DefaultMediaItem from "../components/DefaultMediaItem.svelte";
   import type { MediaCardProps } from "../components/MediaCardProps";
   import type { AnticipatedEntry } from "./useAnticipatedList";
 
@@ -12,4 +12,4 @@
   <AnticipatedTag i18n={TagIntlProvider} score={media.score} />
 {/snippet}
 
-<MediaCard {type} {media} {tag} {style} />
+<DefaultMediaItem {type} {media} {tag} {style} />

--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
@@ -8,8 +8,8 @@
   const { type, media, style }: MediaCardProps<AnticipatedEntry> = $props();
 </script>
 
-{#snippet tags()}
+{#snippet tag()}
   <AnticipatedTag i18n={TagIntlProvider} score={media.score} />
 {/snippet}
 
-<MediaCard {type} {media} {tags} {style} />
+<MediaCard {type} {media} {tag} {style} />

--- a/projects/client/src/lib/sections/lists/components/ActivityCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/ActivityCard.svelte
@@ -8,16 +8,12 @@
   type SocialActivityCardProps = {
     activity: SocialActivity | HistoryEntry;
     activityAt: Date;
-    badges?: Snippet;
+    badge?: Snippet;
     popupActions?: Snippet;
   };
 
-  const {
-    activity,
-    activityAt,
-    badges,
-    popupActions,
-  }: SocialActivityCardProps = $props();
+  const { activity, activityAt, badge, popupActions }: SocialActivityCardProps =
+    $props();
 </script>
 
 {#if activity.type === "episode"}
@@ -26,7 +22,7 @@
     show={activity.show}
     variant="activity"
     date={activityAt}
-    {badges}
+    {badge}
     {popupActions}
   />
 {/if}
@@ -37,7 +33,7 @@
     type="movie"
     variant="activity"
     date={activityAt}
-    {badges}
+    {badge}
     {popupActions}
   />
 {/if}

--- a/projects/client/src/lib/sections/lists/components/ActivitySummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/ActivitySummaryCard.svelte
@@ -7,21 +7,17 @@
   type SocialActivityItemProps = {
     activity: SocialActivity | HistoryEntry;
     activityAt: Date;
-    badges?: Snippet;
+    badge?: Snippet;
     popupActions?: Snippet;
   };
 
-  const {
-    activity,
-    activityAt,
-    badges,
-    popupActions,
-  }: SocialActivityItemProps = $props();
+  const { activity, activityAt, badge, popupActions }: SocialActivityItemProps =
+    $props();
 </script>
 
 {#if activity.type === "episode"}
   <MediaSummaryCard
-    {badges}
+    {badge}
     {popupActions}
     date={activityAt}
     episode={activity.episode}
@@ -39,7 +35,7 @@
 {#if activity.type === "movie"}
   <MediaSummaryCard
     {popupActions}
-    {badges}
+    {badge}
     date={activityAt}
     media={activity.movie}
     type="movie"

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -16,7 +16,7 @@
   }: MediaCardProps<MediaInputDefault> = $props();
 </script>
 
-{#snippet tags()}
+{#snippet tag()}
   {#if media.airDate > new Date()}
     <AirDateTag
       i18n={TagIntlProvider}
@@ -30,4 +30,4 @@
   {/if}
 {/snippet}
 
-<MediaCard {type} {media} {style} {tags} {...rest} />
+<MediaCard {type} {media} {style} {tag} {...rest} />

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -3,7 +3,10 @@
   import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
   import EpisodeCountTag from "$lib/components/media/tags/EpisodeCountTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaInputDefault } from "$lib/models/MediaInput";
+  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
+  import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import MediaCard from "../components/MediaCard.svelte";
   import type { MediaCardProps } from "../components/MediaCardProps";
 
@@ -30,4 +33,25 @@
   {/if}
 {/snippet}
 
-<MediaCard {type} {media} {style} {tag} {...rest} />
+{#snippet popupActions()}
+  {#if rest.popupActions}
+    {@render rest.popupActions()}
+  {:else}
+    <RenderFor audience="authenticated">
+      <WatchlistAction
+        style="dropdown-item"
+        title={media.title}
+        type={media.type}
+        {media}
+      />
+      <MarkAsWatchedAction
+        style="dropdown-item"
+        title={media.title}
+        type={media.type}
+        {media}
+      />
+    </RenderFor>
+  {/if}
+{/snippet}
+
+<MediaCard {type} {media} {style} {tag} {...rest} {popupActions} />

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -29,7 +29,7 @@
   {/if}
 {/snippet}
 
-{#snippet tags()}
+{#snippet tag()}
   {#if props.variant === "next"}
     <ShowProgressTag
       total={props.episode.total}
@@ -55,7 +55,7 @@
         },
       }}
       popupActions={props.popupActions}
-      {tags}
+      {tag}
       {action}
       type="episode"
       variant="thumb"
@@ -64,7 +64,7 @@
   {/if}
 
   {#if style === "cover"}
-    <EpisodeItemCard {...props} {tags} {action} />
+    <EpisodeItemCard {...props} {tag} {action} />
   {/if}
 {/snippet}
 

--- a/projects/client/src/lib/sections/lists/components/EpisodeCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCardProps.ts
@@ -14,9 +14,9 @@ export type EpisodeItemVariant =
   | { variant: 'activity'; episode: EpisodeEntry; date: Date };
 
 export type EpisodeCardProps = EpisodeItemVariant & {
-  badges?: Snippet;
+  badge?: Snippet;
   action?: Snippet;
-  tags?: Snippet;
+  tag?: Snippet;
   show: MediaInputDefault;
   style?: 'cover' | 'summary';
   popupActions?: Snippet;

--- a/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
@@ -20,9 +20,9 @@
 
   const {
     popupActions,
-    badges,
+    badge,
     action,
-    tags,
+    tag,
     episode,
     show,
     ...rest
@@ -70,8 +70,8 @@
       title={episode.title}
       src={$src ?? EPISODE_COVER_PLACEHOLDER}
       alt={`${show.title} - ${episode.title}`}
-      {badges}
-      {tags}
+      {badge}
+      {tag}
     />
   </Link>
 

--- a/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
@@ -36,16 +36,16 @@
   const isActivity = $derived(rest.variant === "activity");
 </script>
 
-{#snippet nonActivityTag()}
-  {#if rest.variant === "upcoming"}
-    <AirDateTag
-      i18n={TagIntlProvider}
-      airDate={episode.airDate}
-      year={episode.year}
-    />
-  {:else}
-    <DurationTag i18n={TagIntlProvider} runtime={episode.runtime} />
-  {/if}
+{#snippet upcomingTag()}
+  <AirDateTag
+    i18n={TagIntlProvider}
+    airDate={episode.airDate}
+    year={episode.year}
+  />
+{/snippet}
+
+{#snippet durationTag()}
+  <DurationTag i18n={TagIntlProvider} runtime={episode.runtime} />
 {/snippet}
 
 <LandscapeCard>
@@ -75,7 +75,20 @@
     />
   </Link>
 
-  <CardFooter {action} tag={isActivity ? undefined : nonActivityTag}>
+  <CardFooter
+    {action}
+    tag={(() => {
+      if (isActivity) {
+        return;
+      }
+
+      if (rest.variant === "upcoming") {
+        return upcomingTag;
+      }
+
+      return durationTag;
+    })()}
+  >
     {#if isShowContext}
       <p class="trakt-card-title ellipsis">
         <Spoiler media={episode} {show} {episode} type="episode">

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-  import RenderFor from "$lib/guards/RenderFor.svelte";
-  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
-  import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import type { MediaCardProps } from "./MediaCardProps";
   import MediaItemCard from "./MediaItemCard.svelte";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
@@ -10,33 +7,12 @@
   const style = $derived(props.style ?? "cover");
 </script>
 
-{#snippet popupActions()}
-  {#if props.popupActions}
-    {@render props.popupActions()}
-  {:else}
-    <RenderFor audience="authenticated">
-      <WatchlistAction
-        style="dropdown-item"
-        title={props.media.title}
-        type={props.media.type}
-        media={props.media}
-      />
-      <MarkAsWatchedAction
-        style="dropdown-item"
-        title={props.media.title}
-        type={props.media.type}
-        media={props.media}
-      />
-    </RenderFor>
-  {/if}
-{/snippet}
-
 {#if style === "cover"}
   <MediaItemCard
     {...props}
     {style}
     action={props.action}
-    popupActions={props.badge ? undefined : popupActions}
+    popupActions={props.badge ? undefined : props.popupActions}
   />
 {/if}
 
@@ -45,6 +21,6 @@
     {...props}
     {style}
     action={props.action}
-    popupActions={props.badge ? undefined : popupActions}
+    popupActions={props.badge ? undefined : props.popupActions}
   />
 {/if}

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -36,7 +36,7 @@
     {...props}
     {style}
     action={props.action}
-    popupActions={props.badges ? undefined : popupActions}
+    popupActions={props.badge ? undefined : popupActions}
   />
 {/if}
 
@@ -45,6 +45,6 @@
     {...props}
     {style}
     action={props.action}
-    popupActions={props.badges ? undefined : popupActions}
+    popupActions={props.badge ? undefined : popupActions}
   />
 {/if}

--- a/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
@@ -13,8 +13,8 @@ export type MediaItemVariant<T> =
   | { variant: 'activity'; date: Date } & MediaInput<T>;
 
 type BaseItemProps<T> = MediaItemVariant<T> & {
-  badges?: Snippet;
-  tags?: Snippet;
+  badge?: Snippet;
+  tag?: Snippet;
   action?: Snippet;
   popupActions?: Snippet;
   style?: 'cover' | 'summary';

--- a/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
@@ -17,8 +17,8 @@
   const {
     type,
     media,
-    badges,
-    tags,
+    badge,
+    tag,
     action,
     popupActions,
     ...rest
@@ -49,11 +49,11 @@
       title={media.title}
       src={mediaCoverImageUrl}
       alt={m.media_poster({ title: media.title })}
-      {badges}
+      {badge}
     />
   </Link>
 
-  <CardFooter {action} tag={tags}>
+  <CardFooter {action} {tag}>
     {#if rest.variant === "activity"}
       <Link href={UrlBuilder.media(type, media.slug)}>
         <p

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -16,9 +16,9 @@
   import type { EpisodeCardProps, MediaCardProps } from "./MediaCardProps";
 
   const {
-    tags,
+    tag,
     action,
-    badges,
+    badge,
     popupActions,
     media,
     ...rest
@@ -28,8 +28,8 @@
 {#snippet footerTag()}
   {#if rest.type === "episode" && rest.variant !== "activity"}
     <DurationTag i18n={TagIntlProvider} runtime={rest.episode.runtime} />
-  {:else if tags != null}
-    {@render tags()}
+  {:else if tag != null}
+    {@render tag()}
   {/if}
 {/snippet}
 
@@ -54,8 +54,8 @@
   <Link href={UrlBuilder.media(media.type, media.slug)} color="inherit">
     {#if rest.type === "episode"}
       <CardCover
-        {badges}
-        {tags}
+        {badge}
+        {tag}
         title={rest.episode.title}
         alt={rest.episode.title}
         src={rest.episode.cover.url ?? EPISODE_COVER_PLACEHOLDER}
@@ -64,7 +64,7 @@
 
     {#if rest.type === "movie"}
       <CardCover
-        {badges}
+        {badge}
         title={media.title}
         alt={media.title}
         src={media.thumb.url}
@@ -73,7 +73,7 @@
 
     {#if rest.type === "show"}
       <CardCover
-        {badges}
+        {badge}
         title={media.title}
         alt={media.title}
         src={media.cover.url.thumb}

--- a/projects/client/src/lib/sections/lists/social/SocialActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/social/SocialActivityItem.svelte
@@ -13,7 +13,7 @@
   const { activity, style = "cover" }: SocialActivityItemProps = $props();
 </script>
 
-{#snippet badges()}
+{#snippet badge()}
   <div class="user-profile-badge">
     <UserProfileLink user={activity.user} />
     <UserAvatar user={activity.user} size="small" />
@@ -21,11 +21,11 @@
 {/snippet}
 
 {#if style === "cover"}
-  <ActivityCard {activity} activityAt={activity.activityAt} {badges} />
+  <ActivityCard {activity} activityAt={activity.activityAt} {badge} />
 {/if}
 
 {#if style === "summary"}
-  <ActivitySummaryCard {activity} activityAt={activity.activityAt} {badges} />
+  <ActivitySummaryCard {activity} activityAt={activity.activityAt} {badge} />
 {/if}
 
 <style>

--- a/projects/client/src/lib/sections/lists/streaming/StreamingListItem.svelte
+++ b/projects/client/src/lib/sections/lists/streaming/StreamingListItem.svelte
@@ -8,8 +8,8 @@
   const { type, media, style }: MediaCardProps<StreamingEntry> = $props();
 </script>
 
-{#snippet tags()}
+{#snippet tag()}
   <TrendTag i18n={TagIntlProvider} delta={media.delta} />
 {/snippet}
 
-<MediaCard {type} {media} {tags} {style} />
+<MediaCard {type} {media} {tag} {style} />

--- a/projects/client/src/lib/sections/lists/streaming/StreamingListItem.svelte
+++ b/projects/client/src/lib/sections/lists/streaming/StreamingListItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import TrendTag from "$lib/components/media/tags/TrendTag.svelte";
-  import MediaCard from "../components/MediaCard.svelte";
+  import DefaultMediaItem from "../components/DefaultMediaItem.svelte";
   import type { MediaCardProps } from "../components/MediaCardProps";
   import type { StreamingEntry } from "./useStreamingList";
 
@@ -12,4 +12,4 @@
   <TrendTag i18n={TagIntlProvider} delta={media.delta} />
 {/snippet}
 
-<MediaCard {type} {media} {tag} {style} />
+<DefaultMediaItem {type} {media} {tag} {style} />

--- a/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
@@ -8,8 +8,8 @@
   const { type, media, style }: MediaCardProps<TrendingEntry> = $props();
 </script>
 
-{#snippet tags()}
+{#snippet tag()}
   <WatchersTag i18n={TagIntlProvider} watchers={media.watchers} />
 {/snippet}
 
-<MediaCard {type} {media} {tags} {style} />
+<MediaCard {type} {media} {tag} {style} />

--- a/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import WatchersTag from "$lib/components/media/tags/WatchersTag.svelte";
-  import MediaCard from "../components/MediaCard.svelte";
+  import DefaultMediaItem from "../components/DefaultMediaItem.svelte";
   import type { MediaCardProps } from "../components/MediaCardProps";
   import type { TrendingEntry } from "./useTrendingList";
 
@@ -12,4 +12,4 @@
   <WatchersTag i18n={TagIntlProvider} watchers={media.watchers} />
 {/snippet}
 
-<MediaCard {type} {media} {tag} {style} />
+<DefaultMediaItem {type} {media} {tag} {style} />

--- a/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
+++ b/projects/client/src/lib/sections/navbar/components/search/SearchInput.svelte
@@ -64,7 +64,7 @@
     <div class="trakt-search-results" use:clearOnClick>
       {#each $results as result}
         <MediaSummaryCard media={result} type={result.type}>
-          {#snippet tags()}
+          {#snippet tag()}
             <InfoTag>
               {result.type}
             </InfoTag>


### PR DESCRIPTION
##   Property Standardization and Component Streamlining

This pull request undertakes a significant act of purification, standardizing property names across various components. The many `badges` and `tags` are now unified under the singular banners of `badge` and `tag`. A linguistic cleansing, ensuring that the very vocabulary of these components speaks a consistent truth.

###   Property Unification:

* The pluralistic reigns of `badges` and `tags` have ended in `CardCoverProps` and `MediaCardProps`. Long live the singular `badge` and `tag`, ensuring a harmonious nomenclature across the digital landscape of components.
* Across `CardCover.svelte`, the many instances of `badges` and `tags` have been meticulously replaced with their singular counterparts. Markup, styles, conditional rendering – all now sing the same, unified tune.
* This linguistic reformation extends to other key components: `ActivityCard.svelte`, `EpisodeCard.svelte`, and `MediaSummaryCard.svelte` now march to the beat of `badge` and `tag`.

###   Component Simplification:

* The `MediaCard`, once burdened with the logic of default popup actions like "Mark as Watched" and "Add to Watchlist," has shed this weight. This responsibility now rests with the `DefaultMediaItem`, a consolidation of behavior, a streamlining of purpose.
* In the wake of this simplification, `MediaCard` has been replaced by the more focused `DefaultMediaItem` in various corners of the application, such as `TrendingItems.svelte` and `AnticipatedListItem.svelte`.

###   Tag Rendering Precision:

* Within `EpisodeItemCard.svelte`, the rendering of episode-specific tags has gained a new level of flexibility with the introduction of snippet tags: `upcomingTag` and `durationTag`. The previous hardcoded approach has been relegated to the archives.

(This refactor is akin to a detective meticulously organizing their case files. Every piece of information, every property name, now has its rightful place, clear and consistent. The simplification of `MediaCard` and the enhanced tag rendering in `EpisodeItemCard` further contribute to a more efficient and understandable codebase. It’s about bringing order to the digital precinct, ensuring that every component speaks the same language and serves its purpose with clarity.)