### PR TITLE
feat(recommended): expose watch_window param to play around

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "npm:@cucumber/cucumber@^11.2.0": "11.2.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.0.2_@cucumber+messages@27.0.2",
     "npm:@google/generative-ai@0.24": "0.24.0",
     "npm:@inlang/paraglide-sveltekit@~0.16.1": "0.16.1_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
-    "npm:@jsr/trakt__api@~0.1.20": "0.1.20_zod@3.24.1",
+    "npm:@jsr/trakt__api@~0.1.21": "0.1.21_zod@3.24.1",
     "npm:@playwright/test@^1.51.1": "1.51.1",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.25.3__acorn@8.14.1",
     "npm:@sveltejs/adapter-auto@5": "5.0.0_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
@@ -2161,8 +2161,8 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.1.20_zod@3.24.1": {
-      "integrity": "sha512-z6mQKNSt6d5EQ83zEYyerXArsxbLEzDLSCqUuiYbezuuiRyHCbcBgFirZm/VulXCCnkBllCQxJGVUsROKFZWcA==",
+    "@jsr/trakt__api@0.1.21_zod@3.24.1": {
+      "integrity": "sha512-AgK4UKlMOhVW6mh7invWWJLecbY30Npjsi19QhpiHJuhXeuZ1P6leXvADiiFi/fphWtm9+ZWHZ8j8mTU46oynQ==",
       "dependencies": [
         "@ts-rest/core",
         "zod@3.24.1"
@@ -7001,7 +7001,7 @@
             "npm:@cucumber/cucumber@^11.2.0",
             "npm:@google/generative-ai@0.24",
             "npm:@inlang/paraglide-sveltekit@~0.16.1",
-            "npm:@jsr/trakt__api@~0.1.20",
+            "npm:@jsr/trakt__api@~0.1.21",
             "npm:@playwright/test@^1.51.1",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@sveltejs/adapter-auto@5",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -61,7 +61,7 @@
     "@tanstack/svelte-query": "^5.69.0",
     "@tanstack/svelte-query-devtools": "^5.69.0",
     "@tanstack/svelte-query-persist-client": "^5.69.0",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.1.20",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.1.21",
     "@ts-rest/core": "^3.52.1",
     "date-fns": "^4.1.0",
     "firebase": "^11.5.0",

--- a/projects/client/src/lib/requests/models/FilterParams.ts
+++ b/projects/client/src/lib/requests/models/FilterParams.ts
@@ -7,5 +7,6 @@ export type FilterParams = DeepPartial<{
     */
     genres: string;
     watch_window: number;
+    min_year: number;
   };
 }>;

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
@@ -38,7 +38,12 @@ export const recommendedMoviesQuery = defineQuery({
   ],
   dependencies: (
     params,
-  ) => [params.limit, params.filter?.genres, params.filter?.watch_window],
+  ) => [
+    params.limit,
+    params.filter?.genres,
+    params.filter?.watch_window,
+    params.filter?.min_year,
+  ],
   request: recommendedMoviesRequest,
   mapper: (response) => response.body.map(mapToMovieEntry),
   schema: RecommendedMovieSchema.array(),

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
@@ -42,7 +42,12 @@ export const recommendedShowsQuery = defineQuery({
   ],
   dependencies: (
     params,
-  ) => [params.limit, params.filter?.genres, params.filter?.watch_window],
+  ) => [
+    params.limit,
+    params.filter?.genres,
+    params.filter?.watch_window,
+    params.filter?.min_year,
+  ],
   request: recommendedShowsRequest,
   mapper: (response) =>
     response.body.map((show: RecommendedShowResponse[0]) => ({

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedList.svelte
@@ -4,6 +4,7 @@
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
+  import { extractMinYearParam } from "./extractMinYearParam";
   import { extractWatchWindowParam } from "./extractWatchWindowParam";
   import RecommendedListItem from "./RecommendedListItem.svelte";
   import { useRecommendedList } from "./useRecommendedList";
@@ -26,6 +27,7 @@
   filter={{
     ...$filterMap,
     ...extractWatchWindowParam(page.url.searchParams),
+    ...extractMinYearParam(page.url.searchParams),
   }}
   useList={useRecommendedList}
   urlBuilder={UrlBuilder.recommended}

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
@@ -4,6 +4,7 @@
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
+  import { extractMinYearParam } from "./extractMinYearParam";
   import { extractWatchWindowParam } from "./extractWatchWindowParam";
   import RecommendedListItem from "./RecommendedListItem.svelte";
   import { useRecommendedList } from "./useRecommendedList";
@@ -27,6 +28,7 @@
   filter={{
     ...$filterMap,
     ...extractWatchWindowParam(page.url.searchParams),
+    ...extractMinYearParam(page.url.searchParams),
   }}
   useList={useRecommendedList}
 >

--- a/projects/client/src/lib/sections/lists/recommended/extractMinYearParam.ts
+++ b/projects/client/src/lib/sections/lists/recommended/extractMinYearParam.ts
@@ -1,0 +1,10 @@
+import { RECOMMENDED_DEFAULT_MIN_YEAR } from '$lib/utils/constants.ts';
+
+export function extractMinYearParam(params: URLSearchParams) {
+  return {
+    min_year: parseInt(
+      params.get('min_year') ?? RECOMMENDED_DEFAULT_MIN_YEAR.toString(),
+      10,
+    ),
+  };
+}

--- a/projects/client/src/lib/utils/constants.ts
+++ b/projects/client/src/lib/utils/constants.ts
@@ -68,3 +68,4 @@ export const PAGE_UPPER_LIMIT = 3;
  * We expose it to tinker around and fine-tune the default value.
  */
 export const RECOMMENDED_DEFAULT_WATCH_WINDOW = 25;
+export const RECOMMENDED_DEFAULT_MIN_YEAR = 1990;

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -8,6 +8,7 @@ type TypeParams = {
 type WellKnownQueryParams = {
   page?: number;
   watch_window?: number;
+  min_year?: number;
 };
 
 type UrlBuilderParams = TypeParams & WellKnownQueryParams;
@@ -18,6 +19,7 @@ function sanitizeParams(
   return {
     page: params.page,
     watch_window: params.watch_window,
+    min_year: params.min_year,
   };
 }
 


### PR DESCRIPTION
##   Temporal Precision: Introducing the `min_year` Filter

This pull request grants us a finer degree of temporal control over the recommended content, introducing the `min_year` filter.

###   Refining the Temporal Lens:

* **Filter Parameter Expansion**: The `FilterParams` type now accommodates the `min_year`, allowing us to specify the dawn of an era for our recommendations. And the queries for `recommendedMoviesQuery` and `recommendedShowsQuery` now keenly observe this `min_year` parameter.
* **Navigating the Temporal Stream**: A new tool, `extractMinYearParam`, has been forged to pluck the `min_year` from the chaotic currents of URL search parameters, with a default set to the nostalgic year of 1990. The `UrlBuilder` now also recognizes and sanitizes this temporal marker.
* **A Foundation in Time**: A constant, `RECOMMENDED_DEFAULT_MIN_YEAR`, has been established, anchoring the default starting point for our temporal filtering.

###   Weaving Time into the Interface:

* **Dynamic Temporal Filtering**: Both `RecommendedList.svelte` and `RecommendedPaginatedList.svelte` now harness the `extractMinYearParam`, dynamically applying the `min_year` filter to the recommendations displayed.

###   Dependency Evolution:

* The `@trakt/api` dependency has been nudged forward, from version `^0.1.20` to `^0.1.21`. Keeping pace with the relentless march of progress.

(This update, like a detective meticulously cross-referencing dates in a complex case, adds a crucial layer of precision to our recommendation engine. The ability to filter by `min_year` allows for a more targeted exploration of media history, focusing our gaze on specific periods. It’s about more than just finding something to watch; it’s about finding something from a particular moment in time, a specific vintage of cinematic or televisual artistry.)