### PR TITLE
feat(rating): new rating icons

### DIFF
--- a/projects/client/src/lib/components/icons/RateIcon.svelte
+++ b/projects/client/src/lib/components/icons/RateIcon.svelte
@@ -10,27 +10,40 @@
   viewBox="0 0 24 24"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
+  class="trakt-rate-icon"
 >
   {#if rating === SimpleRating.Bad}
     <path
       d="M20 14.6568L20 7.46154C20 6.10207 18.8979 5 17.5385 5L9.75555 5C8.47336 5 7.28296 5.66519 6.61097 6.75718L5.53233 8.50996C4.54795 10.1096 4.21009 12.0242 4.58751 13.8641L5.02904 16.0165C5.14647 16.589 5.6503 17 6.2347 17L11.3846 17L10.6777 18.6083C10.0284 20.0855 10.5893 21.8148 11.9821 22.6295C12.3631 22.8524 12.8423 22.8157 13.1848 22.5373L18.1814 18.4776C19.332 17.5428 20 16.1392 20 14.6568Z"
-      fill="currentColor"
+      stroke="var(--icon-color)"
+      stroke-width="2"
+      fill="var(--icon-fill-color)"
     />
   {/if}
 
   {#if rating === SimpleRating.Good}
     <path
       d="M4 9.34324V16.5385C4 17.8979 5.10207 19 6.46154 19H14.2444C15.5266 19 16.717 18.3348 17.389 17.2428L18.4677 15.49C19.4521 13.8904 19.7899 11.9758 19.4125 10.1359L18.971 7.98345C18.8535 7.41097 18.3497 7 17.7653 7H12.6154L13.3223 5.39173C13.9716 3.91455 13.4107 2.18525 12.0179 1.37047C11.6369 1.14761 11.1577 1.18435 10.8152 1.46266L5.81862 5.52237C4.66805 6.45721 4 7.86076 4 9.34324Z"
-      fill="currentColor"
+      stroke="var(--icon-color)"
+      stroke-width="2"
+      fill="var(--icon-fill-color)"
     />
   {/if}
 
   {#if rating === SimpleRating.Great}
     <path
       d="M8 5C10 5 11 6.5 12 7.5C13 6.5 14 5 16 5C17.5 5 20 6 20 9C20 12.5 16 17 12 19C8 17 4 12.5 4 9C4 6 6.5 5 8 5Z"
-      fill="currentColor"
-      stroke="currentColor"
+      stroke="var(--icon-color)"
       stroke-width="2"
+      fill="var(--icon-fill-color)"
     />
   {/if}
 </svg>
+
+<style>
+  .trakt-rate-icon {
+    path {
+      transition: fill var(--transition-increment) ease-in-out;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/SentimentComment.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/SentimentComment.svelte
@@ -15,10 +15,12 @@
     {
       sentiments: comment.good,
       rating: SimpleRating.Good,
+      color: "var(--color-text-sentiment-good)",
     },
     {
       sentiments: comment.bad,
       rating: SimpleRating.Bad,
+      color: "var(--color-text-sentiment-bad)",
     },
   ];
 </script>
@@ -26,13 +28,9 @@
 <SentimentHeader {comment} />
 <ShadowScroller>
   <div class="trakt-sentiment-body">
-    {#each mappedSentiments as { rating, sentiments }}
-      <div
-        class="trakt-sentiment-container"
-        class:sentiment-good={rating === SimpleRating.Good}
-        class:sentiment-bad={rating === SimpleRating.Bad}
-      >
-        <RateIcon {rating} />
+    {#each mappedSentiments as { rating, sentiments, color }}
+      <div class="trakt-sentiment-container">
+        <RateIcon {rating} --icon-fill-color={color} />
         <ol>
           {#each sentiments as sentiment}
             <li><p class="small">{sentiment}</p></li>
@@ -65,13 +63,5 @@
   .trakt-sentiment-container {
     display: flex;
     gap: var(--gap-s);
-  }
-
-  .sentiment-good {
-    color: var(--color-text-sentiment-good);
-  }
-
-  .sentiment-bad {
-    color: var(--color-text-sentiment-bad);
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/UserRatingIcon.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/UserRatingIcon.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import RateIcon from "$lib/components/icons/RateIcon.svelte";
-  import type { SimpleRating } from "$lib/models/SimpleRating";
+  import { SimpleRating } from "$lib/models/SimpleRating";
+  import UserRating from "../../rating/UserRating.svelte";
 
   const { rating }: { rating: SimpleRating } = $props();
 </script>
 
 <div class="trakt-user-rating-icon">
-  <RateIcon {rating} />
+  <UserRating {rating} isCurrentRating={true} />
 </div>
 
 <style>

--- a/projects/client/src/lib/sections/summary/components/rating/UserRating.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/UserRating.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import RateIcon from "$lib/components/icons/RateIcon.svelte";
+  import { SimpleRating } from "$lib/models/SimpleRating";
+
+  const {
+    rating,
+    isCurrentRating,
+  }: { rating: SimpleRating; isCurrentRating: boolean } = $props();
+
+  const iconColor = $derived(
+    rating === SimpleRating.Great ? "var(--red-500)" : "var(--shade-10)",
+  );
+  const iconFillColor = $derived(isCurrentRating ? iconColor : "none");
+</script>
+
+<RateIcon {rating} --icon-color={iconColor} --icon-fill-color={iconFillColor} />

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RateActionButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RateActionButton.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
-  import RateIcon from "$lib/components/icons/RateIcon.svelte";
   import { SimpleRating } from "$lib/models/SimpleRating";
   import { toTranslatedValue } from "$lib/utils/formatting/string/toTranslatedValue";
+  import UserRating from "../UserRating.svelte";
 
   const {
     rating,
@@ -15,24 +15,36 @@
     isDisabled: boolean;
     onAddRating: (rating: SimpleRating) => void;
   } = $props();
-
-  const style = $derived(isCurrentRating ? "flat" : "ghost");
-  const variant = $derived(isCurrentRating ? "primary" : "secondary");
-
-  const colorMap: Record<SimpleRating, "red" | "default"> = {
-    [SimpleRating.Great]: "red",
-    [SimpleRating.Good]: "default",
-    [SimpleRating.Bad]: "default",
-  };
 </script>
 
-<ActionButton
-  disabled={isDisabled}
-  label={toTranslatedValue("rating", rating)}
-  onclick={() => onAddRating(rating)}
-  color={colorMap[rating]}
-  {style}
-  {variant}
->
-  <RateIcon {rating} />
-</ActionButton>
+<trakt-rate-button class:is-current-rating={isCurrentRating}>
+  <ActionButton
+    disabled={isDisabled}
+    label={toTranslatedValue("rating", rating)}
+    onclick={() => onAddRating(rating)}
+    style="flat"
+    variant="primary"
+  >
+    <UserRating {rating} {isCurrentRating} />
+  </ActionButton>
+</trakt-rate-button>
+
+<style>
+  trakt-rate-button {
+    --rating-active-color: var(--shade-400);
+
+    :global(.trakt-action-button) {
+      &:hover {
+        background-color: var(--rating-active-color);
+      }
+    }
+
+    &.is-current-rating {
+      :global(.trakt-action-button) {
+        background-color: var(--rating-active-color);
+        cursor: default;
+        pointer-events: none;
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
## ♪ Note ♪

- Switches to the new design for the rate buttons.

## 👀 Examples 👀
Before:
<img width="1093" alt="Screenshot 2025-04-23 at 10 28 36" src="https://github.com/user-attachments/assets/8bcbc435-5102-4ee1-bab0-26ccae5b3b4a" />

After:
<img width="1093" alt="Screenshot 2025-04-23 at 10 28 22" src="https://github.com/user-attachments/assets/dfbdbc0a-a425-4ba2-a3cf-bd0d108ad817" />
