### PR TITLE
fix(up-next): default to show runtime when episode runtime is null

### DIFF
--- a/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextQuery.ts
@@ -52,11 +52,13 @@ const upNextRequest = (params: UpNextParams) => {
 };
 
 export function mapUpNextResponse(item: UpNextResponse[0]): UpNextEntry {
-  const episode = item.progress.next_episode;
+  const show = mapToShowEntry(item.show);
+  const episode = mapToEpisodeEntry(item.progress.next_episode);
+  episode.runtime ??= show.runtime;
 
   return {
-    show: mapToShowEntry(item.show),
-    ...mapToEpisodeEntry(episode),
+    show,
+    ...episode,
     total: item.progress.aired,
     completed: item.progress.completed,
     remaining: item.progress.aired - item.progress.completed,


### PR DESCRIPTION
This pull request refines the `mapUpNextResponse` function in `upNextQuery.ts` to improve data mapping and ensure consistency between show and episode entries.

### Improvements to data mapping:
* [`projects/client/src/lib/requests/queries/sync/upNextQuery.ts`](diffhunk://#diff-5088ccb5d851e956dd8c3522301d26c981bd3c386957a9c63beb271837340973L55-R61): Updated `mapUpNextResponse` to use `mapToShowEntry` and `mapToEpisodeEntry` for clearer separation of concerns. Additionally, the `episode.runtime` is now set to the `show.runtime` if it is undefined, ensuring runtime consistency between the show and its episodes.