### PR TITLE
Feat/home button

### DIFF
--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import { TestId } from "$e2e/models/TestId";
   import Button from "$lib/components/buttons/Button.svelte";
-  import Link from "$lib/components/link/Link.svelte";
-  import Logo from "$lib/components/logo/Logo.svelte";
-  import LogoMark from "$lib/components/logo/LogoMark.svelte";
   import Switch from "$lib/components/toggles/Switch.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
@@ -19,6 +16,7 @@
   import FilterButton from "./components/filter/FilterButton.svelte";
   import GetVIPLink from "./components/GetVIPLink.svelte";
   import JoinTraktButton from "./components/JoinTraktButton.svelte";
+  import TraktLogo from "./components/TraktLogo.svelte";
   import ProfileButton from "./ProfileButton.svelte";
 
   let windowScrollY = $state(0);
@@ -56,21 +54,7 @@
     class:trakt-navbar-scroll={isScrolled}
     data-dpad-navigation={DpadNavigationType.List}
   >
-    <RenderFor
-      audience="authenticated"
-      device={["tablet-sm", "tablet-lg", "desktop"]}
-    >
-      <div class="trakt-logo">
-        <Link href={UrlBuilder.home()}>
-          <LogoMark />
-        </Link>
-      </div>
-    </RenderFor>
-    <RenderFor audience="public">
-      <div class="trakt-logo">
-        <Logo />
-      </div>
-    </RenderFor>
+    <TraktLogo />
 
     <div class="trakt-navbar-content">
       <RenderFor
@@ -249,17 +233,6 @@
       width: calc(100dvw - 2 * var(--layout-distance-side));
 
       @include navbar-spacing(var(--layout-distance-side));
-    }
-  }
-
-  .trakt-logo {
-    height: var(--ni-32);
-    display: flex;
-    justify-content: center;
-
-    :global(svg) {
-      /* Safari 🥲 */
-      height: var(--ni-32);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/navbar/components/TraktLogo.svelte
+++ b/projects/client/src/lib/sections/navbar/components/TraktLogo.svelte
@@ -2,6 +2,7 @@
   import Link from "$lib/components/link/Link.svelte";
   import Logo from "$lib/components/logo/Logo.svelte";
   import LogoMark from "$lib/components/logo/LogoMark.svelte";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 </script>
@@ -9,6 +10,7 @@
 <RenderFor
   audience="authenticated"
   device={["tablet-sm", "tablet-lg", "desktop"]}
+  navigation="default"
 >
   <div class="trakt-logo">
     <Link href={UrlBuilder.home()}>
@@ -16,6 +18,21 @@
     </Link>
   </div>
 </RenderFor>
+
+<RenderFor
+  audience="authenticated"
+  device={["tablet-sm", "tablet-lg", "desktop"]}
+  navigation="dpad"
+>
+  <button
+    class="trakt-logo-button"
+    data-dpad-navigation={DpadNavigationType.Item}
+    onclick={() => window.location.reload()}
+  >
+    <LogoMark />
+  </button>
+</RenderFor>
+
 <RenderFor audience="public">
   <div class="trakt-logo">
     <Logo />
@@ -23,7 +40,18 @@
 </RenderFor>
 
 <style>
-  .trakt-logo {
+  .trakt-logo-button {
+    all: unset;
+    border-radius: var(--border-radius-xs);
+
+    &:focus-visible {
+      outline: var(--border-thickness-xs) solid var(--purple-500);
+      outline-offset: var(--gap-xs);
+    }
+  }
+
+  .trakt-logo,
+  .trakt-logo-button {
     height: var(--ni-32);
     display: flex;
     justify-content: center;

--- a/projects/client/src/lib/sections/navbar/components/TraktLogo.svelte
+++ b/projects/client/src/lib/sections/navbar/components/TraktLogo.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
+  import Logo from "$lib/components/logo/Logo.svelte";
+  import LogoMark from "$lib/components/logo/LogoMark.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+</script>
+
+<RenderFor
+  audience="authenticated"
+  device={["tablet-sm", "tablet-lg", "desktop"]}
+>
+  <div class="trakt-logo">
+    <Link href={UrlBuilder.home()}>
+      <LogoMark />
+    </Link>
+  </div>
+</RenderFor>
+<RenderFor audience="public">
+  <div class="trakt-logo">
+    <Logo />
+  </div>
+</RenderFor>
+
+<style>
+  .trakt-logo {
+    height: var(--ni-32);
+    display: flex;
+    justify-content: center;
+
+    :global(svg) {
+      /* Safari 🥲 */
+      height: var(--ni-32);
+    }
+  }
+</style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Small refactor to extract the logo from the navbar
- When d-pad is enabled, for authenticated users:
  - The logo is a button that can be reached using the d-pad.
  - Clicking it reloads the page.

## 👀 Example 👀
<img width="622" alt="Screenshot 2025-04-24 at 18 46 42" src="https://github.com/user-attachments/assets/bd6e598e-b238-4e86-8c64-dd439bc5133f" />
