### PR TITLE
Feat/dpad ratings

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -15,6 +15,7 @@
     color = "default",
     size = "normal",
     style = "flat",
+    navigationType,
     ...props
   }: TraktActionButtonProps | TraktActionButtonAnchorProps = $props();
 
@@ -37,6 +38,7 @@
     data-color={color}
     data-variant={variant}
     data-style={style}
+    data-dpad-navigation={navigationType}
     {...props}
   >
     {@render children()}
@@ -50,6 +52,7 @@
     data-variant={variant}
     data-size={size}
     data-style={style}
+    data-dpad-navigation={navigationType}
     {...props}
   >
     {@render children()}
@@ -92,7 +95,7 @@
       @include for-mouse {
         &:focus-visible {
           outline: var(--border-thickness-xs) solid
-            var(--color-foreground-action-button);
+            var(--color-background-action-button);
         }
       }
     }

--- a/projects/client/src/lib/components/buttons/TraktActionButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/TraktActionButtonProps.ts
@@ -1,6 +1,9 @@
+import type { DpadNavigationType } from '$lib/features/navigation/models/DpadNavigationType.ts';
+
 export type TraktActionButtonProps = ButtonProps & {
   color?: 'purple' | 'red' | 'blue' | 'orange' | 'default';
   variant?: 'primary' | 'secondary';
   size?: 'normal' | 'small';
   style?: 'flat' | 'ghost';
+  navigationType?: DpadNavigationType;
 };

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -99,6 +99,9 @@
     {/if}
   </RenderFor>
   <MarkAsWatchedAction {...markAsWatchedProps} />
+  <RenderFor audience="authenticated" navigation="dpad">
+    <RateNow {type} {media} />
+  </RenderFor>
 {/snippet}
 
 <CoverImageSetter src={media.cover.url.medium} {type} />
@@ -170,7 +173,9 @@
       </RenderFor>
 
       {#snippet contextualActions()}
-        <RateNow {type} {media} />
+        <RenderFor audience="authenticated" navigation="default">
+          <RateNow {type} {media} />
+        </RenderFor>
       {/snippet}
     </SummaryActions>
   </RenderFor>

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import { SimpleRating } from "$lib/models/SimpleRating";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
@@ -38,7 +39,7 @@
   );
 </script>
 
-<div class="trakt-rate-now">
+<div class="trakt-rate-now" data-dpad-navigation={DpadNavigationType.List}>
   {#if $isWatched}
     <h6>{m.rate_now()}</h6>
     <div class="trakt-rate-actions" transition:fade={{ duration: 150 }}>
@@ -79,6 +80,7 @@
   .trakt-rate-actions {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
   }
 
   .trakt-rate-now {

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RateActionButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RateActionButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import { SimpleRating } from "$lib/models/SimpleRating";
   import { toTranslatedValue } from "$lib/utils/formatting/string/toTranslatedValue";
   import UserRating from "../UserRating.svelte";
@@ -24,6 +25,7 @@
     onclick={() => onAddRating(rating)}
     style="flat"
     variant="primary"
+    navigationType={DpadNavigationType.Item}
   >
     <UserRating {rating} {isCurrentRating} />
   </ActionButton>
@@ -34,7 +36,8 @@
     --rating-active-color: var(--shade-400);
 
     :global(.trakt-action-button) {
-      &:hover {
+      &:hover,
+      &:focus-visible {
         background-color: var(--rating-active-color);
       }
     }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Action buttons can now also have a navigation type.
- It is now possible to rate using the d-pad.
- Changes the location of the rating buttons when d-pad is enabled.
  - This is temporary until we have support for more complex navigation skeletons.

## 👀 Examples 👀

Before:

https://github.com/user-attachments/assets/2a3963ef-51eb-477a-8ac0-11755b11624d

After:

https://github.com/user-attachments/assets/257fd5b2-c35d-4c77-a887-dc7639c1b7a3

