### PR TITLE
feat(navigation): prioritize active links when focusing something

### DIFF
--- a/projects/client/src/lib/features/navigation/_internal/focusSomething.ts
+++ b/projects/client/src/lib/features/navigation/_internal/focusSomething.ts
@@ -6,6 +6,14 @@ export function focusSomething() {
     return;
   }
 
+  const navigableActiveLink = document.querySelector(
+    `.trakt-link-active[data-dpad-navigation="${DpadNavigationType.Item}"]`,
+  );
+  if (navigableActiveLink) {
+    focusAndScrollIntoView(navigableActiveLink);
+    return;
+  }
+
   const firstNavigableElement = document.querySelector(
     `[data-dpad-navigation="${DpadNavigationType.Item}"]`,
   );


### PR DESCRIPTION
## 🎶 Notes 🎶

- Ran into this one when testing the webview reload:
  - On a reload, if movies was the active page, it would still be the active link, but the first item in the navbar would be focused instead.
- This updates `focusSomething` to check active links first.

## 👀 Examples 👀
Before:

https://github.com/user-attachments/assets/b3f21aef-6b58-4123-b33b-7c3788e3a238

After:

https://github.com/user-attachments/assets/17229772-a222-4da8-b914-83ab27269b91
