### PR TITLE
Fix/small fixes

### DIFF
--- a/projects/client/src/lib/features/navigation/_internal/focusSomething.ts
+++ b/projects/client/src/lib/features/navigation/_internal/focusSomething.ts
@@ -1,4 +1,4 @@
-import { DpadNavigationType } from '../models/DpadNavigationType.ts';
+import { getRelevantItem } from '$lib/features/navigation/_internal/getRelevantItem.ts';
 import { focusAndScrollIntoView } from './focusAndScrollIntoView.ts';
 
 export function focusSomething() {
@@ -6,17 +6,6 @@ export function focusSomething() {
     return;
   }
 
-  const navigableActiveLink = document.querySelector(
-    `.trakt-link-active[data-dpad-navigation="${DpadNavigationType.Item}"]`,
-  );
-  if (navigableActiveLink) {
-    focusAndScrollIntoView(navigableActiveLink);
-    return;
-  }
-
-  const firstNavigableElement = document.querySelector(
-    `[data-dpad-navigation="${DpadNavigationType.Item}"]`,
-  );
-
+  const firstNavigableElement = getRelevantItem(document);
   focusAndScrollIntoView(firstNavigableElement);
 }

--- a/projects/client/src/lib/features/navigation/_internal/getRelevantItem.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getRelevantItem.ts
@@ -1,0 +1,11 @@
+import { DpadNavigationType } from '$lib/features/navigation/models/DpadNavigationType.ts';
+
+export const getRelevantItem = (target: Document | Element) => {
+  const navigableActiveLink = target.querySelector(
+    `.trakt-link-active[data-dpad-navigation="${DpadNavigationType.Item}"]`,
+  );
+
+  return navigableActiveLink ? navigableActiveLink : target.querySelector(
+    `[data-dpad-navigation="${DpadNavigationType.Item}"]`,
+  );
+};

--- a/projects/client/src/lib/features/navigation/_internal/handleListNavigation.ts
+++ b/projects/client/src/lib/features/navigation/_internal/handleListNavigation.ts
@@ -1,8 +1,8 @@
+import { getRelevantItem } from '$lib/features/navigation/_internal/getRelevantItem.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { focusAndScrollIntoView } from './focusAndScrollIntoView.ts';
 import { getNavigationState } from './getNavigationState.ts';
 import { getNextIndex } from './getNextIndex.ts';
-import { getSelectableItems } from './getSelectableItems.ts';
 
 export const handleListNavigation = (key: 'ArrowUp' | 'ArrowDown') => {
   const { lists, currentListIndex } = getNavigationState();
@@ -14,7 +14,7 @@ export const handleListNavigation = (key: 'ArrowUp' | 'ArrowDown') => {
   );
 
   const targetList = assertDefined(lists[newListIndex], 'No list found');
-  const targetItems = getSelectableItems(targetList);
+  const targetItem = getRelevantItem(targetList);
 
-  focusAndScrollIntoView(targetItems.at(0));
+  focusAndScrollIntoView(targetItem);
 };

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -59,6 +59,9 @@
     {size}
     allowRewatch={$watchCount > 0}
   />
+  <RenderFor audience="authenticated" navigation="dpad">
+    <RateNow type="episode" media={episode} {episode} {show} />
+  </RenderFor>
 {/snippet}
 
 <CoverImageSetter src={episode.cover.url ?? ""} type="show" />
@@ -121,7 +124,9 @@
   <RenderFor audience="authenticated">
     <SummaryActions>
       {#snippet contextualActions()}
-        <RateNow type="episode" media={episode} {episode} {show} />
+        <RenderFor audience="authenticated" navigation="default">
+          <RateNow type="episode" media={episode} {episode} {show} />
+        </RenderFor>
       {/snippet}
 
       <RenderFor device={["tablet-sm"]} audience="authenticated">


### PR DESCRIPTION
## 🎶 Notes 🎶

- Forgot about episodes when making ratings d-pad navigate-able 😅
- Focusing into a list uses the same heuristic as `focusSomething`; e.g. if there's an active link, it will focus that one.

## 👀 Examples 👀

Before:
<img width="1541" alt="Screenshot 2025-04-24 at 22 48 56" src="https://github.com/user-attachments/assets/92ee59d1-66ec-49c4-8a7c-8cf0ed8f31ff" />

After:
<img width="1541" alt="Screenshot 2025-04-24 at 22 48 13" src="https://github.com/user-attachments/assets/96319020-bfcd-4b81-a271-6a2027a2ea44" />

Before:

https://github.com/user-attachments/assets/ecd506cd-a29d-4632-9891-6a7baeae6bf5

After:

https://github.com/user-attachments/assets/f71a21b1-bff8-4776-ab20-bb6932f39c46
