### PR TITLE
feat / mark as watched gesture for up-next

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -53,6 +53,7 @@ module.exports = {
         'filter',
         'formatter',
         'footer',
+        'gestures',
         'guards',
         'i18n',
         'landing',

--- a/deno.lock
+++ b/deno.lock
@@ -24,6 +24,7 @@
     "npm:@ts-rest/core@^3.52.1": "3.52.1_zod@3.24.1",
     "npm:@types/eslint@^9.6.1": "9.6.1",
     "npm:@types/serviceworker@^0.0.127": "0.0.127",
+    "npm:@use-gesture/vanilla@^10.3.1": "10.3.1",
     "npm:@vite-pwa/sveltekit@~0.6.7": "0.6.7_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_vite-plugin-pwa@0.21.2__vite@6.2.3___sass-embedded@1.86.0__workbox-build@7.3.0___ajv@8.17.1___@babel+core@7.26.10___rollup@2.79.2__workbox-window@7.3.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
     "npm:@vitest/coverage-istanbul@3.0.9": "3.0.9_vitest@3.0.9__jsdom@26.0.0__msw@2.7.3___typescript@5.8.2__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0__typescript@5.8.2_jsdom@26.0.0_msw@2.7.3__typescript@5.8.2_sass-embedded@1.86.0_typescript@5.8.2",
     "npm:date-fns@^4.1.0": "4.1.0",
@@ -2960,6 +2961,15 @@
       "dependencies": [
         "@typescript-eslint/types",
         "eslint-visitor-keys@4.2.0"
+      ]
+    },
+    "@use-gesture/core@10.3.1": {
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="
+    },
+    "@use-gesture/vanilla@10.3.1": {
+      "integrity": "sha512-lT4scGLu59ovA3zmtUonukAGcA0AdOOh+iwNDS05Bsu7Lq9aZToDHhI6D8Q2qvsVraovtsLLYwPrWdG/noMAKw==",
+      "dependencies": [
+        "@use-gesture/core"
       ]
     },
     "@vite-pwa/sveltekit@0.6.7_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_vite-plugin-pwa@0.21.2__vite@6.2.3___sass-embedded@1.86.0__workbox-build@7.3.0___ajv@8.17.1___@babel+core@7.26.10___rollup@2.79.2__workbox-window@7.3.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0": {
@@ -7030,6 +7040,7 @@
             "npm:@ts-rest/core@^3.52.1",
             "npm:@types/eslint@^9.6.1",
             "npm:@types/serviceworker@^0.0.127",
+            "npm:@use-gesture/vanilla@^10.3.1",
             "npm:@vite-pwa/sveltekit@~0.6.7",
             "npm:@vitest/coverage-istanbul@3.0.9",
             "npm:date-fns@^4.1.0",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -64,6 +64,7 @@
     "@tanstack/svelte-query-persist-client": "^5.69.0",
     "@trakt/api": "npm:@jsr/trakt__api@^0.1.23",
     "@ts-rest/core": "^3.52.1",
+    "@use-gesture/vanilla": "^10.3.1",
     "date-fns": "^4.1.0",
     "firebase": "^11.5.0",
     "idb-keyval": "^6.2.1",

--- a/projects/client/src/lib/components/gestures/SwipeX.svelte
+++ b/projects/client/src/lib/components/gestures/SwipeX.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import { appendClassList } from "$lib/utils/actions/appendClassList";
+  import { DragGesture } from "@use-gesture/vanilla";
+  import type { Snippet } from "svelte";
+  import { get, writable } from "svelte/store";
+
+  type SwipeXState = {
+    progress: number;
+    direction: "left" | "right" | "inactive";
+    isActive: boolean;
+  };
+
+  type Direction = "left" | "right";
+
+  type SwipeXProps = {
+    classList: string;
+    indicator: Snippet<[SwipeXState]>;
+    directions: Direction[];
+    onSwipe: (state: SwipeXState) => void;
+  };
+
+  const {
+    children,
+    classList,
+    indicator,
+    directions,
+    onSwipe,
+  }: ChildrenProps & SwipeXProps = $props();
+
+  const swipeState = writable<SwipeXState>({
+    progress: 0,
+    direction: "inactive",
+    isActive: false,
+  });
+
+  function setupGesture(node: HTMLDivElement) {
+    const threshold = window.innerWidth * 0.25;
+
+    if (!node) return;
+
+    const gesture = new DragGesture(
+      node,
+      (state) => {
+        const {
+          last,
+          movement: [movementX],
+        } = state;
+
+        const x = last ? 0 : movementX;
+        const clampedX = Math.sign(x) * Math.min(Math.abs(x), threshold);
+        const absX = Math.abs(clampedX);
+        const progress = Math.min(Math.abs(x) / threshold, 1);
+        const direction = movementX > 0 ? "right" : "left";
+
+        if (!directions.includes(direction)) {
+          return;
+        }
+
+        node.style.setProperty("--swipe-progress", progress.toString());
+        node.style.setProperty("--swipe-x", `${clampedX}px`);
+
+        if (direction === "right") {
+          node.style.setProperty("--indicator-right", ``);
+          node.style.setProperty("--indicator-left", `-${clampedX}px`);
+          node.style.setProperty("--indicator-width", `${absX}px`);
+        }
+
+        if (direction === "left") {
+          node.style.setProperty("--indicator-left", ``);
+          node.style.setProperty("--indicator-right", `${clampedX}px`);
+          node.style.setProperty("--indicator-width", `${absX}px`);
+        }
+
+        const color = (() => {
+          if (last) {
+            return "transparent";
+          }
+
+          return direction === "right"
+            ? "var(--indicator-color-right)"
+            : "var(--indicator-color-left)";
+        })();
+
+        node.style.setProperty("--indicator-color", color);
+
+        const isActive = Math.abs(x) > threshold * 0.9;
+
+        const { isActive: isPreviouslyActive } = get(swipeState);
+
+        const isTriggered = isPreviouslyActive && last;
+
+        swipeState.set({
+          progress,
+          direction,
+          isActive,
+        });
+
+        if (isTriggered) {
+          onSwipe($swipeState);
+        }
+      },
+      {
+        axis: "x",
+        filterTaps: true,
+        pointer: {
+          touch: true,
+          mouse: false,
+          keys: false,
+        },
+      },
+    );
+
+    return {
+      destroy() {
+        gesture.destroy();
+      },
+    };
+  }
+</script>
+
+<div
+  class="trakt-gesture-container"
+  use:appendClassList={classList}
+  use:setupGesture
+>
+  {@render indicator($swipeState)}
+  {@render children()}
+</div>
+
+<style>
+  .trakt-gesture-container {
+    touch-action: pan-y;
+
+    position: relative;
+
+    will-change: transform;
+
+    transform: translateX(var(--swipe-x));
+    transition: transform var(--transition-increment)
+      cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  }
+
+  :global(.trakt-gesture-container .trakt-gesture-indicator) {
+    position: absolute;
+
+    height: var(--indicator-height, 100%);
+
+    left: var(--indicator-left);
+    right: var(--indicator-right);
+    width: var(--indicator-width, 0);
+
+    background-color: var(--indicator-color, transparent);
+    opacity: var(--swipe-progress, 0);
+
+    transition:
+      opacity var(--transition-increment) ease-out,
+      width var(--transition-increment) ease-out,
+      background-color var(--transition-increment) ease-out,
+      left var(--transition-increment) ease-out,
+      right var(--transition-increment) ease-out,
+      color var(--transition-increment) ease-in-out,
+      outline-color var(--transition-increment) ease-in-out;
+  }
+</style>

--- a/projects/client/src/lib/components/icons/MarkAsWatchedIcon.svelte
+++ b/projects/client/src/lib/components/icons/MarkAsWatchedIcon.svelte
@@ -5,6 +5,7 @@
   }: IconProps & {
     state: "watched" | "unwatched";
   } = $props();
+
   const strokeWidth = $derived(size === "small" ? 3 : 2);
 </script>
 

--- a/projects/client/src/lib/sections/lists/progress/EpisodeProgressItem.svelte
+++ b/projects/client/src/lib/sections/lists/progress/EpisodeProgressItem.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+  import SwipeX from "$lib/components/gestures/SwipeX.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { EpisodeProgressEntry } from "$lib/requests/models/EpisodeProgressEntry";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
+  import MarkAsWatchedSwipeIndicator from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedSwipeIndicator.svelte";
+  import { useMarkAsWatched } from "$lib/sections/media-actions/mark-as-watched/useMarkAsWatched";
   import RestoreAction from "$lib/sections/media-actions/restore/RestoreAction.svelte";
   import DropAction from "../../media-actions/drop/DropAction.svelte";
   import MarkAsWatchedAction from "../../media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
@@ -20,27 +23,58 @@
   const { episode, show, status, style }: UpNextEpisodeProps = $props();
 
   const isHidden = $derived(status === "hidden");
+
+  const { markAsWatched } = $derived(
+    useMarkAsWatched({
+      type: "episode",
+      media: [episode],
+      show: show,
+      episode: episode,
+    }),
+  );
 </script>
 
-<EpisodeCard {episode} {show} {status} {style} variant="next">
-  {#snippet popupActions()}
-    <RenderFor audience="authenticated">
-      <MarkAsWatchedAction
-        style="dropdown-item"
-        type="episode"
-        allowRewatch
-        title={episode.title}
-        {show}
-        {episode}
-        media={episode}
-      />
-      {#if $isNitroEnabled}
-        <DropAction style="dropdown-item" title={show.title} id={show.id} />
-      {/if}
+{#snippet card()}
+  <EpisodeCard {episode} {show} {status} {style} variant="next">
+    {#snippet popupActions()}
+      <RenderFor audience="authenticated">
+        <MarkAsWatchedAction
+          style="dropdown-item"
+          type="episode"
+          allowRewatch
+          title={episode.title}
+          {show}
+          {episode}
+          media={episode}
+        />
+        {#if $isNitroEnabled}
+          <DropAction style="dropdown-item" title={show.title} id={show.id} />
+        {/if}
 
-      {#if $isNitroEnabled && isHidden}
-        <RestoreAction style="dropdown-item" title={show.title} id={show.id} />
-      {/if}
-    </RenderFor>
-  {/snippet}
-</EpisodeCard>
+        {#if $isNitroEnabled && isHidden}
+          <RestoreAction
+            style="dropdown-item"
+            title={show.title}
+            id={show.id}
+          />
+        {/if}
+      </RenderFor>
+    {/snippet}
+  </EpisodeCard>
+{/snippet}
+
+{#if style === "summary"}
+  <SwipeX
+    children={card}
+    directions={["left"]}
+    classList="trakt-up-next-episode"
+    onSwipe={markAsWatched}
+    --indicator-height="var(--height-summary-card-cover)"
+  >
+    {#snippet indicator({ isActive })}
+      <MarkAsWatchedSwipeIndicator {isActive} />
+    {/snippet}
+  </SwipeX>
+{:else}
+  {@render card()}
+{/if}

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedSwipeIndicator.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedSwipeIndicator.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import MarkAsWatchedIcon from "$lib/components/icons/MarkAsWatchedIcon.svelte";
+
+  const { isActive }: { isActive: boolean } = $props();
+</script>
+
+<div class="trakt-gesture-indicator" class:trakt-gesture-active={isActive}>
+  <MarkAsWatchedIcon size="normal" state="unwatched" />
+</div>
+
+<style>
+  .trakt-gesture-indicator {
+    border-radius: var(--border-radius-m);
+
+    width: calc(var(--indicator-width, 0) + calc(var(--border-radius-m) * 2));
+
+    backdrop-filter: blur(var(--ni-8)) brightness(0.85);
+    color: var(--color-foreground);
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    outline: var(--color-foreground) var(--ni-1) solid;
+    outline-offset: var(--ni-neg-2);
+
+    &.trakt-gesture-active {
+      outline-color: var(--color-background-purple);
+      color: var(--color-background-purple);
+    }
+
+    :global(svg) {
+      opacity: var(--swipe-progress, 0);
+      transition: color var(--transition-increment) ease-in-out;
+    }
+  }
+</style>


### PR DESCRIPTION
This pull request introduces a swipe gesture feature for marking episodes as watched in the client application. It includes the addition of a new `SwipeX` component, integration of gesture-based interactions in the episode progress list, and supporting UI updates. Below are the most important changes grouped by theme:

### Gesture Feature Implementation:
* Added a new `SwipeX` component in `projects/client/src/lib/components/gestures/SwipeX.svelte`, which utilizes the `@use-gesture/vanilla` library to handle swipe gestures. It includes logic for detecting swipe direction, progress, and triggering actions based on thresholds.

### Integration of Swipe Gesture in Episode Progress:
* Integrated the `SwipeX` component into `EpisodeProgressItem.svelte` to enable swipe gestures for marking episodes as watched. The swipe gesture is configured to trigger the `markAsWatched` action when swiping left. [[1]](diffhunk://#diff-1fa29a100e32f8e1f20b8eb040358420866829c0faa7c98e4a949cfffcb28dabR2-R7) [[2]](diffhunk://#diff-1fa29a100e32f8e1f20b8eb040358420866829c0faa7c98e4a949cfffcb28dabR26-R42) [[3]](diffhunk://#diff-1fa29a100e32f8e1f20b8eb040358420866829c0faa7c98e4a949cfffcb28dabL42-R73)
* Added a swipe indicator (`MarkAsWatchedSwipeIndicator.svelte`) that visually represents the swipe action and its progress.

### Dependency Updates:
* Added the `@use-gesture/vanilla` library as a new dependency in `projects/client/package.json` to support gesture handling.

### Configuration Updates:
* Updated `commitlint.config.js` to include `gestures` as a new module category.

### Minor Adjustments:
* Added a placeholder `<style>` block in `UpNextList.svelte` to prepare for potential future styling changes.

https://github.com/user-attachments/assets/3da4cbdb-cb7c-4c48-899e-899c024040d5

