### PR TITLE
Fix/hidden nav

### DIFF
--- a/projects/client/src/lib/components/card/Card.svelte
+++ b/projects/client/src/lib/components/card/Card.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import { useNavigation } from "$lib/features/navigation/useNavigation";
   import { whenInViewport } from "$lib/utils/actions/whenInViewport";
   import { writable } from "svelte/store";
+  import { dPadTrigger } from "./_internal/dPadTrigger";
 
   const {
     children,
@@ -14,8 +16,10 @@
 
 <div
   use:whenInViewport={() => isVisible.set(true)}
+  use:dPadTrigger={".trakt-card-content > .trakt-link"}
   class="trakt-card"
   data-navigation-type={$navigation}
+  data-dpad-navigation={DpadNavigationType.Item}
 >
   <div
     class="trakt-card-content"
@@ -29,6 +33,8 @@
 
 <style>
   .trakt-card {
+    all: unset;
+
     position: relative;
 
     min-width: var(--width-card);
@@ -36,7 +42,8 @@
   }
 
   .trakt-card[data-navigation-type="dpad"] {
-    &:has(:global(.trakt-link[data-dpad-navigation="item"])) {
+    &:has(:global(.trakt-link)) {
+      /* TODO: this is broken for personcards now... */
       transform: scale(0.95);
       transition: none;
 
@@ -46,7 +53,7 @@
         content: "";
       }
 
-      &:has(:global(.trakt-link:focus-visible)) {
+      &:focus-visible {
         transition: transform var(--transition-increment) ease-in;
         transform: scale(1);
 

--- a/projects/client/src/lib/components/card/_internal/dPadTrigger.ts
+++ b/projects/client/src/lib/components/card/_internal/dPadTrigger.ts
@@ -1,0 +1,37 @@
+import { useNavigation } from '$lib/features/navigation/useNavigation.ts';
+import { onMount } from 'svelte';
+import { get } from 'svelte/store';
+
+export function dPadTrigger(
+  element: HTMLElement,
+  targetSelector: string,
+) {
+  const { navigation } = useNavigation();
+
+  const handler = (event: KeyboardEvent) => {
+    if (event.code !== 'Enter' && event.code !== 'Space') {
+      return;
+    }
+
+    const link = element.querySelector(targetSelector);
+    if (!(link instanceof HTMLAnchorElement)) {
+      return;
+    }
+
+    link.click();
+  };
+
+  onMount(() => {
+    if (get(navigation) !== 'dpad') {
+      return;
+    }
+
+    element.setAttribute('tabindex', '0');
+    element.setAttribute('role', 'button');
+    element.addEventListener('keydown', handler);
+
+    return () => {
+      element.removeEventListener('keydown', handler);
+    };
+  });
+}

--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -44,11 +44,11 @@
     ($scrollX.right - $sideDistance) / $windowShadowWidth,
   );
 
-  const isVisible = writable(false);
+  const { navigation } = useNavigation();
+  const isVisible = writable($navigation === "dpad");
   const isMounted = writable(false);
 
   const { scrollHistory } = useScrollHistoryAction("horizontal");
-  const { navigation } = useNavigation();
 
   onMount(() => {
     isMounted.set(true);

--- a/projects/client/src/lib/features/navigation/models/NavigationType.ts
+++ b/projects/client/src/lib/features/navigation/models/NavigationType.ts
@@ -1,0 +1,1 @@
+export type NavigationType = 'default' | 'dpad';

--- a/projects/client/src/lib/features/navigation/useNavigation.ts
+++ b/projects/client/src/lib/features/navigation/useNavigation.ts
@@ -1,6 +1,7 @@
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
 import { dpadController } from '$lib/features/navigation/_internal/dpadController.ts';
+import type { NavigationType } from '$lib/features/navigation/models/NavigationType.ts';
 import type { DeviceType } from '$lib/models/DeviceType.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { getContext, setContext } from 'svelte';
@@ -10,7 +11,6 @@ const NAVIGATION_CONTEXT_KEY = Symbol('navigation');
 const PARAM_NAME = 'navigation';
 const DPAD_REF = 'd-pad';
 
-type NavigationType = 'default' | 'dpad';
 type Controller = (node: HTMLElement) => void;
 type NavigationContextData = Readable<NavigationType>;
 

--- a/projects/client/src/lib/sections/lists/components/CastMemberCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/CastMemberCard.svelte
@@ -4,7 +4,6 @@
   import Link from "$lib/components/link/Link.svelte";
   import PersonCard from "$lib/components/people/card/PersonCard.svelte";
   import * as m from "$lib/features/i18n/messages";
-  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import type { CastMember } from "$lib/requests/models/MediaCrew";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
@@ -15,39 +14,21 @@
   const { castMember }: CastMemberCardProps = $props();
 </script>
 
-<trakt-cast-member>
-  <PersonCard>
-    <Link
-      focusable={false}
-      href={UrlBuilder.people(castMember.id)}
-      navigationType={DpadNavigationType.Item}
-    >
-      <CardCover
-        title={castMember.name}
-        src={castMember.headShotUrl}
-        alt={`${m.person_headshot({ person: castMember.name })}`}
-        style="flat"
-      />
-      <CardFooter>
-        <p class="trakt-card-title ellipsis">
-          {castMember.name}
-        </p>
-        <p class="trakt-card-subtitle ellipsis">
-          {castMember.characterName}
-        </p>
-      </CardFooter>
-    </Link>
-  </PersonCard>
-</trakt-cast-member>
-
-<style lang="scss">
-  @use "$style/scss/mixins/index" as *;
-
-  trakt-cast-member {
-    position: relative;
-
-    :global(.trakt-link) {
-      text-decoration: none;
-    }
-  }
-</style>
+<PersonCard>
+  <Link focusable={false} href={UrlBuilder.people(castMember.id)}>
+    <CardCover
+      title={castMember.name}
+      src={castMember.headShotUrl}
+      alt={`${m.person_headshot({ person: castMember.name })}`}
+      style="flat"
+    />
+    <CardFooter>
+      <p class="trakt-card-title ellipsis">
+        {castMember.name}
+      </p>
+      <p class="trakt-card-subtitle ellipsis">
+        {castMember.characterName}
+      </p>
+    </CardFooter>
+  </Link>
+</PersonCard>

--- a/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItemCard.svelte
@@ -10,7 +10,6 @@
   import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import * as m from "$lib/features/i18n/messages.ts";
-  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage";
   import { EpisodeComputedType } from "$lib/requests/models/EpisodeType";
@@ -64,7 +63,6 @@
   <Link
     focusable={false}
     href={UrlBuilder.episode(show.slug, episode.season, episode.number)}
-    navigationType={DpadNavigationType.Item}
   >
     <CardCover
       title={episode.title}

--- a/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
@@ -8,7 +8,6 @@
   import PortraitCard from "$lib/components/media/card/PortraitCard.svelte";
   import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
-  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import { toHumanDate } from "$lib/utils/formatting/date/toHumanDate";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CardActionBar from "../../../components/card/CardActionBar.svelte";
@@ -40,11 +39,7 @@
     </CardActionBar>
   {/if}
 
-  <Link
-    focusable={false}
-    href={UrlBuilder.media(type, media.slug)}
-    navigationType={DpadNavigationType.Item}
-  >
+  <Link focusable={false} href={UrlBuilder.media(type, media.slug)}>
     <CardCover
       title={media.title}
       src={mediaCoverImageUrl}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Shadow lists are always added when d-pad is enabled.
- Moves d-pad navigation handling of cards to card level:
  - It is now possible to navigate to it even if the content is outside of the viewport.

## 👀 Examples 👀

Before:

https://github.com/user-attachments/assets/037cd210-13df-4610-8c73-b45b2cc6d3f8

After:

https://github.com/user-attachments/assets/0f27359d-f70c-4cf1-94c5-7fad26a614ee

