### PR TITLE
feat / use landscape cards when navigating via dpad

### DIFF
--- a/projects/client/src/lib/components/media/card/PortraitCard.svelte
+++ b/projects/client/src/lib/components/media/card/PortraitCard.svelte
@@ -6,9 +6,9 @@
 
 <Card
   variant="transparent"
-  --width-card="var(--width-poster-card)"
-  --height-card="var(--height-poster-card)"
-  --height-card-cover="var(--height-poster-card-cover)"
+  --width-card="var(--width-portrait-card)"
+  --height-card="var(--height-portrait-card)"
+  --height-card-cover="var(--height-portrait-card-cover)"
 >
   {@render children()}
 </Card>

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -58,7 +58,7 @@
       {tag}
       {action}
       type="episode"
-      variant="thumb"
+      variant="landscape"
       style="summary"
     />
   {/if}

--- a/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
@@ -8,7 +8,7 @@ import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { Snippet } from 'svelte';
 
 export type MediaItemVariant<T> =
-  | { variant?: 'portrait' } & MediaInput<T>
+  | { variant?: 'portrait' | 'landscape' } & MediaInput<T>
   | { variant: 'landscape' } & MediaInput<T>
   | { variant: 'activity'; date: Date } & MediaInput<T>;
 

--- a/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
@@ -8,8 +8,8 @@ import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { Snippet } from 'svelte';
 
 export type MediaItemVariant<T> =
-  | { variant?: 'poster' } & MediaInput<T>
-  | { variant: 'thumb' } & MediaInput<T>
+  | { variant?: 'portrait' } & MediaInput<T>
+  | { variant: 'landscape' } & MediaInput<T>
   | { variant: 'activity'; date: Date } & MediaInput<T>;
 
 type BaseItemProps<T> = MediaItemVariant<T> & {

--- a/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
@@ -6,8 +6,10 @@
   import CardCover from "$lib/components/card/CardCover.svelte";
   import LandscapeCard from "$lib/components/media/card/LandscapeCard.svelte";
   import PortraitCard from "$lib/components/media/card/PortraitCard.svelte";
+  import GenreList from "$lib/components/summary/GenreList.svelte";
   import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
   import { toHumanDate } from "$lib/utils/formatting/date/toHumanDate";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CardActionBar from "../../../components/card/CardActionBar.svelte";
@@ -23,7 +25,8 @@
     ...rest
   }: MediaCardProps = $props();
 
-  const variant = $derived(rest.variant ?? "portrait");
+  const defaultVariant = $derived(useDefaultCardVariant());
+  const variant = $derived(rest.variant ?? $defaultVariant);
 </script>
 
 {#snippet content(mediaCoverImageUrl: string)}
@@ -47,13 +50,40 @@
       {badge}
     />
   </Link>
+{/snippet}
 
-  <CardFooter {action} {tag}>
-    {#if rest.variant === "activity"}
+{#if variant === "portrait"}
+  <PortraitCard>
+    {@render content(media.poster.url.thumb)}
+    <CardFooter {action} {tag} />
+  </PortraitCard>
+{/if}
+
+{#if variant === "landscape"}
+  <LandscapeCard>
+    {@render content(media.cover.url.thumb)}
+    <CardFooter {action} {tag}>
+      <Link href={UrlBuilder.media(type, media.slug)}>
+        <p class="trakt-card-title small ellipsis">
+          {media.title}
+        </p>
+      </Link>
+      <GenreList
+        genres={media.genres}
+        classList="trakt-card-subtitle small ellipsis"
+      />
+    </CardFooter>
+  </LandscapeCard>
+{/if}
+
+{#if rest.variant === "activity"}
+  <LandscapeCard>
+    {@render content(media.thumb.url)}
+    <CardFooter {action} {tag}>
       <Link href={UrlBuilder.media(type, media.slug)}>
         <p
           class="trakt-card-title small ellipsis"
-          class:small={rest.variant !== "activity"}
+          class:small={variant !== "activity"}
         >
           {media.title}
         </p>
@@ -61,24 +91,6 @@
       <p class="trakt-card-subtitle small ellipsis">
         {toHumanDate(new Date(), rest.date, getLocale())}
       </p>
-    {/if}
-  </CardFooter>
-{/snippet}
-
-{#if variant === "portrait"}
-  <PortraitCard>
-    {@render content(media.poster.url.thumb)}
-  </PortraitCard>
-{/if}
-
-{#if variant === "landscape"}
-  <LandscapeCard>
-    {@render content(media.thumb.url)}
-  </LandscapeCard>
-{/if}
-
-{#if variant === "activity"}
-  <LandscapeCard>
-    {@render content(media.thumb.url)}
+    </CardFooter>
   </LandscapeCard>
 {/if}

--- a/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
@@ -23,7 +23,7 @@
     ...rest
   }: MediaCardProps = $props();
 
-  const variant = $derived(rest.variant ?? "poster");
+  const variant = $derived(rest.variant ?? "portrait");
 </script>
 
 {#snippet content(mediaCoverImageUrl: string)}
@@ -65,13 +65,13 @@
   </CardFooter>
 {/snippet}
 
-{#if variant === "poster"}
+{#if variant === "portrait"}
   <PortraitCard>
     {@render content(media.poster.url.thumb)}
   </PortraitCard>
 {/if}
 
-{#if variant === "thumb"}
+{#if variant === "landscape"}
   <LandscapeCard>
     {@render content(media.thumb.url)}
   </LandscapeCard>

--- a/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" generics="T extends { id: unknown }, M">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
   import { DEFAULT_PAGE_SIZE } from "$lib/utils/constants";
   import { mediaListHeightResolver } from "../utils/mediaListHeightResolver";
   import type { MediaListProps } from "./MediaListProps";
@@ -19,6 +20,8 @@
   const { list, isLoading } = $derived(
     useList({ type, page: 1, limit: DEFAULT_PAGE_SIZE, filter }),
   );
+
+  const defaultVariant = useDefaultCardVariant();
 </script>
 
 {#snippet actions()}
@@ -34,7 +37,7 @@
   {item}
   {title}
   actions={externalActions ? actions : undefined}
-  --height-list={mediaListHeightResolver(type)}
+  --height-list={mediaListHeightResolver($defaultVariant)}
 >
   {#snippet empty()}
     {#if !$isLoading}

--- a/projects/client/src/lib/sections/lists/utils/mediaCardWidthResolver.ts
+++ b/projects/client/src/lib/sections/lists/utils/mediaCardWidthResolver.ts
@@ -7,6 +7,6 @@ export function mediaCardWidthResolver<M = MediaType>(
     case 'episode':
       return 'var(--width-landscape-card)';
     default:
-      return 'var(--width-poster-card)';
+      return 'var(--width-portrait-card)';
   }
 }

--- a/projects/client/src/lib/sections/lists/utils/mediaCardWidthResolver.ts
+++ b/projects/client/src/lib/sections/lists/utils/mediaCardWidthResolver.ts
@@ -4,8 +4,10 @@ export function mediaCardWidthResolver<M = MediaType>(
   type: M,
 ) {
   switch (type) {
+    case 'landscape':
     case 'episode':
       return 'var(--width-landscape-card)';
+    case 'portrait':
     default:
       return 'var(--width-portrait-card)';
   }

--- a/projects/client/src/lib/sections/lists/utils/mediaListHeightResolver.ts
+++ b/projects/client/src/lib/sections/lists/utils/mediaListHeightResolver.ts
@@ -4,10 +4,12 @@ export function mediaListHeightResolver<M = MediaType>(
   type: M,
 ) {
   switch (type) {
+    case 'landscape':
     case 'episode':
       return 'var(--height-landscape-list)';
     case 'person':
       return 'var(--height-person-list)';
+    case 'portrait':
     default:
       return 'var(--height-poster-list)';
   }

--- a/projects/client/src/lib/stores/useDefaultCardVariant.ts
+++ b/projects/client/src/lib/stores/useDefaultCardVariant.ts
@@ -1,0 +1,12 @@
+import { useNavigation } from '$lib/features/navigation/useNavigation.ts';
+import { derived } from 'svelte/store';
+
+export function useDefaultCardVariant() {
+  const { navigation } = useNavigation();
+
+  return derived(navigation, ($navigation) => {
+    const isDPad = $navigation === 'dpad';
+
+    return isDPad ? 'landscape' : 'portrait';
+  });
+}

--- a/projects/client/src/routes/search/+page.svelte
+++ b/projects/client/src/routes/search/+page.svelte
@@ -31,7 +31,7 @@
     id="search-grid-list"
     title={m.results_for_title({ query })}
     items={$results}
-    --width-item="var(--width-poster-card)"
+    --width-item="var(--width-portrait-card)"
   >
     {#snippet item(result)}
       <DefaultMediaItem type={result.type} media={result} {style}>

--- a/projects/client/src/style/layout/index.css
+++ b/projects/client/src/style/layout/index.css
@@ -2,9 +2,9 @@
   /**
    * Card dimensions
    */
-  --width-poster-card: var(--ni-132);
-  --height-poster-card: var(--ni-238);
-  --height-poster-card-cover: var(--ni-198);
+  --width-portrait-card: var(--ni-132);
+  --height-portrait-card: var(--ni-238);
+  --height-portrait-card-cover: var(--ni-198);
 
   --width-landscape-card: var(--ni-200);
   --height-landscape-card: var(--ni-152);
@@ -37,7 +37,7 @@
     var(--height-person-card) + var(--layout-scrollbar-width)
   );
   --height-poster-list: calc(
-    var(--height-poster-card) + var(--layout-scrollbar-width)
+    var(--height-portrait-card) + var(--layout-scrollbar-width)
   );
   --height-lists-list: calc(
     var(--height-list-card) + var(--layout-scrollbar-width)


### PR DESCRIPTION
This pull request introduces a new "portrait" card variant across the media card components, updates the default card variant logic, and refactors related styles and utilities. The key changes include replacing the "poster" variant with "portrait," adding dynamic default variant selection based on navigation type, and updating the associated styles and utilities to align with the new naming convention.

### Card Variant Updates:
* Replaced the "poster" variant with "portrait" across all relevant components, including `PortraitCard.svelte` and `MediaItemCard.svelte`. Updated conditional rendering logic to handle "portrait" and "landscape" variants. (`[[1]](diffhunk://#diff-3a81fd0d523a8e3a3686bdec98474cd8d46912d9c99ef36f2be2adc73d633362L9-R11)`, `[[2]](diffhunk://#diff-0a05c68a4ddcdfdac5b8747483b7df66a5db38151d95bcf6dfa3b568e6401190R53-L82)`)
* Updated `MediaItemVariant` type to include "portrait" and "landscape" variants, removing references to "poster" and "thumb." (`[projects/client/src/lib/sections/lists/components/MediaCardProps.tsL11-R12](diffhunk://#diff-6ee1893fcd70dea8d58e52dd9673ac06770e1e7351609c274b2f2505be015ad0L11-R12)`)

### Default Variant Logic:
* Introduced `useDefaultCardVariant` in `useDefaultCardVariant.ts`, which dynamically determines the default card variant ("portrait" or "landscape") based on navigation type (e.g., D-Pad navigation). (`[projects/client/src/lib/stores/useDefaultCardVariant.tsR1-R12](diffhunk://#diff-b2a9c5997e08cb10e4fd07ddd5d56e9a49140951c4fa3cf9c71eaa44343c5dbbR1-R12)`)
* Integrated `useDefaultCardVariant` into `MediaItemCard.svelte` and `MediaList.svelte` to set the default variant dynamically. (`[[1]](diffhunk://#diff-0a05c68a4ddcdfdac5b8747483b7df66a5db38151d95bcf6dfa3b568e6401190L26-R29)`, `[[2]](diffhunk://#diff-435b5f2fac4b1ab34887aabe35df66ba96132c34f9be9168e540f9f78bbe652fR23-R24)`)

### Style and Utility Updates:
* Refactored CSS variables to replace "poster" with "portrait" (e.g., `--width-poster-card` → `--width-portrait-card`) and updated layout calculations accordingly. (`[[1]](diffhunk://#diff-4befaa8e8251404364f15de7393c2bd0131cf46e525af170b7ff1836e6426fc6L5-R7)`, `[[2]](diffhunk://#diff-4befaa8e8251404364f15de7393c2bd0131cf46e525af170b7ff1836e6426fc6L40-R40)`)
* Adjusted utility functions like `mediaCardWidthResolver` and `mediaListHeightResolver` to support the new "portrait" variant. (`[[1]](diffhunk://#diff-687982c1521f8b13ea319d93a80d45cb1043c640333f79ad24181c3202378e39R7-R12)`, `[[2]](diffhunk://#diff-64ae56ff2d15d7517de5fa5f7400615855b3f07f3b9b6c739e22df415cb82d68R7-R12)`)

### Miscellaneous:
* Updated the search results page to use the "portrait" card variant for grid items. (`[projects/client/src/routes/search/+page.svelteL34-R34](diffhunk://#diff-b5711ab1bb01b6510c45f360398833e0281c52a6d33eba0d2d23ee7edb8b0ea9L34-R34)`)