### PR TITLE
fix(card): correctly compute default card varian

### DIFF
--- a/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItemCard.svelte
@@ -25,7 +25,7 @@
     ...rest
   }: MediaCardProps = $props();
 
-  const defaultVariant = $derived(useDefaultCardVariant());
+  const defaultVariant = $derived(useDefaultCardVariant(type));
   const variant = $derived(rest.variant ?? $defaultVariant);
 </script>
 

--- a/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
@@ -21,7 +21,7 @@
     useList({ type, page: 1, limit: DEFAULT_PAGE_SIZE, filter }),
   );
 
-  const defaultVariant = useDefaultCardVariant();
+  const defaultVariant = useDefaultCardVariant(type);
 </script>
 
 {#snippet actions()}

--- a/projects/client/src/lib/sections/lists/utils/mediaListHeightResolver.ts
+++ b/projects/client/src/lib/sections/lists/utils/mediaListHeightResolver.ts
@@ -1,14 +1,11 @@
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 
 export function mediaListHeightResolver<M = MediaType>(
-  type: M,
+  type: 'landscape' | 'portrait' | M,
 ) {
   switch (type) {
     case 'landscape':
-    case 'episode':
       return 'var(--height-landscape-list)';
-    case 'person':
-      return 'var(--height-person-list)';
     case 'portrait':
     default:
       return 'var(--height-poster-list)';

--- a/projects/client/src/lib/stores/useDefaultCardVariant.ts
+++ b/projects/client/src/lib/stores/useDefaultCardVariant.ts
@@ -1,10 +1,14 @@
 import { useNavigation } from '$lib/features/navigation/useNavigation.ts';
 import { derived } from 'svelte/store';
 
-export function useDefaultCardVariant() {
+export function useDefaultCardVariant<M>(type: M) {
   const { navigation } = useNavigation();
 
   return derived(navigation, ($navigation) => {
+    if (type === 'episode') {
+      return 'landscape';
+    }
+
     const isDPad = $navigation === 'dpad';
 
     return isDPad ? 'landscape' : 'portrait';


### PR DESCRIPTION
This pull request refactors how default card variants are determined and simplifies the media list height resolver logic. The changes ensure that the `type` parameter is consistently passed to relevant functions, improving flexibility and maintainability.

### Refactoring of default card variant logic:
* [`projects/client/src/lib/stores/useDefaultCardVariant.ts`](diffhunk://#diff-b2a9c5997e08cb10e4fd07ddd5d56e9a49140951c4fa3cf9c71eaa44343c5dbbL4-R11): Updated `useDefaultCardVariant` to accept a `type` parameter and added logic to return `'landscape'` for `'episode'` types.
* [`projects/client/src/lib/sections/lists/components/MediaItemCard.svelte`](diffhunk://#diff-0a05c68a4ddcdfdac5b8747483b7df66a5db38151d95bcf6dfa3b568e6401190L28-R28): Modified the `defaultVariant` to use the updated `useDefaultCardVariant` function with the `type` parameter.
* [`projects/client/src/lib/sections/lists/drilldown/MediaList.svelte`](diffhunk://#diff-435b5f2fac4b1ab34887aabe35df66ba96132c34f9be9168e540f9f78bbe652fL24-R24): Updated the `defaultVariant` initialization to pass the `type` parameter to `useDefaultCardVariant`.

### Simplification of media list height resolver:
* [`projects/client/src/lib/sections/lists/utils/mediaListHeightResolver.ts`](diffhunk://#diff-64ae56ff2d15d7517de5fa5f7400615855b3f07f3b9b6c739e22df415cb82d68L4-L11): Adjusted the `type` parameter to explicitly include `'landscape'` and `'portrait'` options, removed handling for `'episode'` and `'person'`, and streamlined the height resolution logic.