### PR TITLE
Feat/streaming filter

### DIFF
--- a/projects/client/i18n/messages/bg-bg.json
+++ b/projects/client/i18n/messages/bg-bg.json
@@ -386,5 +386,7 @@
   "filter_all": "Всички",
   "filters_title": "Филтри",
   "ignore_watched": "Пренебрегвай гледаното",
-  "ignore_watchlisted": "Пренебрегвай в списъка за гледане"
+  "ignore_watchlisted": "Пренебрегвай в списъка за гледане",
+  "watchnow_favorites_only": "Само любими",
+  "watchnow_any_service": "Навсякъде"
 }

--- a/projects/client/i18n/messages/da-dk.json
+++ b/projects/client/i18n/messages/da-dk.json
@@ -386,5 +386,7 @@
   "filter_all": "Alle",
   "filters_title": "Filtre",
   "ignore_watched": "Ignorer set",
-  "ignore_watchlisted": "Ignorer på listen"
+  "ignore_watchlisted": "Ignorer på listen",
+  "watchnow_favorites_only": "Favorites only",
+  "watchnow_any_service": "On any service"
 }

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -386,5 +386,7 @@
   "filter_all": "Alle",
   "filters_title": "Filter",
   "ignore_watched": "Gesehene ignorieren",
-  "ignore_watchlisted": "Merkliste ignorieren"
+  "ignore_watchlisted": "Merkliste ignorieren",
+  "watchnow_favorites_only": "Nur Favoriten",
+  "watchnow_any_service": "Auf jedem Dienst"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -386,5 +386,7 @@
   "filter_all": "All",
   "filters_title": "Filters",
   "ignore_watched": "Ignore Watched",
-  "ignore_watchlisted": "Ignore Watchlisted"
+  "ignore_watchlisted": "Ignore Watchlisted",
+  "watchnow_favorites_only": "Favorites only",
+  "watchnow_any_service": "On any service"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -386,5 +386,7 @@
   "filter_all": "Todo",
   "filters_title": "Filtros",
   "ignore_watched": "Ignorar Visto",
-  "ignore_watchlisted": "Ignorar en lista"
+  "ignore_watchlisted": "Ignorar en lista",
+  "watchnow_favorites_only": "Solo favoritos",
+  "watchnow_any_service": "En cualquier servicio"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -386,5 +386,7 @@
   "filter_all": "Todo",
   "filters_title": "Filtros",
   "ignore_watched": "Ignorar Visto",
-  "ignore_watchlisted": "Ignorar Por Ver"
+  "ignore_watchlisted": "Ignorar Por Ver",
+  "watchnow_favorites_only": "Solo favoritos",
+  "watchnow_any_service": "En cualquier plataforma"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -386,5 +386,7 @@
   "filter_all": "Tout",
   "filters_title": "Filtres",
   "ignore_watched": "Ignorer vu(e)s",
-  "ignore_watchlisted": "Ignorer à voir"
+  "ignore_watchlisted": "Ignorer à voir",
+  "watchnow_favorites_only": "Favorites only",
+  "watchnow_any_service": "On any service"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -386,5 +386,7 @@
   "filter_all": "Tous",
   "filters_title": "Filtres",
   "ignore_watched": "Ignorer les vus",
-  "ignore_watchlisted": "Ignorer les listés"
+  "ignore_watchlisted": "Ignorer les listés",
+  "watchnow_favorites_only": "Favorites only",
+  "watchnow_any_service": "On any service"
 }

--- a/projects/client/i18n/messages/it-it.json
+++ b/projects/client/i18n/messages/it-it.json
@@ -386,5 +386,7 @@
   "filter_all": "Tutti",
   "filters_title": "Filtri",
   "ignore_watched": "Ignora visti",
-  "ignore_watchlisted": "Ignora da vedere"
+  "ignore_watchlisted": "Ignora da vedere",
+  "watchnow_favorites_only": "Solo preferiti",
+  "watchnow_any_service": "Su qualsiasi piattaforma"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -386,5 +386,7 @@
   "filter_all": "すべて",
   "filters_title": "フィルター",
   "ignore_watched": "視聴済みを無視",
-  "ignore_watchlisted": "ウォッチリストを無視"
+  "ignore_watchlisted": "ウォッチリストを無視",
+  "watchnow_favorites_only": "Favorites only",
+  "watchnow_any_service": "On any service"
 }

--- a/projects/client/i18n/messages/nb-no.json
+++ b/projects/client/i18n/messages/nb-no.json
@@ -386,5 +386,7 @@
   "filter_all": "Alle",
   "filters_title": "Filtre",
   "ignore_watched": "Ignorer sett",
-  "ignore_watchlisted": "Ignorer på huskeliste"
+  "ignore_watchlisted": "Ignorer på huskeliste",
+  "watchnow_favorites_only": "Kun favoritter",
+  "watchnow_any_service": "På alle tjenester"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -386,5 +386,7 @@
   "filter_all": "Alles",
   "filters_title": "Filters",
   "ignore_watched": "Bekeken negeren",
-  "ignore_watchlisted": "Op de lijst negeren"
+  "ignore_watchlisted": "Op de lijst negeren",
+  "watchnow_favorites_only": "Alleen favorieten",
+  "watchnow_any_service": "Op elke dienst"
 }

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -386,5 +386,7 @@
   "filter_all": "Wszystko",
   "filters_title": "Filtry",
   "ignore_watched": "Pomiń obejrzane",
-  "ignore_watchlisted": "Pomiń z listy"
+  "ignore_watchlisted": "Pomiń z listy",
+  "watchnow_favorites_only": "Tylko ulubione",
+  "watchnow_any_service": "Na każdym serwisie"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -386,5 +386,7 @@
   "filter_all": "Todos",
   "filters_title": "Filtros",
   "ignore_watched": "Ignorar Vistos",
-  "ignore_watchlisted": "Ignorar Lista"
+  "ignore_watchlisted": "Ignorar Lista",
+  "watchnow_favorites_only": "Só Favoritos",
+  "watchnow_any_service": "Em qualquer serviço"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -386,5 +386,7 @@
   "filter_all": "Toate",
   "filters_title": "Filtre",
   "ignore_watched": "Ignoră Văzute",
-  "ignore_watchlisted": "Ignoră de Vizionat"
+  "ignore_watchlisted": "Ignoră de Vizionat",
+  "watchnow_favorites_only": "Doar favoritele",
+  "watchnow_any_service": "Pe orice platformă"
 }

--- a/projects/client/i18n/messages/sv-se.json
+++ b/projects/client/i18n/messages/sv-se.json
@@ -386,5 +386,7 @@
   "filter_all": "Alla",
   "filters_title": "Filter",
   "ignore_watched": "Ignorera sett",
-  "ignore_watchlisted": "Ignorera att se"
+  "ignore_watchlisted": "Ignorera att se",
+  "watchnow_favorites_only": "Endast favoriter",
+  "watchnow_any_service": "På vilken tjänst som helst"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -386,5 +386,7 @@
   "filter_all": "Всі",
   "filters_title": "Фільтри",
   "ignore_watched": "Ігнорувати переглянуте",
-  "ignore_watchlisted": "Ігнорувати у списку"
+  "ignore_watchlisted": "Ігнорувати у списку",
+  "watchnow_favorites_only": "Тільки улюблене",
+  "watchnow_any_service": "На будь-якому сервісі"
 }

--- a/projects/client/src/lib/features/filters/constants.ts
+++ b/projects/client/src/lib/features/filters/constants.ts
@@ -16,6 +16,16 @@ const GENRE_FILTER: Filter = {
     .sort((a, b) => a.label.localeCompare(b.label, languageTag())),
 };
 
+const STREAMING_FILTER: Filter = {
+  label: m.streaming(),
+  key: FilterKey.Streaming,
+  type: 'list',
+  options: [
+    { label: m.watchnow_favorites_only(), value: 'favorites' },
+    { label: m.watchnow_any_service(), value: 'any' },
+  ],
+};
+
 const IGNORE_WATCHED_FILTER: Filter = {
   label: m.ignore_watched(),
   key: FilterKey.IgnoreWatched,
@@ -32,6 +42,7 @@ const IGNORE_WATCHLISTED_FILTER: Filter = {
 
 export const FILTERS = [
   GENRE_FILTER,
+  STREAMING_FILTER,
   IGNORE_WATCHED_FILTER,
   IGNORE_WATCHLISTED_FILTER,
 ] as const;

--- a/projects/client/src/lib/features/filters/models/Filter.ts
+++ b/projects/client/src/lib/features/filters/models/Filter.ts
@@ -7,6 +7,7 @@ export enum FilterKey {
   Genres = 'genres',
   IgnoreWatched = 'ignore_watched',
   IgnoreWatchlisted = 'ignore_watchlisted',
+  Streaming = 'watchnow',
 }
 
 type BaseFilter = {

--- a/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
@@ -1,5 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
+import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
 import { mapToListItem } from '$lib/requests/_internal/mapToListItem.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
@@ -65,7 +66,7 @@ export const listItemsQuery = defineQuery({
     params.limit,
     params.page,
     params.type,
-    params.filter?.genres,
+    ...getGlobalFilterDependencies(params),
   ],
   request: userListItemsRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
@@ -1,5 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
+import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
 import { mapToMovieListItem } from '$lib/requests/_internal/mapToListItem.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
@@ -50,7 +51,12 @@ export const movieWatchlistQuery = defineQuery({
   ],
   dependencies: (
     params: MovieWatchlistParams,
-  ) => [params.sort, params.limit, params.page, params.filter?.genres],
+  ) => [
+    params.sort,
+    params.limit,
+    params.page,
+    ...getGlobalFilterDependencies(params),
+  ],
   request: watchlistRequest,
   mapper: (response) => ({
     entries: response.body.map(mapToMovieListItem),

--- a/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
@@ -1,5 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
+import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
 import { mapToShowListItem } from '$lib/requests/_internal/mapToListItem.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
@@ -56,7 +57,12 @@ export const showWatchlistQuery = defineQuery({
   ],
   dependencies: (
     params: ShowWatchlistParams,
-  ) => [params.sort, params.limit, params.page, params.filter?.genres],
+  ) => [
+    params.sort,
+    params.limit,
+    params.page,
+    ...getGlobalFilterDependencies(params),
+  ],
   request: watchlistRequest,
   mapper: (response) => ({
     entries: response.body.map(mapToShowListItem),

--- a/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
@@ -1,5 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
+import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
 import { mapToListItem } from '$lib/requests/_internal/mapToListItem.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
@@ -77,7 +78,7 @@ export const userListItemsQuery = defineQuery({
     params.limit,
     params.page,
     params.type,
-    params.filter?.genres,
+    ...getGlobalFilterDependencies(params),
   ],
   request: userListItemsRequest,
   mapper: (response) => ({


### PR DESCRIPTION
## 🎶 Notes 🎶

- Uses the global filters dependencies on all queries that should(*) be filterable
  - *: will need a follow up API-side. Lists/watchlists don't support things like the watchnow, years, and ratings.
- Adds a streaming filter.

## 👀 Example 👀

https://github.com/user-attachments/assets/df622620-e19f-4c34-81ad-e20275a5c591

