### PR TITLE
feat(filter): use a more condensed lists of genres for filtering

### DIFF
--- a/projects/client/src/lib/features/filters/_internal/constants.ts
+++ b/projects/client/src/lib/features/filters/_internal/constants.ts
@@ -3,13 +3,13 @@ import { type Filter, FilterKey } from '$lib/features/filters/models/Filter.ts';
 import { languageTag } from '$lib/features/i18n/index.ts';
 import * as m from '$lib/features/i18n/messages.ts';
 import { toTranslatedValue } from '$lib/utils/formatting/string/toTranslatedValue.ts';
-import { genreOptionSchema } from '@trakt/api';
+import { GENRES } from './genres.ts';
 
 const GENRE_FILTER: Filter = {
   label: m.genre(),
   key: FilterKey.Genres,
   type: 'list',
-  options: genreOptionSchema.options
+  options: GENRES
     .map((genre) => ({
       label: toTranslatedValue('genre', genre),
       value: genre,

--- a/projects/client/src/lib/features/filters/_internal/genres.ts
+++ b/projects/client/src/lib/features/filters/_internal/genres.ts
@@ -1,0 +1,28 @@
+import type { Genre } from '@trakt/api';
+
+export const GENRES: Genre[] = [
+  'action',
+  'adventure',
+  'animation',
+  'anime',
+  'biography',
+  'children',
+  'comedy',
+  'crime',
+  'documentary',
+  'drama',
+  'family',
+  'fantasy',
+  'history',
+  'holiday',
+  'horror',
+  'musical',
+  'mystery',
+  'romance',
+  'science-fiction',
+  'superhero',
+  'suspense',
+  'thriller',
+  'war',
+  'western',
+] as const;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Uses a more condensed list of genres.
- I left out things that either seem redundant or not genre-like. The following items are left out:
````
'game-show',
'home-and-garden',
'mini-series',
'special-interest',
'sporting-event',
'talk-show',
'none',
'news',
'donghua',
'music',
'short',
'soap',
'reality'
````