### PR TITLE
fix(summary): show stream on button when navigation with d-pad

### DIFF
--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -3,6 +3,7 @@
 
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
   import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
+  import StreamingServiceButton from "$lib/components/buttons/streaming-service/StreamingServiceButton.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import GenreList from "$lib/components/summary/GenreList.svelte";
   import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
@@ -49,6 +50,16 @@
 </script>
 
 {#snippet mediaActions(size: "small" | "normal" = "normal")}
+  <RenderFor audience="authenticated" navigation="dpad">
+    {#if streamOn?.preferred}
+      <StreamingServiceButton
+        mediaTitle={episode.title}
+        service={streamOn.preferred}
+        style="normal"
+        size="normal"
+      />
+    {/if}
+  </RenderFor>
   <MarkAsWatchedAction
     style="normal"
     {type}


### PR DESCRIPTION
## ♪ Note ♪

- Episode stream on was missing when d-pad was enabled.

## 👀 Example 👀

Before:
<img width="1199" alt="Screenshot 2025-04-30 at 11 01 20" src="https://github.com/user-attachments/assets/7433dd33-52c4-41cd-8585-b5f80ae7ef88" />

After:
<img width="1199" alt="Screenshot 2025-04-30 at 11 01 11" src="https://github.com/user-attachments/assets/a477bfac-573d-4a74-92ef-70a871991b62" />

