### PR TITLE
feat(summary): add watch list button when navigating with d-pad

### DIFF
--- a/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
+++ b/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
@@ -2,6 +2,7 @@
   import Button from "$lib/components/buttons/Button.svelte";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import WatchlistIcon from "$lib/components/icons/WatchlistIcon.svelte";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import ActionButton from "../ActionButton.svelte";
   import { useDangerButton } from "../_internal/useDangerButton";
   import { WatchlistButtonIntlProvider } from "./WatchlistButtonIntlProvider";
@@ -35,12 +36,18 @@
 </script>
 
 {#if type === "normal"}
-  <Button {...commonProps} {...props}>
-    {i18n.text({ isWatchlisted, title })}
-    {#snippet icon()}
-      <WatchlistIcon size="small" {state} />
-    {/snippet}
-  </Button>
+  <div data-dpad-navigation={DpadNavigationType.List} style="display: contents">
+    <Button
+      {...commonProps}
+      {...props}
+      navigationType={DpadNavigationType.Item}
+    >
+      {i18n.text({ isWatchlisted, title })}
+      {#snippet icon()}
+        <WatchlistIcon size="small" {state} />
+      {/snippet}
+    </Button>
+  </div>
 {/if}
 
 {#if type === "action"}

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -97,6 +97,7 @@
         size="normal"
       />
     {/if}
+    <WatchlistAction {...watchlistProps} />
   </RenderFor>
   <MarkAsWatchedAction {...markAsWatchedProps} />
   <RenderFor audience="authenticated" navigation="dpad">


### PR DESCRIPTION
## ♪ Note ♪

- When in d-pad mode, the movie & show summary pages now have the watchlist button

## 👀 Examples 👀
Before:
<img width="1199" alt="Screenshot 2025-04-30 at 11 26 54" src="https://github.com/user-attachments/assets/407310fd-c17a-490f-8d44-e251183d3f9d" />

<img width="1199" alt="Screenshot 2025-04-30 at 11 27 21" src="https://github.com/user-attachments/assets/f1b8a46f-bee0-4dad-a737-ee4e1b6c619c" />

After:
<img width="1199" alt="Screenshot 2025-04-30 at 11 27 56" src="https://github.com/user-attachments/assets/9b3c25ff-6bbf-4d23-9e27-f61fe4a8f5c3" />

<img width="1199" alt="Screenshot 2025-04-30 at 11 27 30" src="https://github.com/user-attachments/assets/4f07eaf2-40ce-4734-a6bc-f5215187440b" />
