### PR TITLE
fix(list): use correct popup actions for media items in lists

### DIFF
--- a/projects/client/src/lib/sections/lists/popular/PopularListItem.svelte
+++ b/projects/client/src/lib/sections/lists/popular/PopularListItem.svelte
@@ -3,7 +3,8 @@
   import type { MediaCardProps } from "../components/MediaCardProps";
   import type { PopularEntry } from "./usePopularList";
 
-  const { type, media, style }: MediaCardProps<PopularEntry> = $props();
+  const { type, media, style, popupActions }: MediaCardProps<PopularEntry> =
+    $props();
 </script>
 
-<DefaultMediaItem {type} {media} {style} />
+<DefaultMediaItem {type} {media} {style} {popupActions} />


### PR DESCRIPTION
## ♪ Note ♪

- `remove from list` is available again on listed items

## 👀 Example 👀
Before:
<img width="1198" alt="Screenshot 2025-04-30 at 12 08 05" src="https://github.com/user-attachments/assets/7535c77e-a555-4329-84e7-00071503bfc3" />

After:
<img width="1198" alt="Screenshot 2025-04-30 at 12 08 16" src="https://github.com/user-attachments/assets/16d9e317-bde7-4a46-b04b-010953529467" />
