### PR TITLE
ci: enable deno dependency cache

### DIFF
--- a/.github/actions/setup-deno/action.yml
+++ b/.github/actions/setup-deno/action.yml
@@ -1,0 +1,34 @@
+name: Setup Deno Environment
+description: Prepares a Deno development environment with caching and dependencies
+
+inputs:
+  deno-version:
+    description: 'Deno version to install'
+    required: false
+    default: 'v2.x'
+
+runs:
+  using: composite
+  steps:
+    - name: Secure the Evidence aka Checkout Code
+      id: checkout
+      uses: actions/checkout@v4
+
+    - name: Summon the Digital Oracle aka Install Deno
+      uses: denoland/setup-deno@v2
+      with:
+        deno-version: ${{ inputs.deno-version }}
+
+    - name: The Vault of Memories aka Cache Deno Dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/deno
+          ~/.deno
+        key: ${{ runner.os }}-deno-${{ hashFiles('**/deno.json', '**/deno.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-deno-
+
+    - name: Gather the Tools aka Install Dependencies
+      shell: bash
+      run: 'deno task install'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,8 @@ jobs:
       - name: Secure the Evidence aka Checkout Code
         uses: actions/checkout@v4
 
-      - name: Summon the Digital Oracle aka Install Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Gather the Tools aka Install Dependencies
-        run: 'deno task install'
+      - name: Setup Deno Environment
+        uses: ./.github/actions/setup-deno
 
       - name: Probe the Client's Mind aka Run Tests
         working-directory: projects/client
@@ -141,13 +136,8 @@ jobs:
       - name: Secure the Evidence aka Checkout Code
         uses: actions/checkout@v4
 
-      - name: Summon the Digital Oracle aka Install Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Gather the Tools aka Install Dependencies
-        run: 'deno task install'
+      - name: Setup Deno Environment
+        uses: ./.github/actions/setup-deno
 
       - name: Weaving the Digital Tapestry aka Build
         working-directory: projects/client


### PR DESCRIPTION
This pull request updates the CI workflow by introducing caching for Deno dependencies. The caching mechanism is added to improve build performance by reusing previously downloaded dependencies.

### CI Workflow Enhancements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR69-R78): Added a step to cache Deno dependencies using `actions/cache@v4`. The cache includes paths `~/.cache/deno` and `~/.deno`, with a key based on the operating system and a hash of `deno.json` and `deno.lock` files. Restore keys are also specified for fallback. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR69-R78) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR159-R168)