### PR TITLE
feat(card): new focus effect when navigating with d-pad

### DIFF
--- a/projects/client/src/lib/components/card/Card.svelte
+++ b/projects/client/src/lib/components/card/Card.svelte
@@ -43,29 +43,28 @@
 
   .trakt-card[data-navigation-type="dpad"] {
     &:has(:global(.trakt-link)) {
-      /* TODO: this is broken for personcards now... */
-      transform: scale(0.95);
-      transition: none;
-
-      :global(.trakt-card-cover)::after {
-        transition: var(--transition-increment) ease-in;
-        transition-property: outline, outline-offset;
-        content: "";
+      .trakt-card-content {
+        transform: scale(0.95);
+        /* To compensate that we're scaling a non 1:1 aspect ratio element */
+        padding-top: var(--ni-1);
+        box-sizing: border-box;
       }
 
       &:focus-visible {
-        transition: transform var(--transition-increment) ease-in;
-        transform: scale(1);
+        &::after {
+          content: "";
 
-        :global(.trakt-card-cover)::after {
           position: absolute;
           top: 0;
           left: 0;
-          width: 100%;
-          height: 100%;
-          outline: var(--border-thickness-s) solid var(--color-link-active);
-          border-radius: var(--border-radius-m);
-          outline-offset: calc(-1 * var(--border-thickness-s));
+
+          width: var(--width-card);
+          height: var(--height-card);
+
+          outline: var(--border-thickness-xs) solid var(--color-link-active);
+          outline-offset: calc(-1 * var(--border-thickness-xs));
+
+          border-radius: var(--border-radius-l);
         }
       }
     }


### PR DESCRIPTION
## 🎶 Notes 🎶

- New card focus state when navigating using the d-pad.
  - Matches the designed version more closely.
  - No zoom effect (for now)
- Ideally we do a follow up to do this without scaling, even if we want to keep it without zoom.
  - With the scaling approach the margins/paddings are not equal.
  - Using the scaling approach with a bigger zoom effect leads to cards that are too tiny and gaps between them too large.

## 👀 Examples 👀
Before:

https://github.com/user-attachments/assets/352f26f9-d74a-4066-b60b-a81f4e991ad2

After:

https://github.com/user-attachments/assets/9bd8687e-7a63-42c9-9d9f-2898a2354b46
