### PR TITLE
feat / smart lists

### DIFF
--- a/.github/actions/setup-deno/action.yml
+++ b/.github/actions/setup-deno/action.yml
@@ -19,16 +19,6 @@ runs:
       with:
         deno-version: ${{ inputs.deno-version }}
 
-    - name: The Vault of Memories aka Cache Deno Dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/deno
-          ~/.deno
-        key: ${{ runner.os }}-deno-${{ hashFiles('**/deno.json', '**/deno.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-deno-
-
     - name: Gather the Tools aka Install Dependencies
       shell: bash
       run: 'deno task install'

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -60,6 +60,7 @@ module.exports = {
         'layout',
         'link',
         'list',
+        'smart-list',
         'mir',
         'movie',
         'msw',

--- a/deno.lock
+++ b/deno.lock
@@ -1,11 +1,11 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
     "npm:@cucumber/cucumber@11.2.0": "11.2.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.0.2_@cucumber+messages@27.0.2",
     "npm:@cucumber/cucumber@^11.2.0": "11.2.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.0.2_@cucumber+messages@27.0.2",
     "npm:@google/generative-ai@0.24": "0.24.0",
     "npm:@inlang/paraglide-sveltekit@~0.16.1": "0.16.1_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0",
-    "npm:@jsr/trakt__api@~0.1.23": "0.1.23_zod@3.24.1",
+    "npm:@jsr/trakt__api@~0.1.26": "0.1.26_zod@3.24.1",
     "npm:@playwright/test@^1.51.1": "1.51.1",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.25.3__acorn@8.14.1",
     "npm:@svelte-put/qr@^2.1.0": "2.1.0_svelte@5.25.3__acorn@8.14.1",
@@ -262,7 +262,8 @@
       "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dependencies": [
         "@babel/types"
-      ]
+      ],
+      "bin": true
     },
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9_@babel+core@7.26.10": {
       "integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
@@ -868,22 +869,35 @@
       "dependencies": [
         "unenv",
         "workerd"
+      ],
+      "optionalPeers": [
+        "workerd"
       ]
     },
     "@cloudflare/workerd-darwin-64@1.20250310.0": {
-      "integrity": "sha512-LkLJO6F8lRNaCbK5sQCITi66SyCirDpffRuI5/5iILDJWQU4KVvAOKPvHrd4E5h/WDm9FGd22zMJwky7SxaNjg=="
+      "integrity": "sha512-LkLJO6F8lRNaCbK5sQCITi66SyCirDpffRuI5/5iILDJWQU4KVvAOKPvHrd4E5h/WDm9FGd22zMJwky7SxaNjg==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
     "@cloudflare/workerd-darwin-arm64@1.20250310.0": {
-      "integrity": "sha512-WythDJQbsU3Ii1hhA7pJZLBQlHezeYWAnaMnv3gS2Exj45oF8G4chFvrO7zCzjlcJXwSeBTtQRJqxw9AiUDhyA=="
+      "integrity": "sha512-WythDJQbsU3Ii1hhA7pJZLBQlHezeYWAnaMnv3gS2Exj45oF8G4chFvrO7zCzjlcJXwSeBTtQRJqxw9AiUDhyA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
     "@cloudflare/workerd-linux-64@1.20250310.0": {
-      "integrity": "sha512-LbP769tT4/5QBHSj4lCt99QIKTi6cU+wYhLfF7rEtYHBnZS2+nIw9xttAzxeERx/aFrU+mxLcYPFV8fUeVxGng=="
+      "integrity": "sha512-LbP769tT4/5QBHSj4lCt99QIKTi6cU+wYhLfF7rEtYHBnZS2+nIw9xttAzxeERx/aFrU+mxLcYPFV8fUeVxGng==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@cloudflare/workerd-linux-arm64@1.20250310.0": {
-      "integrity": "sha512-FzWeKM6id20EMZACaDg0Kkvg1C4lvXZgLBXVI6h6xaXTNFReoyEp4v4eMrRTuja5ec5k+m5iGKjP4/bMWJp9ew=="
+      "integrity": "sha512-FzWeKM6id20EMZACaDg0Kkvg1C4lvXZgLBXVI6h6xaXTNFReoyEp4v4eMrRTuja5ec5k+m5iGKjP4/bMWJp9ew==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@cloudflare/workerd-windows-64@1.20250310.0": {
-      "integrity": "sha512-04OgaDzm8/8nkjF3tovB+WywZLjSdAHCQT2omXKCwH3EDd1kpd8vvzE1pErtdIyKCOf9/sArY4BhPdxRj7ijlg=="
+      "integrity": "sha512-04OgaDzm8/8nkjF3tovB+WywZLjSdAHCQT2omXKCwH3EDd1kpd8vvzE1pErtdIyKCOf9/sArY4BhPdxRj7ijlg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@cloudflare/workers-types@4.20250321.0": {
       "integrity": "sha512-jPwtZJC7tVFOwFazuwq96be8haTnY9qik8hJ+oLFi50d9LTWPPrnrNHC4OxZmJTEcPIAy0y1WFZHe8C/b7xFXQ=="
@@ -978,7 +992,8 @@
         "util-arity",
         "yaml@2.7.0",
         "yup"
-      ]
+      ],
+      "bin": true
     },
     "@cucumber/gherkin-streams@5.0.1_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.0.2_@cucumber+messages@27.0.2": {
       "integrity": "sha512-/7VkIE/ASxIP/jd4Crlp4JHXqdNFxPGQokqWqsaCCiqBiu5qHoKMxcWNlp9njVL/n9yN4S08OmY3ZR8uC5x74Q==",
@@ -988,7 +1003,8 @@
         "@cucumber/messages@27.0.2",
         "commander@9.1.0",
         "source-map-support"
-      ]
+      ],
+      "bin": true
     },
     "@cucumber/gherkin-utils@9.0.0": {
       "integrity": "sha512-clk4q39uj7pztZuZtyI54V8lRsCUz0Y/p8XRjIeHh7ExeEztpWkp4ca9q1FjUOPfQQ8E7OgqFbqoQQXZ1Bx7fw==",
@@ -998,7 +1014,8 @@
         "@teppeis/multimaps",
         "commander@12.0.0",
         "source-map-support"
-      ]
+      ],
+      "bin": true
     },
     "@cucumber/gherkin@28.0.0": {
       "integrity": "sha512-Ee6zJQq0OmIUPdW0mSnsCsrWA2PZAELNDPICD2pLfs0Oz7RAPgj80UsD2UCtqyAhw2qAR62aqlktKUlai5zl/A==",
@@ -1092,220 +1109,364 @@
       ]
     },
     "@esbuild/aix-ppc64@0.24.2": {
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA=="
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
     },
     "@esbuild/aix-ppc64@0.25.1": {
-      "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ=="
+      "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
     },
     "@esbuild/android-arm64@0.17.19": {
-      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA=="
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "os": ["android"],
+      "cpu": ["arm64"]
     },
     "@esbuild/android-arm64@0.24.2": {
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg=="
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
     },
     "@esbuild/android-arm64@0.25.1": {
-      "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA=="
+      "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
+      "os": ["android"],
+      "cpu": ["arm64"]
     },
     "@esbuild/android-arm@0.17.19": {
-      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A=="
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "os": ["android"],
+      "cpu": ["arm"]
     },
     "@esbuild/android-arm@0.24.2": {
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q=="
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "os": ["android"],
+      "cpu": ["arm"]
     },
     "@esbuild/android-arm@0.25.1": {
-      "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q=="
+      "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
+      "os": ["android"],
+      "cpu": ["arm"]
     },
     "@esbuild/android-x64@0.17.19": {
-      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww=="
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "os": ["android"],
+      "cpu": ["x64"]
     },
     "@esbuild/android-x64@0.24.2": {
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw=="
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "os": ["android"],
+      "cpu": ["x64"]
     },
     "@esbuild/android-x64@0.25.1": {
-      "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw=="
+      "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
+      "os": ["android"],
+      "cpu": ["x64"]
     },
     "@esbuild/darwin-arm64@0.17.19": {
-      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg=="
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
     "@esbuild/darwin-arm64@0.24.2": {
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA=="
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
     "@esbuild/darwin-arm64@0.25.1": {
-      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ=="
+      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
     "@esbuild/darwin-x64@0.17.19": {
-      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw=="
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
     "@esbuild/darwin-x64@0.24.2": {
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA=="
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
     "@esbuild/darwin-x64@0.25.1": {
-      "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA=="
+      "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
     "@esbuild/freebsd-arm64@0.17.19": {
-      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ=="
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
     },
     "@esbuild/freebsd-arm64@0.24.2": {
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg=="
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
     },
     "@esbuild/freebsd-arm64@0.25.1": {
-      "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A=="
+      "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
     },
     "@esbuild/freebsd-x64@0.17.19": {
-      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ=="
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
     },
     "@esbuild/freebsd-x64@0.24.2": {
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q=="
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
     },
     "@esbuild/freebsd-x64@0.25.1": {
-      "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww=="
+      "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
     },
     "@esbuild/linux-arm64@0.17.19": {
-      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg=="
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@esbuild/linux-arm64@0.24.2": {
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg=="
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@esbuild/linux-arm64@0.25.1": {
-      "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ=="
+      "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@esbuild/linux-arm@0.17.19": {
-      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA=="
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "@esbuild/linux-arm@0.24.2": {
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA=="
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "@esbuild/linux-arm@0.25.1": {
-      "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ=="
+      "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "@esbuild/linux-ia32@0.17.19": {
-      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ=="
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
     },
     "@esbuild/linux-ia32@0.24.2": {
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw=="
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
     },
     "@esbuild/linux-ia32@0.25.1": {
-      "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ=="
+      "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
     },
     "@esbuild/linux-loong64@0.17.19": {
-      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ=="
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
     },
     "@esbuild/linux-loong64@0.24.2": {
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ=="
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
     },
     "@esbuild/linux-loong64@0.25.1": {
-      "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg=="
+      "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
     },
     "@esbuild/linux-mips64el@0.17.19": {
-      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A=="
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
     },
     "@esbuild/linux-mips64el@0.24.2": {
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw=="
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
     },
     "@esbuild/linux-mips64el@0.25.1": {
-      "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg=="
+      "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
     },
     "@esbuild/linux-ppc64@0.17.19": {
-      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg=="
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
     },
     "@esbuild/linux-ppc64@0.24.2": {
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw=="
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
     },
     "@esbuild/linux-ppc64@0.25.1": {
-      "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg=="
+      "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
     },
     "@esbuild/linux-riscv64@0.17.19": {
-      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA=="
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
     },
     "@esbuild/linux-riscv64@0.24.2": {
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q=="
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
     },
     "@esbuild/linux-riscv64@0.25.1": {
-      "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ=="
+      "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
     },
     "@esbuild/linux-s390x@0.17.19": {
-      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q=="
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
     },
     "@esbuild/linux-s390x@0.24.2": {
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw=="
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
     },
     "@esbuild/linux-s390x@0.25.1": {
-      "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ=="
+      "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
     },
     "@esbuild/linux-x64@0.17.19": {
-      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw=="
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@esbuild/linux-x64@0.24.2": {
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q=="
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@esbuild/linux-x64@0.25.1": {
-      "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA=="
+      "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@esbuild/netbsd-arm64@0.24.2": {
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw=="
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
     },
     "@esbuild/netbsd-arm64@0.25.1": {
-      "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g=="
+      "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
     },
     "@esbuild/netbsd-x64@0.17.19": {
-      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q=="
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
     },
     "@esbuild/netbsd-x64@0.24.2": {
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw=="
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
     },
     "@esbuild/netbsd-x64@0.25.1": {
-      "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA=="
+      "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
     },
     "@esbuild/openbsd-arm64@0.24.2": {
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A=="
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
     },
     "@esbuild/openbsd-arm64@0.25.1": {
-      "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg=="
+      "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
     },
     "@esbuild/openbsd-x64@0.17.19": {
-      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g=="
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
     },
     "@esbuild/openbsd-x64@0.24.2": {
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA=="
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
     },
     "@esbuild/openbsd-x64@0.25.1": {
-      "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw=="
+      "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
     },
     "@esbuild/sunos-x64@0.17.19": {
-      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg=="
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
     },
     "@esbuild/sunos-x64@0.24.2": {
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig=="
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
     },
     "@esbuild/sunos-x64@0.25.1": {
-      "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg=="
+      "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
     },
     "@esbuild/win32-arm64@0.17.19": {
-      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag=="
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
     },
     "@esbuild/win32-arm64@0.24.2": {
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ=="
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
     },
     "@esbuild/win32-arm64@0.25.1": {
-      "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ=="
+      "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
     },
     "@esbuild/win32-ia32@0.17.19": {
-      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw=="
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
     },
     "@esbuild/win32-ia32@0.24.2": {
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA=="
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
     },
     "@esbuild/win32-ia32@0.25.1": {
-      "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A=="
+      "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
     },
     "@esbuild/win32-x64@0.17.19": {
-      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA=="
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@esbuild/win32-x64@0.24.2": {
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg=="
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@esbuild/win32-x64@0.25.1": {
-      "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg=="
+      "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@eslint-community/eslint-utils@4.5.1_eslint@9.23.0": {
       "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
@@ -1718,7 +1879,8 @@
       "integrity": "sha512-PzSrhIr++KI6y4P6C/IdgBNMkEx0Ex6554/cYd0Hm+ovyFSJtJXqb/3OSIdnBoa2cpwZT1/GW56EmRc5qEc5fQ==",
       "dependencies": [
         "tslib"
-      ]
+      ],
+      "scripts": true
     },
     "@firebase/vertexai@1.2.0_@firebase+app@0.11.3_@firebase+app-types@0.9.3": {
       "integrity": "sha512-WUYIzFpOipjFXT2i0hT26wivJoIximizQptVs3KAxFAqbVlO8sjKPsMkgz0bh+tdKlqP4SUDda71fMUZXUKHgA==",
@@ -1768,7 +1930,8 @@
         "long",
         "protobufjs",
         "yargs"
-      ]
+      ],
+      "bin": true
     },
     "@humanfs/core@0.19.1": {
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="
@@ -1791,105 +1954,145 @@
     },
     "@img/sharp-darwin-arm64@0.33.5": {
       "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
-      "dependencies": [
+      "optionalDependencies": [
         "@img/sharp-libvips-darwin-arm64"
-      ]
+      ],
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
     "@img/sharp-darwin-x64@0.33.5": {
       "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-      "dependencies": [
+      "optionalDependencies": [
         "@img/sharp-libvips-darwin-x64"
-      ]
+      ],
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
     "@img/sharp-libvips-darwin-arm64@1.0.4": {
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
     "@img/sharp-libvips-darwin-x64@1.0.4": {
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
     "@img/sharp-libvips-linux-arm64@1.0.4": {
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@img/sharp-libvips-linux-arm@1.0.5": {
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "@img/sharp-libvips-linux-s390x@1.0.4": {
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
     },
     "@img/sharp-libvips-linux-x64@1.0.4": {
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@img/sharp-libvips-linuxmusl-arm64@1.0.4": {
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@img/sharp-libvips-linuxmusl-x64@1.0.4": {
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@img/sharp-linux-arm64@0.33.5": {
       "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
-      "dependencies": [
+      "optionalDependencies": [
         "@img/sharp-libvips-linux-arm64"
-      ]
+      ],
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@img/sharp-linux-arm@0.33.5": {
       "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-      "dependencies": [
+      "optionalDependencies": [
         "@img/sharp-libvips-linux-arm"
-      ]
+      ],
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "@img/sharp-linux-s390x@0.33.5": {
       "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
-      "dependencies": [
+      "optionalDependencies": [
         "@img/sharp-libvips-linux-s390x"
-      ]
+      ],
+      "os": ["linux"],
+      "cpu": ["s390x"]
     },
     "@img/sharp-linux-x64@0.33.5": {
       "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-      "dependencies": [
+      "optionalDependencies": [
         "@img/sharp-libvips-linux-x64"
-      ]
+      ],
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@img/sharp-linuxmusl-arm64@0.33.5": {
       "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
-      "dependencies": [
+      "optionalDependencies": [
         "@img/sharp-libvips-linuxmusl-arm64"
-      ]
+      ],
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@img/sharp-linuxmusl-x64@0.33.5": {
       "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-      "dependencies": [
+      "optionalDependencies": [
         "@img/sharp-libvips-linuxmusl-x64"
-      ]
+      ],
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@img/sharp-wasm32@0.33.5": {
       "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
       "dependencies": [
         "@emnapi/runtime"
-      ]
+      ],
+      "cpu": ["wasm32"]
     },
     "@img/sharp-win32-ia32@0.33.5": {
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
     },
     "@img/sharp-win32-x64@0.33.5": {
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@inlang/detect-json-formatting@1.0.0": {
       "integrity": "sha512-o0jeI8U4TgNlsPwI0y92jld8/18Loh2KEgHCYCJ42rCOdxFrA8R60cydlEd2/6jkdHFn5DxKj8rOyiKv3z9uOw==",
       "dependencies": [
         "guess-json-indent"
-      ]
+      ],
+      "deprecated": true
     },
     "@inlang/json-types@1.1.0_@sinclair+typebox@0.31.28": {
       "integrity": "sha512-n6vS6AqETsCFbV4TdBvR/EH57waVXzKsMqeUQ+eH2Q6NUATfKhfLabgNms2A+QV3aedH/hLtb1pRmjl2ykBVZg==",
       "dependencies": [
         "@sinclair/typebox"
-      ]
+      ],
+      "deprecated": true
     },
     "@inlang/language-tag@1.5.1": {
       "integrity": "sha512-+NlYDxDvN5h/TKUmkuQv+Ct1flxaVRousCbek7oFEk3/afZPVLNTJhm+cX2xiOg3tmi2KKrBLfy/V9oUDHj6GQ==",
       "dependencies": [
         "@sinclair/typebox"
-      ]
+      ],
+      "deprecated": true
     },
     "@inlang/message-lint-rule@1.4.7_@sinclair+typebox@0.31.28": {
       "integrity": "sha512-FCiFe/H25fqhsIb/YTb0K7eDJqEYzdr6ectF0xG4zARiS7nXz0FHxk2niJrIO8kFkB4mx6tszsgQ0xqD5cHQag==",
@@ -1900,14 +2103,16 @@
         "@inlang/project-settings",
         "@inlang/translatable",
         "@sinclair/typebox"
-      ]
+      ],
+      "deprecated": true
     },
     "@inlang/message@2.1.0_@sinclair+typebox@0.31.28": {
       "integrity": "sha512-Gr3wiErI7fW4iW11xgZzsJEUTjlZuz02fB/EO+ENTBlSHGyI1kzbCCeNqLr1mnGdQYiOxfuZxY0S4G5C6Pju3Q==",
       "dependencies": [
         "@inlang/language-tag",
         "@sinclair/typebox"
-      ]
+      ],
+      "deprecated": true
     },
     "@inlang/module@1.2.14_@sinclair+typebox@0.31.28": {
       "integrity": "sha512-Z7rRa6x3RkzjdvNA7x+KskNGdSBEO46X9c7bTl6eZmLXy0J9yGDn6s4jpYqQzyKRG8g5mEqWcRqcVqdNwzj5Gg==",
@@ -1915,7 +2120,8 @@
         "@inlang/message-lint-rule",
         "@inlang/plugin",
         "@sinclair/typebox"
-      ]
+      ],
+      "deprecated": true
     },
     "@inlang/paraglide-js@1.11.8": {
       "integrity": "sha512-PxzrmDP63fbMNF4/AtiLFTnUodFxVbOkLpIrOzPZvNuLg0wCWnsaBfNT87/rNjL/A7ZPzEBmuDi0P2pn8iB0Fw==",
@@ -1933,7 +2139,8 @@
         "dedent",
         "json5",
         "posthog-node"
-      ]
+      ],
+      "bin": true
     },
     "@inlang/paraglide-sveltekit@0.16.1_@sveltejs+kit@2.20.2__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.25.3____acorn@8.14.1___vite@6.2.3____sass-embedded@1.86.0___sass-embedded@1.86.0__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0": {
       "integrity": "sha512-NDmfbeH2lWlktsQrVp/bKpih6fxNMFph4VpRp3wCrK04ZqOkhIRHlCpMlmrb3ol+zuUcFdojTqBC1gz8pZ8bbA==",
@@ -1947,7 +2154,9 @@
         "devalue@4.3.3",
         "magic-string@0.30.17",
         "svelte"
-      ]
+      ],
+      "deprecated": true,
+      "bin": true
     },
     "@inlang/paraglide-unplugin@1.9.5": {
       "integrity": "sha512-5KklLBvl/y+R4SccWH74USTGQNFW5IwEyMLQ3WIHX9cHX2pnnA5wGqQxYg3EcgCyErHLc3+sm7EMNB5Z0dSeTg==",
@@ -1957,13 +2166,15 @@
         "@lix-js/client",
         "typescript@5.8.2",
         "unplugin"
-      ]
+      ],
+      "deprecated": true
     },
     "@inlang/paraglide-vite@1.4.0": {
       "integrity": "sha512-JXfHOOhXNMlHkouO6nuYoIYL5iqM6Y6FtLNq64nIUOpVnXSQfyYCF73lHYE7ZqRMQxoCvUWnqAlyUb4MTmP2IQ==",
       "dependencies": [
         "@inlang/paraglide-unplugin"
-      ]
+      ],
+      "deprecated": true
     },
     "@inlang/plugin-message-format@2.2.0": {
       "integrity": "sha512-6MJLExr3OLqbR8gCP4UEgNMgdaJFFCug2GLmFwid7Ana4kObnbCA33YN3m3eN8p+lmnv7zpfW7oeyTZXZLoptg=="
@@ -1978,7 +2189,8 @@
         "@inlang/translatable",
         "@lix-js/fs",
         "@sinclair/typebox"
-      ]
+      ],
+      "deprecated": true
     },
     "@inlang/project-settings@2.4.2_@sinclair+typebox@0.31.28": {
       "integrity": "sha512-Okus2JdwTzNebZHkXCrUH/zIWwqu7kWm/ZQaM6a31oRIEA2JdQJtyNGM8E/KrwGfEuq18U+WV03+tR3tkwsGvA==",
@@ -1996,7 +2208,8 @@
         "@lix-js/fs",
         "@sinclair/typebox",
         "js-yaml"
-      ]
+      ],
+      "deprecated": true
     },
     "@inlang/recommend-sherlock@0.1.1": {
       "integrity": "sha512-8qZ8FJ/QqVh6YqKmHo3SxI4ENM0O80TCzETm+hxeQ2JzPKPFYucFINpLvUygiLFp/hJwhoI5TjRz6jNI2QdfMQ==",
@@ -2008,7 +2221,8 @@
       ]
     },
     "@inlang/result@1.1.0": {
-      "integrity": "sha512-zLGroi9EUiHuOjUOaglUVTFO7EWdo2OARMJLBO1Q5Ga/xJmSQb6XS1lhqEXBFAjgFarfEMX5YEJWWALogYV3wA=="
+      "integrity": "sha512-zLGroi9EUiHuOjUOaglUVTFO7EWdo2OARMJLBO1Q5Ga/xJmSQb6XS1lhqEXBFAjgFarfEMX5YEJWWALogYV3wA==",
+      "deprecated": true
     },
     "@inlang/sdk@0.36.3_@sinclair+typebox@0.31.28": {
       "integrity": "sha512-wjsavc44H24v74tdEQ13FqZZcr43T106oEfHJnBLzEP55Zz2JJWABLund+DEdosZx+9E8mJBEW5JlVnlBwP3Zw==",
@@ -2083,7 +2297,8 @@
       "integrity": "sha512-VAtle21vRpIrB+axtHFrFB0d1HtDaaNj+lV77eZQTJyOWbTFYTVIQJ8WAbyw9eu4F6h6QC2FutLyxjMomxfpcQ==",
       "dependencies": [
         "@inlang/language-tag"
-      ]
+      ],
+      "deprecated": true
     },
     "@inquirer/confirm@5.1.8": {
       "integrity": "sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==",
@@ -2163,12 +2378,13 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.1.23_zod@3.24.1": {
-      "integrity": "sha512-a5T8NKp28vR72vwDQw+fnHc8ILdqLUk0TfM/rCHBLGzO5tBSXcC2fys3NlPATdy7p0GPXjpT3mcTW1G80LASCQ==",
+    "@jsr/trakt__api@0.1.26_zod@3.24.1": {
+      "integrity": "sha512-SKMijtOkMWLXgDU37fWHPVocNThbvld+y+DqnbT3yNcWzClrt/ydXdlF4pIMDmY1dhtDb+UwiPCKUpt+e1+zkA==",
       "dependencies": [
         "@ts-rest/core",
         "zod@3.24.1"
-      ]
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.1.26.tgz"
     },
     "@lix-js/client@2.2.1": {
       "integrity": "sha512-6DTJdRN2L2a1A8OxW1Wqh3ZOORqq8+YlCALMF5UMoxhfHE4Fcq9FZztMkAV+KwhrDSsp0USWvD9myG0XX+v6QQ==",
@@ -2182,13 +2398,15 @@
         "pako",
         "pify",
         "sha.js"
-      ]
+      ],
+      "deprecated": true
     },
     "@lix-js/fs@2.2.0": {
       "integrity": "sha512-B9X3FjD8WmdG7tbA44JuniSO0KdKBWnjfxl8zpgrDCkavrp/GP7U0xxBkc0WgeeoHjQ/pkqq9VqtWB2kS9jIUg==",
       "dependencies": [
         "typescript@5.2.2"
-      ]
+      ],
+      "deprecated": true
     },
     "@mswjs/interceptors@0.37.6": {
       "integrity": "sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==",
@@ -2446,7 +2664,8 @@
       "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
       "dependencies": [
         "playwright"
-      ]
+      ],
+      "bin": true
     },
     "@polka/url@1.0.0-next.28": {
       "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw=="
@@ -2505,6 +2724,9 @@
         "deepmerge",
         "is-module",
         "resolve"
+      ],
+      "optionalPeers": [
+        "rollup@^2.78.0||^3.0.0||^4.0.0"
       ]
     },
     "@rollup/plugin-node-resolve@15.3.1_rollup@2.79.2": {
@@ -2515,6 +2737,9 @@
         "deepmerge",
         "is-module",
         "resolve",
+        "rollup@2.79.2"
+      ],
+      "optionalPeers": [
         "rollup@2.79.2"
       ]
     },
@@ -2533,6 +2758,9 @@
         "serialize-javascript",
         "smob",
         "terser"
+      ],
+      "optionalPeers": [
+        "rollup@2.79.2"
       ]
     },
     "@rollup/pluginutils@3.1.0_rollup@2.79.2": {
@@ -2550,6 +2778,9 @@
         "@types/estree@1.0.6",
         "estree-walker@2.0.2",
         "picomatch@4.0.2"
+      ],
+      "optionalPeers": [
+        "rollup@^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       ]
     },
     "@rollup/pluginutils@5.1.4_rollup@2.79.2": {
@@ -2559,67 +2790,110 @@
         "estree-walker@2.0.2",
         "picomatch@4.0.2",
         "rollup@2.79.2"
+      ],
+      "optionalPeers": [
+        "rollup@2.79.2"
       ]
     },
     "@rollup/rollup-android-arm-eabi@4.37.0": {
-      "integrity": "sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ=="
+      "integrity": "sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==",
+      "os": ["android"],
+      "cpu": ["arm"]
     },
     "@rollup/rollup-android-arm64@4.37.0": {
-      "integrity": "sha512-6U3SlVyMxezt8Y+/iEBcbp945uZjJwjZimu76xoG7tO1av9VO691z8PkhzQ85ith2I8R2RddEPeSfcbyPfD4hA=="
+      "integrity": "sha512-6U3SlVyMxezt8Y+/iEBcbp945uZjJwjZimu76xoG7tO1av9VO691z8PkhzQ85ith2I8R2RddEPeSfcbyPfD4hA==",
+      "os": ["android"],
+      "cpu": ["arm64"]
     },
     "@rollup/rollup-darwin-arm64@4.37.0": {
-      "integrity": "sha512-+iTQ5YHuGmPt10NTzEyMPbayiNTcOZDWsbxZYR1ZnmLnZxG17ivrPSWFO9j6GalY0+gV3Jtwrrs12DBscxnlYA=="
+      "integrity": "sha512-+iTQ5YHuGmPt10NTzEyMPbayiNTcOZDWsbxZYR1ZnmLnZxG17ivrPSWFO9j6GalY0+gV3Jtwrrs12DBscxnlYA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
     "@rollup/rollup-darwin-x64@4.37.0": {
-      "integrity": "sha512-m8W2UbxLDcmRKVjgl5J/k4B8d7qX2EcJve3Sut7YGrQoPtCIQGPH5AMzuFvYRWZi0FVS0zEY4c8uttPfX6bwYQ=="
+      "integrity": "sha512-m8W2UbxLDcmRKVjgl5J/k4B8d7qX2EcJve3Sut7YGrQoPtCIQGPH5AMzuFvYRWZi0FVS0zEY4c8uttPfX6bwYQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
     "@rollup/rollup-freebsd-arm64@4.37.0": {
-      "integrity": "sha512-FOMXGmH15OmtQWEt174v9P1JqqhlgYge/bUjIbiVD1nI1NeJ30HYT9SJlZMqdo1uQFyt9cz748F1BHghWaDnVA=="
+      "integrity": "sha512-FOMXGmH15OmtQWEt174v9P1JqqhlgYge/bUjIbiVD1nI1NeJ30HYT9SJlZMqdo1uQFyt9cz748F1BHghWaDnVA==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
     },
     "@rollup/rollup-freebsd-x64@4.37.0": {
-      "integrity": "sha512-SZMxNttjPKvV14Hjck5t70xS3l63sbVwl98g3FlVVx2YIDmfUIy29jQrsw06ewEYQ8lQSuY9mpAPlmgRD2iSsA=="
+      "integrity": "sha512-SZMxNttjPKvV14Hjck5t70xS3l63sbVwl98g3FlVVx2YIDmfUIy29jQrsw06ewEYQ8lQSuY9mpAPlmgRD2iSsA==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
     },
     "@rollup/rollup-linux-arm-gnueabihf@4.37.0": {
-      "integrity": "sha512-hhAALKJPidCwZcj+g+iN+38SIOkhK2a9bqtJR+EtyxrKKSt1ynCBeqrQy31z0oWU6thRZzdx53hVgEbRkuI19w=="
+      "integrity": "sha512-hhAALKJPidCwZcj+g+iN+38SIOkhK2a9bqtJR+EtyxrKKSt1ynCBeqrQy31z0oWU6thRZzdx53hVgEbRkuI19w==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "@rollup/rollup-linux-arm-musleabihf@4.37.0": {
-      "integrity": "sha512-jUb/kmn/Gd8epbHKEqkRAxq5c2EwRt0DqhSGWjPFxLeFvldFdHQs/n8lQ9x85oAeVb6bHcS8irhTJX2FCOd8Ag=="
+      "integrity": "sha512-jUb/kmn/Gd8epbHKEqkRAxq5c2EwRt0DqhSGWjPFxLeFvldFdHQs/n8lQ9x85oAeVb6bHcS8irhTJX2FCOd8Ag==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "@rollup/rollup-linux-arm64-gnu@4.37.0": {
-      "integrity": "sha512-oNrJxcQT9IcbcmKlkF+Yz2tmOxZgG9D9GRq+1OE6XCQwCVwxixYAa38Z8qqPzQvzt1FCfmrHX03E0pWoXm1DqA=="
+      "integrity": "sha512-oNrJxcQT9IcbcmKlkF+Yz2tmOxZgG9D9GRq+1OE6XCQwCVwxixYAa38Z8qqPzQvzt1FCfmrHX03E0pWoXm1DqA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@rollup/rollup-linux-arm64-musl@4.37.0": {
-      "integrity": "sha512-pfxLBMls+28Ey2enpX3JvjEjaJMBX5XlPCZNGxj4kdJyHduPBXtxYeb8alo0a7bqOoWZW2uKynhHxF/MWoHaGQ=="
+      "integrity": "sha512-pfxLBMls+28Ey2enpX3JvjEjaJMBX5XlPCZNGxj4kdJyHduPBXtxYeb8alo0a7bqOoWZW2uKynhHxF/MWoHaGQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@rollup/rollup-linux-loongarch64-gnu@4.37.0": {
-      "integrity": "sha512-yCE0NnutTC/7IGUq/PUHmoeZbIwq3KRh02e9SfFh7Vmc1Z7atuJRYWhRME5fKgT8aS20mwi1RyChA23qSyRGpA=="
+      "integrity": "sha512-yCE0NnutTC/7IGUq/PUHmoeZbIwq3KRh02e9SfFh7Vmc1Z7atuJRYWhRME5fKgT8aS20mwi1RyChA23qSyRGpA==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
     },
     "@rollup/rollup-linux-powerpc64le-gnu@4.37.0": {
-      "integrity": "sha512-NxcICptHk06E2Lh3a4Pu+2PEdZ6ahNHuK7o6Np9zcWkrBMuv21j10SQDJW3C9Yf/A/P7cutWoC/DptNLVsZ0VQ=="
+      "integrity": "sha512-NxcICptHk06E2Lh3a4Pu+2PEdZ6ahNHuK7o6Np9zcWkrBMuv21j10SQDJW3C9Yf/A/P7cutWoC/DptNLVsZ0VQ==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
     },
     "@rollup/rollup-linux-riscv64-gnu@4.37.0": {
-      "integrity": "sha512-PpWwHMPCVpFZLTfLq7EWJWvrmEuLdGn1GMYcm5MV7PaRgwCEYJAwiN94uBuZev0/J/hFIIJCsYw4nLmXA9J7Pw=="
+      "integrity": "sha512-PpWwHMPCVpFZLTfLq7EWJWvrmEuLdGn1GMYcm5MV7PaRgwCEYJAwiN94uBuZev0/J/hFIIJCsYw4nLmXA9J7Pw==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
     },
     "@rollup/rollup-linux-riscv64-musl@4.37.0": {
-      "integrity": "sha512-DTNwl6a3CfhGTAOYZ4KtYbdS8b+275LSLqJVJIrPa5/JuIufWWZ/QFvkxp52gpmguN95eujrM68ZG+zVxa8zHA=="
+      "integrity": "sha512-DTNwl6a3CfhGTAOYZ4KtYbdS8b+275LSLqJVJIrPa5/JuIufWWZ/QFvkxp52gpmguN95eujrM68ZG+zVxa8zHA==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
     },
     "@rollup/rollup-linux-s390x-gnu@4.37.0": {
-      "integrity": "sha512-hZDDU5fgWvDdHFuExN1gBOhCuzo/8TMpidfOR+1cPZJflcEzXdCy1LjnklQdW8/Et9sryOPJAKAQRw8Jq7Tg+A=="
+      "integrity": "sha512-hZDDU5fgWvDdHFuExN1gBOhCuzo/8TMpidfOR+1cPZJflcEzXdCy1LjnklQdW8/Et9sryOPJAKAQRw8Jq7Tg+A==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
     },
     "@rollup/rollup-linux-x64-gnu@4.37.0": {
-      "integrity": "sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ=="
+      "integrity": "sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@rollup/rollup-linux-x64-musl@4.37.0": {
-      "integrity": "sha512-E2lPrLKE8sQbY/2bEkVTGDEk4/49UYRVWgj90MY8yPjpnGBQ+Xi1Qnr7b7UIWw1NOggdFQFOLZ8+5CzCiz143w=="
+      "integrity": "sha512-E2lPrLKE8sQbY/2bEkVTGDEk4/49UYRVWgj90MY8yPjpnGBQ+Xi1Qnr7b7UIWw1NOggdFQFOLZ8+5CzCiz143w==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@rollup/rollup-win32-arm64-msvc@4.37.0": {
-      "integrity": "sha512-Jm7biMazjNzTU4PrQtr7VS8ibeys9Pn29/1bm4ph7CP2kf21950LgN+BaE2mJ1QujnvOc6p54eWWiVvn05SOBg=="
+      "integrity": "sha512-Jm7biMazjNzTU4PrQtr7VS8ibeys9Pn29/1bm4ph7CP2kf21950LgN+BaE2mJ1QujnvOc6p54eWWiVvn05SOBg==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
     },
     "@rollup/rollup-win32-ia32-msvc@4.37.0": {
-      "integrity": "sha512-e3/1SFm1OjefWICB2Ucstg2dxYDkDTZGDYgwufcbsxTHyqQps1UQf33dFEChBNmeSsTOyrjw2JJq0zbG5GF6RA=="
+      "integrity": "sha512-e3/1SFm1OjefWICB2Ucstg2dxYDkDTZGDYgwufcbsxTHyqQps1UQf33dFEChBNmeSsTOyrjw2JJq0zbG5GF6RA==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
     },
     "@rollup/rollup-win32-x64-msvc@4.37.0": {
-      "integrity": "sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA=="
+      "integrity": "sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@sinclair/typebox@0.31.28": {
       "integrity": "sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ=="
@@ -2698,7 +2972,8 @@
         "sirv",
         "svelte",
         "vite"
-      ]
+      ],
+      "bin": true
     },
     "@sveltejs/vite-plugin-svelte-inspector@4.0.1_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.25.3___acorn@8.14.1__vite@6.2.3___sass-embedded@1.86.0__sass-embedded@1.86.0_svelte@5.25.3__acorn@8.14.1_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0": {
       "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
@@ -2793,6 +3068,10 @@
         "svelte",
         "vite",
         "vitest"
+      ],
+      "optionalPeers": [
+        "vite",
+        "vitest"
       ]
     },
     "@testing-library/user-event@14.6.1_@testing-library+dom@10.4.0": {
@@ -2804,6 +3083,9 @@
     "@ts-rest/core@3.52.1_zod@3.24.1": {
       "integrity": "sha512-tAjz7Kxq/grJodcTA1Anop4AVRDlD40fkksEV5Mmal88VoZeRKAG8oMHsDwdwPZz+B/zgnz0q2sF+cm5M7Bc7g==",
       "dependencies": [
+        "zod@3.24.1"
+      ],
+      "optionalPeers": [
         "zod@3.24.1"
       ]
     },
@@ -3014,6 +3296,10 @@
         "magic-string@0.30.17",
         "msw",
         "vite"
+      ],
+      "optionalPeers": [
+        "msw",
+        "vite"
       ]
     },
     "@vitest/pretty-format@3.0.9": {
@@ -3067,10 +3353,12 @@
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="
     },
     "acorn@8.14.0": {
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "bin": true
     },
     "acorn@8.14.1": {
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "bin": true
     },
     "agent-base@7.1.3": {
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="
@@ -3287,7 +3575,8 @@
         "electron-to-chromium",
         "node-releases",
         "update-browserslist-db"
-      ]
+      ],
+      "bin": true
     },
     "btoa-lite@1.0.0": {
       "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="
@@ -3386,8 +3675,10 @@
     "cli-table3@0.6.3": {
       "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
       "dependencies": [
-        "@colors/colors",
         "string-width@4.2.3"
+      ],
+      "optionalDependencies": [
+        "@colors/colors"
       ]
     },
     "cli-width@4.1.0": {
@@ -3492,7 +3783,8 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "crc-32@1.2.2": {
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "bin": true
     },
     "cross-spawn@7.0.6": {
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
@@ -3509,7 +3801,8 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="
     },
     "cssesc@3.0.0": {
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "bin": true
     },
     "cssstyle@4.2.1": {
       "integrity": "sha512-9+vem03dMXG7gDmZ62uqmRiMRNtinIZ9ZyuF6BdxzfOD+FdN5hretzynkn0ReS2DO2GSw76RWHs0UmJPI2zUjw==",
@@ -3649,7 +3942,8 @@
       "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dependencies": [
         "jake"
-      ]
+      ],
+      "bin": true
     },
     "electron-to-chromium@1.5.126": {
       "integrity": "sha512-AtH1uLcTC72LA4vfYcEJJkrMk/MY/X0ub8Hv7QGAePW2JkeUFHEL/QfS4J77R6M87Sss8O0OcqReSaN1bpyA+Q=="
@@ -3759,7 +4053,7 @@
     },
     "esbuild@0.17.19": {
       "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
-      "dependencies": [
+      "optionalDependencies": [
         "@esbuild/android-arm@0.17.19",
         "@esbuild/android-arm64@0.17.19",
         "@esbuild/android-x64@0.17.19",
@@ -3782,11 +4076,13 @@
         "@esbuild/win32-arm64@0.17.19",
         "@esbuild/win32-ia32@0.17.19",
         "@esbuild/win32-x64@0.17.19"
-      ]
+      ],
+      "scripts": true,
+      "bin": true
     },
     "esbuild@0.24.2": {
       "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
-      "dependencies": [
+      "optionalDependencies": [
         "@esbuild/aix-ppc64@0.24.2",
         "@esbuild/android-arm@0.24.2",
         "@esbuild/android-arm64@0.24.2",
@@ -3812,11 +4108,13 @@
         "@esbuild/win32-arm64@0.24.2",
         "@esbuild/win32-ia32@0.24.2",
         "@esbuild/win32-x64@0.24.2"
-      ]
+      ],
+      "scripts": true,
+      "bin": true
     },
     "esbuild@0.25.1": {
       "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
-      "dependencies": [
+      "optionalDependencies": [
         "@esbuild/aix-ppc64@0.25.1",
         "@esbuild/android-arm@0.25.1",
         "@esbuild/android-arm64@0.25.1",
@@ -3842,7 +4140,9 @@
         "@esbuild/win32-arm64@0.25.1",
         "@esbuild/win32-ia32@0.25.1",
         "@esbuild/win32-x64@0.25.1"
-      ]
+      ],
+      "scripts": true,
+      "bin": true
     },
     "escalade@3.2.0": {
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
@@ -3876,6 +4176,9 @@
         "semver@7.6.3",
         "svelte",
         "svelte-eslint-parser"
+      ],
+      "optionalPeers": [
+        "svelte"
       ]
     },
     "eslint-scope@7.2.2": {
@@ -3936,7 +4239,8 @@
         "minimatch@3.1.2",
         "natural-compare",
         "optionator"
-      ]
+      ],
+      "bin": true
     },
     "esm-env@1.2.2": {
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="
@@ -3958,7 +4262,8 @@
       ]
     },
     "esprima@4.0.1": {
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": true
     },
     "esquery@1.6.0": {
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
@@ -4043,11 +4348,17 @@
       ]
     },
     "fdir@6.4.3": {
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw=="
+      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "optionalPeers": [
+        "picomatch@^3 || ^4"
+      ]
     },
     "fdir@6.4.3_picomatch@4.0.2": {
       "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
       "dependencies": [
+        "picomatch@4.0.2"
+      ],
+      "optionalPeers": [
         "picomatch@4.0.2"
       ]
     },
@@ -4199,10 +4510,14 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents@2.3.2": {
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
     },
     "fsevents@2.3.3": {
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "os": ["darwin"],
+      "scripts": true
     },
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
@@ -4291,7 +4606,8 @@
         "minipass",
         "package-json-from-dist",
         "path-scurry"
-      ]
+      ],
+      "bin": true
     },
     "glob@7.2.3": {
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
@@ -4302,7 +4618,8 @@
         "minimatch@3.1.2",
         "once",
         "path-is-absolute"
-      ]
+      ],
+      "deprecated": true
     },
     "global-dirs@3.0.1": {
       "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
@@ -4469,7 +4786,8 @@
       "dependencies": [
         "once",
         "wrappy"
-      ]
+      ],
+      "deprecated": true
     },
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
@@ -4717,7 +5035,9 @@
     "jackspeak@3.4.3": {
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dependencies": [
-        "@isaacs/cliui",
+        "@isaacs/cliui"
+      ],
+      "optionalDependencies": [
         "@pkgjs/parseargs"
       ]
     },
@@ -4728,7 +5048,8 @@
         "chalk@4.1.2",
         "filelist",
         "minimatch@3.1.2"
-      ]
+      ],
+      "bin": true
     },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
@@ -4737,7 +5058,8 @@
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": [
         "argparse"
-      ]
+      ],
+      "bin": true
     },
     "jsdom@26.0.0": {
       "integrity": "sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==",
@@ -4766,10 +5088,12 @@
       ]
     },
     "jsesc@3.0.2": {
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "bin": true
     },
     "jsesc@3.1.0": {
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "bin": true
     },
     "json-buffer@3.0.1": {
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
@@ -4787,13 +5111,16 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "json5@2.2.3": {
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": true
     },
     "jsonfile@6.1.0": {
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": [
-        "graceful-fs",
         "universalify@2.0.1"
+      ],
+      "optionalDependencies": [
+        "graceful-fs"
       ]
     },
     "jsonpointer@5.0.1": {
@@ -4945,7 +5272,8 @@
       "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ=="
     },
     "lz-string@1.5.0": {
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "bin": true
     },
     "magic-string@0.25.9": {
       "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
@@ -4974,7 +5302,8 @@
       ]
     },
     "marked@15.0.7": {
-      "integrity": "sha512-dgLIeKGLx5FwziAnsk4ONoGwHwGPJzselimvlVskE9XLN4Orv9u2VA3GWw/lYUqjfA0rUT/6fqKwfZJapP9BEg=="
+      "integrity": "sha512-dgLIeKGLx5FwziAnsk4ONoGwHwGPJzselimvlVskE9XLN4Orv9u2VA3GWw/lYUqjfA0rUT/6fqKwfZJapP9BEg==",
+      "bin": true
     },
     "math-intrinsics@1.1.0": {
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
@@ -4999,13 +5328,15 @@
       ]
     },
     "mime@3.0.0": {
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "bin": true
     },
     "min-indent@1.0.1": {
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "mini-svg-data-uri@1.4.4": {
-      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg=="
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "bin": true
     },
     "miniflare@3.20250310.1": {
       "integrity": "sha512-c9QPrgBUFzjL4pYvW6GIUw+NqeYlZGVHASKJqjIXB1WVsl14nYfpfHphYK8tluKaBqwA9NFyO5dC2zatJkC/mA==",
@@ -5021,7 +5352,8 @@
         "ws",
         "youch",
         "zod@3.22.3"
-      ]
+      ],
+      "bin": true
     },
     "minimatch@3.1.2": {
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
@@ -5045,7 +5377,8 @@
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
     },
     "mkdirp@2.1.6": {
-      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A=="
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+      "bin": true
     },
     "mri@1.2.0": {
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
@@ -5078,13 +5411,19 @@
         "type-fest@4.33.0",
         "typescript@5.8.2",
         "yargs"
-      ]
+      ],
+      "optionalPeers": [
+        "typescript@5.8.2"
+      ],
+      "scripts": true,
+      "bin": true
     },
     "murmurhash3js@3.0.1": {
       "integrity": "sha512-KL8QYUaxq7kUbcl0Yto51rMcYt7E/4N4BG3/c96Iqw1PQrTRspu8Cpx4TZ4Nunib1d4bEkIH3gjCYlP2RLBdow=="
     },
     "mustache@4.2.0": {
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "bin": true
     },
     "mute-stream@2.0.0": {
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="
@@ -5098,7 +5437,8 @@
       ]
     },
     "nanoid@3.3.11": {
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "bin": true
     },
     "natural-compare@1.4.0": {
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
@@ -5275,14 +5615,18 @@
       "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
     },
     "playwright-core@1.51.1": {
-      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw=="
+      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "bin": true
     },
     "playwright@1.51.1": {
       "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
       "dependencies": [
-        "fsevents@2.3.2",
         "playwright-core"
-      ]
+      ],
+      "optionalDependencies": [
+        "fsevents@2.3.2"
+      ],
+      "bin": true
     },
     "possible-typed-array-names@1.1.0": {
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
@@ -5293,6 +5637,9 @@
         "lilconfig",
         "postcss",
         "yaml@1.10.2"
+      ],
+      "optionalPeers": [
+        "postcss"
       ]
     },
     "postcss-safe-parser@6.0.0_postcss@8.5.3": {
@@ -5339,7 +5686,8 @@
       ]
     },
     "prettier@3.5.3": {
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw=="
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "bin": true
     },
     "pretty-bytes@5.6.0": {
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="
@@ -5379,7 +5727,8 @@
         "@protobufjs/utf8",
         "@types/node@22.10.9",
         "long"
-      ]
+      ],
+      "scripts": true
     },
     "proxy-from-env@1.1.0": {
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
@@ -5437,7 +5786,8 @@
       ]
     },
     "reflect-metadata@0.2.1": {
-      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw=="
+      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==",
+      "deprecated": true
     },
     "reflect-metadata@0.2.2": {
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
@@ -5480,7 +5830,8 @@
       ]
     },
     "regexp-tree@0.1.27": {
-      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "bin": true
     },
     "regexp.prototype.flags@1.5.4": {
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
@@ -5514,7 +5865,8 @@
       "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
       "dependencies": [
         "jsesc@3.0.2"
-      ]
+      ],
+      "bin": true
     },
     "repeat-string@1.6.1": {
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
@@ -5546,7 +5898,8 @@
         "is-core-module",
         "path-parse",
         "supports-preserve-symlinks-flag"
-      ]
+      ],
+      "bin": true
     },
     "reusify@1.1.0": {
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
@@ -5557,7 +5910,8 @@
         "estree-walker@0.6.1",
         "magic-string@0.25.9",
         "rollup-pluginutils"
-      ]
+      ],
+      "deprecated": true
     },
     "rollup-plugin-node-polyfills@0.2.1": {
       "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
@@ -5573,13 +5927,17 @@
     },
     "rollup@2.79.2": {
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
-      "dependencies": [
+      "optionalDependencies": [
         "fsevents@2.3.3"
-      ]
+      ],
+      "bin": true
     },
     "rollup@4.37.0": {
       "integrity": "sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==",
       "dependencies": [
+        "@types/estree@1.0.6"
+      ],
+      "optionalDependencies": [
         "@rollup/rollup-android-arm-eabi",
         "@rollup/rollup-android-arm64",
         "@rollup/rollup-darwin-arm64",
@@ -5600,9 +5958,9 @@
         "@rollup/rollup-win32-arm64-msvc",
         "@rollup/rollup-win32-ia32-msvc",
         "@rollup/rollup-win32-x64-msvc",
-        "@types/estree@1.0.6",
         "fsevents@2.3.3"
-      ]
+      ],
+      "bin": true
     },
     "rrweb-cssom@0.8.0": {
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="
@@ -5657,64 +6015,104 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-embedded-android-arm64@1.86.0": {
-      "integrity": "sha512-r7MZtlAI2VFUnKE8B5UOrpoE6OGpdf1dIB6ndoxb3oiURgMyfTVU7yvJcL12GGvtVwQ2boCj6dq//Lqq9CXPlQ=="
+      "integrity": "sha512-r7MZtlAI2VFUnKE8B5UOrpoE6OGpdf1dIB6ndoxb3oiURgMyfTVU7yvJcL12GGvtVwQ2boCj6dq//Lqq9CXPlQ==",
+      "os": ["android"],
+      "cpu": ["arm64"]
     },
     "sass-embedded-android-arm@1.86.0": {
-      "integrity": "sha512-NS8v6BCbzskXUMBtzfuB+j2yQMgiwg5edKHTYfQU7gAWai2hkRhS06YNEMff3aRxV0IFInxPRHOobd8xWPHqeA=="
+      "integrity": "sha512-NS8v6BCbzskXUMBtzfuB+j2yQMgiwg5edKHTYfQU7gAWai2hkRhS06YNEMff3aRxV0IFInxPRHOobd8xWPHqeA==",
+      "os": ["android"],
+      "cpu": ["arm"]
     },
     "sass-embedded-android-ia32@1.86.0": {
-      "integrity": "sha512-UjfElrGaOTNOnxLZLxf6MFndFIe7zyK+81f83BioZ7/jcoAd6iCHZT8yQMvu8wINyVodPcaXZl8KxlKcl62VAA=="
+      "integrity": "sha512-UjfElrGaOTNOnxLZLxf6MFndFIe7zyK+81f83BioZ7/jcoAd6iCHZT8yQMvu8wINyVodPcaXZl8KxlKcl62VAA==",
+      "os": ["android"],
+      "cpu": ["ia32"]
     },
     "sass-embedded-android-riscv64@1.86.0": {
-      "integrity": "sha512-TsqCLxHWLFS2mbpUkL/nge3jSkaPK2VmLkkoi5iO/EQT4SFvm1lNUgPwlLXu9DplZ+aqGVzRS9Y6Psjv+qW7kw=="
+      "integrity": "sha512-TsqCLxHWLFS2mbpUkL/nge3jSkaPK2VmLkkoi5iO/EQT4SFvm1lNUgPwlLXu9DplZ+aqGVzRS9Y6Psjv+qW7kw==",
+      "os": ["android"],
+      "cpu": ["riscv64"]
     },
     "sass-embedded-android-x64@1.86.0": {
-      "integrity": "sha512-8Q263GgwGjz7Jkf7Eghp7NrwqskDL95WO9sKrNm9iOd2re/M48W7RN/lpdcZwrUnEOhueks0RRyYyZYBNRz8Tg=="
+      "integrity": "sha512-8Q263GgwGjz7Jkf7Eghp7NrwqskDL95WO9sKrNm9iOd2re/M48W7RN/lpdcZwrUnEOhueks0RRyYyZYBNRz8Tg==",
+      "os": ["android"],
+      "cpu": ["x64"]
     },
     "sass-embedded-darwin-arm64@1.86.0": {
-      "integrity": "sha512-d8oMEaIweq1tjrb/BT43igDviOMS1TeDpc51QF7vAHkt9drSjPmqEmbqStdFYPAGZj1j0RA4WCRoVl6jVixi/w=="
+      "integrity": "sha512-d8oMEaIweq1tjrb/BT43igDviOMS1TeDpc51QF7vAHkt9drSjPmqEmbqStdFYPAGZj1j0RA4WCRoVl6jVixi/w==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
     "sass-embedded-darwin-x64@1.86.0": {
-      "integrity": "sha512-5NLRtn0ZUDBkfpKOsgLGl9B34po4Qui8Nff/lXTO+YkxBQFX4GoMkYNk9EJqHwoLLzICsxIhNDMMDiPGz7Fdrw=="
+      "integrity": "sha512-5NLRtn0ZUDBkfpKOsgLGl9B34po4Qui8Nff/lXTO+YkxBQFX4GoMkYNk9EJqHwoLLzICsxIhNDMMDiPGz7Fdrw==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
     "sass-embedded-linux-arm64@1.86.0": {
-      "integrity": "sha512-50A+0rhahRDRkKkv+qS7GDAAkW1VPm2RCX4zY4JWydhV4NwMXr6HbkLnsJ2MGixCyibPh59iflMpNBhe7SEMNg=="
+      "integrity": "sha512-50A+0rhahRDRkKkv+qS7GDAAkW1VPm2RCX4zY4JWydhV4NwMXr6HbkLnsJ2MGixCyibPh59iflMpNBhe7SEMNg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "sass-embedded-linux-arm@1.86.0": {
-      "integrity": "sha512-b6wm0+Il+blJDleRXAqA6JISGMjRb0/thTEg4NWgmiJwUoZjDycj5FTbfYPnLXjCEIMGaYmW3patrJ3JMJcT3Q=="
+      "integrity": "sha512-b6wm0+Il+blJDleRXAqA6JISGMjRb0/thTEg4NWgmiJwUoZjDycj5FTbfYPnLXjCEIMGaYmW3patrJ3JMJcT3Q==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "sass-embedded-linux-ia32@1.86.0": {
-      "integrity": "sha512-h0mr9w71TV3BRPk9JHr0flnRCznhkraY14gaj5T+t78vUFByOUMxp4hTr+JpZAR5mv0mIeoMwrQYwWJoqKI0mw=="
+      "integrity": "sha512-h0mr9w71TV3BRPk9JHr0flnRCznhkraY14gaj5T+t78vUFByOUMxp4hTr+JpZAR5mv0mIeoMwrQYwWJoqKI0mw==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
     },
     "sass-embedded-linux-musl-arm64@1.86.0": {
-      "integrity": "sha512-5OZjiJIUyhvKJIGNDEjyRUWDe+W91hq4Bji27sy8gdEuDzPWLx4NzwpKwsBUALUfyW/J5dxgi0ZAQnI3HieyQg=="
+      "integrity": "sha512-5OZjiJIUyhvKJIGNDEjyRUWDe+W91hq4Bji27sy8gdEuDzPWLx4NzwpKwsBUALUfyW/J5dxgi0ZAQnI3HieyQg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "sass-embedded-linux-musl-arm@1.86.0": {
-      "integrity": "sha512-KZU70jBMVykC9HzS+o2FhrJaprFLDk3LWXVPtBFxgLlkcQ/apCkUCh2WVNViLhI2U4NrMSnTvd4kDnC/0m8qIw=="
+      "integrity": "sha512-KZU70jBMVykC9HzS+o2FhrJaprFLDk3LWXVPtBFxgLlkcQ/apCkUCh2WVNViLhI2U4NrMSnTvd4kDnC/0m8qIw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "sass-embedded-linux-musl-ia32@1.86.0": {
-      "integrity": "sha512-vq9wJ7kaELrsNU6Ld6kvrIHxoIUWaD+5T6TQVj4SJP/iw1NjonyCDMQGGs6UgsIEzvaIwtlSlDbRewAq+4PchA=="
+      "integrity": "sha512-vq9wJ7kaELrsNU6Ld6kvrIHxoIUWaD+5T6TQVj4SJP/iw1NjonyCDMQGGs6UgsIEzvaIwtlSlDbRewAq+4PchA==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
     },
     "sass-embedded-linux-musl-riscv64@1.86.0": {
-      "integrity": "sha512-UZJPu4zKe3phEzoSVRh5jcSicBBPe+jEbVNALHSSz881iOAYnDQXHITGeQ4mM1/7e/LTyryHk6EPBoaLOv6JrA=="
+      "integrity": "sha512-UZJPu4zKe3phEzoSVRh5jcSicBBPe+jEbVNALHSSz881iOAYnDQXHITGeQ4mM1/7e/LTyryHk6EPBoaLOv6JrA==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
     },
     "sass-embedded-linux-musl-x64@1.86.0": {
-      "integrity": "sha512-8taAgbWMk4QHneJcouWmWZJlmKa2O03g4I/CFo4bfMPL87bibY90pAsSDd+C+t81g0+2aK0/lY/BoB0r3qXLiA=="
+      "integrity": "sha512-8taAgbWMk4QHneJcouWmWZJlmKa2O03g4I/CFo4bfMPL87bibY90pAsSDd+C+t81g0+2aK0/lY/BoB0r3qXLiA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "sass-embedded-linux-riscv64@1.86.0": {
-      "integrity": "sha512-yREY6o2sLwiiA03MWHVpnUliLscz0flEmFW/wzxYZJDqg9eZteB3hUWgZD63eLm2PTZsYxDQpjAHpa48nnIEmA=="
+      "integrity": "sha512-yREY6o2sLwiiA03MWHVpnUliLscz0flEmFW/wzxYZJDqg9eZteB3hUWgZD63eLm2PTZsYxDQpjAHpa48nnIEmA==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
     },
     "sass-embedded-linux-x64@1.86.0": {
-      "integrity": "sha512-sH0F8np9PTgTbFcJWxfr1NzPkL5ID2NcpMtZyKPTdnn9NkE/L2UwXSo6xOvY0Duc4Hg+58wSrDnj6KbvdeHCPg=="
+      "integrity": "sha512-sH0F8np9PTgTbFcJWxfr1NzPkL5ID2NcpMtZyKPTdnn9NkE/L2UwXSo6xOvY0Duc4Hg+58wSrDnj6KbvdeHCPg==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "sass-embedded-win32-arm64@1.86.0": {
-      "integrity": "sha512-4O1XVUxLTIjMOvrziYwEZgvFqC5sF6t0hTAPJ+h2uiAUZg9Joo0PvuEedXurjISgDBsb5W5DTL9hH9q1BbP4cQ=="
+      "integrity": "sha512-4O1XVUxLTIjMOvrziYwEZgvFqC5sF6t0hTAPJ+h2uiAUZg9Joo0PvuEedXurjISgDBsb5W5DTL9hH9q1BbP4cQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
     },
     "sass-embedded-win32-ia32@1.86.0": {
-      "integrity": "sha512-zuSP2axkGm4VaJWt38P464H+4424Swr9bzFNfbbznxe3Ue4RuqSBqwiLiYdg9Q1cecTQ2WGH7G7WO56KK7WLwg=="
+      "integrity": "sha512-zuSP2axkGm4VaJWt38P464H+4424Swr9bzFNfbbznxe3Ue4RuqSBqwiLiYdg9Q1cecTQ2WGH7G7WO56KK7WLwg==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
     },
     "sass-embedded-win32-x64@1.86.0": {
-      "integrity": "sha512-GVX0CHtukr3kjqfqretSlPiJzV7V4JxUjpRZV+yC9gUMTiDErilJh2Chw1r0+MYiYvumCDUSDlticmvJs7v0tA=="
+      "integrity": "sha512-GVX0CHtukr3kjqfqretSlPiJzV7V4JxUjpRZV+yC9gUMTiDErilJh2Chw1r0+MYiYvumCDUSDlticmvJs7v0tA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "sass-embedded@1.86.0": {
       "integrity": "sha512-Ibq5DzxjSf9f/IJmKeHVeXlVqiZWdRJF+RXy6v6UupvMYVMU5Ei+teSFBvvpPD5bB2QhhnU/OJlSM0EBCtfr9g==",
@@ -5724,6 +6122,11 @@
         "colorjs.io",
         "immutable",
         "rxjs",
+        "supports-color@8.1.1",
+        "sync-child-process",
+        "varint"
+      ],
+      "optionalDependencies": [
         "sass-embedded-android-arm",
         "sass-embedded-android-arm64",
         "sass-embedded-android-ia32",
@@ -5743,11 +6146,9 @@
         "sass-embedded-linux-x64",
         "sass-embedded-win32-arm64",
         "sass-embedded-win32-ia32",
-        "sass-embedded-win32-x64",
-        "supports-color@8.1.1",
-        "sync-child-process",
-        "varint"
-      ]
+        "sass-embedded-win32-x64"
+      ],
+      "bin": true
     },
     "saxes@6.0.0": {
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
@@ -5759,16 +6160,19 @@
       "integrity": "sha512-34EQV6AAHQGhoc0tn/96a9Fsi6v2xdqe/dMUwljGRaFOzR3EgRmECvD0O8vi8X+/uQ50LGHfkNu/Eue5TPKZkQ=="
     },
     "semver@6.3.1": {
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": true
     },
     "semver@7.5.3": {
       "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dependencies": [
         "lru-cache@6.0.0"
-      ]
+      ],
+      "bin": true
     },
     "semver@7.6.3": {
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "bin": true
     },
     "serialize-javascript@6.0.2": {
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
@@ -5812,11 +6216,17 @@
       "dependencies": [
         "inherits",
         "safe-buffer"
-      ]
+      ],
+      "bin": true
     },
     "sharp@0.33.5": {
       "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
       "dependencies": [
+        "color",
+        "detect-libc",
+        "semver@7.6.3"
+      ],
+      "optionalDependencies": [
         "@img/sharp-darwin-arm64",
         "@img/sharp-darwin-x64",
         "@img/sharp-libvips-darwin-arm64",
@@ -5835,11 +6245,9 @@
         "@img/sharp-linuxmusl-x64",
         "@img/sharp-wasm32",
         "@img/sharp-win32-ia32",
-        "@img/sharp-win32-x64",
-        "color",
-        "detect-libc",
-        "semver@7.6.3"
-      ]
+        "@img/sharp-win32-x64"
+      ],
+      "scripts": true
     },
     "shebang-command@2.0.0": {
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
@@ -5935,7 +6343,8 @@
       ]
     },
     "sourcemap-codec@1.4.8": {
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": true
     },
     "spdx-correct@3.2.0": {
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
@@ -6105,7 +6514,8 @@
         "sade",
         "svelte",
         "typescript@5.8.2"
-      ]
+      ],
+      "bin": true
     },
     "svelte-eslint-parser@0.43.0_svelte@5.25.3__acorn@8.14.1_postcss@8.5.3": {
       "integrity": "sha512-GpU52uPKKcVnh8tKN5P4UZpJ/fUDndmq7wfsvoVXsyP+aY0anol7Yqo01fyrlaWGMFfm4av5DyrjlaXdLRJvGA==",
@@ -6115,6 +6525,9 @@
         "espree@9.6.1_acorn@8.14.1",
         "postcss",
         "postcss-scss",
+        "svelte"
+      ],
+      "optionalPeers": [
         "svelte"
       ]
     },
@@ -6223,7 +6636,8 @@
         "acorn@8.14.1",
         "commander@2.20.3",
         "source-map-support"
-      ]
+      ],
+      "bin": true
     },
     "test-exclude@7.0.1": {
       "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
@@ -6280,7 +6694,8 @@
       "integrity": "sha512-O5vTZ1UmmEmrLl/59U9igitnSMlprALLaLgbv//dEvjobPT9vyURhHXKMCDLEhn3qxZFIkb9PwAfNYV0Ol7RPQ==",
       "dependencies": [
         "tldts-core"
-      ]
+      ],
+      "bin": true
     },
     "tmp@0.2.3": {
       "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w=="
@@ -6403,10 +6818,12 @@
       ]
     },
     "typescript@5.2.2": {
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": true
     },
     "typescript@5.8.2": {
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "bin": true
     },
     "ufo@1.5.4": {
       "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
@@ -6499,7 +6916,8 @@
         "browserslist",
         "escalade",
         "picocolors"
-      ]
+      ],
+      "bin": true
     },
     "upper-case-first@2.0.2": {
       "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
@@ -6527,10 +6945,12 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid@10.0.0": {
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "bin": true
     },
     "uuid@9.0.1": {
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "bin": true
     },
     "validate-npm-package-license@3.0.4": {
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
@@ -6558,7 +6978,8 @@
         "es-module-lexer",
         "pathe",
         "vite"
-      ]
+      ],
+      "bin": true
     },
     "vite-plugin-pwa@0.21.2_vite@6.2.3__sass-embedded@1.86.0_workbox-build@7.3.0__ajv@8.17.1__@babel+core@7.26.10__rollup@2.79.2_workbox-window@7.3.0_sass-embedded@1.86.0": {
       "integrity": "sha512-vFhH6Waw8itNu37hWUJxL50q+CBbNcMVzsKaYHQVrfxTt3ihk3PeLO22SbiP1UNWzcEPaTQv+YVxe4G0KOjAkg==",
@@ -6575,15 +6996,24 @@
       "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dependencies": [
         "esbuild@0.25.1",
-        "fsevents@2.3.3",
         "postcss",
         "rollup@4.37.0",
         "sass-embedded"
-      ]
+      ],
+      "optionalDependencies": [
+        "fsevents@2.3.3"
+      ],
+      "optionalPeers": [
+        "sass-embedded"
+      ],
+      "bin": true
     },
     "vitefu@1.0.6_vite@6.2.3__sass-embedded@1.86.0_sass-embedded@1.86.0": {
       "integrity": "sha512-+Rex1GlappUyNN6UfwbVZne/9cYC4+R2XDk9xkNXBKMw6HQagdX9PgZ8V2v1WUSK1wfBLp7qbI1+XSNIlB1xmA==",
       "dependencies": [
+        "vite"
+      ],
+      "optionalPeers": [
         "vite"
       ]
     },
@@ -6611,7 +7041,11 @@
         "vite",
         "vite-node",
         "why-is-node-running"
-      ]
+      ],
+      "optionalPeers": [
+        "jsdom"
+      ],
+      "bin": true
     },
     "w3c-xmlserializer@5.0.0": {
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
@@ -6719,14 +7153,16 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": [
         "isexe"
-      ]
+      ],
+      "bin": true
     },
     "why-is-node-running@2.3.0": {
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dependencies": [
         "siginfo",
         "stackback"
-      ]
+      ],
+      "bin": true
     },
     "word-wrap@1.2.5": {
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
@@ -6873,13 +7309,15 @@
     },
     "workerd@1.20250310.0": {
       "integrity": "sha512-bAaZ9Bmts3mArbIrXYAtr+ZRsAJAAUEsCtvwfBavIYXaZ5sgdEOJBEiBbvsHp6CsVObegOM85tIWpYLpbTxQrQ==",
-      "dependencies": [
+      "optionalDependencies": [
         "@cloudflare/workerd-darwin-64",
         "@cloudflare/workerd-darwin-arm64",
         "@cloudflare/workerd-linux-64",
         "@cloudflare/workerd-linux-arm64",
         "@cloudflare/workerd-windows-64"
-      ]
+      ],
+      "scripts": true,
+      "bin": true
     },
     "worktop@0.8.0-next.18": {
       "integrity": "sha512-+TvsA6VAVoMC3XDKR5MoC/qlLqDixEfOBysDEKnPIPou/NvoPWCAuXHXMsswwlvmEuvX56lQjvELLyLuzTKvRw==",
@@ -6898,13 +7336,19 @@
         "@esbuild-plugins/node-modules-polyfill",
         "blake3-wasm",
         "esbuild@0.17.19",
-        "fsevents@2.3.3",
         "miniflare",
         "path-to-regexp",
-        "sharp",
         "unenv",
         "workerd"
-      ]
+      ],
+      "optionalDependencies": [
+        "fsevents@2.3.3",
+        "sharp"
+      ],
+      "optionalPeers": [
+        "@cloudflare/workers-types"
+      ],
+      "bin": true
     },
     "wrap-ansi@6.2.0": {
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
@@ -6958,7 +7402,8 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yaml@2.7.0": {
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA=="
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "bin": true
     },
     "yargs-parser@21.1.1": {
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
@@ -7022,7 +7467,7 @@
             "npm:@cucumber/cucumber@^11.2.0",
             "npm:@google/generative-ai@0.24",
             "npm:@inlang/paraglide-sveltekit@~0.16.1",
-            "npm:@jsr/trakt__api@~0.1.23",
+            "npm:@jsr/trakt__api@~0.1.26",
             "npm:@playwright/test@^1.51.1",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@svelte-put/qr@^2.1.0",

--- a/projects/client/i18n/messages/bg-bg.json
+++ b/projects/client/i18n/messages/bg-bg.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Само любими",
   "watchnow_any_service": "Навсякъде",
   "decade": "Десетилетие",
-  "ratings": "Оценки"
+  "ratings": "Оценки",
+  "view_all_items_in": "Виж всички в {title}"
 }

--- a/projects/client/i18n/messages/da-dk.json
+++ b/projects/client/i18n/messages/da-dk.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Favorites only",
   "watchnow_any_service": "On any service",
   "decade": "Årti",
-  "ratings": "Bedømmelser"
+  "ratings": "Bedømmelser",
+  "view_all_items_in": "Se alle i {title}"
 }

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Nur Favoriten",
   "watchnow_any_service": "Auf jedem Dienst",
   "decade": "Dekade",
-  "ratings": "Bewertungen"
+  "ratings": "Bewertungen",
+  "view_all_items_in": "Alle {title} ansehen"
 }

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Favorites only",
   "watchnow_any_service": "On any service",
   "decade": "Decade",
-  "ratings": "Ratings"
+  "ratings": "Ratings",
+  "view_all_items_in": "View all items in {title}"
 }

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Solo favoritos",
   "watchnow_any_service": "En cualquier servicio",
   "decade": "Década",
-  "ratings": "Valoraciones"
+  "ratings": "Valoraciones",
+  "view_all_items_in": "Ver todo en {title}"
 }

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Solo favoritos",
   "watchnow_any_service": "En cualquier plataforma",
   "decade": "Década",
-  "ratings": "Calificaciones"
+  "ratings": "Calificaciones",
+  "view_all_items_in": "Ver todos en {title}"
 }

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Favorites only",
   "watchnow_any_service": "On any service",
   "decade": "Décennie",
-  "ratings": "Cotes"
+  "ratings": "Cotes",
+  "view_all_items_in": "Voir tous les titres dans {title}"
 }

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Favorites only",
   "watchnow_any_service": "On any service",
   "decade": "Décennie",
-  "ratings": "Notes"
+  "ratings": "Notes",
+  "view_all_items_in": "Voir tous les titres dans {title}"
 }

--- a/projects/client/i18n/messages/it-it.json
+++ b/projects/client/i18n/messages/it-it.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Solo preferiti",
   "watchnow_any_service": "Su qualsiasi piattaforma",
   "decade": "Decennio",
-  "ratings": "Valutazioni"
+  "ratings": "Valutazioni",
+  "view_all_items_in": "Vedi tutti gli elementi in {title}"
 }

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Favorites only",
   "watchnow_any_service": "On any service",
   "decade": "年代",
-  "ratings": "評価"
+  "ratings": "評価",
+  "view_all_items_in": "{title} のアイテムをすべて表示"
 }

--- a/projects/client/i18n/messages/nb-no.json
+++ b/projects/client/i18n/messages/nb-no.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Kun favoritter",
   "watchnow_any_service": "På alle tjenester",
   "decade": "Tiår",
-  "ratings": "Vurderinger"
+  "ratings": "Vurderinger",
+  "view_all_items_in": "Vis alle i {title}"
 }

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Alleen favorieten",
   "watchnow_any_service": "Op elke dienst",
   "decade": "Decennium",
-  "ratings": "Beoordelingen"
+  "ratings": "Beoordelingen",
+  "view_all_items_in": "Bekijk alle items in {title}"
 }

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Tylko ulubione",
   "watchnow_any_service": "Na każdym serwisie",
   "decade": "Dekada",
-  "ratings": "Oceny"
+  "ratings": "Oceny",
+  "view_all_items_in": "Zobacz wszystko w {title}"
 }

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Só Favoritos",
   "watchnow_any_service": "Em qualquer serviço",
   "decade": "Década",
-  "ratings": "Avaliações"
+  "ratings": "Avaliações",
+  "view_all_items_in": "Ver tudo em {title}"
 }

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Doar favoritele",
   "watchnow_any_service": "Pe orice platformă",
   "decade": "Deceniu",
-  "ratings": "Evaluări"
+  "ratings": "Evaluări",
+  "view_all_items_in": "Vezi toate în {title}"
 }

--- a/projects/client/i18n/messages/sv-se.json
+++ b/projects/client/i18n/messages/sv-se.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Endast favoriter",
   "watchnow_any_service": "På vilken tjänst som helst",
   "decade": "Årtionde",
-  "ratings": "Betyg"
+  "ratings": "Betyg",
+  "view_all_items_in": "Visa alla i {title}"
 }

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -388,5 +388,6 @@
   "watchnow_favorites_only": "Тільки улюблене",
   "watchnow_any_service": "На будь-якому сервісі",
   "decade": "Десятиліття",
-  "ratings": "Оцінки"
+  "ratings": "Оцінки",
+  "view_all_items_in": "Переглянути все у {title}"
 }

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -62,7 +62,7 @@
     "@tanstack/svelte-query": "^5.69.0",
     "@tanstack/svelte-query-devtools": "^5.69.0",
     "@tanstack/svelte-query-persist-client": "^5.69.0",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.1.23",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.1.26",
     "@ts-rest/core": "^3.52.1",
     "@use-gesture/vanilla": "^10.3.1",
     "date-fns": "^4.1.0",

--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -147,7 +147,7 @@ declare global {
   };
 
   type AudienceProps = {
-    audience: 'authenticated' | 'public' | 'all';
+    audience: 'authenticated' | 'public' | 'all' | 'director';
   };
 
   export type ButtonProps =

--- a/projects/client/src/lib/features/parameters/GlobalParameterEscaper.svelte
+++ b/projects/client/src/lib/features/parameters/GlobalParameterEscaper.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { setContext } from "svelte";
+  import { writable, type Writable } from "svelte/store";
+  import { PARAMETER_ESCAPE_KEY } from "./_internal/createParameterContext";
+
+  const { children, enabled }: ChildrenProps & { enabled: boolean } = $props();
+
+  setContext<Writable<boolean>>(PARAMETER_ESCAPE_KEY, writable(enabled));
+</script>
+
+{@render children()}

--- a/projects/client/src/lib/features/parameters/GlobalParameterSetter.svelte
+++ b/projects/client/src/lib/features/parameters/GlobalParameterSetter.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import { setContext } from "svelte";
   import { writable, type Writable } from "svelte/store";
-  import {
-    PARAMETER_OVERRIDE_CONTEXT_KEY,
-    useParameters,
-  } from "./useParameters";
+  import { PARAMETER_SETTER_CONTEXT_KEY } from "./_internal/createParameterContext";
+  import { useParameters } from "./useParameters";
 
   useParameters();
 
@@ -12,7 +10,7 @@
     $props();
 
   setContext<Writable<string>>(
-    PARAMETER_OVERRIDE_CONTEXT_KEY,
+    PARAMETER_SETTER_CONTEXT_KEY,
     writable(parameter),
   );
 </script>

--- a/projects/client/src/lib/features/parameters/_internal/createParameterContext.ts
+++ b/projects/client/src/lib/features/parameters/_internal/createParameterContext.ts
@@ -1,0 +1,31 @@
+import { getContext, setContext } from 'svelte';
+import { type Writable, writable } from 'svelte/store';
+import type { ParameterContextData } from '../useParameters.ts';
+
+export type ParameterType = string | number;
+export const PARAMETER_CONTEXT_KEY = Symbol('parameters');
+export const PARAMETER_SETTER_CONTEXT_KEY = Symbol('parameters_setter');
+export const PARAMETER_ESCAPE_KEY = Symbol('parameters_escape');
+
+export function createParameterContext() {
+  const ctx = setContext(
+    PARAMETER_CONTEXT_KEY,
+    getContext<ParameterContextData>(PARAMETER_CONTEXT_KEY) ??
+      {
+        parameters: writable(new Map<string, ParameterType>()),
+      },
+  );
+
+  const override = setContext(
+    PARAMETER_SETTER_CONTEXT_KEY,
+    getContext<Writable<string>>(PARAMETER_SETTER_CONTEXT_KEY) ??
+      writable(''),
+  );
+
+  const isEscaped = setContext(
+    PARAMETER_ESCAPE_KEY,
+    getContext<Writable<boolean>>(PARAMETER_ESCAPE_KEY) ?? writable(false),
+  );
+
+  return { ...ctx, override, isEscaped };
+}

--- a/projects/client/src/lib/features/parameters/useParameters.ts
+++ b/projects/client/src/lib/features/parameters/useParameters.ts
@@ -1,28 +1,15 @@
-import { getContext, setContext } from 'svelte';
-import { derived, type Writable, writable } from 'svelte/store';
-
-export const PARAMETER_CONTEXT_KEY = Symbol('parameters');
-export const PARAMETER_OVERRIDE_CONTEXT_KEY = Symbol('parameters_override');
-
-type ParameterType = string | number;
+import { derived, type Writable } from 'svelte/store';
+import {
+  createParameterContext,
+  type ParameterType,
+} from './_internal/createParameterContext.ts';
 
 export type ParameterContextData = {
   parameters: Writable<Map<string, ParameterType>>;
 };
 
 export function useParameters() {
-  const { parameters } = setContext(
-    PARAMETER_CONTEXT_KEY,
-    getContext<ParameterContextData>(PARAMETER_CONTEXT_KEY) ?? {
-      parameters: writable(new Map<string, ParameterType>()),
-    },
-  );
-
-  const override = setContext(
-    PARAMETER_OVERRIDE_CONTEXT_KEY,
-    getContext<Writable<string>>(PARAMETER_OVERRIDE_CONTEXT_KEY) ??
-      writable(''),
-  );
+  const { parameters, override, isEscaped } = createParameterContext();
 
   function update(params: Record<string, ParameterType>) {
     parameters.update((current) => {
@@ -62,5 +49,6 @@ export function useParameters() {
     search,
     update,
     override,
+    isEscaped,
   };
 }

--- a/projects/client/src/lib/features/query/defineQuery.ts
+++ b/projects/client/src/lib/features/query/defineQuery.ts
@@ -57,12 +57,15 @@ export function defineQuery<
     ...params
   }: DefineQueryProps<TInput, TOutput, TRequestParams>,
 ) {
-  const key = queryId(params.key);
   const hash = schemaId(monitor(zodToHash, `${params.key} hashing`)(schema));
 
   return (
     requestParams: TRequestParams = {} as TRequestParams,
   ): CreateQueryOptions<z.infer<TOutput>, TError> => {
+    const key = queryId(
+      typeof params.key === 'function' ? params.key(requestParams) : params.key,
+    );
+
     const resolved = Array.isArray(params.dependencies)
       ? params.dependencies
       : params.dependencies(requestParams);

--- a/projects/client/src/lib/features/query/models/DefineQueryProps.ts
+++ b/projects/client/src/lib/features/query/models/DefineQueryProps.ts
@@ -10,7 +10,7 @@ export type DefineQueryProps<
   TOutput extends ZodType,
   TRequestParams extends ApiParams,
 > = {
-  key: string;
+  key: string | ((params: TRequestParams) => string);
   invalidations: InvalidateActionOptions[];
   dependencies: Dependency[] | ((params: TRequestParams) => Dependency[]);
   request: RequestDefinition<TInput, TRequestParams>;

--- a/projects/client/src/lib/guards/_internal/RenderForAudience.svelte
+++ b/projects/client/src/lib/guards/_internal/RenderForAudience.svelte
@@ -10,7 +10,8 @@
   const isAvailableForAudience = $derived(
     audience === "all" ||
       (audience === "authenticated" && $isAuthorized && $user != null) ||
-      (audience === "public" && !$isAuthorized),
+      (audience === "public" && !$isAuthorized) ||
+      (audience === "director" && $isAuthorized && $user?.isDirector),
   );
 </script>
 

--- a/projects/client/src/lib/requests/_internal/getGlobalFilterDependencies.ts
+++ b/projects/client/src/lib/requests/_internal/getGlobalFilterDependencies.ts
@@ -1,10 +1,8 @@
 import { FilterKey } from '$lib/features/filters/models/Filter.ts';
-import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
+import { getRecordDependencies } from './getRecordDependencies.ts';
 
-export function getGlobalFilterDependencies(params: FilterParams) {
-  const filterKeys = Object.values(FilterKey);
-
-  return filterKeys
-    .filter((key) => key in (params.filter || {}))
-    .map((key) => params.filter?.[key as keyof typeof params.filter]);
+export function getGlobalFilterDependencies(
+  params: Record<string, string | number | boolean> | Nil,
+): string[] {
+  return getRecordDependencies(params, Object.values(FilterKey));
 }

--- a/projects/client/src/lib/requests/_internal/getRecordDependencies.ts
+++ b/projects/client/src/lib/requests/_internal/getRecordDependencies.ts
@@ -1,0 +1,18 @@
+export function getRecordDependencies(
+  params: Record<string, string | number | boolean> | Nil,
+  whitelist?: string[],
+): string[] {
+  if (!params) {
+    return [];
+  }
+
+  const dependencies: string[] = [];
+
+  for (const key in params) {
+    if (params[key] && (!whitelist || whitelist.includes(key))) {
+      dependencies.push(`${key}=${params[key]}`);
+    }
+  }
+
+  return dependencies;
+}

--- a/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
@@ -1,11 +1,9 @@
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
-import type { MovieRatingsResponse, ShowRatingsResponse } from '@trakt/api';
+import type { RatingsResponse } from '@trakt/api';
 import type { MediaRating } from '../models/MediaRating.ts';
 
-type RatingResponse = MovieRatingsResponse | ShowRatingsResponse;
-
 export function mapToMediaRating(
-  ratings: RatingResponse,
+  ratings: RatingsResponse,
 ): MediaRating {
   const mapImdbRating = () => {
     const { imdb } = ratings;

--- a/projects/client/src/lib/requests/models/InlineParams.ts
+++ b/projects/client/src/lib/requests/models/InlineParams.ts
@@ -1,0 +1,3 @@
+export type InlineParams = {
+  inlineParams?: Record<string, string>;
+};

--- a/projects/client/src/lib/requests/models/SearchParams.ts
+++ b/projects/client/src/lib/requests/models/SearchParams.ts
@@ -1,0 +1,3 @@
+export type SearchParams = Partial<{
+  search: Record<string, string | number | boolean>;
+}>;

--- a/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
@@ -1,6 +1,5 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
-import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
 import { mapToListItem } from '$lib/requests/_internal/mapToListItem.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
@@ -13,6 +12,7 @@ import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts'
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
+import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
 
 type ListItemsParams =
   & {
@@ -66,7 +66,7 @@ export const listItemsQuery = defineQuery({
     params.limit,
     params.page,
     params.type,
-    ...getGlobalFilterDependencies(params),
+    ...getGlobalFilterDependencies(params.filter),
   ],
   request: userListItemsRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/movies/movieIntlQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieIntlQuery.ts
@@ -5,7 +5,7 @@ import type {
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import type { MovieTranslationResponse } from '@trakt/api';
+import type { TranslationResponse } from '@trakt/api';
 import { type MediaIntl, MediaIntlSchema } from '../../models/MediaIntl.ts';
 
 type MovieIntlParams = {
@@ -15,7 +15,7 @@ type MovieIntlParams = {
 } & ApiParams;
 
 function mapMovieIntlResponse(
-  translation?: MovieTranslationResponse[0],
+  translation?: TranslationResponse[0],
 ): MediaIntl | undefined {
   if (!translation) {
     return undefined;

--- a/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
@@ -1,19 +1,25 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
+import { getRecordDependencies } from '$lib/requests/_internal/getRecordDependencies.ts';
+import { mapToMovieEntry } from '$lib/requests/_internal/mapToMovieEntry.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { MovieEntrySchema } from '$lib/requests/models/MovieEntry.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import type { SearchParams } from '$lib/requests/models/SearchParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
-import { MovieEntrySchema } from '../../models/MovieEntry.ts';
 
-type MoviePopularParams = PaginationParams & ApiParams & FilterParams;
+type MoviePopularParams =
+  & PaginationParams
+  & ApiParams
+  & FilterParams
+  & SearchParams;
 
 const moviePopularRequest = (
-  { fetch, limit, page, filter }: MoviePopularParams,
+  { fetch, limit, page, filter, search }: MoviePopularParams,
 ) =>
   api({ fetch })
     .movies
@@ -24,6 +30,7 @@ const moviePopularRequest = (
         page,
         limit,
         ...filter,
+        ...search,
       },
     });
 
@@ -38,7 +45,8 @@ export const moviePopularQuery = defineQuery({
   ) => [
     params.limit,
     params.page,
-    ...getGlobalFilterDependencies(params),
+    ...getGlobalFilterDependencies(params.filter),
+    ...getRecordDependencies(params.search),
   ],
   request: moviePopularRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/movies/movieStreamingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieStreamingQuery.ts
@@ -62,7 +62,7 @@ export const movieStreamingQuery = defineQuery({
   ) => [
     params.limit,
     params.page,
-    ...getGlobalFilterDependencies(params),
+    ...getGlobalFilterDependencies(params.filter),
   ],
   request: movieStreamingRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
@@ -1,23 +1,29 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
-import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { MovieEntrySchema } from '$lib/requests/models/MovieEntry.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import type { SearchParams } from '$lib/requests/models/SearchParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { MovieTrendingResponse } from '@trakt/api';
 import { z } from 'zod';
+import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
+import { getRecordDependencies } from '../../_internal/getRecordDependencies.ts';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
-import { MovieEntrySchema } from '../../models/MovieEntry.ts';
 
 export const TrendingMovieSchema = MovieEntrySchema.extend({
   watchers: z.number(),
 });
 export type TrendingMovie = z.infer<typeof TrendingMovieSchema>;
 
-type MovieTrendingParams = PaginationParams & ApiParams & FilterParams;
+type MovieTrendingParams =
+  & PaginationParams
+  & ApiParams
+  & FilterParams
+  & SearchParams;
 
 function mapToTrendingMovie({
   watchers,
@@ -30,7 +36,7 @@ function mapToTrendingMovie({
 }
 
 const movieTrendingRequest = (
-  { fetch, limit, page, filter }: MovieTrendingParams,
+  { fetch, limit, page, filter, search }: MovieTrendingParams,
 ) =>
   api({ fetch })
     .movies
@@ -41,6 +47,7 @@ const movieTrendingRequest = (
         page,
         limit,
         ...filter,
+        ...search,
       },
     });
 
@@ -55,7 +62,8 @@ export const movieTrendingQuery = defineQuery({
   ) => [
     params.limit,
     params.page,
-    ...getGlobalFilterDependencies(params),
+    ...getGlobalFilterDependencies(params.filter),
+    ...getRecordDependencies(params.search),
   ],
   request: movieTrendingRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
@@ -40,7 +40,7 @@ export const recommendedMoviesQuery = defineQuery({
   ) => [
     params.limit,
     params.filter?.watch_window,
-    ...getGlobalFilterDependencies(params),
+    ...getGlobalFilterDependencies(params.filter),
   ],
   request: recommendedMoviesRequest,
   mapper: (response) => response.body.map(mapToMovieEntry),

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
@@ -44,7 +44,7 @@ export const recommendedShowsQuery = defineQuery({
   ) => [
     params.limit,
     params.filter?.watch_window,
-    ...getGlobalFilterDependencies(params),
+    ...getGlobalFilterDependencies(params.filter),
   ],
   request: recommendedShowsRequest,
   mapper: (response) =>

--- a/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
@@ -1,12 +1,14 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
+import { getRecordDependencies } from '$lib/requests/_internal/getRecordDependencies.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
 import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import type { SearchParams } from '$lib/requests/models/SearchParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { ShowAnticipatedResponse } from '@trakt/api';
 import { z } from 'zod';
@@ -20,7 +22,11 @@ export const AnticipatedShowSchema = ShowEntrySchema
   });
 export type AnticipatedShow = z.infer<typeof AnticipatedShowSchema>;
 
-type ShowAnticipatedParams = PaginationParams & ApiParams & FilterParams;
+type ShowAnticipatedParams =
+  & PaginationParams
+  & ApiParams
+  & FilterParams
+  & SearchParams;
 
 function mapToAnticipatedShow({
   list_count,
@@ -39,7 +45,7 @@ function mapToAnticipatedShow({
 }
 
 const showAnticipatedRequest = (
-  { fetch, limit, page, filter }: ShowAnticipatedParams,
+  { fetch, limit, page, filter, search }: ShowAnticipatedParams,
 ) =>
   api({ fetch })
     .shows
@@ -50,6 +56,7 @@ const showAnticipatedRequest = (
         page,
         limit,
         ...filter,
+        ...search,
       },
     });
 
@@ -65,7 +72,8 @@ export const showAnticipatedQuery = defineQuery({
   ) => [
     params.limit,
     params.page,
-    ...getGlobalFilterDependencies(params),
+    ...getGlobalFilterDependencies(params.filter),
+    ...getRecordDependencies(params.search),
   ],
   request: showAnticipatedRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/shows/showIntlQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showIntlQuery.ts
@@ -5,7 +5,7 @@ import type {
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import type { ShowTranslationResponse } from '@trakt/api';
+import type { TranslationResponse } from '@trakt/api';
 import { type MediaIntl, MediaIntlSchema } from '../../models/MediaIntl.ts';
 
 type ShowIntlParams = {
@@ -15,7 +15,7 @@ type ShowIntlParams = {
 } & ApiParams;
 
 function mapShowIntlResponse(
-  translation?: ShowTranslationResponse[0],
+  translation?: TranslationResponse[0],
 ): MediaIntl | undefined {
   if (!translation) {
     return undefined;

--- a/projects/client/src/lib/requests/queries/shows/showSeasonEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSeasonEpisodesQuery.ts
@@ -14,6 +14,7 @@ const showSeasonEpisodesRequest = (
 ) =>
   api({ fetch })
     .shows
+    .season
     .episodes({
       params: {
         id: slug,

--- a/projects/client/src/lib/requests/queries/shows/showStreamingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showStreamingQuery.ts
@@ -62,7 +62,7 @@ export const showStreamingQuery = defineQuery({
   ) => [
     params.limit,
     params.page,
-    ...getGlobalFilterDependencies(params),
+    ...getGlobalFilterDependencies(params.filter),
   ],
   request: showStreamingRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
@@ -55,7 +55,7 @@ export const movieWatchlistQuery = defineQuery({
     params.sort,
     params.limit,
     params.page,
-    ...getGlobalFilterDependencies(params),
+    ...getGlobalFilterDependencies(params.filter),
   ],
   request: watchlistRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
@@ -61,7 +61,7 @@ export const showWatchlistQuery = defineQuery({
     params.sort,
     params.limit,
     params.page,
-    ...getGlobalFilterDependencies(params),
+    ...getGlobalFilterDependencies(params.filter),
   ],
   request: watchlistRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/users/smartListQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/smartListQuery.spec.ts
@@ -1,0 +1,40 @@
+import { smartListQuery } from '$lib/requests/queries/users/smartListQuery.ts';
+import { MovieSmartListMappedMock } from '$mocks/data/users/mapped/MovieSmartListMappedMock.ts';
+import { ShowSmartListMappedMock } from '$mocks/data/users/mapped/ShowSmartListMappedMock.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { createQuery } from '@tanstack/svelte-query';
+import { describe, expect, it } from 'vitest';
+
+describe('smartListQuery', () => {
+  it('should request movie smart lists', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          smartListQuery({
+            type: 'movie',
+            limit: 10,
+            page: 1,
+          }),
+        ),
+      mapper: (response) => response?.data?.entries,
+    });
+
+    expect(result).to.deep.equal(MovieSmartListMappedMock);
+  });
+
+  it('should request show smart lists', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createQuery(
+          smartListQuery({
+            type: 'show',
+            limit: 10,
+            page: 1,
+          }),
+        ),
+      mapper: (response) => response?.data?.entries,
+    });
+
+    expect(result).to.deep.equal(ShowSmartListMappedMock);
+  });
+});

--- a/projects/client/src/lib/requests/queries/users/smartListQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/smartListQuery.ts
@@ -1,0 +1,103 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
+import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import type { FilterResponse } from '@trakt/api';
+import { z } from 'zod';
+import { type MediaType, MediaTypeSchema } from '../../models/MediaType.ts';
+import type { PaginationParams } from '../../models/PaginationParams.ts';
+
+type SavedFilterParams =
+  & { type: MediaType }
+  & PaginationParams
+  & ApiParams
+  & FilterParams;
+
+const SmartListTargetSchema = z.enum([
+  'trending',
+  'popular',
+  'anticipated',
+  'unknown',
+]);
+export type SmartListTarget = z.infer<typeof SmartListTargetSchema>;
+
+const SmartListSchema = z.object({
+  title: z.string(),
+  target: SmartListTargetSchema,
+  type: MediaTypeSchema,
+  params: z.record(z.string(), z.string()),
+});
+
+function mapToType(
+  section: string,
+): MediaType {
+  switch (section) {
+    case 'movies':
+      return 'movie';
+    case 'shows':
+      return 'show';
+    default:
+      throw new Error(`Unsupported section: ${section}`);
+  }
+}
+
+function mapToTarget(path: string): SmartListTarget {
+  if (path.endsWith('/trending')) {
+    return 'trending';
+  }
+
+  if (path.endsWith('/popular')) {
+    return 'popular';
+  }
+
+  if (path.endsWith('/anticipated')) {
+    return 'anticipated';
+  }
+
+  return 'unknown';
+}
+
+function mapToSmartList(
+  entry: FilterResponse,
+): SmartList {
+  return {
+    title: entry.name,
+    type: mapToType(entry.section),
+    target: mapToTarget(entry.path),
+    params: Object.fromEntries(new URLSearchParams(entry.query)),
+  };
+}
+
+export type SmartList = z.infer<typeof SmartListSchema>;
+
+const smartListRequest = (
+  { fetch, type }: SavedFilterParams,
+) =>
+  api({ fetch })
+    .users
+    .filters
+    .saved({
+      params: {
+        section: `${type}s`,
+      },
+    });
+
+export const smartListQuery = defineQuery({
+  key: (params: SavedFilterParams) => `${params.type}SavedFilters`,
+  invalidations: [],
+  dependencies: (
+    params: SavedFilterParams,
+  ) => [
+    params.limit,
+    params.page,
+  ],
+  request: smartListRequest,
+  mapper: (response) => ({
+    entries: response.body.map(mapToSmartList),
+    page: extractPageMeta(response.headers),
+  }),
+  schema: PaginatableSchemaFactory(SmartListSchema),
+  ttl: time.seconds(1),
+});

--- a/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
@@ -1,6 +1,5 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
-import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
 import { mapToListItem } from '$lib/requests/_internal/mapToListItem.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeCountSchema } from '$lib/requests/models/EpisodeCount.ts';
@@ -14,6 +13,7 @@ import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts'
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
+import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
 
 type UserListItemsParams =
   & {
@@ -78,7 +78,7 @@ export const userListItemsQuery = defineQuery({
     params.limit,
     params.page,
     params.type,
-    ...getGlobalFilterDependencies(params),
+    ...getGlobalFilterDependencies(params.filter),
   ],
   request: userListItemsRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/sync/addRatingRequest.ts
+++ b/projects/client/src/lib/requests/sync/addRatingRequest.ts
@@ -1,8 +1,8 @@
 import { api, type ApiParams } from '$lib/requests/api.ts';
-import type { RatingsRequest } from '@trakt/api';
+import type { RatingsSyncRequest } from '@trakt/api';
 
 type AddRatingParams = {
-  body: RatingsRequest;
+  body: RatingsSyncRequest;
 } & ApiParams;
 
 export function addRatingRequest(

--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedList.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedList.svelte
@@ -10,9 +10,10 @@
     title: string;
     drilldownLabel: string;
     type: MediaType;
+    search?: Record<string, string>;
   };
 
-  const { title, drilldownLabel, type }: TrendingListProps = $props();
+  const { title, drilldownLabel, type, search }: TrendingListProps = $props();
   const { filterMap } = useFilter();
 </script>
 
@@ -22,8 +23,16 @@
   {drilldownLabel}
   {type}
   filter={$filterMap}
-  useList={useAnticipatedList}
-  urlBuilder={UrlBuilder.anticipated}
+  useList={(params) =>
+    useAnticipatedList({
+      ...params,
+      search,
+    })}
+  urlBuilder={(params) =>
+    UrlBuilder.anticipated({
+      ...params,
+      search,
+    })}
 >
   {#snippet item(media)}
     <AnticipatedListItem {type} {media} />

--- a/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
+++ b/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
@@ -1,6 +1,7 @@
 import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import type { SearchParams } from '$lib/requests/models/SearchParams.ts';
 import {
   type AnticipatedMovie,
   movieAnticipatedQuery,
@@ -16,17 +17,12 @@ type AnticipatedListStoreProps =
     type: MediaType;
   }
   & PaginationParams
-  & FilterParams;
+  & FilterParams
+  & SearchParams;
 
 function typeToQuery(
-  { type, limit, page, filter }: AnticipatedListStoreProps,
+  { type, ...params }: AnticipatedListStoreProps,
 ) {
-  const params = {
-    limit,
-    page,
-    filter,
-  };
-
   switch (type) {
     case 'movie':
       return movieAnticipatedQuery(params);

--- a/projects/client/src/lib/sections/lists/popular/PopularList.svelte
+++ b/projects/client/src/lib/sections/lists/popular/PopularList.svelte
@@ -10,9 +10,10 @@
     title: string;
     drilldownLabel: string;
     type: MediaType;
+    search?: Record<string, string>;
   };
 
-  const { title, drilldownLabel, type }: PopularListProps = $props();
+  const { title, drilldownLabel, type, search }: PopularListProps = $props();
   const { filterMap } = useFilter();
 </script>
 
@@ -22,8 +23,16 @@
   {drilldownLabel}
   {type}
   filter={$filterMap}
-  useList={usePopularList}
-  urlBuilder={UrlBuilder.popular}
+  useList={(params) =>
+    usePopularList({
+      ...params,
+      search,
+    })}
+  urlBuilder={(params) =>
+    UrlBuilder.popular({
+      ...params,
+      search,
+    })}
 >
   {#snippet item(media)}
     <PopularListItem {type} {media} />

--- a/projects/client/src/lib/sections/lists/popular/PopularPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/popular/PopularPaginatedList.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import { useFilter } from "$lib/features/filters/useFilter";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import { decodeRecord } from "$lib/utils/url/UrlBuilder";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import PopularListItem from "./PopularListItem.svelte";
   import { usePopularList } from "./usePopularList";
@@ -23,7 +25,11 @@
   {title}
   {type}
   filter={$filterMap}
-  useList={usePopularList}
+  useList={(params) =>
+    usePopularList({
+      ...params,
+      search: decodeRecord(page.url.searchParams.get("search") ?? ""),
+    })}
 >
   {#snippet item(media)}
     <PopularListItem {type} {media} {style} />

--- a/projects/client/src/lib/sections/lists/popular/usePopularList.ts
+++ b/projects/client/src/lib/sections/lists/popular/usePopularList.ts
@@ -2,6 +2,7 @@ import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { type MovieEntry } from '$lib/requests/models/MovieEntry.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import type { SearchParams } from '$lib/requests/models/SearchParams.ts';
 import { moviePopularQuery } from '$lib/requests/queries/movies/moviePopularQuery.ts';
 import {
   type PopularShow,
@@ -17,17 +18,12 @@ type PopularListStoreProps =
     type: MediaType;
   }
   & PaginationParams
-  & FilterParams;
+  & FilterParams
+  & SearchParams;
 
 function typeToQuery(
-  { type, limit, page, filter }: PopularListStoreProps,
+  { type, ...params }: PopularListStoreProps,
 ) {
-  const params = {
-    limit,
-    page,
-    filter,
-  };
-
   switch (type) {
     case 'movie':
       return moviePopularQuery(params);

--- a/projects/client/src/lib/sections/lists/smart/SmartListRenderer.svelte
+++ b/projects/client/src/lib/sections/lists/smart/SmartListRenderer.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+
+  import GlobalParameterEscaper from "$lib/features/parameters/GlobalParameterEscaper.svelte";
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import AnticipatedList from "../anticipated/AnticipatedList.svelte";
+  import PopularList from "../popular/PopularList.svelte";
+  import TrendingList from "../trending/TrendingList.svelte";
+
+  import { useSmartLists } from "./useSmartLists";
+
+  type SmartListRendererProps = {
+    type: MediaType;
+  };
+
+  const { type }: SmartListRendererProps = $props();
+
+  const { list } = $derived(useSmartLists(type));
+</script>
+
+<GlobalParameterEscaper enabled>
+  {#each $list as collection}
+    {#if collection.target === "trending"}
+      <TrendingList
+        title={collection.title}
+        drilldownLabel={m.view_all_items_in({ title: collection.title })}
+        type={collection.type}
+        search={collection.params}
+      />
+    {/if}
+
+    {#if collection.target === "anticipated"}
+      <AnticipatedList
+        title={collection.title}
+        drilldownLabel={m.view_all_items_in({ title: collection.title })}
+        type={collection.type}
+        search={collection.params}
+      />
+    {/if}
+
+    {#if collection.target === "popular"}
+      <PopularList
+        title={collection.title}
+        drilldownLabel={m.view_all_items_in({ title: collection.title })}
+        type={collection.type}
+        search={collection.params}
+      />
+    {/if}
+  {/each}
+</GlobalParameterEscaper>

--- a/projects/client/src/lib/sections/lists/smart/useSmartLists.ts
+++ b/projects/client/src/lib/sections/lists/smart/useSmartLists.ts
@@ -1,0 +1,12 @@
+import { smartListQuery } from '$lib/requests/queries/users/smartListQuery.ts';
+import type { MediaType } from '../../../requests/models/MediaType.ts';
+import { DEFAULT_SMART_LIST_LIMIT } from '../../../utils/constants.ts';
+import { usePaginatedListQuery } from '../stores/usePaginatedListQuery.ts';
+
+export function useSmartLists(type: MediaType) {
+  return usePaginatedListQuery(smartListQuery({
+    type,
+    limit: DEFAULT_SMART_LIST_LIMIT,
+    page: 1,
+  }));
+}

--- a/projects/client/src/lib/sections/lists/trending/TrendingList.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingList.svelte
@@ -10,9 +10,10 @@
     title: string;
     drilldownLabel: string;
     type: MediaType;
+    search?: Record<string, string>;
   };
 
-  const { title, drilldownLabel, type }: TrendingListProps = $props();
+  const { title, drilldownLabel, type, search }: TrendingListProps = $props();
   const { filterMap } = useFilter();
 </script>
 
@@ -22,8 +23,16 @@
   {drilldownLabel}
   {type}
   filter={$filterMap}
-  useList={useTrendingList}
-  urlBuilder={UrlBuilder.trending}
+  useList={(params) =>
+    useTrendingList({
+      ...params,
+      search,
+    })}
+  urlBuilder={(params) =>
+    UrlBuilder.trending({
+      ...params,
+      search,
+    })}
 >
   {#snippet item(media)}
     <TrendingListItem {type} {media} />

--- a/projects/client/src/lib/sections/lists/trending/TrendingPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingPaginatedList.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import { useFilter } from "$lib/features/filters/useFilter";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import { decodeRecord } from "$lib/utils/url/UrlBuilder";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import TrendingListItem from "./TrendingListItem.svelte";
   import { useTrendingList } from "./useTrendingList";
@@ -23,7 +25,11 @@
   {title}
   {type}
   filter={$filterMap}
-  useList={useTrendingList}
+  useList={(params) =>
+    useTrendingList({
+      ...params,
+      search: decodeRecord(page.url.searchParams.get("search") ?? ""),
+    })}
 >
   {#snippet item(media)}
     <TrendingListItem {type} {media} {style} />

--- a/projects/client/src/lib/sections/lists/trending/useTrendingList.ts
+++ b/projects/client/src/lib/sections/lists/trending/useTrendingList.ts
@@ -2,6 +2,7 @@ import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { Paginatable } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import type { SearchParams } from '$lib/requests/models/SearchParams.ts';
 import {
   movieTrendingQuery,
   type TrendingMovie,
@@ -16,7 +17,7 @@ import { type CreateQueryOptions } from '@tanstack/svelte-query';
 export type TrendingEntry = TrendingMovie | TrendingShow;
 export type TrendingMediaList = Paginatable<TrendingEntry>;
 
-type TrendingListStoreProps = PaginationParams & FilterParams & {
+type TrendingListStoreProps = PaginationParams & FilterParams & SearchParams & {
   type: MediaType;
 };
 

--- a/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
@@ -7,7 +7,7 @@ import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { addRatingRequest } from '$lib/requests/sync/addRatingRequest.ts';
 import { mapRatingToSimpleRating } from '$lib/sections/summary/components/rating/mapRatingToSimpleRating.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import type { RatingsRequest } from '@trakt/api';
+import type { RatingsSyncRequest } from '@trakt/api';
 import { derived, get, writable } from 'svelte/store';
 import { SIMPLE_RATINGS } from './constants.ts';
 
@@ -22,7 +22,7 @@ function toRatingPayload(
   type: RateableType,
   id: number,
   simpleRating: SimpleRating,
-): RatingsRequest {
+): RatingsSyncRequest {
   const ratingPayload = {
     ids: { trakt: id },
     rating: SIMPLE_RATINGS[simpleRating],

--- a/projects/client/src/lib/utils/constants.ts
+++ b/projects/client/src/lib/utils/constants.ts
@@ -73,3 +73,5 @@ export const PAGE_UPPER_LIMIT = 3;
  */
 export const RECOMMENDED_DEFAULT_WATCH_WINDOW = 25;
 export const RECOMMENDED_DEFAULT_MIN_YEAR = 1990;
+
+export const DEFAULT_SMART_LIST_LIMIT = 10;

--- a/projects/client/src/mocks/data/summary/episodes/silo/response/EpisodeSiloRatingsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/response/EpisodeSiloRatingsResponseMock.ts
@@ -1,6 +1,6 @@
-import type { ShowRatingsResponse } from '@trakt/api';
+import type { RatingsResponse } from '@trakt/api';
 
-export const EpisodeSiloRatingsResponseMock: ShowRatingsResponse = {
+export const EpisodeSiloRatingsResponseMock: RatingsResponse = {
   'trakt': {
     'rating': 8.15357,
     'votes': 7241,

--- a/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticLanguageResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticLanguageResponseMock.ts
@@ -1,6 +1,6 @@
-import type { MovieTranslationResponse } from '@trakt/api';
+import type { TranslationResponse } from '@trakt/api';
 
-export const MovieHereticLanguageResponseMock: MovieTranslationResponse = [
+export const MovieHereticLanguageResponseMock: TranslationResponse = [
   {
     'title': 'Kafir',
     'overview':

--- a/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticRatingsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticRatingsResponseMock.ts
@@ -1,6 +1,6 @@
-import type { MovieRatingsResponse } from '@trakt/api';
+import type { RatingsResponse } from '@trakt/api';
 
-export const MovieHereticRatingsResponseMock: MovieRatingsResponse = {
+export const MovieHereticRatingsResponseMock: RatingsResponse = {
   'trakt': {
     'rating': 7.22561,
     'votes': 3803,

--- a/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloLanguageResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloLanguageResponseMock.ts
@@ -1,6 +1,6 @@
-import type { ShowTranslationResponse } from '@trakt/api';
+import type { TranslationResponse } from '@trakt/api';
 
-export const ShowSiloLanguageResponseMock: ShowTranslationResponse = [
+export const ShowSiloLanguageResponseMock: TranslationResponse = [
   {
     'title': null,
     'overview':

--- a/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloRatingsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloRatingsResponseMock.ts
@@ -1,6 +1,6 @@
-import type { ShowRatingsResponse } from '@trakt/api';
+import type { RatingsResponse } from '@trakt/api';
 
-export const ShowSiloRatingsResponseMock: ShowRatingsResponse = {
+export const ShowSiloRatingsResponseMock: RatingsResponse = {
   'trakt': {
     'rating': 8.15357,
     'votes': 7241,

--- a/projects/client/src/mocks/data/users/mapped/MovieSmartListMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/MovieSmartListMappedMock.ts
@@ -1,0 +1,15 @@
+export const MovieSmartListMappedMock = [
+  {
+    params: {
+      genres: 'adventure,comedy',
+      imdb_ratings: '7.0-10.0',
+      ratings: '60-100',
+      rt_meters: '75-100',
+      runtimes: '115-500',
+      years: '2010-2030',
+    },
+    title: '[Smart] Top Adventure Movies',
+    target: 'trending',
+    type: 'movie',
+  },
+];

--- a/projects/client/src/mocks/data/users/mapped/ShowSmartListMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/ShowSmartListMappedMock.ts
@@ -1,0 +1,14 @@
+export const ShowSmartListMappedMock = [
+  {
+    params: {
+      genres: 'science-fiction',
+      imdb_ratings: '8.0-10.0',
+      ratings: '80-100',
+      rt_meters: '80-100',
+      rt_user_meters: '80-100',
+    },
+    title: '[Smart] Top Science Fiction Series',
+    target: 'trending',
+    type: 'show',
+  },
+];

--- a/projects/client/src/mocks/data/users/response/FilterResponseMock.ts
+++ b/projects/client/src/mocks/data/users/response/FilterResponseMock.ts
@@ -1,0 +1,23 @@
+import type { FilterResponse } from '@trakt/api';
+export const FilterResponseMock: FilterResponse[] = [
+  {
+    rank: 1,
+    id: 21230,
+    section: 'shows',
+    name: '[Smart] Top Science Fiction Series',
+    path: '/shows/trending',
+    query:
+      'genres=science-fiction&ratings=80-100&imdb_ratings=8.0-10.0&rt_meters=80-100&rt_user_meters=80-100',
+    updated_at: '2025-04-30T12:42:42.000Z',
+  },
+  {
+    rank: 1,
+    id: 21229,
+    section: 'movies',
+    name: '[Smart] Top Adventure Movies',
+    path: '/movies/trending',
+    query:
+      'genres=adventure,comedy&years=2010-2030&runtimes=115-500&ratings=60-100&imdb_ratings=7.0-10.0&rt_meters=75-100',
+    updated_at: '2025-04-30T12:39:22.000Z',
+  },
+];

--- a/projects/client/src/mocks/handlers/users.ts
+++ b/projects/client/src/mocks/handlers/users.ts
@@ -14,6 +14,7 @@ import { PersonalListsResponseMock } from '$mocks/data/users/response/PersonalLi
 import { RatedShowsResponseMock } from '$mocks/data/users/response/RatedShowsResponseMock.ts';
 import { EpisodeActivityHistoryResponseMock } from '../data/users/response/EpisodeActivityHistoryResponseMock.ts';
 import { ExtendedUsersResponseMock } from '../data/users/response/ExtendedUserSettingsResponseMock.ts';
+import { FilterResponseMock } from '../data/users/response/FilterResponseMock.ts';
 import { HiddenShowProgressResponseMock } from '../data/users/response/HiddenShowProgressResponseMock.ts';
 import { MovieActivityHistoryResponseMock } from '../data/users/response/MovieActivityHistoryResponseMock.ts';
 import { RatedEpisodesResponseMock } from '../data/users/response/RatedEpisodesResponseMock.ts';
@@ -119,6 +120,14 @@ export const users = [
     }/items/movie*`,
     () => {
       return HttpResponse.json(ListedMoviesResponseMock);
+    },
+  ),
+  http.get(
+    'http://localhost/users/saved_filters/:section',
+    (req) => {
+      return HttpResponse.json(
+        FilterResponseMock.filter((f) => f.section === req.params.section),
+      );
     },
   ),
 ];

--- a/projects/client/src/routes/users/[user]/lists/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
 
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -33,6 +34,8 @@
   <PersonalLists slug="me" type="personal" variant="preview" />
   <PersonalLists slug="me" type="collaboration" variant="summary" />
 
-  <SmartListRenderer type="movie" />
-  <SmartListRenderer type="show" />
+  <RenderFor audience="director">
+    <SmartListRenderer type="movie" />
+    <SmartListRenderer type="show" />
+  </RenderFor>
 </TraktPage>

--- a/projects/client/src/routes/users/[user]/lists/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/+page.svelte
@@ -3,6 +3,7 @@
 
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import SmartListRenderer from "$lib/sections/lists/smart/SmartListRenderer.svelte";
   import PersonalLists from "$lib/sections/lists/user/PersonalLists.svelte";
   import WatchList from "$lib/sections/lists/watchlist/WatchList.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
@@ -14,6 +15,7 @@
   title={m.navbar_link_lists()}
 >
   <TraktPageCoverSetter />
+
   <WatchList
     title={m.watchlist_movies()}
     drilldownLabel={m.view_all_watchlist_movies()}
@@ -30,4 +32,7 @@
 
   <PersonalLists slug="me" type="personal" variant="preview" />
   <PersonalLists slug="me" type="collaboration" variant="summary" />
+
+  <SmartListRenderer type="movie" />
+  <SmartListRenderer type="show" />
 </TraktPage>


### PR DESCRIPTION
##   Linguistic Expansion, Dependency Shift, and Parameter Taming

This pull request brings forth a trio of notable changes: an expansion of our multilingual lexicon, a subtle shift in our reliance on the digital ether, and the introduction of a curious device for wrangling unruly parameters.

###   A Chorus of Tongues:

* The phrase `view_all_items_in` has been carefully translated and inscribed into the digital scrolls of numerous languages: Bulgarian, Danish, German, English, Spanish, French, Italian, Japanese, Norwegian Bokmål, Dutch, Polish, Portuguese (Brazilian), Romanian, Swedish, and Ukrainian. A testament to our commitment to be understood, no matter the mother tongue.

###   Whispers from the API:

* Our connection to the `@trakt/api` has been subtly adjusted, moving from version `^0.1.23` to `^0.1.26`. Perhaps the whispers from the digital void have changed their tune, offering new insights or correcting old mispronunciations.

###   A Device for Order:

* A new contraption has been assembled in the digital workshop: the `GlobalParameterEscaper` Svelte component. Utilizing the arcane arts of Svelte's context API, it promises to manage the escaping of parameters, bringing order to the potentially chaotic flow of information.

###   A Note in the Margins:

* The sacred texts of commit messages, `commitlint.config.js`, now recognize a new category: `smart-list`. Another nuance in the delicate art of documenting our digital endeavors.

(This update is like a cartographer meticulously adding new landmarks to their maps, a linguist expanding their dictionary, and an engineer crafting a specialized tool for a specific task. We are broadening our reach, updating our instruments, and preparing for the intricate dance of parameters in the digital realm. The `GlobalParameterEscaper` in particular hints at a desire for control, a way to tame the wild variables that roam the landscape of our application.)