### PR TITLE
fix(auth): always try a reload on authentication fail

### DIFF
--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
@@ -2,14 +2,6 @@ import { getToken } from '$lib/features/auth/token/index.ts';
 
 import { error } from '$lib/utils/console/print.ts';
 
-function hasExpiredToken(expiresAt: number | Nil) {
-  if (!expiresAt) {
-    return false;
-  }
-
-  return new Date(expiresAt).getTime() - Date.now() < 0;
-}
-
 export function createAuthenticatedFetch<
   T extends typeof fetch,
 >(baseFetch: T): T {
@@ -21,7 +13,7 @@ export function createAuthenticatedFetch<
     const headers = new Headers(modifiedInit?.headers || {});
 
     try {
-      const { value: token, expiresAt } = getToken();
+      const { value: token } = getToken();
 
       if (token) {
         headers.set('Authorization', `Bearer ${token}`);
@@ -34,7 +26,7 @@ export function createAuthenticatedFetch<
           headers,
         } as Parameters<T>[1],
       ).then((response) => {
-        if (response.status === 401 && hasExpiredToken(expiresAt)) {
+        if (response.status === 401 && token) {
           globalThis.window.location.reload();
         }
 


### PR DESCRIPTION
## ♪ Note ♪

- No longer rely on checking for expired token. If we send an Authorization header, and get a 401 back, we reload.