### PR TITLE
fix(summary): hide details when navigating with d-pad

### DIFF
--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -151,16 +151,18 @@
   </RenderFor>
 </SummaryContainer>
 
-<SummaryContainer>
-  <MediaDetails {episode} {crew} type="episode" />
+<RenderFor audience="all" navigation="default">
+  <SummaryContainer>
+    <MediaDetails {episode} {crew} type="episode" />
 
-  {#if streamOn}
-    <MediaStreamingServices
-      services={streamOn.services}
-      preferred={streamOn.preferred}
-    />
-  {/if}
-</SummaryContainer>
+    {#if streamOn}
+      <MediaStreamingServices
+        services={streamOn.services}
+        preferred={streamOn.preferred}
+      />
+    {/if}
+  </SummaryContainer>
+</RenderFor>
 
 <CastList title={m.actors()} cast={crew.cast} slug={show.slug} />
 

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -182,15 +182,17 @@
   </RenderFor>
 </SummaryContainer>
 
-<SummaryContainer>
-  <MediaDetails {media} {studios} {crew} {type} />
+<RenderFor audience="all" navigation="default">
+  <SummaryContainer>
+    <MediaDetails {media} {studios} {crew} {type} />
 
-  {#if streamOn}
-    <RenderFor audience="authenticated" navigation="default">
-      <MediaStreamingServices
-        services={streamOn.services}
-        preferred={streamOn.preferred}
-      />
-    </RenderFor>
-  {/if}
-</SummaryContainer>
+    {#if streamOn}
+      <RenderFor audience="authenticated" navigation="default">
+        <MediaStreamingServices
+          services={streamOn.services}
+          preferred={streamOn.preferred}
+        />
+      </RenderFor>
+    {/if}
+  </SummaryContainer>
+</RenderFor>


### PR DESCRIPTION
## ♪ Note ♪

- Gets rid of unusable clutter in summary pages (i.e. no more details section).

## 👀 Example 👀

Before:
<img width="969" alt="Screenshot 2025-05-01 at 11 52 18" src="https://github.com/user-attachments/assets/2b074121-ec10-47df-9021-e9d6285c911a" />

After:
<img width="969" alt="Screenshot 2025-05-01 at 11 52 23" src="https://github.com/user-attachments/assets/d8a02b6a-c459-443a-aec4-a5a865dbf148" />
