### PR TITLE
fix(navigation): scroll when navigation to lists

### DIFF
--- a/projects/client/src/lib/features/navigation/_internal/focusAndScrollIntoView.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/focusAndScrollIntoView.spec.ts
@@ -25,6 +25,19 @@ describe('focusAndScrollIntoView', () => {
     expect(mockElement.scrollIntoView).toHaveBeenCalledWith({
       block: 'center',
       inline: 'center',
+      behavior: 'instant',
+    });
+  });
+
+  it('should focus and scroll to the element smoothly', () => {
+    focusAndScrollIntoView(mockElement, 'smooth');
+
+    expect(mockElement.focus).toHaveBeenCalledTimes(1);
+    expect(mockElement.scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(mockElement.scrollIntoView).toHaveBeenCalledWith({
+      block: 'center',
+      inline: 'center',
+      behavior: 'smooth',
     });
   });
 

--- a/projects/client/src/lib/features/navigation/_internal/focusAndScrollIntoView.ts
+++ b/projects/client/src/lib/features/navigation/_internal/focusAndScrollIntoView.ts
@@ -1,4 +1,7 @@
-export const focusAndScrollIntoView = (element?: Element | null) => {
+export const focusAndScrollIntoView = (
+  element?: Element | null,
+  behavior?: ScrollBehavior,
+) => {
   if (!element) return;
   if (!(element instanceof HTMLElement)) return;
 
@@ -6,5 +9,6 @@ export const focusAndScrollIntoView = (element?: Element | null) => {
   element.scrollIntoView({
     block: 'center',
     inline: 'center',
+    behavior: behavior ?? 'instant',
   });
 };

--- a/projects/client/src/lib/features/navigation/_internal/handleListNavigation.ts
+++ b/projects/client/src/lib/features/navigation/_internal/handleListNavigation.ts
@@ -4,6 +4,8 @@ import { focusAndScrollIntoView } from './focusAndScrollIntoView.ts';
 import { getNavigationState } from './getNavigationState.ts';
 import { getNextIndex } from './getNextIndex.ts';
 
+const LIST_SCROLL_BEHAVIOR: ScrollBehavior = 'smooth';
+
 export const handleListNavigation = (key: 'ArrowUp' | 'ArrowDown') => {
   const { lists, currentListIndex } = getNavigationState();
 
@@ -16,5 +18,15 @@ export const handleListNavigation = (key: 'ArrowUp' | 'ArrowDown') => {
   const targetList = assertDefined(lists[newListIndex], 'No list found');
   const targetItem = getRelevantItem(targetList);
 
-  focusAndScrollIntoView(targetItem);
+  const isFirstList = newListIndex === 0;
+  const isLastList = newListIndex === lists.length - 1;
+
+  if (isFirstList || isLastList) {
+    globalThis.window.scrollTo({
+      top: isFirstList ? 0 : document.documentElement.scrollHeight,
+      behavior: LIST_SCROLL_BEHAVIOR,
+    });
+  }
+
+  focusAndScrollIntoView(targetItem, LIST_SCROLL_BEHAVIOR);
 };


### PR DESCRIPTION
## 🎶 Notes 🎶

- When scrolling through lists, the scroll behavior is smooth.
- When navigating to the top or bottom list, the page is scrolled to the top/bottom respectively.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/6f98a0fd-225a-40b5-a3d5-a2b46f0ac419

After:

https://github.com/user-attachments/assets/68b24c43-dfd6-4d89-938a-bb5e5175ac7c

