### PR TITLE
Feat/filter dpad

### DIFF
--- a/projects/client/src/lib/components/toggles/Switch.svelte
+++ b/projects/client/src/lib/components/toggles/Switch.svelte
@@ -6,6 +6,7 @@
     label,
     innerText,
     color = "purple",
+    navigationType,
     ...props
   }: SwitchProps = $props();
 </script>
@@ -16,6 +17,7 @@
     role="switch"
     data-color={color}
     aria-label={label}
+    data-dpad-navigation={navigationType}
     {...props}
   />
 

--- a/projects/client/src/lib/components/toggles/SwitchProps.ts
+++ b/projects/client/src/lib/components/toggles/SwitchProps.ts
@@ -1,4 +1,7 @@
+import type { DpadNavigationType } from '../../features/navigation/models/DpadNavigationType.ts';
+
 export type SwitchProps = CheckboxProps & {
   innerText?: string;
   color?: 'purple' | 'red' | 'blue' | 'orange' | 'default' | 'custom';
+  navigationType?: DpadNavigationType;
 };

--- a/projects/client/src/lib/features/navigation/_internal/focusSomething.ts
+++ b/projects/client/src/lib/features/navigation/_internal/focusSomething.ts
@@ -1,11 +1,14 @@
 import { getRelevantItem } from '$lib/features/navigation/_internal/getRelevantItem.ts';
 import { focusAndScrollIntoView } from './focusAndScrollIntoView.ts';
+import { getNavigationScope } from './getNavigationScope.ts';
 
 export function focusSomething() {
   if (document.activeElement && document.activeElement !== document.body) {
     return;
   }
 
-  const firstNavigableElement = getRelevantItem(document);
+  const scope = getNavigationScope();
+  const firstNavigableElement = getRelevantItem(scope);
+
   focusAndScrollIntoView(firstNavigableElement);
 }

--- a/projects/client/src/lib/features/navigation/_internal/getAllUsableLists.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getAllUsableLists.spec.ts
@@ -29,4 +29,26 @@ describe('getAllUsableLists', () => {
     const lists = getAllUsableLists();
     expect(lists).toEqual([list]);
   });
+
+  it('should get lists within the navigation trap', () => {
+    const item = document.createElement('button');
+    item.setAttribute('data-dpad-navigation', DpadNavigationType.Item);
+    list.appendChild(item);
+
+    const trap = document.createElement('div');
+    trap.setAttribute(
+      'data-dpad-navigation',
+      DpadNavigationType.Trap,
+    );
+
+    const trappedList = createList(true);
+    const trappedItem = document.createElement('button');
+
+    trappedItem.setAttribute('data-dpad-navigation', DpadNavigationType.Item);
+    trappedList.appendChild(trappedItem);
+    trap.appendChild(trappedList);
+
+    const lists = getAllUsableLists();
+    expect(lists).toEqual([trappedList]);
+  });
 });

--- a/projects/client/src/lib/features/navigation/_internal/getAllUsableLists.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getAllUsableLists.ts
@@ -1,13 +1,18 @@
 import { DpadNavigationType } from '$lib/features/navigation/models/DpadNavigationType.ts';
+import { getNavigationScope } from './getNavigationScope.ts';
+import { getSelectableItems } from './getSelectableItems.ts';
 
 export function getAllUsableLists() {
+  const scope = getNavigationScope();
+
   const lists = Array.from(
-    document.querySelectorAll(
+    scope.querySelectorAll(
       `[data-dpad-navigation="${DpadNavigationType.List}"]`,
     ),
   );
 
-  return lists.filter((list) =>
-    list.querySelector(`[data-dpad-navigation="${DpadNavigationType.Item}"]`)
-  );
+  return lists.filter((list) => {
+    const selectableItems = getSelectableItems(list);
+    return selectableItems.length > 0;
+  });
 }

--- a/projects/client/src/lib/features/navigation/_internal/getNavigationScope.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getNavigationScope.ts
@@ -1,0 +1,9 @@
+import { DpadNavigationType } from '../models/DpadNavigationType.ts';
+
+export function getNavigationScope() {
+  const navigationTrap = document.querySelector(
+    `[data-dpad-navigation="${DpadNavigationType.Trap}"]`,
+  );
+
+  return navigationTrap ?? document;
+}

--- a/projects/client/src/lib/features/navigation/_internal/getSelectableItems.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getSelectableItems.spec.ts
@@ -31,4 +31,19 @@ describe('getSelectableItems', () => {
     const items = getSelectableItems(list);
     expect(items).toEqual([item]);
   });
+
+  it('should not get disabled items in a list', () => {
+    const item = document.createElement('button');
+    item.setAttribute('data-dpad-navigation', DpadNavigationType.Item);
+
+    const disabledItem = document.createElement('button');
+    disabledItem.setAttribute('data-dpad-navigation', DpadNavigationType.Item);
+    disabledItem.setAttribute('disabled', 'true');
+
+    list.appendChild(item);
+    list.appendChild(disabledItem);
+
+    const items = getSelectableItems(list);
+    expect(items).toEqual([item]);
+  });
 });

--- a/projects/client/src/lib/features/navigation/_internal/getSelectableItems.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getSelectableItems.ts
@@ -3,7 +3,7 @@ import { DpadNavigationType } from '../models/DpadNavigationType.ts';
 export const getSelectableItems = (list: Element) => {
   return Array.from(
     list.querySelectorAll(
-      `[data-dpad-navigation="${DpadNavigationType.Item}"]`,
+      `[data-dpad-navigation="${DpadNavigationType.Item}"]:not([disabled]):not([disabled="true"])`,
     ),
   );
 };

--- a/projects/client/src/lib/features/navigation/_internal/handleListNavigation.ts
+++ b/projects/client/src/lib/features/navigation/_internal/handleListNavigation.ts
@@ -1,6 +1,7 @@
 import { getRelevantItem } from '$lib/features/navigation/_internal/getRelevantItem.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { focusAndScrollIntoView } from './focusAndScrollIntoView.ts';
+import { getNavigationScope } from './getNavigationScope.ts';
 import { getNavigationState } from './getNavigationState.ts';
 import { getNextIndex } from './getNextIndex.ts';
 
@@ -20,8 +21,12 @@ export const handleListNavigation = (key: 'ArrowUp' | 'ArrowDown') => {
 
   const isFirstList = newListIndex === 0;
   const isLastList = newListIndex === lists.length - 1;
+  const scope = getNavigationScope();
 
-  if (isFirstList || isLastList) {
+  // Trigger scrolling only when the navigation scope is the document.
+  // This ensures that navigating to the first or last list scrolls the page
+  // to the top or bottom, respectively, for a seamless user experience.
+  if (scope === document && (isFirstList || isLastList)) {
     globalThis.window.scrollTo({
       top: isFirstList ? 0 : document.documentElement.scrollHeight,
       behavior: LIST_SCROLL_BEHAVIOR,

--- a/projects/client/src/lib/features/navigation/models/DpadNavigationType.ts
+++ b/projects/client/src/lib/features/navigation/models/DpadNavigationType.ts
@@ -1,4 +1,5 @@
 export enum DpadNavigationType {
   Item = 'item',
   List = 'list',
+  Trap = 'trap',
 }

--- a/projects/client/src/lib/features/navigation/useNavigationTrap.ts
+++ b/projects/client/src/lib/features/navigation/useNavigationTrap.ts
@@ -1,0 +1,30 @@
+import { onMount } from 'svelte';
+import { get, writable } from 'svelte/store';
+import { focusAndScrollIntoView } from './_internal/focusAndScrollIntoView.ts';
+import { DpadNavigationType } from './models/DpadNavigationType.ts';
+
+export function useNavigationTrap(
+  element: HTMLElement,
+  itemParentSelector: string,
+) {
+  const currentElement = writable<Element | null>(null);
+
+  onMount(() => {
+    currentElement.set(document.activeElement);
+
+    element.setAttribute(
+      'data-dpad-navigation',
+      DpadNavigationType.Trap,
+    );
+
+    const selectableElement = element.querySelector(
+      `${itemParentSelector} [data-dpad-navigation='${DpadNavigationType.Item}']`,
+    );
+    focusAndScrollIntoView(selectableElement);
+
+    return () => {
+      element.removeAttribute('data-dpad-navigation');
+      focusAndScrollIntoView(get(currentElement));
+    };
+  });
+}

--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -131,9 +131,7 @@
         {#if !isVip}
           <GetVIPLink />
         {/if}
-        <RenderFor audience="authenticated" navigation="default">
-          <FilterButton />
-        </RenderFor>
+        <FilterButton />
         <ProfileButton />
       </RenderFor>
     </div>

--- a/projects/client/src/lib/sections/navbar/components/filter/FilterButton.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/FilterButton.svelte
@@ -3,6 +3,7 @@
   import FilterIcon from "$lib/components/icons/FilterIcon.svelte";
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import { writable } from "svelte/store";
   import FilterSidebar from "./FilterSidebar.svelte";
 
@@ -22,6 +23,7 @@
     variant="secondary"
     text="capitalize"
     {color}
+    navigationType={DpadNavigationType.Item}
     onclick={() => {
       isSidebarOpen.set(true);
     }}

--- a/projects/client/src/lib/sections/navbar/components/filter/FilterSidebar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/FilterSidebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import type { Writable } from "svelte/store";
   import ResetAllButton from "./_internal/ResetAllButton.svelte";
   import Sidebar from "./_internal/Sidebar.svelte";
@@ -27,5 +28,10 @@
     {/if}
   {/each}
 
-  <ResetAllButton />
+  <div
+    class="trakt-filter-actions"
+    data-dpad-navigation={DpadNavigationType.List}
+  >
+    <ResetAllButton />
+  </div>
 </Sidebar>

--- a/projects/client/src/lib/sections/navbar/components/filter/_internal/ResetAllButton.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/_internal/ResetAllButton.svelte
@@ -3,6 +3,7 @@
   import Button from "$lib/components/buttons/Button.svelte";
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import GlobalParameterEscaper from "$lib/features/parameters/GlobalParameterEscaper.svelte";
 
   const { hasActiveFilter } = useFilter();
@@ -17,6 +18,7 @@
     variant="secondary"
     disabled={!$hasActiveFilter || undefined}
     href={page.url.pathname}
+    navigationType={DpadNavigationType.Item}
   >
     {m.filter_reset_all()}
   </Button>

--- a/projects/client/src/lib/sections/navbar/components/filter/_internal/Sidebar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/_internal/Sidebar.svelte
@@ -2,11 +2,13 @@
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
   import CloseIcon from "$lib/components/icons/CloseIcon.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
+  import { useNavigationTrap } from "$lib/features/navigation/useNavigationTrap";
   import { createUnderlay } from "$lib/features/portal/_internal/createUnderlay";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { GlobalEventBus } from "$lib/utils/events/GlobalEventBus";
   import { onMount } from "svelte";
-  import { type Writable } from "svelte/store";
+  import type { Writable } from "svelte/store";
   import { slide } from "svelte/transition";
 
   type SidebarProps = {
@@ -49,13 +51,18 @@
     class="trakt-sidebar"
     transition:slide={{ duration: 150, axis: slideAxis }}
     use:portal
+    use:useNavigationTrap={".trakt-filter"}
   >
-    <div class="trakt-sidebar-header">
+    <div
+      class="trakt-sidebar-header"
+      data-dpad-navigation={DpadNavigationType.List}
+    >
       {title}
       <ActionButton
         onclick={() => isOpen.set(false)}
         label={m.close_label()}
         style="ghost"
+        navigationType={DpadNavigationType.Item}
         --color-foreground-default="var(--color-text-secondary)"
       >
         <CloseIcon />

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/ListFilter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/ListFilter.svelte
@@ -33,10 +33,14 @@
   <RenderFor
     audience="authenticated"
     device={["tablet-sm", "tablet-lg", "desktop"]}
+    navigation="default"
   >
     <DropdownFilter {...commonProps} />
   </RenderFor>
-  <RenderFor audience="authenticated" device={["mobile"]}>
+  <RenderFor audience="authenticated" device={["mobile"]} navigation="default">
+    <SelectFilter {...commonProps} />
+  </RenderFor>
+  <RenderFor audience="authenticated" navigation="dpad">
     <SelectFilter {...commonProps} />
   </RenderFor>
 </Filter>

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/RatingsFilter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/RatingsFilter.svelte
@@ -4,6 +4,7 @@
   import type { RatingsFilter } from "$lib/features/filters/models/Filter";
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import RateActionButton from "$lib/sections/summary/components/rating/_internal/RateActionButton.svelte";
   import Filter from "./_internal/Filter.svelte";
   import { useFilterSetter } from "./_internal/useFilterSetter";
@@ -31,6 +32,7 @@
       label={m.filter_reset()}
       onclick={() => handler(null)}
       style={$currentValue ? "flat" : "ghost"}
+      navigationType={DpadNavigationType.Item}
     >
       <CloseIcon />
     </ActionButton>

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/ToggleFilter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/ToggleFilter.svelte
@@ -2,6 +2,7 @@
   import Switch from "$lib/components/toggles/Switch.svelte";
   import type { ToggleFilter } from "$lib/features/filters/models/Filter";
   import { useFilter } from "$lib/features/filters/useFilter";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import Filter from "./_internal/Filter.svelte";
   import { useFilterSetter } from "./_internal/useFilterSetter";
 
@@ -27,5 +28,6 @@
     checked={$currentValue === "true"}
     color="blue"
     onclick={handler}
+    navigationType={DpadNavigationType.Item}
   />
 </Filter>

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/Filter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/Filter.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
+
   const { title, children }: { title: string } & ChildrenProps = $props();
 </script>
 
-<div class="trakt-filter">
+<div class="trakt-filter" data-dpad-navigation={DpadNavigationType.List}>
   <span class="meta-info">{title}</span>
   {@render children()}
 </div>

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/SelectFilter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/SelectFilter.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import type { ListFilterProps } from "../ListFilterProps";
   import { useFilterSetter } from "./useFilterSetter";
 
@@ -27,7 +28,10 @@
   >
     {display}
   </Button>
-  <select onchange={(ev) => handleFilterChange(ev.currentTarget.value)}>
+  <select
+    onchange={(ev) => handleFilterChange(ev.currentTarget.value)}
+    data-dpad-navigation={DpadNavigationType.Item}
+  >
     <option selected={false} value={null} aria-label={m.filter_reset()}>
       {m.filter_reset()}
     </option>
@@ -68,6 +72,12 @@
 
       cursor: pointer;
       opacity: 0;
+    }
+
+    &:has(select:focus-visible) {
+      outline: var(--border-thickness-xs) solid var(--purple-500);
+      outline-offset: var(--border-thickness-xs);
+      border-radius: calc(var(--border-radius-m) * 0.76925);
     }
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds support for d-pad navigation to the filters.
- d-pad navigation now can deal with disabled elements.
- d-pad navigation now supports navigation traps.
- ⚠️ Will need a follow up to deal with the browser back button. Experimented a bit with shallow routing, might have potential. I'll look into dealing with the back button separately.

## 👀 Example 👀

https://github.com/user-attachments/assets/88080cae-b6b0-47cb-a00c-a28f58174181

