### PR TITLE
feat(android-tv): open extras in native app

### DIFF
--- a/projects/client/src/lib/sections/lists/components/VideoItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/VideoItem.svelte
@@ -4,13 +4,26 @@
   import Link from "$lib/components/link/Link.svelte";
   import LandscapeCard from "$lib/components/media/card/LandscapeCard.svelte";
   import { lineClamp } from "$lib/components/text/lineClamp";
+  import { getDeepLinkHandler } from "$lib/features/deep-link/getDeepLinkHandler";
   import type { MediaVideo } from "$lib/requests/models/MediaVideo";
 
   const { video }: { video: MediaVideo } = $props();
+  const deepLinkHandler = getDeepLinkHandler();
 </script>
 
 <LandscapeCard>
-  <Link focusable={false} href={video.url} target="_blank">
+  <Link
+    focusable={false}
+    href={video.url}
+    target="_blank"
+    onclick={(ev) => {
+      if (!deepLinkHandler) {
+        return;
+      }
+      ev.preventDefault();
+      deepLinkHandler.open("YouTube", video.url);
+    }}
+  >
     <CardCover
       title={video.title}
       src={video.thumbnail}


### PR DESCRIPTION
## ♪ Note ♪

- On android tv, open extras in native app.

👀 Example 👀
Before:

https://github.com/user-attachments/assets/c35142f6-2ed4-4332-bd97-ad899c670e90

After:

https://github.com/user-attachments/assets/eb4e4d28-1403-4137-b7ae-020eaa54622f
