### PR TITLE
feat(search): default to typesense engine

### DIFF
--- a/projects/client/src/lib/requests/queries/search/searchQuery.ts
+++ b/projects/client/src/lib/requests/queries/search/searchQuery.ts
@@ -35,6 +35,10 @@ function mapToSearchResultEntry(item: SearchResultResponse[0]): MediaEntry {
 
 export const searchCancellationId = () => 'search_cancellation_token';
 
+const EXPERIMENTAL_PARAMS = {
+  engine: 'typesense',
+};
+
 const searchRequest = ({ query, fetch }: SearchParams) =>
   api({
     fetch,
@@ -47,6 +51,7 @@ const searchRequest = ({ query, fetch }: SearchParams) =>
         query,
         extended: 'full,images',
         limit: DEFAULT_SEARCH_LIMIT,
+        ...EXPERIMENTAL_PARAMS,
       },
       params: {
         type: 'movie,show',


### PR DESCRIPTION
This pull request introduces experimental parameters for the search functionality in the `searchQuery.ts` file. The changes aim to enhance the search engine configuration by adding a new parameter group and integrating it into the search request.

### Enhancements to search functionality:

* [`projects/client/src/lib/requests/queries/search/searchQuery.ts`](diffhunk://#diff-21b94df79ee224ff189ab19d0165fd42166981fa2e53d0986d2d2bfa5c32271cR38-R41): Introduced a new constant `EXPERIMENTAL_PARAMS` containing experimental search engine parameters (e.g., `engine: 'typesense'`). This is intended to enable testing of alternative search configurations.
* [`projects/client/src/lib/requests/queries/search/searchQuery.ts`](diffhunk://#diff-21b94df79ee224ff189ab19d0165fd42166981fa2e53d0986d2d2bfa5c32271cR54): Integrated `EXPERIMENTAL_PARAMS` into the `searchRequest` function, allowing the experimental parameters to be included in search requests.