### PR TITLE
feat(cover): update designs such that focus is more on main content

### DIFF
--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -6,7 +6,7 @@
 </script>
 
 {#if $state === "ready"}
-  <div class="background-cover-image">
+  <div class="trakt-background-cover-image" data-cover-type={$cover.type}>
     <CrossOriginImage
       loading="eager"
       src={$cover.src}
@@ -18,7 +18,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .background-cover-image {
+  .trakt-background-cover-image {
     z-index: var(--layer-background);
     position: absolute;
     max-height: 100dvh;
@@ -28,6 +28,8 @@
     left: 0;
     width: 100%;
     background: var(--shade-900);
+
+    filter: grayscale(1);
 
     :global(img) {
       width: 100%;
@@ -47,6 +49,16 @@
       @include for-mobile {
         width: 180%;
         left: -40%;
+      }
+    }
+
+    &:not([data-cover-type="main"]) {
+      &::after {
+        backdrop-filter: blur(2px);
+
+        @include for-tablet-sm-and-below {
+          backdrop-filter: unset;
+        }
       }
     }
 

--- a/projects/client/src/lib/components/background/TraktCoverImage.svelte
+++ b/projects/client/src/lib/components/background/TraktCoverImage.svelte
@@ -6,7 +6,7 @@
 </script>
 
 {#if $state === "ready"}
-  <div class="trakt-cover-image">
+  <div class="trakt-cover-image" data-cover-type={$cover.type}>
     <div class="trakt-cover-image-overlay">
       <CrossOriginImage src={$cover.src} alt={`Background for footer`} />
     </div>

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -1,3 +1,5 @@
+@use "$style/scss/mixins/index" as *;
+
 // Define theme variables for light mode
 @mixin light-theme {
   /**
@@ -93,11 +95,6 @@
   /*
   * Overrides
   */
-  .background-cover-image,
-  .trakt-cover-image {
-    filter: grayscale(1);
-  }
-
   .trakt-cover-image {
     opacity: 0.25;
   }
@@ -184,6 +181,16 @@
    */
   --color-text-sentiment-good: var(--purple-100);
   --color-text-sentiment-bad: var(--red-100);
+
+  /*
+  * Overrides
+  */
+  .trakt-background-cover-image:not([data-cover-type="main"]),
+  .trakt-cover-image:not([data-cover-type="main"]) {
+    @include for-tablet-sm-and-below {
+      filter: grayscale(0) !important;
+    }
+  }
 }
 
 // Apply themes to selectors


### PR DESCRIPTION
## Summary 

### Dark Mode
<img width="200" alt="image" src="https://github.com/user-attachments/assets/1a4fa5fd-541a-4f2c-80f7-a4805282e4a9" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/9e5e842b-e21f-4de4-8625-a10a636f65e8" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/80e22857-c2c0-495d-950f-9b3afc928d65" />

### Light Mode
<img width="200" alt="image" src="https://github.com/user-attachments/assets/d73c519f-ac96-4b67-a391-2b9bbc32d503" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/ead7defa-ea62-4fed-9a55-60ce35aed103" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/3a1fd699-756b-49a7-be88-421d3919132e" />


## Main

### Dark Mode
<img width="200" alt="image" src="https://github.com/user-attachments/assets/a669d30f-fdaf-4c19-a7d2-650fbaa5cb06" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/ed1ef07e-f0d1-483d-88c8-2096d3d9b867" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/511b6f94-6411-4bc8-891f-4784800b6780" />

### Light Mode
<img width="200" alt="image" src="https://github.com/user-attachments/assets/03ded4d9-b8cf-4865-b91b-bbffa8643636" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/b4d096e7-a8a3-4bac-8b7a-9d5dbab6fb39" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/cd456234-8649-44e2-92af-1513322c7b21" />

