### PR TITLE
chore: move sloppy-imports to workspace level config

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -11,7 +11,8 @@
     "client:i18n:resolve": "cd projects/client && deno task i18n:resolve"
   },
   "unstable": [
-    "broadcast-channel"
+    "broadcast-channel",
+    "sloppy-imports"
   ],
   "nodeModulesDir": "auto",
   "fmt": {

--- a/projects/client/deno.json
+++ b/projects/client/deno.json
@@ -32,8 +32,5 @@
       "vitest/globals",
       "@testing-library/jest-dom"
     ]
-  },
-  "unstable": [
-    "sloppy-imports"
-  ]
+  }
 }


### PR DESCRIPTION
Fixes this:
<img width="687" alt="Screenshot 2025-05-06 at 16 58 56" src="https://github.com/user-attachments/assets/7fcdceb9-4911-4fb9-9c46-21f1ef4e131e" />
