### PR TITLE
Feat/qr landing

### DIFF
--- a/projects/client/src/lib/sections/navbar/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/SideNavbar.svelte
@@ -9,7 +9,6 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import FilterButton from "./components/filter/FilterButton.svelte";
-  import JoinTraktButton from "./components/JoinTraktButton.svelte";
   import TraktLogo from "./components/TraktLogo.svelte";
   import ProfileButton from "./ProfileButton.svelte";
 </script>
@@ -59,9 +58,6 @@
     </div>
 
     <div class="trakt-side-navbar-bottom">
-      <RenderFor audience="public">
-        <JoinTraktButton />
-      </RenderFor>
       <RenderFor audience="authenticated">
         <FilterButton />
         <ProfileButton />
@@ -174,15 +170,6 @@
     gap: var(--gap-m);
     transform: scale(0.8);
     transform-origin: bottom left;
-
-    :global(join-trakt-button) {
-      writing-mode: vertical-rl;
-      text-orientation: upright;
-
-      :global(.trakt-button) {
-        height: auto;
-      }
-    }
   }
 
   .trakt-side-navbar-content {

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Redirect from "$lib/components/router/Redirect.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import Landing from "$lib/sections/landing/Landing.svelte";
@@ -11,6 +12,7 @@
   import UnreleasedList from "$lib/sections/lists/watchlist/UnreleasedList.svelte";
   import MonthInReview from "$lib/sections/month-in-review/MonthInReview.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 </script>
 
 <TraktPage
@@ -28,7 +30,10 @@
     <UnreleasedList />
     <SocialActivityList />
   </RenderFor>
-  <RenderFor audience="public">
+  <RenderFor audience="public" navigation="default">
     <Landing />
+  </RenderFor>
+  <RenderFor audience="public" navigation="dpad">
+    <Redirect to={UrlBuilder.login.activate()} />
   </RenderFor>
 </TraktPage>


### PR DESCRIPTION
## 🎶 Notes 🎶

- When using d-pad, use the qr/activation code page as the landing page when not logged in.
- We can do a better designed version later.

## 👀 Example 👀

<img width="1177" alt="Screenshot 2025-05-06 at 17 22 01" src="https://github.com/user-attachments/assets/aa2638d8-d79e-47d2-a8e5-05a8d3a09072" />
