### PR TITLE
fat / add season list to show view

### DIFF
--- a/projects/client/i18n/messages/bg-bg.json
+++ b/projects/client/i18n/messages/bg-bg.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Сигурни ли сте, че искате да премахнете {title} от наблюдавани? Всички гледания ще бъдат премахнати.",
   "remove_single_watched_label": "Премахни това гледане на {title} от наблюдавани",
   "remove_single_watched_warning": "Сигурни ли сте, че искате да премахнете това гледне на {title} от наблюдавани?",
+  "seasons_label": "Сезони",
   "season_number_label": "Сезон {number}",
   "expand_media_overview": "Разшири прегледа на {title}",
   "season_episode_number_label": "Сезон {season} • Епизод {number}",

--- a/projects/client/i18n/messages/da-dk.json
+++ b/projects/client/i18n/messages/da-dk.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Er du sikker på, at du vil fjerne {title} fra din set-liste? Alle afspilninger vil blive fjernet.",
   "remove_single_watched_label": "Fjern denne afspilning af {title} fra din set-liste",
   "remove_single_watched_warning": "Er du sikker på, at du vil fjerne denne afspilning af {title} fra din set-liste?",
+  "seasons_label": "Sæsoner",
   "season_number_label": "Sæson {number}",
   "expand_media_overview": "Udvid {title} oversigt",
   "season_episode_number_label": "Sæson {season} • Afsnit {number}",

--- a/projects/client/i18n/messages/de-de.json
+++ b/projects/client/i18n/messages/de-de.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Sind Sie sicher, dass Sie {title} von Ihrer Favoritenliste entfernen möchten? Alle Wiedergaben werden gelöscht.",
   "remove_single_watched_label": "Diese Wiedergabe von {title} aus deiner Gesehen-Liste entfernen",
   "remove_single_watched_warning": "Möchtest du diese Wiedergabe von {title} wirklich von deiner Gesehen-Liste entfernen?",
+  "seasons_label": "Staffeln",
   "season_number_label": "Staffel {number}",
   "expand_media_overview": "Übersicht über {title} erweitern",
   "season_episode_number_label": "Staffel {season} • Folge {number}",

--- a/projects/client/i18n/messages/en.json
+++ b/projects/client/i18n/messages/en.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Are you sure you want to remove {title} from your Watched list? All plays will be removed.",
   "remove_single_watched_label": "Remove this play of {title} from your Watched list",
   "remove_single_watched_warning": "Are you sure you want to remove this play of {title} from your Watched list?",
+  "seasons_label": "Seasons",
   "season_number_label": "Season {number}",
   "expand_media_overview": "Expand {title} overview",
   "season_episode_number_label": "Season {season} • Episode {number}",

--- a/projects/client/i18n/messages/es-es.json
+++ b/projects/client/i18n/messages/es-es.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "¿Estás seguro de que deseas quitar {title} de tu lista de Visto? Se borrarán todas las reproducciones.",
   "remove_single_watched_label": "Eliminar esta reproducción de {title} de tu lista de contenidos vistos",
   "remove_single_watched_warning": "¿Seguro que quieres eliminar esta reproducción de {title} de tu lista de Vistos?",
+  "seasons_label": "Temporadas",
   "season_number_label": "Temporada {number}",
   "expand_media_overview": "Expandir descripción de {title}",
   "season_episode_number_label": "Temporada {season} • Episodio {number}",

--- a/projects/client/i18n/messages/es-mx.json
+++ b/projects/client/i18n/messages/es-mx.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "¿Estás seguro de que quieres eliminar {title} de tu lista de Vistos? Se eliminarán todas las reproducciones.",
   "remove_single_watched_label": "Eliminar esta reproducción de {title} de tu lista de Visto",
   "remove_single_watched_warning": "¿Estás seguro de que quieres eliminar esta reproducción de {title} de tu lista de Vistos?",
+  "seasons_label": "Temporadas",
   "season_number_label": "Temporada {number}",
   "expand_media_overview": "Expandir descripción de {title}",
   "season_episode_number_label": "Temporada {season} • Episodio {number}",

--- a/projects/client/i18n/messages/fr-ca.json
+++ b/projects/client/i18n/messages/fr-ca.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Êtes-vous certain de vouloir supprimer {title} de votre liste Vue? Toutes les lectures seront supprimées.",
   "remove_single_watched_label": "Retirer cette lecture de {title} de votre liste Vu(e)",
   "remove_single_watched_warning": "Êtes-vous sûr de vouloir supprimer cette lecture de {title} de votre liste Vu ?",
+  "seasons_label": "Saisons",
   "season_number_label": "Saison {number}",
   "expand_media_overview": "Développer la description de {title}",
   "season_episode_number_label": "Saison {season} • Épisode {number}",

--- a/projects/client/i18n/messages/fr-fr.json
+++ b/projects/client/i18n/messages/fr-fr.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Êtes-vous sûr de vouloir supprimer {title} de votre liste Visionnés? Toutes les lectures seront supprimées.",
   "remove_single_watched_label": "Supprimer ce visionnage de {title} de votre liste Regardés",
   "remove_single_watched_warning": "Voulez-vous vraiment supprimer cette lecture de {title} de votre liste Vu ?",
+  "seasons_label": "Saisons",
   "season_number_label": "Saison {number}",
   "expand_media_overview": "Découvrir plus sur {title}",
   "season_episode_number_label": "Saison {season} • Épisode {number}",

--- a/projects/client/i18n/messages/it-it.json
+++ b/projects/client/i18n/messages/it-it.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Sei sicuro di voler rimuovere {title} dalla tua Watchlist? Tutte le visualizzazioni saranno eliminate.",
   "remove_single_watched_label": "Rimuovi questa visione di {title} dalla lista Visti",
   "remove_single_watched_warning": "Sei sicuro di voler rimuovere questa visione di {title} dalla tua lista Visti?",
+  "seasons_label": "Stagioni",
   "season_number_label": "Stagione {number}",
   "expand_media_overview": "Espandi la panoramica di {title}",
   "season_episode_number_label": "Stagione {season} • Episodio {number}",

--- a/projects/client/i18n/messages/ja-jp.json
+++ b/projects/client/i18n/messages/ja-jp.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "{title} を視聴済リストから削除しますか？すべての再生記録が削除されます。",
   "remove_single_watched_label": "{title}の視聴履歴からこの記録を削除",
   "remove_single_watched_warning": "{title}の視聴記録を視聴済みリストから削除してもよろしいですか？",
+  "seasons_label": "シーズン",
   "season_number_label": "第{number}シーズン",
   "expand_media_overview": "{title} の概要を表示",
   "season_episode_number_label": "シーズン{season}・エピソード{number}",

--- a/projects/client/i18n/messages/nb-no.json
+++ b/projects/client/i18n/messages/nb-no.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Er du sikker på at du vil fjerne {title} fra din Sett-liste? Alle visninger vil bli fjernet.",
   "remove_single_watched_label": "Fjern denne visningen av {title} fra din Sett-liste",
   "remove_single_watched_warning": "Er du sikker på at du vil fjerne denne visningen av {title} fra din Sett-liste?",
+  "seasons_label": "Sesonger",
   "season_number_label": "Sesong {number}",
   "expand_media_overview": "Utvid {title} oversikt",
   "season_episode_number_label": "Sesong {season} • Episode {number}",

--- a/projects/client/i18n/messages/nl-nl.json
+++ b/projects/client/i18n/messages/nl-nl.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Weet je zeker dat je {title} wilt verwijderen van je Bekeken lijst? Alle afspeelbeurten worden verwijderd.",
   "remove_single_watched_label": "Verwijder deze weergave van {title} uit je Bekeken lijst",
   "remove_single_watched_warning": "Weet je zeker dat je deze afspeelbeurt van {title} uit je Bekeken lijst wilt verwijderen?",
+  "seasons_label": "Seizoenen",
   "season_number_label": "Seizoen {number}",
   "expand_media_overview": "Bekijk {title} overzicht",
   "season_episode_number_label": "Seizoen {season} • Aflevering {number}",

--- a/projects/client/i18n/messages/pl-pl.json
+++ b/projects/client/i18n/messages/pl-pl.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Czy na pewno chcesz usunąć {title} z twojej listy obejrzanych? Wszystkie odtworzenia zostaną usunięte.",
   "remove_single_watched_label": "Usuń odtworzenie {title} z listy Obejrzane",
   "remove_single_watched_warning": "Na pewno chcesz usunąć to odtworzenie {title} z listy Obejrzanych?",
+  "seasons_label": "Sezony",
   "season_number_label": "Sezon {number}",
   "expand_media_overview": "Rozwiń podsumowanie {title}",
   "season_episode_number_label": "Sezon {season} • Odcinek {number}",

--- a/projects/client/i18n/messages/pt-br.json
+++ b/projects/client/i18n/messages/pt-br.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Tem certeza que deseja remover {title} da sua lista de Assistidos? Todas as reproduções serão removidas.",
   "remove_single_watched_label": "Remover esta exibição de {title} da sua lista de Já Vistos",
   "remove_single_watched_warning": "Tem certeza de que deseja remover esta reprodução de {title} da sua lista de Vistos?",
+  "seasons_label": "Temporadas",
   "season_number_label": "Temporada {number}",
   "expand_media_overview": "Expandir a visão geral de {title}",
   "season_episode_number_label": "Temporada {season} • Episódio {number}",

--- a/projects/client/i18n/messages/ro-ro.json
+++ b/projects/client/i18n/messages/ro-ro.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Esti sigur că vrei să elimini {title} din lista ta de Vizionate? Toate vizionările vor fi șterse.",
   "remove_single_watched_label": "Șterge această vizionare a lui {title} din lista ta de Conținut Văzut",
   "remove_single_watched_warning": "Sigur vrei să ștergi această vizionare a {title} din lista ta de vizionate?",
+  "seasons_label": "Sezoane",
   "season_number_label": "Sezonul {number}",
   "expand_media_overview": "Detaliază prezentarea {title}",
   "season_episode_number_label": "Sezon {season} • Episod {number}",

--- a/projects/client/i18n/messages/sv-se.json
+++ b/projects/client/i18n/messages/sv-se.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Är du säker på att du vill ta bort {title} från din Sedda-lista? Alla visningar kommer att tas bort.",
   "remove_single_watched_label": "Ta bort den här visningen av {title} från din Sedda-lista",
   "remove_single_watched_warning": "Är du säker på att du vill ta bort den här visningen av {title} från din Sedda-lista?",
+  "seasons_label": "Säsonger",
   "season_number_label": "Säsong {number}",
   "expand_media_overview": "Utvidga {title} översikt",
   "season_episode_number_label": "Säsong {season} • Avsnitt {number}",

--- a/projects/client/i18n/messages/uk-ua.json
+++ b/projects/client/i18n/messages/uk-ua.json
@@ -222,6 +222,7 @@
   "remove_from_watched_warning": "Ви впевнені, що хочете видалити {title} зі списку Переглянутого? Усі перегляди буде видалено.",
   "remove_single_watched_label": "Видалити цей перегляд {title} зі списку Переглянуто",
   "remove_single_watched_warning": "Ви впевнені, що хочете видалити це відтворення {title} зі списку Переглянуто?",
+  "seasons_label": "Сезони",
   "season_number_label": "Сезон {number}",
   "expand_media_overview": "Розгорнути огляд {title}",
   "season_episode_number_label": "Сезон {season} • Епізод {number}",

--- a/projects/client/src/lib/components/lists/ListProps.ts
+++ b/projects/client/src/lib/components/lists/ListProps.ts
@@ -2,7 +2,7 @@ import type { Snippet } from 'svelte';
 
 export type ListProps<T> = {
   id: string;
-  title: string;
+  title: string | Nil;
   items: T[];
   item: Snippet<[T]>;
   actions?: Snippet;

--- a/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
@@ -5,6 +5,7 @@
 
   const {
     title,
+    subtitle,
     inset,
     titleAction,
     actions,
@@ -12,6 +13,7 @@
     ...props
   }: {
     title: string;
+    subtitle?: string;
     titleAction?: Snippet;
     actions?: Snippet;
     badge?: Snippet;
@@ -29,7 +31,12 @@
     {#if titleAction}
       {@render titleAction()}
     {/if}
-    <ListTitle {title} />
+    {#if subtitle == null}
+      <ListTitle {title} style="primary" />
+    {:else}
+      <ListTitle {title} style="secondary" />
+      <ListTitle title={`/ ${subtitle}`} style="primary" />
+    {/if}
     {#if badge}
       {@render badge()}
     {/if}

--- a/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  const { title }: { title: string } = $props();
+  const { title, style }: { title: string; style: "primary" | "secondary" } =
+    $props();
 </script>
 
-<h4 class="shadow-list-title ellipsis">{title}</h4>
+<h4 class="shadow-list-title ellipsis" data-style={style}>{title}</h4>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
   .shadow-list-title {
-    color: var(--color-text-primary);
     transition: font-size calc(var(--transition-increment) * 2) ease-in-out;
 
     @include for-tablet-sm {
@@ -17,6 +17,14 @@
 
     @include for-mobile {
       font-size: var(--ni-24);
+    }
+
+    &[data-style="primary"] {
+      color: var(--color-text-primary);
+    }
+
+    &[data-style="secondary"] {
+      color: var(--color-text-secondary);
     }
   }
 </style>

--- a/projects/client/src/lib/components/lists/grid-list/GridList.svelte
+++ b/projects/client/src/lib/components/lists/grid-list/GridList.svelte
@@ -20,7 +20,9 @@
 </script>
 
 <section class="trakt-grid-list-container">
-  <ListHeader {title} {actions} {badge} inset="all" />
+  {#if title}
+    <ListHeader {title} {actions} {badge} inset="all" />
+  {/if}
 
   {#if items.length > 0}
     <div class="trakt-list-item-container trakt-list-items">

--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -17,6 +17,7 @@
   import { scrollTracking } from "./scrollTracking";
 
   type SectionListProps<T> = ListProps<T> & {
+    subtitle?: string;
     empty?: Snippet;
     scrollContainer?: Writable<HTMLDivElement>;
     scrollX?: Writable<{ left: number; right: number }>;
@@ -27,6 +28,7 @@
     id,
     items,
     title,
+    subtitle,
     scrollX = writable({ left: 0, right: 0 }),
     scrollContainer = writable(),
     item,
@@ -40,6 +42,8 @@
 
   const isLeftShadowVisible = $derived($scrollX.left > $sideDistance);
   const isRightShadowVisible = $derived($scrollX.right > $sideDistance);
+
+  const isHeaderVisible = $derived(Boolean(title));
 
   const leftShadowIntensity = $derived(
     ($scrollX.left - $sideDistance) / $windowShadowWidth,
@@ -83,15 +87,19 @@
   class="shadow-list-container"
   class:shadow-list-container-collapsed={$isCollapsed}
   class:shadow-list-container-mounted={$isMounted}
+  class:shadow-list-container-no-header={!isHeaderVisible}
 >
   {#if $isVisible}
-    <ListHeader
-      {title}
-      {titleAction}
-      actions={$isCollapsed ? undefined : actions}
-      {badge}
-      inset="title"
-    />
+    {#if isHeaderVisible && title}
+      <ListHeader
+        {title}
+        {subtitle}
+        {titleAction}
+        actions={$isCollapsed ? undefined : actions}
+        {badge}
+        inset="title"
+      />
+    {/if}
     <div
       class="shadow-list"
       class:shadow-list-left-shadow={isLeftShadowVisible}
@@ -135,6 +143,12 @@
     flex-direction: column;
 
     @include adaptive-list-gap();
+
+    &.shadow-list-container-no-header {
+      --height-container: var(--height-list);
+      --height-min-container: 0;
+      gap: 0;
+    }
 
     &.shadow-list-container-mounted {
       transition:

--- a/projects/client/src/lib/requests/_internal/mapToPoster.ts
+++ b/projects/client/src/lib/requests/_internal/mapToPoster.ts
@@ -1,13 +1,16 @@
 import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/constants.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
-import type { MovieResponse, ShowResponse } from '@trakt/api';
+import type { MovieResponse, SeasonsResponse, ShowResponse } from '@trakt/api';
 import type { MediaEntry } from '../models/MediaEntry.ts';
 import { mediumUrl } from './mediumUrl.ts';
 import { thumbUrl } from './thumbUrl.ts';
 
 export function mapToPoster(
-  images: ShowResponse['images'] | MovieResponse['images'],
+  images:
+    | ShowResponse['images']
+    | MovieResponse['images']
+    | SeasonsResponse[0]['images'],
 ): MediaEntry['poster'] {
   const posterCandidate = findDefined(
     ...(images?.poster ?? []),

--- a/projects/client/src/lib/requests/models/ImageUrlsSchema.ts
+++ b/projects/client/src/lib/requests/models/ImageUrlsSchema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+import { HttpsUrlSchema } from './HttpsUrlSchema.ts';
+
+export const ImageUrlsSchema = z.object({
+  medium: HttpsUrlSchema,
+  thumb: HttpsUrlSchema,
+});

--- a/projects/client/src/lib/requests/models/Season.ts
+++ b/projects/client/src/lib/requests/models/Season.ts
@@ -1,10 +1,14 @@
 import { z } from 'zod';
+import { ImageUrlsSchema } from './ImageUrlsSchema.ts';
 
 export const SeasonSchema = z.object({
   id: z.number(),
   number: z.number(),
   episodes: z.object({
     count: z.number(),
+  }),
+  poster: z.object({
+    url: ImageUrlsSchema,
   }),
 });
 export type Season = z.infer<typeof SeasonSchema>;

--- a/projects/client/src/lib/requests/queries/shows/showSeasonsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSeasonsQuery.ts
@@ -3,6 +3,7 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { SeasonsResponse } from '@trakt/api';
 import { z } from 'zod';
+import { mapToPoster } from '../../_internal/mapToPoster.ts';
 import { type Season, SeasonSchema } from '../../models/Season.ts';
 
 type ShowSeasonsParams = {
@@ -19,16 +20,17 @@ const showSeasonsRequest = (
         id: slug,
       },
       query: {
-        extended: 'full',
+        extended: 'full,images',
       },
     });
 
-const mapSeasonResponseToSeason = (item: SeasonsResponse[0]): Season => ({
+const mapToSeason = (item: SeasonsResponse[0]): Season => ({
   id: item.ids.trakt,
   number: item.number,
   episodes: {
     count: item.episode_count ?? 0,
   },
+  poster: mapToPoster(item.images),
 });
 
 export const showSeasonsQuery = defineQuery({
@@ -38,7 +40,7 @@ export const showSeasonsQuery = defineQuery({
   request: showSeasonsRequest,
   mapper: (response) =>
     response.body
-      .map(mapSeasonResponseToSeason)
+      .map(mapToSeason)
       .filter((season) => season.episodes.count > 0 && season.number !== 0),
   schema: z.array(SeasonSchema),
   ttl: time.days(1),

--- a/projects/client/src/lib/sections/lists/SeasonEpisodeList.svelte
+++ b/projects/client/src/lib/sections/lists/SeasonEpisodeList.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import ShadowList from "$lib/components/lists/section-list/ShadowList.svelte";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
+  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import EpisodeItem from "./components/EpisodeItem.svelte";
+  import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
+
+  type SeasonEpisodeListProps = {
+    show: MediaEntry;
+    episodes: EpisodeEntry[];
+    title?: string;
+    subtitle?: string;
+  };
+
+  const { show, episodes, title, subtitle }: SeasonEpisodeListProps = $props();
+</script>
+
+<ShadowList
+  id={`season-episode-list-${show.slug}`}
+  items={episodes}
+  {title}
+  {subtitle}
+  --height-list={mediaListHeightResolver("landscape")}
+>
+  {#snippet item(episode)}
+    <EpisodeItem {episode} {show} variant="default" context="show" />
+  {/snippet}
+</ShadowList>

--- a/projects/client/src/lib/sections/lists/SeasonList.svelte
+++ b/projects/client/src/lib/sections/lists/SeasonList.svelte
@@ -1,84 +1,40 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages";
 
-  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
-  import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
-  import ShadowList from "$lib/components/lists/section-list/ShadowList.svelte";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import type { Season } from "$lib/requests/models/Season";
-  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
-  import { get, writable } from "svelte/store";
-  import EpisodeItem from "./components/EpisodeItem.svelte";
+  import SeasonEpisodeList from "./SeasonEpisodeList.svelte";
+  import SeasonPosterList from "./SeasonPosterList.svelte";
   import { useSeasonEpisodes } from "./stores/useSeasonEpisodes";
-  import { useUserSeason } from "./stores/useUserSeason";
-  import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
 
   type SeasonListProps = {
     show: MediaEntry;
     seasons: Season[];
+    currentSeason: number;
   };
 
-  const { show, seasons }: SeasonListProps = $props();
+  const { show, seasons, currentSeason }: SeasonListProps = $props();
 
-  const active = $derived.by(() => {
-    const lastWatchedSeason = useUserSeason(show.id);
-    const season = seasons.find((s) => s.number === get(lastWatchedSeason));
+  const { list: episodes } = $derived(
+    useSeasonEpisodes(show.slug, currentSeason),
+  );
 
-    return writable(season ?? seasons.at(0));
-  });
+  const title = m.seasons_label();
+  const subtitle = $derived(m.season_number_label({ number: currentSeason }));
 
-  const { list } = $derived(useSeasonEpisodes(show.slug, $active.number));
-
-  const title = $derived(m.season_number_label({ number: $active.number }));
+  const episodeProps = $derived(
+    seasons.length === 1 ? { title, subtitle } : {},
+  );
 </script>
 
-<ShadowList
-  id={`season-list-${show.slug}`}
-  items={$list}
-  {title}
-  --height-list={mediaListHeightResolver("landscape")}
->
-  {#snippet item(episode)}
-    <EpisodeItem {episode} {show} variant="default" context="show" />
-  {/snippet}
-  {#snippet actions()}
-    {#if seasons.length > 1}
-      <DropdownList
-        label="Seasons"
-        style="flat"
-        variant="primary"
-        color="blue"
-        text="capitalize"
-        size="small"
-      >
-        {title}
-        {#snippet items()}
-          {#each seasons as season}
-            <DropdownItem color="blue" onclick={() => active.set(season)}>
-              {m.season_number_label({ number: season.number })}
-            </DropdownItem>
-          {/each}
-        {/snippet}
-      </DropdownList>
-    {/if}
-    <RenderFor audience="authenticated">
-      <MarkAsWatchedAction
-        style="action"
-        type="episode"
-        title={m.season_number_label({ number: $active.number })}
-        media={$list}
-        episode={$list}
-        {show}
-      />
-    </RenderFor>
-  {/snippet}
-</ShadowList>
-
-<style>
-  :global(.shadow-list-container) {
-    :global(.trakt-dropdown-list-container[data-size="small"]) {
-      margin-right: var(--ni-neg-10);
-    }
-  }
-</style>
+{#if seasons.length > 1}
+  <SeasonPosterList
+    {currentSeason}
+    {show}
+    {seasons}
+    episodes={$episodes}
+    {title}
+    {subtitle}
+  />
+{/if}
+<SeasonEpisodeList {show} episodes={$episodes} {...episodeProps} />

--- a/projects/client/src/lib/sections/lists/SeasonPosterList.svelte
+++ b/projects/client/src/lib/sections/lists/SeasonPosterList.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import ShadowList from "$lib/components/lists/section-list/ShadowList.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
+  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import type { Season } from "$lib/requests/models/Season";
+  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import SeasonItem from "./components/SeasonItem.svelte";
+  import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
+
+  type SeasonListProps = {
+    currentSeason: number;
+    show: MediaEntry;
+    seasons: Season[];
+    episodes: EpisodeEntry[];
+    title: string;
+    subtitle: string;
+  };
+
+  const {
+    currentSeason,
+    show,
+    seasons,
+    episodes,
+    title,
+    subtitle,
+  }: SeasonListProps = $props();
+</script>
+
+<ShadowList
+  {title}
+  {subtitle}
+  id={`season-poster-list-${show.slug}`}
+  items={seasons}
+  --height-list={mediaListHeightResolver("portrait")}
+>
+  {#snippet item(season)}
+    <SeasonItem
+      {season}
+      urlBuilder={() => UrlBuilder.show(show.slug, { season: season.number })}
+    />
+  {/snippet}
+  {#snippet actions()}
+    <RenderFor audience="authenticated">
+      <MarkAsWatchedAction
+        style="normal"
+        type="episode"
+        size="small"
+        title={subtitle}
+        media={episodes}
+        episode={episodes}
+        {show}
+      />
+    </RenderFor>
+  {/snippet}
+</ShadowList>

--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+
+  import CardCover from "$lib/components/card/CardCover.svelte";
+  import CardFooter from "$lib/components/card/CardFooter.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import PortraitCard from "$lib/components/media/card/PortraitCard.svelte";
+  import { lineClamp } from "$lib/components/text/lineClamp";
+  import { getDeepLinkHandler } from "$lib/features/deep-link/getDeepLinkHandler";
+  import type { Season } from "$lib/requests/models/Season";
+
+  const { season, urlBuilder }: { season: Season; urlBuilder: () => string } =
+    $props();
+  const deepLinkHandler = getDeepLinkHandler();
+</script>
+
+<PortraitCard>
+  <Link focusable={false} href={urlBuilder()} noscroll>
+    <CardCover
+      title={m.season_number_label({ number: season.number })}
+      src={season.poster.url.medium}
+      alt="{m.season_number_label({ number: season.number })}}"
+      style="flat"
+    />
+  </Link>
+  <CardFooter>
+    <p use:lineClamp={{ lines: 2 }} class="trakt-card-title trakt-video-title">
+      {m.season_number_label({ number: season.number })}
+    </p>
+  </CardFooter>
+</PortraitCard>
+
+<style>
+  .trakt-video-title {
+    line-height: var(--ni-16);
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -174,7 +174,7 @@
 
 <CastList title={m.actors()} cast={crew.cast} slug={show.slug} />
 
-<SeasonList {show} {seasons} />
+<SeasonList {show} {seasons} currentSeason={episode.season} />
 
 <Comments
   media={show}

--- a/projects/client/src/lib/sections/summary/ShowSummary.svelte
+++ b/projects/client/src/lib/sections/summary/ShowSummary.svelte
@@ -26,6 +26,7 @@
     crew: MediaCrew;
     seasons: Season[];
     videos: MediaVideo[];
+    currentSeason: number;
   };
 
   const {
@@ -39,6 +40,7 @@
     seasons,
     streamOn,
     videos,
+    currentSeason,
   }: ShowSummaryProps = $props();
 
   const { progress } = $derived(useShowProgress(media.slug));
@@ -70,7 +72,7 @@
 
 <VideoList slug={media.slug} {videos} />
 
-<SeasonList show={media} {seasons} />
+<SeasonList show={media} {seasons} {currentSeason} />
 
 <Comments {media} type="show" />
 

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -106,7 +106,8 @@ export const UrlBuilder = {
         return UrlBuilder.movie(id);
     }
   },
-  show: (id: string) => `/shows/${id}`,
+  show: (id: string, params: Record<string, string | number> = {}) =>
+    `/shows/${id}${buildParamString(params)}`,
   movies: () => '/movies',
   movie: (id: string) => `/movies/${id}`,
   people: (id: string) => `/people/${id}`,

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts
@@ -7,12 +7,41 @@ export const ShowSiloSeasonsMappedMock: Season[] = [
     'episodes': {
       'count': 10,
     },
+    'poster': {
+      'url': {
+        'medium':
+          'https://walter-r2.trakt.tv/images/seasons/000/257/490/posters/medium/091450c60d.jpg.webp',
+        'thumb':
+          'https://walter-r2.trakt.tv/images/seasons/000/257/490/posters/thumb/091450c60d.jpg.webp',
+      },
+    },
   },
   {
     'id': 402288,
     'number': 2,
     'episodes': {
       'count': 10,
+    },
+    'poster': {
+      'url': {
+        'medium':
+          'https://walter-r2.trakt.tv/images/seasons/000/402/288/posters/medium/44533bd556.jpg.webp',
+        'thumb':
+          'https://walter-r2.trakt.tv/images/seasons/000/402/288/posters/thumb/44533bd556.jpg.webp',
+      },
+    },
+  },
+  {
+    'id': 456019,
+    'number': 3,
+    'episodes': {
+      'count': 1,
+    },
+    'poster': {
+      'url': {
+        'medium': '/placeholders/portrait_placeholder.png' as HttpsUrl,
+        'thumb': '/placeholders/portrait_placeholder.png' as HttpsUrl,
+      },
     },
   },
 ];

--- a/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloSeasonsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloSeasonsResponseMock.ts
@@ -2,23 +2,6 @@ import type { SeasonsResponse } from '@trakt/api';
 
 export const ShowSiloSeasonsResponseMock: SeasonsResponse = [
   {
-    'number': 0,
-    'ids': {
-      'trakt': 434165,
-      'tvdb': null,
-      'tmdb': 432135,
-    },
-    'aired_episodes': 4,
-    'rating': 8,
-    'votes': 1,
-    'episode_count': 4,
-    'title': 'Specials',
-    'overview': null,
-    'first_aired': '2023-05-06T01:00:00.000Z',
-    'updated_at': '2024-12-28T05:56:50.000Z',
-    'network': 'Apple TV+',
-  },
-  {
     'number': 1,
     'ids': {
       'trakt': 257490,
@@ -26,14 +9,23 @@ export const ShowSiloSeasonsResponseMock: SeasonsResponse = [
       'tmdb': 196076,
     },
     'aired_episodes': 10,
-    'rating': 8.0617,
-    'votes': 1475,
+    'rating': 8.05422,
+    'votes': 2416,
     'episode_count': 10,
     'title': 'Season 1',
-    'overview': null,
+    'overview':
+      'In a bleak dystopian future, humanity clings to survival deep underground within the confines of a colossal silo. Juliette, an engineer tasked with unraveling the mystery behind the death of a colleague, uncovers startling secrets that threaten the very fabric of their enclosed world.',
     'first_aired': '2023-05-05T01:00:00.000Z',
-    'updated_at': '2024-12-28T08:15:29.000Z',
+    'updated_at': '2025-05-07T10:56:59.000Z',
     'network': 'Apple TV+',
+    'images': {
+      'poster': [
+        'walter-r2.trakt.tv/images/seasons/000/257/490/posters/thumb/091450c60d.jpg.webp',
+      ],
+      'thumb': [
+        'walter-r2.trakt.tv/images/seasons/000/257/490/thumbs/medium/ef1893a5e9.jpg.webp',
+      ],
+    },
   },
   {
     'number': 2,
@@ -42,15 +34,44 @@ export const ShowSiloSeasonsResponseMock: SeasonsResponse = [
       'tvdb': 2087050,
       'tmdb': 404198,
     },
-    'aired_episodes': 7,
-    'rating': 7.38889,
-    'votes': 72,
+    'aired_episodes': 10,
+    'rating': 7.40559,
+    'votes': 895,
     'episode_count': 10,
     'title': 'Season 2',
     'overview':
       'Stranded outside her silo with a failing suit, Juliette Nichols races against time, stunned to find another silo nearby that could be her only hope for survival. Meanwhile, unrest brews inside her original silo as Bernard Holland rallies citizens to maintain order amid rising questions about their world. As Juliette faces unexpected dangers near the new silo, hidden truths about the silos’ origins and the world beyond begin to surface, deepening the mystery.',
     'first_aired': '2024-11-15T02:00:00.000Z',
-    'updated_at': '2024-12-28T08:36:39.000Z',
+    'updated_at': '2025-05-07T12:39:53.000Z',
     'network': 'Apple TV+',
+    'images': {
+      'poster': [
+        'walter-r2.trakt.tv/images/seasons/000/402/288/posters/thumb/44533bd556.jpg.webp',
+      ],
+      'thumb': [
+        'walter-r2.trakt.tv/images/seasons/000/402/288/thumbs/medium/7b1183feff.jpg.webp',
+      ],
+    },
+  },
+  {
+    'number': 3,
+    'ids': {
+      'trakt': 456019,
+      'tvdb': null,
+      'tmdb': 449548,
+    },
+    'aired_episodes': 0,
+    'rating': 5.0,
+    'votes': 1,
+    'episode_count': 1,
+    'title': 'Season 3',
+    'overview': null,
+    'first_aired': undefined,
+    'updated_at': '2025-05-07T06:49:14.000Z',
+    'network': 'Apple TV+',
+    'images': {
+      'poster': [],
+      'thumb': [],
+    },
   },
 ];

--- a/projects/client/src/routes/shows/[slug]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/+page.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import { page } from "$app/state";
+  import { useParameters } from "$lib/features/parameters/useParameters";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import { useUserSeason } from "$lib/sections/lists/stores/useUserSeason";
   import ShowSummary from "$lib/sections/summary/ShowSummary.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { readable } from "svelte/store";
   import { useShow } from "./useShow";
   import { useShowDetails } from "./useShowDetails";
   import { useShowVideos } from "./useShowVideos";
@@ -31,6 +36,46 @@
       seasons: ($seasons ?? []).map((season) => season.number),
     }),
   );
+
+  const currentSeason = $derived(
+    parseInt(page.url.searchParams.get("season") ?? ""),
+  );
+
+  const lastWatchedSeason = $derived(
+    $show == null ? readable(-1) : useUserSeason($show.id),
+  );
+
+  const { search } = useParameters();
+
+  $effect.pre(() => {
+    if (currentSeason) return;
+
+    if ($seasons == null) return;
+
+    if ($lastWatchedSeason === -1) return;
+
+    const active = $seasons.find((s) => s.number === $lastWatchedSeason);
+
+    const activeSeason = active?.number;
+    const firstSeason = $seasons?.at(0)?.number;
+
+    if ($show == null) return;
+
+    /*
+     * TODO: Consider implementing a custom navigation helper within useParameters
+     * to simplify URL management with query parameters, reducing the need for
+     * manual parameter handling throughout the application.
+     */
+    goto(
+      UrlBuilder.show($show.slug, {
+        season: activeSeason ?? firstSeason ?? 1,
+        ...Object.fromEntries($search),
+      }),
+      {
+        replaceState: true,
+      },
+    );
+  });
 </script>
 
 <TraktPage
@@ -52,6 +97,7 @@
       seasons={$seasons!}
       streamOn={$streamOn}
       videos={$videos}
+      {currentSeason}
     />
   {:else}
     <!-- TODO: remove this when we have empty state, currently prevents content jumps -->


### PR DESCRIPTION
Implements a season list on the show details view, allowing users to select and browse episodes within a specific season.

- Introduces a new `SeasonList` component to display seasons with their posters.
- Includes a `SeasonEpisodeList` to show episodes for the selected season.
- Updates the show view to display the season list.
- Adds an endpoint to fetch seasons with images.