### PR TITLE
feat / internal table components and formatting examples

### DIFF
--- a/projects/client/src/routes/_design_system/_internal/table/FormatSection.svelte
+++ b/projects/client/src/routes/_design_system/_internal/table/FormatSection.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  const { title, description = "", children } = $props();
+</script>
+
+<section>
+  <h2>{title}</h2>
+  <p>{@html description}</p>
+
+  {@render children()}
+</section>
+
+<style>
+  section {
+    margin-bottom: 3rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 1.5rem;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+    color: var(--color-text-primary);
+  }
+
+  p {
+    color: var(--color-text-secondary);
+    margin-bottom: 1rem;
+  }
+
+  :global(code) {
+    background-color: #f5f5f5;
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 0.9em;
+  }
+</style>

--- a/projects/client/src/routes/_design_system/_internal/table/Table.svelte
+++ b/projects/client/src/routes/_design_system/_internal/table/Table.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  const { children, ...rest } = $props();
+</script>
+
+<table {...rest}>
+  {@render children()}
+</table>
+
+<style>
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+  }
+</style>

--- a/projects/client/src/routes/_design_system/_internal/table/TableBody.svelte
+++ b/projects/client/src/routes/_design_system/_internal/table/TableBody.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  const { children, ...rest } = $props();
+</script>
+
+<tbody {...rest}>
+  {@render children()}
+</tbody>

--- a/projects/client/src/routes/_design_system/_internal/table/TableCell.svelte
+++ b/projects/client/src/routes/_design_system/_internal/table/TableCell.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  const { header = false, children, ...rest } = $props();
+</script>
+
+{#if header}
+  <th {...rest}>
+    {@render children()}
+  </th>
+{:else}
+  <td {...rest}>
+    {@render children()}
+  </td>
+{/if}
+
+<style>
+  th,
+  td {
+    padding: 0.75rem;
+    text-align: left;
+    border: 1px solid var(--color-border);
+  }
+
+  th {
+    background-color: var(--color-background);
+    font-weight: 600;
+  }
+</style>

--- a/projects/client/src/routes/_design_system/_internal/table/TableHead.svelte
+++ b/projects/client/src/routes/_design_system/_internal/table/TableHead.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  const { children, ...rest } = $props();
+</script>
+
+<thead {...rest}>
+  {@render children()}
+</thead>

--- a/projects/client/src/routes/_design_system/_internal/table/TableRow.svelte
+++ b/projects/client/src/routes/_design_system/_internal/table/TableRow.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  const { highlight = false, children, ...rest } = $props();
+</script>
+
+<tr class:trakt-row-highlighted={highlight} {...rest}>
+  {@render children()}
+</tr>
+
+<style>
+  tr:nth-child(even) {
+    background-color: color-mix(
+      in srgb,
+      var(--color-background) 97.5%,
+      var(--color-foreground)
+    );
+  }
+
+  tr:nth-child(odd) {
+    background-color: color-mix(
+      in srgb,
+      var(--color-background) 95%,
+      var(--color-foreground)
+    );
+  }
+
+  tr.trakt-row-highlighted {
+    font-weight: bold;
+    border-top: 2px solid var(--blue-600);
+    border-bottom: 2px solid var(--blue-600);
+    background-color: color-mix(
+      in srgb,
+      var(--color-background) 95%,
+      var(--blue-600)
+    );
+  }
+</style>

--- a/projects/client/src/routes/_design_system/_internal/table/index.ts
+++ b/projects/client/src/routes/_design_system/_internal/table/index.ts
@@ -1,0 +1,6 @@
+export { default as FormatSection } from './FormatSection.svelte';
+export { default as Table } from './Table.svelte';
+export { default as TableBody } from './TableBody.svelte';
+export { default as TableCell } from './TableCell.svelte';
+export { default as TableHead } from './TableHead.svelte';
+export { default as TableRow } from './TableRow.svelte';

--- a/projects/client/src/routes/_design_system/formatting/dates/+page.svelte
+++ b/projects/client/src/routes/_design_system/formatting/dates/+page.svelte
@@ -5,6 +5,14 @@
   import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration";
   import { toHumanETA } from "$lib/utils/formatting/date/toHumanETA";
   import { toHumanMonth } from "$lib/utils/formatting/date/toHumanMonth";
+  import {
+    FormatSection,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+  } from "../../_internal/table";
 
   // Svelte 5 runes
   const today = $state(new Date());
@@ -178,189 +186,92 @@
   }
 </script>
 
-<div class="container">
+<div class="trakt-format-section">
   <h1>Date Formatting Examples</h1>
 
-  <section>
-    <h2>Date Formatters</h2>
-    <p>
-      Comparison of different date formatters and how they display the same
-      dates.
-    </p>
-    <table>
-      <thead>
-        <tr>
-          <th>Input Date</th>
-          <th>toHumanDate</th>
-          <th>toHumanDay</th>
-          <th>toHumanMonth</th>
-          <th>toHumanETA</th>
-        </tr>
-      </thead>
-      <tbody>
+  <FormatSection
+    title="Date Formatters"
+    description="Comparison of different date formatters and how they display the same dates."
+  >
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell header>Input Date</TableCell>
+          <TableCell header>toHumanDate</TableCell>
+          <TableCell header>toHumanDay</TableCell>
+          <TableCell header>toHumanMonth</TableCell>
+          <TableCell header>toHumanETA</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
         {#each testDates as date}
-          <tr class={isToday(date) ? "today" : ""}>
-            <td>{getDateLabel(date)}</td>
-            <td>{toHumanDate(today, date, getLocale())}</td>
-            <td>{toHumanDay(date, getLocale())}</td>
-            <td>{toHumanMonth(date, languageTag())}</td>
-            <td>{toHumanETA(today, date, getLocale())}</td>
-          </tr>
+          <TableRow highlight={isToday(date)}>
+            <TableCell>{getDateLabel(date)}</TableCell>
+            <TableCell>{toHumanDate(today, date, getLocale())}</TableCell>
+            <TableCell>{toHumanDay(date, getLocale())}</TableCell>
+            <TableCell>{toHumanMonth(date, languageTag())}</TableCell>
+            <TableCell>{toHumanETA(today, date, getLocale())}</TableCell>
+          </TableRow>
         {/each}
-      </tbody>
-    </table>
-  </section>
+      </TableBody>
+    </Table>
+  </FormatSection>
 
-  <section>
-    <h2>Duration Formatting</h2>
-    <p>
-      Formats time durations with various display options for real-world
-      scenarios.
-    </p>
-    <table>
-      <thead>
-        <tr>
-          <th>Scenario</th>
-          <th>Raw Duration</th>
-          <th>Default</th>
-          <th>Long</th>
-          <th>Short</th>
-          <th>Clamp at Day</th>
-          <th>Clamp at Hour</th>
-        </tr>
-      </thead>
-      <tbody>
+  <FormatSection
+    title="Duration Formatting"
+    description="Formats time durations with various display options for real-world scenarios."
+  >
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell header>Scenario</TableCell>
+          <TableCell header>Raw Duration</TableCell>
+          <TableCell header>Default</TableCell>
+          <TableCell header>Long</TableCell>
+          <TableCell header>Short</TableCell>
+          <TableCell header>Clamp at Day</TableCell>
+          <TableCell header>Clamp at Hour</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
         {#each durations as duration}
-          <tr>
-            <td><strong>{duration.scenario}</strong></td>
-            <td>
+          <TableRow>
+            <TableCell><strong>{duration.scenario}</strong></TableCell>
+            <TableCell>
               {duration.days ? `${duration.days}d ` : ""}
               {duration.hours ? `${duration.hours}h ` : ""}
               {duration.minutes ? `${duration.minutes}m` : ""}
-            </td>
-            <td>{toHumanDuration(duration, languageTag())}</td>
-            <td
-              >{toHumanDuration(
+            </TableCell>
+            <TableCell>{toHumanDuration(duration, languageTag())}</TableCell>
+            <TableCell>
+              {toHumanDuration(
                 { ...duration, unitDisplay: "long" },
                 languageTag(),
-              )}</td
-            >
-            <td
-              >{toHumanDuration(
+              )}
+            </TableCell>
+            <TableCell>
+              {toHumanDuration(
                 { ...duration, unitDisplay: "short" },
                 languageTag(),
-              )}</td
-            >
-            <td
-              >{toHumanDuration(
-                { ...duration, clampAt: "day" },
-                languageTag(),
-              )}</td
-            >
-            <td
-              >{toHumanDuration(
-                { ...duration, clampAt: "hour" },
-                languageTag(),
-              )}</td
-            >
-          </tr>
+              )}
+            </TableCell>
+            <TableCell>
+              {toHumanDuration({ ...duration, clampAt: "day" }, languageTag())}
+            </TableCell>
+            <TableCell>
+              {toHumanDuration({ ...duration, clampAt: "hour" }, languageTag())}
+            </TableCell>
+          </TableRow>
         {/each}
-      </tbody>
-    </table>
-  </section>
+      </TableBody>
+    </Table>
+  </FormatSection>
 </div>
 
 <style>
-  .container {
-    font-family:
-      system-ui,
-      -apple-system,
-      BlinkMacSystemFont,
-      "Segoe UI",
-      Roboto,
-      sans-serif;
+  .trakt-format-section {
     max-width: 1200px;
     margin: 0 auto;
     padding: 2rem;
-  }
-
-  section {
-    margin-bottom: 3rem;
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
-    padding: 1.5rem;
-  }
-
-  h1 {
-    font-size: 2rem;
-    margin-bottom: 2rem;
-  }
-
-  h2 {
-    font-size: 1.5rem;
-    margin-bottom: 0.5rem;
-    color: var(--color-text-primary);
-  }
-
-  p {
-    color: var(--color-text-secondary);
-    margin-bottom: 1rem;
-  }
-
-  table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 1rem;
-    font-size: 0.9rem;
-  }
-
-  th,
-  td {
-    padding: 0.75rem;
-    text-align: left;
-    border: 1px solid var(--color-border);
-  }
-
-  th {
-    background-color: var(--color-background);
-    font-weight: 600;
-  }
-
-  tr:nth-child(even) {
-    background-color: color-mix(
-      in srgb,
-      var(--color-background) 97.5%,
-      var(--color-foreground)
-    );
-  }
-
-  tr:nth-child(odd) {
-    background-color: color-mix(
-      in srgb,
-      var(--color-background) 95%,
-      var(--color-foreground)
-    );
-  }
-
-  .today {
-    font-weight: bold;
-  }
-
-  tr.today td {
-    border-top: 2px solid var(--blue-600);
-    border-bottom: 2px solid var(--blue-600);
-    background-color: color-mix(
-      in srgb,
-      var(--color-background) 95%,
-      var(--blue-600)
-    );
-  }
-
-  tr.today td:first-child {
-    border-left: 2px solid var(--blue-600);
-  }
-
-  tr.today td:last-child {
-    border-right: 2px solid var(--blue-600);
   }
 </style>

--- a/projects/client/src/routes/_design_system/formatting/numbers/+page.svelte
+++ b/projects/client/src/routes/_design_system/formatting/numbers/+page.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { getLocale } from "$lib/features/i18n";
+  import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber";
+  import { toPercentage } from "$lib/utils/formatting/number/toPercentage";
+  import {
+    FormatSection,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+  } from "../../_internal/table";
+
+  // Svelte 5 runes
+  const numbers = $state([
+    { value: 0, description: "Zero" },
+    { value: 42, description: "Small number" },
+    { value: 999, description: "Just under thousand" },
+    { value: 1000, description: "One thousand" },
+    { value: 1234, description: "Four digits" },
+    { value: 12345, description: "Five digits" },
+    { value: 123456, description: "Six digits" },
+    { value: 1234567, description: "Seven digits" },
+    { value: 12345678, description: "Eight digits" },
+    { value: 123456789, description: "Nine digits" },
+    { value: 1234567890, description: "Ten digits" },
+    { value: 1234567890123, description: "Trillions" },
+  ]);
+
+  const percentages = $state([
+    { value: 0, description: "0%" },
+    { value: 0.111111, description: "Repeating decimals" },
+    { value: 0.25, description: "Quarter" },
+    { value: 0.33, description: "One third" },
+    { value: 0.5, description: "Half" },
+    { value: 0.66, description: "Two thirds" },
+    { value: 0.75, description: "Three quarters" },
+    { value: 0.95, description: "Almost complete" },
+    { value: 0.999, description: "Very close to 100%" },
+    { value: 1, description: "100%" },
+    { value: 1.5, description: "Over 100%" },
+    { value: 2.25, description: "Over 200%" },
+    { value: 0.123456789, description: "Many decimal places" },
+  ]);
+</script>
+
+<div class="trakt-format-section">
+  <h1>Number Formatting Examples</h1>
+
+  <FormatSection
+    title="Human-Readable Numbers"
+    description="Formats numbers into compact, human-readable representations using the <code>toHumanNumber</code> utility."
+  >
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell header>Description</TableCell>
+          <TableCell header>Raw Value</TableCell>
+          <TableCell header>Formatted Output</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {#each numbers as num}
+          <TableRow>
+            <TableCell>{num.description}</TableCell>
+            <TableCell>{num.value.toLocaleString()}</TableCell>
+            <TableCell>{toHumanNumber(num.value, getLocale())}</TableCell>
+          </TableRow>
+        {/each}
+      </TableBody>
+    </Table>
+  </FormatSection>
+
+  <FormatSection
+    title="Percentage Formatting"
+    description="Converts decimal values to percentage strings using the <code>toPercentage</code> utility."
+  >
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell header>Description</TableCell>
+          <TableCell header>Decimal Value</TableCell>
+          <TableCell header>Percentage</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {#each percentages as pct}
+          <TableRow>
+            <TableCell>{pct.description}</TableCell>
+            <TableCell>{pct.value}</TableCell>
+            <TableCell>{toPercentage(pct.value, getLocale())}</TableCell>
+          </TableRow>
+        {/each}
+      </TableBody>
+    </Table>
+  </FormatSection>
+</div>
+
+<style>
+  .trakt-format-section {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+  }
+</style>


### PR DESCRIPTION
Introduces a set of internal table components for the design system.

- Adds FormatSection, Table, TableBody, TableCell, TableHead, and TableRow components.
- Implements number formatting examples page, showcasing toHumanNumber and toPercentage utilities.
- Updates date formatting examples page, utilizing the new table components to display formatting outputs.