### PR TITLE
perf(tv): disable idb on tv

### DIFF
--- a/projects/client/src/lib/features/query/QueryClientProvider.svelte
+++ b/projects/client/src/lib/features/query/QueryClientProvider.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
+  import type { DeviceType } from "$lib/models/DeviceType";
   import { type QueryClient } from "@tanstack/svelte-query";
   import { PersistQueryClientProvider } from "@tanstack/svelte-query-persist-client";
   import { createPersister } from "./_internal/createPersister";
 
-  const { children, client }: ChildrenProps & { client: QueryClient } =
-    $props();
+  const {
+    children,
+    client,
+    device,
+  }: ChildrenProps & { client: QueryClient; device?: DeviceType } = $props();
 </script>
 
 <PersistQueryClientProvider
   {client}
   persistOptions={{
-    persister: createPersister(),
+    persister: createPersister(device),
   }}
 >
   {@render children()}

--- a/projects/client/src/lib/features/query/_internal/createPersister.ts
+++ b/projects/client/src/lib/features/query/_internal/createPersister.ts
@@ -7,15 +7,18 @@ import type {
   Persister,
 } from '@tanstack/svelte-query-persist-client';
 import { del, get, set } from 'idb-keyval';
+import type { DeviceType } from '../../../models/DeviceType.ts';
+
+const IDB_VALID_KEY = 'trakt-query-client';
 
 /**
  * Creates an Indexed DB persister
  * @see https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
  */
 export function createPersister(
-  idbValidKey: IDBValidKey = 'trakt-query-client',
+  device?: DeviceType,
 ): Persister {
-  if (!browser) {
+  if (!browser || device === 'tv') {
     return {
       persistClient: NOOP_FN,
       restoreClient: () => Promise.resolve(undefined),
@@ -30,15 +33,15 @@ export function createPersister(
 
   return {
     persistClient: monitor(async (client: PersistedClient) => {
-      await set(idbValidKey, client)
+      await set(IDB_VALID_KEY, client)
         .catch(handleError);
     }, 'IDB Persister'),
     restoreClient: monitor(async () => {
-      return await get<PersistedClient>(idbValidKey)
+      return await get<PersistedClient>(IDB_VALID_KEY)
         .catch(handleError);
     }, 'IDB Restorer'),
     removeClient: async () => {
-      await del(idbValidKey);
+      await del(IDB_VALID_KEY);
     },
   };
 }

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -91,7 +91,7 @@
 </svelte:head>
 
 <ErrorProvider>
-  <QueryClientProvider client={data.queryClient}>
+  <QueryClientProvider client={data.queryClient} device={data.device}>
     <GlobalParameterProvider>
       <AuthProvider isAuthorized={data.auth.isAuthorized} url={data.auth.url}>
         <AnalyticsProvider>


### PR DESCRIPTION
## 🎶 Notes 🎶

- No indexed db on TV. Likely culprit for slowness on TV.
- Could not test in dev env; can't login on preview build running on actual android tv device.

## Reasoning
All queries are fine (e.g. they're not taking ages):
<img width="1166" alt="Screenshot 2025-05-07 at 20 51 55" src="https://github.com/user-attachments/assets/58e223a9-766f-44bb-a769-b0b8efa3a1d8" />

Slowdown seems to be caused by indexed db operations:
<img width="1166" alt="Screenshot 2025-05-07 at 20 53 17" src="https://github.com/user-attachments/assets/f4b0eed5-eb57-4d8a-9407-1d30512c67cb" />
