### PR TITLE
fix(formatter): swedish date formatting

### DIFF
--- a/projects/client/src/lib/utils/formatting/date/LOCALE_MAP.ts
+++ b/projects/client/src/lib/utils/formatting/date/LOCALE_MAP.ts
@@ -14,7 +14,7 @@ import {
   pl,
   ptBR,
   ro,
-  se,
+  sv,
   uk,
 } from 'date-fns/locale';
 
@@ -35,7 +35,7 @@ export const LOCALE_MAP: Record<AvailableLocale, Locale> = {
   'pl-pl': pl,
   'it-it': it,
   'bg-bg': bg,
-  'sv-se': se,
+  'sv-se': sv,
   'nb-no': nb,
   'da-dk': da,
 };


### PR DESCRIPTION
## ♪ Note ♪

- Swedish date formats were wrong. Woops 😅

## 👀 Example 👀

Before:
<img width="1091" alt="Screenshot 2025-05-08 at 22 09 26" src="https://github.com/user-attachments/assets/bed42e98-7267-4ca1-a206-45cd98b52675" />

After:

<img width="1091" alt="Screenshot 2025-05-08 at 22 09 10" src="https://github.com/user-attachments/assets/684e193f-1fd6-436d-ac0f-1b3ec8b07c0a" />
