### PR TITLE
feat / suppresses targeted areas from heatmap

### DIFF
--- a/projects/client/src/lib/features/search/SearchInput.svelte
+++ b/projects/client/src/lib/features/search/SearchInput.svelte
@@ -57,6 +57,7 @@
 <div
   class="trakt-search"
   class:search-is-loading={$isSearchingMovies || $isSearchingShows}
+  data-hj-suppress
 >
   <div use:focusOnClick class="trakt-search-icon">
     <SearchIcon />

--- a/projects/client/src/lib/sections/navbar/ProfileButton.svelte
+++ b/projects/client/src/lib/sections/navbar/ProfileButton.svelte
@@ -14,7 +14,7 @@
   const style = $derived(isVip ? "textured" : "flat");
 </script>
 
-<trakt-profile-button>
+<trakt-profile-button data-hj-suppress>
   <Button
     size="small"
     href={UrlBuilder.profile.me()}

--- a/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
@@ -28,7 +28,7 @@
       <VipBadge isDirector={profile.isDirector} />
     {/if}
   </div>
-  <div class="profile-info">
+  <div class="profile-info" data-hj-suppress>
     <h5>
       {nameLabel}
     </h5>


### PR DESCRIPTION
Suppresses specific elements from heatmap tracking instead of using a global suppression setting, global text suppression ruined the CSS styles. 