### PR TITLE
Fix/small tv fixes

### DIFF
--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -79,4 +79,13 @@
       }
     }
   }
+
+  :global([data-device="tv"]) {
+    .trakt-card-footer .trakt-card-footer-information {
+      :global(.trakt-card-title),
+      :global(.trakt-card-subtitle) {
+        font-size: var(--ni-14);
+      }
+    }
+  }
 </style>

--- a/projects/client/src/lib/features/devices/handle.spec.ts
+++ b/projects/client/src/lib/features/devices/handle.spec.ts
@@ -27,6 +27,6 @@ describe('handle: devices', () => {
 
     const transformed = transformPageChunk?.({ html, done: true });
 
-    expect(transformed).toMatch('<html>0.75</html>');
+    expect(transformed).toMatch('<html>0.65</html>');
   });
 });

--- a/projects/client/src/lib/features/devices/handle.ts
+++ b/projects/client/src/lib/features/devices/handle.ts
@@ -7,7 +7,7 @@ export const DEVICE_TYPE_PLACEHOLDER = '%device.type%';
 
 const SCALE_MAP: Record<DeviceType, string> = {
   unknown: '1',
-  tv: '0.75',
+  tv: '0.65',
 } as const;
 
 export const handle: Handle = (

--- a/projects/client/src/lib/sections/navbar/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/SideNavbar.svelte
@@ -120,7 +120,11 @@
     &:has(:global(*):focus-visible),
     &:hover {
       width: fit-content;
-      min-width: var(--ni-200);
+
+      &,
+      .trakt-side-navbar-content {
+        min-width: var(--ni-200);
+      }
     }
 
     /** 

--- a/projects/client/src/lib/sections/navbar/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/SideNavbar.svelte
@@ -197,8 +197,11 @@
     }
 
     :global(svg) {
-      width: var(--navbar-item-width);
-      height: var(--navbar-item-width);
+      --icon-padding: var(--ni-4);
+
+      padding: var(--icon-padding);
+      width: calc(var(--navbar-item-width) - var(--icon-padding) * 2);
+      height: calc(var(--navbar-item-width) - var(--icon-padding) * 2);
     }
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

Some TV related fixes:
- Changes the scaling to fit a tiny bite more content on screen.
- Side bar links now fill the width.
- Decreases the icon sizes.

## 👀 Examples 👀
Before:
<img width="1233" alt="Screenshot 2025-05-09 at 13 19 17" src="https://github.com/user-attachments/assets/98a32734-1cf2-4bab-873c-d683d01cd247" />

After:
<img width="1233" alt="Screenshot 2025-05-09 at 13 17 42" src="https://github.com/user-attachments/assets/5d7db9d3-b3de-424b-8b8a-fdf0192815d5" />

Before:
<img width="1233" alt="Screenshot 2025-05-09 at 13 19 21" src="https://github.com/user-attachments/assets/daab9d80-e94f-41b7-ba76-6b50d0a65eff" />

After:
<img width="1233" alt="Screenshot 2025-05-09 at 13 17 48" src="https://github.com/user-attachments/assets/bc12c826-b3df-4683-929c-2ec27cf4c7b7" />
