### PR TITLE
revert: "feat(tv): use android deep links"

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToStreamingServices.ts
+++ b/projects/client/src/lib/requests/_internal/mapToStreamingServices.ts
@@ -13,7 +13,7 @@ function mapToStreamNow(
   return {
     type: 'streaming',
     link: prependHttps(serviceResponse.link),
-    deepLink: serviceResponse.link_android,
+    deepLink: serviceResponse.link_direct,
     source: serviceResponse.source,
     is4k: serviceResponse.uhd,
   };
@@ -33,7 +33,7 @@ function mapToStreamOnDemand(
   return {
     type: 'on-demand',
     link: prependHttps(serviceResponse.link),
-    deepLink: serviceResponse.link_android,
+    deepLink: serviceResponse.link_direct,
     source: serviceResponse.source,
     is4k: serviceResponse.uhd,
     currency: serviceResponse.currency,

--- a/projects/client/src/lib/requests/queries/episode/streamEpisodeQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/streamEpisodeQuery.ts
@@ -25,7 +25,7 @@ const streamEpisodeRequest = (
         country,
       },
       query: {
-        links: 'android',
+        links: 'direct',
       },
     });
 

--- a/projects/client/src/lib/requests/queries/movies/streamMovieQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/streamMovieQuery.ts
@@ -20,7 +20,7 @@ const streamMovieRequest = (
         country,
       },
       query: {
-        links: 'android',
+        links: 'direct',
       },
     });
 

--- a/projects/client/src/lib/requests/queries/shows/streamShowQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/streamShowQuery.ts
@@ -20,7 +20,7 @@ const showWatchNowRequest = (
         country,
       },
       query: {
-        links: 'android',
+        links: 'direct',
       },
     });
 


### PR DESCRIPTION
## ♪ Note ♪

- Reverts the android deeplinks. They seem worse than the direct links