### PR TITLE
feat(cover): improved contrast for light covers

### DIFF
--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -76,16 +76,6 @@
       }
     }
 
-    &:not([data-cover-type="main"]) {
-      &::after {
-        backdrop-filter: blur(var(--ni-2));
-
-        @include for-tablet-sm-and-below {
-          backdrop-filter: unset;
-        }
-      }
-    }
-
     &::after,
     &::before {
       content: "";
@@ -120,15 +110,28 @@
 
     &::before {
       background: linear-gradient(
-        360deg,
-        var(--color-background) 0%,
-        color-mix(in srgb, var(--color-background) 60%, transparent) 40%,
-        color-mix(in srgb, var(--color-background) 30%, transparent) 50%,
-        color-mix(in srgb, var(--color-background) 0%, transparent) 100%
+        180deg,
+        transparent 0%,
+        color-mix(in srgb, var(--color-background) 95%, transparent) 65%,
+        color-mix(in srgb, var(--color-background) 100%, transparent) 100%
       );
+    }
 
-      @include for-tablet-sm-and-below {
-        background: none;
+    &:not([data-cover-type="main"]) {
+      &::after {
+        backdrop-filter: blur(var(--ni-2));
+
+        @include for-tablet-sm-and-below {
+          backdrop-filter: unset;
+        }
+      }
+    }
+
+    &[data-cover-type="main"] {
+      &::before {
+        @include for-mobile {
+          background: none;
+        }
       }
     }
   }


### PR DESCRIPTION
##   Cover Image Illumination and Clarity

This pull request delves into the visual presentation of the `CoverImage` component, seeking to fine-tune its appearance for various cover types and enhance the underlying structure.

###   Gradient Alchemy:

* The gradient background, that subtle wash of color that hints at the world beyond the frame, has been alchemized. Now set at a precise 180-degree angle, its color mixing logic has been refined, aiming for smoother, more evocative transitions. Like the slow fade of a memory.

###   Conditional Clarity:

* The `backdrop-filter`, that subtle blurring effect, makes a conditional return for non-main cover types. A touch of visual separation, with a fallback to `unset` on smaller screens, like a whispered secret that fades with distance.
* And for the main cover types, a new rule emerges: in the cramped confines of mobile views, the background shall now recede entirely. Allowing the core image to command attention, unburdened by distraction.

(This update is akin to a meticulous cinematographer adjusting the lighting on a scene. The gradients are softened, the clarity enhanced through conditional blurring, and the main focus is brought sharply into view on smaller stages. It's about guiding the eye, ensuring that the visual narrative is conveyed with precision and intent.)