### PR TITLE
test: return single element when creating raw snippet

### DIFF
--- a/projects/client/src/lib/components/episode/tags/ShowProgressTag.spec.ts
+++ b/projects/client/src/lib/components/episode/tags/ShowProgressTag.spec.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import ShowProgressTag from './ShowProgressTag.svelte';
 
 const children = createRawSnippet(() => ({
-  render: () => 'Custom Text',
+  render: () => '<span>Custom Text</span>',
 }));
 
 describe('ShowProgressTag', () => {


### PR DESCRIPTION
## 👀 Example 👀

Before:
<img width="1054" alt="Screenshot 2025-05-12 at 16 51 44" src="https://github.com/user-attachments/assets/c01beb55-3edc-4612-88a1-229bb056de2c" />

After:
<img width="1258" alt="Screenshot 2025-05-12 at 16 52 24" src="https://github.com/user-attachments/assets/f6412213-8958-432f-815c-d03440b3293d" />
