### PR TITLE
Fix/side navbar nav

### DIFF
--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -16,6 +16,8 @@
   import ExpandIcon from "./ExpandIcon.svelte";
   import { scrollTracking } from "./scrollTracking";
 
+  const EMPTY_STATE_CLASS = "shadow-list-empty-state";
+
   type SectionListProps<T> = ListProps<T> & {
     subtitle?: string;
     empty?: Snippet;
@@ -88,6 +90,7 @@
   class:shadow-list-container-collapsed={$isCollapsed}
   class:shadow-list-container-mounted={$isMounted}
   class:shadow-list-container-no-header={!isHeaderVisible}
+  data-dynamic-selector={`[data-dpad-navigation="${DpadNavigationType.Item}"], .${EMPTY_STATE_CLASS}`}
 >
   {#if $isVisible}
     {#if isHeaderVisible && title}
@@ -123,7 +126,7 @@
           {/each}
         </div>
       {:else if empty != null && $isMounted}
-        <div class="shadow-list-empty-state">
+        <div class={EMPTY_STATE_CLASS}>
           {@render empty()}
         </div>
       {/if}

--- a/projects/client/src/lib/features/navigation/_internal/dpadController.ts
+++ b/projects/client/src/lib/features/navigation/_internal/dpadController.ts
@@ -1,3 +1,4 @@
+import { afterNavigate } from '$app/navigation';
 import { GlobalEventBus } from '$lib/utils/events/GlobalEventBus.ts';
 import { onMount } from 'svelte';
 import { useNavbarNavigation } from '../useNavbarNavigation.ts';
@@ -53,10 +54,10 @@ const handler = ({ ev, enterNavbar, leaveNavbar }: HandlerProps) => {
 };
 
 export function dpadController(_: HTMLElement) {
-  const { leaveNavbar, enterNavbar } = useNavbarNavigation();
+  const { leaveNavbar, enterNavbar, reset } = useNavbarNavigation();
 
   onMount(() => {
-    focusSomething();
+    focusSomething(true);
 
     const destroy = GlobalEventBus.getInstance().register('keydown', (ev) => {
       handler({ ev, leaveNavbar, enterNavbar });
@@ -65,5 +66,14 @@ export function dpadController(_: HTMLElement) {
     return {
       destroy,
     };
+  });
+
+  afterNavigate((nav) => {
+    if (!['link', 'popstate'].includes(nav.type) || nav.willUnload) {
+      return;
+    }
+
+    reset();
+    focusSomething(true);
   });
 }

--- a/projects/client/src/lib/features/navigation/_internal/focusSomething.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/focusSomething.spec.ts
@@ -1,19 +1,18 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { DpadNavigationType } from '../models/DpadNavigationType.ts';
 import { focusSomething } from './focusSomething.ts';
+import { createList } from './test/createList.ts';
 
 describe('focusSomething', () => {
-  let element: HTMLButtonElement;
+  let list: HTMLDivElement;
 
   beforeEach(() => {
-    element = document.createElement('button');
-    element.scrollIntoView = vi.fn();
-    element.setAttribute('data-dpad-navigation', DpadNavigationType.Item);
-    document.body.appendChild(element);
+    list = createList();
+    document.body.appendChild(list);
   });
 
   afterEach(() => {
-    element.remove();
+    list.remove();
   });
 
   it('should focus the first navigable element when no element is focused', () => {
@@ -22,7 +21,9 @@ describe('focusSomething', () => {
 
     focusSomething();
 
-    expect(document.activeElement).toBe(element);
+    expect(document.activeElement).toBe(list.querySelector(
+      `[data-dpad-navigation="${DpadNavigationType.Item}"]`,
+    ));
   });
 
   it('should not focus anything if an element is already focused', () => {
@@ -38,7 +39,7 @@ describe('focusSomething', () => {
   });
 
   it('should do nothing when no navigable element is found', () => {
-    document.body.removeChild(element);
+    document.body.removeChild(list);
     document.body.focus();
 
     focusSomething();

--- a/projects/client/src/lib/features/navigation/_internal/focusSomething.ts
+++ b/projects/client/src/lib/features/navigation/_internal/focusSomething.ts
@@ -1,10 +1,18 @@
 import { getRelevantItem } from '$lib/features/navigation/_internal/getRelevantItem.ts';
 import { focusAndScrollIntoView } from './focusAndScrollIntoView.ts';
 import { getNavigationScope } from './getNavigationScope.ts';
+import { waitForDynamicContent } from './waitForDynamicContent.ts';
 
-export function focusSomething() {
-  if (document.activeElement && document.activeElement !== document.body) {
+export async function focusSomething(isRefocus = false) {
+  const hasValidFocusedElement = document.activeElement &&
+    document.activeElement !== document.body;
+
+  if (!isRefocus && hasValidFocusedElement) {
     return;
+  }
+
+  if (isRefocus) {
+    await waitForDynamicContent();
   }
 
   const scope = getNavigationScope();

--- a/projects/client/src/lib/features/navigation/_internal/getRelevantItem.ts
+++ b/projects/client/src/lib/features/navigation/_internal/getRelevantItem.ts
@@ -1,6 +1,10 @@
 import { DpadNavigationType } from '$lib/features/navigation/models/DpadNavigationType.ts';
 
 export const getRelevantItem = (target: Document | Element) => {
+  const item = target.querySelector(
+    `[data-dpad-navigation="${DpadNavigationType.List}"] [data-dpad-navigation="${DpadNavigationType.Item}"]`,
+  );
+
   const navigableActiveLink = target.querySelector(
     `.trakt-link-active[data-dpad-navigation="${DpadNavigationType.Item}"]`,
   );
@@ -9,9 +13,5 @@ export const getRelevantItem = (target: Document | Element) => {
     `[data-dpad-navigation="${DpadNavigationType.Navbar}"] .trakt-link[data-dpad-navigation="${DpadNavigationType.Item}"]`,
   );
 
-  const item = target.querySelector(
-    `[data-dpad-navigation="${DpadNavigationType.Item}"]`,
-  );
-
-  return navigableActiveLink ?? navbarLink ?? item;
+  return item ?? navigableActiveLink ?? navbarLink;
 };

--- a/projects/client/src/lib/features/navigation/_internal/waitForDynamicContent.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/waitForDynamicContent.spec.ts
@@ -1,0 +1,66 @@
+import { waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CHECK_INTERVAL,
+  MAX_WAIT_TIME,
+  waitForDynamicContent,
+} from './waitForDynamicContent.ts';
+
+describe('waitForDynamicContent', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('should resolve immediately if no dynamic elements exist', async () => {
+    const promise = waitForDynamicContent();
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it('should wait for dynamic content to load', async () => {
+    let resolved = false;
+
+    container.setAttribute('data-dynamic-selector', '.dynamic-item');
+
+    const promise = waitForDynamicContent();
+    promise.then(() => {
+      resolved = true;
+    });
+
+    vi.advanceTimersByTime(CHECK_INTERVAL);
+    expect(resolved).toBe(false);
+
+    const dynamicItem = document.createElement('div');
+    dynamicItem.className = 'dynamic-item';
+    container.appendChild(dynamicItem);
+
+    vi.advanceTimersByTime(CHECK_INTERVAL);
+
+    await waitFor(() => expect(resolved).toBe(true));
+  });
+
+  it('should resolve after MAX_WAIT_TIME if content never loads', async () => {
+    let resolved = false;
+
+    container.setAttribute('data-dynamic-selector', '.never-loads');
+
+    const promise = waitForDynamicContent();
+    promise.then(() => {
+      resolved = true;
+    });
+
+    vi.advanceTimersByTime(MAX_WAIT_TIME + CHECK_INTERVAL);
+
+    await waitFor(() => expect(resolved).toBe(true));
+  });
+});

--- a/projects/client/src/lib/features/navigation/_internal/waitForDynamicContent.ts
+++ b/projects/client/src/lib/features/navigation/_internal/waitForDynamicContent.ts
@@ -1,0 +1,37 @@
+import { time } from '$lib/utils/timing/time.ts';
+import { assertDefined } from '../../../utils/assert/assertDefined.ts';
+import { getNavigationScope } from './getNavigationScope.ts';
+
+const MAX_WAIT_TIME = time.seconds(5);
+const CHECK_INTERVAL = time.fps(30);
+
+export function waitForDynamicContent() {
+  const scope = getNavigationScope();
+
+  const dynamicElements = Array.from(scope.querySelectorAll(
+    '[data-dynamic-selector]',
+  ));
+
+  if (dynamicElements.length === 0) return Promise.resolve(null);
+
+  return new Promise((resolve) => {
+    let elapsed = 0;
+
+    const intervalId = setInterval(() => {
+      elapsed += CHECK_INTERVAL;
+
+      const hasLoadedElements = dynamicElements.every((element) => {
+        const selector = assertDefined(
+          element.getAttribute('data-dynamic-selector'),
+          'Expected data-dynamic-selector attribute to be defined',
+        );
+        return element.querySelector(selector) !== null;
+      });
+
+      if (hasLoadedElements || elapsed >= MAX_WAIT_TIME) {
+        clearInterval(intervalId);
+        resolve(null);
+      }
+    }, CHECK_INTERVAL);
+  });
+}

--- a/projects/client/src/lib/features/navigation/_internal/waitForDynamicContent.ts
+++ b/projects/client/src/lib/features/navigation/_internal/waitForDynamicContent.ts
@@ -2,8 +2,8 @@ import { time } from '$lib/utils/timing/time.ts';
 import { assertDefined } from '../../../utils/assert/assertDefined.ts';
 import { getNavigationScope } from './getNavigationScope.ts';
 
-const MAX_WAIT_TIME = time.seconds(5);
-const CHECK_INTERVAL = time.fps(30);
+export const MAX_WAIT_TIME = time.seconds(5);
+export const CHECK_INTERVAL = time.fps(30);
 
 export function waitForDynamicContent() {
   const scope = getNavigationScope();

--- a/projects/client/src/lib/features/navigation/useNavbarNavigation.ts
+++ b/projects/client/src/lib/features/navigation/useNavbarNavigation.ts
@@ -50,5 +50,9 @@ export function useNavbarNavigation() {
   return {
     leaveNavbar,
     enterNavbar,
+    reset: () => {
+      outsideElement.set(null);
+      navbarElement.set(null);
+    },
   };
 }

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
@@ -15,6 +16,7 @@
       overview: string;
       runtime: number;
     };
+    hasDynamicContent?: boolean;
   };
 
   const {
@@ -24,6 +26,7 @@
     type = "webpage",
     image = DEFAULT_SHARE_COVER,
     info: _info,
+    hasDynamicContent = false,
   }: ChildrenProps & TraktPageProps & AudienceProps = $props();
 
   const websiteName = "Trakt Lite";
@@ -54,6 +57,14 @@
         }
       : _info,
   );
+
+  const dynamicContentProps = $derived(
+    hasDynamicContent
+      ? {
+          "data-dynamic-selector": `[data-dpad-navigation="${DpadNavigationType.List}"]`,
+        }
+      : {},
+  );
 </script>
 
 <svelte:head>
@@ -83,7 +94,7 @@
 </svelte:head>
 
 <RenderFor {audience}>
-  <div class="trakt-content">
+  <div class="trakt-content" {...dynamicContentProps}>
     {@render children()}
   </div>
 

--- a/projects/client/src/routes/lists/official/[id]/+page.svelte
+++ b/projects/client/src/routes/lists/official/[id]/+page.svelte
@@ -18,7 +18,12 @@
   const listName = $derived($list?.name ?? "");
 </script>
 
-<TraktPage audience="all" image={DEFAULT_SHARE_COVER} title={listName}>
+<TraktPage
+  audience="all"
+  image={DEFAULT_SHARE_COVER}
+  title={listName}
+  hasDynamicContent={true}
+>
   <TraktPageCoverSetter />
 
   <UserListPaginatedList

--- a/projects/client/src/routes/movies/[slug]/+page.svelte
+++ b/projects/client/src/routes/movies/[slug]/+page.svelte
@@ -25,6 +25,7 @@
   info={$movie}
   image={$movie?.poster.url.thumb ?? $movie?.cover.url.thumb}
   type="movie"
+  hasDynamicContent={true}
 >
   {#if !$isLoading}
     <MovieSummary

--- a/projects/client/src/routes/profile/[slug]/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/+page.svelte
@@ -17,7 +17,12 @@
   );
 </script>
 
-<TraktPage audience="all" image={DEFAULT_SHARE_COVER} {title}>
+<TraktPage
+  audience="all"
+  image={DEFAULT_SHARE_COVER}
+  {title}
+  hasDynamicContent={true}
+>
   {#if !$isLoading && $user}
     <CoverImageSetter src={$user.cover?.url ?? DEFAULT_COVER} type="main" />
     {#if $user.private}

--- a/projects/client/src/routes/profile/me/+page.svelte
+++ b/projects/client/src/routes/profile/me/+page.svelte
@@ -13,6 +13,7 @@
   audience="authenticated"
   image={DEFAULT_SHARE_COVER}
   title={m.profile()}
+  hasDynamicContent={true}
 >
   <TraktPageCoverSetter />
   {#if $user !== null}

--- a/projects/client/src/routes/shows/[slug]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/+page.svelte
@@ -103,6 +103,7 @@
   info={$show}
   image={$show?.poster.url.thumb ?? $show?.cover.url.thumb}
   type="show"
+  hasDynamicContent={true}
 >
   {#if !isLoading}
     <ShowSummary

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.svelte
@@ -39,6 +39,7 @@
   info={$episode}
   image={$episode?.cover.url}
   type="movie"
+  hasDynamicContent={true}
 >
   {#if !isLoading}
     <EpisodeSummary

--- a/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
@@ -18,7 +18,12 @@
   const listName = $derived($list?.name ?? "");
 </script>
 
-<TraktPage audience="all" image={DEFAULT_SHARE_COVER} title={listName}>
+<TraktPage
+  audience="all"
+  image={DEFAULT_SHARE_COVER}
+  title={listName}
+  hasDynamicContent={true}
+>
   <TraktPageCoverSetter />
 
   <UserListPaginatedList


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes some d-pad navigation issues:
  - It can now wait for dynamic content
  - On main pages, it will wait for the lists to be available, and select the first item instead of opening the side navbar.
  - Similarly for trakt pages, e.g. when going to a summary page. It will now select the first action button instead.
- If it times out, it will fall back to it's old behavior and open the sidebar.

## 👀 Examples 👀
Before:

https://github.com/user-attachments/assets/37757e84-7a02-4443-98bc-9a5258d508e6

After:

https://github.com/user-attachments/assets/2f0fcf98-e7c9-4bb2-98b6-4453cbe1867e
