### PR TITLE
fix(streaming): map to more usable netflix and disney links

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToDirectLink.ts
+++ b/projects/client/src/lib/requests/_internal/mapToDirectLink.ts
@@ -1,0 +1,24 @@
+import type { WatchNowServiceResponse } from '@trakt/api';
+
+export function mapToDirectLink(response: WatchNowServiceResponse) {
+  const { source, link_direct } = response;
+
+  if (!link_direct) {
+    return;
+  }
+
+  if (source.includes('netflix')) {
+    return link_direct.replace('/title/', '/watch/');
+  }
+
+  if (source.includes('disney')) {
+    const uParam = new URL(link_direct).searchParams.get('u');
+    if (!uParam) {
+      return link_direct;
+    }
+
+    return decodeURIComponent(uParam);
+  }
+
+  return link_direct;
+}

--- a/projects/client/src/lib/requests/_internal/mapToStreamingServices.ts
+++ b/projects/client/src/lib/requests/_internal/mapToStreamingServices.ts
@@ -5,6 +5,7 @@ import type {
   StreamNow,
   StreamOnDemand,
 } from '../models/StreamingServiceOptions.ts';
+import { mapToDirectLink } from './mapToDirectLink.ts';
 import { sortStreamingServices } from './sortStreamingServices.ts';
 
 function mapToStreamNow(
@@ -13,7 +14,7 @@ function mapToStreamNow(
   return {
     type: 'streaming',
     link: prependHttps(serviceResponse.link),
-    deepLink: serviceResponse.link_direct,
+    deepLink: mapToDirectLink(serviceResponse),
     source: serviceResponse.source,
     is4k: serviceResponse.uhd,
   };
@@ -33,7 +34,7 @@ function mapToStreamOnDemand(
   return {
     type: 'on-demand',
     link: prependHttps(serviceResponse.link),
-    deepLink: serviceResponse.link_direct,
+    deepLink: mapToDirectLink(serviceResponse),
     source: serviceResponse.source,
     is4k: serviceResponse.uhd,
     currency: serviceResponse.currency,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Better links for netflix and disney.
- Movies go to the movie page, episodes unfortunately take you to the show page (but still an improvement over not opening at all or taking you to the home dashboard).
- For netflix to work, it depends on: https://github.com/trakt/trakt-android/pull/101