### PR TITLE
fix(auth): vertically center qr code container

### DIFF
--- a/projects/client/src/routes/auth/device/+page.svelte
+++ b/projects/client/src/routes/auth/device/+page.svelte
@@ -45,7 +45,9 @@
 
 <style>
   .trakt-authorization-container {
-    height: var(--authentication-height);
+    height: calc(100dvh - var(--content-gap));
+    display: flex;
+    justify-content: center;
   }
 
   .trakt-authorization-codes {


### PR DESCRIPTION
## 👀 Example 👀

Before:
<img width="981" alt="Screenshot 2025-05-14 at 21 05 37" src="https://github.com/user-attachments/assets/898d54c7-31e7-46d4-a185-93225cccb468" />


After:
<img width="981" alt="Screenshot 2025-05-14 at 21 04 47" src="https://github.com/user-attachments/assets/948eee90-46b7-4833-acb8-40a17a96c6ee" />
