### PR TITLE
fix: also set the background color on the html

### DIFF
--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -75,6 +75,18 @@
       height: fill-available;
     }
 
+    html::before {
+      content: "";
+      height: 100vh;
+      width: 100vw;
+      z-index: calc(var(--layer-background) - 1);
+
+      display: block;
+      position: fixed;
+
+      background-color: var(--color-background);
+    }
+
     body {
       background-color: var(--color-background);
       color: var(--color-foreground);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Also sets the background color in the html element
- Set in a pseudo element so it will always be below background images

## 👀 Example 👀
Example with body hidden, in dark mode.

Before:
<img width="1427" alt="Screenshot 2025-05-16 at 12 37 41" src="https://github.com/user-attachments/assets/61022250-e25f-4686-965b-b619bd98e6a7" />

After:
<img width="1427" alt="Screenshot 2025-05-16 at 12 37 34" src="https://github.com/user-attachments/assets/08934cb6-50b9-48c3-84bc-a2428997d7ce" />

