### PR TITLE
Fix/d pad nav fixes

### DIFF
--- a/projects/client/src/lib/components/buttons/streaming-service/StreamingServiceButton.svelte
+++ b/projects/client/src/lib/components/buttons/streaming-service/StreamingServiceButton.svelte
@@ -76,7 +76,8 @@
         transition: transform var(--transition-increment) ease-in-out;
       }
 
-      &:hover {
+      &:hover,
+      &:focus-visible {
         :global(.trakt-streaming-service-logo) {
           filter: drop-shadow(0 var(--ni-40) 0 var(--color-background-purple));
           transform: translateY(var(--ni-neg-40));

--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -90,7 +90,7 @@
   class:shadow-list-container-collapsed={$isCollapsed}
   class:shadow-list-container-mounted={$isMounted}
   class:shadow-list-container-no-header={!isHeaderVisible}
-  data-dynamic-selector={`[data-dpad-navigation="${DpadNavigationType.Item}"], .${EMPTY_STATE_CLASS}`}
+  data-dynamic-selector={`[data-dpad-navigation="${DpadNavigationType.Item}"], .${EMPTY_STATE_CLASS}:not(:empty)`}
 >
   {#if $isVisible}
     {#if isHeaderVisible && title}

--- a/projects/client/src/lib/features/cookie-consent/CookieConsentProvider.svelte
+++ b/projects/client/src/lib/features/cookie-consent/CookieConsentProvider.svelte
@@ -1,19 +1,20 @@
 <script lang="ts">
+  import type { DeviceType } from "$lib/models/DeviceType";
   import CookieNotice from "$lib/sections/cookie/CookieNotice.svelte";
-  import { getDeviceType } from "$lib/utils/devices/getDeviceType";
   import { useCookieConsent } from "./useCookieConsent";
 
-  const { hasConsent, children }: { hasConsent: boolean } & ChildrenProps =
-    $props();
+  const {
+    hasConsent,
+    device,
+    children,
+  }: { hasConsent: boolean; device: DeviceType } & ChildrenProps = $props();
 
   const { setConsent } = useCookieConsent();
   setConsent(hasConsent);
-
-  const isTV = $derived(getDeviceType(navigator.userAgent) === "tv");
 </script>
 
 {@render children()}
 
-{#if !isTV}
+{#if device !== "tv"}
   <CookieNotice />
 {/if}

--- a/projects/client/src/lib/features/navigation/_internal/waitForDynamicContent.spec.ts
+++ b/projects/client/src/lib/features/navigation/_internal/waitForDynamicContent.spec.ts
@@ -63,4 +63,24 @@ describe('waitForDynamicContent', () => {
 
     await waitFor(() => expect(resolved).toBe(true));
   });
+
+  it('should resolve if the container is removed', async () => {
+    let resolved = false;
+
+    container.setAttribute('data-dynamic-selector', '.dynamic-item');
+
+    const promise = waitForDynamicContent();
+    promise.then(() => {
+      resolved = true;
+    });
+
+    vi.advanceTimersByTime(CHECK_INTERVAL);
+    expect(resolved).toBe(false);
+
+    container.remove();
+
+    vi.advanceTimersByTime(CHECK_INTERVAL);
+
+    await waitFor(() => expect(resolved).toBe(true));
+  });
 });

--- a/projects/client/src/lib/features/navigation/_internal/waitForDynamicContent.ts
+++ b/projects/client/src/lib/features/navigation/_internal/waitForDynamicContent.ts
@@ -20,6 +20,12 @@ export function waitForDynamicContent() {
     const intervalId = setInterval(() => {
       elapsed += CHECK_INTERVAL;
 
+      if (dynamicElements.some((element) => !element.isConnected)) {
+        clearInterval(intervalId);
+        resolve(null);
+        return;
+      }
+
       const hasLoadedElements = dynamicElements.every((element) => {
         const selector = assertDefined(
           element.getAttribute('data-dynamic-selector'),

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -96,7 +96,10 @@
   <QueryClientProvider client={data.queryClient} device={data.device}>
     <GlobalParameterProvider>
       <AuthProvider isAuthorized={data.auth.isAuthorized} url={data.auth.url}>
-        <CookieConsentProvider hasConsent={data.hasConsent}>
+        <CookieConsentProvider
+          hasConsent={data.hasConsent}
+          device={data.device}
+        >
           <AnalyticsProvider>
             <AutoSigninProvider>
               <LocaleProvider>


### PR DESCRIPTION
## 🎶 Notes 🎶

Some TV/D-pad fixes:

- Waiting for dynamic lists now properly checks the empty state.
- Stop waiting for content if the container is gone.
- The cookie notice now no longer flashes on screen.
- The logo in the stream on button is visible when the button is focused.

## 👀 Example 👀
Before:
<img width="664" alt="Screenshot 2025-05-16 at 13 51 20" src="https://github.com/user-attachments/assets/5f0f1489-18b8-41e8-ab0c-6b95224514ab" />

After:
<img width="664" alt="Screenshot 2025-05-16 at 13 51 09" src="https://github.com/user-attachments/assets/07cf47f9-9f28-4669-8673-09781d5653d2" />
