### PR TITLE
feat(up-next): route director requests to hd instance

### DIFF
--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -20,6 +20,7 @@ import {
   currentUserWatchlistQuery,
   type UserWatchlist,
 } from '../queries/currentUserWatchlistQuery.ts';
+import { getToken, setToken } from '../token/index.ts';
 import { useAuth } from './useAuth.ts';
 
 const ANONYMOUS_USER: UserSettings = {
@@ -103,7 +104,17 @@ export function useUser() {
 
   const user = derived(
     userQueryResponse,
-    ($query) => definedData($query.data),
+    ($query) => {
+      /**
+       * FIXME: this is a quick hack to enable hd nitro only for internal testing
+       * remove once the system is tested
+       */
+      setToken({
+        ...getToken(),
+        isDirector: $query.data?.isDirector,
+      });
+      return definedData($query.data);
+    },
   );
   const history = derived(
     historyQueryResponse,

--- a/projects/client/src/lib/features/auth/token/index.ts
+++ b/projects/client/src/lib/features/auth/token/index.ts
@@ -1,11 +1,13 @@
 type Token = {
   value: string | Nil;
   expiresAt: number | Nil;
+  isDirector?: boolean;
 };
 
 const token: Token = {
   value: null,
   expiresAt: null,
+  isDirector: false,
 };
 
 export function getToken() {
@@ -13,6 +15,8 @@ export function getToken() {
 }
 
 export function setToken(newToken: Token | Nil) {
+  token.isDirector = newToken?.isDirector ?? false;
+
   if (!newToken) {
     token.value = null;
     token.expiresAt = null;

--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
@@ -13,10 +13,18 @@ export function createAuthenticatedFetch<
     const headers = new Headers(modifiedInit?.headers || {});
 
     try {
-      const { value: token } = getToken();
+      const { value: token, isDirector } = getToken();
+      const url = input.toString();
 
       if (token) {
         headers.set('Authorization', `Bearer ${token}`);
+
+        const isNitro = url.includes('/sync/progress/up_next_nitro');
+        const isApiCall = url.includes('apiz.trakt.tv');
+        if (isNitro && isApiCall && isDirector) {
+          input = input.toString().replaceAll('apiz.trakt.tv', 'hd.trakt.tv')
+            .toString();
+        }
       }
 
       return baseFetch(


### PR DESCRIPTION
- Enables routing requests from users with "director" status to the HD instance of the up-next nitro endpoint.
- This allows internal testing of the HD nitro feature.