### PR TITLE
feat: define pwa simulator for android

### DIFF
--- a/projects/client/src/app.html
+++ b/projects/client/src/app.html
@@ -15,8 +15,8 @@
       content="
         default-src 'self';
         img-src 'self' data: https://*.trakt.tv https://trakt.tv https://secure.gravatar.com https://i2.wp.com/ https://*.contentsquare.net https://*.youtube.com;
-        script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.trakt.tv https://*.googletagmanager.com https://*.contentsquare.net;
-        script-src-elem 'self' 'unsafe-inline' https://*.googletagmanager.com https://*.cloudflareinsights.com https://*.trakt.tv/ https://*.contentsquare.net https://static.hj.contentsquare.net;
+        script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.trakt.tv https://*.googletagmanager.com https://*.contentsquare.net http://*.contentsquare.net;
+        script-src-elem 'self' 'unsafe-inline' https://*.googletagmanager.com https://*.cloudflareinsights.com https://*.trakt.tv/ https://*.contentsquare.net https://static.hj.contentsquare.net http://*.contentsquare.net http://t.contentsquare.net;
         worker-src 'self' blob:;
         connect-src 'self' https://*.jsdelivr.net https://*.googleapis.com https://*.gstatic.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.trakt.tv https://*.posthog.com https://*.contentsquare.net https://*.hotjar.com https://*.hotjar.io wss://*.hotjar.com;
         font-src 'self' data: https://fonts.gstatic.com http://fonts.gstatic.com;

--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -199,7 +199,7 @@
       }
     }
 
-    @include for-pwa {
+    &.trakt-navbar-pwa {
       border-radius: 0%;
     }
   }

--- a/projects/client/src/lib/utils/devices/isPWA.ts
+++ b/projects/client/src/lib/utils/devices/isPWA.ts
@@ -6,6 +6,7 @@ export function isPWA() {
   }
 
   return (
+    sessionStorage.getItem('__trakt_pwa_simulator') === 'true' ||
     globalThis.matchMedia('(display-mode: standalone)').matches ||
     globalThis.matchMedia('(display-mode: fullscreen)').matches ||
     globalThis.matchMedia('(display-mode: minimal-ui)').matches

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -25,6 +25,7 @@
   import Navbar from "$lib/sections/navbar/Navbar.svelte";
   import SideNavbar from "$lib/sections/navbar/SideNavbar.svelte";
   import NowPlaying from "$lib/sections/now-playing/NowPlaying.svelte";
+  import { isPWA } from "$lib/utils/devices/isPWA.ts";
   import { WorkerMessage } from "$worker/WorkerMessage";
   import { workerRequest } from "$worker/workerRequest";
   import { SvelteQueryDevtools } from "@tanstack/svelte-query-devtools";
@@ -33,6 +34,10 @@
   const { data, children } = $props();
 
   onMount(async () => {
+    if (isPWA()) {
+      document.body.classList.add("trakt-pwa");
+    }
+
     const ACTIVE_SHA = TRAKT_GIT_SHA;
     const DEPLOYED_SHA = await fetch(DeploymentEndpoint.Get).then((res) =>
       res.text(),
@@ -257,11 +262,9 @@
     );
   }
 
-  @include for-pwa {
-    :global([data-mobile-os="android"] body) {
-      &::after {
-        @include pwa-navbar-shadow(fixed);
-      }
+  :global([data-mobile-os="android"] body.trakt-pwa) {
+    &::after {
+      @include pwa-navbar-shadow(fixed);
     }
   }
 </style>

--- a/projects/client/src/routes/_design_system/pwa/+layout.svelte
+++ b/projects/client/src/routes/_design_system/pwa/+layout.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import { page } from "$app/state";
+
+  const { children } = $props();
+</script>
+
+<div class="trakt-pwa-simulator">
+  <div class="trakt-pwa-simulator-controls">
+    <h5>PWA Simulator</h5>
+    <nav>
+      <a
+        href="/_design_system/pwa/android"
+        class:active={page.url.pathname.includes("/android")}
+      >
+        Android
+      </a>
+      <a
+        href="/_design_system/pwa/ios"
+        class:active={page.url.pathname.includes("/ios")}
+      >
+        iOS
+      </a>
+    </nav>
+  </div>
+
+  <div class="trakt-simulator-content">
+    {@render children()}
+  </div>
+</div>
+
+<style>
+  .trakt-pwa-simulator {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+
+    color: var(--shade-10);
+    background-color: var(--shade-700);
+  }
+
+  .trakt-pwa-simulator-controls {
+    padding: var(--ni-16);
+    background-color: var(--shade-900);
+    border-bottom: 1px solid var(--shade-600);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  nav {
+    display: flex;
+    gap: var(--ni-8);
+  }
+
+  a {
+    padding: var(--ni-8) var(--ni-16);
+    border-radius: var(--border-radius-l);
+    background-color: var(--shade-50);
+    color: var(--shade-900);
+    transition: background-color var(--transition-increment);
+  }
+
+  a:hover {
+    color: var(--shade-100);
+    background-color: var(--purple-500);
+  }
+
+  a.active {
+    background-color: var(--purple-700);
+    color: var(--shade-10);
+  }
+
+  .trakt-simulator-content {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex: 1;
+  }
+</style>

--- a/projects/client/src/routes/_design_system/pwa/android/+page.svelte
+++ b/projects/client/src/routes/_design_system/pwa/android/+page.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+  import { writable } from "svelte/store";
+
+  const themeColor = writable("transparent");
+
+  function setupFrame(ev: Event) {
+    const iframeElement = ev.target as HTMLIFrameElement;
+
+    try {
+      const iframeDocument = iframeElement.contentDocument;
+      const iframeWindow = iframeElement.contentWindow;
+
+      if (!iframeDocument || !iframeWindow) {
+        console.error("Cannot access iframe document or window");
+        return;
+      }
+
+      const scriptElement = iframeDocument.createElement("script");
+      scriptElement.textContent = `
+          // Set PWA simulator flag in localStorage
+          sessionStorage.setItem('__trakt_pwa_simulator', 'true');
+
+          console.log('📱 PWA Simulator activated - App will behave as if installed as PWA');
+        `;
+
+      iframeDocument.head.appendChild(scriptElement);
+      iframeDocument.documentElement.setAttribute("data-mobile-os", "android");
+
+      const themeColorMeta = iframeDocument.querySelector(
+        'meta[name="theme-color"]',
+      ) as HTMLMetaElement;
+
+      function setThemeColor() {
+        const color = themeColorMeta?.getAttribute("content");
+        if (!color) {
+          console.error("🎨 Theme color not found");
+
+          return;
+        }
+
+        console.log("🎨 Theme color found:", color);
+        themeColor.set(color);
+      }
+
+      setThemeColor();
+
+      const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+          if (
+            mutation.type === "attributes" &&
+            mutation.attributeName === "content"
+          ) {
+            setThemeColor();
+          }
+        });
+      });
+      observer.observe(themeColorMeta, { attributes: true });
+
+      console.log("🤖 Android mode activated");
+    } catch (e) {
+      console.error("Failed to inject PWA simulator into iframe:", e);
+    }
+  }
+
+  function formatTime(date: Date): string {
+    return date.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  }
+
+  const time = writable(formatTime(new Date()));
+
+  setInterval(() => {
+    time.set(formatTime(new Date()));
+  }, 1000);
+</script>
+
+<div
+  class="trakt-android-phone-container"
+  style:--background-android-theme-color={$themeColor}
+>
+  <div class="trakt-android-phone-top-bar">
+    <div class="trakt-android-phone-top-bar-left">{$time}</div>
+    <div class="trakt-android-phone-top-bar-right">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        height="24px"
+        viewBox="0 -960 960 960"
+        width="24px"
+        fill="currentColor"
+        style:scale="0.75"
+      >
+        <path
+          d="M480-120 0-600q96-98 220-149t260-51q137 0 261 51t219 149L480-120ZM299-415q38-28 84-43.5t97-15.5q51 0 97 15.5t84 43.5l183-183q-78-59-170.5-90.5T480-720q-101 0-193.5 31.5T116-598l183 183Z"
+        />
+      </svg>
+
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        height="24px"
+        viewBox="0 -960 960 960"
+        width="24px"
+        fill="currentColor"
+        style:scale="0.75"
+      >
+        <path d="m80-80 800-800v800H80Z" />
+      </svg>
+
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        height="24px"
+        viewBox="0 -960 960 960"
+        width="24px"
+        fill="currentColor"
+        style:scale="0.75"
+      >
+        <path
+          d="M320-80q-17 0-28.5-11.5T280-120v-640q0-17 11.5-28.5T320-800h80v-80h160v80h80q17 0 28.5 11.5T680-760v640q0 17-11.5 28.5T640-80H320Z"
+        />
+      </svg>
+    </div>
+  </div>
+  <div class="trakt-pwa-content">
+    <iframe
+      class="trakt-lite-android-pwa"
+      title="Trakt Lite Android PWA"
+      onload={setupFrame}
+      src="/"
+    >
+    </iframe>
+  </div>
+  <div class="trakt-android-gesture-navbar">
+    <div class="trakt-android-gesture-pill"></div>
+  </div>
+</div>
+
+<style>
+  * {
+    transition:
+      background-color var(--transition-increment) ease-in-out,
+      color var(--transition-increment) ease-in-out;
+  }
+
+  .trakt-android-phone-container {
+    --width-android: 390px;
+    --height-android: 860px;
+    --height-android-gesture: 24px;
+    --width-gesture-pill: 80px;
+    --height-gesture-pill: 4px;
+
+    --width-pwa: 390px;
+    --height-pwa: 800px;
+
+    display: flex;
+    position: relative;
+    justify-content: center;
+    height: var(--height-android);
+    background-color: var(--shade-900);
+    border-radius: var(--border-radius-xl);
+    overflow: hidden;
+
+    .trakt-android-phone-top-bar {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: calc(
+        var(--height-android) - var(--height-pwa) -
+          var(--height-android-gesture)
+      );
+      background-color: var(--background-android-theme-color);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      padding: var(--ni-16);
+      box-sizing: border-box;
+
+      font-size: var(--ni-12);
+
+      .trakt-android-phone-top-bar-left {
+        font-size: var(--font-size-m);
+        font-weight: var(--font-weight-bold);
+        text-align: left;
+        flex-grow: 1;
+        color: var(--background-android-theme-color);
+        filter: invert(1);
+      }
+
+      .trakt-android-phone-top-bar-right {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        color: var(--background-android-theme-color);
+        filter: invert(1);
+
+        svg {
+          margin: 0 var(--ni-neg-2);
+        }
+      }
+    }
+
+    .trakt-pwa-content {
+      margin-top: calc(
+        var(--height-android) - var(--height-pwa) -
+          var(--height-android-gesture)
+      );
+    }
+
+    .trakt-android-gesture-navbar {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: var(--height-android-gesture);
+      background-color: black;
+      display: flex;
+      justify-content: center;
+
+      .trakt-android-gesture-pill {
+        width: var(--width-gesture-pill);
+        height: var(--height-gesture-pill);
+        margin-top: calc(
+          calc(var(--height-android-gesture) / 2) -
+            calc(var(--height-gesture-pill) / 2)
+        );
+
+        background-color: var(--shade-50);
+        border-radius: var(--border-radius-l);
+      }
+    }
+  }
+
+  iframe {
+    display: block;
+    margin: 0 auto;
+    width: var(--width-pwa);
+    height: var(--height-pwa);
+    border: none;
+  }
+
+  :global(header, footer, .trakt-mobile-navbar, .trakt-mobile-navbar-spacer) {
+    display: none !important;
+  }
+</style>

--- a/projects/client/src/routes/_design_system/pwa/ios/+page.svelte
+++ b/projects/client/src/routes/_design_system/pwa/ios/+page.svelte
@@ -1,0 +1,1 @@
+<pre>TODO: @seferturan</pre>

--- a/projects/client/src/style/scss/mixins/index.scss
+++ b/projects/client/src/style/scss/mixins/index.scss
@@ -48,20 +48,6 @@
   }
 }
 
-@mixin for-pwa {
-  @media (display-mode: standalone) {
-    @content;
-  }
-
-  @media (display-mode: fullscreen) {
-    @content;
-  }
-
-  @media (display-mode: minimal-ui) {
-    @content;
-  }
-}
-
 @mixin default-link-style {
   text-decoration-color: var(--color-link-active);
 


### PR DESCRIPTION
Adds a PWA simulator for testing and development, enhancing the design system.

Key changes:
- Introduces routes for simulating PWA behavior on Android and iOS.
- Define simulator for Android.
- Enhances PWA detection logic to include simulator flag.
- Improves Content Security Policy to allow simulator scripts.
- Applies PWA styling using a class on the body element.

Test here: http://localhost:5173/_design_system/pwa/android

https://github.com/user-attachments/assets/2fd752e0-5801-43de-8734-d057691f861a