### PR TITLE
feat(summary): ensure videos are in publish order

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToMediaVideo.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaVideo.ts
@@ -17,5 +17,6 @@ export function mapToMediaVideo(
     type: video.type,
     url: video.url,
     thumbnail,
+    publishedAt: new Date(video.published_at),
   };
 }

--- a/projects/client/src/lib/requests/models/MediaVideo.ts
+++ b/projects/client/src/lib/requests/models/MediaVideo.ts
@@ -16,5 +16,6 @@ export const MediaVideoSchema = z.object({
   url: z.string().url(),
   thumbnail: z.string().url(),
   title: z.string(),
+  publishedAt: z.date(),
 });
 export type MediaVideo = z.infer<typeof MediaVideoSchema>;

--- a/projects/client/src/lib/requests/queries/movies/movieVideosQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieVideosQuery.spec.ts
@@ -15,6 +15,6 @@ describe('movieVideosQuery', () => {
       mapper: (response) => response?.data,
     });
 
-    expect(result).to.deep.equal(MovieHereticVideoMappedMock);
+    expect(result).to.have.deep.members(MovieHereticVideoMappedMock);
   });
 });

--- a/projects/client/src/lib/requests/queries/movies/movieVideosQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieVideosQuery.ts
@@ -29,7 +29,13 @@ export const movieVideosQuery = defineQuery({
   mapper: (response) =>
     response.body
       .filter((video) => video.site === 'youtube')
-      .map(mapToMediaVideo),
+      .map(mapToMediaVideo)
+      .sort((a, b) => {
+        return (
+          new Date(a.publishedAt).getTime() -
+          new Date(b.publishedAt).getTime()
+        );
+      }),
   schema: MediaVideoSchema.array(),
   ttl: time.days(7),
 });

--- a/projects/client/src/lib/requests/queries/movies/showVideosQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/showVideosQuery.spec.ts
@@ -18,6 +18,6 @@ describe('showVideosQuery', () => {
       mapper: (response) => response?.data,
     });
 
-    expect(result).to.deep.equal(ShowSiloVideoMappedMock);
+    expect(result).to.have.deep.members(ShowSiloVideoMappedMock);
   });
 });

--- a/projects/client/src/lib/requests/queries/movies/showVideosQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/showVideosQuery.ts
@@ -80,6 +80,12 @@ export const showVideosQuery = defineQuery({
         }
         seen.add(video.id);
         return true;
+      })
+      .sort((a, b) => {
+        return (
+          new Date(a.publishedAt).getTime() -
+          new Date(b.publishedAt).getTime()
+        );
       });
   },
   schema: MediaVideoSchema.array(),

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticVideoMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticVideoMappedMock.ts
@@ -7,6 +7,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'clip',
     'url': 'https://youtube.com/watch?v=72-5rMRKN9s',
     'thumbnail': 'https://img.youtube.com/vi/72-5rMRKN9s/hqdefault.jpg',
+    'publishedAt': new Date('2025-03-19T20:00:03.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4l333mit5svrd',
@@ -14,6 +15,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'clip',
     'url': 'https://youtube.com/watch?v=Sansjt4DiIY',
     'thumbnail': 'https://img.youtube.com/vi/Sansjt4DiIY/hqdefault.jpg',
+    'publishedAt': new Date('2025-03-18T20:00:24.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lms8kjc47iul',
@@ -21,6 +23,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'clip',
     'url': 'https://youtube.com/watch?v=nhCGUYhfubA',
     'thumbnail': 'https://img.youtube.com/vi/nhCGUYhfubA/hqdefault.jpg',
+    'publishedAt': new Date('2025-03-17T20:00:26.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4l3jiejts104u',
@@ -28,6 +31,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'teaser',
     'url': 'https://youtube.com/watch?v=Swm7m1xGNwg',
     'thumbnail': 'https://img.youtube.com/vi/Swm7m1xGNwg/hqdefault.jpg',
+    'publishedAt': new Date('2025-01-02T16:31:42.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4ks9na9ull4lp',
@@ -36,6 +40,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'featurette',
     'url': 'https://youtube.com/watch?v=IwGYCQvl3Bk',
     'thumbnail': 'https://img.youtube.com/vi/IwGYCQvl3Bk/hqdefault.jpg',
+    'publishedAt': new Date('2024-12-05T16:00:06.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lmu3np70n7vi',
@@ -43,6 +48,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'clip',
     'url': 'https://youtube.com/watch?v=nk1m1_pigwA',
     'thumbnail': 'https://img.youtube.com/vi/nk1m1_pigwA/hqdefault.jpg',
+    'publishedAt': new Date('2024-11-20T16:00:51.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4kcks9ns30tba',
@@ -50,6 +56,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'clip',
     'url': 'https://youtube.com/watch?v=5GulXtPKj10',
     'thumbnail': 'https://img.youtube.com/vi/5GulXtPKj10/hqdefault.jpg',
+    'publishedAt': new Date('2024-11-19T16:00:06.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lojvi7phvhea',
@@ -57,6 +64,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'clip',
     'url': 'https://youtube.com/watch?v=r5fW-Qjh_YY',
     'thumbnail': 'https://img.youtube.com/vi/r5fW-Qjh_YY/hqdefault.jpg',
+    'publishedAt': new Date('2024-11-18T16:00:48.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lr7df4up65qv',
@@ -64,6 +72,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'featurette',
     'url': 'https://youtube.com/watch?v=uGh5EZ4mWMA',
     'thumbnail': 'https://img.youtube.com/vi/uGh5EZ4mWMA/hqdefault.jpg',
+    'publishedAt': new Date('2024-11-04T16:00:06.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lgvo3nkn3ol1',
@@ -72,6 +81,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'featurette',
     'url': 'https://youtube.com/watch?v=feFiiN82PpA',
     'thumbnail': 'https://img.youtube.com/vi/feFiiN82PpA/hqdefault.jpg',
+    'publishedAt': new Date('2024-10-28T17:00:18.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lpbi85bgkpta',
@@ -79,6 +89,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'teaser',
     'url': 'https://youtube.com/watch?v=qsqs2WwjYiU',
     'thumbnail': 'https://img.youtube.com/vi/qsqs2WwjYiU/hqdefault.jpg',
+    'publishedAt': new Date('2024-10-27T11:52:14.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lptl1fjgejc6',
@@ -86,6 +97,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'teaser',
     'url': 'https://youtube.com/watch?v=rmUWhjwIols',
     'thumbnail': 'https://img.youtube.com/vi/rmUWhjwIols/hqdefault.jpg',
+    'publishedAt': new Date('2024-10-24T09:02:23.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4ld082fm72f6m',
@@ -93,6 +105,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'teaser',
     'url': 'https://youtube.com/watch?v=aW1o_WvHVtQ',
     'thumbnail': 'https://img.youtube.com/vi/aW1o_WvHVtQ/hqdefault.jpg',
+    'publishedAt': new Date('2024-10-15T08:57:58.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4k9q10kjtie91',
@@ -101,6 +114,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'featurette',
     'url': 'https://youtube.com/watch?v=0jZP-4pieI4',
     'thumbnail': 'https://img.youtube.com/vi/0jZP-4pieI4/hqdefault.jpg',
+    'publishedAt': new Date('2024-10-14T19:51:58.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lk5j2pgf99fu',
@@ -108,6 +122,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'trailer',
     'url': 'https://youtube.com/watch?v=jpWUOxRozZg',
     'thumbnail': 'https://img.youtube.com/vi/jpWUOxRozZg/hqdefault.jpg',
+    'publishedAt': new Date('2024-10-08T12:59:00.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4l5lnu5qps8sa',
@@ -115,6 +130,7 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'trailer',
     'url': 'https://youtube.com/watch?v=WSo0lmONZIU',
     'thumbnail': 'https://img.youtube.com/vi/WSo0lmONZIU/hqdefault.jpg',
+    'publishedAt': new Date('2024-09-19T12:59:00.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4kv7mhlirc1de',
@@ -122,5 +138,6 @@ export const MovieHereticVideoMappedMock: MediaVideo[] = [
     'type': 'trailer',
     'url': 'https://youtube.com/watch?v=O9i2vmFhSSY',
     'thumbnail': 'https://img.youtube.com/vi/O9i2vmFhSSY/hqdefault.jpg',
+    'publishedAt': new Date('2024-06-25T13:00:31.000Z'),
   },
 ];

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloVideoMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloVideoMappedMock.ts
@@ -7,6 +7,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'behind the scenes',
     'url': 'https://youtube.com/watch?v=QQ6x6NjVM_E',
     'thumbnail': 'https://img.youtube.com/vi/QQ6x6NjVM_E/hqdefault.jpg',
+    'publishedAt': new Date('2023-06-30T16:59:46.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4koigfptp0usb',
@@ -14,6 +15,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'featurette',
     'url': 'https://youtube.com/watch?v=DsQzTUeLkbA',
     'thumbnail': 'https://img.youtube.com/vi/DsQzTUeLkbA/hqdefault.jpg',
+    'publishedAt': new Date('2023-04-26T14:59:56.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4klee39hiflde',
@@ -21,6 +23,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'opening credits',
     'url': 'https://youtube.com/watch?v=AJlOS6ZeIcA',
     'thumbnail': 'https://img.youtube.com/vi/AJlOS6ZeIcA/hqdefault.jpg',
+    'publishedAt': new Date('2023-04-25T21:00:04.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4kf8bnk17v714',
@@ -28,6 +31,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'trailer',
     'url': 'https://youtube.com/watch?v=8ZYhuvIv1pA',
     'thumbnail': 'https://img.youtube.com/vi/8ZYhuvIv1pA/hqdefault.jpg',
+    'publishedAt': new Date('2023-04-06T12:59:48.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4ld8dth432lhj',
@@ -35,6 +39,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'teaser',
     'url': 'https://youtube.com/watch?v=bBMajXwi6Cs',
     'thumbnail': 'https://img.youtube.com/vi/bBMajXwi6Cs/hqdefault.jpg',
+    'publishedAt': new Date('2023-03-06T14:00:51.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lc80ejiglkjj',
@@ -42,6 +47,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'featurette',
     'url': 'https://youtube.com/watch?v=_tHrcff6BgI',
     'thumbnail': 'https://img.youtube.com/vi/_tHrcff6BgI/hqdefault.jpg',
+    'publishedAt': new Date('2025-01-28T19:59:52.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4li0g9cfvocft',
@@ -49,6 +55,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'behind the scenes',
     'url': 'https://youtube.com/watch?v=gr9s1ubiH3w',
     'thumbnail': 'https://img.youtube.com/vi/gr9s1ubiH3w/hqdefault.jpg',
+    'publishedAt': new Date('2025-01-15T19:59:59.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4l1soj14rpvuh',
@@ -56,6 +63,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'behind the scenes',
     'url': 'https://youtube.com/watch?v=QlmvFwUlIA4',
     'thumbnail': 'https://img.youtube.com/vi/QlmvFwUlIA4/hqdefault.jpg',
+    'publishedAt': new Date('2024-12-09T20:29:49.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lfhhc18ircb5',
@@ -63,6 +71,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'featurette',
     'url': 'https://youtube.com/watch?v=deWAAmrHvVQ',
     'thumbnail': 'https://img.youtube.com/vi/deWAAmrHvVQ/hqdefault.jpg',
+    'publishedAt': new Date('2024-11-15T17:59:51.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lfrmf7sdmlu5',
@@ -70,6 +79,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'recap',
     'url': 'https://youtube.com/watch?v=eTGbi_oElCQ',
     'thumbnail': 'https://img.youtube.com/vi/eTGbi_oElCQ/hqdefault.jpg',
+    'publishedAt': new Date('2024-11-14T19:59:49.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4ls7jg7lloocs',
@@ -77,6 +87,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'recap',
     'url': 'https://youtube.com/watch?v=w5BoJmMt0t4',
     'thumbnail': 'https://img.youtube.com/vi/w5BoJmMt0t4/hqdefault.jpg',
+    'publishedAt': new Date('2024-11-12T17:59:46.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4kc4u6lrihte4',
@@ -84,6 +95,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'recap',
     'url': 'https://youtube.com/watch?v=3qPZM6S56ww',
     'thumbnail': 'https://img.youtube.com/vi/3qPZM6S56ww/hqdefault.jpg',
+    'publishedAt': new Date('2024-11-11T22:59:52.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4leqai4m226hd',
@@ -91,6 +103,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'recap',
     'url': 'https://youtube.com/watch?v=ceYm0eDw7tg',
     'thumbnail': 'https://img.youtube.com/vi/ceYm0eDw7tg/hqdefault.jpg',
+    'publishedAt': new Date('2024-11-11T18:04:51.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4ls025968sjp1',
@@ -98,6 +111,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'clip',
     'url': 'https://youtube.com/watch?v=uiBM-BCgANE',
     'thumbnail': 'https://img.youtube.com/vi/uiBM-BCgANE/hqdefault.jpg',
+    'publishedAt': new Date('2024-11-01T15:00:50.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lqqpustcdkes',
@@ -105,6 +119,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'featurette',
     'url': 'https://youtube.com/watch?v=suP0-oMb9fA',
     'thumbnail': 'https://img.youtube.com/vi/suP0-oMb9fA/hqdefault.jpg',
+    'publishedAt': new Date('2024-10-21T18:59:51.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4kmtme45fmg5t',
@@ -112,6 +127,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'trailer',
     'url': 'https://youtube.com/watch?v=CLJDR-vFUdY',
     'thumbnail': 'https://img.youtube.com/vi/CLJDR-vFUdY/hqdefault.jpg',
+    'publishedAt': new Date('2024-10-14T13:59:46.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4kbote16c5t4g',
@@ -119,6 +135,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'featurette',
     'url': 'https://youtube.com/watch?v=3aPXnDXpdHw',
     'thumbnail': 'https://img.youtube.com/vi/3aPXnDXpdHw/hqdefault.jpg',
+    'publishedAt': new Date('2024-07-30T18:23:01.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4ltf5g6g304fq',
@@ -126,6 +143,7 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'behind the scenes',
     'url': 'https://youtube.com/watch?v=wiVr54aeXwI',
     'thumbnail': 'https://img.youtube.com/vi/wiVr54aeXwI/hqdefault.jpg',
+    'publishedAt': new Date('2024-07-28T01:29:46.000Z'),
   },
   {
     'id': 'vrlu23ub93cpubuqs4v4lf215nj06js1',
@@ -133,5 +151,6 @@ export const ShowSiloVideoMappedMock: MediaVideo[] = [
     'type': 'teaser',
     'url': 'https://youtube.com/watch?v=e1ajCMLUYHw',
     'thumbnail': 'https://img.youtube.com/vi/e1ajCMLUYHw/hqdefault.jpg',
+    'publishedAt': new Date('2024-07-27T23:59:48.000Z'),
   },
 ];


### PR DESCRIPTION
This pull request introduces changes to include a `publishedAt` field for media videos, ensuring proper handling of publication dates across the application. The changes also add sorting functionality to organize videos by their publication date in ascending order.

### Enhancements to Media Video Data Model:

* [`projects/client/src/lib/requests/models/MediaVideo.ts`](diffhunk://#diff-611fe6545b7777cace9df7b71460788e0e90e2fb54a11aae3a2d0a382420149fR19): Added a new `publishedAt` field to the `MediaVideoSchema` with a `z.date()` type to validate media video publication dates.

### Mapping and Query Updates:

* [`projects/client/src/lib/requests/_internal/mapToMediaVideo.ts`](diffhunk://#diff-0df72f0e06a7b20291e4a11ae2996477a3e137eeb29af40f60f64ac7edcaba50R20): Updated the `mapToMediaVideo` function to include the `publishedAt` field when mapping video data.
* [`projects/client/src/lib/requests/queries/movies/movieVideosQuery.ts`](diffhunk://#diff-91f44444884e6f83c62b8ebdf7146de40611e2c3f2e06509e278b8d696363206L32-R38): Modified the `movieVideosQuery` to sort videos by their `publishedAt` field in ascending order after filtering and mapping.
* [`projects/client/src/lib/requests/queries/movies/showVideosQuery.ts`](diffhunk://#diff-dc2c393e70a16ab1a0efa1e7414868dcd7b125932c806b1fc9e2513e7ed4924aR83-R88): Added sorting by the `publishedAt` field in the `showVideosQuery` to ensure consistent ordering of videos.