### PR TITLE
Enables HD up-next data for all users

### DIFF
--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -20,7 +20,6 @@ import {
   currentUserWatchlistQuery,
   type UserWatchlist,
 } from '../queries/currentUserWatchlistQuery.ts';
-import { getToken, setToken } from '../token/index.ts';
 import { useAuth } from './useAuth.ts';
 
 const ANONYMOUS_USER: UserSettings = {
@@ -104,17 +103,7 @@ export function useUser() {
 
   const user = derived(
     userQueryResponse,
-    ($query) => {
-      /**
-       * FIXME: this is a quick hack to enable hd nitro only for internal testing
-       * remove once the system is tested
-       */
-      setToken({
-        ...getToken(),
-        isDirector: $query.data?.isDirector,
-      });
-      return definedData($query.data);
-    },
+    ($query) => definedData($query.data),
   );
   const history = derived(
     historyQueryResponse,

--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
@@ -13,7 +13,7 @@ export function createAuthenticatedFetch<
     const headers = new Headers(modifiedInit?.headers || {});
 
     try {
-      const { value: token, isDirector } = getToken();
+      const { value: token } = getToken();
       const url = input.toString();
 
       if (token) {
@@ -21,7 +21,7 @@ export function createAuthenticatedFetch<
 
         const isNitro = url.includes('/sync/progress/up_next_nitro');
         const isApiCall = url.includes('apiz.trakt.tv');
-        if (isNitro && isApiCall && isDirector) {
+        if (isNitro && isApiCall) {
           input = input.toString().replaceAll('apiz.trakt.tv', 'hd.trakt.tv')
             .toString();
         }


### PR DESCRIPTION
- Removes the `isDirector` check for accessing HD up-next data, making it available to all users.
- Cleans up associated code related to internal testing.