### PR TITLE
fix(summary): poster overlay colors in light mode

### DIFF
--- a/projects/client/src/lib/components/summary/SummaryPoster.svelte
+++ b/projects/client/src/lib/components/summary/SummaryPoster.svelte
@@ -85,7 +85,7 @@
 
     pointer-events: none;
 
-    border: var(--overlay-border-size) solid var(--color-foreground);
+    border: var(--overlay-border-size) solid var(--color-overlay-foreground);
   }
 
   .has-active-overlay:hover {

--- a/projects/client/src/lib/sections/summary/components/overlay/StreamOnOverlay.svelte
+++ b/projects/client/src/lib/sections/summary/components/overlay/StreamOnOverlay.svelte
@@ -32,6 +32,8 @@
     --source-shadow: var(--ni-2) var(--ni-2) var(--ni-4)
       var(--color-background-purple);
 
+    color: var(--color-overlay-foreground);
+
     width: 100%;
     height: 100%;
     display: flex;

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -100,4 +100,9 @@
     var(--color-background) 70%,
     transparent 30%
   );
+
+  /**
+   * Poster overlay
+   */
+  --color-overlay-foreground: var(--shade-10);
 }


### PR DESCRIPTION
## ♪ Note ♪

- The overlay needs a static color.

## 👀 Example 👀
Before:
<img width="1043" alt="Screenshot 2025-05-19 at 20 46 02" src="https://github.com/user-attachments/assets/acd38c12-c1f2-4643-9778-75b9d27b6f0a" />

After:
<img width="1043" alt="Screenshot 2025-05-19 at 20 49 39" src="https://github.com/user-attachments/assets/02f42174-0a14-4621-8298-47dc9f2f31cb" />
