### PR TITLE
feat / enhances card covers with logo overlays

### DIFF
--- a/projects/client/src/lib/components/card/CardCover.svelte
+++ b/projects/client/src/lib/components/card/CardCover.svelte
@@ -7,6 +7,7 @@
 
   const {
     src,
+    overlaySrc,
     alt,
     badge,
     tag,
@@ -43,15 +44,35 @@
       {@render tag()}
     </div>
   {/if}
-  <div class="trakt-card-cover-image" class:has-gradient={style === "gradient"}>
-    <span {id} class="trakt-cover-image-title meta-info">{title}</span>
+  <div
+    class="trakt-card-cover-image"
+    class:has-overlay={overlaySrc}
+    class:has-gradient={style === "gradient"}
+  >
     <CrossOriginImage
+      classList="trakt-card-cover-image"
       animate={false}
       {src}
       {alt}
       onload={() => (isImagePending = false)}
       aria-labelledby={id}
     />
+    {#if overlaySrc && !PLACEHOLDERS.includes(overlaySrc)}
+      <CrossOriginImage
+        classList="trakt-logo-overlay"
+        animate={false}
+        src={overlaySrc}
+        {alt}
+        onload={() => (isImagePending = false)}
+        aria-labelledby={id}
+      />
+    {/if}
+
+    {#if overlaySrc && PLACEHOLDERS.includes(overlaySrc)}
+      <p class="trakt-logo-overlay">
+        {title}
+      </p>
+    {/if}
   </div>
 </div>
 
@@ -100,7 +121,7 @@
     }
 
     &:not(.trakt-card-cover-placeholder):not(.trakt-card-cover-youtube) {
-      :global(img) {
+      :global(img.trakt-card-cover-image) {
         object-position: top;
       }
     }
@@ -114,26 +135,68 @@
       opacity calc(var(--transition-increment) * 2) ease-in-out,
       filter var(--transition-increment) ease-in-out;
 
-    .trakt-cover-image-title {
+    :global(.trakt-logo-overlay) {
       position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
       bottom: 0;
 
-      display: flex;
-      justify-content: center;
-      align-items: flex-end;
-      padding: var(--ni-8);
+      padding-bottom: var(--ni-8);
 
-      text-align: center;
+      z-index: var(--layer-raised);
+
+      filter: drop-shadow(
+        var(--ni-1) var(--ni-1) var(--ni-2) rgba(0, 0, 0, 0.25)
+      );
     }
 
-    :global(img) {
+    :global(img.trakt-card-cover-image) {
       position: relative;
       width: 100%;
       height: 100%;
       object-fit: cover;
+    }
+
+    :global(img.trakt-logo-overlay) {
+      --logo-width: 60%;
+
+      width: var(--logo-width);
+      height: 100%;
+
+      position: absolute;
+      bottom: 0;
+      left: calc((100% - var(--logo-width)) / 2);
+
+      object-fit: contain;
+      object-position: bottom;
+    }
+
+    p.trakt-logo-overlay {
+      width: 100%;
+
+      color: var(--shade-20);
+
+      text-align: center;
+      text-transform: uppercase;
+      font-weight: bold;
+
+      padding: 8px;
+      box-sizing: border-box;
+    }
+
+    &.has-overlay::after {
+      content: "";
+
+      position: absolute;
+      bottom: 0;
+      left: 0;
+
+      width: 100%;
+      height: 75%;
+
+      background: linear-gradient(
+        180deg,
+        transparent 0%,
+        var(--shade-900) 100%
+      );
     }
   }
 </style>

--- a/projects/client/src/lib/components/card/CardCoverProps.ts
+++ b/projects/client/src/lib/components/card/CardCoverProps.ts
@@ -2,6 +2,7 @@ import type { Snippet } from 'svelte';
 
 export type CardCoverProps = {
   src: string;
+  overlaySrc?: string;
   alt: string;
   title: string;
   badge?: Snippet;

--- a/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
+++ b/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { appendClassList } from "$lib/utils/actions/appendClassList";
   import { writable } from "svelte/store";
   import type { ImageProps } from "./ImageProps";
   import { resolveEnvironmentUri } from "./resolveEnvironmentUri";
@@ -10,6 +11,7 @@
     animate = true,
     onload: _onload,
     onerror: _onerror,
+    classList = "",
     ...rest
   }: ImageProps = $props();
 
@@ -21,6 +23,7 @@
   {loading}
   class:image-loaded={$isImageLoaded}
   class:image-animation-enabled={animate}
+  use:appendClassList={classList}
   src={$response.uri}
   {alt}
   onerror={(ev) => {

--- a/projects/client/src/lib/features/image/components/ImageProps.ts
+++ b/projects/client/src/lib/features/image/components/ImageProps.ts
@@ -1,1 +1,4 @@
-export type ImageProps = HTMLImageElementProps & { animate?: boolean };
+export type ImageProps = HTMLImageElementProps & {
+  animate?: boolean;
+  classList?: string;
+};

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -6,7 +6,6 @@
   import CardCover from "$lib/components/card/CardCover.svelte";
   import LandscapeCard from "$lib/components/media/card/LandscapeCard.svelte";
   import PortraitCard from "$lib/components/media/card/PortraitCard.svelte";
-  import GenreList from "$lib/components/summary/GenreList.svelte";
   import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
@@ -29,7 +28,7 @@
   const variant = $derived(rest.variant ?? $defaultVariant);
 </script>
 
-{#snippet content(mediaCoverImageUrl: string)}
+{#snippet content(mediaCoverImageUrl: string, mediaCoverOverlay?: string)}
   {#if popupActions}
     <CardActionBar>
       {#snippet actions()}
@@ -46,6 +45,7 @@
     <CardCover
       title={media.title}
       src={mediaCoverImageUrl}
+      overlaySrc={mediaCoverOverlay}
       alt={m.media_poster({ title: media.title })}
       {badge}
     />
@@ -61,18 +61,8 @@
 
 {#if variant === "landscape"}
   <LandscapeCard>
-    {@render content(media.cover.url.thumb)}
-    <CardFooter {action} {tag}>
-      <Link href={UrlBuilder.media(type, media.slug)}>
-        <p class="trakt-card-title small ellipsis">
-          {media.title}
-        </p>
-      </Link>
-      <GenreList
-        genres={media.genres}
-        classList="trakt-card-subtitle small ellipsis"
-      />
-    </CardFooter>
+    {@render content(media.cover.url.thumb, media.logo.url.medium)}
+    <CardFooter {action} {tag} />
   </LandscapeCard>
 {/if}
 

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -96,9 +96,12 @@
   /*
   * Overrides
   */
+  .trakt-background-cover-image,
   .trakt-cover-image {
-    opacity: 0.25;
+    opacity: 0.75;
   }
+
+
 
   /**
    * Now playing


### PR DESCRIPTION
Improves the visual appeal of media cards by displaying logos over the cover images.

- Adds an `overlaySrc` property to the `CardCover` component, allowing a logo to be displayed on top of the cover image.
- Implements styling to ensure the logo is appropriately positioned and visually appealing.
- Introduces fallback to title text if a logo is unavailable.