### PR TITLE
fix(list): render lists expanded on mobile

### DIFF
--- a/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
+++ b/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia.ts";
   import ListSummaryItem from "../components/list-summary/ListSummaryItem.svelte";
   import type { PersonalListType } from "./models/PersonalListType.ts";
   import { usePersonalListsSummary } from "./usePersonalListsSummary.ts";
@@ -25,8 +26,10 @@
     }
   });
 
+  const isMobile = useMedia(WellKnownMediaQuery.mobile);
+
   const variant = $derived.by(() => {
-    if ($lists.length === 1) {
+    if ($lists.length === 1 || $isMobile) {
       return "preview";
     }
 


### PR DESCRIPTION
This pull request introduces a responsive enhancement to the `PersonalLists.svelte` component by incorporating media query detection to adjust the UI based on device type. The most notable changes include importing and utilizing a media query utility to determine if the user is on a mobile device and updating the logic for determining the `variant` property accordingly.

### Responsive Behavior Enhancements:
* [`projects/client/src/lib/sections/lists/user/PersonalLists.svelte`](diffhunk://#diff-2036229705f11feb979fbd64e8b958db57fb8e73c38d38eb100efde1933f0cbcR4): Added the `useMedia` utility and `WellKnownMediaQuery.mobile` to detect mobile devices and introduced the `isMobile` constant. Updated the `variant` logic to set it to "preview" when the user is on a mobile device or when there is only one list. [[1]](diffhunk://#diff-2036229705f11feb979fbd64e8b958db57fb8e73c38d38eb100efde1933f0cbcR4) [[2]](diffhunk://#diff-2036229705f11feb979fbd64e8b958db57fb8e73c38d38eb100efde1933f0cbcR29-R32)