### PR TITLE
feat / data fetching with color palette

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "npm:@cucumber/cucumber@^11.2.0": "11.2.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.0.2_@cucumber+messages@27.0.2",
     "npm:@google/generative-ai@0.24": "0.24.0",
     "npm:@inlang/paraglide-js@^2.0.12": "2.0.12",
-    "npm:@jsr/trakt__api@~0.1.37": "0.1.37_zod@3.24.1",
+    "npm:@jsr/trakt__api@~0.1.38": "0.1.38_zod@3.24.1",
     "npm:@playwright/test@^1.51.1": "1.51.1",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.25.3__acorn@8.14.1",
     "npm:@svelte-put/qr@^2.1.0": "2.1.0_svelte@5.25.3__acorn@8.14.1",
@@ -2189,14 +2189,14 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.1.37_zod@3.24.1": {
-      "integrity": "sha512-AqDVLt/j0fGTpLzOhOXBHaa0PeaLvdUTURcT0bXy+unxCWsMLKJMDAxsC/ekjksHs2zDaKDLdTXrZFNjSZjX3g==",
+    "@jsr/trakt__api@0.1.38_zod@3.24.1": {
+      "integrity": "sha512-r8Qq4VXNKVX2q8WllbIW0YsYEpZBalak3zteC7t8Asyr0sE9F9D5Pzft2rvA5rhGoTWdTP5h1yKyVV7X+0nZzQ==",
       "dependencies": [
         "@anatine/zod-openapi",
         "@ts-rest/core",
         "zod@3.24.1"
       ],
-      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.1.37.tgz"
+      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.1.38.tgz"
     },
     "@lix-js/sdk@0.4.7_kysely@0.27.6": {
       "integrity": "sha512-pRbW+joG12L0ULfMiWYosIW0plmW4AsUdiPCp+Z8rAsElJ+wJ6in58zhD3UwUcd4BNcpldEGjg6PdA7e0RgsDQ==",
@@ -6891,7 +6891,7 @@
             "npm:@cucumber/cucumber@^11.2.0",
             "npm:@google/generative-ai@0.24",
             "npm:@inlang/paraglide-js@^2.0.12",
-            "npm:@jsr/trakt__api@~0.1.37",
+            "npm:@jsr/trakt__api@~0.1.38",
             "npm:@playwright/test@^1.51.1",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@svelte-put/qr@^2.1.0",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -62,7 +62,7 @@
     "@tanstack/svelte-query": "^5.76.0",
     "@tanstack/svelte-query-devtools": "^5.76.0",
     "@tanstack/svelte-query-persist-client": "^5.76.1",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.1.37",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.1.38",
     "@ts-rest/core": "^3.52.1",
     "@use-gesture/vanilla": "^10.3.1",
     "date-fns": "^4.1.0",

--- a/projects/client/src/lib/components/card/CardCover.svelte
+++ b/projects/client/src/lib/components/card/CardCover.svelte
@@ -195,7 +195,7 @@
       background: linear-gradient(
         180deg,
         transparent 0%,
-        var(--shade-900) 100%
+        var(--color-card-cover-shadow, var(--shade-900)) 100%
       );
     }
   }

--- a/projects/client/src/lib/components/icons/WatchlistIcon.svelte
+++ b/projects/client/src/lib/components/icons/WatchlistIcon.svelte
@@ -30,44 +30,7 @@
     transition: opacity var(--transition-increment) ease-in-out;
   }
 
-  .icon-state-idle {
-    opacity: 1;
-  }
-
-  .icon-state-active {
-    opacity: 0;
-  }
-
-  @include for-mouse {
-    :global(li):focus,
-    :global(li):hover,
-    :global(button):focus,
-    :global(button):hover {
-      .icon-state-idle {
-        opacity: 0;
-      }
-
-      .icon-state-active {
-        opacity: 1;
-      }
-    }
-  }
-
   svg[data-size="small"] {
     transform: scale(0.75);
-  }
-
-  @include for-touch {
-    svg {
-      &[data-state="added"] {
-        .icon-state-active {
-          opacity: 1;
-        }
-
-        .icon-state-idle {
-          opacity: 0;
-        }
-      }
-    }
   }
 </style>

--- a/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/lists/listItemsQuery.ts
@@ -49,7 +49,7 @@ const userListItemsRequest = (
         type,
       },
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         page,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
@@ -42,7 +42,7 @@ const movieAnticipatedRequest = (
     .movies
     .anticipated({
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         ignore_collected: true,
         page,
         limit,

--- a/projects/client/src/lib/requests/queries/movies/movieFavoritesQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieFavoritesQuery.ts
@@ -21,7 +21,7 @@ const favoritedMoviesRequest = (
         sort: 'rank',
       },
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
       },
     });
 

--- a/projects/client/src/lib/requests/queries/movies/movieListsQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieListsQuery.ts
@@ -22,7 +22,7 @@ const movieListsRequest = (
         sort: 'popular',
       },
       query: {
-        extended: 'images',
+        extended: 'images,colors',
         limit,
       },
     });

--- a/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
@@ -25,7 +25,7 @@ const moviePopularRequest = (
     .movies
     .popular({
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         ignore_collected: true,
         page,
         limit,

--- a/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
@@ -21,7 +21,7 @@ const movieRelatedRequest = (
     .movies
     .related({
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         limit,
         page,
       },

--- a/projects/client/src/lib/requests/queries/movies/movieStreamingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieStreamingQuery.ts
@@ -42,7 +42,7 @@ const movieStreamingRequest = (
         period: 'daily',
       },
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         watchnow: 'favorites',
         ignore_collected: true,
         page,

--- a/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
@@ -42,7 +42,7 @@ const movieTrendingRequest = (
     .movies
     .trending({
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         ignore_collected: true,
         page,
         limit,

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
@@ -29,7 +29,7 @@ const recommendedMoviesRequest = (
     .movies
     .recommend({
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         ignore_collected: true,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
@@ -32,7 +32,7 @@ const recommendedShowsRequest = (
     .shows
     .recommend({
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         ignore_collected: true,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
@@ -51,7 +51,7 @@ const showAnticipatedRequest = (
     .shows
     .anticipated({
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         ignore_collected: true,
         page,
         limit,

--- a/projects/client/src/lib/requests/queries/shows/showFavoritesQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showFavoritesQuery.ts
@@ -21,7 +21,7 @@ const favoritedShowsRequest = (
         sort: 'rank',
       },
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
       },
     });
 

--- a/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
@@ -45,7 +45,7 @@ const showPopularRequest = (
     .shows
     .popular({
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         ignore_collected: true,
         page,
         limit,

--- a/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
@@ -35,7 +35,7 @@ const showRelatedRequest = (
     .shows
     .related({
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         limit,
         page,
       },

--- a/projects/client/src/lib/requests/queries/shows/showStreamingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showStreamingQuery.ts
@@ -42,7 +42,7 @@ const showStreamingRequest = (
         period: 'daily',
       },
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         watchnow: 'favorites',
         ignore_collected: true,
         page,

--- a/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
@@ -47,7 +47,7 @@ const showTrendingRequest = (
     .shows
     .trending({
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         ignore_collected: true,
         page,
         limit,

--- a/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieWatchlistQuery.ts
@@ -36,7 +36,7 @@ const watchlistRequest = (
         sort,
       },
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         page,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/users/personalListsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/personalListsQuery.ts
@@ -17,7 +17,7 @@ const personalListsRequest = (
         id: slug,
       },
       query: {
-        extended: 'images',
+        extended: 'images,colors',
       },
     });
 

--- a/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showWatchlistQuery.ts
@@ -43,7 +43,7 @@ const watchlistRequest = (
         sort,
       },
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         page,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
@@ -57,7 +57,7 @@ const userListItemsRequest = (
         type,
       },
       query: {
-        extended: 'full,images',
+        extended: 'full,images,colors',
         page,
         limit,
         ...filter,

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -47,6 +47,7 @@
       src={mediaCoverImageUrl}
       overlaySrc={mediaCoverOverlay}
       alt={m.media_poster({ title: media.title })}
+      --color-card-cover-shadow={media.colors[1]}
       {badge}
     />
   </Link>


### PR DESCRIPTION
- Updates several queries to include `colors` in the extended data.

- Modifies card cover to use the secondary color from the fetched media palette as the cover shadow, enhancing visual appeal.

- Removes unused CSS rules for watchlist icon states, simplifying the component's styling.