### PR TITLE
Fix/auth

### DIFF
--- a/.github/actions/setup-deno/action.yml
+++ b/.github/actions/setup-deno/action.yml
@@ -5,7 +5,7 @@ inputs:
   deno-version:
     description: 'Deno version to install'
     required: false
-    default: 'v2.x'
+    default: 'v2.3.3'
 
 runs:
   using: composite

--- a/projects/client/src/lib/features/auth/handle.spec.ts
+++ b/projects/client/src/lib/features/auth/handle.spec.ts
@@ -7,9 +7,16 @@ import { describe, expect, it, vi } from 'vitest';
 import { AUTH_COOKIE_NAME, handle } from './handle.ts';
 
 describe('handle: auth', () => {
+  const request = new Request('http://localhost', {
+    headers: {
+      accept: 'text/html',
+    },
+  });
+
   it('should handle logout', async () => {
     const event = mockRequestEvent({
       url: `http://localhost${AuthEndpoint.Logout}`,
+      request,
     });
 
     const response = await handle({ event, resolve: vi.fn() });
@@ -24,6 +31,7 @@ describe('handle: auth', () => {
   it('should handle auth code exchange', async () => {
     const event = mockRequestEvent({
       url: 'http://localhost?code=test-code',
+      request,
     });
 
     const response = await handle({ event, resolve: vi.fn() });
@@ -42,6 +50,7 @@ describe('handle: auth', () => {
   it('should handle invalid cookie contents', async () => {
     const event = mockRequestEvent({
       url: 'http://localhost',
+      request,
       cookieHandler: (key: string) => {
         if (key === AUTH_COOKIE_NAME) {
           return 'invalid';
@@ -61,6 +70,7 @@ describe('handle: auth', () => {
   it('should handle auth cookie', async () => {
     const event = mockRequestEvent({
       url: 'http://localhost',
+      request,
       cookieHandler: (key: string) => {
         if (key === AUTH_COOKIE_NAME) {
           return AuthMock;
@@ -78,6 +88,7 @@ describe('handle: auth', () => {
   it('should handle expiring cookies', async () => {
     const event = mockRequestEvent({
       url: 'http://localhost',
+      request,
       cookieHandler: (key: string) => {
         if (key === AUTH_COOKIE_NAME) {
           return ExpiredAuthMock;

--- a/projects/client/src/lib/features/auth/handle.ts
+++ b/projects/client/src/lib/features/auth/handle.ts
@@ -24,8 +24,17 @@ function getAuth(event: RequestEvent): SerializedAuthResponse | null {
   }
 }
 
+function isContentRequest(event: RequestEvent) {
+  const acceptHeader = event.request.headers.get('accept');
+  return acceptHeader?.includes('text/html');
+}
+
 // FIXME: split up this file
 export const handle: Handle = async ({ event, resolve }) => {
+  if (!isContentRequest(event)) {
+    return await resolve(event);
+  }
+
   const setAuth = (auth: SerializedAuthResponse | Nil) => {
     event.locals.auth = auth;
   };

--- a/projects/client/src/lib/features/auth/requests/verifyAuth.ts
+++ b/projects/client/src/lib/features/auth/requests/verifyAuth.ts
@@ -4,7 +4,7 @@ import {
   mapToDeviceAuth,
 } from '$lib/features/auth/requests/_internal/mapToDeviceAuth.ts';
 import { warn as printWarning } from '$lib/utils/console/print.ts';
-import { api } from '../../../requests/api.ts';
+import { unauthorizedApi } from '../../../requests/api.ts';
 import type { AuthToken } from '../models/AuthToken.ts';
 import { getGrantTypeAndCode } from './_internal/getGrantTypeAndCode.ts';
 
@@ -22,7 +22,7 @@ export async function verifyAuth({
   const client_secret = env.TRAKT_CLIENT_SECRET ?? '';
   const client_id = env.TRAKT_CLIENT_ID ?? '';
 
-  const tokenResponse = await api({
+  const tokenResponse = await unauthorizedApi({
     environment: TRAKT_TARGET_ENVIRONMENT,
   })
     .oauth

--- a/projects/client/src/lib/features/auth/requests/verifyDeviceCode.ts
+++ b/projects/client/src/lib/features/auth/requests/verifyDeviceCode.ts
@@ -1,4 +1,4 @@
-import { api } from '../../../requests/api.ts';
+import { unauthorizedApi } from '../../../requests/api.ts';
 
 import { env } from '$env/dynamic/private';
 import {
@@ -17,7 +17,7 @@ export async function verifyDeviceCode(
   const client_id = env.TRAKT_CLIENT_ID ?? '';
   const client_secret = env.TRAKT_CLIENT_SECRET ?? '';
 
-  const tokenResponse = await api({
+  const tokenResponse = await unauthorizedApi({
     environment: TRAKT_TARGET_ENVIRONMENT,
   }).oauth
     .device

--- a/projects/client/src/lib/requests/api.ts
+++ b/projects/client/src/lib/requests/api.ts
@@ -32,3 +32,13 @@ export const api = ({
     cancellable,
     cancellationId,
   });
+
+export const unauthorizedApi = ({
+  environment = ENV,
+  fetch = globalThis.fetch,
+}: ApiParams = {}) =>
+  traktApi({
+    apiKey: TRAKT_CLIENT_ID,
+    environment,
+    fetch,
+  });

--- a/projects/client/src/mocks/data/summary/episodes/silo/response/EpisodeSiloRatingsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/response/EpisodeSiloRatingsResponseMock.ts
@@ -35,5 +35,7 @@ export const EpisodeSiloRatingsResponseMock: RatingsResponse = {
     'rating': 92,
     'user_rating': 64,
     'link': null,
+    'state': null,
+    'user_state': null,
   },
 };

--- a/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticRatingsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticRatingsResponseMock.ts
@@ -35,5 +35,7 @@ export const MovieHereticRatingsResponseMock: RatingsResponse = {
     'rating': 0,
     'user_rating': 0,
     'link': 'https://www.rottentomatoes.com/m/heretic_2023',
+    'state': null,
+    'user_state': null,
   },
 };

--- a/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloRatingsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloRatingsResponseMock.ts
@@ -35,5 +35,7 @@ export const ShowSiloRatingsResponseMock: RatingsResponse = {
     'rating': 92,
     'user_rating': 64,
     'link': 'https://www.rottentomatoes.com/tv/silo',
+    'state': null,
+    'user_state': null,
   },
 };


### PR DESCRIPTION
## 🎶 Notes 🎶

- Use regular fetch for auth requests.
- Reload only in case of expired tokens.
- Reload only once in case of auth error.
- Skip auth handle in case of non content requests.
- If you want to test this on staging, set the `minutesToExpiry` to 5 seconds or something in the handle.