### PR TITLE
fix(layout): account for larger scrollbars in firefox

### DIFF
--- a/projects/client/src/style/layout/index.css
+++ b/projects/client/src/style/layout/index.css
@@ -68,4 +68,8 @@
   --layout-distance-side: var(--ni-24);
   --layout-scrollbar-width: var(--ni-8);
   --layout-footer-less-padding: var(--ni-16);
+
+  @-moz-document url-prefix() {
+    --layout-scrollbar-width: var(--ni-16);
+  }
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Lists in Firefox were not properly scrollable.
- This is a quick fix for now. Ideally we detect the scrollbar size in any situation since they can differ between browsers and operating systems.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/c2baefc3-8b78-40cf-ba33-f867abc92bf4

After:

https://github.com/user-attachments/assets/90ab0f48-3a8b-4cbe-96ce-59c49d2ee126
