### PR TITLE
Fix/ff filter

### DIFF
--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -159,7 +159,7 @@
 
     &:not([data-cover-type="main"]) {
       &::after {
-        backdrop-filter: blur(var(--ni-2));
+        @include backdrop-filter-blur(var(--ni-2));
 
         @include for-tablet-sm-and-below {
           backdrop-filter: unset;

--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -179,7 +179,7 @@
     &[data-style="ghost"] {
       background-color: transparent;
       /** This is required for improved readability when rendering over a cover image */
-      backdrop-filter: blur(var(--ni-16));
+      @include backdrop-filter-blur(var(--ni-16));
     }
   }
 </style>

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -353,7 +353,7 @@
       transform: scale(calc(var(--scale-factor-button) * 0.76925));
       background: transparent;
       /** This is required for improved readability when rendering over a cover image */
-      backdrop-filter: blur(var(--ni-16));
+      @include backdrop-filter-blur(var(--ni-16));
 
       &:not([data-variant="secondary"]) {
         color: var(--color-foreground);

--- a/projects/client/src/lib/components/dialogs/Dialog.svelte
+++ b/projects/client/src/lib/components/dialogs/Dialog.svelte
@@ -43,7 +43,9 @@
   </div>
 </dialog>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index.scss" as *;
+
   dialog {
     all: unset;
 
@@ -70,7 +72,7 @@
       var(--color-background) 88%,
       transparent 12%
     );
-    backdrop-filter: blur(var(--ni-8));
+    @include backdrop-filter-blur(var(--ni-8));
 
     opacity: 0;
   }

--- a/projects/client/src/lib/components/dropdown/DropdownList.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownList.svelte
@@ -255,7 +255,7 @@
         &::-webkit-scrollbar-thumb {
           background-color: var(--shade-300);
           border-radius: var(--border-radius-xs);
-          backdrop-filter: blur(var(--ni-4));
+          @include backdrop-filter-blur(var(--ni-4));
         }
       }
     }

--- a/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
+++ b/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
@@ -25,7 +25,9 @@
   </TagContent>
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index.scss" as *;
+
   .show-progress-tag {
     width: 100%;
   }
@@ -53,7 +55,7 @@
 
       position: relative;
       background: var(--color-background-progress-base-tag);
-      backdrop-filter: blur(var(--ni-16));
+      @include backdrop-filter-blur(var(--ni-16));
       color: var(--color-text-progress-tag);
     }
   }

--- a/projects/client/src/lib/features/search/SearchInput.svelte
+++ b/projects/client/src/lib/features/search/SearchInput.svelte
@@ -157,7 +157,7 @@
         var(--color-background) 75%,
         transparent 25%
       );
-      backdrop-filter: blur(var(--ni-8));
+      @include backdrop-filter-blur(var(--ni-8));
 
       transition: var(--transition-increment) ease-in-out;
       transition-property:

--- a/projects/client/src/lib/sections/cookie/CookieNotice.svelte
+++ b/projects/client/src/lib/sections/cookie/CookieNotice.svelte
@@ -75,7 +75,7 @@
 
     width: min(var(--ni-480), 85%);
 
-    backdrop-filter: blur(var(--ni-16));
+    @include backdrop-filter-blur(var(--ni-16));
     background-color: var(--color-cookie-background);
     box-shadow:
       0px 280px 78px 0px color-mix(in srgb, var(--color-shadow) 0%, transparent),
@@ -122,7 +122,7 @@
     right: 0;
     bottom: 0;
 
-    backdrop-filter: blur(var(--ni-8));
+    @include backdrop-filter-blur(var(--ni-8));
     background-color: color-mix(
       in srgb,
       var(--color-cookie-background) 70%,

--- a/projects/client/src/lib/sections/lists/social/SocialActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/social/SocialActivityItem.svelte
@@ -28,7 +28,9 @@
   <ActivitySummaryCard {activity} activityAt={activity.activityAt} {badge} />
 {/if}
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index.scss" as *;
+
   .user-profile-badge {
     max-width: calc(100% - var(--ni-32));
     display: flex;
@@ -36,7 +38,7 @@
     align-items: center;
 
     padding: 0 var(--ni-4);
-    backdrop-filter: blur(var(--ni-8));
+    @include backdrop-filter-blur(var(--ni-8));
     background: color-mix(in srgb, var(--color-background) 50%, transparent);
     border-radius: var(--border-radius-m);
     overflow: hidden;

--- a/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
@@ -38,7 +38,9 @@
 
 <div class="trakt-mobile-navbar-spacer"></div>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index.scss" as *;
+
   .trakt-mobile-navbar-spacer,
   .trakt-mobile-navbar {
     padding: var(--ni-12) 0;
@@ -57,7 +59,7 @@
     background-color: var(--color-background-mobile-navbar);
     box-shadow: 0px -24px 64px 0px
       color-mix(in srgb, var(--color-shadow) 32%, transparent 68%);
-    backdrop-filter: blur(8px);
+    @include backdrop-filter-blur(8px);
 
     display: flex;
     justify-content: center;

--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -207,14 +207,14 @@
   .trakt-navbar-scroll,
   .trakt-navbar-pwa {
     background-color: var(--color-background-navbar);
-    backdrop-filter: blur(var(--ni-8));
+    @include backdrop-filter-blur(var(--ni-8));
   }
 
   .trakt-navbar-scroll:not(.trakt-navbar-pwa) {
     box-shadow: 0px 24px 64px 0px
       color-mix(in srgb, var(--color-shadow) 32%, transparent 68%);
 
-    backdrop-filter: blur(8px);
+    @include backdrop-filter-blur(8px);
 
     color: var(--color-foreground-navbar);
 

--- a/projects/client/src/lib/sections/navbar/components/filter/_internal/Sidebar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/_internal/Sidebar.svelte
@@ -100,7 +100,7 @@
       var(--color-background) 88%,
       transparent 12%
     );
-    backdrop-filter: blur(var(--ni-12));
+    @include backdrop-filter-blur(var(--ni-12));
 
     box-shadow: var(--ni-0) var(--ni-8) var(--ni-8) var(--ni-0)
       color-mix(in srgb, var(--color-shadow) 25%, transparent 75%);

--- a/projects/client/src/lib/sections/now-playing/_internal/NowPlayingToast.svelte
+++ b/projects/client/src/lib/sections/now-playing/_internal/NowPlayingToast.svelte
@@ -87,7 +87,7 @@
 
     box-shadow: var(--ni-0) var(--ni-8) var(--ni-8) var(--ni-0)
       color-mix(in srgb, var(--color-shadow) 25%, transparent 75%);
-    backdrop-filter: blur(var(--ni-16));
+    @include backdrop-filter-blur(var(--ni-16));
 
     background-color: var(--color-now-playing-background);
     border: var(--border-thickness-xxs) solid var(--color-now-playing-border);

--- a/projects/client/src/lib/sections/profile/components/ProfileHistorySummary.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileHistorySummary.svelte
@@ -42,7 +42,7 @@
     border-radius: var(--ni-12);
     color: var(--color-text-primary);
     background-color: color-mix(in srgb, var(--purple-500), transparent 85%);
-    backdrop-filter: blur(var(--ni-16));
+    @include backdrop-filter-blur(var(--ni-16));
     padding: var(--ni-24);
     display: flex;
     flex-direction: column;

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/dialog/CommentInput.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/dialog/CommentInput.svelte
@@ -74,7 +74,9 @@
   {/if}
 </trakt-comment-input>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index.scss" as *;
+
   trakt-comment-input {
     display: flex;
     flex-direction: column;
@@ -95,7 +97,7 @@
     border-radius: var(--border-radius-s);
     border: var(--ni-2) var(--purple-50) solid;
 
-    backdrop-filter: blur(var(--ni-4));
+    @include backdrop-filter-blur(var(--ni-4));
     color: var(--color-text-primary);
 
     transition: border-color var(--transition-increment) ease-in-out;

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -222,7 +222,7 @@
         transparent 100%
       );
       border-radius: var(--border-radius-xs);
-      backdrop-filter: blur(var(--ni-4));
+      @include backdrop-filter-blur(var(--ni-4));
       opacity: 0;
     }
 

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -30,6 +30,7 @@
   import { workerRequest } from "$worker/workerRequest";
   import { SvelteQueryDevtools } from "@tanstack/svelte-query-devtools";
   import { onMount } from "svelte";
+  import FirefoxBlurHack from "./_internal/FirefoxBlurHack.svelte";
 
   const { data, children } = $props();
 
@@ -161,6 +162,7 @@
                                 buttonPosition="bottom-left"
                                 styleNonce="opacity: 0.5"
                               />
+                              <FirefoxBlurHack />
                             </ListScrollHistoryProvider>
                           </ThemeProvider>
                         </CoverProvider>

--- a/projects/client/src/routes/_internal/FirefoxBlurHack.svelte
+++ b/projects/client/src/routes/_internal/FirefoxBlurHack.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  const isFirefox = $derived(
+    navigator.userAgent.toLowerCase().includes("firefox"),
+  );
+</script>
+
+<!--
+  Firefox performs terrible in case of backdrop-filter: blur(),
+  so we use a hack to use an svg filter instead.
+-->
+{#if isFirefox}
+  <svg style="position: absolute; width: 0; height: 0">
+    <filter id="trakt-firefox-blur">
+      <feGaussianBlur stdDeviation="8" />
+    </filter>
+  </svg>
+{/if}

--- a/projects/client/src/style/scss/mixins/index.scss
+++ b/projects/client/src/style/scss/mixins/index.scss
@@ -64,3 +64,7 @@
     }
   }
 }
+
+@mixin backdrop-filter-blur($blur) {
+  backdrop-filter: blur($blur);
+}

--- a/projects/client/src/style/scss/mixins/index.scss
+++ b/projects/client/src/style/scss/mixins/index.scss
@@ -67,4 +67,8 @@
 
 @mixin backdrop-filter-blur($blur) {
   backdrop-filter: blur($blur);
+
+  @-moz-document url-prefix() {
+    backdrop-filter: url('#trakt-firefox-blur')
+  }
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- In case of Firefox, use an svg filter for `backdrop-filter: blur()`.
- All blur effects in FF will have the same blur intensity, but good enough for now