### PR TITLE
chore: change config to generate cloudflare files

### DIFF
--- a/projects/client/vite.config.ts
+++ b/projects/client/vite.config.ts
@@ -82,12 +82,12 @@ export default defineConfig(({ mode }) => ({
 
   plugins: [
     enhancedImages(),
+    sveltekit(),
     paraglideVitePlugin({
       project: './i18n/project.inlang',
       outdir: './src/lib/paraglide',
     }),
     denoSveltekitExit(),
-    sveltekit(),
     SvelteKitPWA({
       injectRegister: 'script-defer',
       strategies: 'injectManifest',


### PR DESCRIPTION
## 🎶 Notes 🎶

- Deployments were broken after the package updates.
- The cloudflare files were not generated.
- Strange that the adapter is ignored depending on the plugin order 🤔

## 👀 Example 👀
Files are generated now:
<img width="835" alt="Screenshot 2025-06-05 at 00 01 15" src="https://github.com/user-attachments/assets/e04afc0f-a7e9-4ca3-b05a-ce4192f97562" />
