### PR TITLE
chore: move mixins to after style declarations

### DIFF
--- a/projects/client/src/lib/components/dialogs/Dialog.svelte
+++ b/projects/client/src/lib/components/dialogs/Dialog.svelte
@@ -72,9 +72,9 @@
       var(--color-background) 88%,
       transparent 12%
     );
-    @include backdrop-filter-blur(var(--ni-8));
-
     opacity: 0;
+
+    @include backdrop-filter-blur(var(--ni-8));
   }
 
   @keyframes dialogOpen {

--- a/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
+++ b/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
@@ -55,8 +55,8 @@
 
       position: relative;
       background: var(--color-background-progress-base-tag);
-      @include backdrop-filter-blur(var(--ni-16));
       color: var(--color-text-progress-tag);
+      @include backdrop-filter-blur(var(--ni-16));
     }
   }
 </style>

--- a/projects/client/src/lib/features/search/SearchInput.svelte
+++ b/projects/client/src/lib/features/search/SearchInput.svelte
@@ -157,12 +157,12 @@
         var(--color-background) 75%,
         transparent 25%
       );
-      @include backdrop-filter-blur(var(--ni-8));
 
       transition: var(--transition-increment) ease-in-out;
       transition-property:
         border-color, background-color, padding, width, top, left, opacity;
 
+      @include backdrop-filter-blur(var(--ni-8));
       @include for-mobile {
         width: var(--search-icon-size);
         position: absolute;

--- a/projects/client/src/lib/sections/cookie/CookieNotice.svelte
+++ b/projects/client/src/lib/sections/cookie/CookieNotice.svelte
@@ -74,8 +74,6 @@
     padding-left: var(--ni-40);
 
     width: min(var(--ni-480), 85%);
-
-    @include backdrop-filter-blur(var(--ni-16));
     background-color: var(--color-cookie-background);
     box-shadow:
       0px 280px 78px 0px color-mix(in srgb, var(--color-shadow) 0%, transparent),
@@ -100,6 +98,8 @@
       line-height: 1;
     }
 
+    @include backdrop-filter-blur(var(--ni-16));
+
     @include for-mobile {
       padding-left: var(--ni-24);
       padding-top: var(--ni-40);
@@ -122,11 +122,12 @@
     right: 0;
     bottom: 0;
 
-    @include backdrop-filter-blur(var(--ni-8));
     background-color: color-mix(
       in srgb,
       var(--color-cookie-background) 70%,
       transparent 30%
     );
+
+    @include backdrop-filter-blur(var(--ni-8));
   }
 </style>

--- a/projects/client/src/lib/sections/lists/social/SocialActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/social/SocialActivityItem.svelte
@@ -38,11 +38,11 @@
     align-items: center;
 
     padding: 0 var(--ni-4);
-    @include backdrop-filter-blur(var(--ni-8));
     background: color-mix(in srgb, var(--color-background) 50%, transparent);
     border-radius: var(--border-radius-m);
     overflow: hidden;
 
+    @include backdrop-filter-blur(var(--ni-8));
     :global(.trakt-link) {
       max-width: 75%;
     }

--- a/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
@@ -59,11 +59,12 @@
     background-color: var(--color-background-mobile-navbar);
     box-shadow: 0px -24px 64px 0px
       color-mix(in srgb, var(--color-shadow) 32%, transparent 68%);
-    @include backdrop-filter-blur(8px);
 
     display: flex;
     justify-content: center;
     gap: var(--gap-m);
+
+    @include backdrop-filter-blur(8px);
   }
 
   .trakt-mobile-navbar-link {

--- a/projects/client/src/lib/sections/navbar/Navbar.svelte
+++ b/projects/client/src/lib/sections/navbar/Navbar.svelte
@@ -214,8 +214,6 @@
     box-shadow: 0px 24px 64px 0px
       color-mix(in srgb, var(--color-shadow) 32%, transparent 68%);
 
-    @include backdrop-filter-blur(8px);
-
     color: var(--color-foreground-navbar);
 
     /** 
@@ -226,6 +224,8 @@
     :global(.trakt-button[data-style="underlined"]) {
       color: var(--color-foreground-navbar);
     }
+
+    @include backdrop-filter-blur(8px);
 
     @include for-mouse {
       :global(.trakt-button[data-style="underlined"]) {

--- a/projects/client/src/lib/sections/navbar/components/filter/_internal/Sidebar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/_internal/Sidebar.svelte
@@ -100,7 +100,6 @@
       var(--color-background) 88%,
       transparent 12%
     );
-    @include backdrop-filter-blur(var(--ni-12));
 
     box-shadow: var(--ni-0) var(--ni-8) var(--ni-8) var(--ni-0)
       color-mix(in srgb, var(--color-shadow) 25%, transparent 75%);
@@ -111,6 +110,8 @@
 
     border-top-left-radius: var(--border-radius-m);
     border-bottom-left-radius: var(--border-radius-m);
+
+    @include backdrop-filter-blur(var(--ni-12));
 
     @include for-mobile {
       top: initial;

--- a/projects/client/src/lib/sections/now-playing/_internal/NowPlayingToast.svelte
+++ b/projects/client/src/lib/sections/now-playing/_internal/NowPlayingToast.svelte
@@ -87,13 +87,14 @@
 
     box-shadow: var(--ni-0) var(--ni-8) var(--ni-8) var(--ni-0)
       color-mix(in srgb, var(--color-shadow) 25%, transparent 75%);
-    @include backdrop-filter-blur(var(--ni-16));
 
     background-color: var(--color-now-playing-background);
     border: var(--border-thickness-xxs) solid var(--color-now-playing-border);
 
     transition: var(--transition-increment) ease-in-out;
     transition-property: padding, gap;
+
+    @include backdrop-filter-blur(var(--ni-16));
 
     @include for-tablet-sm-and-below {
       --now-playing-bottom-distance: calc(

--- a/projects/client/src/lib/sections/profile/components/ProfileHistorySummary.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileHistorySummary.svelte
@@ -42,13 +42,14 @@
     border-radius: var(--ni-12);
     color: var(--color-text-primary);
     background-color: color-mix(in srgb, var(--purple-500), transparent 85%);
-    @include backdrop-filter-blur(var(--ni-16));
     padding: var(--ni-24);
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     gap: var(--gap-xs);
     box-shadow: 0 var(--ni-4) var(--ni-8) 0 rgba(0, 0, 0, 0.24);
+
+    @include backdrop-filter-blur(var(--ni-16));
   }
 
   .trakt-profile-history-content {

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/dialog/CommentInput.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/dialog/CommentInput.svelte
@@ -97,10 +97,11 @@
     border-radius: var(--border-radius-s);
     border: var(--ni-2) var(--purple-50) solid;
 
-    @include backdrop-filter-blur(var(--ni-4));
     color: var(--color-text-primary);
 
     transition: border-color var(--transition-increment) ease-in-out;
+
+    @include backdrop-filter-blur(var(--ni-4));
 
     textarea {
       all: unset;

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -224,8 +224,9 @@
         transparent 100%
       );
       border-radius: var(--border-radius-xs);
-      @include backdrop-filter-blur(var(--ni-4));
       opacity: 0;
+
+      @include backdrop-filter-blur(var(--ni-4));
     }
 
     :global(:hover::-webkit-scrollbar-thumb) {


### PR DESCRIPTION
## ♪ Note ♪

Some moving around to handle upcoming deprecation:
<img width="1275" alt="Screenshot 2025-06-05 at 21 01 07" src="https://github.com/user-attachments/assets/7dc93eef-c65d-450a-8fb1-04ce24464217" />
