### PR TITLE
fix(profile): show correct favorites on profile pages

### DIFF
--- a/projects/client/src/lib/requests/queries/movies/movieFavoritesQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieFavoritesQuery.spec.ts
@@ -7,7 +7,7 @@ import { movieFavoritesQuery } from './movieFavoritesQuery.ts';
 describe('movieFavoritesQuery', () => {
   it('should query for favorited movies', async () => {
     const result = await runQuery({
-      factory: () => createQuery(movieFavoritesQuery()),
+      factory: () => createQuery(movieFavoritesQuery({ slug: 'me' })),
       mapper: (response) => response?.data,
     });
 

--- a/projects/client/src/lib/requests/queries/movies/movieFavoritesQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieFavoritesQuery.ts
@@ -9,15 +9,19 @@ import {
   FavoritedEntrySchema,
 } from '../../models/FavoritedEntry.ts';
 
+type FavoriteMoviesParams = {
+  slug: string;
+} & ApiParams;
+
 const favoritedMoviesRequest = (
-  { fetch }: ApiParams,
+  { fetch, slug }: FavoriteMoviesParams,
 ) =>
   api({ fetch })
     .users
     .favorites
     .movies({
       params: {
-        id: 'me',
+        id: slug,
         sort: 'rank',
       },
       query: {
@@ -38,7 +42,7 @@ function mapToFavoriteMovie(
 export const movieFavoritesQuery = defineQuery({
   key: 'movieFavorites',
   invalidations: [InvalidateAction.Favorited('movie')],
-  dependencies: () => [],
+  dependencies: (params) => [params.slug],
   request: favoritedMoviesRequest,
   mapper: (response) => response.body.map(mapToFavoriteMovie),
   schema: FavoritedEntrySchema.array(),

--- a/projects/client/src/lib/requests/queries/shows/showFavoritesQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/shows/showFavoritesQuery.spec.ts
@@ -7,7 +7,7 @@ import { showFavoritesQuery } from './showFavoritesQuery.ts';
 describe('showFavoritesQuery', () => {
   it('should query for favorited shows', async () => {
     const result = await runQuery({
-      factory: () => createQuery(showFavoritesQuery()),
+      factory: () => createQuery(showFavoritesQuery({ slug: 'me' })),
       mapper: (response) => response?.data,
     });
 

--- a/projects/client/src/lib/requests/queries/shows/showFavoritesQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showFavoritesQuery.ts
@@ -9,15 +9,19 @@ import {
   FavoritedEntrySchema,
 } from '../../models/FavoritedEntry.ts';
 
+type FavoriteShowsParams = {
+  slug: string;
+} & ApiParams;
+
 const favoritedShowsRequest = (
-  { fetch }: ApiParams,
+  { fetch, slug }: FavoriteShowsParams,
 ) =>
   api({ fetch })
     .users
     .favorites
     .shows({
       params: {
-        id: 'me',
+        id: slug,
         sort: 'rank',
       },
       query: {
@@ -38,7 +42,7 @@ function mapToFavoriteShow(
 export const showFavoritesQuery = defineQuery({
   key: 'showFavorites',
   invalidations: [InvalidateAction.Favorited('show')],
-  dependencies: () => [],
+  dependencies: (params) => [params.slug],
   request: favoritedShowsRequest,
   mapper: (response) => response.body.map(mapToFavoriteShow),
   schema: FavoritedEntrySchema.array(),

--- a/projects/client/src/lib/sections/lists/FavoritesList.svelte
+++ b/projects/client/src/lib/sections/lists/FavoritesList.svelte
@@ -10,9 +10,11 @@
     type,
     title,
     emptyMessage,
-  }: { type: MediaType; title: string; emptyMessage: string } = $props();
+    slug,
+  }: { type: MediaType; title: string; emptyMessage: string; slug: string } =
+    $props();
 
-  const { list, isLoading } = useFavoritesList({ type });
+  const { list, isLoading } = useFavoritesList({ type, slug });
 </script>
 
 <SectionList

--- a/projects/client/src/lib/sections/lists/stores/useFavoritesList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useFavoritesList.ts
@@ -7,21 +7,22 @@ import { derived } from 'svelte/store';
 
 type UseFavoritesProps = {
   type: MediaType;
+  slug: string;
 };
 
 function typeToQuery(
-  { type }: UseFavoritesProps,
+  { type, slug }: UseFavoritesProps,
 ) {
   switch (type) {
     case 'movie':
-      return movieFavoritesQuery({});
+      return movieFavoritesQuery({ slug });
     case 'show':
-      return showFavoritesQuery({});
+      return showFavoritesQuery({ slug });
   }
 }
 
-export function useFavoritesList({ type }: UseFavoritesProps) {
-  const query = useQuery(typeToQuery({ type }));
+export function useFavoritesList({ type, slug }: UseFavoritesProps) {
+  const query = useQuery(typeToQuery({ type, slug }));
 
   return {
     list: derived(query, ($query) => $query.data ?? []),

--- a/projects/client/src/lib/sections/profile/Profile.svelte
+++ b/projects/client/src/lib/sections/profile/Profile.svelte
@@ -41,11 +41,14 @@
 </ProfileContainer>
 
 <FavoritesList
+  {slug}
   type="movie"
   title={m.favorite_movies()}
   emptyMessage={m.favorite_movies_empty()}
 />
+
 <FavoritesList
+  {slug}
   type="show"
   title={m.favorite_shows()}
   emptyMessage={m.favorite_shows_empty()}


### PR DESCRIPTION
## ♪ Note ♪

- Fixes the issue where all profile pages showed the current users favorites 😅

## 👀 Example 👀
Before:
<img width="1410" alt="Screenshot 2025-06-06 at 12 38 24" src="https://github.com/user-attachments/assets/359e2904-c1ce-46e4-95d3-29288a74c05a" />

After:
<img width="1410" alt="Screenshot 2025-06-06 at 12 38 38" src="https://github.com/user-attachments/assets/3152bc3b-a3d0-4e1a-b71e-8d3383ebf7f4" />

