### PR TITLE
fix(footer): allow dynamic footer sizing

### DIFF
--- a/projects/client/src/lib/sections/footer/Footer.svelte
+++ b/projects/client/src/lib/sections/footer/Footer.svelte
@@ -2,9 +2,10 @@
   import TraktCoverImage from "$lib/components/background/TraktCoverImage.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import FooterContent from "./components/FooterContent.svelte";
+  import { FOOTER_CLASS_NAME } from "./constants";
 </script>
 
-<footer class="trakt-footer">
+<footer class={FOOTER_CLASS_NAME}>
   <RenderFor device={["tablet-lg", "desktop"]} audience="all">
     <TraktCoverImage />
   </RenderFor>
@@ -15,13 +16,13 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-footer {
-    height: var(--footer-height);
+    height: var(--ni-300);
     margin-top: var(--ni-120);
     padding-left: var(--layout-distance-side);
     padding-right: var(--layout-distance-side);
 
     @include for-tablet-sm-and-below {
-      height: var(--footer-mobile-height);
+      height: fit-content;
     }
   }
 </style>

--- a/projects/client/src/lib/sections/footer/constants.ts
+++ b/projects/client/src/lib/sections/footer/constants.ts
@@ -1,0 +1,1 @@
+export const FOOTER_CLASS_NAME = 'trakt-footer';

--- a/projects/client/src/lib/sections/now-playing/_internal/NowPlayingToast.svelte
+++ b/projects/client/src/lib/sections/now-playing/_internal/NowPlayingToast.svelte
@@ -6,6 +6,7 @@
   import { episodeActivityTitle } from "$lib/utils/string/episodeActivityTitle";
   import NowPlayingItemCard from "./NowPlayingItemCard.svelte";
   import ProgressBar from "./ProgressBar.svelte";
+  import { useFooterHeight } from "./useFooterHeight";
   import { useNowPlayingProgress } from "./useNowPlayingProgress";
   import { useScrollDistance } from "./useScrollDistance";
 
@@ -16,6 +17,7 @@
   );
 
   const { distanceFromBottom } = useScrollDistance();
+  const { footerHeight } = useFooterHeight();
 
   const title = $derived(
     nowPlaying.type === "movie"
@@ -27,7 +29,7 @@
 {#if $isPlaying}
   <div
     class="trakt-now-playing-toast"
-    style="--distance-from-bottom: {$distanceFromBottom}px"
+    style="--distance-from-bottom: {$distanceFromBottom}px; --footer-height: {$footerHeight}px"
   >
     <NowPlayingItemCard nowPlayingItem={nowPlaying} />
     <div class="trakt-now-playing-content">
@@ -100,8 +102,9 @@
       --now-playing-bottom-distance: calc(
         var(--ni-12) + var(--mobile-navbar-height)
       );
-      --now-playing-footer-offset: var(--mobile-navbar-height) +
-        var(--footer-mobile-height);
+      --now-playing-footer-offset: calc(
+        var(--mobile-navbar-height) + var(--footer-height)
+      );
     }
 
     @include for-mobile {

--- a/projects/client/src/lib/sections/now-playing/_internal/useFooterHeight.ts
+++ b/projects/client/src/lib/sections/now-playing/_internal/useFooterHeight.ts
@@ -1,0 +1,30 @@
+import { FOOTER_CLASS_NAME } from '$lib/sections/footer/constants.ts';
+import { onMount } from 'svelte';
+import { derived, writable } from 'svelte/store';
+
+export function useFooterHeight() {
+  const footerHeight = writable(0);
+
+  onMount(() => {
+    const footer = globalThis.document.querySelector(`.${FOOTER_CLASS_NAME}`);
+    if (!footer) {
+      return;
+    }
+
+    footerHeight.set(footer.clientHeight);
+
+    const observer = new MutationObserver(() => {
+      footerHeight.set(footer.clientHeight);
+    });
+
+    observer.observe(footer, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+    };
+  });
+
+  return {
+    footerHeight: derived(footerHeight, ($footerHeight) => $footerHeight),
+  };
+}

--- a/projects/client/src/style/layout/index.css
+++ b/projects/client/src/style/layout/index.css
@@ -61,8 +61,6 @@
   --navbar-height: var(--ni-72);
   --side-navbar-width: var(--ni-66);
   --mobile-navbar-height: calc(var(--ni-56) + env(safe-area-inset-bottom, 0));
-  --footer-height: var(--ni-300);
-  --footer-mobile-height: var(--ni-72);
   --footer-bar-padding: var(--ni-40);
 
   --layout-distance-side: var(--ni-24);


### PR DESCRIPTION
## 🎶 Notes 🎶

- On mobile layout, on your own profile page, the footer was cut off.
  - This was because the content could be dynamic, but the height was static.
- The footer size can now also be dynamic; the now playing toast checks the actual element for its size.

## 👀 Examples 👀
Before:

https://github.com/user-attachments/assets/dad47419-3a79-4ca2-82bc-6f6e0260c302

After:

https://github.com/user-attachments/assets/7a299e4e-911d-4302-8e0f-9afd40391ee0

<img width="371" alt="Screenshot 2025-06-06 at 19 27 12" src="https://github.com/user-attachments/assets/c94a2caf-a531-4550-a62c-5955b8700601" />

<img width="371" alt="Screenshot 2025-06-06 at 19 27 19" src="https://github.com/user-attachments/assets/2266fe5b-e89d-4454-9a2b-ee29f8716610" />

