### PR TITLE
fix: use english media information as fallback when intl is missing

### DIFF
--- a/projects/client/src/lib/utils/media/toMediaIntl.ts
+++ b/projects/client/src/lib/utils/media/toMediaIntl.ts
@@ -1,10 +1,13 @@
 import type { MediaEntry } from '../../requests/models/MediaEntry.ts';
 import type { MediaIntl } from '../../requests/models/MediaIntl.ts';
 
-export function toMediaIntl(item?: MediaIntl | MediaEntry): MediaIntl {
+export function toMediaIntl(
+  item?: MediaIntl | MediaEntry,
+  fallback?: MediaEntry,
+): MediaIntl {
   return {
-    title: item?.title ?? '',
-    overview: item?.overview ?? '',
-    tagline: item?.tagline ?? '',
+    title: item?.title ?? fallback?.title ?? '',
+    overview: item?.overview ?? fallback?.overview ?? '',
+    tagline: item?.tagline ?? fallback?.tagline ?? '',
   };
 }

--- a/projects/client/src/routes/movies/[slug]/useMovie.ts
+++ b/projects/client/src/routes/movies/[slug]/useMovie.ts
@@ -53,12 +53,12 @@ export function useMovie(slug: string) {
     studios: derived(studios, ($studios) => $studios.data),
     crew: derived(crew, ($crew) => $crew.data),
     videos: derived(videos, ($videos) => $videos.data ?? []),
-    intl: derived(intl, ($intl) => {
-      if ($intl.isFetching) {
+    intl: derived([intl, movie], ([$intl, $movie]) => {
+      if ($intl.isFetching || $movie.isFetching) {
         return;
       }
 
-      return toMediaIntl($intl?.data);
+      return toMediaIntl($intl?.data, $movie?.data);
     }),
     streamOn: derived(
       streamOn,

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/useEpisode.ts
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/useEpisode.ts
@@ -85,12 +85,12 @@ export function useEpisode(
         };
       },
     ),
-    showIntl: derived(showIntl, ($showIntl) => {
-      if ($showIntl.isFetching) {
+    showIntl: derived([showIntl, show], ([$showIntl, $show]) => {
+      if ($showIntl.isFetching || $show.isFetching) {
         return;
       }
 
-      return toMediaIntl($showIntl?.data);
+      return toMediaIntl($showIntl?.data, $show?.data);
     }),
     streamOn: derived(
       streamOn,

--- a/projects/client/src/routes/shows/[slug]/useShow.ts
+++ b/projects/client/src/routes/shows/[slug]/useShow.ts
@@ -46,16 +46,13 @@ export function useShow(slug: string) {
     studios: derived(studios, ($studios) => $studios.data),
     crew: derived(crew, ($crew) => $crew.data),
     seasons: derived(seasons, ($seasons) => $seasons.data),
-    intl: derived(
-      intl,
-      ($intl) => {
-        if ($intl.isFetching) {
-          return;
-        }
+    intl: derived([intl, show], ([$intl, $show]) => {
+      if ($intl.isFetching || $show.isFetching) {
+        return;
+      }
 
-        return toMediaIntl($intl.data);
-      },
-    ),
+      return toMediaIntl($intl?.data, $show?.data);
+    }),
     streamOn: derived(
       streamOn,
       ($streamOn) => {


### PR DESCRIPTION
Ensures a smoother user experience by displaying default data when internationalized content is unavailable.

- Modifies the `toMediaIntl` function to utilize fallback data (typically the original entry) if the internationalized data is missing.
- Updates relevant components to provide the original data as the fallback.

Fixes: #764