### PR TITLE
fix(episode): do not show mark as watched for unauthenticated users

### DIFF
--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { EpisodeIntlProvider } from "$lib/components/episode/EpisodeIntlProvider";
   import ShowProgressTag from "$lib/components/episode/tags/ShowProgressTag.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import EpisodeCard from "./EpisodeCard.svelte";
   import type { EpisodeCardProps } from "./EpisodeCardProps";
@@ -16,16 +17,18 @@
 
 {#snippet action()}
   {#if !isFuture && !isActivity && !isHidden}
-    <MarkAsWatchedAction
-      allowRewatch={props.variant === "next"}
-      style="action"
-      type="episode"
-      size="small"
-      title={props.episode.title}
-      media={props.episode}
-      episode={props.episode}
-      show={props.show}
-    />
+    <RenderFor audience="authenticated">
+      <MarkAsWatchedAction
+        allowRewatch={props.variant === "next"}
+        style="action"
+        type="episode"
+        size="small"
+        title={props.episode.title}
+        media={props.episode}
+        episode={props.episode}
+        show={props.show}
+      />
+    </RenderFor>
   {/if}
 {/snippet}
 


### PR DESCRIPTION
## ♪ Note ♪

- Add render guard for the episode action.

## 👀 Example 👀

Before:
<img width="1599" alt="Screenshot 2025-06-11 at 11 18 04" src="https://github.com/user-attachments/assets/7117259c-e6ec-499a-9730-fca814087607" />

After:
<img width="1599" alt="Screenshot 2025-06-11 at 11 17 23" src="https://github.com/user-attachments/assets/f9af3f88-9ae1-4196-823d-0213714b6ca3" />

