### PR TITLE
feat(analytics): add telemetry on extras

### DIFF
--- a/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
@@ -28,6 +28,7 @@ export const AnalyticsEvent = {
   LikeComment: buildEventKey(MEDIA_ACTION_PREFIX, 'like-comment'),
   Rate: buildEventKey(MEDIA_ACTION_PREFIX, 'rate'),
   CheckIn: buildEventKey(MEDIA_ACTION_PREFIX, 'check-in'),
+  Extras: buildEventKey(MEDIA_ACTION_PREFIX, 'extras'),
 
   Settings: buildEventKey(USER_ACTION_PREFIX, 'settings'),
 

--- a/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
@@ -1,5 +1,6 @@
 import type { Theme } from '$lib/features/theme/models/Theme.ts';
 import type { SimpleRating } from '$lib/models/SimpleRating.ts';
+import type { MediaVideoType } from '$lib/requests/models/MediaVideo.ts';
 import type { UpNextType } from '$lib/sections/lists/progress/useUpNextExperiment.ts';
 import { AnalyticsEvent } from './AnalyticsEvent.ts';
 
@@ -8,6 +9,7 @@ type RatingType = { action: 'added' | 'changed'; rating: SimpleRating };
 type FilterType = { id: string; action: 'set' | 'reset' };
 type CheckInType = { type: 'episode' | 'movie' };
 type FollowType = { action: 'follow' | 'unfollow' };
+type ExtrasType = { slug: string; type: MediaVideoType };
 
 export type AnalyticsEventDataMap = {
   [AnalyticsEvent.EnterLite]: never;
@@ -27,6 +29,7 @@ export type AnalyticsEventDataMap = {
   [AnalyticsEvent.LikeComment]: ActionType;
   [AnalyticsEvent.Rate]: RatingType;
   [AnalyticsEvent.CheckIn]: CheckInType;
+  [AnalyticsEvent.Extras]: ExtrasType;
 
   [AnalyticsEvent.Settings]: { settings: string };
 

--- a/projects/client/src/lib/requests/models/MediaVideo.ts
+++ b/projects/client/src/lib/requests/models/MediaVideo.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const MediaVideoType = z.enum([
+export const MediaVideoTypeSchema = z.enum([
   'trailer',
   'clip',
   'teaser',
@@ -12,10 +12,12 @@ export const MediaVideoType = z.enum([
 
 export const MediaVideoSchema = z.object({
   id: z.string(),
-  type: MediaVideoType,
+  type: MediaVideoTypeSchema,
   url: z.string().url(),
   thumbnail: z.string().url(),
   title: z.string(),
   publishedAt: z.date(),
 });
+
+export type MediaVideoType = z.infer<typeof MediaVideoTypeSchema>;
 export type MediaVideo = z.infer<typeof MediaVideoSchema>;

--- a/projects/client/src/lib/sections/lists/VideoList.svelte
+++ b/projects/client/src/lib/sections/lists/VideoList.svelte
@@ -2,6 +2,8 @@
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
   import ShadowList from "$lib/components/lists/section-list/ShadowList.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
   import type { MediaVideo } from "$lib/requests/models/MediaVideo";
   import { toTranslatedValue } from "$lib/utils/formatting/string/toTranslatedValue";
   import { writable } from "svelte/store";
@@ -14,6 +16,8 @@
   };
 
   const { slug, videos }: VideoListProps = $props();
+
+  const { track } = useTrack(AnalyticsEvent.Extras);
 
   const { record, types } = $derived.by(() => {
     if (!videos.length) return { record: {}, types: [] };
@@ -35,6 +39,8 @@
   const firstType = $derived(types.at(0));
   const active = $derived(writable(firstType));
   const items = $derived(record[$active] ?? []);
+
+  const trackHandler = $derived(() => track({ slug, type: $active }));
 </script>
 
 {#if videos.length > 0}
@@ -45,7 +51,7 @@
     --height-list={mediaListHeightResolver("landscape")}
   >
     {#snippet item(video)}
-      <VideoItem {video} />
+      <VideoItem {video} {trackHandler} />
     {/snippet}
 
     {#snippet actions()}

--- a/projects/client/src/lib/sections/lists/components/VideoItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/VideoItem.svelte
@@ -7,7 +7,11 @@
   import { getDeepLinkHandler } from "$lib/features/deep-link/getDeepLinkHandler";
   import type { MediaVideo } from "$lib/requests/models/MediaVideo";
 
-  const { video }: { video: MediaVideo } = $props();
+  const {
+    video,
+    trackHandler,
+  }: { video: MediaVideo; trackHandler: () => void } = $props();
+
   const deepLinkHandler = getDeepLinkHandler();
 </script>
 
@@ -17,6 +21,8 @@
     href={video.url}
     target="_blank"
     onclick={(ev) => {
+      trackHandler();
+
       if (!deepLinkHandler) {
         return;
       }


### PR DESCRIPTION
## ♪ Note ♪

- Adds telemetry for extras (tracking slug, and video type (e.g. `trailer`, `teaser`, etc.)