### PR TITLE
fix(summary): ellipse content in details grid

### DIFF
--- a/projects/client/src/lib/sections/summary/components/details/_internal/CollapsableValues.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/CollapsableValues.svelte
@@ -67,6 +67,7 @@
   .trakt-collapsable-values-content {
     display: flex;
     flex-direction: column;
+    min-width: 0;
 
     gap: var(--gap-xxs);
 
@@ -82,5 +83,9 @@
     gap: var(--gap-xxs);
 
     min-height: var(--ni-18);
+
+    :global(.trakt-link) {
+      min-width: 0;
+    }
   }
 </style>


### PR DESCRIPTION
## ♪ Note ♪

- Fixes ellipsis for links in the details grid on summary pages

## 👀 Example 👀

Before/after:
<img width="364" alt="Screenshot 2025-06-14 at 16 03 01" src="https://github.com/user-attachments/assets/46f15ec8-9e13-48dd-b350-0c6779cfe0ac" />

<img width="369" alt="Screenshot 2025-06-14 at 16 02 21" src="https://github.com/user-attachments/assets/7c5c9d45-7652-4b14-a342-a76d0ebbe9dd" />

Before/after:
<img width="1182" alt="Screenshot 2025-06-14 at 16 03 12" src="https://github.com/user-attachments/assets/bd37506d-3f93-4757-bd98-13289ec281e9" />

<img width="1183" alt="Screenshot 2025-06-14 at 16 02 40" src="https://github.com/user-attachments/assets/fdc879d3-5ed8-4b71-8a52-1ef5017a5b44" />
