### PR TITLE
fix(gestures): keep consistent size when lazy loading gesture container

### DIFF
--- a/projects/client/src/lib/components/gestures/SwipeX.svelte
+++ b/projects/client/src/lib/components/gestures/SwipeX.svelte
@@ -134,6 +134,7 @@
     touch-action: pan-y;
 
     position: relative;
+    min-width: 100%;
 
     will-change: transform;
 


### PR DESCRIPTION
## ♪ Note ♪

- After lazy loading elements with a gesture container, the width could become larger than the column.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/cdbf84dc-58ea-430a-9524-e1ea1c50873d

After:

https://github.com/user-attachments/assets/ac33c135-4590-48cc-9a7d-0d53caec0099


