### PR TITLE
fix(favorite): use correct list height when using d-pad

### DIFF
--- a/projects/client/src/lib/sections/lists/FavoritesList.svelte
+++ b/projects/client/src/lib/sections/lists/FavoritesList.svelte
@@ -2,6 +2,7 @@
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { mediaListHeightResolver } from "$lib/sections/lists/utils/mediaListHeightResolver";
+  import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
   import FavoriteAction from "../media-actions/favorite/FavoriteAction.svelte";
   import DefaultMediaItem from "./components/DefaultMediaItem.svelte";
   import { useFavoritesList } from "./stores/useFavoritesList";
@@ -15,13 +16,14 @@
     $props();
 
   const { list, isLoading } = useFavoritesList({ type, slug });
+  const defaultVariant = $derived(useDefaultCardVariant(type));
 </script>
 
 <SectionList
   id={`favorites-list-${type}`}
   items={$list}
   {title}
-  --height-list={mediaListHeightResolver("portrait")}
+  --height-list={mediaListHeightResolver($defaultVariant)}
 >
   {#snippet item(media)}
     <DefaultMediaItem {type} media={media.item}>


### PR DESCRIPTION
## ♪ Note ♪

- Use the correct list height for favorites when d-pad navigation is enabled

## 👀 Example 👀
Before:
<img width="1207" alt="Screenshot 2025-06-16 at 14 13 43" src="https://github.com/user-attachments/assets/b470ac40-ad63-4e1d-a108-78a803df74fb" />

After:
<img width="1207" alt="Screenshot 2025-06-16 at 14 13 49" src="https://github.com/user-attachments/assets/fe6c7384-7d42-460c-b9ab-651b608fb0cb" />
