### PR TITLE
fix(streaming): prioritize services over plex

### DIFF
--- a/projects/client/src/lib/stores/_internal/findPreferredStreamingService.spec.ts
+++ b/projects/client/src/lib/stores/_internal/findPreferredStreamingService.spec.ts
@@ -11,7 +11,7 @@ describe('findPreferredStreamingService', () => {
     })).toBe(undefined);
   });
 
-  it('should return undefined if are no matching favorite subscriptions', () => {
+  it('should return the first available if there are no matching favorite subscriptions', () => {
     expect(findPreferredStreamingService({
       services: {
         streaming: [{
@@ -24,7 +24,12 @@ describe('findPreferredStreamingService', () => {
       },
       favorites: ['us-netflix'],
       countryCode: 'nl',
-    })).toBeUndefined();
+    })).toStrictEqual({
+      'is4k': false,
+      'link': 'https://www.netflix.com/',
+      'source': 'netflix',
+      'type': 'streaming',
+    });
   });
 
   it('should return the matching service', () => {

--- a/projects/client/src/lib/stores/_internal/findPreferredStreamingService.ts
+++ b/projects/client/src/lib/stores/_internal/findPreferredStreamingService.ts
@@ -1,6 +1,7 @@
 import { getDeepLinkHandler } from '$lib/features/deep-link/getDeepLinkHandler.ts';
 import type {
   StreamingServiceOptions,
+  StreamNow,
 } from '$lib/requests/models/StreamingServiceOptions.ts';
 
 type FindPreferredStreamingServiceProps = {
@@ -8,6 +9,11 @@ type FindPreferredStreamingServiceProps = {
   favorites: string[];
   countryCode: string;
 };
+
+function findViablePreferredService(services: StreamNow[]) {
+  // TODO we'll need to revisit and come up with a better heuristic
+  return services.at(0);
+}
 
 export function findPreferredStreamingService({
   services,
@@ -32,5 +38,6 @@ export function findPreferredStreamingService({
         favorites.includes(`${countryCode}-${subscription.source}`),
     );
 
-  return favoriteSubscriptionMatch;
+  return favoriteSubscriptionMatch ??
+    findViablePreferredService(streamNowServices);
 }


### PR DESCRIPTION
## ♪ Note ♪

- Fixes the services match priority to be:
  - Match one of your favorites.
  - If no hit, pick the first available streaming service, based on the sorted list.
  - If no hit, fall back to plex.