### PR TITLE
fix(episode): show more relevant info for coalesced episodes

### DIFF
--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -112,22 +112,23 @@
     {/if}
 
     {#if !isShowContext && !isActivity}
-      {#if episode.type === EpisodeComputedType.full_season}
-        <Link href={UrlBuilder.show(show.slug)}>
-          <p class="trakt-card-title uppercase ellipsis">
-            {seasonLabel(episode.season)}
-          </p>
-        </Link>
-      {:else}
-        <Link href={UrlBuilder.show(show.slug)}>
-          <p class="trakt-card-title ellipsis">{show.title}</p>
-        </Link>
-      {/if}
+      <Link href={UrlBuilder.show(show.slug)}>
+        <p
+          class="trakt-card-title ellipsis"
+          class:uppercase={episode.type === EpisodeComputedType.full_season}
+        >
+          {show.title}
+        </p>
+      </Link>
       <p class="trakt-card-subtitle ellipsis small">
-        {episode.season}x{episode.number}
-        <Spoiler media={episode} {show} {episode} type="episode">
-          - {episode.title}
-        </Spoiler>
+        {#if episode.type === EpisodeComputedType.full_season}
+          {seasonLabel(episode.season)}
+        {:else}
+          {episode.season}x{episode.number}
+          <Spoiler media={episode} {show} {episode} type="episode">
+            - {episode.title}
+          </Spoiler>
+        {/if}
       </p>
     {/if}
   </CardFooter>


### PR DESCRIPTION
## ♪ Note ♪

- Show more relevant info for coalesced episodes

## 👀 Example 👀
Before:
<img width="267" alt="Screenshot 2025-06-16 at 15 36 20" src="https://github.com/user-attachments/assets/74da0d60-3114-42ca-961f-ee72087e1de2" />

After:
<img width="267" alt="Screenshot 2025-06-16 at 15 36 27" src="https://github.com/user-attachments/assets/fa934074-5b5a-40b7-9a57-efc0a6ceb40f" />
