### PR TITLE
fix(streaming): fall back to service name when there is no image

### DIFF
--- a/projects/client/src/lib/components/media/streaming-service/StreamingServiceLogo.svelte
+++ b/projects/client/src/lib/components/media/streaming-service/StreamingServiceLogo.svelte
@@ -21,7 +21,11 @@
 </script>
 
 <div class="trakt-streaming-service-logo">
-  <CrossOriginImage src={service?.logoUrl ?? ""} alt={i18n.alt(displayName)} />
+  {#if service?.logoUrl}
+    <CrossOriginImage src={service.logoUrl} alt={i18n.alt(displayName)} />
+  {:else}
+    <span class="meta-info uppercase">{displayName}</span>
+  {/if}
 </div>
 
 <style>


### PR DESCRIPTION
## ♪ Note ♪

- Fall back to displaying service name if there is no logo.

## 👀 Example 👀
Hardcoded example:

When there is an image:
<img width="199" alt="Screenshot 2025-06-17 at 11 19 57" src="https://github.com/user-attachments/assets/ed32cae9-ba6e-446a-94ce-c30e12e1a4fa" />

When there is no image:
<img width="199" alt="Screenshot 2025-06-17 at 11 20 08" src="https://github.com/user-attachments/assets/b6195229-efa0-4ff2-b4c3-8f855dbd1da0" />

