### PR TITLE
feat(episode): new tags designs for episode cards

### DIFF
--- a/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
+++ b/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
@@ -19,7 +19,7 @@
   aria-valuemax={total}
 >
   <TagContent>
-    <p class="meta-info capitalize">
+    <p class="meta-info capitalize tag-label">
       {@render children()}
     </p>
   </TagContent>
@@ -28,11 +28,14 @@
 <style lang="scss">
   @use "$style/scss/mixins/index.scss" as *;
 
-  .show-progress-tag {
+  .tag-label {
     width: 100%;
   }
 
   .show-progress-tag {
+    width: 100%;
+    min-width: 0;
+
     :global(.trakt-tag) {
       overflow: hidden;
 
@@ -54,7 +57,7 @@
       }
 
       position: relative;
-      background: var(--color-background-progress-base-tag);
+      background: var(--color-background-cover-tag);
       color: var(--color-text-progress-tag);
       @include backdrop-filter-blur(var(--ni-16));
     }

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -6,9 +6,6 @@
   import { EpisodeIntlProvider } from "$lib/components/episode/EpisodeIntlProvider";
   import Link from "$lib/components/link/Link.svelte";
   import LandscapeCard from "$lib/components/media/card/LandscapeCard.svelte";
-  import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
-  import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
-  import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import * as m from "$lib/features/i18n/messages.ts";
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage";
@@ -37,18 +34,6 @@
   const isActivity = $derived(rest.variant === "activity");
 </script>
 
-{#snippet upcomingTag()}
-  <AirDateTag
-    i18n={TagIntlProvider}
-    airDate={episode.airDate}
-    year={episode.year}
-  />
-{/snippet}
-
-{#snippet durationTag()}
-  <DurationTag i18n={TagIntlProvider} runtime={episode.runtime} />
-{/snippet}
-
 <LandscapeCard>
   {#if popupActions}
     <CardActionBar>
@@ -75,20 +60,7 @@
     />
   </Link>
 
-  <CardFooter
-    {action}
-    tag={(() => {
-      if (isActivity) {
-        return;
-      }
-
-      if (rest.variant === "upcoming") {
-        return upcomingTag;
-      }
-
-      return durationTag;
-    })()}
-  >
+  <CardFooter {action}>
     {#if isShowContext}
       <p class="trakt-card-title ellipsis">
         <Spoiler media={episode} {show} {episode} type="episode">

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { EpisodeIntlProvider } from "$lib/components/episode/EpisodeIntlProvider";
   import ShowProgressTag from "$lib/components/episode/tags/ShowProgressTag.svelte";
+  import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
+  import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
+  import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import EpisodeCard from "./EpisodeCard.svelte";
@@ -33,18 +36,35 @@
 {/snippet}
 
 {#snippet tag()}
-  {#if props.variant === "next"}
-    <ShowProgressTag
-      total={props.episode.total}
-      progress={props.episode.completed}
-    >
-      <span class="show-progress-label">
-        {EpisodeIntlProvider.remainingText(props.episode.remaining)} / {EpisodeIntlProvider.durationText(
-          props.episode.minutesLeft,
-        )}
-      </span>
-    </ShowProgressTag>
-  {/if}
+  <div class="trakt-episode-tag">
+    {#if ["next", "default"].includes(props.variant)}
+      <DurationTag i18n={TagIntlProvider} runtime={props.episode.runtime} />
+    {/if}
+
+    {#if props.variant === "next"}
+      <ShowProgressTag
+        total={props.episode.total}
+        progress={props.episode.completed}
+      >
+        <div class="show-progress">
+          <span class="ellipsis">
+            {EpisodeIntlProvider.remainingText(props.episode.remaining)}
+          </span>
+          <span>
+            {EpisodeIntlProvider.durationText(props.episode.minutesLeft)}
+          </span>
+        </div>
+      </ShowProgressTag>
+    {/if}
+
+    {#if props.variant === "upcoming"}
+      <AirDateTag
+        i18n={TagIntlProvider}
+        airDate={props.episode.airDate}
+        year={props.episode.year}
+      />
+    {/if}
+  </div>
 {/snippet}
 
 {#snippet card()}
@@ -79,8 +99,16 @@
   {@render card()}
 {/if}
 
-<style>
-  .show-progress-label {
+<style lang="scss">
+  @use "$style/scss/mixins/index.scss" as *;
+
+  .show-progress {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    gap: var(--gap-xs);
+
     position: relative;
   }
 
@@ -89,6 +117,20 @@
     :global(.trakt-card-cover),
     :global(.trakt-summary-item) {
       filter: contrast(0.65) grayscale(1);
+    }
+  }
+
+  .trakt-episode-tag {
+    width: 100%;
+
+    display: flex;
+    align-items: center;
+
+    gap: var(--gap-micro);
+
+    :global(.trakt-tag) {
+      background: var(--color-background-cover-tag);
+      @include backdrop-filter-blur(var(--ni-16));
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -5,8 +5,6 @@
   import CardCover from "$lib/components/card/CardCover.svelte";
   import CardFooter from "$lib/components/card/CardFooter.svelte";
   import Link from "$lib/components/link/Link.svelte";
-  import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
-  import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import GenreList from "$lib/components/summary/GenreList.svelte";
   import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -26,10 +24,8 @@
 </script>
 
 {#snippet footerTag()}
-  {#if rest.type === "episode" && rest.variant !== "activity"}
-    <DurationTag i18n={TagIntlProvider} runtime={rest.episode.runtime} />
-  {:else if tag != null}
-    {@render tag()}
+  {#if rest.type !== "episode"}
+    {@render tag?.()}
   {/if}
 {/snippet}
 

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -18,7 +18,7 @@
 
   --color-text-progress-tag: var(--shade-10);
   --color-background-progress-tag: var(--purple-800);
-  --color-background-progress-base-tag: color-mix(
+  --color-background-cover-tag: color-mix(
     in srgb,
     var(--shade-700) 35%,
     transparent


### PR DESCRIPTION
## 🎶 Notes 🎶

- Pt. 1 of updated card designs:
  - For episode cards, place tags on the cover.
- The duration and airdate tags have a local style override in the episode item, because in other cases they use the default style.

## 👀 Examples 👀
Before/after:
<img width="655" alt="Screenshot 2025-06-17 at 12 16 16" src="https://github.com/user-attachments/assets/cf928cdf-2672-4fad-b120-5b43bd935118" />

<img width="655" alt="Screenshot 2025-06-17 at 12 16 20" src="https://github.com/user-attachments/assets/ef6ac693-3d60-4afb-9f1e-2c835d43d80c" />

Before/after:
<img width="655" alt="Screenshot 2025-06-17 at 12 16 28" src="https://github.com/user-attachments/assets/baba2ddf-be04-48e6-b8d5-f0549f3218aa" />

<img width="655" alt="Screenshot 2025-06-17 at 12 16 32" src="https://github.com/user-attachments/assets/83bec299-1686-454c-a824-cd4fe3cd0c27" />

Before/after:
<img width="369" alt="Screenshot 2025-06-17 at 12 17 04" src="https://github.com/user-attachments/assets/a6e9e30a-7c72-4d40-acdd-b7f7b5bb644f" />

<img width="369" alt="Screenshot 2025-06-17 at 12 17 32" src="https://github.com/user-attachments/assets/4e84862e-af5c-44fb-95de-1c1bf534b45f" />

Before/after:
<img width="654" alt="Screenshot 2025-06-17 at 12 18 33" src="https://github.com/user-attachments/assets/ec93e59e-a52f-4885-a81d-a74cba8b8cce" />

<img width="654" alt="Screenshot 2025-06-17 at 12 18 42" src="https://github.com/user-attachments/assets/b8d54e9d-f76c-4e6c-86ed-8a479fdeb446" />

