### PR TITLE
perf: less blurring for increased performance

### DIFF
--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -78,6 +78,12 @@
         font-size: var(--ni-12);
       }
     }
+
+    .trakt-card-footer-action {
+      :global(.trakt-action-button[data-style="ghost"]) {
+        backdrop-filter: none;
+      }
+    }
   }
 
   :global([data-device="tv"]) {

--- a/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
+++ b/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
@@ -59,7 +59,6 @@
       position: relative;
       background: var(--color-background-cover-tag);
       color: var(--color-text-progress-tag);
-      @include backdrop-filter-blur(var(--ni-16));
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -130,7 +130,6 @@
 
     :global(.trakt-tag) {
       background: var(--color-background-cover-tag);
-      @include backdrop-filter-blur(var(--ni-16));
     }
   }
 </style>

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -20,7 +20,7 @@
   --color-background-progress-tag: var(--purple-800);
   --color-background-cover-tag: color-mix(
     in srgb,
-    var(--shade-700) 35%,
+    var(--shade-700) 75%,
     transparent
   );
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- The amount of blurred backgrounds were causing some performance issues; especially on the home page, since all these items have blurs:
<img width="1516" alt="Screenshot 2025-06-17 at 17 23 01" src="https://github.com/user-attachments/assets/cd38db2b-fea1-4cdb-82f0-ee19ca499c08" />

- Changes:
  - For the tags, the blur is removed, and the background color is made less transparent.
  - For the action buttons in the card footers, the blur is removed.
- These changes were discussed with @anodpixels 
- Until we can find a better way of dealing with blurs, we should refrain from using blur on components that repeat so often on a page.
- Still strange that it's so computationally heavy, might be worth it to investigate this more later on. For now this is a good enough alternative I'd say.

## 👀 Example 👀
I hope the screen recording captures it well enough. When scrolling you can see how choppy/smooth the navbar transitions.

Before:

https://github.com/user-attachments/assets/e3911813-8fde-44d1-9b4b-daf19200b484

After:

https://github.com/user-attachments/assets/7cdefeec-037e-4667-a83e-8d28f9fc19c8
