### PR TITLE
Feat/makes extras dpad navigateable

### DIFF
--- a/projects/client/src/lib/components/dropdown/DropdownList.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownList.svelte
@@ -14,6 +14,7 @@
     items,
     preferNative = false,
     size,
+    navigationType,
     ...props
   }: TraktDropdownListProps = $props();
 
@@ -50,6 +51,9 @@
     const select = document.createElement("select");
     select.classList.add("trakt-shadow-select");
     select.setAttribute("tabindex", "-1");
+
+    navigationType &&
+      select.setAttribute("data-dpad-navigation", navigationType);
 
     select.addEventListener("change", (event) => {
       const selectedIndex = (event.target as HTMLSelectElement).selectedIndex;
@@ -98,6 +102,10 @@
       },
     };
   }
+
+  const buttonNavigationType = $derived(
+    !isActuallyNative && navigationType ? navigationType : undefined,
+  );
 </script>
 
 <div
@@ -107,7 +115,12 @@
   use:shadowNativeSelect
   data-size={size}
 >
-  <Button style="textured" {size} {...props}>
+  <Button
+    style="textured"
+    navigationType={buttonNavigationType}
+    {size}
+    {...props}
+  >
     {@render children()}
     {#snippet icon()}
       <div class="trakt-dropdown-list-icon">
@@ -158,6 +171,13 @@
       width: 0;
       height: 0;
       overflow: hidden;
+    }
+
+    //FIXME: merge with SelectFilter
+    &:has(:global(select:focus-visible)) {
+      outline: var(--border-thickness-xs) solid var(--purple-500);
+      outline-offset: var(--border-thickness-xs);
+      border-radius: calc(var(--border-radius-m) * 0.76925);
     }
 
     :global(.trakt-shadow-select) {

--- a/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
+  import { useNavigation } from "$lib/features/navigation/useNavigation";
   import type { Snippet } from "svelte";
   import ListTitle from "./ListTitle.svelte";
 
@@ -10,6 +11,7 @@
     titleAction,
     actions,
     badge,
+    navigationType,
     ...props
   }: {
     title: string;
@@ -18,7 +20,13 @@
     actions?: Snippet;
     badge?: Snippet;
     inset: "all" | "title";
+    navigationType?: DpadNavigationType;
   } & HTMLElementProps = $props();
+
+  const { navigation } = useNavigation();
+  const hasHiddenActions = $derived(
+    $navigation === "dpad" && !Boolean(navigationType),
+  );
 </script>
 
 <div
@@ -41,12 +49,10 @@
       {@render badge()}
     {/if}
   </div>
-  {#if actions != null}
-    <RenderFor audience="all" navigation="default">
-      <div class="trakt-list-actions">
-        {@render actions()}
-      </div>
-    </RenderFor>
+  {#if actions != null && !hasHiddenActions}
+    <div class="trakt-list-actions" data-dpad-navigation={navigationType}>
+      {@render actions()}
+    </div>
   {/if}
 </div>
 

--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -24,6 +24,7 @@
     scrollContainer?: Writable<HTMLDivElement>;
     scrollX?: Writable<{ left: number; right: number }>;
     variant?: "normal" | "centered";
+    headerNavigationType?: DpadNavigationType;
   };
 
   const {
@@ -37,6 +38,7 @@
     actions,
     badge,
     empty,
+    headerNavigationType,
     variant = "normal",
   }: SectionListProps<T> = $props();
   const sideDistance = useVarToPixels("var(--layout-distance-side)");
@@ -101,6 +103,7 @@
         actions={$isCollapsed ? undefined : actions}
         {badge}
         inset="title"
+        navigationType={headerNavigationType}
       />
     {/if}
     <div

--- a/projects/client/src/lib/sections/lists/VideoList.svelte
+++ b/projects/client/src/lib/sections/lists/VideoList.svelte
@@ -4,6 +4,7 @@
   import ShadowList from "$lib/components/lists/section-list/ShadowList.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import type { MediaVideo } from "$lib/requests/models/MediaVideo";
   import { toTranslatedValue } from "$lib/utils/formatting/string/toTranslatedValue";
   import { writable } from "svelte/store";
@@ -49,6 +50,7 @@
     {items}
     title="Extras"
     --height-list={mediaListHeightResolver("landscape")}
+    headerNavigationType={DpadNavigationType.List}
   >
     {#snippet item(video)}
       <VideoItem {video} {trackHandler} />
@@ -64,6 +66,7 @@
           color="blue"
           text="capitalize"
           size="small"
+          navigationType={DpadNavigationType.Item}
         >
           {toTranslatedValue("video_type", $active)}
           {#snippet items()}


### PR DESCRIPTION
## ♪ Note ♪

- Makes the `Extras` dropdown on summary pages d-pad navigateable.

## 👀 Example 👀

https://github.com/user-attachments/assets/641ccf2e-f987-4cae-aadf-f635382d88e0

