### PR TITLE
refactor: merge episode info

### DIFF
--- a/projects/client/src/lib/features/spoilers/useEpisodeSpoilerImage.ts
+++ b/projects/client/src/lib/features/spoilers/useEpisodeSpoilerImage.ts
@@ -12,7 +12,6 @@ export function useEpisodeSpoilerImage(props: SpoilerImageProps) {
   const { episode, show } = props;
 
   const { isSpoilerHidden } = useMediaSpoiler({
-    episode,
     show,
     media: episode,
     type: 'episode',

--- a/projects/client/src/lib/models/MediaStoreProps.ts
+++ b/projects/client/src/lib/models/MediaStoreProps.ts
@@ -2,12 +2,8 @@ type ArrayOrSingle<T> = T | T[];
 
 type EpisodeProps<T> = {
   type: 'episode';
-  media: ArrayOrSingle<T>;
+  media: ArrayOrSingle<T & { season: number; number: number }>;
   show: { id: number };
-  episode: ArrayOrSingle<{
-    season: number;
-    number: number;
-  }>;
 };
 
 type MediaProps<T> = {

--- a/projects/client/src/lib/sections/lists/SeasonPosterList.svelte
+++ b/projects/client/src/lib/sections/lists/SeasonPosterList.svelte
@@ -49,7 +49,6 @@
         size="small"
         title={subtitle}
         media={episodes}
-        episode={episodes}
         {show}
       />
     </RenderFor>
@@ -60,7 +59,6 @@
         size="small"
         title={subtitle}
         media={episodes}
-        episode={episodes}
         {show}
       />
     </RenderFor>

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -63,7 +63,7 @@
   <CardFooter {action}>
     {#if isShowContext}
       <p class="trakt-card-title ellipsis">
-        <Spoiler media={episode} {show} {episode} type="episode">
+        <Spoiler media={episode} {show} type="episode">
           {episode.title}
         </Spoiler>
       </p>
@@ -97,7 +97,7 @@
           {seasonLabel(episode.season)}
         {:else}
           {episode.season}x{episode.number}
-          <Spoiler media={episode} {show} {episode} type="episode">
+          <Spoiler media={episode} {show} type="episode">
             - {episode.title}
           </Spoiler>
         {/if}

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -28,7 +28,6 @@
         size="small"
         title={props.episode.title}
         media={props.episode}
-        episode={props.episode}
         show={props.show}
       />
     </RenderFor>

--- a/projects/client/src/lib/sections/lists/progress/UpNextItem.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextItem.svelte
@@ -33,7 +33,6 @@
           allowRewatch
           title={episode.title}
           {show}
-          {episode}
           media={episode}
         />
         {#if $isNitroEnabled}

--- a/projects/client/src/lib/sections/lists/progress/UpNextSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextSwipe.svelte
@@ -18,9 +18,8 @@
   const { markAsWatched } = $derived(
     useMarkAsWatched({
       type: "episode",
-      media: [episode],
+      media: episode,
       show: show,
-      episode: episode,
     }),
   );
 

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
@@ -29,8 +29,8 @@
   const isShow = $derived(target.type === "show");
   const episodeCount = $derived(
     target.type === "episode" &&
-      Array.isArray(target.episode) &&
-      target.episode.length,
+      Array.isArray(target.media) &&
+      target.media.length,
   );
 
   const isMultipleEpisodes = $derived(episodeCount && episodeCount > 1);

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
@@ -20,9 +20,9 @@ export function useIsWatched(props: IsWatchedProps) {
         case 'movie':
           return media.every((m) => $history.movies.has(m.id));
         case 'episode': {
-          const episodes = Array.isArray(props.episode)
-            ? props.episode
-            : [props.episode];
+          const episodes = Array.isArray(props.media)
+            ? props.media
+            : [props.media];
 
           const watchedEpisodes = $history.shows.get(props.show.id)?.episodes ??
             [];

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.spec.ts
@@ -144,8 +144,7 @@ describe('useMarkAsWatched', () => {
   describe('media type: episode', () => {
     const props = {
       type: 'episode' as const,
-      media: { id: 1, airDate: new Date() },
-      episode: { season: 1, number: 1 },
+      media: { id: 1, season: 1, number: 1, airDate: new Date() },
       show: { id: 3 },
     };
 
@@ -155,9 +154,8 @@ describe('useMarkAsWatched', () => {
       const { isWatched } = await renderStore(() =>
         useMarkAsWatched({
           ...props,
-          media: { id: 1, airDate: new Date() },
+          media: { id: 1, season: 1, number: 1, airDate: new Date() },
           show: ShowSiloMappedMock,
-          episode: { season: 1, number: 1 },
         })
       );
 
@@ -168,15 +166,14 @@ describe('useMarkAsWatched', () => {
       const { isWatched } = await renderStore(() =>
         useMarkAsWatched({
           ...props,
-          media: { id: 1, airDate: new Date() },
-          show: ShowSiloMappedMock,
-          episode: [
-            { season: 1, number: 1 },
-            { season: 1, number: 2 },
-            { season: 1, number: 3 },
-            { season: 1, number: 4 },
-            { season: 1, number: 5 },
+          media: [
+            { id: 1, season: 1, number: 1, airDate: new Date() },
+            { id: 2, season: 1, number: 2, airDate: new Date() },
+            { id: 3, season: 1, number: 3, airDate: new Date() },
+            { id: 4, season: 1, number: 4, airDate: new Date() },
+            { id: 5, season: 1, number: 5, airDate: new Date() },
           ],
+          show: ShowSiloMappedMock,
         })
       );
 
@@ -187,9 +184,8 @@ describe('useMarkAsWatched', () => {
       const { isWatched } = await renderStore(() =>
         useMarkAsWatched({
           ...props,
-          media: { id: 1, airDate: new Date() },
+          media: { id: 1, season: 1, number: 2, airDate: new Date() },
           show: ShowSiloMappedMock,
-          episode: { season: 1, number: 2 },
         })
       );
 
@@ -200,18 +196,17 @@ describe('useMarkAsWatched', () => {
       const { isWatched } = await renderStore(() =>
         useMarkAsWatched({
           ...props,
-          media: ShowDevsMappedMock,
-          show: ShowDevsMappedMock,
-          episode: [
-            { season: 1, number: 1 },
-            { season: 1, number: 2 },
-            { season: 1, number: 3 },
-            { season: 1, number: 4 },
-            { season: 1, number: 5 },
-            { season: 1, number: 6 },
-            { season: 1, number: 7 },
-            { season: 1, number: 8 },
+          media: [
+            { id: 1, season: 1, number: 1, airDate: new Date() },
+            { id: 2, season: 1, number: 2, airDate: new Date() },
+            { id: 3, season: 1, number: 3, airDate: new Date() },
+            { id: 4, season: 1, number: 4, airDate: new Date() },
+            { id: 5, season: 1, number: 5, airDate: new Date() },
+            { id: 6, season: 1, number: 6, airDate: new Date() },
+            { id: 7, season: 1, number: 7, airDate: new Date() },
+            { id: 8, season: 1, number: 8, airDate: new Date() },
           ],
+          show: ShowDevsMappedMock,
         })
       );
 

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -63,13 +63,12 @@
     {type}
     {title}
     media={episode}
-    {episode}
     {show}
     {size}
     allowRewatch={$watchCount > 0}
   />
   <RenderFor audience="authenticated" navigation="dpad">
-    <RateNow type="episode" media={episode} {episode} {show} />
+    <RateNow type="episode" media={episode} {show} />
   </RenderFor>
 {/snippet}
 <!-- 
@@ -140,7 +139,7 @@
     media={show}
   />
 
-  <Spoiler media={episode} {episode} {show} {type}>
+  <Spoiler media={episode} {show} {type}>
     <SummaryOverview {title} {overview} />
   </Spoiler>
 
@@ -148,7 +147,7 @@
     <SummaryActions>
       {#snippet contextualActions()}
         <RenderFor audience="authenticated" navigation="default">
-          <RateNow type="episode" media={episode} {episode} {show} />
+          <RateNow type="episode" media={episode} {show} />
         </RenderFor>
       {/snippet}
 

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -15,7 +15,6 @@
     type: "episode";
     media: EpisodeEntry;
     show: MediaEntry;
-    episode: EpisodeEntry;
   };
 
   type RateableMedia = {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Refactors the store props. In case of episodes we no longer have to pass in an episode twice.
- Also fixes potential bugs; previously, it would (in case of episode), allow an episode to be marked as watched (via the `media` property), but the history check could be done on `episodes` instead.