### PR TITLE
feat(card): adds new action bar design

### DIFF
--- a/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
+++ b/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
@@ -17,7 +17,7 @@
   class="trakt-popup-menu-button"
   {...props}
 >
-  <MoreIcon shadowColor="var(--purple-900)" />
+  <MoreIcon />
 </button>
 
 {#if $isOpened}
@@ -69,10 +69,6 @@
     &[data-popup-state="opened"] {
       background-color: var(--shade-10);
       color: var(--purple-900);
-
-      :global(svg circle) {
-        filter: none;
-      }
     }
 
     @include for-touch {

--- a/projects/client/src/lib/components/card/CardActionBar.svelte
+++ b/projects/client/src/lib/components/card/CardActionBar.svelte
@@ -13,16 +13,49 @@
 
 <style>
   .trakt-card-action-bar {
+    --height-action-bar: var(--ni-48);
+
     position: absolute;
+    height: var(--height-action-bar);
 
     top: 0;
     right: 0;
     left: 0;
     z-index: var(--layer-floating);
 
+    &::before {
+      content: "";
+
+      width: var(--height-action-bar);
+      height: var(--height-action-bar);
+
+      position: absolute;
+      top: 0;
+      right: 0;
+
+      border-top-right-radius: var(--border-radius-m);
+
+      background-image: radial-gradient(
+        circle at top right,
+        color-mix(in srgb, var(--shade-920) 30%, transparent) 15%,
+        color-mix(in srgb, var(--shade-920) 0%, transparent) 65%
+      );
+    }
+
     :global(.trakt-popup-menu-button) {
       position: absolute;
       right: 0;
+    }
+  }
+
+  :global(.trakt-card):has(:global(.trakt-card-cover-image)) {
+    :global(.trakt-card-action-bar)::before {
+      opacity: 0;
+      transition: opacity var(--transition-increment) ease-in-out;
+    }
+
+    &:has(:global(.image-loaded)) :global(.trakt-card-action-bar)::before {
+      opacity: 1;
     }
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Updates action bar design.
  - Shadow is moved from the popup menu icon to the action bar corner.

## 👀 Examples 👀
Before:
<img width="1457" alt="Screenshot 2025-06-20 at 15 14 27" src="https://github.com/user-attachments/assets/6ef6e11a-d2cf-41b1-a7fe-3d1a1fb61c84" />

After:
<img width="1457" alt="Screenshot 2025-06-20 at 15 14 33" src="https://github.com/user-attachments/assets/18ba2cfc-207b-4dd0-bf6e-15d35ac827f2" />
