### PR TITLE
fix(summary): waits for valid season number before opening summary

### DIFF
--- a/projects/client/src/routes/shows/[slug]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/+page.svelte
@@ -80,6 +80,8 @@
 
     goToSeason($show.slug, activeSeason);
   });
+
+  const isReady = $derived(!$isLoading && !isNaN(currentSeason));
 </script>
 
 <TraktPage
@@ -90,7 +92,7 @@
   type="show"
   hasDynamicContent={true}
 >
-  {#if !$isLoading}
+  {#if isReady}
     <ShowSummary
       media={$show!}
       intl={$intl!}


### PR DESCRIPTION
## ♪ Note ♪

- Could have a race condition when going to a show summary. This now waits for the season number to be there.