### PR TITLE
fix(list): makes recent watched items ionly actionable for current user

### DIFF
--- a/projects/client/src/lib/sections/lists/history/MediaWatchHistoryList.svelte
+++ b/projects/client/src/lib/sections/lists/history/MediaWatchHistoryList.svelte
@@ -31,7 +31,7 @@
       })}
   >
     {#snippet item(media)}
-      <RecentlyWatchedItem {media} />
+      <RecentlyWatchedItem {media} isActionable />
     {/snippet}
 
     {#snippet empty()}

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
@@ -8,11 +8,15 @@
 
   type RecentlyWatchedItemProps = {
     media: HistoryEntry;
+    isActionable?: boolean;
     style?: "summary" | "cover";
   };
 
-  const { media: activity, style = "cover" }: RecentlyWatchedItemProps =
-    $props();
+  const {
+    media: activity,
+    style = "cover",
+    isActionable = false,
+  }: RecentlyWatchedItemProps = $props();
 </script>
 
 {#snippet popupActions()}
@@ -40,13 +44,17 @@
 {/snippet}
 
 {#if style === "cover"}
-  <ActivityItem activityAt={activity.watchedAt} {activity} {popupActions} />
+  <ActivityItem
+    activityAt={activity.watchedAt}
+    {activity}
+    popupActions={isActionable ? popupActions : undefined}
+  />
 {/if}
 
 {#if style === "summary"}
   <ActivitySummaryCard
     activityAt={activity.watchedAt}
     {activity}
-    {popupActions}
+    popupActions={isActionable ? popupActions : undefined}
   />
 {/if}

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedList.svelte
@@ -37,7 +37,7 @@
     urlBuilder={UrlBuilder.history.all}
   >
     {#snippet item(media)}
-      <RecentlyWatchedItem {media} />
+      <RecentlyWatchedItem {media} isActionable />
     {/snippet}
   </DrillableMediaList>
 {:else}

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
@@ -25,6 +25,6 @@
     })}
 >
   {#snippet item(media)}
-    <RecentlyWatchedItem {media} {style} />
+    <RecentlyWatchedItem {media} {style} isActionable />
   {/snippet}
 </DrilledMediaList>


### PR DESCRIPTION
## ♪ Note ♪

- Recently watched items on other peoples profile pages are no longer actionable.

## 👀 Example 👀
Before:
<img width="1043" alt="Screenshot 2025-06-25 at 22 06 37" src="https://github.com/user-attachments/assets/3d9905a9-3517-48c5-941e-34af04dd67d7" />

After:
<img width="1043" alt="Screenshot 2025-06-25 at 22 06 19" src="https://github.com/user-attachments/assets/31bc99bd-6447-42bb-915d-d9ec30b5ee56" />
