### PR TITLE
fix(button): accounts for the now existing padding

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -135,6 +135,7 @@
     width: var(--button-size);
     height: var(--button-size);
     padding: var(--ni-6);
+    box-sizing: border-box;
     justify-content: center;
     align-items: center;
     flex-shrink: 0;


### PR DESCRIPTION
## ♪ Note ♪

- Action buttons used `ni-6`; which didn't exist. But which I added in an earlier commit. Causing action buttons suddenly to be bigger.

## 👀 Example 👀

Before:
<img width="402" alt="Screenshot 2025-06-26 at 17 29 40" src="https://github.com/user-attachments/assets/b8ed2060-2c5d-4243-bc8f-a527a8de9fbe" />

After:
<img width="402" alt="Screenshot 2025-06-26 at 17 29 35" src="https://github.com/user-attachments/assets/07361f76-45a9-4e69-9377-11afadbe5bad" />

