### PR TITLE
fix(profile): uses actual slug when sharing own profile

### DIFF
--- a/projects/client/src/lib/components/buttons/share/ShareButton.svelte
+++ b/projects/client/src/lib/components/buttons/share/ShareButton.svelte
@@ -8,14 +8,15 @@
   type ShareButtonProps = {
     title: string;
     textFactory: ({ title }: { title: string }) => string;
+    urlOverride?: string;
   };
 
-  const { title, textFactory }: ShareButtonProps = $props();
+  const { title, textFactory, urlOverride }: ShareButtonProps = $props();
 
   const data = $derived({
     title,
     text: textFactory({ title }),
-    url: page.url.toString(),
+    url: urlOverride ?? page.url.toString(),
   });
 
   const isShareable = $derived(

--- a/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
@@ -4,6 +4,7 @@
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { DisplayableProfileProps } from "../profile/DisplayableProfileProps";
   import FollowUserButton from "./_internal/FollowUserButton.svelte";
   import ProfileImage from "./ProfileImage.svelte";
@@ -18,6 +19,7 @@
       ? m.profile_banner_greeting({ name: profile.name.first })
       : profile.name.first,
   );
+  const shareableSlug = $derived(isMe ? $user.slug : slug);
 </script>
 
 <div class="profile-page-banner-container">
@@ -49,6 +51,7 @@
       </RenderFor>
       <ShareButton
         title={profile.name.first}
+        urlOverride={UrlBuilder.profile.user(shareableSlug)}
         textFactory={({ title: name }) => m.share_person({ name })}
       />
     </div>


### PR DESCRIPTION
## ♪ Note ♪

- Own profiles were shared with the `/me` link. This fix uses the actual slug when sharing your own profile.