### PR TITLE
feat(tv): show top list on summary pages

### DIFF
--- a/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
+++ b/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
@@ -29,6 +29,12 @@
   const topList = $derived(lists.at(0));
 </script>
 
+{#snippet topUserList()}
+  {#if topList}
+    <UserList list={topList} {type} />
+  {/if}
+{/snippet}
+
 <RenderFor
   audience="all"
   device={["tablet-sm", "tablet-lg", "desktop"]}
@@ -61,7 +67,9 @@
 </RenderFor>
 
 <RenderFor audience="all" device={["mobile"]} navigation="default">
-  {#if topList}
-    <UserList list={topList} {type} />
-  {/if}
+  {@render topUserList()}
+</RenderFor>
+
+<RenderFor audience="all" navigation="dpad">
+  {@render topUserList()}
 </RenderFor>


### PR DESCRIPTION
## ♪ Note ♪

- Show the top list on summary pages when on TV.

## 👀 Example 👀

Before:
<img width="1143" alt="Screenshot 2025-07-03 at 12 14 46" src="https://github.com/user-attachments/assets/acdb9aa0-8fe2-410d-bea5-5e6357b2b261" />

After:
<img width="1143" alt="Screenshot 2025-07-03 at 12 14 08" src="https://github.com/user-attachments/assets/0db94738-246f-49d0-8f65-5e26736eb3ee" />
