### PR TITLE
fix(tv): makes favorite button navigateable

### DIFF
--- a/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
+++ b/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
@@ -14,6 +14,7 @@
     style,
     onAdd,
     onRemove,
+    navigationType,
     ...props
   }: FavoriteButtonProps = $props();
 
@@ -25,6 +26,7 @@
     variant: "primary",
     onclick: handler,
     disabled: isFavoriteUpdating,
+    navigationType,
   });
 </script>
 

--- a/projects/client/src/lib/components/buttons/favorite/FavoriteButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/favorite/FavoriteButtonProps.ts
@@ -1,3 +1,4 @@
+import type { DpadNavigationType } from '$lib/features/navigation/models/DpadNavigationType.ts';
 import type { FavoriteButtonIntl } from './FavoriteButtonIntl.ts';
 
 export type FavoriteButtonProps = {
@@ -8,4 +9,5 @@ export type FavoriteButtonProps = {
   style: 'action' | 'normal' | 'dropdown-item';
   onAdd: () => void;
   onRemove: () => void;
+  navigationType?: DpadNavigationType;
 } & Omit<ButtonProps, 'children' | 'onclick' | 'label'>;

--- a/projects/client/src/lib/sections/media-actions/favorite/FavoriteAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/favorite/FavoriteAction.svelte
@@ -2,6 +2,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
 
   import FavoriteButton from "$lib/components/buttons/favorite/FavoriteButton.svelte";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { onMount } from "svelte";
   import { attachWarning } from "../_internal/attachWarning";
@@ -13,6 +14,7 @@
     type: MediaType;
     id: number;
     onAction?: (state: boolean) => void;
+    navigationType?: DpadNavigationType;
   };
 
   const {
@@ -21,6 +23,7 @@
     type,
     id,
     onAction,
+    navigationType,
   }: FavoriteActionProps = $props();
 
   const {
@@ -45,6 +48,7 @@
 <FavoriteButton
   {style}
   {title}
+  {navigationType}
   isFavorited={$isFavorited}
   isFavoriteUpdating={$isUpdatingFavorite}
   onAdd={addToFavorites}

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -62,6 +62,7 @@
           title={props.media.title}
           type={props.type}
           id={props.media.id}
+          navigationType={DpadNavigationType.Item}
         />
       {/if}
     </div>


### PR DESCRIPTION
## ♪ Note ♪

- Makes the `favorite` button d-pad navigate-able.