### PR TITLE
fix(card): makes action bar ignore pointer events

### DIFF
--- a/projects/client/src/lib/components/card/CardActionBar.svelte
+++ b/projects/client/src/lib/components/card/CardActionBar.svelte
@@ -23,6 +23,8 @@
     left: 0;
     z-index: var(--layer-floating);
 
+    pointer-events: none;
+
     &::before {
       content: "";
 
@@ -45,6 +47,10 @@
     :global(.trakt-popup-menu-button) {
       position: absolute;
       right: 0;
+    }
+
+    :global(> *) {
+      pointer-events: auto;
     }
   }
 


### PR DESCRIPTION
## ♪ Note ♪

- Action bar no longer blocks clicks on the card.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/34b0648a-1580-41fe-8c3c-62076590cdfb

After:

https://github.com/user-attachments/assets/a6142ee0-f9b4-4ad3-b7d7-9f2801271f63

