### PR TITLE
fix(list): do not persist scroll position on list length change

### DIFF
--- a/projects/client/src/lib/components/lists/grid-list/GridList.svelte
+++ b/projects/client/src/lib/components/lists/grid-list/GridList.svelte
@@ -36,7 +36,7 @@
 
   {#if items.length > 0}
     <div class="trakt-list-item-container trakt-list-items" use:customAction>
-      {#each items as i (i.id)}
+      {#each items as i (`${items.length}_${i.id}`)}
         {@render item(i)}
       {/each}
     </div>

--- a/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/ShadowList.svelte
@@ -124,7 +124,7 @@
           data-dpad-navigation={DpadNavigationType.List}
           data-navigation-type={$navigation}
         >
-          {#each items as i (i.id)}
+          {#each items as i (`${items.length}_${i.id}`)}
             {@render item(i)}
           {/each}
         </div>


### PR DESCRIPTION
## ♪ Note ♪

- Uses the list length also as part of the key; scroll positions are no longer maintained on list length changes.
  - Could probably be improved by using a hash based on the exact content 🤔 

## 👀 Examples 👀
Before:

https://github.com/user-attachments/assets/98beb0e7-50e1-48c6-a23c-f800d8c7ee0b

After:

https://github.com/user-attachments/assets/1118d5fa-6c49-4139-9db2-12399f750b6a

