### PR TITLE
fix(comment): places comment shadow below list shadow

### DIFF
--- a/projects/client/src/lib/sections/summary/components/comments/_internal/ShadowScroller.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/ShadowScroller.svelte
@@ -34,7 +34,7 @@
     &::before,
     &::after {
       content: "";
-      z-index: var(--layer-floating);
+      z-index: var(--layer-raised);
       pointer-events: none;
 
       position: absolute;


### PR DESCRIPTION
## ♪ Note ♪

- Comment shadows no longer cross list shadows.

## 👀 Examples 👀
Before:

https://github.com/user-attachments/assets/00e5d028-f0e6-4ad4-a159-8da902f60e1d

After:

https://github.com/user-attachments/assets/dbf80618-e558-4869-8965-e10d9c2ad39a

