### PR TITLE
feat: uses more descriptive support links

### DIFF
--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -34,6 +34,7 @@ declare global {
   type Nil = null | undefined;
 
   type HttpsUrl = `https://${string}`;
+  type MailToUrl = `mailto:${string}`;
 
   type DeepPartial<T> = {
     [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : Partial<T[P]>;

--- a/projects/client/src/lib/pages/errors/ErrorLockedAccountPage.svelte
+++ b/projects/client/src/lib/pages/errors/ErrorLockedAccountPage.svelte
@@ -2,15 +2,18 @@
   import * as m from "$lib/features/i18n/messages.ts";
 
   import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
+  import { useUser } from "$lib/features/auth/stores/useUser";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import ErrorPage from "./ErrorPage.svelte";
+
+  const { user } = useUser();
 </script>
 
 <ErrorPage title={m.page_title_account_locked()}>
   <p>
     <MessageWithLink
       message={m.error_page_locked_account_message()}
-      href={UrlBuilder.og.support()}
+      href={UrlBuilder.og.support($user.slug)}
       target="_blank"
     />
   </p>

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -68,6 +68,25 @@ const ogIframeFactory = (url: HttpsUrl, token: string | Nil): HttpsUrl => {
   return `${url}/?embedded_mode=true${tokenParam}`;
 };
 
+const ogSupportFactory = (username?: string): HttpsUrl | MailToUrl => {
+  const page = globalThis.location?.href ?? 'https://app.trakt.tv';
+  const supportSubject = 'Trakt Support Request';
+  const supportBody = 'Please describe your issue...';
+  const supportDetails = username
+    ? `**Username:** ${username}\n**Page:** ${page}`
+    : `Page: ${page}`;
+
+  const encodedBody = encodeURIComponent(
+    `${supportBody}\n\n---\n\n${supportDetails}`,
+  );
+
+  if (!username) {
+    return `mailto:support@trakt.tv?subject=${supportSubject}&body=${encodedBody}`;
+  }
+
+  return `https://forums.trakt.tv/new-message?username=support&title=${supportSubject}&body=${encodedBody}`;
+};
+
 export const UrlBuilder = {
   history: {
     category: (params: UrlBuilderParams) => {
@@ -153,7 +172,7 @@ export const UrlBuilder = {
     site: () => 'https://trakt.tv',
     status: () => 'https://status.trakt.tv',
     privacy: () => 'https://trakt.tv/privacy',
-    support: () => 'mailto:support@trakt.tv',
+    support: (username?: string) => ogSupportFactory(username),
     frame: {
       yearToDate: (slug: string, year: string, token: string | Nil) =>
         ogIframeFactory(`https://trakt.tv/users/${slug}/year/${year}`, token),


### PR DESCRIPTION
## 🎶 Notes 🎶

- Follows the same logic as on OG when contacting support:
  - Signed in users: will automatically start a forum post.
  - Public users: will use the mailto link.

## 👀 Examples 👀
<img width="981" alt="Screenshot 2025-07-04 at 10 11 46" src="https://github.com/user-attachments/assets/e1be90ce-27b5-4886-ac3b-10af23d5552a" />

<img width="368" alt="Screenshot 2025-07-04 at 10 14 24" src="https://github.com/user-attachments/assets/c86053a0-cd70-4947-b27c-ca33505d3749" />
