### PR TITLE
fix(auth): refresh oidc tokens

### DIFF
--- a/projects/client/src/lib/features/auth/components/AuthProvider.svelte
+++ b/projects/client/src/lib/features/auth/components/AuthProvider.svelte
@@ -12,7 +12,9 @@
 
   createAuthContext({ isAuthorized: isAuthorizedLegacy || isAuthorized });
 
-  initializeUserManager(isAuthorizedLegacy);
+  const { isRefreshing } = initializeUserManager(isAuthorizedLegacy);
 </script>
 
-{@render children()}
+{#if !$isRefreshing}
+  {@render children()}
+{/if}

--- a/projects/client/src/lib/features/auth/getOidcConfig.ts
+++ b/projects/client/src/lib/features/auth/getOidcConfig.ts
@@ -1,13 +1,24 @@
+import { IS_DEV } from '$lib/utils/env/index.ts';
+import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import { type UserManagerSettings, WebStorageStateStore } from 'oidc-client-ts';
 
-const TRAKT_OIDC_AUTHORITY = 'https://trakt.tv';
+function getAuthority() {
+  return prependHttps(
+    TRAKT_TARGET_ENVIRONMENT
+      .replace('api.', '')
+      .replace('apiz.', '')
+      .replace('api-staging.', 'staging.'),
+  );
+}
 
-export function getOidcConfig(origin: string): UserManagerSettings {
+export function getOidcConfig(): UserManagerSettings {
+  const referrer = IS_DEV ? 'http://localhost:5173' : 'https://app.trakt.tv';
+
   return {
-    authority: TRAKT_OIDC_AUTHORITY,
+    authority: getAuthority(),
     client_id: TRAKT_CLIENT_ID,
-    redirect_uri: `${origin}/callback`,
-    silent_redirect_uri: `${origin}/silent-redirect`,
+    redirect_uri: `${referrer}/callback`,
+    silent_redirect_uri: `${referrer}/silent-redirect`,
     response_type: 'code',
     scope: 'public openid profile email',
     automaticSilentRenew: true,

--- a/projects/client/src/lib/features/auth/queries/currentUserSettingsQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserSettingsQuery.ts
@@ -19,7 +19,7 @@ import { z } from 'zod';
 import { assertDefined } from '../../../utils/assert/assertDefined.ts';
 
 export const UserSettingsSchema = z.object({
-  id: z.number(),
+  id: z.union([z.number(), z.string()]),
   slug: z.string(),
   token: z.string().nullish(),
   name: UserNameSchema,
@@ -75,7 +75,10 @@ function mapUserSettingsResponse(response: SettingsResponse): UserSettings {
   const { user, account, browsing } = response;
 
   return {
-    id: assertDefined(user.ids.trakt, 'Current user should have a trakt ID'),
+    id: assertDefined(
+      user.ids.trakt ?? user.ids.uuid,
+      'Current user should have a valid ID',
+    ),
     slug: user.ids.slug,
     token: account.token,
     name: toUserName(user.name),

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -27,7 +27,7 @@ export function initializeUserManager(hasLegacyAuth: boolean) {
   const { isAuthorized } = getAuthContext();
 
   const manager = new UserManager(
-    getOidcConfig(globalThis.window.location.origin),
+    getOidcConfig(),
   );
 
   const setAuthState = (user: User | null) => {

--- a/projects/client/src/routes/+layout.server.ts
+++ b/projects/client/src/routes/+layout.server.ts
@@ -6,7 +6,6 @@ import { buildOAuthUrl } from '$lib/utils/url/buildOAuthLink.ts';
 
 import { AUTH_COOKIE_NAME } from '$lib/features/auth/handle.ts';
 import type { OidcAuthToken } from '$lib/features/auth/models/OidcAuthToken.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import type { LayoutServerLoad } from './$types.ts';
 
 const getAuth = (auth: Nil | OidcAuthToken) => {
@@ -18,12 +17,10 @@ const getAuth = (auth: Nil | OidcAuthToken) => {
     };
   }
 
-  const now = new Date().getTime() / time.seconds(1);
-
   return {
     token: auth.token,
     expiresAt: auth.expiresAt,
-    isAuthorized: auth.expiresAt ? auth.expiresAt > now : false,
+    isAuthorized: true,
   };
 };
 

--- a/projects/client/src/routes/api/store-token/+server.ts
+++ b/projects/client/src/routes/api/store-token/+server.ts
@@ -7,9 +7,7 @@ import { json, type RequestHandler } from '@sveltejs/kit';
 export const POST: RequestHandler = async ({ request, cookies }) => {
   const { token, expiresAt }: OidcAuthToken = await request.json();
 
-  const maxAge = expiresAt
-    ? expiresAt - Math.floor(Date.now() / time.seconds(1))
-    : 0;
+  const maxAge = expiresAt ? time.years(1) : 0;
   const cookieContent = JSON.stringify({ token, expiresAt });
 
   cookies.set(OIDC_AUTH_COOKIE_NAME, cookieContent, {

--- a/projects/client/src/routes/silent-redirect/+page.svelte
+++ b/projects/client/src/routes/silent-redirect/+page.svelte
@@ -7,7 +7,7 @@
   onMount(async () => {
     try {
       const userManager = new UserManager({
-        ...getOidcConfig(globalThis.window.location.origin),
+        ...getOidcConfig(),
         automaticSilentRenew: false,
       });
 

--- a/projects/client/test/mocks/oidc-client-ts.mock.ts
+++ b/projects/client/test/mocks/oidc-client-ts.mock.ts
@@ -17,6 +17,7 @@ const mockUserManager = vi.fn(() => ({
   events: {
     addUserLoaded: vi.fn().mockResolvedValue(OidcUserMock),
     addUserUnloaded: vi.fn(),
+    addSilentRenewError: vi.fn(),
   },
 }));
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Pt. 1 of some OIDC fixes (flows tested on staging with shorter token expiry):
  - While using Lite, tokens will be refreshed one minute before expiry.
  - When opening Lite after a token was already expired, it will now be refreshed properly.
  - The refresh triggered by the initialization will block rendering until refreshed.
- Small fix to the user settings that broke testing on non official apps.
  - Non official apps only return a uuid instead of the trakt id when requesting user settings.