### PR TITLE
Feat/coalesce social activity

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Оцени като страхотно"
+    },
+    "badge_text_more": {
+      "default": "и още {count}",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Vurder som fantastisk"
+    },
+    "badge_text_more": {
+      "default": "og {count} mere",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Als großartig bewerten"
+    },
+    "badge_text_more": {
+      "default": "und {count} mehr",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2295,6 +2295,15 @@
     "button_label_rating_great": {
       "default": "Rate as great",
       "description": "Aria-label for the button that allows users to rate a movie, show, or episode as great."
+    },
+    "badge_text_more": {
+      "default": "and {count} more",
+      "description": "Text for badges shown on covers, used when there are more badges than can fit on the cover. This should be as short as possible.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Calificar como excelente"
+    },
+    "badge_text_more": {
+      "default": "y {count} más",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Calificar como excelente"
+    },
+    "badge_text_more": {
+      "default": "y {count} más",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Noter comme excellent"
+    },
+    "badge_text_more": {
+      "default": "pis {count} autres",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Noter comme excellent"
+    },
+    "badge_text_more": {
+      "default": "et {count} de plus",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Valuta come fantastico"
+    },
+    "badge_text_more": {
+      "default": "e altri {count}",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "素晴らしいと評価"
+    },
+    "badge_text_more": {
+      "default": "その他{count}件",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Vurder som flott"
+    },
+    "badge_text_more": {
+      "default": "og {count} til",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Beoordeel als geweldig"
+    },
+    "badge_text_more": {
+      "default": "en {count} meer",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Oceń jako świetny"
+    },
+    "badge_text_more": {
+      "default": "i {count} więcej",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Avaliar como ótimo"
+    },
+    "badge_text_more": {
+      "default": "e mais {count}",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Evaluează ca grozav"
+    },
+    "badge_text_more": {
+      "default": "și încă {count}",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Betygsätt som utmärkt"
+    },
+    "badge_text_more": {
+      "default": "och {count} till",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1815,6 +1815,14 @@
     },
     "button_label_rating_great": {
       "default": "Оцінити як чудово"
+    },
+    "badge_text_more": {
+      "default": "та ще {count}",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
     }
   }
 }

--- a/projects/client/src/lib/requests/_internal/coalesceSocialActivities.spec.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceSocialActivities.spec.ts
@@ -1,0 +1,79 @@
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { SocialActivityMappedMock } from '$mocks/data/users/mapped/SocialActivityMappedMock.ts';
+import { describe, expect, it } from 'vitest';
+import type { UserProfile } from '../models/UserProfile.ts';
+import {
+  ACTIVITY_COALESCE_WINDOW,
+  coalesceSocialActivities,
+} from './coalesceSocialActivities.ts';
+
+describe('coalesceSocialActivities', () => {
+  const createUserProfile = (username: string): UserProfile => ({
+    'name': {
+      'full': username,
+      'first': username,
+      'last': username,
+    },
+    username,
+    'slug': username,
+    'avatar': { 'url': 'https://avatar.png' },
+    'private': false,
+    'isVip': true,
+    'isDirector': false,
+    'isDeleted': false,
+  });
+
+  it('should not coalesce activities of differing media items', () => {
+    const activities = SocialActivityMappedMock;
+    expect(coalesceSocialActivities(activities)).toEqual(activities);
+  });
+
+  it('should coalesce activities that are similar', () => {
+    const now = new Date();
+
+    const userA = createUserProfile('user_a');
+    const userB = createUserProfile('user_b');
+
+    const activityA = {
+      ...assertDefined(SocialActivityMappedMock.at(0)),
+      users: [userA],
+      activityAt: now,
+    };
+
+    const activityB = {
+      ...activityA,
+      users: [userB],
+      activityAt: new Date(now.getTime() + ACTIVITY_COALESCE_WINDOW / 2),
+    };
+
+    const coalesced = coalesceSocialActivities([activityA, activityB]);
+
+    expect(coalesced).toHaveLength(1);
+    expect(coalesced.at(0)?.users).toEqual([userB, userA]);
+  });
+
+  it('should not coalesce activities that are too far apart', () => {
+    const now = new Date();
+
+    const userA = createUserProfile('user_a');
+    const userB = createUserProfile('user_b');
+
+    const activityA = {
+      ...assertDefined(SocialActivityMappedMock.at(0)),
+      users: [userA],
+      activityAt: now,
+    };
+
+    const activityB = {
+      ...activityA,
+      users: [userB],
+      activityAt: new Date(now.getTime() + ACTIVITY_COALESCE_WINDOW * 2),
+    };
+
+    const coalesced = coalesceSocialActivities([activityA, activityB]);
+
+    expect(coalesced).toHaveLength(2);
+    expect(coalesced.at(0)?.users).toEqual([userA]);
+    expect(coalesced.at(1)?.users).toEqual([userB]);
+  });
+});

--- a/projects/client/src/lib/requests/_internal/coalesceSocialActivities.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceSocialActivities.ts
@@ -1,0 +1,60 @@
+import { time } from '$lib/utils/timing/time.ts';
+import type { SocialActivity } from '../models/SocialActivity.ts';
+
+const ACTIVITY_COALESCE_WINDOW = time.minutes(10);
+
+function isSameMovie(
+  activityA: SocialActivity,
+  activityB: SocialActivity,
+): boolean {
+  if (activityA.type !== 'movie' || activityB.type !== 'movie') {
+    return false;
+  }
+
+  return activityA.movie.id === activityB.movie.id;
+}
+
+function isSameEpisode(
+  activityA: SocialActivity,
+  activityB: SocialActivity,
+): boolean {
+  if (activityA.type !== 'episode' || activityB.type !== 'episode') {
+    return false;
+  }
+
+  return activityA.show.id === activityB.show.id &&
+    activityA.episode.id === activityB.episode.id;
+}
+
+function isSimilarActivity(
+  activityA: SocialActivity,
+  activityB: SocialActivity,
+): boolean {
+  const isSameMedia = isSameMovie(activityA, activityB) ||
+    isSameEpisode(activityA, activityB);
+
+  if (!isSameMedia) return false;
+
+  const timeDifference = Math.abs(
+    activityA.activityAt.getTime() - activityB.activityAt.getTime(),
+  );
+  return timeDifference <= ACTIVITY_COALESCE_WINDOW;
+}
+
+export function coalesceSocialActivities(
+  activities: SocialActivity[],
+): SocialActivity[] {
+  return activities.reduce((acc, activity) => {
+    const similarActivity = acc.find((currentActivity) =>
+      isSimilarActivity(currentActivity, activity)
+    );
+
+    if (similarActivity) {
+      similarActivity.users = [...activity.users, ...similarActivity.users];
+      return acc;
+    }
+
+    acc.push(activity);
+    return acc;
+  }, [] as SocialActivity[]);
+}

--- a/projects/client/src/lib/requests/_internal/coalesceSocialActivities.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceSocialActivities.ts
@@ -1,7 +1,7 @@
 import { time } from '$lib/utils/timing/time.ts';
 import type { SocialActivity } from '../models/SocialActivity.ts';
 
-const ACTIVITY_COALESCE_WINDOW = time.minutes(10);
+export const ACTIVITY_COALESCE_WINDOW = time.minutes(10);
 
 function isSameMovie(
   activityA: SocialActivity,

--- a/projects/client/src/lib/requests/models/SocialActivity.ts
+++ b/projects/client/src/lib/requests/models/SocialActivity.ts
@@ -8,7 +8,7 @@ export const SocialActivityMovieSchema = z.object({
   id: z.number(),
   activityAt: z.date(),
   type: z.literal('movie'),
-  user: UserProfileSchema,
+  users: z.array(UserProfileSchema),
   movie: MovieEntrySchema,
 });
 
@@ -16,7 +16,7 @@ export const SocialActivityEpisodeSchema = z.object({
   id: z.number(),
   activityAt: z.date(),
   type: z.literal('episode'),
-  user: UserProfileSchema,
+  users: z.array(UserProfileSchema),
   show: ShowEntrySchema,
   episode: EpisodeEntrySchema,
 });

--- a/projects/client/src/lib/sections/lists/components/UserAvatar.svelte
+++ b/projects/client/src/lib/sections/lists/components/UserAvatar.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import type { UserProfile } from "$lib/requests/models/UserProfile";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { Snippet } from "svelte";
 
   type UserAvatarProps = {
@@ -13,20 +15,30 @@
   const { user, size = "large", icon }: UserAvatarProps = $props();
 </script>
 
-<div
-  class="trakt-user-avatar"
-  class:trakt-vip-user={user.isVip}
-  data-size={size}
->
-  <CrossOriginImage
-    src={user.avatar.url}
-    alt={m.image_alt_user_avatar({ username: user.username })}
-  />
+{#snippet avatar()}
+  <div
+    class="trakt-user-avatar"
+    class:trakt-vip-user={user.isVip}
+    data-size={size}
+  >
+    <CrossOriginImage
+      src={user.avatar.url}
+      alt={m.image_alt_user_avatar({ username: user.username })}
+    />
 
-  {#if icon}
-    {@render icon()}
-  {/if}
-</div>
+    {#if icon}
+      {@render icon()}
+    {/if}
+  </div>
+{/snippet}
+
+{#if user.slug}
+  <Link href={UrlBuilder.profile.user(user.slug)}>
+    {@render avatar()}
+  </Link>
+{:else}
+  {@render avatar()}
+{/if}
 
 <style>
   .trakt-user-avatar {

--- a/projects/client/src/lib/sections/lists/social/SocialActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/social/SocialActivityItem.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
   import type { SocialActivity } from "$lib/requests/models/SocialActivity";
   import ActivityItem from "../components/ActivityItem.svelte";
   import ActivitySummaryCard from "../components/ActivitySummaryCard.svelte";
   import UserAvatar from "../components/UserAvatar.svelte";
   import UserProfileLink from "../components/UserProfileLink.svelte";
+
+  const MAX_USERS = 10;
 
   type SocialActivityItemProps = {
     activity: SocialActivity;
@@ -11,12 +14,32 @@
   };
 
   const { activity, style = "cover" }: SocialActivityItemProps = $props();
+
+  const hasMultipleUsers = $derived(activity.users.length > 1);
+  const cappedUsers = $derived(activity.users.slice(0, MAX_USERS));
+  const remainingUsersCount = $derived(
+    activity.users.length - cappedUsers.length,
+  );
 </script>
 
 {#snippet badge()}
-  <div class="user-profile-badge">
-    <UserProfileLink user={activity.user} />
-    <UserAvatar user={activity.user} size="small" />
+  <div class="user-profile-badges">
+    {#each cappedUsers as user (user.slug)}
+      <div class="user-profile-badge" class:has-background={!hasMultipleUsers}>
+        {#if !hasMultipleUsers}
+          <UserProfileLink {user} />
+        {/if}
+        <UserAvatar {user} size="small" />
+      </div>
+    {/each}
+
+    {#if remainingUsersCount > 0}
+      <div class="user-profile-badge has-background">
+        <p class="meta-info user-count-label">
+          {m.badge_text_more({ count: remainingUsersCount })}
+        </p>
+      </div>
+    {/if}
   </div>
 {/snippet}
 
@@ -31,20 +54,39 @@
 <style lang="scss">
   @use "$style/scss/mixins/index.scss" as *;
 
+  .user-profile-badges {
+    width: 100%;
+
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    align-items: center;
+
+    gap: var(--gap-xxs);
+  }
+
   .user-profile-badge {
     max-width: calc(100% - var(--ni-32));
     display: flex;
-    gap: var(--gap-xs);
-    align-items: center;
 
-    padding: 0 var(--ni-4);
-    background: color-mix(in srgb, var(--color-background) 50%, transparent);
-    border-radius: var(--border-radius-m);
-    overflow: hidden;
+    &.has-background {
+      gap: var(--gap-xs);
+      align-items: center;
 
-    @include backdrop-filter-blur(var(--ni-8));
-    :global(.trakt-link) {
-      max-width: 75%;
+      padding: 0 var(--ni-4);
+      background: color-mix(in srgb, var(--color-background) 50%, transparent);
+      border-radius: var(--border-radius-m);
+      overflow: hidden;
+
+      @include backdrop-filter-blur(var(--ni-8));
     }
+
+    :global(.trakt-link) {
+      max-width: calc(100% - var(--ni-32) - var(--gap-xs));
+    }
+  }
+
+  .user-count-label {
+    padding: var(--ni-8);
   }
 </style>

--- a/projects/client/src/mocks/data/users/mapped/SocialActivityMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/SocialActivityMappedMock.ts
@@ -8,14 +8,14 @@ export const SocialActivityMappedMock: SocialActivity[] = [
   {
     id: 1,
     activityAt: new Date('2025-01-31T23:12:41.000Z'),
-    user: UserProfileHarryMappedMock,
+    users: [UserProfileHarryMappedMock],
     type: 'movie',
     movie: MovieHereticMappedMock,
   },
   {
     id: 2,
     activityAt: new Date('2025-01-31T23:12:41.000Z'),
-    user: UserProfileHarryMappedMock,
+    users: [UserProfileHarryMappedMock],
     type: 'episode',
     show: ShowSiloMappedMock,
     episode: EpisodeSiloMappedMock,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds a small update to make avatars clickable.
- Coalesces social activities when they are similar:
  - Same media item.
  - Within a certain time frame (atm, 10 minutes, we can fine tune as needed).
- For now simple UX, checked with @anodpixels 

## 👀 Examples 👀
Before:
<img width="1504" alt="Screenshot 2025-07-08 at 11 25 43" src="https://github.com/user-attachments/assets/091ef86c-8a71-48c9-a119-e755b6edde7a" />

After:
<img width="1504" alt="Screenshot 2025-07-08 at 11 28 07" src="https://github.com/user-attachments/assets/1ef5d4c0-711c-4b18-83f7-9636a4171a3d" />

Hardcoded example in case there are too many users:
<img width="212" alt="Screenshot 2025-07-08 at 11 44 55" src="https://github.com/user-attachments/assets/b3491adb-0137-44c9-94c5-0dc7a7a2326c" />
