### PR TITLE
fix(auth): handles failed silent sign-ins

### DIFF
--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -53,8 +53,12 @@ export function initializeUserManager(hasLegacyAuth: boolean) {
     if (user?.expired) {
       isRefreshing.set(true);
 
-      const refreshedUser = await manager.signinSilent();
-      handleUserEvent(refreshedUser);
+      try {
+        const refreshedUser = await manager.signinSilent();
+        handleUserEvent(refreshedUser);
+      } catch (_) {
+        handleUserEvent(null);
+      }
 
       isRefreshing.set(false);
       return;


### PR DESCRIPTION
## ♪ Note ♪

- The refresh in `signinSilent` does not trigger `addSilentRenewError` apparently