### PR TITLE
Feat/rewatch counts

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Брой гледания"
     },
-    "tag_text_watched_episodes": {
-      "default": "Гледани епизоди"
-    },
     "list_placeholder_media_history": {
       "default": "Все още не сте гледали {title}",
       "variables": {

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Antal set"
     },
-    "tag_text_watched_episodes": {
-      "default": "Afsnit set"
-    },
     "list_placeholder_media_history": {
       "default": "Du har ikke set {title} endnu",
       "variables": {

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Anzahl gesehen"
     },
-    "tag_text_watched_episodes": {
-      "default": "Gesehene Episoden"
-    },
     "list_placeholder_media_history": {
       "default": "Du hast {title} noch nicht gesehen",
       "variables": {

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -1627,10 +1627,6 @@
       "default": "Watch count",
       "description": "Text for the tag that is shown before the movie or show watch count. This should be as short as possible."
     },
-    "tag_text_watched_episodes": {
-      "default": "Watched episodes",
-      "description": "Text for the tag that is shown before the episode watch count. This should be as short as possible."
-    },
     "list_placeholder_media_history": {
       "default": "You haven't watched {title} yet",
       "description": "Placeholder text shown when there is no watch history for a movie, show, or episode.",

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Veces vista"
     },
-    "tag_text_watched_episodes": {
-      "default": "Episodios vistos"
-    },
     "list_placeholder_media_history": {
       "default": "Aún no has visto {title}",
       "variables": {

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Contador de visualizaciones"
     },
-    "tag_text_watched_episodes": {
-      "default": "Episodios vistos"
-    },
     "list_placeholder_media_history": {
       "default": "Aún no has visto {title}",
       "variables": {

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Nombre de visionnements"
     },
-    "tag_text_watched_episodes": {
-      "default": "Épisodes visionnés"
-    },
     "list_placeholder_media_history": {
       "default": "Vous n'avez pas encore vu {title}",
       "variables": {

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Nombre de visionnages"
     },
-    "tag_text_watched_episodes": {
-      "default": "Épisodes regardés"
-    },
     "list_placeholder_media_history": {
       "default": "Vous n'avez pas encore vu {title}",
       "variables": {

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Conti visualizzazioni"
     },
-    "tag_text_watched_episodes": {
-      "default": "Episodi visti"
-    },
     "list_placeholder_media_history": {
       "default": "Non hai ancora visto {title}",
       "variables": {

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "視聴回数"
     },
-    "tag_text_watched_episodes": {
-      "default": "視聴済みエピソード"
-    },
     "list_placeholder_media_history": {
       "default": "{title} はまだ見ていないよ",
       "variables": {

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Visningsantall"
     },
-    "tag_text_watched_episodes": {
-      "default": "Episoder sett"
-    },
     "list_placeholder_media_history": {
       "default": "Du har ikke sett {title} ennå",
       "variables": {

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Aantal keer bekeken"
     },
-    "tag_text_watched_episodes": {
-      "default": "Bekeken afleveringen"
-    },
     "list_placeholder_media_history": {
       "default": "Je hebt {title} nog niet bekeken",
       "variables": {

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Liczba seansów"
     },
-    "tag_text_watched_episodes": {
-      "default": "Odcinki obejrzane"
-    },
     "list_placeholder_media_history": {
       "default": "Jeszcze nie widziałeś {title}",
       "variables": {

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Visto"
     },
-    "tag_text_watched_episodes": {
-      "default": "Episódios vistos"
-    },
     "list_placeholder_media_history": {
       "default": "Você ainda não assistiu {title}",
       "variables": {

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Număr de vizionări"
     },
-    "tag_text_watched_episodes": {
-      "default": "Episoade vizionate"
-    },
     "list_placeholder_media_history": {
       "default": "Încă nu ai urmărit {title}!",
       "variables": {

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Antal visningar"
     },
-    "tag_text_watched_episodes": {
-      "default": "Visade avsnitt"
-    },
     "list_placeholder_media_history": {
       "default": "Du har inte sett {title} än",
       "variables": {

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1287,9 +1287,6 @@
     "tag_text_watch_count": {
       "default": "Кількість переглядів"
     },
-    "tag_text_watched_episodes": {
-      "default": "Переглянуто епізодів"
-    },
     "list_placeholder_media_history": {
       "default": "Ви ще не дивилися {title}",
       "variables": {

--- a/projects/client/src/lib/components/media/tags/TagIntl.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntl.ts
@@ -6,6 +6,6 @@ export type TagIntl = {
   toReleaseEstimate: (airDate: Date) => string;
   tbaLabel: () => string;
   toAnticipatedCount: (count: number) => string;
-  watchCountLabel: (isShow: boolean) => string;
+  watchCountLabel: () => string;
   trendLabel: (delta: number) => string;
 };

--- a/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
@@ -21,8 +21,7 @@ export const TagIntlProvider: TagIntl = {
     m.tag_text_anticipated_count({
       count: toHumanNumber(count, languageTag()),
     }),
-  watchCountLabel: (isShow) =>
-    isShow ? m.tag_text_watched_episodes() : m.tag_text_watch_count(),
+  watchCountLabel: () => m.tag_text_watch_count(),
   trendLabel: (delta) =>
     delta ? toHumanNumber(Math.abs(delta), languageTag()) : '—',
 };

--- a/projects/client/src/lib/components/media/tags/WatchCountTag.svelte
+++ b/projects/client/src/lib/components/media/tags/WatchCountTag.svelte
@@ -1,18 +1,11 @@
 <script lang="ts">
   import StemTag from "$lib/components/tags/StemTag.svelte";
-  import type { EpisodeType } from "$lib/requests/models/EpisodeType";
-  import type { MediaType } from "$lib/requests/models/MediaType";
   import { linear } from "svelte/easing";
   import { slide } from "svelte/transition";
   import type { TagIntl } from "./TagIntl";
 
-  const {
-    i18n,
-    count,
-    type,
-  }: { i18n: TagIntl; count: number; type: MediaType | EpisodeType } = $props();
+  const { i18n, count }: { i18n: TagIntl; count: number } = $props();
 
-  const isForShow = $derived(type === "show");
   const TRANSITION_DURATION = 300;
 </script>
 
@@ -23,7 +16,7 @@
     classList="trakt-tag-label"
   >
     <p class="meta-info uppercase no-wrap">
-      {i18n.watchCountLabel(isForShow)}
+      {i18n.watchCountLabel()}
     </p>
   </StemTag>
 

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
@@ -32,10 +32,7 @@
   const showProgress = $derived($history.shows.get(show.id));
   const watchedEpisodes = $derived(showProgress?.episodes);
 
-  const hasUnseenEpisodes = $derived(
-    Boolean(showProgress?.isPartiallyWatched) &&
-      !Boolean(showProgress?.isWatched),
-  );
+  const hasUnseenEpisodes = $derived(!Boolean(showProgress?.isWatched));
 
   const hasBulkMarkAsWatched = (episode: EpisodeEntry) =>
     hasUnseenEpisodes && episode.airDate && episode.airDate <= new Date();

--- a/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
@@ -29,7 +29,9 @@
   <div class="trakt-summary-meta-container">
     <RatingList ratings={$ratings} airDate={media.airDate} />
     <div class="trakt-meta-tags">
-      <WatchCountTag i18n={TagIntlProvider} count={watchCount} />
+      {#if watchCount > 1}
+        <WatchCountTag i18n={TagIntlProvider} count={watchCount} />
+      {/if}
 
       {#if media.certification}
         <InfoTag>

--- a/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
@@ -29,11 +29,7 @@
   <div class="trakt-summary-meta-container">
     <RatingList ratings={$ratings} airDate={media.airDate} />
     <div class="trakt-meta-tags">
-      <WatchCountTag
-        i18n={TagIntlProvider}
-        count={watchCount}
-        type={media.type}
-      />
+      <WatchCountTag i18n={TagIntlProvider} count={watchCount} />
 
       {#if media.certification}
         <InfoTag>

--- a/projects/client/src/mocks/data/users/mapped/UserHistoryMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/UserHistoryMappedMock.ts
@@ -75,7 +75,7 @@ export const UserHistoryMappedMock: {
       'id': 147971,
       'isWatched': true,
       'isPartiallyWatched': false,
-      'plays': 8,
+      'plays': 1,
       'watchedAt': new Date('2024-12-27T16:28:32.000Z'),
     }],
     [180770, {
@@ -90,7 +90,7 @@ export const UserHistoryMappedMock: {
       'id': 180770,
       'isWatched': false,
       'isPartiallyWatched': true,
-      'plays': 1,
+      'plays': 0,
       'watchedAt': new Date('2024-12-27T16:13:42.000Z'),
     }],
   ]),


### PR DESCRIPTION
## 🎶 Notes 🎶

- Small fix to `watched until here`; it was only available if a show was already partially watched 😅
- `plays` on show history now counts the amount of times all aired episodes have been watched.
  - Left a fixme here to see if we can move that logic to the server.
- The watch count for shows now shows the amount of times a show has been fully watched, and no longer shows the episode play count.
- The watch count badge is only shown at 2 plays or more.

## 👀 Example 👀
Before:
<img width="1335" alt="Screenshot 2025-07-09 at 10 26 11" src="https://github.com/user-attachments/assets/9dfda48c-dade-40fb-bc73-03f0c2d6ec90" />

After:
<img width="1335" alt="Screenshot 2025-07-09 at 10 26 15" src="https://github.com/user-attachments/assets/b3136f92-08a9-4393-865b-c1ebf64a3412" />

Show rewatch example:

https://github.com/user-attachments/assets/b52a7cd5-643c-4767-8eb5-8b3e4294397f

