### PR TITLE
fix(navigation): do not reset focus when staying on the same route

### DIFF
--- a/projects/client/src/lib/features/navigation/_internal/dpadController.ts
+++ b/projects/client/src/lib/features/navigation/_internal/dpadController.ts
@@ -69,7 +69,12 @@ export function dpadController(_: HTMLElement) {
   });
 
   afterNavigate((nav) => {
-    if (!['link', 'popstate'].includes(nav.type) || nav.willUnload) {
+    const isSameRoute = nav.from?.route.id === nav.to?.route.id;
+    const isLinkNavigation = ['link', 'popstate'].includes(nav.type);
+
+    if (
+      !isLinkNavigation || nav.willUnload || isSameRoute
+    ) {
       return;
     }
 


### PR DESCRIPTION
## ♪ Note ♪

- Fixes the case where when using the d-pad, selecting a season would jump to the top of the page.

## 👀 Example 👀

Before:

https://github.com/user-attachments/assets/c7a091f8-15b1-45f6-b1e3-76145f1bbf38

After:

https://github.com/user-attachments/assets/6a8a8137-c431-4022-a6c3-2c56cae09cd2
