### PR TITLE
chore: removes stream on plex for now

### DIFF
--- a/projects/client/src/lib/sections/summary/components/stream/StreamOnButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/stream/StreamOnButton.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import PlexButton from "$lib/components/buttons/plex/PlexButton.svelte";
   import StreamingServiceButton from "$lib/components/buttons/streaming-service/StreamingServiceButton.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { StreamOnButtonProps } from "./StreamOnButtonProps";
@@ -15,27 +14,15 @@
     target.type === "episode" ? target.episode.airDate : target.media.airDate,
   );
   const isAiredItem = $derived(airDate < new Date());
-
-  const hasPlexSlug = $derived(target.media.plexSlug !== undefined);
 </script>
 
-{#if isAiredItem}
+{#if isAiredItem && streamOn?.preferred}
   <RenderFor audience="authenticated">
-    {#if streamOn?.preferred}
-      <StreamingServiceButton
-        service={streamOn.preferred}
-        mediaTitle={target.media.title}
-        {style}
-        {size}
-      />
-    {:else if hasPlexSlug}
-      <PlexButton {style} {size} {target} />
-    {/if}
-  </RenderFor>
-
-  <RenderFor audience="director">
-    {#if streamOn?.preferred && hasPlexSlug}
-      <PlexButton {style} {size} {target} />
-    {/if}
+    <StreamingServiceButton
+      service={streamOn.preferred}
+      mediaTitle={target.media.title}
+      {style}
+      {size}
+    />
   </RenderFor>
 {/if}


### PR DESCRIPTION
## ♪ Note ♪

- Removes the current versions of the `stream on plex` buttons. We've tested the links already, and the Plex sync is almost prod ready. We should then add this as a proper feature and check users collections.