### PR TITLE
fix: corrects alignments for page and summary content

### DIFF
--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -112,7 +112,11 @@
       gap: var(--content-gap);
 
       &:first-child {
-        margin-top: var(--content-gap);
+        margin-top: calc(var(--gap-m) + env(safe-area-inset-top));
+
+        @include for-tablet-sm-and-below {
+          margin-top: var(--content-gap);
+        }
       }
 
       @include for-tablet-lg-and-below {

--- a/projects/client/src/lib/sections/navbar/components/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/SideNavbar.svelte
@@ -187,11 +187,9 @@
   header {
     --navbar-width: var(--ni-66);
     --navbar-item-width: var(--ni-32);
-    --navbar-margin: var(--ni-12);
-    --navbar-margin-top: calc(var(--navbar-margin) + env(safe-area-inset-top));
-    --navbar-margin-bottom: calc(
-      var(--navbar-margin) + env(safe-area-inset-bottom)
-    );
+    --navbar-margin: var(--gap-s);
+    --navbar-margin-top: calc(var(--gap-m) + env(safe-area-inset-top));
+    --navbar-margin-bottom: calc(var(--gap-m) + env(safe-area-inset-bottom));
     --navbar-padding: calc(
       (var(--navbar-width) - var(--navbar-item-width)) / 2
     );

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
@@ -45,11 +45,7 @@
     display: grid;
     gap: var(--gap-xl);
     grid-template-columns: minmax(var(--ni-320), 1fr) 2fr 1fr;
-    margin: 0 calc(var(--ni-32) + var(--layout-distance-side));
-
-    @include for-tablet-sm-and-below {
-      margin: 0 var(--layout-distance-side);
-    }
+    margin: 0 var(--layout-distance-side);
 
     @include for-tablet-sm-and-below {
       grid-template-columns: 1fr;


### PR DESCRIPTION
## ♩ Note ♩

- Some alignment fixes

## 👀 Examples 👀
Before:
<img width="528" height="372" alt="Screenshot 2025-07-14 at 21 11 57" src="https://github.com/user-attachments/assets/e7880ad2-ffb4-4ce6-8d67-a9cbf2fdf123" />

After:
<img width="528" height="372" alt="Screenshot 2025-07-14 at 21 12 03" src="https://github.com/user-attachments/assets/3819d42e-0b00-44b1-938b-c5aaac3671a9" />


Before:
<img width="1226" height="712" alt="Screenshot 2025-07-14 at 21 12 23" src="https://github.com/user-attachments/assets/79034cac-0b1b-4010-9bdf-bb2d3e8a60a8" />

After:
<img width="1226" height="712" alt="Screenshot 2025-07-14 at 21 12 28" src="https://github.com/user-attachments/assets/c4f07186-d1a2-4143-b7ca-77071b50adf4" />
