### PR TITLE
fix(profile): constrain profile image within actual size

### DIFF
--- a/projects/client/src/lib/sections/profile-banner/ProfileImage.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfileImage.svelte
@@ -60,6 +60,9 @@
     height: var(--height);
     border-radius: 50%;
 
+    padding: var(--border-width);
+    box-sizing: border-box;
+
     :global(.trakt-editable-image img) {
       transition: outline-color var(--transition-increment) ease-in-out;
     }


### PR DESCRIPTION
## ♩Note ♩

- Constrain profile image in actual size.

## 👀 Example 👀

Before / after:
<img width="350" height="215" alt="Screenshot 2025-07-14 at 21 39 03" src="https://github.com/user-attachments/assets/6552ecfd-df7e-4af8-b928-f7edb1deb95c" /> <img width="350" height="215" alt="Screenshot 2025-07-14 at 21 38 47" src="https://github.com/user-attachments/assets/6c364006-d0df-405a-bd77-95c0a3d16f6c" />
