### PR TITLE
fix(navbar): profile image sizes

### DIFF
--- a/projects/client/src/lib/sections/navbar/components/ProfileButton.svelte
+++ b/projects/client/src/lib/sections/navbar/components/ProfileButton.svelte
@@ -29,8 +29,8 @@
     {#snippet icon()}
       <div class="profile-icon">
         <ProfileImage
-          --width="var(--ni-16)"
-          --height="var(--ni-16)"
+          --width="var(--ni-20)"
+          --height="var(--ni-20)"
           --border-width="var(--border-thickness-xs)"
           name={$user?.name?.first ?? ""}
           src={$user?.avatar?.url ?? ""}

--- a/projects/client/src/lib/sections/navbar/components/ProfileLink.svelte
+++ b/projects/client/src/lib/sections/navbar/components/ProfileLink.svelte
@@ -83,8 +83,10 @@
     position: relative;
 
     :global(.vip-badge) {
-      position: absolute;
+      width: var(--ni-24);
+      height: auto;
 
+      position: absolute;
       top: var(--ni-neg-10);
       right: var(--ni-neg-10);
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Woops, previous fix was incomplete 🥲
- Also fixes the size of the vip icon in the side navbar

## 👀 Examples 👀

Before/after:
<img width="146" height="71" alt="Screenshot 2025-07-14 at 22 32 49" src="https://github.com/user-attachments/assets/479fbaf9-0568-4928-bbb3-42b366d3512c" /> <img width="146" height="71" alt="Screenshot 2025-07-14 at 22 32 55" src="https://github.com/user-attachments/assets/9fc42f6b-566b-452a-b89b-649a1d51d622" />


Before/after:
<img width="98" height="215" alt="Screenshot 2025-07-14 at 22 32 23" src="https://github.com/user-attachments/assets/27a5d619-9ec9-43d3-9f29-7ae54ad088e3" /> <img width="98" height="215" alt="Screenshot 2025-07-14 at 22 32 29" src="https://github.com/user-attachments/assets/cf774abb-e313-42e2-b666-a1e68a10a5cd" />
