### PR TITLE
Refactor/list images

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "npm:@cucumber/cucumber@11.3.0": "11.3.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.2.0_@cucumber+messages@27.2.0",
     "npm:@google/generative-ai@0.24.1": "0.24.1",
     "npm:@inlang/paraglide-js@^2.0.13": "2.1.0",
-    "npm:@jsr/trakt__api@~0.2.5": "0.2.5_zod@3.25.67",
+    "npm:@jsr/trakt__api@~0.2.7": "0.2.7_zod@3.25.67",
     "npm:@playwright/test@1.52.0": "1.52.0",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.33.14__acorn@8.15.0",
     "npm:@svelte-put/qr@^2.1.0": "2.1.0_svelte@5.33.14__acorn@8.15.0",
@@ -74,7 +74,7 @@
         "@jridgewell/trace-mapping@0.3.25"
       ]
     },
-    "@anatine/zod-openapi@2.2.8_openapi3-ts@4.4.0_zod@3.25.67": {
+    "@anatine/zod-openapi@2.2.8_openapi3-ts@4.5.0_zod@3.25.67": {
       "integrity": "sha512-iyM8mB556KdiZ6a1GTZ67ACLnJakU1hrzzXoh7PLaReldAdMq88MlZn/Ir/U56/TBuQctBhh/4seo0b0B343uw==",
       "dependencies": [
         "openapi3-ts",
@@ -2194,14 +2194,14 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.2.5_zod@3.25.67": {
-      "integrity": "sha512-REDv7zcwKYAYl83VDuyP8091BX9+BgQIpPb986Awvspn6oREXJhsTZPiH53e+zqHU4E4FMQ9ILE5vZtG9q3xrg==",
+    "@jsr/trakt__api@0.2.7_zod@3.25.67": {
+      "integrity": "sha512-ZgTkSKsV7FrboRQE0VZgc0/D+S6TpcdI1ylv3bSKAdZx5gq3B8pPvjw63KV3bj1Z0OwLcL1JzCANIK0xlzb0lQ==",
       "dependencies": [
         "@anatine/zod-openapi",
         "@ts-rest/core",
         "zod@3.25.67"
       ],
-      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.2.5.tgz"
+      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.2.7.tgz"
     },
     "@lix-js/sdk@0.4.7_kysely@0.27.6": {
       "integrity": "sha512-pRbW+joG12L0ULfMiWYosIW0plmW4AsUdiPCp+Z8rAsElJ+wJ6in58zhD3UwUcd4BNcpldEGjg6PdA7e0RgsDQ==",
@@ -4926,8 +4926,8 @@
         "wrappy"
       ]
     },
-    "openapi3-ts@4.4.0": {
-      "integrity": "sha512-9asTNB9IkKEzWMcHmVZE7Ts3kC9G7AFHfs8i7caD8HbI76gEjdkId4z/AkP83xdZsH7PLAnnbl47qZkXuxpArw==",
+    "openapi3-ts@4.5.0": {
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
       "dependencies": [
         "yaml@2.8.0"
       ]
@@ -6806,7 +6806,7 @@
             "npm:@cucumber/cucumber@11.3.0",
             "npm:@google/generative-ai@0.24.1",
             "npm:@inlang/paraglide-js@^2.0.13",
-            "npm:@jsr/trakt__api@~0.2.5",
+            "npm:@jsr/trakt__api@~0.2.7",
             "npm:@playwright/test@1.52.0",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@svelte-put/qr@^2.1.0",

--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Търсене"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Плакат за запис в {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Søg"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Plakat for en post i {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Suchen"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Poster für einen Eintrag in {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2317,6 +2317,15 @@
     "button_label_search": {
       "default": "Search",
       "description": "Aria-label for the button that opens the search page."
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Poster for an entry in {title}",
+      "description": "Alt text for the poster image of a list preview.",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Buscar"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Póster de una entrada en {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Buscar"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Póster para una entrada en {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Recherche"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "L'affiche d'un élément dans {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Rechercher"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Affiche pour une entrée dans {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Cerca"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Poster per una voce in {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "検索"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "{title} のリストのエントリのポスター",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Søk"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Plakat for en oppføring i {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Zoeken"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Poster voor een item in {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Szukaj"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Plakat dla pozycji w {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Pesquisar"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Pôster para uma entrada em {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Caută"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Afiș pentru o intrare în {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Sök"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Affisch för en post i {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1834,6 +1834,14 @@
     },
     "button_label_search": {
       "default": "Пошук"
+    },
+    "image_alt_list_preview_poster": {
+      "default": "Постер для запису в {title}",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -73,7 +73,7 @@
     "@tanstack/svelte-query": "^5.80.2",
     "@tanstack/svelte-query-devtools": "^5.80.2",
     "@tanstack/svelte-query-persist-client": "^5.80.2",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.2.5",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.2.7",
     "@ts-rest/core": "^3.52.1",
     "@use-gesture/vanilla": "^10.3.1",
     "date-fns": "^4.1.0",

--- a/projects/client/src/lib/requests/_internal/mapToEpisodeEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToEpisodeEntry.ts
@@ -25,7 +25,7 @@ export function mapToEpisodeEntry(
     season: episode.season,
     genres: [],
     number: episode.number,
-    runtime: episode.runtime,
+    runtime: episode.runtime ?? NaN,
     cover: {
       url: prependHttps(
         thumbUrl(posterCandidate),

--- a/projects/client/src/lib/requests/_internal/mapToMediaListSummary.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaListSummary.ts
@@ -9,7 +9,7 @@ export function mapToMediaListSummary(
     id: listResponse.ids.trakt,
     slug: listResponse.ids.slug,
     name: listResponse.name,
-    description: listResponse.description,
+    description: listResponse.description ?? '',
     user: mapToUserProfile(listResponse.user),
     count: listResponse.item_count,
   };

--- a/projects/client/src/lib/requests/_internal/mapToMediaListSummary.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaListSummary.ts
@@ -1,10 +1,18 @@
 import type { ListResponse } from '@trakt/api';
 import type { MediaListSummary } from '../models/MediaListSummary.ts';
+import { mapToPoster } from './mapToPoster.ts';
 import { mapToUserProfile } from './mapToUserProfile.ts';
+
+// FIXME: remove this when the API is fixed
+const PLACEHOLDERS_PATH = 'placeholders/original/poster.png';
 
 export function mapToMediaListSummary(
   listResponse: ListResponse,
 ): MediaListSummary {
+  const posters = (listResponse.images?.posters ?? [])
+    .filter((poster) => poster !== PLACEHOLDERS_PATH)
+    .map((poster) => mapToPoster({ poster: [poster] }));
+
   return {
     id: listResponse.ids.trakt,
     slug: listResponse.ids.slug,
@@ -12,5 +20,6 @@ export function mapToMediaListSummary(
     description: listResponse.description ?? '',
     user: mapToUserProfile(listResponse.user),
     count: listResponse.item_count,
+    posters,
   };
 }

--- a/projects/client/src/lib/requests/_internal/mapToPoster.ts
+++ b/projects/client/src/lib/requests/_internal/mapToPoster.ts
@@ -1,16 +1,16 @@
 import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/constants.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
-import type { MovieResponse, SeasonsResponse, ShowResponse } from '@trakt/api';
 import type { MediaEntry } from '../models/MediaEntry.ts';
 import { mediumUrl } from './mediumUrl.ts';
 import { thumbUrl } from './thumbUrl.ts';
 
+type Images = {
+  poster?: string[];
+};
+
 export function mapToPoster(
-  images:
-    | ShowResponse['images']
-    | MovieResponse['images']
-    | SeasonsResponse[0]['images'],
+  images: Images | Nil,
 ): MediaEntry['poster'] {
   const posterCandidate = findDefined(
     ...(images?.poster ?? []),

--- a/projects/client/src/lib/requests/_internal/mediumUrl.ts
+++ b/projects/client/src/lib/requests/_internal/mediumUrl.ts
@@ -3,5 +3,7 @@ export function mediumUrl(url: string | Nil): string | Nil {
     return;
   }
 
-  return url.replace('/thumb/', '/medium/');
+  return url
+    .replace('/thumb/', '/medium/')
+    .replace('/original/', '/medium/');
 }

--- a/projects/client/src/lib/requests/_internal/thumbUrl.ts
+++ b/projects/client/src/lib/requests/_internal/thumbUrl.ts
@@ -3,5 +3,7 @@ export function thumbUrl(url: string | Nil): string | Nil {
     return;
   }
 
-  return url.replace('/medium/', '/thumb/');
+  return url
+    .replace('/medium/', '/thumb/')
+    .replace('/original/', '/thumb/');
 }

--- a/projects/client/src/lib/requests/models/MediaListSummary.ts
+++ b/projects/client/src/lib/requests/models/MediaListSummary.ts
@@ -1,5 +1,6 @@
 import { UserProfileSchema } from '$lib/requests/models/UserProfile.ts';
 import { z } from 'zod';
+import { ImageUrlsSchema } from './ImageUrlsSchema.ts';
 
 export const MediaListSummarySchema = z.object({
   id: z.number(),
@@ -8,6 +9,9 @@ export const MediaListSummarySchema = z.object({
   description: z.string(),
   user: UserProfileSchema,
   count: z.number(),
+  posters: z.array(z.object({
+    url: ImageUrlsSchema,
+  })),
 });
 
 export type MediaListSummary = z.infer<typeof MediaListSummarySchema>;

--- a/projects/client/src/lib/requests/models/StreamingServiceOptions.ts
+++ b/projects/client/src/lib/requests/models/StreamingServiceOptions.ts
@@ -18,7 +18,7 @@ export const OnDemandStreamingSchema = z.object({
   source: z.string(),
   is4k: z.boolean(),
   type: z.literal('on-demand'),
-  currency: z.string(),
+  currency: z.string().nullish(),
   prices: z.object({
     rent: z.number().optional(),
     purchase: z.number().optional(),

--- a/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
@@ -44,7 +44,7 @@ function mapShowProgressResponse(
     title: episode.title,
     season: episode.season,
     number: episode.number,
-    runtime: episode.runtime,
+    runtime: episode.runtime ?? NaN,
     cover: {
       url: prependHttps(posterCandidate),
     },

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
@@ -18,7 +18,7 @@
       {#each posters as poster, index (`${list.id}_poster_${index}`)}
         <div class="poster-wrapper" style="--poster-index: {index}">
           <CrossOriginImage
-            src={poster.url.medium}
+            src={poster.url.thumb}
             alt={m.image_alt_list_preview_poster({ title: list.name })}
           />
         </div>

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
@@ -4,29 +4,22 @@
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
   import type { MediaType } from "$lib/requests/models/MediaType.ts";
-  import { useListItems } from "$lib/sections/lists/user/useListItems.ts";
   import { getListUrl } from "./getListUrl.ts";
 
   const POSTER_LIMIT = 8;
   const { list, type }: { list: MediaListSummary; type?: MediaType } = $props();
 
-  const { list: items } = useListItems({
-    list,
-    type,
-    limit: POSTER_LIMIT,
-    page: 1,
-  });
+  const posters = $derived(list.posters.slice(0, POSTER_LIMIT));
 </script>
 
-{#if $items}
+{#if posters}
   <Link href={getListUrl(list, type)}>
-    <div class="trakt-list-posters" style="--poster-count: {$items.length}">
-      {#each $items as item, index}
+    <div class="trakt-list-posters" style="--poster-count: {posters.length}">
+      {#each posters as poster, index (`${list.id}_poster_${index}`)}
         <div class="poster-wrapper" style="--poster-index: {index}">
           <CrossOriginImage
-            animate={false}
-            src={item.entry.poster.url.medium}
-            alt={m.image_alt_media_poster({ title: item.entry.title })}
+            src={poster.url.medium}
+            alt={m.image_alt_list_preview_poster({ title: list.name })}
           />
         </div>
       {/each}

--- a/projects/client/src/lib/sections/summary/components/details/_internal/getMediaCost.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/getMediaCost.ts
@@ -4,7 +4,7 @@ import { toHumanCurrency } from '$lib/utils/formatting/currency/toHumanCurrency.
 
 export function getMediaCost(onDemandService: StreamOnDemand) {
   const price = onDemandService.prices.rent ?? onDemandService.prices.purchase;
-  if (!price) {
+  if (!price || !onDemandService.currency) {
     return '';
   }
 

--- a/projects/client/src/mocks/data/lists/mapped/OfficialListsMappedMock.ts
+++ b/projects/client/src/mocks/data/lists/mapped/OfficialListsMappedMock.ts
@@ -27,5 +27,6 @@ export const OfficialListsMappedMock: MediaListSummary[] = [
       'location': undefined,
       'cover': undefined,
     },
+    'posters': [],
   },
 ];

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/HereticListsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/HereticListsMappedMock.ts
@@ -9,5 +9,6 @@ export const HereticListsMappedMock: MediaListSummary[] = [
     'slug': 'heretics-only',
     'user': UserProfileHarryMappedMock,
     'count': 1,
+    'posters': [],
   },
 ];

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/SiloListsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/SiloListsMappedMock.ts
@@ -9,5 +9,6 @@ export const SiloListsMappedMock: MediaListSummary[] = [
     'slug': 'silos',
     'user': UserProfileHarryMappedMock,
     'count': 1,
+    'posters': [],
   },
 ];

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/SiloListsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/SiloListsMappedMock.ts
@@ -9,6 +9,87 @@ export const SiloListsMappedMock: MediaListSummary[] = [
     'slug': 'silos',
     'user': UserProfileHarryMappedMock,
     'count': 1,
-    'posters': [],
+    'posters': [
+      {
+        'url': {
+          'medium':
+            'https://walter-r2.trakt.tv/images/shows/000/173/996/posters/medium/f498a2fa2b.jpg',
+          'thumb':
+            'https://walter-r2.trakt.tv/images/shows/000/173/996/posters/thumb/f498a2fa2b.jpg',
+        },
+      },
+      {
+        'url': {
+          'medium':
+            'https://walter-r2.trakt.tv/images/shows/000/156/110/posters/medium/1d002ba117.jpg',
+          'thumb':
+            'https://walter-r2.trakt.tv/images/shows/000/156/110/posters/thumb/1d002ba117.jpg',
+        },
+      },
+      {
+        'url': {
+          'medium':
+            'https://walter-r2.trakt.tv/images/shows/000/126/995/posters/medium/55b80503e9.jpg',
+          'thumb':
+            'https://walter-r2.trakt.tv/images/shows/000/126/995/posters/thumb/55b80503e9.jpg',
+        },
+      },
+      {
+        'url': {
+          'medium':
+            'https://walter-r2.trakt.tv/images/shows/000/170/649/posters/medium/39eb828a7a.jpg',
+          'thumb':
+            'https://walter-r2.trakt.tv/images/shows/000/170/649/posters/thumb/39eb828a7a.jpg',
+        },
+      },
+      {
+        'url': {
+          'medium':
+            'https://walter-r2.trakt.tv/images/shows/000/043/764/posters/medium/9ef9162506.jpg',
+          'thumb':
+            'https://walter-r2.trakt.tv/images/shows/000/043/764/posters/thumb/9ef9162506.jpg',
+        },
+      },
+      {
+        'url': {
+          'medium':
+            'https://walter-r2.trakt.tv/images/shows/000/058/454/posters/medium/e7ca7525cb.jpg',
+          'thumb':
+            'https://walter-r2.trakt.tv/images/shows/000/058/454/posters/thumb/e7ca7525cb.jpg',
+        },
+      },
+      {
+        'url': {
+          'medium':
+            'https://walter-r2.trakt.tv/images/shows/000/134/421/posters/medium/6295516e91.jpg',
+          'thumb':
+            'https://walter-r2.trakt.tv/images/shows/000/134/421/posters/thumb/6295516e91.jpg',
+        },
+      },
+      {
+        'url': {
+          'medium':
+            'https://walter-r2.trakt.tv/images/shows/000/001/390/posters/medium/93df9cd612.jpg',
+          'thumb':
+            'https://walter-r2.trakt.tv/images/shows/000/001/390/posters/thumb/93df9cd612.jpg',
+        },
+      },
+      {
+        'url': {
+          'medium':
+            'https://walter-r2.trakt.tv/images/shows/000/104/578/posters/medium/f43fc7f7db.jpg',
+          'thumb':
+            'https://walter-r2.trakt.tv/images/shows/000/104/578/posters/thumb/f43fc7f7db.jpg',
+        },
+      },
+      {
+        'url': {
+          'medium':
+            'https://walter-r2.trakt.tv/images/shows/000/191/758/posters/medium/3917ba20d9.jpg',
+          'thumb':
+            'https://walter-r2.trakt.tv/images/shows/000/191/758/posters/thumb/3917ba20d9.jpg',
+        },
+      },
+    ],
   },
 ];

--- a/projects/client/src/mocks/data/summary/shows/silo/response/SiloListsResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/SiloListsResponseMock.ts
@@ -22,5 +22,19 @@ export const SiloListsResponseMock: ListResponse[] = [
       'slug': 'silos',
     },
     'user': UserProfileHarryResponseMock,
+    'images': {
+      'posters': [
+        'walter-r2.trakt.tv/images/shows/000/173/996/posters/original/f498a2fa2b.jpg',
+        'walter-r2.trakt.tv/images/shows/000/156/110/posters/original/1d002ba117.jpg',
+        'walter-r2.trakt.tv/images/shows/000/126/995/posters/original/55b80503e9.jpg',
+        'walter-r2.trakt.tv/images/shows/000/170/649/posters/original/39eb828a7a.jpg',
+        'walter-r2.trakt.tv/images/shows/000/043/764/posters/original/9ef9162506.jpg',
+        'walter-r2.trakt.tv/images/shows/000/058/454/posters/original/e7ca7525cb.jpg',
+        'walter-r2.trakt.tv/images/shows/000/134/421/posters/original/6295516e91.jpg',
+        'walter-r2.trakt.tv/images/shows/000/001/390/posters/original/93df9cd612.jpg',
+        'walter-r2.trakt.tv/images/shows/000/104/578/posters/original/f43fc7f7db.jpg',
+        'walter-r2.trakt.tv/images/shows/000/191/758/posters/original/3917ba20d9.jpg',
+      ],
+    },
   },
 ];

--- a/projects/client/src/mocks/data/users/mapped/CollaborationListsMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/CollaborationListsMappedMock.ts
@@ -9,5 +9,6 @@ export const CollaborationListsMappedMock: MediaListSummary[] = [
     'slug': 'our-list',
     'user': UserProfileHarryMappedMock,
     'count': 1,
+    'posters': [],
   },
 ];

--- a/projects/client/src/mocks/data/users/mapped/PersonalListsMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/PersonalListsMappedMock.ts
@@ -9,5 +9,6 @@ export const PersonalListsMappedMock: MediaListSummary[] = [
     'slug': 'my-personal-list',
     'user': UserProfileHarryMappedMock,
     'count': 1,
+    'posters': [],
   },
 ];


### PR DESCRIPTION
## 🎶 Notes 🎶

- Switch to using the images returned by the lists api, instead of querying items per list to get the posters; meaning it greatly reduces the amount of requests per list summary card.
- Also contains a small fix to use smaller images (~50kB difference per poster).

## 👀 Examples 👀
Before:
<img width="850" height="213" alt="Screenshot 2025-07-15 at 12 09 57" src="https://github.com/user-attachments/assets/417734a0-a286-4899-9a18-c52867d2e333" />

After:
<img width="684" height="43" alt="Screenshot 2025-07-15 at 12 08 48" src="https://github.com/user-attachments/assets/8fa7880b-8f37-4ed7-97e2-2107ded1b96f" />
