### PR TITLE
Fix/videos

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "npm:@cucumber/cucumber@11.3.0": "11.3.0_@cucumber+gherkin@30.0.4_@cucumber+message-streams@4.0.1__@cucumber+messages@27.2.0_@cucumber+messages@27.2.0",
     "npm:@google/generative-ai@0.24.1": "0.24.1",
     "npm:@inlang/paraglide-js@^2.0.13": "2.1.0",
-    "npm:@jsr/trakt__api@~0.2.8": "0.2.8_zod@3.25.67",
+    "npm:@jsr/trakt__api@~0.2.9": "0.2.9_zod@3.25.67",
     "npm:@playwright/test@1.52.0": "1.52.0",
     "npm:@svelte-plugins/tooltips@^3.0.3": "3.0.3_svelte@5.33.14__acorn@8.15.0",
     "npm:@svelte-put/qr@^2.1.0": "2.1.0_svelte@5.33.14__acorn@8.15.0",
@@ -2194,14 +2194,14 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@jsr/trakt__api@0.2.8_zod@3.25.67": {
-      "integrity": "sha512-yy+6DQPwwhPW4bXf+/PU0KcHI524jM9TPt3be5sddKJ6/S5efy45jDxkYbEAtvI4fq1zsEV09GblYC+ZtlKmgQ==",
+    "@jsr/trakt__api@0.2.9_zod@3.25.67": {
+      "integrity": "sha512-meL/KQtzbDSNwobwCyXTbdt/9sXwXH6IasoABEfcrvK+evmgbfwUgKqWMxqMh8yhrMTt+flcvWBsZmjmLWV1gA==",
       "dependencies": [
         "@anatine/zod-openapi",
         "@ts-rest/core",
         "zod@3.25.67"
       ],
-      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.2.8.tgz"
+      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.2.9.tgz"
     },
     "@lix-js/sdk@0.4.7_kysely@0.27.6": {
       "integrity": "sha512-pRbW+joG12L0ULfMiWYosIW0plmW4AsUdiPCp+Z8rAsElJ+wJ6in58zhD3UwUcd4BNcpldEGjg6PdA7e0RgsDQ==",
@@ -6806,7 +6806,7 @@
             "npm:@cucumber/cucumber@11.3.0",
             "npm:@google/generative-ai@0.24.1",
             "npm:@inlang/paraglide-js@^2.0.13",
-            "npm:@jsr/trakt__api@~0.2.8",
+            "npm:@jsr/trakt__api@~0.2.9",
             "npm:@playwright/test@1.52.0",
             "npm:@svelte-plugins/tooltips@^3.0.3",
             "npm:@svelte-put/qr@^2.1.0",

--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Зад кулисите"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Гафове"
+    },
     "header_now_playing": {
       "default": "В ефир"
     },

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Bag kulisserne"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Bloopers"
+    },
     "header_now_playing": {
       "default": "Spiller nu"
     },

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Hinter den Kulissen"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Pannen"
+    },
     "header_now_playing": {
       "default": "Läuft jetzt"
     },

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -1985,6 +1985,10 @@
       "default": "Behind the Scenes",
       "description": "Value for the behind the scenes video type. The value is sent back from the Trakt API."
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Bloopers",
+      "description": "Value for the bloopers video type. The value is sent back from the Trakt API."
+    },
     "header_now_playing": {
       "default": "Now Playing",
       "description": "Header for the 'now playing' toast that shows the movie or episode the user is currently watching."

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Detrás de cámaras"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Tomas Falsas"
+    },
     "header_now_playing": {
       "default": "En emisión"
     },

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Detrás de cámaras"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Errores de grabación"
+    },
     "header_now_playing": {
       "default": "En emisión"
     },

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Coulisses"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Bloopers"
+    },
     "header_now_playing": {
       "default": "À l'affiche"
     },

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Coulisses"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Bêtisier"
+    },
     "header_now_playing": {
       "default": "En cours"
     },

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Dietro le quinte"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Errori sul set"
+    },
     "header_now_playing": {
       "default": "In riproduzione"
     },

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "舞台裏"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "NG集"
+    },
     "header_now_playing": {
       "default": "再生中"
     },

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Bak kulissene"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Bloopers"
+    },
     "header_now_playing": {
       "default": "Spilles nå"
     },

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Achter de schermen"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Bloopers"
+    },
     "header_now_playing": {
       "default": "Nu bezig"
     },

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Kulisy"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Wpadki"
+    },
     "header_now_playing": {
       "default": "Odtwarzane"
     },

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Bastidores"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Erros de Gravação"
+    },
     "header_now_playing": {
       "default": "Em exibição"
     },

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Din culise"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Gafe"
+    },
     "header_now_playing": {
       "default": "Rulează acum"
     },

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "Bakom kulisserna"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Bloopers"
+    },
     "header_now_playing": {
       "default": "Spelas nu"
     },

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1574,6 +1574,9 @@
     "translated_value_video_type_behind_the_scenes": {
       "default": "За лаштунками"
     },
+    "translated_value_video_type_bloopers": {
+      "default": "Перли"
+    },
     "header_now_playing": {
       "default": "Зараз в ефірі"
     },

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -73,7 +73,7 @@
     "@tanstack/svelte-query": "^5.80.2",
     "@tanstack/svelte-query-devtools": "^5.80.2",
     "@tanstack/svelte-query-persist-client": "^5.80.2",
-    "@trakt/api": "npm:@jsr/trakt__api@^0.2.8",
+    "@trakt/api": "npm:@jsr/trakt__api@^0.2.9",
     "@ts-rest/core": "^3.52.1",
     "@use-gesture/vanilla": "^10.3.1",
     "date-fns": "^4.1.0",

--- a/projects/client/src/lib/requests/_internal/mapToMediaVideo.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaVideo.ts
@@ -2,21 +2,6 @@ import { type MediaVideo } from '$lib/requests/models/MediaVideo.ts';
 import { checksum } from '$lib/utils/string/checksum.ts';
 import type { VideoResponse } from '@trakt/api';
 
-// FIXME: figure out why the response type is not the enum
-function mapToVideoType(type: string): MediaVideo['type'] {
-  switch (type) {
-    case 'trailer':
-    case 'clip':
-    case 'teaser':
-    case 'featurette':
-    case 'recap':
-    case 'behind the scenes':
-    case 'opening credits':
-      return type as MediaVideo['type'];
-    default:
-      throw new Error(`Unknown video type: ${type}`);
-  }
-}
 export function mapToMediaVideo(
   video: VideoResponse,
 ): MediaVideo {
@@ -30,7 +15,7 @@ export function mapToMediaVideo(
   return {
     id: checksum(video.url),
     title: video.title,
-    type: mapToVideoType(video.type),
+    type: video.type,
     url: video.url,
     thumbnail,
     publishedAt: new Date(video.published_at),

--- a/projects/client/src/lib/requests/models/MediaVideo.ts
+++ b/projects/client/src/lib/requests/models/MediaVideo.ts
@@ -1,23 +1,14 @@
+import { videoTypeSchema } from '@trakt/api';
 import { z } from 'zod';
-
-export const MediaVideoTypeSchema = z.enum([
-  'trailer',
-  'clip',
-  'teaser',
-  'featurette',
-  'recap',
-  'behind the scenes',
-  'opening credits',
-]);
 
 export const MediaVideoSchema = z.object({
   id: z.string(),
-  type: MediaVideoTypeSchema,
+  type: videoTypeSchema,
   url: z.string().url(),
   thumbnail: z.string().url(),
   title: z.string(),
   publishedAt: z.date(),
 });
 
-export type MediaVideoType = z.infer<typeof MediaVideoTypeSchema>;
+export type MediaVideoType = z.infer<typeof videoTypeSchema>;
 export type MediaVideo = z.infer<typeof MediaVideoSchema>;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Uses the videos from the api instead of duplicating entries.
- Adds missing `bloopers`
- Pages with blooper videos open much faster now, and actually shows the videos list.

## 👀 Examples 👀
Before:

https://github.com/user-attachments/assets/69d4b658-4294-4453-b960-e8f23fc6a87c

After:

https://github.com/user-attachments/assets/a0c29e4e-c53a-48fa-8210-6642d6519d18

