### PR TITLE
fix: do not ignore collected

### DIFF
--- a/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
@@ -44,7 +44,6 @@ const movieAnticipatedRequest = (
     .anticipated({
       query: {
         extended: 'full,images,colors',
-        ignore_collected: true,
         page,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/movies/movieHotQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieHotQuery.ts
@@ -43,7 +43,6 @@ const movieHotRequest = (
     .hot({
       query: {
         extended: 'full,images,colors',
-        ignore_collected: true,
         page,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/moviePopularQuery.ts
@@ -26,7 +26,6 @@ const moviePopularRequest = (
     .popular({
       query: {
         extended: 'full,images,colors',
-        ignore_collected: true,
         page,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
@@ -43,7 +43,6 @@ const movieTrendingRequest = (
     .trending({
       query: {
         extended: 'full,images,colors',
-        ignore_collected: true,
         page,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
@@ -53,7 +53,6 @@ const showAnticipatedRequest = (
     .anticipated({
       query: {
         extended: 'full,images,colors',
-        ignore_collected: true,
         page,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/shows/showHotQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showHotQuery.ts
@@ -48,7 +48,6 @@ const showHotRequest = (
     .hot({
       query: {
         extended: 'full,images,colors',
-        ignore_collected: true,
         page,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showPopularQuery.ts
@@ -46,7 +46,6 @@ const showPopularRequest = (
     .popular({
       query: {
         extended: 'full,images,colors',
-        ignore_collected: true,
         page,
         limit,
         ...filter,

--- a/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
@@ -48,7 +48,6 @@ const showTrendingRequest = (
     .trending({
       query: {
         extended: 'full,images,colors',
-        ignore_collected: true,
         page,
         limit,
         ...filter,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Removes a bunch of `ignore_collected` params (except for recommendations).
  - With the plex sync, this was hiding a bit too much.
  - With ignoring watchlisted/watched we have alternative ways to still easily see that content (in the `available now`/`coming soon` lists, in your `watch history`, and by disabling the filters). For collections we don't have anything yet; we could add it as a filter when collections are more of a thing).


## 👀 Examples 👀
Before:
<img width="1212" height="657" alt="Screenshot 2025-07-18 at 15 02 49" src="https://github.com/user-attachments/assets/1d0eb109-ac19-4435-8c4e-f326049c5ef1" />

After:
<img width="1212" height="657" alt="Screenshot 2025-07-18 at 15 02 54" src="https://github.com/user-attachments/assets/1389db7f-c88a-41ae-9654-3f26741b7bb9" />

