### PR TITLE
fix(comment): use more space for the comment itself

### DIFF
--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentCard.svelte
@@ -37,7 +37,7 @@
 
     display: flex;
     flex-direction: column;
-    gap: var(--gap-m);
+    gap: var(--gap-s);
     justify-content: space-between;
 
     padding: var(--ni-16) var(--ni-20);

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentFooter.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentFooter.svelte
@@ -20,8 +20,7 @@
       flex-shrink: 1;
     }
 
-    /* To align icons of the first and last ghost buttons */
-    margin-left: var(--ni-neg-16);
-    margin-right: var(--ni-neg-16);
+    /* To align icons of the ghost buttons */
+    margin: var(--ni-neg-10) var(--ni-neg-16);
   }
 </style>


### PR DESCRIPTION
## ♪ Note ♪

- Uses more space for the comment itself

## 👀 Example 👀
Before:
<img width="498" height="241" alt="Screenshot 2025-07-21 at 09 42 52" src="https://github.com/user-attachments/assets/8b6797d5-fa31-47a3-8609-fc2efa6476f4" />

After:
<img width="498" height="241" alt="Screenshot 2025-07-21 at 09 46 07" src="https://github.com/user-attachments/assets/5d91b880-a8d9-4ec3-aa3d-a0620b30f028" />
