### PR TITLE
feat(tags): use icons for some tags

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Намери предавания"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} гледат",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Предавания"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Актьори"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} очакващи",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Виж всички популярни филми в момента"

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Find serier"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} ser med",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Serier"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Skuespillere"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} forventningsfulde",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Se alle populære film"

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Serien finden"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} schauen gerade",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Serien"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Schauspieler"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} gespannt",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Alle Trendfilme ansehen"

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -548,15 +548,6 @@
       "default": "Find Shows",
       "description": "Text for the button that allows users to find shows. This button is shown in some empty lists."
     },
-    "tag_text_active_watchers": {
-      "default": "{count} watching",
-      "description": "Text for the tag that shows the number of active watchers of a movie or show. This should be as short as possible.",
-      "variables": {
-        "count": {
-          "type": "number"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Shows",
       "description": "Title for lists containing shows related to a person's credits. This title should be as short and concise as possible."
@@ -1130,15 +1121,6 @@
     "list_title_actors": {
       "default": "Actors",
       "description": "Title for lists containing actors of a movie, show, or episode. This title should be as short and concise as possible."
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} eager",
-      "description": "Text for the tag that shows the number of users who are eagerly anticipating a movie or show. This should be as short as possible.",
-      "variables": {
-        "count": {
-          "type": "number"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "View all trending movies",

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Encuentra Series"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} viendo",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Series"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Actores"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} con ganas",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Ver todas las películas populares"

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Encuentra Series"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} disfrutando",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Series"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Actores"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} con ansias",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Ver todas las pelis populares"

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Trouver des séries"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} en train de regarder",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Séries"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Acteurs"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} impatients",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Voir tous les films populaires"

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Trouver des séries"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} en train de regarder",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Séries"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Acteurs"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} impatients",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Voir tous les films populaires"

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Trova serie TV"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} stanno guardando",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Serie TV"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Attori"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} attesi",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Visualizza tutti i film in tendenza"

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "番組を探す"
     },
-    "tag_text_active_watchers": {
-      "default": "{count}人が視聴中",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "番組"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "出演者"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} が待ち遠しい",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "話題の作品をすべて見る"

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Finn Serier"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} ser på",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Serier"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Skuespillere"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} forventninger",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Se alle populære filmer"

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Series zoeken"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} kijken",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Series"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Acteurs"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} zin in",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Bekijk alle populaire films"

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Znajdź seriale"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} oglądających",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Seriale"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Aktorzy"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} wyczekujących",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Zobacz wszystkie popularne filmy"

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Encontre Séries"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} assistindo",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Séries"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Atores"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} na expectativa",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Ver todos os filmes populares"

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Găsește Serialuri"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} urmăresc",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Seriale"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Actori"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} nerăbdători",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Vezi toate filmele populare"

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Hitta serier"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} tittar",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Serier"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Skådespelare"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} förväntansfulla",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Se alla trendiga filmer"

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -427,14 +427,6 @@
     "button_text_find_shows": {
       "default": "Знайти серіали"
     },
-    "tag_text_active_watchers": {
-      "default": "{count} дивляться",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
-    },
     "list_title_show_credits": {
       "default": "Серіали"
     },
@@ -884,14 +876,6 @@
     },
     "list_title_actors": {
       "default": "Актори"
-    },
-    "tag_text_anticipated_count": {
-      "default": "{count} в очікуванні",
-      "variables": {
-        "count": {
-          "type": "string"
-        }
-      }
     },
     "button_label_view_all_trending_movies": {
       "default": "Дивитись всі популярні фільми"

--- a/projects/client/src/lib/components/icons/AnticipatedIcon.svelte
+++ b/projects/client/src/lib/components/icons/AnticipatedIcon.svelte
@@ -1,0 +1,15 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M12 2L14.8214 8.11672L21.5106 8.90983L16.5651 13.4833L17.8779 20.0902L12 16.8L6.12215 20.0902L7.43493 13.4833L2.48944 8.90983L9.17863 8.11672L12 2Z"
+    stroke="currentColor"
+    fill="currentColor"
+    stroke-width="2"
+    stroke-linejoin="bevel"
+  />
+</svg>

--- a/projects/client/src/lib/components/icons/ClockIcon.svelte
+++ b/projects/client/src/lib/components/icons/ClockIcon.svelte
@@ -1,0 +1,13 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <circle cx="12" cy="13" r="8" stroke="currentColor" stroke-width="2" />
+  <path d="M17 20L19 22" stroke="currentColor" stroke-width="2" />
+  <path d="M7 20L5 22" stroke="currentColor" stroke-width="2" />
+  <path d="M9 2H15" stroke="currentColor" stroke-width="2" />
+  <path d="M12 7V13L15 15" stroke="currentColor" stroke-width="2" />
+</svg>

--- a/projects/client/src/lib/components/icons/UserIcon.svelte
+++ b/projects/client/src/lib/components/icons/UserIcon.svelte
@@ -1,0 +1,24 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M20 20C15.5817 15.5817 8.41828 15.5817 4 20Z"
+    stroke="currentColor"
+    fill="currentColor"
+    stroke-width="2"
+    stroke-linecap="square"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M16 6C16 9.20914 14.2091 12 12 12C9.79086 12 8 9.20914 8 6C8 3.79086 9.79086 2 12 2C14.2091 2 16 3.79086 16 6Z"
+    stroke="currentColor"
+    fill="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/projects/client/src/lib/components/media/tags/AnticipatedTag.svelte
+++ b/projects/client/src/lib/components/media/tags/AnticipatedTag.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import AnticipatedIcon from "$lib/components/icons/AnticipatedIcon.svelte";
   import StemTag from "$lib/components/tags/StemTag.svelte";
   import type { TagIntl } from "./TagIntl";
 
@@ -12,6 +13,9 @@
 </script>
 
 <StemTag>
+  {#snippet icon()}
+    <AnticipatedIcon />
+  {/snippet}
   <p class="meta-info capitalize no-wrap">
     {i18n.toAnticipatedCount(score)}
   </p>

--- a/projects/client/src/lib/components/media/tags/DurationTag.svelte
+++ b/projects/client/src/lib/components/media/tags/DurationTag.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
   import StemTag from "$lib/components/tags/StemTag.svelte";
   import type { TagIntl } from "./TagIntl";
 
@@ -12,6 +13,9 @@
 </script>
 
 <StemTag>
+  {#snippet icon()}
+    <ClockIcon />
+  {/snippet}
   <p class="meta-info capitalize no-wrap">
     {i18n.toDuration(runtime)}
   </p>

--- a/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
@@ -13,14 +13,10 @@ export const TagIntlProvider: TagIntl = {
   toEpisodeCount: (count) => m.tag_text_number_of_episodes({ count }),
   toPlayCount: (count) =>
     m.tag_text_plays({ number: toHumanNumber(count, languageTag()) }),
-  toWatcherCount: (count) =>
-    m.tag_text_active_watchers({ count: toHumanNumber(count, languageTag()) }),
+  toWatcherCount: (count) => toHumanNumber(count, languageTag()),
   toReleaseEstimate: (airDate) => toHumanETA(new Date(), airDate, getLocale()),
   tbaLabel: () => m.tag_text_tba(),
-  toAnticipatedCount: (count) =>
-    m.tag_text_anticipated_count({
-      count: toHumanNumber(count, languageTag()),
-    }),
+  toAnticipatedCount: (count) => toHumanNumber(count, languageTag()),
   watchCountLabel: () => m.tag_text_watch_count(),
   trendLabel: (delta) =>
     delta ? toHumanNumber(Math.abs(delta), languageTag()) : '—',

--- a/projects/client/src/lib/components/media/tags/WatchersTag.svelte
+++ b/projects/client/src/lib/components/media/tags/WatchersTag.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import UserIcon from "$lib/components/icons/UserIcon.svelte";
   import StemTag from "$lib/components/tags/StemTag.svelte";
   import type { TagIntl } from "./TagIntl";
 
@@ -12,6 +13,9 @@
 </script>
 
 <StemTag>
+  {#snippet icon()}
+    <UserIcon />
+  {/snippet}
   <p class="meta-info capitalize no-wrap">
     {i18n.toWatcherCount(watchers)}
   </p>

--- a/projects/client/src/lib/components/tags/StemTag.svelte
+++ b/projects/client/src/lib/components/tags/StemTag.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
   import TagContent from "$lib/components/tags/TagContent.svelte";
   import { appendClassList } from "$lib/utils/actions/appendClassList";
+  import type { Snippet } from "svelte";
 
   type StemTagProps = {
     classList?: string;
     text?: string;
+    icon?: Snippet;
   } & Partial<ChildrenProps>;
 
-  const { children, text, classList = "" }: StemTagProps = $props();
+  const { children, text, classList = "", icon }: StemTagProps = $props();
 </script>
 
 <div class="trakt-stem-tag" use:appendClassList={classList}>
   <TagContent>
+    {#if icon}
+      <trakt-tag-icon>
+        {@render icon()}
+      </trakt-tag-icon>
+    {/if}
     {#if children}
       {@render children()}
     {:else}
@@ -25,8 +32,19 @@
 <style>
   .trakt-stem-tag {
     :global(.trakt-tag) {
+      display: flex;
+      align-items: center;
+      gap: var(--gap-xxs);
+
       background: var(--color-background-stem-tag);
       color: var(--color-foreground-stem-tag);
+    }
+
+    trakt-tag-icon {
+      :global(svg) {
+        width: var(--ni-12);
+        height: var(--ni-12);
+      }
     }
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Gets rid of `watchers` and `eager` from tags.
- Tags with numbers only have icons
  - For now I took some matching icons from Figma, but we can fine tune and come up with better ones.
- For episode count, I left it as is. I couldn't find an icon that would represent episode count cleary.

## 👀 Examples 👀
Before:
<img width="1288" height="977" alt="Screenshot 2025-07-23 at 20 26 46" src="https://github.com/user-attachments/assets/a0d70918-3201-4f18-b1df-00c460052182" />

After:
<img width="1288" height="977" alt="Screenshot 2025-07-23 at 20 26 19" src="https://github.com/user-attachments/assets/97eb7ef3-7521-4e19-8e47-e363b5893255" />
