### PR TITLE
fix(list): use smaller gaps on mobile

### DIFF
--- a/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
@@ -111,6 +111,14 @@
 
     .trakt-list-title-container {
       gap: var(--gap-s);
+
+      @include for-mobile {
+        gap: var(--gap-xs);
+      }
+    }
+
+    @include for-mobile {
+      gap: var(--gap-xs);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/watchlist/_internal/TypeToggles.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/_internal/TypeToggles.svelte
@@ -46,6 +46,6 @@
     gap: var(--gap-xxs);
 
     /* To visually align the buttons better with the header */
-    padding-top: var(--ni-4);
+    padding-top: var(--ni-2);
   }
 </style>


### PR DESCRIPTION
## ♪ Note ♪

- Small sizing fix.
 
## 👀 Example 👀

Before/after:
<img width="376" height="664" alt="Screenshot 2025-07-30 at 21 13 35" src="https://github.com/user-attachments/assets/4870a413-bc49-4c9c-b3f1-b95fb713a757" /> <img width="376" height="664" alt="Screenshot 2025-07-30 at 21 13 17" src="https://github.com/user-attachments/assets/7e73a5e3-16a6-4b9d-b654-4ef953288f0e" />
