### PR TITLE
Removes extra gap in summary on mobile

### DIFF
--- a/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
@@ -44,6 +44,10 @@
   .trakt-summary-container {
     display: grid;
     gap: var(--gap-xl);
+    @include for-mobile {
+      /* Poster is hidden in mobile layout. */
+      gap: initial;
+    }
     grid-template-columns: minmax(var(--ni-320), 1fr) 2fr 1fr;
     margin: 0 var(--layout-distance-side);
 


### PR DESCRIPTION
Removes the unintended extra gap present in the summary section when viewed on mobile devices.

This ensures a cleaner and more consistent layout across different screen sizes.