### PR TITLE
fix(card): show correct tags in summary cards

### DIFF
--- a/projects/client/src/lib/components/card/CardCover.svelte
+++ b/projects/client/src/lib/components/card/CardCover.svelte
@@ -111,8 +111,7 @@
       bottom: 0;
       left: 0;
 
-      flex-direction: column;
-      align-items: flex-start;
+      justify-content: flex-start;
       gap: var(--gap-xxs);
 
       :global(.trakt-tag) {

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -22,14 +22,6 @@
     media,
     ...rest
   }: MediaCardProps | EpisodeCardProps = $props();
-
-  function footerTag() {
-    if (rest.type === "episode") {
-      return tag;
-    }
-
-    return undefined;
-  }
 </script>
 
 <Card
@@ -64,6 +56,7 @@
     {#if rest.type === "movie"}
       <CardCover
         {badge}
+        {tag}
         title={media.title}
         alt={media.title}
         src={media.thumb.url}
@@ -73,6 +66,7 @@
     {#if rest.type === "show"}
       <CardCover
         {badge}
+        {tag}
         title={media.title}
         alt={media.title}
         src={media.cover.url.thumb}
@@ -80,7 +74,7 @@
     {/if}
   </Link>
 
-  <CardFooter {action} tag={footerTag()}>
+  <CardFooter {action}>
     {#if rest.variant === "activity"}
       {#if rest.type === "episode"}
         <p class="trakt-card-title small ellipsis">


### PR DESCRIPTION
## 🎶 Notes 🎶

- Footer tags were added to the wrong types in summary cards.
- Episode is the only type where they're added on the cover, the other types don't have cover tags. This check for footer tags was the wrong way around.
- Though I'm also not a huge fan of having tags followed by multi-lined text in the footer. It might be better to have them always on the cover in summary cards. I'll add alternatives to the bottom of the examples. Thoughts @vladjerca , @anodpixels ?
  - ⚠️ I went with tags on the covers, see updated examples

## 👀 Examples 👀

Before/after:
<img width="369" height="664" alt="Screenshot 2025-08-06 at 17 08 46" src="https://github.com/user-attachments/assets/f46364b6-558a-40c2-a0bf-622c07fa4fbe" /> <img width="369" height="664" alt="Screenshot 2025-08-06 at 17 07 06" src="https://github.com/user-attachments/assets/71aa4d62-2f43-433d-8125-0e981abb1a22" />

Before:
<img width="369" height="664" alt="Screenshot 2025-08-06 at 17 09 52" src="https://github.com/user-attachments/assets/cd048493-2380-4270-89be-57a305a9380c" />

After:
<img width="369" height="664" alt="Screenshot 2025-08-07 at 09 03 39" src="https://github.com/user-attachments/assets/a064d2c3-edfc-4520-abc1-a4ff05fbfdb0" /> <img width="369" height="664" alt="Screenshot 2025-08-07 at 09 03 45" src="https://github.com/user-attachments/assets/8541f17f-560d-416a-bf36-845790440792" />

