### PR TITLE
fix(i18n): use correct flag for English

### DIFF
--- a/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
+++ b/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
@@ -30,7 +30,7 @@
   }
 
   const localeToFlag: Record<AvailableLocale, string> = {
-    en: "🇬🇧",
+    en: "🇺🇸",
     "en-au": "🇦🇺",
     "fr-fr": "🇫🇷",
     "fr-ca": "🇨🇦",


### PR DESCRIPTION
## ♪ Note ♪

- `English` is treated as en-us, the flag should reflect that.