### PR TITLE
fix / persists marker across page reloads

### DIFF
--- a/projects/client/src/lib/utils/date/Marker.ts
+++ b/projects/client/src/lib/utils/date/Marker.ts
@@ -1,9 +1,31 @@
+import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
+
+const MARKER_STORAGE_KEY = 'trakt-marker';
+
+function loadMarkerFromStorage(): Nil | number {
+  const stored = safeLocalStorage.getItem(MARKER_STORAGE_KEY);
+
+  if (stored) {
+    const parsed = parseInt(stored, 10);
+    return isNaN(parsed) ? null : parsed;
+  }
+
+  return null;
+}
+
+function saveMarkerToStorage(marker: Nil | string | number): void {
+  if (marker != null) {
+    safeLocalStorage.setItem(MARKER_STORAGE_KEY, marker.toString());
+  }
+}
+
 const state = {
-  marker: new Date().setHours(0, 0, 0, 0),
+  marker: loadMarkerFromStorage() ?? Date.now(),
 } as { marker: Nil | string | number };
 
 export const setMarker = () => {
-  state.marker = new Date().getTime();
+  state.marker = Date.now();
+  saveMarkerToStorage(state.marker);
 };
 
 export const getMarker = () => {


### PR DESCRIPTION
Ensures the marker value is persisted in local storage:
- Resolves an issue where the marker would reset to the current day on each page reload.
- Stores the marker timestamp in local storage and retrieves it on page load, maintaining its value across sessions.