### PR TITLE
fix(spoiler): fix target element selector

### DIFF
--- a/projects/client/src/lib/features/spoilers/components/Spoiler.svelte
+++ b/projects/client/src/lib/features/spoilers/components/Spoiler.svelte
@@ -14,7 +14,7 @@
 
 <style>
   trakt-spoiler {
-    :global(&:not(:empty):not(:has(*))),
+    &:global(:not(:empty):not(:has(*))),
     :global(p:not(button p):not(a p)),
     :global(span:not(button span):not(a span)) {
       transition: var(--transition-increment) ease-in-out;
@@ -24,7 +24,7 @@
     &:global(.trakt-spoiler) {
       /* Target elements that contain only text */
       /* Target p and span that don't have button/anchor parents */
-      :global(&:not(:empty):not(:has(*))),
+      &:global(:not(:empty):not(:has(*))),
       :global(p:not(button p):not(a p)),
       :global(span:not(button span):not(a span)) {
         --blur-size: calc(var(--ni-2) * 1.5);


### PR DESCRIPTION
## 👀 Example 👀

Before:
<img width="959" height="577" alt="Screenshot 2025-08-19 at 14 37 16" src="https://github.com/user-attachments/assets/a1d3b453-76aa-480e-8de2-5613499c6b78" />

After:
<img width="959" height="577" alt="Screenshot 2025-08-19 at 14 37 23" src="https://github.com/user-attachments/assets/e90f1b12-36aa-4515-8c0c-1537d37c0579" />
