### PR TITLE
fix: do not depend on iterator helpers

### DIFF
--- a/projects/client/src/lib/features/parameters/appendGlobalParameters.ts
+++ b/projects/client/src/lib/features/parameters/appendGlobalParameters.ts
@@ -18,7 +18,7 @@ export function appendGlobalParameters(anchor: HTMLAnchorElement) {
       const url = new URL(anchor.href);
 
       const params = [
-        ...url.searchParams.entries()
+        ...Array.from(url.searchParams.entries())
           .filter(([key]) =>
             key === $override || !WHITE_LISTED_PARAMS.includes(key)
           ),

--- a/projects/client/src/lib/features/parameters/useParameters.ts
+++ b/projects/client/src/lib/features/parameters/useParameters.ts
@@ -13,7 +13,7 @@ export function useParameters() {
 
   function update(params: Record<string, ParameterType>) {
     parameters.update((current) => {
-      current.entries()
+      Array.from(current.entries())
         .forEach(([key]) => {
           if (!(key in params)) {
             current.delete(key);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Likely fix for:
  - https://trakt-tv.sentry.io/issues/59009147/?project=4509870926463056&query=is%3Aunresolved&referrer=issue-stream&sort=freq
  - https://trakt-tv.sentry.io/issues/59009143/?project=4509870926463056&query=is%3Aunresolved&referrer=issue-stream&sort=freq
- I could not reproduce those, but the only time these `forEach` and `filter` could be undefined is if the browser has no support for iterator helpers. This changes it to not rely on it, but manually turn it into an array first.