### PR TITLE
fix(card): deemphasis on safari

### DIFF
--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -91,14 +91,15 @@
 
   trakt-default-media-item {
     &.is-deemphasized {
-      :global(.trakt-card) {
+      /* FIXME: find the root cause why on safari this does not work on .trakt-card */
+      :global(.trakt-card-content) {
         transition: opacity var(--transition-increment) ease-in-out;
         opacity: var(--de-emphasized-opacity);
       }
 
       @include for-mouse() {
         &:hover {
-          :global(.trakt-card) {
+          :global(.trakt-card-content) {
             opacity: 1;
           }
         }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fix for cards not being deemphasized in safari.
- Not sure why it doesn't work in safari when applying it on the card. Didn't want to deep dive into finding the root cause, for now this also fixes it.