### PR TITLE
fix(summary): disable tap highlight on season items

### DIFF
--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -76,6 +76,8 @@
   }
 
   .trakt-season-item {
+    -webkit-tap-highlight-color: transparent;
+
     cursor: pointer;
     transition: opacity var(--transition-increment) ease-in-out;
 


### PR DESCRIPTION
## ♪ Note ♪

- Disabled tap highlight on season items.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/a7e36bbb-836b-4b0a-8444-78601066b515

After:

https://github.com/user-attachments/assets/c4752b17-dd00-49ea-9240-023bc39ebc83

