### PR TITLE
feat(settings): adds advanced settings iframe

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "История на гледане"
+    },
+    "link_text_general_settings": {
+      "default": "Общи"
+    },
+    "link_text_advanced_settings": {
+      "default": "Разширени"
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Seerhistorik"
+    },
+    "link_text_general_settings": {
+      "default": "Generelt"
+    },
+    "link_text_advanced_settings": {
+      "default": "Avanceret"
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Watch-History"
+    },
+    "link_text_general_settings": {
+      "default": "Allgemein"
+    },
+    "link_text_advanced_settings": {
+      "default": "Erweitert"
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Watch history"
+    },
+    "link_text_general_settings": {
+      "default": "General"
+    },
+    "link_text_advanced_settings": {
+      "default": "Advanced"
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5323,6 +5323,22 @@
       "exclude": [
         "ios"
       ]
+    },
+    "link_text_general_settings": {
+      "default": "General",
+      "description": "Text for the link to the general settings page.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "link_text_advanced_settings": {
+      "default": "Advanced",
+      "description": "Text for the link to the advanced settings page.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
     }
   }
 }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Historial de visionado"
+    },
+    "link_text_general_settings": {
+      "default": "General"
+    },
+    "link_text_advanced_settings": {
+      "default": "Avanzado"
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Historial visto"
+    },
+    "link_text_general_settings": {
+      "default": "General"
+    },
+    "link_text_advanced_settings": {
+      "default": "Avanzado"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Historique de visionnement"
+    },
+    "link_text_general_settings": {
+      "default": "Général"
+    },
+    "link_text_advanced_settings": {
+      "default": "Avancé"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Historique des visionnages"
+    },
+    "link_text_general_settings": {
+      "default": "Général"
+    },
+    "link_text_advanced_settings": {
+      "default": "Avancé"
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Cronologia guardati"
+    },
+    "link_text_general_settings": {
+      "default": "Generale"
+    },
+    "link_text_advanced_settings": {
+      "default": "Avanzate"
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "視聴履歴"
+    },
+    "link_text_general_settings": {
+      "default": "一般"
+    },
+    "link_text_advanced_settings": {
+      "default": "詳細"
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Seerhistorikk"
+    },
+    "link_text_general_settings": {
+      "default": "Generelt"
+    },
+    "link_text_advanced_settings": {
+      "default": "Avansert"
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Kijkgeschiedenis"
+    },
+    "link_text_general_settings": {
+      "default": "Algemeen"
+    },
+    "link_text_advanced_settings": {
+      "default": "Geavanceerd"
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Historia oglądania"
+    },
+    "link_text_general_settings": {
+      "default": "Ogólne"
+    },
+    "link_text_advanced_settings": {
+      "default": "Zaawansowane"
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Histórico de assistidos"
+    },
+    "link_text_general_settings": {
+      "default": "Geral"
+    },
+    "link_text_advanced_settings": {
+      "default": "Avançado"
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Istoric vizionări"
+    },
+    "link_text_general_settings": {
+      "default": "General"
+    },
+    "link_text_advanced_settings": {
+      "default": "Avansat"
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Tittarhistorik"
+    },
+    "link_text_general_settings": {
+      "default": "Allmänt"
+    },
+    "link_text_advanced_settings": {
+      "default": "Avancerat"
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1892,6 +1892,12 @@
     },
     "list_title_watch_history": {
       "default": "Історія переглядів"
+    },
+    "link_text_general_settings": {
+      "default": "Загальне"
+    },
+    "link_text_advanced_settings": {
+      "default": "Розширене"
     }
   }
 }

--- a/projects/client/src/lib/components/buttons/settings/SettingsButton.svelte
+++ b/projects/client/src/lib/components/buttons/settings/SettingsButton.svelte
@@ -9,7 +9,7 @@
 
 <ActionButton
   {style}
-  href={UrlBuilder.settings()}
+  href={UrlBuilder.settings.general()}
   label={m.button_label_settings()}
 >
   <GearIcon />

--- a/projects/client/src/lib/components/frame/SettingsFrame.svelte
+++ b/projects/client/src/lib/components/frame/SettingsFrame.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import { useUser } from "$lib/features/auth/stores/useUser";
+  import { getToken } from "$lib/features/auth/token";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import LoadingIndicator from "$lib/sections/lists/drilldown/_internal/LoadingIndicator.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { writable } from "svelte/store";
+  import { frameListener } from "./_internal/frameListener";
+
+  const { user } = useUser();
+  const { value: token } = getToken();
+
+  const isLoading = writable(true);
+
+  function handleLoad() {
+    isLoading.set(false);
+  }
+</script>
+
+<div class="trakt-settings-frame-container" class:is-loading={$isLoading}>
+  <LoadingIndicator />
+
+  <iframe
+    class="trakt-settings-frame"
+    title={m.page_title_settings()}
+    src={UrlBuilder.og.frame.settings(token ?? "")}
+    use:frameListener={$user.slug}
+    onload={handleLoad}
+  ></iframe>
+</div>
+
+<style>
+  .trakt-settings-frame-container {
+    position: relative;
+    width: 100%;
+    height: fit-content;
+    min-height: var(--ni-480);
+
+    :global(.loading-indicator) {
+      display: none;
+    }
+  }
+
+  iframe {
+    width: 100%;
+    height: var(--ni-480);
+    border: none;
+    overflow: hidden;
+    transition: opacity var(--transition-increment) ease-in-out;
+  }
+
+  .trakt-settings-frame-container.is-loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    iframe {
+      display: none;
+    }
+
+    :global(.loading-indicator) {
+      display: initial;
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/frame/_internal/frameListener.ts
+++ b/projects/client/src/lib/components/frame/_internal/frameListener.ts
@@ -1,7 +1,7 @@
 import { goto } from '$app/navigation';
 import { GlobalEventBus } from '$lib/utils/events/GlobalEventBus.ts';
-import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
 import { onMount } from 'svelte';
+import { UrlBuilder } from '../../../utils/url/UrlBuilder.ts';
 
 const VALID_ORIGINS: string[] = [
   'https://trakt.tv',
@@ -14,6 +14,8 @@ type FrameMessage = {
 } | {
   type: 'embeddedNavigation';
   pathname: string;
+} | {
+  type: 'homeNavigation';
 };
 
 export function frameListener(element: HTMLIFrameElement, slug: string) {
@@ -33,6 +35,12 @@ export function frameListener(element: HTMLIFrameElement, slug: string) {
         : event.data.pathname;
 
       goto(path);
+    }
+
+    if (event.data.type === 'homeNavigation') {
+      goto(UrlBuilder.home(), {
+        replaceState: true,
+      });
     }
   };
 

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -1,2 +1,3 @@
-// deno-lint-ignore no-empty-enum
-export enum FeatureFlag {}
+export enum FeatureFlag {
+  AdvancedSettings = 'advanced-settings',
+}

--- a/projects/client/src/lib/sections/settings/AdvancedSettings.svelte
+++ b/projects/client/src/lib/sections/settings/AdvancedSettings.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import SettingsFrame from "$lib/components/frame/SettingsFrame.svelte";
+</script>
+
+<div class="trakt-advanced-settings">
+  <SettingsFrame />
+</div>
+
+<style>
+  .trakt-advanced-settings {
+    width: 100%;
+    max-width: var(--ni-640);
+
+    border-radius: var(--border-radius-l);
+    overflow: hidden;
+
+    background-color: var(--color-card-background);
+
+    box-shadow:
+      0px var(--ni-16) var(--ni-8) 0px var(--cm-shadow-2),
+      0px var(--ni-8) var(--ni-4) 0px var(--cm-shadow-4),
+      0px var(--ni-4) var(--ni-4) 0px var(--cm-shadow-8),
+      0px var(--ni-1) var(--ni-2) 0px var(--cm-shadow-8);
+  }
+</style>

--- a/projects/client/src/lib/sections/settings/GeneralSettings.svelte
+++ b/projects/client/src/lib/sections/settings/GeneralSettings.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import DangerZone from "./_internal/DangerZone.svelte";
+  import Genres from "./_internal/Genres.svelte";
+  import Profile from "./_internal/Profile.svelte";
+  import Spoilers from "./_internal/Spoilers.svelte";
+</script>
+
+<div class="trakt-general-settings">
+  <Profile />
+  <Spoilers />
+  <Genres />
+
+  <RenderFor audience="authenticated" device={["mobile", "tablet-sm"]}>
+    <DangerZone />
+  </RenderFor>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-general-settings {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xxl);
+
+    min-width: 0;
+    max-width: var(--ni-480);
+    padding: var(--ni-8);
+
+    @include for-tablet-sm-and-below {
+      padding: 0;
+      max-width: 100%;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/settings/Settings.svelte
+++ b/projects/client/src/lib/sections/settings/Settings.svelte
@@ -1,31 +1,16 @@
 <script lang="ts">
-  import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
-  import DangerZone from "./_internal/DangerZone.svelte";
-  import Genres from "./_internal/Genres.svelte";
-  import Profile from "./_internal/Profile.svelte";
-  import Spoilers from "./_internal/Spoilers.svelte";
+  import SettingsNavbar from "./_internal/SettingsNavbar.svelte";
+
+  const { children }: ChildrenProps = $props();
 </script>
 
 <!-- FIXME: make settings page dpad navigate-able -->
 <RenderFor audience="authenticated">
   <div class="trakt-settings">
-    <RenderFor audience="authenticated" device={["tablet-lg", "desktop"]}>
-      <div class="trakt-settings-sidebar">
-        <div class="trakt-settings-sidebar-content">
-          <h4>{m.header_settings()}</h4>
-        </div>
-        <DangerZone />
-      </div>
-    </RenderFor>
+    <SettingsNavbar />
     <div class="trakt-settings-content">
-      <Profile />
-      <Spoilers />
-      <Genres />
-
-      <RenderFor audience="authenticated" device={["mobile", "tablet-sm"]}>
-        <DangerZone />
-      </RenderFor>
+      {@render children()}
     </div>
   </div>
 </RenderFor>
@@ -40,8 +25,6 @@
 
     margin: 0 var(--layout-distance-side);
 
-    min-height: var(--ni-120);
-
     transition: var(--transition-increment) ease-in-out;
     transition-property: grid-template-columns, gap;
 
@@ -49,16 +32,6 @@
       &:not(:hover) {
         background-color: transparent;
       }
-    }
-
-    .trakt-settings-content {
-      display: flex;
-      flex-direction: column;
-      gap: var(--gap-xxl);
-
-      min-width: 0;
-      max-width: var(--ni-480);
-      padding: var(--ni-8);
     }
 
     @include for-tablet-lg {
@@ -69,19 +42,6 @@
     @include for-tablet-sm-and-below {
       grid-template-columns: 1fr;
       grid-template-rows: auto 1fr;
-
-      .trakt-settings-content {
-        padding: 0;
-        max-width: 100%;
-      }
     }
-  }
-
-  .trakt-settings-sidebar {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-
-    gap: var(--gap-s);
   }
 </style>

--- a/projects/client/src/lib/sections/settings/_internal/SettingsNavbar.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsNavbar.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import DangerZone from "./DangerZone.svelte";
+</script>
+
+{#snippet settingsLinks()}
+  <div class="trakt-settings-links">
+    <Link href={UrlBuilder.settings.general()}>
+      <h5 class="uppercase">{m.link_text_general_settings()}</h5>
+    </Link>
+    <Link href={UrlBuilder.settings.advanced()}>
+      <h5 class="uppercase">{m.link_text_advanced_settings()}</h5>
+    </Link>
+  </div>
+{/snippet}
+
+<RenderFor audience="authenticated" device={["tablet-lg", "desktop"]}>
+  <div class="trakt-settings-navbar">
+    <div class="trakt-settings-sidebar-content">
+      <h4>{m.header_settings()}</h4>
+      <RenderForFeature flag={FeatureFlag.AdvancedSettings}>
+        {#snippet enabled()}
+          {@render settingsLinks()}
+        {/snippet}
+      </RenderForFeature>
+    </div>
+    <DangerZone />
+  </div>
+</RenderFor>
+
+<RenderFor audience="authenticated" device={["tablet-sm", "mobile"]}>
+  <RenderForFeature flag={FeatureFlag.AdvancedSettings}>
+    {#snippet enabled()}
+      <div class="trakt-settings-navbar">
+        {@render settingsLinks()}
+      </div>
+    {/snippet}
+  </RenderForFeature>
+</RenderFor>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-settings-navbar {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+
+    gap: var(--gap-s);
+
+    min-height: var(--ni-480);
+    max-height: calc(100dvh - var(--content-gap));
+
+    @include for-tablet-sm-and-below {
+      min-height: 0;
+      height: fit-content;
+    }
+  }
+
+  .trakt-settings-sidebar-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-l);
+  }
+
+  .trakt-settings-links {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+
+    h5 {
+      color: var(--color-text-secondary);
+      font-weight: 600;
+      transition: font-size var(--transition-increment) ease-in-out;
+    }
+
+    :global(.trakt-link) {
+      text-decoration: none;
+    }
+
+    :global(.trakt-link.trakt-link-active) {
+      :global(h5) {
+        color: var(--color-text-primary);
+        font-size: var(--ni-28);
+      }
+    }
+
+    @include for-tablet-sm-and-below {
+      flex-direction: row;
+      align-items: center;
+
+      h5 {
+        font-size: var(--ni-18);
+      }
+
+      :global(.trakt-link.trakt-link-active) {
+        :global(h5) {
+          font-size: var(--ni-22);
+        }
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -65,9 +65,19 @@ const categoryDrilldownFactory =
     return baseUrl + buildParamString(sanitizeParams(params));
   };
 
-const ogIframeFactory = (url: HttpsUrl, token: string | Nil): HttpsUrl => {
+const ogIframeFactory = (url: HttpsUrl): HttpsUrl => {
+  return `${url}/?embedded_mode=true`;
+};
+
+const ogIframeSlurmFactory = (url: HttpsUrl, token: string | Nil): HttpsUrl => {
   const tokenParam = token ? `&slurm=${token}` : '';
-  return `${url}/?embedded_mode=true${tokenParam}`;
+  return `${ogIframeFactory(url)}${tokenParam}`;
+};
+
+const ogIframeAccessTokenFactory = (url: HttpsUrl, token: string): HttpsUrl => {
+  return `${
+    ogIframeFactory(url)
+  }&access_token=${token}&client_id=${TRAKT_CLIENT_ID}`;
 };
 
 const ogSupportFactory = (username?: string): HttpsUrl | MailToUrl => {
@@ -181,15 +191,23 @@ export const UrlBuilder = {
     support: (username?: string) => ogSupportFactory(username),
     forums: () => 'https://forums.trakt.tv/c/trakt/trakt-lite/31',
     frame: {
+      settings: (token: string) =>
+        ogIframeAccessTokenFactory(
+          'https://trakt.tv/settings/data',
+          token,
+        ),
       yearToDate: (slug: string, year: string, token: string | Nil) =>
-        ogIframeFactory(`https://trakt.tv/users/${slug}/year/${year}`, token),
+        ogIframeSlurmFactory(
+          `https://trakt.tv/users/${slug}/year/${year}`,
+          token,
+        ),
       monthInReview: (
         slug: string,
         year: string,
         month: string,
         token: string | Nil,
       ) =>
-        ogIframeFactory(
+        ogIframeSlurmFactory(
           `https://trakt.tv/users/${slug}/mir/${year}/${month}`,
           token,
         ),
@@ -198,5 +216,8 @@ export const UrlBuilder = {
   login: {
     activate: () => '/auth/device',
   },
-  settings: () => '/settings',
+  settings: {
+    general: () => '/settings',
+    advanced: () => '/settings/advanced',
+  },
 };

--- a/projects/client/src/routes/settings/+layout.svelte
+++ b/projects/client/src/routes/settings/+layout.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import Settings from "$lib/sections/settings/Settings.svelte";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+
+  const { children } = $props();
+</script>
+
+<TraktPage
+  audience="authenticated"
+  image={DEFAULT_SHARE_COVER}
+  title={m.page_title_settings()}
+>
+  <TraktPageCoverSetter />
+
+  <Settings>
+    {@render children()}
+  </Settings>
+</TraktPage>

--- a/projects/client/src/routes/settings/+page.svelte
+++ b/projects/client/src/routes/settings/+page.svelte
@@ -1,17 +1,5 @@
 <script lang="ts">
-  import * as m from "$lib/features/i18n/messages.ts";
-  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
-  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
-  import Settings from "$lib/sections/settings/Settings.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import GeneralSettings from "$lib/sections/settings/GeneralSettings.svelte";
 </script>
 
-<TraktPage
-  audience="authenticated"
-  image={DEFAULT_SHARE_COVER}
-  title={m.page_title_settings()}
->
-  <TraktPageCoverSetter />
-
-  <Settings />
-</TraktPage>
+<GeneralSettings />

--- a/projects/client/src/routes/settings/advanced/+page.svelte
+++ b/projects/client/src/routes/settings/advanced/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import AdvancedSettings from "$lib/sections/settings/AdvancedSettings.svelte";
+</script>
+
+<AdvancedSettings />


### PR DESCRIPTION
## 🎶 Notes 🎶

- Embeds advanced settings.
- Feature flagged atm.
- @anodpixels, @ElMagnea, for now I took inspiration from the initial designs. But maybe it's better to have an `advanced` button in the danger zone? See examples below.

## 👀 Examples 👀
Only available with feature flag turned on:
<img width="1249" height="1219" alt="Screenshot 2025-09-11 at 09 53 14" src="https://github.com/user-attachments/assets/6ced0fe2-47d9-4203-9fa6-d843f82358dd" />

<img width="1249" height="1219" alt="Screenshot 2025-09-11 at 09 53 22" src="https://github.com/user-attachments/assets/45ca9af9-7f33-461c-9cae-feb70e268a77" />

<img width="426" height="928" alt="Screenshot 2025-09-11 at 09 53 40" src="https://github.com/user-attachments/assets/71d0f02c-3f33-4cc5-bafc-c71d3af3c580" />

<img width="426" height="928" alt="Screenshot 2025-09-11 at 09 53 50" src="https://github.com/user-attachments/assets/77e49f1c-7fa2-49eb-b0ea-fd1f6b6f05a4" />
