### PR TITLE
Adds Hotjar to Content Security Policy

### DIFF
--- a/projects/client/src/app.html
+++ b/projects/client/src/app.html
@@ -16,7 +16,7 @@
         default-src 'self';
         img-src 'self' data: https://*.trakt.tv https://trakt.tv https://secure.gravatar.com https://i2.wp.com/ https://*.contentsquare.net https://*.youtube.com https://fonts.gstatic.com;
         script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.trakt.tv https://*.googletagmanager.com https://*.contentsquare.net http://*.contentsquare.net;
-        script-src-elem 'self' 'unsafe-inline' https://*.googletagmanager.com https://*.cloudflareinsights.com https://*.trakt.tv/ https://*.contentsquare.net https://static.hj.contentsquare.net http://*.contentsquare.net http://t.contentsquare.net https://static.hj.contentsquare.net https://cdnjs.cloudflare.com;
+        script-src-elem 'self' 'unsafe-inline' https://*.googletagmanager.com https://*.cloudflareinsights.com https://*.trakt.tv/ https://*.contentsquare.net https://static.hj.contentsquare.net http://*.contentsquare.net http://t.contentsquare.net https://static.hj.contentsquare.net https://cdnjs.cloudflare.com https://*.hotjar.com;
         worker-src 'self' blob:;
         connect-src 'self' https://*.jsdelivr.net https://*.googleapis.com https://*.gstatic.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://trakt.tv https://*.trakt.tv https://*.posthog.com https://*.contentsquare.net https://*.hotjar.com https://*.hotjar.io wss://*.hotjar.com https://*.sentry.io;
         font-src 'self' data: https://fonts.gstatic.com http://fonts.gstatic.com;


### PR DESCRIPTION
Adds Hotjar domains to the Content Security Policy (CSP) to allow scripts and connections from Hotjar.

This ensures that Hotjar can function correctly on the client application.