### PR TITLE
fix(search): use correct aspect ratio on mobile

### DIFF
--- a/projects/client/src/routes/search/+page.svelte
+++ b/projects/client/src/routes/search/+page.svelte
@@ -165,7 +165,7 @@
     @include for-mobile {
       --column-count: 3;
       --card-aspect-ratio: calc(
-        var(--height-portrait-card) / var(--width-portrait-card)
+        var(--height-portrait-card-cover) / var(--width-portrait-card)
       );
 
       --container-width: calc(


### PR DESCRIPTION
## ♪ Note ♪

- I'm an idiot 🤦 Use the cover to calculate the aspect ratio.

## 👀 Example 👀

Before/after:
<img width="567" height="982" alt="Screenshot 2025-09-11 at 13 46 45" src="https://github.com/user-attachments/assets/30156e8a-2edc-4216-9d0d-0f73ef5d9113" /> <img width="567" height="982" alt="Screenshot 2025-09-11 at 13 47 34" src="https://github.com/user-attachments/assets/53fcc3c2-f02f-4f64-ba8c-4d7ab42fff64" />
