### PR TITLE
fix(search): apply correct width for people results

### DIFF
--- a/projects/client/src/routes/search/+page.svelte
+++ b/projects/client/src/routes/search/+page.svelte
@@ -123,7 +123,7 @@
         <GridList
           id="search-grid-list-people"
           items={$results.items}
-          --width-item="var(--width-portrait-card)"
+          --width-item="var(--width-override-card, var(--width-person-card))"
         >
           {#snippet item(person)}
             <DefaultPersonItem {person} />


### PR DESCRIPTION
## ♪ Note ♪

- 🤦
  - People results grid was using the wrong card size.
  - People results grid was missing the override on mobile.
  - Quick fix for now, structure is likely to change when I add the placeholders when there is no search query.

## 👀 Example 👀

Before/after:
<img width="373" height="664" alt="Screenshot 2025-09-11 at 15 16 31" src="https://github.com/user-attachments/assets/089edf5a-8250-4207-97aa-c16437ed23db" /> <img width="373" height="664" alt="Screenshot 2025-09-11 at 15 16 23" src="https://github.com/user-attachments/assets/e9b8ba5b-0f25-4abb-9ad1-509982412d33" />

