### PR TITLE
fix(settings): correct style for edit button

### DIFF
--- a/projects/client/src/lib/sections/settings/_internal/Profile.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/Profile.svelte
@@ -56,7 +56,7 @@
 
 {#snippet renameField(field: keyof typeof promptMap)}
   <ActionButton
-    style="flat"
+    style="ghost"
     label={promptMap[field].label}
     onclick={() => handleFieldChange(field)}
     disabled={$isSavingSettings}


### PR DESCRIPTION
## ♪ Note ♩

- Use correct style for the edit button in settings

## 👀 Example 👀
Before:
<img width="372" height="157" alt="Screenshot 2025-09-12 at 08 21 00" src="https://github.com/user-attachments/assets/1aad3101-47b0-4378-90b9-c4f4689e89ca" />

After:
<img width="372" height="157" alt="Screenshot 2025-09-12 at 08 20 38" src="https://github.com/user-attachments/assets/3e672dfa-41ef-4432-80ca-5f3d1bb4334c" />
