### PR TITLE
refactor: split up show and episode in activity schemas

### DIFF
--- a/projects/client/src/lib/requests/_internal/coalesceBinges.spec.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceBinges.spec.ts
@@ -51,9 +51,9 @@ describe('coalesceBinges', () => {
         season: 1,
         number: episodeId,
         type: 'standard',
-        show: {
-          id: showId,
-        },
+      },
+      show: {
+        id: showId,
       },
     } as EpisodeActivity;
   }

--- a/projects/client/src/lib/requests/_internal/coalesceBinges.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceBinges.ts
@@ -10,7 +10,7 @@ function groupEpisodeActivities(activities: EpisodeActivity[]) {
   return activities.reduce((acc, activity) => {
     const userKey = activity.users.map((u) => u.slug).join(',');
     const dayKey = getDayKey(activity.activityAt);
-    const key = `${activity.episode.show.id}_${userKey}_${dayKey}`;
+    const key = `${activity.show.id}_${userKey}_${dayKey}`;
 
     acc[key] = acc[key] ? [...acc[key], activity] : [activity];
     return acc;
@@ -33,7 +33,10 @@ export function coalesceBinges(activities: SocialActivity[]): SocialActivity[] {
       const groupActivity = assertDefined(group.at(0));
       const episodesInGroup = group
         .sort((a, b) => a.activityAt.getTime() - b.activityAt.getTime())
-        .map((activity) => activity.episode);
+        .map((activity) => ({
+          ...activity.episode,
+          show: activity.show,
+        }));
 
       const coalesced = coalesceEpisodes(
         episodesInGroup,

--- a/projects/client/src/lib/requests/_internal/coalesceSocialActivities.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceSocialActivities.ts
@@ -23,7 +23,7 @@ function isSameEpisode(
     return false;
   }
 
-  return activityA.episode.show.id === activityB.episode.show.id &&
+  return activityA.show.id === activityB.show.id &&
     activityA.episode.id === activityB.episode.id;
 }
 

--- a/projects/client/src/lib/requests/models/SocialActivity.ts
+++ b/projects/client/src/lib/requests/models/SocialActivity.ts
@@ -17,9 +17,8 @@ export const SocialActivityEpisodeSchema = z.object({
   activityAt: z.date(),
   type: z.literal('episode'),
   users: z.array(UserProfileSchema),
-  episode: EpisodeEntrySchema.merge(z.object({
-    show: ShowEntrySchema,
-  })),
+  episode: EpisodeEntrySchema,
+  show: ShowEntrySchema,
 });
 
 export const SocialActivitySchema = z.discriminatedUnion('type', [

--- a/projects/client/src/lib/requests/queries/users/episodeActivityHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/episodeActivityHistoryQuery.ts
@@ -23,9 +23,8 @@ type EpisodeActivityHistoryParams = {
 export const EpisodeActivityHistorySchema = z.object({
   id: z.number(),
   watchedAt: z.date(),
-  episode: EpisodeEntrySchema.merge(z.object({
-    show: ShowEntrySchema,
-  })),
+  episode: EpisodeEntrySchema,
+  show: ShowEntrySchema,
   type: z.literal('episode'),
 });
 export type EpisodeActivityHistory = z.infer<
@@ -61,10 +60,8 @@ export function mapToEpisodeActivityHistory(
   return {
     id: historyEpisode.id,
     watchedAt: new Date(historyEpisode.watched_at),
-    episode: {
-      ...mapToEpisodeEntry(historyEpisode.episode),
-      show: mapToShowEntry(historyEpisode.show),
-    },
+    episode: mapToEpisodeEntry(historyEpisode.episode),
+    show: mapToShowEntry(historyEpisode.show),
     type: 'episode' as const,
   };
 }

--- a/projects/client/src/lib/requests/queries/users/showActivityHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showActivityHistoryQuery.ts
@@ -52,10 +52,8 @@ const mapToShowActivityHistory = (
 ) => ({
   id: historyShow.id,
   watchedAt: new Date(historyShow.watched_at),
-  episode: {
-    ...mapToEpisodeEntry(historyShow.episode),
-    show: mapToShowEntry(historyShow.show),
-  },
+  episode: mapToEpisodeEntry(historyShow.episode),
+  show: mapToShowEntry(historyShow.show),
   type: 'episode' as const,
 });
 

--- a/projects/client/src/lib/requests/queries/users/socialActivityQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/socialActivityQuery.ts
@@ -39,10 +39,8 @@ function mapToSocialActivity(
       return {
         ...common,
         type: 'episode',
-        episode: {
-          ...mapToEpisodeEntry(assertDefined(response.episode)),
-          show: mapToShowEntry(assertDefined(response.show)),
-        },
+        episode: mapToEpisodeEntry(assertDefined(response.episode)),
+        show: mapToShowEntry(assertDefined(response.show)),
       };
   }
 }

--- a/projects/client/src/lib/sections/lists/components/ActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/ActivityItem.svelte
@@ -19,7 +19,7 @@
 {#if activity.type === "episode"}
   <EpisodeItem
     episode={activity.episode}
-    show={activity.episode.show}
+    show={activity.show}
     variant="activity"
     date={activityAt}
     {badge}

--- a/projects/client/src/lib/sections/lists/components/ActivitySummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/ActivitySummaryCard.svelte
@@ -22,7 +22,7 @@
     date={activityAt}
     episode={activity.episode}
     media={{
-      ...activity.episode.show,
+      ...activity.show,
       episode: {
         count: 0,
       },

--- a/projects/client/src/lib/sections/profile/stores/_internal/mapToMonthToDateDetails.ts
+++ b/projects/client/src/lib/sections/profile/stores/_internal/mapToMonthToDateDetails.ts
@@ -8,16 +8,14 @@ import { episodeActivityTitle } from '$lib/utils/intl/episodeActivityTitle.ts';
 import type { MonthToDateDetails } from '../../models/MonthToDateDetails.ts';
 
 function mapToCover(activity: MovieActivityHistory | EpisodeActivityHistory) {
-  const media = activity.type === 'movie'
-    ? activity.movie
-    : activity.episode.show;
+  const media = activity.type === 'movie' ? activity.movie : activity.show;
   return media.cover?.url.thumb || DEFAULT_COVER;
 }
 
 function mapToTitle(activity: MovieActivityHistory | EpisodeActivityHistory) {
   return activity.type === 'movie'
     ? activity.movie.title
-    : episodeActivityTitle(activity.episode, activity.episode.show);
+    : episodeActivityTitle(activity.episode, activity.show);
 }
 
 const NOTHING_WATCHED_DETAILS: MonthToDateDetails = {
@@ -43,7 +41,7 @@ export function mapToMonthToDateDetails(
   const movieCount = movies.length;
   const episodeCount = episodes.length;
   const showCount =
-    new Set(episodes.map((activity) => activity.episode.show.slug)).size;
+    new Set(episodes.map((activity) => activity.show.slug)).size;
 
   const firstWatchActivity = assertDefined(allActivity.at(0));
   return {

--- a/projects/client/src/mocks/data/users/mapped/EpisodeActivityHistoryMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/EpisodeActivityHistoryMappedMock.ts
@@ -5,10 +5,8 @@ import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSi
 export const EpisodeActivityHistoryMappedMock: EpisodeActivityHistory[] = [
   {
     'id': 1,
-    'episode': {
-      ...EpisodeSiloMappedMock,
-      'show': ShowSiloMappedMock,
-    },
+    'episode': EpisodeSiloMappedMock,
+    'show': ShowSiloMappedMock,
     'type': 'episode',
     'watchedAt': new Date('2025-01-31T23:12:41.000Z'),
   },

--- a/projects/client/src/mocks/data/users/mapped/ShowActivityHistoryMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/ShowActivityHistoryMappedMock.ts
@@ -5,10 +5,8 @@ import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSi
 export const ShowActivityHistoryMappedMock: ShowActivityHistory[] = [
   {
     'id': 1,
-    'episode': {
-      ...EpisodeSiloMappedMock,
-      'show': ShowSiloMappedMock,
-    },
+    'episode': EpisodeSiloMappedMock,
+    'show': ShowSiloMappedMock,
     'type': 'episode',
     'watchedAt': new Date('2025-01-31T23:12:41.000Z'),
   },

--- a/projects/client/src/mocks/data/users/mapped/SocialActivityMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/SocialActivityMappedMock.ts
@@ -17,9 +17,7 @@ export const SocialActivityMappedMock: SocialActivity[] = [
     activityAt: new Date('2025-01-31T23:12:41.000Z'),
     users: [UserProfileHarryMappedMock],
     type: 'episode',
-    episode: {
-      ...EpisodeSiloMappedMock,
-      show: ShowSiloMappedMock,
-    },
+    episode: EpisodeSiloMappedMock,
+    show: ShowSiloMappedMock,
   },
 ];


### PR DESCRIPTION
## 🎶 Note 🎶

- Split up episode/show in activity schemas (back to how it was). My initial thinking was wrong, and it wasn't a good idea to have both the activity and upcoming episode schemas be similar 😅
  - Did not change the `UpcomingEpisodeEntry` after all: there the end result is an array of episodes, and not activity objects. So we'd have an episode array of `[ { episode: { id: 1, etc.} }, { episode: { id: 2, etc.} } ]` instead of `[ { id: 1, etc.}, { id: 2, etc.} ]`
  - Rather than forcing all schemas to be the same, the activity ones are simply mapped before using `coalesceEpisodes`.