### PR TITLE
refactor(client): remove TRAKT_TARGET_API_ENVIRONMENT and related usages

### DIFF
--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -15,7 +15,6 @@ declare global {
   const TRAKT_CLIENT_ID: string;
   const TRAKT_MODE: 'development' | 'production' | 'test';
   const TRAKT_TARGET_ENVIRONMENT: Environment;
-  const TRAKT_TARGET_API_ENVIRONMENT: Environment;
 
   const TRAKT_GIT_SHA: string;
 

--- a/projects/client/src/lib/features/auth/getOidcConfig.ts
+++ b/projects/client/src/lib/features/auth/getOidcConfig.ts
@@ -7,6 +7,7 @@ function getAuthority() {
     TRAKT_TARGET_ENVIRONMENT
       .replace('api.', '')
       .replace('apiz.', '')
+      .replace('hd.', '')
       .replace('api-staging.', 'staging.'),
   );
 }

--- a/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
+++ b/projects/client/src/lib/requests/_internal/createAuthenticatedFetch.ts
@@ -41,12 +41,6 @@ export function createAuthenticatedFetch<
         headers.set('Authorization', `Bearer ${token}`);
       }
 
-      input = input.toString()
-        .replaceAll(
-          stripHttpsOrHttp(TRAKT_TARGET_ENVIRONMENT),
-          stripHttpsOrHttp(TRAKT_TARGET_API_ENVIRONMENT),
-        );
-
       const method = init?.method?.toUpperCase();
       const marker = getMarker();
 

--- a/projects/client/src/lib/utils/url/buildOAuthLink.ts
+++ b/projects/client/src/lib/utils/url/buildOAuthLink.ts
@@ -10,7 +10,8 @@ export function buildOAuthUrl(clientId: string, origin: string) {
   const env = prependHttps(
     TRAKT_TARGET_ENVIRONMENT
       .replace('api.', '')
-      .replace('apiz.', ''),
+      .replace('apiz.', '')
+      .replace('hd.', ''),
   );
 
   return `${env}/oauth/authorize?client_id=${clientId}&redirect_uri=${origin}&response_type=code&hide_email_form=true`;

--- a/projects/client/vite.config.ts
+++ b/projects/client/vite.config.ts
@@ -50,20 +50,14 @@ const TRAKT_TARGET_ENVIRONMENT = (() => {
     return Environment.staging;
   }
 
-  return Environment.production_private;
+  return Environment.production_private.replace('apiz', 'hd');
 })();
-
-const TRAKT_TARGET_API_ENVIRONMENT = TRAKT_TARGET_ENVIRONMENT.replace(
-  'apiz',
-  'hd',
-);
 
 export default defineConfig(({ mode }) => ({
   define: {
     'TRAKT_CLIENT_ID': `"${process.env.TRAKT_CLIENT_ID}"`,
     'TRAKT_MODE': `"${mode}${process.env.IS_PREVIEW ? '-preview' : ''}"`,
     'TRAKT_TARGET_ENVIRONMENT': `"${TRAKT_TARGET_ENVIRONMENT}"`,
-    'TRAKT_TARGET_API_ENVIRONMENT': `"${TRAKT_TARGET_API_ENVIRONMENT}"`,
     'FIREBASE_PROJECT_ID': `"${process.env.FIREBASE_PROJECT_ID}"`,
     'FIREBASE_API_KEY': `"${process.env.FIREBASE_API_KEY}"`,
     'FIREBASE_APP_ID': `"${process.env.FIREBASE_APP_ID}"`,
@@ -79,7 +73,7 @@ export default defineConfig(({ mode }) => ({
     },
     proxy: {
       '/api/trakt': {
-        target: TRAKT_TARGET_API_ENVIRONMENT,
+        target: TRAKT_TARGET_ENVIRONMENT,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api\/trakt/, ''),
       },


### PR DESCRIPTION
Removes the now-unnecessary `TRAKT_TARGET_API_ENVIRONMENT` variable and related usages. The environment variable `TRAKT_TARGET_ENVIRONMENT` now directly handles the API target, simplifying the configuration.
