### PR TITLE
fix(summary): only show watch count after 1

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/WatchCountTag.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/WatchCountTag.svelte
@@ -17,18 +17,22 @@
   >
     <CheckIcon />
 
-    {#key count}
-      <p
-        class="meta-info uppercase no-wrap counter"
-        transition:slide={{
-          easing: linear,
-          axis: "y",
-          duration: TRANSITION_DURATION,
-        }}
-      >
-        {count}
-      </p>
-    {/key}
+    {#if count > 1}
+      <div transition:slide={{ axis: "x", duration: 150 }}>
+        {#key count}
+          <p
+            class="meta-info uppercase no-wrap counter"
+            transition:slide={{
+              easing: linear,
+              axis: "y",
+              duration: TRANSITION_DURATION,
+            }}
+          >
+            {count}
+          </p>
+        {/key}
+      </div>
+    {/if}
   </StemTag>
 </watch-count-tag>
 


### PR DESCRIPTION
## ♪ Note ♪

- Only show the actual count after 1.

## 👀 Example 👀
<img width="426" height="926" alt="Screenshot 2025-09-25 at 11 57 27" src="https://github.com/user-attachments/assets/7dbe0f8c-3e9f-4ce1-940b-cb5934deb37a" />
