### PR TITLE
feat(tags): place activity dates in a tag

### DIFF
--- a/projects/client/src/lib/components/media/tags/ActivityTag.svelte
+++ b/projects/client/src/lib/components/media/tags/ActivityTag.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import StemTag from "$lib/components/tags/StemTag.svelte";
+  import type { TagIntl } from "./TagIntl";
+
+  const {
+    activityDate,
+    i18n,
+  }: {
+    activityDate: Date;
+    i18n: TagIntl;
+  } = $props();
+</script>
+
+<StemTag>
+  <p class="meta-info capitalize no-wrap">
+    {i18n.toActivityDate(activityDate)}
+  </p>
+</StemTag>

--- a/projects/client/src/lib/components/media/tags/TagIntl.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntl.ts
@@ -4,6 +4,7 @@ export type TagIntl = {
   toPlayCount: (count: number) => string;
   toWatcherCount: (count: number) => string;
   toReleaseEstimate: (airDate: Date) => string;
+  toActivityDate: (activityDate: Date) => string;
   tbaLabel: () => string;
   toAnticipatedCount: (count: number) => string;
   watchCountLabel: () => string;

--- a/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
@@ -4,6 +4,7 @@ import { getLocale, languageTag } from '$lib/features/i18n/index.ts';
 import { toHumanDuration } from '$lib/utils/formatting/date/toHumanDuration.ts';
 
 import { toHumanETA } from '$lib/utils/formatting/date/toHumanETA.ts';
+import { toRelativeHumanDay } from '$lib/utils/formatting/date/toRelativeHumanDay.ts';
 import { toHumanNumber } from '$lib/utils/formatting/number/toHumanNumber.ts';
 import type { TagIntl } from './TagIntl.ts';
 
@@ -15,6 +16,8 @@ export const TagIntlProvider: TagIntl = {
     m.tag_text_plays({ number: toHumanNumber(count, languageTag()) }),
   toWatcherCount: (count) => toHumanNumber(count, languageTag()),
   toReleaseEstimate: (airDate) => toHumanETA(new Date(), airDate, getLocale()),
+  toActivityDate: (activityDate) =>
+    toRelativeHumanDay(new Date(), activityDate, getLocale()),
   tbaLabel: () => m.tag_text_tba(),
   toAnticipatedCount: (count) => toHumanNumber(count, languageTag()),
   watchCountLabel: () => m.tag_text_watch_count(),

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -3,7 +3,6 @@
   import CardActionBar from "$lib/components/card/CardActionBar.svelte";
   import CardCover from "$lib/components/card/CardCover.svelte";
   import CardFooter from "$lib/components/card/CardFooter.svelte";
-  import { EpisodeIntlProvider } from "$lib/components/episode/EpisodeIntlProvider";
   import Link from "$lib/components/link/Link.svelte";
   import LandscapeCard from "$lib/components/media/card/LandscapeCard.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
@@ -83,14 +82,11 @@
     {#if rest.variant === "activity"}
       <Link href={UrlBuilder.show(show.slug)}>
         <p class="trakt-card-title ellipsis">
-          {episodeActivityTitle(episode, show)}
+          {show.title}
         </p>
       </Link>
       <p class="trakt-card-subtitle ellipsis small">
-        {EpisodeIntlProvider.timestampText({
-          type: episode.type,
-          date: rest.date,
-        })}
+        {episodeActivityTitle(episode)}
       </p>
     {/if}
 

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { EpisodeIntlProvider } from "$lib/components/episode/EpisodeIntlProvider";
   import ShowProgressTag from "$lib/components/episode/tags/ShowProgressTag.svelte";
+  import ActivityTag from "$lib/components/media/tags/ActivityTag.svelte";
   import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
   import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
@@ -66,6 +67,10 @@
       {#if props.variant === "upcoming"}
         <AirDateTag i18n={TagIntlProvider} airDate={props.episode.airDate} />
       {/if}
+
+      {#if props.variant === "activity"}
+        <ActivityTag i18n={TagIntlProvider} activityDate={props.date} />
+      {/if}
     </div>
   {/if}
 {/snippet}
@@ -82,7 +87,7 @@
         },
       }}
       popupActions={props.popupActions}
-      tag={props.variant !== "activity" ? tag : undefined}
+      {tag}
       {action}
       type="episode"
       variant="landscape"
@@ -91,11 +96,7 @@
   {/if}
 
   {#if style === "cover"}
-    <EpisodeCard
-      {...props}
-      tag={props.variant !== "activity" ? tag : undefined}
-      {action}
-    />
+    <EpisodeCard {...props} {tag} {action} />
   {/if}
 {/snippet}
 

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -8,10 +8,9 @@
   import PortraitCard from "$lib/components/media/card/PortraitCard.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
-  import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
-  import { toHumanDate } from "$lib/utils/formatting/date/toHumanDate";
+  import { toTranslatedValue } from "$lib/utils/formatting/string/toTranslatedValue";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CardActionBar from "../../../components/card/CardActionBar.svelte";
   import type { MediaCardProps } from "./MediaCardProps";
@@ -21,6 +20,7 @@
     media,
     badge,
     tag,
+    coverTag,
     action,
     popupActions,
     source,
@@ -61,6 +61,7 @@
       alt={m.image_alt_media_poster({ title: media.title })}
       --color-card-cover-shadow={media.colors?.[1]}
       {badge}
+      tag={coverTag}
     />
   </Link>
 {/snippet}
@@ -92,7 +93,7 @@
         </p>
       </Link>
       <p class="trakt-card-subtitle small ellipsis">
-        {toHumanDate(new Date(), rest.date, getLocale())}
+        {toTranslatedValue("type", media.type)}
       </p>
     </CardFooter>
   </LandscapeCard>

--- a/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
@@ -15,6 +15,7 @@ export type MediaItemVariant<T> =
 type BaseItemProps<T> = MediaItemVariant<T> & {
   badge?: Snippet;
   tag?: Snippet;
+  coverTag?: Snippet;
   action?: Snippet;
   popupActions?: Snippet;
   style?: 'cover' | 'summary';

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import ActivityTag from "$lib/components/media/tags/ActivityTag.svelte";
+  import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import MediaCard from "./MediaCard.svelte";
   import type { MediaCardProps } from "./MediaCardProps";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
@@ -7,9 +9,18 @@
   const style = $derived(props.style ?? "cover");
 </script>
 
+{#snippet coverTag()}
+  <div class="trakt-media-tag">
+    {#if props.variant === "activity"}
+      <ActivityTag i18n={TagIntlProvider} activityDate={props.date} />
+    {/if}
+  </div>
+{/snippet}
+
 {#if style === "cover"}
   <MediaCard
     {...props}
+    {coverTag}
     {style}
     action={props.action}
     popupActions={props.badge ? undefined : props.popupActions}

--- a/projects/client/src/lib/utils/intl/episodeActivityTitle.ts
+++ b/projects/client/src/lib/utils/intl/episodeActivityTitle.ts
@@ -10,16 +10,16 @@ type Show = {
 
 export function episodeActivityTitle(
   episode: EpisodeEntry,
-  show: Show,
+  show?: Show,
 ) {
   switch (episode.type) {
     case EpisodeComputedType.full_season:
-      return seasonLabel(episode.season, show.title);
+      return seasonLabel(episode.season, show?.title);
     case EpisodeComputedType.multiple_episodes:
       return multiEpisodeLabel(
         episode.episodes ?? [],
         episode.season,
-        show.title,
+        show?.title,
       );
     default:
       return `${
@@ -27,6 +27,6 @@ export function episodeActivityTitle(
           seasonNumber: episode.season,
           episodeNumber: episode.number,
         })
-      } - ${show.title}`;
+      } - ${show?.title ?? episode.title}`;
   }
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- For activity items, show the date in a tag on the cover.
  - For single episode activities, this now allows us to also show the episode name.
  - Follow-ups: align on icon usage, and showing timestamps (also in the tag, or only in summary).

## 👀 Examples 👀
<img width="428" height="234" alt="Screenshot 2025-09-28 at 19 31 46" src="https://github.com/user-attachments/assets/4b641156-5b15-4c52-b07f-6a5cc6cb0a78" />

<img width="428" height="234" alt="Screenshot 2025-09-28 at 19 32 13" src="https://github.com/user-attachments/assets/4203d9bd-1324-4427-a558-6179890b7d3f" />
