### PR TITLE
refactor(search): simplify typesense search key generation and config

### DIFF
--- a/projects/client/src/lib/features/search/handle.ts
+++ b/projects/client/src/lib/features/search/handle.ts
@@ -20,17 +20,7 @@ export const handle: Handle = ({ event, resolve }) => {
   const mediaSearchKey = typesense
     .keys()
     .generateScopedSearchKey(typesenseKey, {
-      query_by: [
-        'title',
-        'original_title',
-        'aliases',
-        'translations',
-      ],
-      sort_by: [
-        '_text_match:desc',
-        'trending_count:desc',
-        'list_count:desc',
-      ],
+      preset: 'search:media',
       limit_hits: DEFAULT_SEARCH_LIMIT,
       expires_at,
     });
@@ -38,13 +28,7 @@ export const handle: Handle = ({ event, resolve }) => {
   const peopleSearchKey = typesense
     .keys()
     .generateScopedSearchKey(typesenseKey, {
-      query_by: [
-        'name',
-      ],
-      sort_by: [
-        '_text_match:desc',
-        'top_billed_count:desc',
-      ],
+      preset: 'search:people',
       limit_hits: DEFAULT_SEARCH_LIMIT,
       expires_at,
     });

--- a/projects/client/src/lib/requests/search/lookup.ts
+++ b/projects/client/src/lib/requests/search/lookup.ts
@@ -26,6 +26,12 @@ const COLLECTION_MAP: Record<SearchCategory, string> = {
   person: 'Person',
 };
 
+const PRESET_MAP: Record<SearchCategory, string> = {
+  movie: 'search:media',
+  show: 'search:media',
+  person: 'search:people',
+};
+
 export function lookup<T extends SearchCategory>({
   key,
   server,
@@ -41,6 +47,7 @@ export function lookup<T extends SearchCategory>({
     .perform<SchemaForCategory<T>[]>({
       searches: types.map((type) => ({
         collection: COLLECTION_MAP[type],
+        preset: PRESET_MAP[type],
       })),
       union: true,
     }, {


### PR DESCRIPTION
Simplifies the generation of Typesense search keys by using presets.

This change introduces a `PRESET_MAP` to the search lookup to correctly map search categories to the corresponding Typesense search presets.  This simplifies the key generation logic.
