### PR TITLE
fix: reactive meta tags

### DIFF
--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -65,32 +65,48 @@
         }
       : {},
   );
+
+  /*
+    We manually make Svelte render meta tags in a reactive way since
+    Svelte does not update initial tags: https://github.com/sveltejs/svelte/issues/5668
+  */
+  const generateMetaTags = $derived(() => {
+    const tags = [
+      `<meta property="og:site_name" content="${websiteName}" />`,
+      `<meta property="og:type" content="${ogType}" />`,
+      `<meta property="og:url" content="${page.url.toString()}" />`,
+      `<meta property="og:image" content="${image}" />`,
+      `<meta property="og:title" content="${title}" />`,
+      `<meta property="og:locale" content="en_US" />`,
+      `<meta property="og:updated_time" content="${new Date().toISOString()}" />`,
+      `<meta name="twitter:card" content="summary_large_image" />`,
+      `<meta name="twitter:site" content="${twitterHandle}" />`,
+      `<meta name="twitter:title" content="${title}" />`,
+      `<meta name="twitter:image" content="${image}" />`,
+      `<meta name="twitter:creator" content="${twitterHandle}" />`,
+    ];
+
+    if (info != null) {
+      tags.push(
+        `<meta name="description" content="${info.overview}" />`,
+        `<meta property="og:description" content="${info.overview}" />`,
+        `<meta name="twitter:description" content="${info.overview}" />`,
+      );
+
+      if (info.runtime > 0) {
+        tags.push(
+          `<meta property="video:duration" content="${info.runtime * 60}" />`,
+        );
+      }
+    }
+
+    return tags.join("\n");
+  });
 </script>
 
 <svelte:head>
   <title>{displayTitle}</title>
-  <meta property="og:site_name" content={websiteName} />
-  <meta property="og:type" content={ogType} />
-  <meta property="og:url" content={page.url.toString()} />
-  <meta property="og:image" content={image} />
-  <meta property="og:title" content={title} />
-  <meta property="og:locale" content="en_US" />
-  <meta property="og:updated_time" content={new Date().toISOString()} />
-
-  {#if info != null}
-    <meta name="description" content={info.overview} />
-    <meta property="og:description" content={info.overview} />
-    {#if info.runtime > 0}
-      <meta property="video:duration" content={`${info.runtime * 60}`} />
-    {/if}
-    <meta name="twitter:description" content={info.overview} />
-  {/if}
-
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:site" content={twitterHandle} />
-  <meta name="twitter:title" content={title} />
-  <meta name="twitter:image" content={image} />
-  <meta name="twitter:creator" content={twitterHandle} />
+  {@html generateMetaTags()}
 </svelte:head>
 
 <RenderFor {audience}>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Some sites/services did not correctly displayed link previews
- Turns out that the initial tags are never updated, but new ones are added. The newly added ones are updated afterwards (e.g. if you navigate to a different page).
- Why it works on some services: 
  - Guesstimate: those check the last tags, and not the first ones.

## 👀 Example 👀
Before:
<img width="695" height="467" alt="Screenshot 2025-10-13 at 08 28 40" src="https://github.com/user-attachments/assets/ebe580ee-2aa2-4068-83b2-63750a47ee2c" />


After:
<img width="695" height="382" alt="Screenshot 2025-10-13 at 08 26 54" src="https://github.com/user-attachments/assets/a627ead7-a9eb-4166-a94b-f793d109b48a" />
