### PR TITLE
feat(summary): add status below title

### DIFF
--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -62,7 +62,12 @@
 
   {#snippet meta()}
     <RatingList ratings={$ratings} airDate={media.airDate} />
-    <SummaryTitle {title} genres={media.genres} year={media.year} />
+    <SummaryTitle
+      {title}
+      genres={media.genres}
+      year={media.year}
+      status={media.status}
+    />
 
     <RenderFor audience="authenticated">
       <MediaActions {media} {streamOn} {title} />

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/SummaryTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/SummaryTitle.svelte
@@ -9,6 +9,7 @@
     i18n?: GenreIntl;
     separator?: string;
     year: number | Nil;
+    status?: string | Nil;
   };
 
   const {
@@ -17,6 +18,7 @@
     i18n = GenreIntlProvider,
     separator = " / ",
     year,
+    status,
   }: MediaTitleProps = $props();
 
   const subtitle = $derived.by(() => {
@@ -41,6 +43,12 @@
   <p class="secondary smaller">
     {subtitle}
   </p>
+
+  {#if status}
+    <p class="secondary smaller meta-info trakt-media-status">
+      {status}
+    </p>
+  {/if}
 </div>
 
 <style>
@@ -63,5 +71,9 @@
 
     font-size: clamp(var(--ni-24), var(--text-size), var(--ni-32));
     text-align: center;
+  }
+
+  .trakt-media-status {
+    color: var(--color-text-emphasis);
   }
 </style>

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -12,6 +12,7 @@
 
   --color-text-primary: var(--shade-800);
   --color-text-secondary: var(--shade-500);
+  --color-text-emphasis: var(--purple-700);
 
   /**
    * Navbar
@@ -144,6 +145,7 @@
 
   --color-text-primary: var(--shade-10);
   --color-text-secondary: var(--shade-300);
+  --color-text-emphasis: var(--purple-300);
 
   /**
    * Navbar


### PR DESCRIPTION
## ♪ Note ♪

- Adds status in new media summary design

## 👀 Example 👀
<img width="428" height="667" alt="Screenshot 2025-10-13 at 10 46 02" src="https://github.com/user-attachments/assets/7d4c7765-3038-43d1-b42e-3b383d7332c0" />
