### PR TITLE
fix(comment): set marker on post and reply

### DIFF
--- a/projects/client/src/lib/requests/queries/comments/postCommentRequest.ts
+++ b/projects/client/src/lib/requests/queries/comments/postCommentRequest.ts
@@ -1,5 +1,6 @@
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import type { MediaComment } from '$lib/requests/models/MediaComment.ts';
+import { setMarker } from '$lib/utils/date/Marker.ts';
 import { error } from '@sveltejs/kit';
 import type { CommentPostParams } from '@trakt/api';
 import { mapToMediaComment } from '../../_internal/mapToMediaComment.ts';
@@ -19,6 +20,7 @@ export function postCommentRequest(
         throw error(response.status);
       }
 
+      setMarker();
       return mapToMediaComment(response.body);
     });
 }

--- a/projects/client/src/lib/requests/queries/comments/replyCommentRequest.ts
+++ b/projects/client/src/lib/requests/queries/comments/replyCommentRequest.ts
@@ -1,5 +1,6 @@
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import type { MediaComment } from '$lib/requests/models/MediaComment.ts';
+import { setMarker } from '$lib/utils/date/Marker.ts';
 import { error } from '@sveltejs/kit';
 import type { CommentReplyParams } from '@trakt/api';
 import { mapToMediaComment } from '../../_internal/mapToMediaComment.ts';
@@ -22,6 +23,7 @@ export function replyCommentRequest(
         throw error(response.status);
       }
 
+      setMarker();
       return mapToMediaComment(response.body);
     });
 }


### PR DESCRIPTION
## ♪ Note ♪

- Adds missing `setMarker` for posting and replying