### PR TITLE
fix: use fade transition instead of crossfade

### DIFF
--- a/projects/client/src/lib/components/Crossfade.svelte
+++ b/projects/client/src/lib/components/Crossfade.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { type Snippet } from "svelte";
-  import { crossfade } from "svelte/transition";
+  import { cubicInOut } from "svelte/easing";
+  import { fade } from "svelte/transition";
 
-  const CROSSFADE_KEY = Symbol("crossfade");
+  const FADE_DURATION_MS = 500;
 
   const {
     childrenA,
@@ -13,32 +14,20 @@
     childrenB: Snippet;
     showA: boolean;
   } = $props();
-
-  const [send, receive] = crossfade({
-    duration: 300,
-    fallback: () => {
-      return {
-        duration: 0,
-        css: () => "",
-      };
-    },
-  });
 </script>
 
 <div class="crossfade-container">
   {#if showA}
     <div
       class="crossfade-content"
-      in:receive={{ key: CROSSFADE_KEY }}
-      out:send={{ key: CROSSFADE_KEY }}
+      transition:fade={{ duration: FADE_DURATION_MS, easing: cubicInOut }}
     >
       {@render childrenA()}
     </div>
   {:else}
     <div
       class="crossfade-content"
-      in:receive={{ key: CROSSFADE_KEY }}
-      out:send={{ key: CROSSFADE_KEY }}
+      transition:fade={{ duration: FADE_DURATION_MS, easing: cubicInOut }}
     >
       {@render childrenB()}
     </div>


### PR DESCRIPTION
## 🎵 Notes 🎵

- Replaces the `crossfade` transition with the `fade` transition.
  - The `crossfade` one could throw an error when there are a/b switches in quick succession. The transition requires both elements to be there, but if during the transition it's removed, it would error out. It's also a more complex transition that's meant as `a transition that transforms the element to its counterpart’s position and fades it out`; here we just want a simple fade in/out, so the `fade` transition should be fine.
  - This should also fix these: https://trakt-tv.sentry.io/issues/62937126/?project=4509870926463056&query=is%3Aunresolved%20reset&referrer=issue-stream

## 👀 Example 👀
  

https://github.com/user-attachments/assets/afcf2fd3-19f6-4136-9339-80b2c1f48827

