### PR TITLE
fix(show) / improve show progress data handling

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToPostCredits.ts
+++ b/projects/client/src/lib/requests/_internal/mapToPostCredits.ts
@@ -2,9 +2,13 @@ import type { EpisodeResponse, MovieResponse } from '@trakt/api';
 import type { PostCredits } from '../models/PostCreditsSchema.ts';
 
 export function mapToPostCredits(
-  response: EpisodeResponse | MovieResponse,
+  response: EpisodeResponse | MovieResponse | Nil,
 ): PostCredits[] {
   const postCredits: PostCredits[] = [];
+
+  if (!response) {
+    return postCredits;
+  }
 
   response.during_credits && postCredits.push('during');
   response.after_credits && postCredits.push('after');

--- a/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
@@ -39,16 +39,16 @@ function mapShowProgressResponse(
   item: ShowProgressResponse,
 ): EpisodeProgressEntry {
   const episode = item.next_episode;
-  const posterCandidate = findDefined(...(episode.images?.screenshot ?? []));
+  const posterCandidate = findDefined(...(episode?.images?.screenshot ?? []));
 
-  const airDate = new Date(episode.first_aired ?? MAX_DATE);
+  const airDate = new Date(episode?.first_aired ?? MAX_DATE);
 
   return {
-    id: episode.ids.trakt,
-    title: episode.title,
-    season: episode.season,
-    number: episode.number,
-    runtime: episode.runtime ?? NaN,
+    id: episode?.ids.trakt ?? -1,
+    title: episode?.title ?? '',
+    season: episode?.season ?? -1,
+    number: episode?.number ?? -1,
+    runtime: episode?.runtime ?? NaN,
     cover: {
       url: prependHttps(posterCandidate),
     },
@@ -57,9 +57,9 @@ function mapShowProgressResponse(
     completed: item.completed,
     remaining: item.aired - item.completed,
     minutesLeft: item.stats?.minutes_left ?? 0,
-    type: episode.episode_type as EpisodeType ?? EpisodeUnknownType.unknown,
+    type: episode?.episode_type as EpisodeType ?? EpisodeUnknownType.unknown,
     genres: [],
-    overview: episode.overview ?? '',
+    overview: episode?.overview ?? '',
     year: airDate.getFullYear(),
     postCredits: mapToPostCredits(episode),
   };

--- a/projects/client/src/lib/sections/summary/ShowSummary.svelte
+++ b/projects/client/src/lib/sections/summary/ShowSummary.svelte
@@ -52,7 +52,7 @@
   <MediaSummary {media} {studios} {intl} {crew} {streamOn} type="show">
     {#snippet contextualContent()}
       <RenderFor device={["desktop"]} audience="authenticated">
-        {#if episode != null}
+        {#if episode != null && episode.remaining > 0}
           <EpisodeItem {episode} show={media} variant="next" />
         {/if}
       </RenderFor>


### PR DESCRIPTION
**Overview:**

This pull request improves the handling of show progress data within the client application. It addresses potential issues related to missing data and enhances the reliability of the show progress display. The changes ensure that the application gracefully handles cases where certain episode details might be unavailable, thus providing a more robust user experience.

**Changes:**

*   Handles potential null or undefined values within the `mapToPostCredits` function.
*   Improved the handling of missing episode data within `showProgressQuery.ts` to prevent errors.
*   Updates the `ShowSummary.svelte` component to only render the "next episode" item if there are remaining episodes.
*   Incorporates safe navigation operators to prevent runtime errors when accessing nested episode properties.

**Technology:**

These changes primarily affect the client-side application code, with no specific technology dependencies (such as Hono, Cloudflare Workers, or Drizzle). The adjustments focus on improving data handling and component logic within the Svelte and TypeScript codebase.

**Testing:**

No new tests were added but existing functionality was tested to ensure data accuracy and proper rendering of show progress data.