### PR TITLE
fix: use status to check if a movie has aired

### DIFF
--- a/projects/client/src/lib/sections/media-actions/_internal/hasAired.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/_internal/hasAired.spec.ts
@@ -1,4 +1,4 @@
-import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
+import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
 import { describe, expect, it } from 'vitest';
 import { hasAired } from './hasAired.ts';
 
@@ -9,68 +9,59 @@ function addDays(date: Date, days: number): Date {
 }
 
 describe('hasAired', () => {
-  const runCommonTests = (type: ExtendedMediaType) => {
+  describe('for movies', () => {
+    it('returns true for movies with status "released"', () => {
+      expect(hasAired({ status: 'released', type: 'movie' })).toBe(true);
+    });
+
+    it('returns false for movies with status other than "released"', () => {
+      const nonReleasedStatuses: MediaStatus[] = [
+        'rumored',
+        'planned',
+        'in production',
+        'post production',
+        'canceled',
+        'unknown',
+      ];
+
+      nonReleasedStatuses.forEach((status) => {
+        expect(hasAired({ status, type: 'movie' })).toBe(false);
+      });
+    });
+  });
+
+  const runCommonTests = (type: 'show' | 'episode') => {
     it('returns true for items that aired today', () => {
       const today = new Date();
-
       expect(hasAired({ airDate: today, type })).toBe(true);
     });
 
     it('returns true for items that aired yesterday', () => {
       const yesterday = addDays(new Date(), -1);
-
       expect(hasAired({ airDate: yesterday, type })).toBe(true);
     });
 
     it('returns true for items that aired 1 week ago', () => {
       const oneWeekAgo = addDays(new Date(), -7);
-
       expect(hasAired({ airDate: oneWeekAgo, type })).toBe(true);
+    });
+
+    it('returns false for items that will air tomorrow', () => {
+      const tomorrow = addDays(new Date(), 1);
+      expect(hasAired({ airDate: tomorrow, type })).toBe(false);
+    });
+
+    it('returns false for items that will air in 7 days', () => {
+      const sevenDaysFromNow = addDays(new Date(), 7);
+      expect(hasAired({ airDate: sevenDaysFromNow, type })).toBe(false);
     });
   };
 
-  describe('for movies', () => {
-    const type = 'movie';
-    runCommonTests(type);
-
-    it('returns true for movies that will air tomorrow', () => {
-      const tomorrow = addDays(new Date(), 1);
-
-      expect(hasAired({ airDate: tomorrow, type })).toBe(true);
-    });
-
-    it('returns true for movies that will air in 7 days', () => {
-      const sevenDaysFromNow = addDays(new Date(), 7);
-
-      expect(hasAired({ airDate: sevenDaysFromNow, type })).toBe(true);
-    });
-
-    it('returns false for movies that will air in 8 days', () => {
-      const eightDaysFromNow = addDays(new Date(), 8);
-
-      expect(hasAired({ airDate: eightDaysFromNow, type })).toBe(false);
-    });
-  });
-
   describe('for shows', () => {
-    const type = 'show';
-    runCommonTests(type);
-
-    it('returns false for shows that will air tomorrow', () => {
-      const tomorrow = addDays(new Date(), 1);
-
-      expect(hasAired({ airDate: tomorrow, type })).toBe(false);
-    });
+    runCommonTests('show');
   });
 
   describe('for episodes', () => {
-    const type = 'episode';
-    runCommonTests(type);
-
-    it('returns false for episodes that will air tomorrow', () => {
-      const tomorrow = addDays(new Date(), 1);
-
-      expect(hasAired({ airDate: tomorrow, type })).toBe(false);
-    });
+    runCommonTests('episode');
   });
 });

--- a/projects/client/src/lib/sections/media-actions/_internal/hasAired.ts
+++ b/projects/client/src/lib/sections/media-actions/_internal/hasAired.ts
@@ -1,17 +1,21 @@
-import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
+import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
 
-type HasAiredProps = {
+type AirDateProps = {
   airDate: Date;
-  type: ExtendedMediaType;
+  type: 'episode' | 'show';
 };
 
-const MOVIE_AIR_DATE_BUFFER_DAYS = 7;
+type StatusProps = {
+  status: MediaStatus;
+  type: 'movie';
+};
 
-export function hasAired({ airDate, type }: HasAiredProps): boolean {
-  const cutOffDate = new Date();
-  if (type === 'movie') {
-    cutOffDate.setDate(cutOffDate.getDate() + MOVIE_AIR_DATE_BUFFER_DAYS);
+type HasAiredProps = AirDateProps | StatusProps;
+
+export function hasAired(props: HasAiredProps): boolean {
+  if ('status' in props) {
+    return props.status === 'released';
   }
 
-  return airDate <= cutOffDate;
+  return props.airDate <= new Date();
 }

--- a/projects/client/src/lib/sections/media-actions/check-in/useCheckIn.ts
+++ b/projects/client/src/lib/sections/media-actions/check-in/useCheckIn.ts
@@ -81,10 +81,9 @@ export function useCheckIn(props: UseCheckInProps) {
     isCheckingIn.set(false);
   };
 
-  const airDate = type === 'episode'
-    ? props.episode.airDate
-    : props.media.airDate;
-  const isWatchable = airDate && hasAired({ airDate, type });
+  const isWatchable = type === 'episode'
+    ? hasAired({ type: 'episode', airDate: props.episode.airDate })
+    : hasAired({ type: 'movie', status: props.media.status });
 
   return {
     checkin,

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
@@ -1,20 +1,21 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
 import { markAsWatchedRequest } from '$lib/requests/sync/markAsWatchedRequest.ts';
 import { removeWatchedRequest } from '$lib/requests/sync/removeWatchedRequest.ts';
 import { resolveWatchDate } from '$lib/stores/_internal/resolveWatchDate.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { resolve } from '$lib/utils/store/resolve.ts';
 import { writable } from 'svelte/store';
-import type { MediaStoreProps } from '../../../models/MediaStoreProps.ts';
 import { hasAired } from '../_internal/hasAired.ts';
 import { toMarkAsWatchedPayload } from './toMarkAsWatchedPayload.ts';
 import { useIsWatched } from './useIsWatched.ts';
 
 export type MarkAsWatchedStoreProps = MediaStoreProps<
-  { id: number; airDate: Date }
+  { id: number; airDate: Date; status?: MediaStatus }
 >;
 
 export function useMarkAsWatched(
@@ -70,7 +71,9 @@ export function useMarkAsWatched(
   };
 
   const isWatchable = media.every((item) => {
-    return item.airDate && hasAired({ airDate: item.airDate, type });
+    return type === 'movie'
+      ? hasAired({ type, status: item.status ?? 'unknown' })
+      : hasAired({ type, airDate: item.airDate });
   });
 
   return {


### PR DESCRIPTION
## ♪ Note ♪

- Fixes the `hasAired` check to use actual data instead of the air date buffer for movies.

## 👀 Example 👀
<img width="425" height="927" alt="Screenshot 2025-10-17 at 08 33 22" src="https://github.com/user-attachments/assets/eb347c8c-7f4a-4852-92c4-20dc6b7c1aee" />
