### PR TITLE
feat: add active state variant to search icon

### DIFF
--- a/projects/client/src/lib/features/search/SearchIcon.svelte
+++ b/projects/client/src/lib/features/search/SearchIcon.svelte
@@ -5,13 +5,40 @@
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <circle
-    cx="10.5"
-    cy="10.5"
-    r="7.5"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linejoin="round"
+  <path
+    class="icon-inactive"
+    d="M11 2C15.9706 2 20 6.02944 20 11C20 13.125 19.2619 15.0766 18.0303 16.6162L21.707 20.293L20.293 21.707L16.6162 18.0303C15.0766 19.2619 13.125 20 11 20C6.02944 20 2 15.9706 2 11C2 6.02944 6.02944 2 11 2ZM11 4C7.13401 4 4 7.13401 4 11C4 14.866 7.13401 18 11 18C14.866 18 18 14.866 18 11C18 7.13401 14.866 4 11 4Z"
+    fill="currentColor"
   />
-  <path d="M16 16L21 21" stroke="currentColor" stroke-width="2" />
+
+  <path
+    class="icon-active"
+    d="M11 2C15.9706 2 20 6.02944 20 11C20 13.125 19.2619 15.0766 18.0303 16.6162L21.707 20.293L20.293 21.707L16.6162 18.0303C15.0766 19.2619 13.125 20 11 20C6.02944 20 2 15.9706 2 11C2 6.02944 6.02944 2 11 2ZM11 4C7.13401 4 4 7.13401 4 11C4 14.866 7.13401 18 11 18C14.866 18 18 14.866 18 11C18 7.13401 14.866 4 11 4ZM11 6C13.7614 6 16 8.23858 16 11C16 13.7614 13.7614 16 11 16C8.23858 16 6 13.7614 6 11C6 8.23858 8.23858 6 11 6Z"
+    fill="currentColor"
+  />
 </svg>
+
+<style>
+  .icon-inactive {
+    opacity: 1;
+  }
+  .icon-active {
+    opacity: 0;
+  }
+
+  .icon-active,
+  .icon-inactive {
+    transition: opacity var(--transition-increment) ease-in-out;
+  }
+
+  :global(.trakt-link-active),
+  :global(button:active) {
+    .icon-active {
+      opacity: 1;
+    }
+
+    .icon-inactive {
+      opacity: 0;
+    }
+  }
+</style>


### PR DESCRIPTION
## ♪ Note ♪

- Adds an active state to the search icon

## 👀 Example 👀

Before:
<img width="87" height="78" alt="Screenshot 2025-10-17 at 10 11 08" src="https://github.com/user-attachments/assets/48c30bf6-b901-42fc-b486-4579a6208852" />

After:
<img width="87" height="78" alt="Screenshot 2025-10-17 at 10 11 11" src="https://github.com/user-attachments/assets/10525c9d-db83-4e77-894f-e9ec17b7ddcc" />
