### PR TITLE
feat(dropdown): show icons on the left side of dropdown items

### DIFF
--- a/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
+++ b/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
@@ -41,7 +41,7 @@
 
 {#if style === "action"}
   <ActionButton {...commonProps} {...props} style="ghost" color="default">
-    <FavoriteIcon {state} />
+    <FavoriteIcon {state} --icon-color="var(--color-background-orange)" />
   </ActionButton>
 {/if}
 

--- a/projects/client/src/lib/components/dropdown/DropdownItem.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.svelte
@@ -51,22 +51,22 @@
 >
   {#if href}
     <Link {href} {noscroll} {target} color="inherit">
-      {@render text()}
       {#if icon}
         <div class="item-icon">
           {@render icon()}
         </div>
       {/if}
+      {@render text()}
     </Link>
   {:else}
-    <p class="small bold uppercase ellipsis">
-      {@render text()}
-    </p>
     {#if icon}
       <div class="item-icon">
         {@render icon()}
       </div>
     {/if}
+    <p class="small bold uppercase ellipsis">
+      {@render text()}
+    </p>
   {/if}
 </li>
 
@@ -74,6 +74,8 @@
   @use "$style/scss/mixins/index" as *;
 
   li {
+    --icon-gap: var(--gap-s);
+
     text-decoration: none;
     list-style-type: none;
     user-select: none;
@@ -88,8 +90,7 @@
 
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: var(--gap-s);
+    gap: var(--icon-gap);
 
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
@@ -101,8 +102,8 @@
       display: flex;
 
       :global(svg) {
-        width: var(--ni-24);
-        height: var(--ni-24);
+        width: var(--ni-20);
+        height: var(--ni-20);
       }
     }
 
@@ -116,11 +117,14 @@
 
     :global(.trakt-link) {
       color: inherit;
+
       width: 100%;
       height: 100%;
-      align-items: center;
+
       display: flex;
-      justify-content: space-between;
+      align-items: center;
+      gap: var(--icon-gap);
+
       text-decoration: none;
     }
 

--- a/projects/client/src/lib/components/icons/FavoriteIcon.svelte
+++ b/projects/client/src/lib/components/icons/FavoriteIcon.svelte
@@ -10,7 +10,8 @@
   width="24"
   height="23"
   viewBox="0 0 24 23"
-  fill={state === "filled" ? "currentColor" : "none"}
+  fill={state === "filled" ? "var(--icon-color, currentColor)" : "none"}
+  color="var(--icon-color, currentColor)"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
@@ -20,9 +21,3 @@
     stroke-linejoin="bevel"
   />
 </svg>
-
-<style>
-  svg {
-    color: var(--color-background-orange);
-  }
-</style>

--- a/projects/client/src/lib/sections/lists/user/_internal/DeleteListButton.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/DeleteListButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { useDangerButton } from "$lib/components/buttons/_internal/useDangerButton";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import DeleteIcon from "$lib/components/icons/DeleteIcon.svelte";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -43,4 +44,8 @@
 
 <DropdownItem style="flat" {...buttonProps}>
   {m.button_text_delete_list()}
+
+  {#snippet icon()}
+    <DeleteIcon />
+  {/snippet}
 </DropdownItem>

--- a/projects/client/src/lib/sections/lists/user/_internal/RenameListButton.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/RenameListButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import RenameIcon from "$lib/components/icons/RenameIcon.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary";
   import { useRenameList } from "./useRenameList.ts";
@@ -19,4 +20,8 @@
   onclick={renameList}
 >
   {m.button_text_rename_list()}
+
+  {#snippet icon()}
+    <RenameIcon />
+  {/snippet}
 </DropdownItem>


### PR DESCRIPTION
## ♪ Note ♪

- Icons in dropdown items are now always on the left side.

## 👀 Example 👀
<img width="430" height="368" alt="Screenshot 2025-10-19 at 18 03 19" src="https://github.com/user-attachments/assets/5eb32573-8d96-4913-a3fb-0206840d86aa" />
