### PR TITLE
feat(card): show indicator tags for watched and watchlisted items

### DIFF
--- a/projects/client/src/lib/components/link/Link.svelte
+++ b/projects/client/src/lib/components/link/Link.svelte
@@ -56,6 +56,7 @@
     transition: var(--transition-increment) ease-in-out;
     transition-property: color, text-decoration;
     display: inline;
+    position: relative;
 
     :global(p),
     :global(span) {

--- a/projects/client/src/lib/components/media/tags/IndicatorTag.svelte
+++ b/projects/client/src/lib/components/media/tags/IndicatorTag.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import StemTag from "$lib/components/tags/StemTag.svelte";
+
+  const { children }: ChildrenProps = $props();
+</script>
+
+<trakt-indicator-tag>
+  <StemTag
+    --color-background-stem-tag="var(--color-background-indicator-tag)"
+    --color-foreground-stem-tag="var(--color-text-indicator-tag)"
+    icon={children}
+  />
+</trakt-indicator-tag>
+
+<style>
+  trakt-indicator-tag {
+    :global(.trakt-tag) {
+      width: var(--ni-10);
+      height: var(--ni-10);
+      line-height: var(--ni-10);
+
+      :global(trakt-tag-icon svg) {
+        width: var(--ni-10);
+        height: var(--ni-10);
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/tags/IndicatorTags.svelte
+++ b/projects/client/src/lib/components/tags/IndicatorTags.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  const { children }: ChildrenProps = $props();
+</script>
+
+<div class="trakt-indicator-tags">
+  {@render children()}
+</div>
+
+<style>
+  .trakt-indicator-tags {
+    z-index: var(--layer-raised);
+
+    position: absolute;
+    width: 100%;
+
+    bottom: var(--ni-neg-10);
+
+    display: inline-flex;
+    justify-content: center;
+    gap: var(--gap-xxs);
+  }
+</style>

--- a/projects/client/src/lib/components/tags/StemTag.svelte
+++ b/projects/client/src/lib/components/tags/StemTag.svelte
@@ -21,7 +21,7 @@
     {/if}
     {#if children}
       {@render children()}
-    {:else}
+    {:else if text}
       <p class="meta-info">
         {text}
       </p>

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import WatchlistIcon from "$lib/components/icons/mobile/WatchlistIcon.svelte";
   import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
   import CertificationTag from "$lib/components/media/tags/CertificationTag.svelte";
   import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
   import EpisodeCountTag from "$lib/components/media/tags/EpisodeCountTag.svelte";
+  import IndicatorTag from "$lib/components/media/tags/IndicatorTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import TagBar from "$lib/components/tags/TagBar.svelte";
+  import TrackIcon from "$lib/components/TrackIcon.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaInputDefault } from "$lib/models/MediaInput";
   import CheckInAction from "$lib/sections/media-actions/check-in/CheckInAction.svelte";
@@ -50,6 +53,19 @@
 
   {#if isSummary && media.certification}
     <CertificationTag certification={media.certification} />
+  {/if}
+{/snippet}
+
+{#snippet indicatorTags()}
+  {#if $isWatched}
+    <IndicatorTag>
+      <TrackIcon />
+    </IndicatorTag>
+  {/if}
+  {#if $isWatchlisted}
+    <IndicatorTag>
+      <WatchlistIcon />
+    </IndicatorTag>
   {/if}
 {/snippet}
 
@@ -102,6 +118,7 @@
       {media}
       {style}
       tag={rest.variant !== "next" ? tag : undefined}
+      indicators={canDeemphasize ? indicatorTags : undefined}
       {...rest}
       {popupActions}
     />
@@ -114,14 +131,14 @@
   trakt-default-media-item {
     &.is-deemphasized {
       /* FIXME: find the root cause why on safari this does not work on .trakt-card */
-      :global(.trakt-card-content) {
+      :global(.trakt-card-cover-image) {
         transition: opacity var(--transition-increment) ease-in-out;
         opacity: var(--de-emphasized-opacity);
       }
 
       @include for-mouse() {
         &:hover {
-          :global(.trakt-card-content) {
+          :global(.trakt-card-cover-image) {
             opacity: 1;
           }
         }

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -6,6 +6,7 @@
   import CardCover from "$lib/components/card/CardCover.svelte";
   import LandscapeCard from "$lib/components/media/card/LandscapeCard.svelte";
   import PortraitCard from "$lib/components/media/card/PortraitCard.svelte";
+  import IndicatorTags from "$lib/components/tags/IndicatorTags.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
   import { languageTag } from "$lib/features/i18n";
@@ -26,6 +27,7 @@
     action,
     popupActions,
     source,
+    indicators,
     ...rest
   }: MediaCardProps = $props();
 
@@ -65,6 +67,12 @@
       {badge}
       tag={coverTag}
     />
+
+    {#if indicators}
+      <IndicatorTags>
+        {@render indicators()}
+      </IndicatorTags>
+    {/if}
   </Link>
 {/snippet}
 

--- a/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
@@ -19,6 +19,7 @@ type BaseItemProps<T> = MediaItemVariant<T> & {
   coverTag?: Snippet;
   action?: Snippet;
   popupActions?: Snippet;
+  indicators?: Snippet;
   style?: 'cover' | 'summary';
   source?: string;
   onclick?: (item: T) => void;

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -6,6 +6,7 @@
   import { EpisodeIntlProvider } from "$lib/components/episode/EpisodeIntlProvider";
   import Link from "$lib/components/link/Link.svelte";
   import GenreList from "$lib/components/summary/GenreList.svelte";
+  import IndicatorTags from "$lib/components/tags/IndicatorTags.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
   import { getLocale } from "$lib/features/i18n";
@@ -28,6 +29,7 @@
     popupActions,
     media,
     source,
+    indicators,
     ...rest
   }: MediaCardProps | EpisodeCardProps = $props();
 
@@ -77,6 +79,11 @@
         alt={`Poster for ${coverData.title}`}
         src={coverData.poster}
       />
+      {#if indicators}
+        <IndicatorTags>
+          {@render indicators()}
+        </IndicatorTags>
+      {/if}
     </div>
 
     <SummaryCardDetails>
@@ -155,15 +162,23 @@
       display: flex;
       flex-grow: 1;
       text-decoration: none;
-      overflow: hidden;
     }
   }
 
   .trakt-summary-poster {
+    --poster-width: calc(
+      var(--height-summary-card-cover) * var(--poster-aspect-ratio)
+    );
+
     height: var(--height-summary-card-cover);
-    width: calc(var(--height-summary-card-cover) * var(--poster-aspect-ratio));
+    width: var(--poster-width);
 
     flex-shrink: 0;
+
+    :global(.trakt-indicator-tags) {
+      left: 0;
+      width: var(--poster-width);
+    }
   }
 
   .trakt-summary-card-tags {

--- a/projects/client/src/style/states/index.css
+++ b/projects/client/src/style/states/index.css
@@ -1,3 +1,3 @@
 :root {
-  --de-emphasized-opacity: 0.4;
+  --de-emphasized-opacity: 0.75;
 }

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -31,6 +31,9 @@
   --color-text-preview-tag: var(--shade-10);
   --color-background-preview-tag: var(--orange-600);
 
+  --color-text-indicator-tag: var(--shade-10);
+  --color-background-indicator-tag: var(--shade-800);
+
   /**
    * Avatar
    */


### PR DESCRIPTION
## 🎶 Notes 🎶

- Deemphasized cards are now less transparent, and is only applied on the poster now.
  - Went with .75, since .9 was barely noticeable.
- Adds indicator tags to the cover to denote if it's watched, watchlisted, or both.

## 👀 Example 👀
Before:
<img width="426" height="928" alt="Screenshot 2025-10-20 at 11 32 10" src="https://github.com/user-attachments/assets/fb1ee07b-00a3-4436-9d9f-4b33257a7930" />

After:
<img width="426" height="928" alt="Screenshot 2025-10-20 at 11 31 49" src="https://github.com/user-attachments/assets/7ab253a4-d514-4116-b75f-601e8ec8f05e" />
