### PR TITLE
fix(card): non clickable footers for all cards

### DIFF
--- a/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
@@ -21,13 +21,13 @@
       src={castMember.headshot.url.thumb}
       alt={`${m.image_alt_person_headshot({ person: castMember.name })}`}
     />
-    <CardFooter>
-      <p class="trakt-card-title ellipsis">
-        {castMember.name}
-      </p>
-      <p class="trakt-card-subtitle ellipsis">
-        {castMember.characterName}
-      </p>
-    </CardFooter>
   </Link>
+  <CardFooter>
+    <p class="trakt-card-title ellipsis">
+      {castMember.name}
+    </p>
+    <p class="trakt-card-subtitle ellipsis">
+      {castMember.characterName}
+    </p>
+  </CardFooter>
 </PersonCard>

--- a/projects/client/src/lib/sections/lists/components/DefaultPersonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultPersonItem.svelte
@@ -39,15 +39,15 @@
       src={person.headshot.url.thumb}
       alt={`${m.image_alt_person_headshot({ person: person.name })}`}
     />
-    <CardFooter>
-      <p class="trakt-card-title ellipsis">
-        {person.name}
-      </p>
-      {#if person.knownFor}
-        <p class="trakt-card-subtitle ellipsis">
-          {subtitle ?? toTranslatedValue("position", person.knownFor)}
-        </p>
-      {/if}
-    </CardFooter>
   </Link>
+  <CardFooter>
+    <p class="trakt-card-title ellipsis">
+      {person.name}
+    </p>
+    {#if person.knownFor}
+      <p class="trakt-card-subtitle ellipsis">
+        {subtitle ?? toTranslatedValue("position", person.knownFor)}
+      </p>
+    {/if}
+  </CardFooter>
 </PersonCard>

--- a/projects/client/src/lib/sections/lists/components/VideoItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/VideoItem.svelte
@@ -32,15 +32,12 @@
     }}
   >
     <CardCover title={video.title} src={video.thumbnail} alt={video.title} />
-    <CardFooter>
-      <p
-        use:lineClamp={{ lines: 2 }}
-        class="trakt-card-title trakt-video-title"
-      >
-        {video.title}
-      </p>
-    </CardFooter>
   </Link>
+  <CardFooter>
+    <p use:lineClamp={{ lines: 2 }} class="trakt-card-title trakt-video-title">
+      {video.title}
+    </p>
+  </CardFooter>
 </LandscapeCard>
 
 <style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- No more clickable footer text in people and video cards.
- Now all cards are consistent; the cover is clickable, the footers are informational.

## 👀 Examples 👀

Before:
<img width="1216" height="525" alt="Screenshot 2025-10-20 at 16 07 31" src="https://github.com/user-attachments/assets/67e7ef54-de4c-4ce8-8f66-7bccf042709a" />

After:
<img width="1216" height="525" alt="Screenshot 2025-10-20 at 16 07 41" src="https://github.com/user-attachments/assets/262fce40-4605-4756-9ef1-8ba1210b4829" />

Before:
<img width="1216" height="548" alt="Screenshot 2025-10-20 at 16 07 13" src="https://github.com/user-attachments/assets/99c65c31-069e-4458-b5e1-85b53118e9b4" />

After:
<img width="1216" height="548" alt="Screenshot 2025-10-20 at 16 07 00" src="https://github.com/user-attachments/assets/a3bd7700-b7ac-4f31-9843-ae98284e622e" />


