### PR TITLE
fix(tags) / adjust progress tag style

### DIFF
--- a/projects/client/src/lib/components/media/tags/ProgressTag.svelte
+++ b/projects/client/src/lib/components/media/tags/ProgressTag.svelte
@@ -39,7 +39,7 @@
       --progress-bar-spacing: var(--ni-6);
       --progress-bar-offset: calc(var(--progress-bar-spacing) / 2);
       overflow: hidden;
-      padding: var(--ni-4) var(--ni-8);
+      padding: var(--ni-4) var(--ni-10);
 
       &::before {
         content: "";

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -17,7 +17,7 @@
   --color-foreground-stem-tag: var(--shade-10);
 
   --color-text-progress-tag: var(--shade-10);
-  --color-background-progress-tag: var(--shade-940);
+  --color-background-progress-tag: var(--shade-930);
   --color-background-cover-tag: var(--cm-background-cover-tag);
 
   --color-text-watch-count-tag: var(--shade-10);


### PR DESCRIPTION
Overview:
This PR will adjust the style of the progress tag component to improve its appearance and visual consistency. The changes focus on modifying padding and background color to provide a better user experience.

Changes:
- Updates the padding of the `ProgressTag` component.
- Modifies the background color of the `ProgressTag` component.

Technology:
These changes involve modifications to the Svelte component `ProgressTag.svelte` and the global CSS theme in `global.css`.

Testing:
No specific testing details are available in the provided context, but the changes should be visually verified to ensure the style adjustments are applied as intended.

Before:

<img width="1258" height="366" alt="image" src="https://github.com/user-attachments/assets/4e76fa6c-cbc9-41c0-891e-657436d2a0cf" />

After:

<img width="1258" height="366" alt="image" src="https://github.com/user-attachments/assets/9ee3794a-9b9c-4b2f-a445-18c14c5c83f1" />
