### PR TITLE
feat(summary): only show released status for recent items

### DIFF
--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -40,6 +40,17 @@
   const postCreditsCount = $derived(media.postCredits?.length ?? 0);
 
   const hasTags = $derived(postCreditsCount > 0 || $watchCount > 0);
+
+  const status = $derived.by(() => {
+    if (media.status !== "released") {
+      return media.status;
+    }
+
+    const oneMonthAgo = new Date();
+    oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+
+    return media.airDate > oneMonthAgo ? media.status : undefined;
+  });
 </script>
 
 {#snippet tags()}
@@ -63,12 +74,7 @@
 
   {#snippet meta()}
     <RatingList ratings={$ratings} airDate={media.airDate} />
-    <SummaryTitle
-      {title}
-      genres={media.genres}
-      year={media.year}
-      status={media.status}
-    />
+    <SummaryTitle {title} genres={media.genres} year={media.year} {status} />
 
     <RenderFor audience="authenticated">
       <MediaActions {media} {streamOn} {title} />


### PR DESCRIPTION
## ♪ Note ♪

- Only show the `released` status if it was in the past month. Magna had a good point: `otherwise every movie ever that’s been released will have the RELEASED label on that Details page.`

## 👀 Example 👀

Before:
<img width="373" height="666" alt="Screenshot 2025-10-21 at 15 08 25" src="https://github.com/user-attachments/assets/2a59e196-9ea1-4a0e-a731-c49989cdbd29" />

After:
<img width="373" height="666" alt="Screenshot 2025-10-21 at 15 08 37" src="https://github.com/user-attachments/assets/d81f1066-2b2e-4038-9dca-b4667f7fd330" />
