### PR TITLE
fix(tags): positioning in firefox

### DIFF
--- a/projects/client/src/lib/components/tags/IndicatorTags.svelte
+++ b/projects/client/src/lib/components/tags/IndicatorTags.svelte
@@ -2,18 +2,26 @@
   const { children }: ChildrenProps = $props();
 </script>
 
-<div class="trakt-indicator-tags">
-  {@render children()}
+<div class="trakt-indicator-tags-container">
+  <div class="trakt-indicator-tags">
+    {@render children()}
+  </div>
 </div>
 
 <style>
+  /* To make sure Firefox can position it properly */
+  .trakt-indicator-tags-container {
+    position: relative;
+  }
+
   .trakt-indicator-tags {
     z-index: var(--layer-raised);
 
     position: absolute;
     width: var(--width-override-card, var(--width-card, 100%));
 
-    bottom: var(--ni-neg-10);
+    bottom: 0;
+    transform: translateY(50%);
 
     display: inline-flex;
     justify-content: center;


### PR DESCRIPTION
## ♪ Note ♪

- Firefox is also the new IE...

## 👀 Example 👀
Before/after:
<img width="1153" height="310" alt="Screenshot 2025-10-22 at 15 07 07" src="https://github.com/user-attachments/assets/687663c8-f55a-406d-b75e-4d2e27735069" />

<img width="1153" height="310" alt="Screenshot 2025-10-22 at 15 06 34" src="https://github.com/user-attachments/assets/a72f90c7-44c0-4785-b0c8-8be90995040e" />
