### PR TITLE
feat(list): new collapse icon

### DIFF
--- a/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
@@ -114,6 +114,10 @@
       }
     }
 
+    .trakt-list-title {
+      gap: var(--gap-micro);
+    }
+
     .trakt-list-title,
     .trakt-list-actions {
       :global(.trakt-action-button) {

--- a/projects/client/src/lib/components/lists/section-list/CollapseIcon.svelte
+++ b/projects/client/src/lib/components/lists/section-list/CollapseIcon.svelte
@@ -1,13 +1,9 @@
 <svg
-  width="17"
-  height="16"
-  viewBox="0 0 17 16"
-  fill="none"
   xmlns="http://www.w3.org/2000/svg"
+  height="24px"
+  viewBox="0 -960 960 960"
+  width="24px"
+  fill="currentColor"
 >
-  <path
-    d="M15.5 11.5L8.5 4.5L1.5 11.5"
-    stroke="currentColor"
-    stroke-width="2"
-  />
+  <path d="M240-450v-100h480v100H240Z" />
 </svg>


### PR DESCRIPTION
## ♪ Note ♪

- New collapse icon

## 👀 Example 👀
Before

<img width="428" height="927" alt="Screenshot 2025-10-22 at 16 12 01" src="https://github.com/user-attachments/assets/4309983f-0ae2-474b-ab14-17db092f82f0" />

After
<img width="428" height="927" alt="Screenshot 2025-10-22 at 16 11 51" src="https://github.com/user-attachments/assets/01ef245d-6801-4832-82e7-81ba14545c3e" />
