### PR TITLE
fix(tags): show count first in post credits tag

### DIFF
--- a/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
@@ -25,6 +25,6 @@ export const TagIntlProvider: TagIntl = {
   trendLabel: (delta) =>
     delta ? toHumanNumber(Math.abs(delta), languageTag()) : '—',
   postCredits: (count) =>
-    `${m.header_post_credits()} · ${toHumanNumber(count, languageTag())}`,
+    `${toHumanNumber(count, languageTag())} · ${m.header_post_credits()}`,
   mediaTypeLabel: (type) => toTranslatedValue('type', type),
 };


### PR DESCRIPTION
## ♪ Note ♪

- Flip count and text in post credits tag.

## 👀 Example 👀
<img width="428" height="927" alt="Screenshot 2025-10-22 at 16 16 26" src="https://github.com/user-attachments/assets/46e07394-ea9f-4c19-b703-1b2fed3746f7" />
