### PR TITLE
fix(settings): simplify log out button

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -315,7 +315,7 @@
       "default": "{number} гледания"
     },
     "button_text_logout": {
-      "default": "Изход от Trakt"
+      "default": "Изход"
     },
     "button_label_logout": {
       "default": "Изход"

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -315,7 +315,7 @@
       "default": "{number} afspilninger"
     },
     "button_text_logout": {
-      "default": "Log ud af Trakt"
+      "default": "Log ud"
     },
     "button_label_logout": {
       "default": "Log ud"

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -315,7 +315,7 @@
       "default": "{number} Wiedergaben"
     },
     "button_text_logout": {
-      "default": "Von Trakt abmelden"
+      "default": "Ausloggen"
     },
     "button_label_logout": {
       "default": "Abmelden"

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -315,7 +315,7 @@
       "default": "{number} plays"
     },
     "button_text_logout": {
-      "default": "Log out of Trakt"
+      "default": "Log out"
     },
     "button_label_logout": {
       "default": "Logout"

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -805,7 +805,7 @@
       ]
     },
     "button_text_logout": {
-      "default": "Log out of Trakt",
+      "default": "Log out",
       "description": "Text for the logout button.",
       "exclude": [
         "ios"

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -315,7 +315,7 @@
       "default": "{number} reproducciones"
     },
     "button_text_logout": {
-      "default": "Cerrar sesión de Trakt"
+      "default": "Cerrar sesión"
     },
     "button_label_logout": {
       "default": "Cerrar sesión"

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -315,7 +315,7 @@
       "default": "{number} reproducciones"
     },
     "button_text_logout": {
-      "default": "Cerrar sesión de Trakt"
+      "default": "Cerrar sesión"
     },
     "button_label_logout": {
       "default": "Cerrar sesión"

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -315,7 +315,7 @@
       "default": "{number} visionnements"
     },
     "button_text_logout": {
-      "default": "Se déconnecter de Trakt"
+      "default": "Se déconnecter"
     },
     "button_label_logout": {
       "default": "Déconnexion"

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -315,7 +315,7 @@
       "default": "{number} visionnages"
     },
     "button_text_logout": {
-      "default": "Se déconnecter de Trakt"
+      "default": "Se déconnecter"
     },
     "button_label_logout": {
       "default": "Déconnexion"

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -315,7 +315,7 @@
       "default": "{number} riproduzioni"
     },
     "button_text_logout": {
-      "default": "Esci da Trakt"
+      "default": "Esci"
     },
     "button_label_logout": {
       "default": "Esci"

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -315,7 +315,7 @@
       "default": "{number} 回再生"
     },
     "button_text_logout": {
-      "default": "Trakt からログアウト"
+      "default": "ログアウト"
     },
     "button_label_logout": {
       "default": "ログアウト"

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -315,7 +315,7 @@
       "default": "{number} visninger"
     },
     "button_text_logout": {
-      "default": "Logg ut fra Trakt"
+      "default": "Logg ut"
     },
     "button_label_logout": {
       "default": "Logg ut"

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -315,7 +315,7 @@
       "default": "{number} keer bekeken"
     },
     "button_text_logout": {
-      "default": "Uitloggen bij Trakt"
+      "default": "Uitloggen"
     },
     "button_label_logout": {
       "default": "Uitloggen"

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -315,7 +315,7 @@
       "default": "{number} odtworzeń"
     },
     "button_text_logout": {
-      "default": "Wyloguj się z Trakt"
+      "default": "Wyloguj się"
     },
     "button_label_logout": {
       "default": "Wyloguj się"

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -315,7 +315,7 @@
       "default": "{number} reproduções"
     },
     "button_text_logout": {
-      "default": "Sair do Trakt"
+      "default": "Sair"
     },
     "button_label_logout": {
       "default": "Sair"

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -315,7 +315,7 @@
       "default": "{number} vizionări"
     },
     "button_text_logout": {
-      "default": "Deconecte-te de Trakt"
+      "default": "Deconectare"
     },
     "button_label_logout": {
       "default": "Deconectare"

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -315,7 +315,7 @@
       "default": "{number} visningar"
     },
     "button_text_logout": {
-      "default": "Logga ut från Trakt"
+      "default": "Logga ut"
     },
     "button_label_logout": {
       "default": "Logga ut"

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -315,7 +315,7 @@
       "default": "{number} переглядів"
     },
     "button_text_logout": {
-      "default": "Вийти з Trakt"
+      "default": "Вийти"
     },
     "button_label_logout": {
       "default": "Вийти"

--- a/projects/client/src/lib/components/buttons/logout/LogoutButton.svelte
+++ b/projects/client/src/lib/components/buttons/logout/LogoutButton.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
-  import CloseIcon from "$lib/components/icons/CloseIcon.svelte";
   import LogoutIcon from "$lib/components/icons/LogoutIcon.svelte";
   import { useAuth } from "$lib/features/auth/stores/useAuth";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -27,9 +26,6 @@
     {...commonProps}
   >
     {m.button_text_logout()}
-    {#snippet icon()}
-      <CloseIcon />
-    {/snippet}
   </Button>
 {/if}
 

--- a/projects/client/src/lib/sections/settings/_internal/SettingsNavbar.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsNavbar.svelte
@@ -56,6 +56,10 @@
     min-height: var(--ni-480);
     max-height: calc(100dvh - var(--content-gap));
 
+    :global(.trakt-button) {
+      width: fit-content;
+    }
+
     @include for-tablet-sm-and-below {
       min-height: 0;
       height: fit-content;


### PR DESCRIPTION
## ♪ Note ♪

- Had a chat with Magna; we're simplifying the logout button.

## 👀 Example 👀
Before:
<img width="428" height="895" alt="Screenshot 2025-10-22 at 16 39 05" src="https://github.com/user-attachments/assets/bfaaa3d1-304e-4a58-b883-4f1ce4dca388" />

After:
<img width="428" height="895" alt="Screenshot 2025-10-22 at 16 38 59" src="https://github.com/user-attachments/assets/c26269d3-f18a-47d7-b7c6-31fb82456eab" />
