### PR TITLE
fix(list): ellipse clickable long list titles

### DIFF
--- a/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
@@ -38,6 +38,7 @@
   .trakt-list-title {
     display: flex;
     flex-direction: column;
+    min-width: 0;
 
     p.meta-info {
       color: var(--list-meta-info-color);
@@ -60,5 +61,13 @@
     /** FIXME: remove when we have adaptive typography and updated sizes */
     font-size: var(--ni-18);
     line-height: var(--ni-22);
+    &.ellipsis {
+      max-width: 100%;
+      width: 100%;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      display: block;
+    }
   }
 </style>


### PR DESCRIPTION
## ♪ Note ♪

- Woops, I broke list title ellipses when making them clickable 😅

## 👀 Example 👀

Before:

<img width="429" height="287" alt="Screenshot 2025-10-23 at 18 47 00" src="https://github.com/user-attachments/assets/cea4c5d2-c9e7-49fa-bf99-aad1e61268d3" />

After:
<img width="429" height="287" alt="Screenshot 2025-10-23 at 18 46 52" src="https://github.com/user-attachments/assets/7c571125-8dbc-48f1-98c4-2af5c205e3ed" />
