### PR TITLE
fix(navbar): do not hide filter button on non-discover pages

### DIFF
--- a/projects/client/src/lib/sections/navbar/components/TopNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/TopNavbar.svelte
@@ -74,10 +74,9 @@
       <RenderFor audience="authenticated">
         <RenderForFeature flag={FeatureFlag.Discover}>
           {#snippet enabled()}
-            {#if isOnDiscoverablePage}
-              <FilterButton size="small" />
-            {/if}
+            <FilterButton size="small" />
           {/snippet}
+
           <FilterButton size="small" />
           <ProfileLink />
         </RenderForFeature>


### PR DESCRIPTION
## ♪ Note ♪

- In discover mode, do not hide filter button on non-discover pages.

## 👀 Example 👀
Before:
<img width="428" height="380" alt="Screenshot 2025-10-24 at 09 48 41" src="https://github.com/user-attachments/assets/f733f35b-07cc-4317-a931-e4a798a4ddd6" />

After:
<img width="428" height="380" alt="Screenshot 2025-10-24 at 09 48 33" src="https://github.com/user-attachments/assets/811bc5a1-2c76-45c6-a961-86830363a8e1" />
