### PR TITLE
fix(discover): prioritize shows in mixed lists

### DIFF
--- a/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
+++ b/projects/client/src/lib/sections/lists/anticipated/useAnticipatedList.ts
@@ -48,10 +48,10 @@ function typeToQueries(
       >];
     case 'media':
       return [
-        movieAnticipatedQuery(params) as CreateQueryOptions<
+        showAnticipatedQuery(params) as CreateQueryOptions<
           Paginatable<AnticipatedEntry>
         >,
-        showAnticipatedQuery(params) as CreateQueryOptions<
+        movieAnticipatedQuery(params) as CreateQueryOptions<
           Paginatable<AnticipatedEntry>
         >,
       ];

--- a/projects/client/src/lib/sections/lists/popular/usePopularList.ts
+++ b/projects/client/src/lib/sections/lists/popular/usePopularList.ts
@@ -49,10 +49,10 @@ function typeToQueries(
       >];
     case 'media':
       return [
-        moviePopularQuery(params) as CreateQueryOptions<
+        showPopularQuery(params) as CreateQueryOptions<
           Paginatable<PopularEntry>
         >,
-        showPopularQuery(params) as CreateQueryOptions<
+        moviePopularQuery(params) as CreateQueryOptions<
           Paginatable<PopularEntry>
         >,
       ];

--- a/projects/client/src/lib/sections/lists/progress/useUpNextList.ts
+++ b/projects/client/src/lib/sections/lists/progress/useUpNextList.ts
@@ -39,13 +39,13 @@ function typeToQueries(props: UpNextStoreProps) {
       >];
     default:
       return [
+        upNextNitroQuery(props) as CreateQueryOptions<
+          Paginatable<ProgressEntry>
+        >,
         movieProgressQuery({
           ...props,
           limit: props.intent === 'start' ? RELEASED_LIST_LIMIT : props.limit,
         }) as CreateQueryOptions<
-          Paginatable<ProgressEntry>
-        >,
-        upNextNitroQuery(props) as CreateQueryOptions<
           Paginatable<ProgressEntry>
         >,
       ];

--- a/projects/client/src/lib/sections/lists/recommended/useRecommendedList.ts
+++ b/projects/client/src/lib/sections/lists/recommended/useRecommendedList.ts
@@ -49,10 +49,10 @@ function typeToQueries(
       >];
     case 'media':
       return [
-        recommendedMoviesQuery(params) as CreateQueryOptions<
+        recommendedShowsQuery(params) as CreateQueryOptions<
           RecommendedMediaList
         >,
-        recommendedShowsQuery(params) as CreateQueryOptions<
+        recommendedMoviesQuery(params) as CreateQueryOptions<
           RecommendedMediaList
         >,
       ];

--- a/projects/client/src/lib/sections/lists/trending/useTrendingList.ts
+++ b/projects/client/src/lib/sections/lists/trending/useTrendingList.ts
@@ -36,8 +36,8 @@ function typeToQueries(
       ];
     case 'media':
       return [
-        movieTrendingQuery(params) as CreateQueryOptions<TrendingMediaList>,
         showTrendingQuery(params) as CreateQueryOptions<TrendingMediaList>,
+        movieTrendingQuery(params) as CreateQueryOptions<TrendingMediaList>,
       ];
   }
 }


### PR DESCRIPTION
## ♪ Note ♪

- In discover mode, in weaved `media` lists, put shows first.