### PR TITLE
feat(analytics): track discover mode toggle usage

### DIFF
--- a/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
@@ -15,6 +15,7 @@ function buildEventKey<T extends string, K extends string>(
 export const AnalyticsEvent = {
   EnterLite: 'lite-on',
   Cta: 'cta',
+  DiscoverMode: 'discover-mode',
 
   Theme: buildEventKey(ACTION_PREFIX, 'theme'),
   Locale: buildEventKey(ACTION_PREFIX, 'locale'),

--- a/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
@@ -4,6 +4,7 @@ import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.t
 import type { MediaVideoType } from '$lib/requests/models/MediaVideo.ts';
 import type { SearchMode } from '$lib/requests/queries/search/models/SearchMode.ts';
 import type { CtaType } from '$lib/sections/lists/components/cta/models/Cta.ts';
+import type { DiscoverMode } from '../../discover/models/DiscoverMode.ts';
 import { AnalyticsEvent } from './AnalyticsEvent.ts';
 
 type SourceType = { source: string };
@@ -24,10 +25,12 @@ type DrilldownType = SourceType & { type?: string };
 type SearchType = { mode: SearchMode };
 type ShareType = DrilldownType;
 type CoverImageType = { type: ExtendedMediaType };
+type DiscoverType = SourceType & { mode: DiscoverMode };
 
 export type AnalyticsEventDataMap = {
   [AnalyticsEvent.EnterLite]: never;
   [AnalyticsEvent.Cta]: CtaDataType;
+  [AnalyticsEvent.DiscoverMode]: DiscoverType;
 
   [AnalyticsEvent.Theme]: { theme: Theme };
   [AnalyticsEvent.Locale]: { locale: string };

--- a/projects/client/src/lib/features/discover/useDiscover.ts
+++ b/projects/client/src/lib/features/discover/useDiscover.ts
@@ -1,12 +1,17 @@
+import { page } from '$app/state';
 import { useToggler } from '$lib/components/toggles/useToggler.ts';
+import { AnalyticsEvent } from '../analytics/events/AnalyticsEvent.ts';
+import { useTrack } from '../analytics/useTrack.ts';
 import { getDiscoverContext } from './_internal/getDiscoverContext.ts';
 import type { DiscoverMode } from './models/DiscoverMode.ts';
 
 export function useDiscover() {
   const { options, set } = useToggler('discover');
   const { mode, routes } = getDiscoverContext();
+  const { track } = useTrack(AnalyticsEvent.DiscoverMode);
 
   const setMode = (value: DiscoverMode) => {
+    track({ mode: value, source: page.route.id ?? 'unknown' });
     mode.set(value);
     set(value);
   };


### PR DESCRIPTION
## ♪ Note ♪

- Adds telemetry to discover mode toggle usage; tracks the `mode` and the page id.