### PR TITLE
feat(summary): implicitly trigger watchlist on drawer open

### DIFF
--- a/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
+++ b/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
@@ -3,6 +3,7 @@
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import BookmarkIcon from "$lib/components/icons/BookmarkIcon.svelte";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
+  import LoadingIndicator from "$lib/sections/lists/drilldown/_internal/LoadingIndicator.svelte";
   import ActionButton from "../ActionButton.svelte";
   import { useDangerButton } from "../_internal/useDangerButton";
   import { WatchlistButtonIntlProvider } from "./WatchlistButtonIntlProvider";
@@ -64,7 +65,12 @@
   <DropdownItem {...commonProps} style="flat">
     {i18n.text({ isWatchlisted, title })}
     {#snippet icon()}
-      <BookmarkIcon {state} size="normal" />
+      <!-- FIXME: generalize this and do this for all applicable buttons/items  -->
+      {#if isWatchlistUpdating}
+        <LoadingIndicator />
+      {:else}
+        <BookmarkIcon {state} size="normal" />
+      {/if}
     {/snippet}
   </DropdownItem>
 {/if}

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItem.svelte
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItem.svelte
@@ -6,6 +6,7 @@
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { MediaStoreProps } from "$lib/models/MediaStoreProps";
+  import LoadingIndicator from "$lib/sections/lists/drilldown/_internal/LoadingIndicator.svelte";
   import { onMount } from "svelte";
   import { ListDropdownItemIntlProvider } from "./ListDropdownItemIntlProvider";
   import type { ListDropdownItemProps } from "./ListDropdownItemProps";
@@ -72,6 +73,10 @@
   {i18n.text({ isListed: $isListed, listName: list.name, title })}
 
   {#snippet icon()}
-    <BookmarkIcon {state} size="normal" />
+    {#if $isListUpdating}
+      <LoadingIndicator />
+    {:else}
+      <BookmarkIcon {state} size="normal" />
+    {/if}
   {/snippet}
 </DropdownItem>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Opening the lists drawer triggers the watchlist now.
- To make it more clear I added a loading spinner as the icon.
  - Note: I want to do this for all applicable actions.
- I'll also do a follow up to see if all the `useConfirm`s can be in their respective stores instead 🤔

## 👀 Example 👀

https://github.com/user-attachments/assets/93aebdd9-304b-48f4-806a-e7cbb53f5138

