### PR TITLE
feat(discover): add discover mode support to lists page

### DIFF
--- a/projects/client/src/lib/features/discover/_internal/constants/index.ts
+++ b/projects/client/src/lib/features/discover/_internal/constants/index.ts
@@ -9,4 +9,5 @@ export const DISCOVER_ROUTES = [
   UrlBuilder.progress('[user]'),
   UrlBuilder.discover(),
   UrlBuilder.startWatching('[user]'),
+  UrlBuilder.lists.user('[user]'),
 ] as const;

--- a/projects/client/src/lib/sections/lists/components/list-summary/ListSummaryItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/ListSummaryItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Card from "$lib/components/card/Card.svelte";
+  import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
-  import type { MediaType } from "$lib/requests/models/MediaType.ts";
   import ListHeader from "./_internal/ListHeader.svelte";
   import ListPosters from "./_internal/ListPosters.svelte";
 
@@ -9,7 +9,7 @@
     list,
     type,
     isOfficial,
-  }: { list: MediaListSummary; type?: MediaType; isOfficial: boolean } =
+  }: { list: MediaListSummary; type?: DiscoverMode; isOfficial: boolean } =
     $props();
 </script>
 

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListHeader.svelte
@@ -2,15 +2,16 @@
   import Link from "$lib/components/link/Link.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
+  import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
-  import type { MediaType } from "$lib/requests/models/MediaType";
   import UserAvatar from "$lib/sections/lists/components/UserAvatar.svelte";
   import UserProfileLink from "$lib/sections/lists/components/UserProfileLink.svelte";
   import ListActions from "$lib/sections/lists/user/ListActions.svelte";
   import { getListUrl } from "./getListUrl";
 
-  const { list, type }: { list: MediaListSummary; type?: MediaType } = $props();
+  const { list, type }: { list: MediaListSummary; type?: DiscoverMode } =
+    $props();
 
   // In list summaries, clicking on the header is considered a drilldown action
   const { track } = useTrack(AnalyticsEvent.Drilldown);

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import Link from "$lib/components/link/Link.svelte";
+  import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
-  import type { MediaType } from "$lib/requests/models/MediaType.ts";
   import { getListUrl } from "./getListUrl.ts";
 
   const POSTER_LIMIT = 8;
-  const { list, type }: { list: MediaListSummary; type?: MediaType } = $props();
+  const { list, type }: { list: MediaListSummary; type?: DiscoverMode } =
+    $props();
 
   const posters = $derived(list.posters.slice(0, POSTER_LIMIT));
 </script>

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/getListUrl.ts
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/getListUrl.ts
@@ -1,8 +1,10 @@
+import type { DiscoverMode } from '$lib/features/discover/models/DiscoverMode.ts';
 import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
-import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
 
-export function getListUrl(list: MediaListSummary, type?: MediaType) {
+export function getListUrl(list: MediaListSummary, mode?: DiscoverMode) {
+  const type = mode === 'media' ? undefined : mode;
+
   if (list.user.slug) {
     return UrlBuilder.users(list.user.slug).lists(list.slug, type);
   }

--- a/projects/client/src/lib/sections/lists/user/ListActions.svelte
+++ b/projects/client/src/lib/sections/lists/user/ListActions.svelte
@@ -24,7 +24,7 @@
 
 <RenderFor audience="authenticated" navigation="default">
   {#if $isDeleted && isOnListPage}
-    <Redirect to={UrlBuilder.lists.user()} />
+    <Redirect to={UrlBuilder.lists.user("me")} />
   {/if}
 
   {#if isListOwner}

--- a/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
+++ b/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
@@ -4,6 +4,7 @@
   import ThumbsUpIcon from "$lib/components/icons/ThumbsUpIcon.svelte";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import { useIsMe } from "$lib/features/auth/stores/useIsMe.ts";
+  import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import { useNavigation } from "$lib/features/navigation/useNavigation.ts";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia.ts";
@@ -18,7 +19,11 @@
   import { usePersonalListsSummary } from "./usePersonalListsSummary.ts";
   import UserList from "./UserList.svelte";
 
-  const { type, slug }: { type: PersonalListType; slug: string } = $props();
+  const {
+    type,
+    slug,
+    mode,
+  }: { type: PersonalListType; slug: string; mode?: DiscoverMode } = $props();
 
   const { lists, isLoading } = $derived(
     usePersonalListsSummary({ type, slug }),
@@ -98,7 +103,7 @@
       {/if}
 
       {#each $lists as list (list.id)}
-        <UserList {list} empty={emptyList} />
+        <UserList {list} empty={emptyList} type={mode} />
       {/each}
     </div>
   {/if}
@@ -111,7 +116,7 @@
       --height-list="var(--height-lists-list)"
     >
       {#snippet item(list)}
-        <ListSummaryItem {list} isOfficial={false} />
+        <ListSummaryItem {list} isOfficial={false} type={mode} />
       {/snippet}
 
       {#snippet dynamicActions()}

--- a/projects/client/src/lib/sections/lists/user/UserList.svelte
+++ b/projects/client/src/lib/sections/lists/user/UserList.svelte
@@ -2,8 +2,8 @@
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
 
+  import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
-  import type { MediaType } from "$lib/requests/models/MediaType";
   import { useListItems } from "$lib/sections/lists/user/useListItems";
   import type { Snippet } from "svelte";
   import { getListUrl } from "../components/list-summary/_internal/getListUrl";
@@ -16,7 +16,8 @@
     list,
     type,
     empty,
-  }: { list: MediaListSummary; type?: MediaType; empty?: Snippet } = $props();
+  }: { list: MediaListSummary; type?: DiscoverMode; empty?: Snippet } =
+    $props();
   const { filterMap } = useFilter();
 </script>
 
@@ -24,7 +25,7 @@
   {type}
   {empty}
   source={{ id: "user-list", type }}
-  id={`user-list-${type ?? "media"}-${list.id}`}
+  id={`user-list-${type}-${list.id}`}
   drilldownLabel={m.button_text_view_all()}
   filter={$filterMap}
   useList={(params) => useListItems({ list, ...params })}

--- a/projects/client/src/lib/sections/lists/user/useListItems.ts
+++ b/projects/client/src/lib/sections/lists/user/useListItems.ts
@@ -1,5 +1,5 @@
+import type { DiscoverMode } from '$lib/features/discover/models/DiscoverMode.ts';
 import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
-import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { listItemsQuery } from '$lib/requests/queries/lists/listItemsQuery.ts';
 import { userListItemsQuery } from '$lib/requests/queries/users/userListItemsQuery.ts';
@@ -18,7 +18,7 @@ export type ListParams = {
 
 type UseListItemsProps = PaginationParams & FilterParams & {
   list: ListParams;
-  type?: MediaType;
+  type?: DiscoverMode;
 };
 
 // FIXME: remove when official lists are sluggable
@@ -39,7 +39,7 @@ function listToQuery(
   { list, limit, type, page, filter }: UseListItemsProps,
 ) {
   const commonParams = {
-    type,
+    type: type === 'media' ? undefined : type,
     page,
     filter,
     limit: limit ?? LIST_LIMIT,

--- a/projects/client/src/lib/sections/lists/watchlist/useWatchList.ts
+++ b/projects/client/src/lib/sections/lists/watchlist/useWatchList.ts
@@ -1,5 +1,5 @@
+import type { DiscoverMode } from '$lib/features/discover/models/DiscoverMode.ts';
 import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
-import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { watchlistQuery } from '$lib/requests/queries/users/watchlistQuery.ts';
 import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
@@ -8,7 +8,7 @@ import type { SortType } from '@trakt/api';
 import { derived } from 'svelte/store';
 
 export type WatchListStoreProps = PaginationParams & FilterParams & {
-  type?: MediaType;
+  type?: DiscoverMode;
   sort?: SortType;
   limit?: number;
 };
@@ -17,7 +17,7 @@ export function useWatchList(params: WatchListStoreProps) {
   const { isLoading, list: items, page } = usePaginatedListQuery(
     watchlistQuery({
       limit: params.limit ?? DEFAULT_PAGE_SIZE,
-      type: params.type,
+      type: params.type === 'media' ? undefined : params.type,
       page: params.page,
       sort: params.sort ?? 'added',
       filter: params.filter,

--- a/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
@@ -65,7 +65,7 @@
     </RenderForFeature>
 
     <RenderFor audience="authenticated">
-      <Link href={UrlBuilder.lists.user()}>
+      <Link href={UrlBuilder.lists.user("me")}>
         <div class="trakt-mobile-navbar-link">
           <WatchlistIcon />
         </div>

--- a/projects/client/src/lib/sections/navbar/components/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/SideNavbar.svelte
@@ -142,7 +142,7 @@
 
       <RenderFor audience="authenticated">
         <Button
-          href={UrlBuilder.lists.user()}
+          href={UrlBuilder.lists.user("me")}
           label={m.button_label_browse_lists()}
           style="flat"
           variant="secondary"

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -169,12 +169,12 @@ export const UrlBuilder = {
   lists: {
     official: (id: number, type?: MediaType) =>
       `/lists/official/${id}?type=${type}`,
-    user: (params?: UrlBuilderParams) => {
+    user: (user: string, params?: UrlBuilderParams) => {
       if (!params) {
-        return '/users/me/lists';
+        return `/users/${user}/lists`;
       }
 
-      return categoryDrilldownFactory('users/me/lists')(params);
+      return categoryDrilldownFactory(`users/${user}/lists`)(params);
     },
     watchlist: () => {
       return '/users/me/watchlist';

--- a/projects/client/src/routes/users/[user]/lists/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
+  import { type DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
+  import { useDiscover } from "$lib/features/discover/useDiscover";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
 
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -9,7 +13,34 @@
   import PersonalLists from "$lib/sections/lists/user/PersonalLists.svelte";
   import WatchList from "$lib/sections/lists/watchlist/WatchList.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+
+  const { mode } = useDiscover();
 </script>
+
+{#snippet content(mode?: DiscoverMode)}
+  <WatchList
+    drilldownLabel={m.button_label_view_all_watchlist_items()}
+    status="all"
+    type={mode}
+  />
+
+  <PersonalLists slug="me" type="personal" {mode} />
+  <PersonalLists slug="me" type="liked" {mode} />
+  <PersonalLists slug="me" type="collaboration" {mode} />
+
+  <RenderFor audience="director">
+    <div class="trakt-lists-preview">
+      <ListsHeader title="Smart lists" />
+
+      {#if mode === "media" || !mode}
+        <SmartListRenderer type="movie" />
+        <SmartListRenderer type="show" />
+      {:else}
+        <SmartListRenderer type={mode} />
+      {/if}
+    </div>
+  </RenderFor>
+{/snippet}
 
 <TraktPage
   audience="authenticated"
@@ -18,22 +49,13 @@
 >
   <TraktPageCoverSetter />
 
-  <WatchList
-    drilldownLabel={m.button_label_view_all_watchlist_items()}
-    status="all"
-  />
+  <RenderForFeature flag={FeatureFlag.Discover}>
+    {#snippet enabled()}
+      {@render content($mode)}
+    {/snippet}
 
-  <PersonalLists slug="me" type="personal" />
-  <PersonalLists slug="me" type="liked" />
-  <PersonalLists slug="me" type="collaboration" />
-
-  <RenderFor audience="director">
-    <div class="trakt-lists-preview">
-      <ListsHeader title="Smart lists" />
-      <SmartListRenderer type="movie" />
-      <SmartListRenderer type="show" />
-    </div>
-  </RenderFor>
+    {@render content()}
+  </RenderForFeature>
 </TraktPage>
 
 <style>


### PR DESCRIPTION
## ♪ Note ♪

- Adds discover mode support to the lists page.


## 👀 Example 👀

https://github.com/user-attachments/assets/246305a9-ba12-4115-a54d-b3352d3c4e97

