### PR TITLE
refactor: move confirmations to their respective stores

### DIFF
--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -117,7 +117,7 @@
   {/if}
 {/snippet}
 
-<MediaSwipe {type} {media} {style}>
+<MediaSwipe {type} {media} {style} title={media.title}>
   <trakt-default-media-item class:is-deemphasized={isDeemphasized}>
     <MediaItem
       {type}

--- a/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { MediaInput } from "$lib/models/MediaInput";
   import MarkAsWatchedSwipeIndicator from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedSwipeIndicator.svelte";
   import { useMarkAsWatched } from "$lib/sections/media-actions/mark-as-watched/useMarkAsWatched";
@@ -11,9 +9,10 @@
   type MediaSwipeProps = MediaInput &
     ChildrenProps & {
       style?: "cover" | "summary";
+      title: string;
     };
 
-  const { type, media, style, children }: MediaSwipeProps = $props();
+  const { type, media, style, children, title }: MediaSwipeProps = $props();
 
   if (type === "episode") {
     throw new Error("MediaSwipe does not support episode type");
@@ -21,22 +20,13 @@
 
   const target = $derived({ type, media });
 
-  const { markAsWatched } = $derived(useMarkAsWatched(target));
-
-  const { confirm } = useConfirm();
-  const confirmMarkAsWatched = $derived(
-    confirm({
-      type: ConfirmationType.MarkAsWatched,
-      title: media.title,
-      target,
-      onConfirm: markAsWatched,
-    }),
-  );
+  const { markAsWatched } = $derived(useMarkAsWatched({ ...target, title }));
 
   const { addToWatchlist, isWatchlisted } = $derived(
     useWatchlist({
       type,
       media,
+      title,
     }),
   );
 </script>
@@ -48,7 +38,7 @@
     classList="trakt-up-next-episode"
     onSwipe={(state) => {
       if (state.direction === "left") {
-        confirmMarkAsWatched();
+        markAsWatched();
       }
 
       if (state.direction === "right") {

--- a/projects/client/src/lib/sections/lists/progress/UpNextItem.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextItem.svelte
@@ -29,7 +29,12 @@
 </script>
 
 {#if "episode" in props}
-  <UpNextSwipe episode={props.episode} show={props.show} {style}>
+  <UpNextSwipe
+    episode={props.episode}
+    show={props.show}
+    title={props.episode.title}
+    {style}
+  >
     <EpisodeItem
       episode={props.episode}
       show={props.show}

--- a/projects/client/src/lib/sections/lists/progress/UpNextSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextSwipe.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { EpisodeProgressEntry } from "$lib/requests/models/EpisodeProgressEntry";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
   import DropSwipeIndicator from "$lib/sections/media-actions/drop/DropSwipeIndicator.svelte";
@@ -13,30 +11,25 @@
     episode: EpisodeProgressEntry;
     show: ShowEntry;
     style: "cover" | "summary";
+    title: string;
   } & ChildrenProps;
 
-  const { episode, show, style, children }: UpNextEpisodeProps = $props();
+  const { episode, show, style, children, title }: UpNextEpisodeProps =
+    $props();
 
   const { markAsWatched } = $derived(
     useMarkAsWatched({
       type: "episode",
       media: episode,
       show: show,
+      title,
     }),
   );
 
   const { drop } = $derived(
     useDrop({
       ids: [show.id],
-    }),
-  );
-
-  const { confirm } = useConfirm();
-  const confirmDrop = $derived(
-    confirm({
-      type: ConfirmationType.DropShow,
-      title: show.title,
-      onConfirm: drop,
+      title,
     }),
   );
 </script>
@@ -52,7 +45,7 @@
       }
 
       if (state.direction === "right") {
-        confirmDrop();
+        drop();
       }
     }}
     --indicator-height="var(--height-summary-card-cover)"

--- a/projects/client/src/lib/sections/lists/user/_internal/DeleteListButton.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/DeleteListButton.svelte
@@ -2,8 +2,6 @@
   import { useDangerButton } from "$lib/components/buttons/_internal/useDangerButton";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import DeleteIcon from "$lib/components/icons/DeleteIcon.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary";
 
@@ -14,7 +12,7 @@
   }: {
     list: MediaListSummary;
     isDeleting: boolean;
-    onDelete: () => {};
+    onDelete: () => void;
   } = $props();
 
   const {
@@ -23,19 +21,10 @@
     ...events
   } = $derived(useDangerButton({ isActive: true, color: "default" }));
 
-  const { confirm } = useConfirm();
-  const confirmDelete = $derived(
-    confirm({
-      type: ConfirmationType.DeleteList,
-      name: list.name,
-      onConfirm: onDelete,
-    }),
-  );
-
   const buttonProps: Omit<ButtonProps, "children"> = $derived({
     label: m.button_label_delete_list({ name: list.name }),
     color: $color,
-    onclick: confirmDelete,
+    onclick: onDelete,
     disabled: isDeleting,
     variant: "secondary",
     ...events,

--- a/projects/client/src/lib/sections/lists/user/_internal/useDeleteList.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useDeleteList.ts
@@ -1,5 +1,7 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
+import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
 import { deleteListRequest } from '$lib/requests/queries/users/deleteListRequest.ts';
@@ -12,6 +14,7 @@ export function useDeleteList(list: MediaListSummary) {
   const isDeleted = writable(false);
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.ListDelete);
+  const { confirm } = useConfirm();
 
   const deleteList = async () => {
     isDeleting.set(true);
@@ -34,6 +37,10 @@ export function useDeleteList(list: MediaListSummary) {
   return {
     isDeleting: derived(isDeleting, ($isDeleting) => $isDeleting),
     isDeleted: derived(isDeleted, ($isDeleted) => $isDeleted),
-    deleteList,
+    deleteList: confirm({
+      type: ConfirmationType.DeleteList,
+      name: list.name,
+      onConfirm: deleteList,
+    }),
   };
 }

--- a/projects/client/src/lib/sections/media-actions/drop/DropAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/drop/DropAction.svelte
@@ -19,6 +19,7 @@
   const { drop, isDropping } = $derived(
     useDrop({
       ids: [target.id],
+      title,
     }),
   );
 </script>

--- a/projects/client/src/lib/sections/media-actions/drop/DropButton.svelte
+++ b/projects/client/src/lib/sections/media-actions/drop/DropButton.svelte
@@ -6,21 +6,10 @@
   import Button from "$lib/components/buttons/Button.svelte";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import DropIcon from "$lib/components/icons/DropIcon.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { DropButtonProps } from "./DropButtonProps";
 
   const { title, onDrop, isDropping, style, ...props }: DropButtonProps =
     $props();
-
-  const { confirm } = useConfirm();
-  const confirmDrop = $derived(
-    confirm({
-      type: ConfirmationType.DropShow,
-      title,
-      onConfirm: onDrop,
-    }),
-  );
 
   const { color, variant, ...events } = $derived(
     useDangerButton({ isActive: false, color: "default" }),
@@ -30,7 +19,7 @@
     label: m.button_label_drop_show({ title }),
     color: $color,
     variant: $variant,
-    onclick: confirmDrop,
+    onclick: onDrop,
     disabled: isDropping,
     ...events,
   });

--- a/projects/client/src/lib/sections/media-actions/drop/useDrop.ts
+++ b/projects/client/src/lib/sections/media-actions/drop/useDrop.ts
@@ -1,6 +1,8 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
+import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { dropShowRequest } from '$lib/requests/queries/users/dropShowRequest.ts';
 import { hideShowCalendarRequest } from '$lib/requests/queries/users/hideShowCalendarRequest.ts';
@@ -11,6 +13,7 @@ import { writable } from 'svelte/store';
 
 export type DropShowStoreProps = {
   ids: number[];
+  title: string;
 };
 
 export function useDrop(
@@ -21,6 +24,7 @@ export function useDrop(
   const { user } = useUser();
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Drop);
+  const { confirm } = useConfirm();
 
   const drop = async () => {
     const current = await resolve(user);
@@ -50,6 +54,10 @@ export function useDrop(
 
   return {
     isDropping,
-    drop,
+    drop: confirm({
+      type: ConfirmationType.DropShow,
+      title: props.title,
+      onConfirm: drop,
+    }),
   };
 }

--- a/projects/client/src/lib/sections/media-actions/favorite/FavoriteAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/favorite/FavoriteAction.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import FavoriteButton from "$lib/components/buttons/favorite/FavoriteButton.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { onMount } from "svelte";
@@ -30,16 +28,7 @@
     isFavorited,
     addToFavorites,
     removeFromFavorites,
-  } = $derived(useFavorites({ type, id }));
-
-  const { confirm } = useConfirm();
-  const confirmRemove = $derived(
-    confirm({
-      type: ConfirmationType.RemoveFavorite,
-      title,
-      onConfirm: removeFromFavorites,
-    }),
-  );
+  } = $derived(useFavorites({ type, id, title }));
 
   onMount(() => {
     return isUpdatingFavorite.subscribe((value) => onAction?.(value));
@@ -53,5 +42,5 @@
   isFavorited={$isFavorited}
   isFavoriteUpdating={$isUpdatingFavorite}
   onAdd={addToFavorites}
-  onRemove={confirmRemove}
+  onRemove={removeFromFavorites}
 />

--- a/projects/client/src/lib/sections/media-actions/favorite/useFavorites.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/favorite/useFavorites.spec.ts
@@ -96,6 +96,7 @@ describe('useFavorites', () => {
     const props = {
       type: 'movie' as const,
       id: 1,
+      title: 'Some Movie',
     };
 
     runCommonTests(props, InvalidateAction.Favorited('movie'));
@@ -121,6 +122,7 @@ describe('useFavorites', () => {
     const props = {
       type: 'show' as const,
       id: 1,
+      title: 'Some Show',
     };
 
     runCommonTests(props, InvalidateAction.Favorited('show'));

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import MarkAsWatchedButton from "$lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import { useIsWatchlisted } from "../watchlist/useIsWatchlisted";
   import type { MarkAsWatchedActionProps } from "./MarkAsWatchedActionProps";
   import { useMarkAsWatched } from "./useMarkAsWatched";
@@ -21,27 +19,10 @@
     markAsWatched,
     removeWatched,
     isWatchable,
-  } = $derived(useMarkAsWatched(target));
+  } = $derived(useMarkAsWatched({ ...target, title }));
 
   const { isWatchlisted } = $derived(useIsWatchlisted(target));
   const isRewatching = $derived(allowRewatch && $isWatched);
-
-  const { confirm } = useConfirm();
-  const confirmMarkAsWatched = $derived(
-    confirm({
-      type: ConfirmationType.MarkAsWatched,
-      title,
-      target,
-      onConfirm: markAsWatched,
-    }),
-  );
-  const confirmRemoveFromWatched = $derived(
-    confirm({
-      type: ConfirmationType.RemoveFromWatched,
-      title,
-      onConfirm: removeWatched,
-    }),
-  );
 </script>
 
 {#if isWatchable}
@@ -53,7 +34,7 @@
     isWatched={$isWatched && !$isWatchlisted}
     {isRewatching}
     isMarkingAsWatched={$isMarkingAsWatched}
-    onWatch={confirmMarkAsWatched}
-    onRemove={confirmRemoveFromWatched}
+    onWatch={markAsWatched}
+    onRemove={removeWatched}
   />
 {/if}

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/TrackAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/TrackAction.svelte
@@ -3,8 +3,6 @@
   import type { MarkAsWatchedButtonIntl } from "$lib/components/buttons/mark-as-watched/MarkAsWatchedButtonIntl";
   import { MarkAsWatchedButtonIntlProvider } from "$lib/components/buttons/mark-as-watched/MarkAsWatchedButtonIntlProvider";
   import TrackIcon from "$lib/components/TrackIcon.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import {
     useMarkAsWatched,
     type MarkAsWatchedStoreProps,
@@ -22,17 +20,7 @@
   }: TrackButtonProps = $props();
 
   const { isMarkingAsWatched, markAsWatched, isWatchable } = $derived(
-    useMarkAsWatched(target),
-  );
-
-  const { confirm } = useConfirm();
-  const confirmMarkAsWatched = $derived(
-    confirm({
-      type: ConfirmationType.MarkAsWatched,
-      title,
-      target,
-      onConfirm: markAsWatched,
-    }),
+    useMarkAsWatched({ ...target, title }),
   );
 </script>
 
@@ -40,7 +28,7 @@
   <ActionButton
     disabled={$isMarkingAsWatched || !isWatchable}
     label={i18n.label({ title, isWatched: false, isRewatching: false })}
-    onclick={confirmMarkAsWatched}
+    onclick={markAsWatched}
     color="purple"
   >
     <TrackIcon />

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.spec.ts
@@ -105,6 +105,7 @@ describe('useMarkAsWatched', () => {
     const props = {
       type: 'movie' as const,
       media: { id: 1, airDate: new Date() },
+      title: 'Some Movie',
     };
 
     runCommonTests(props, InvalidateAction.MarkAsWatched('movie'));
@@ -122,6 +123,7 @@ describe('useMarkAsWatched', () => {
     const props = {
       type: 'show' as const,
       media: { id: 1, airDate: new Date() },
+      title: 'Some Show',
     };
 
     runCommonTests(props, InvalidateAction.MarkAsWatched('show'));
@@ -148,6 +150,7 @@ describe('useMarkAsWatched', () => {
       type: 'episode' as const,
       media: { id: 1, season: 1, number: 1, airDate: new Date() },
       show: { id: 3 },
+      title: 'Some Episode',
     };
 
     runCommonTests(props, InvalidateAction.MarkAsWatched('episode'));

--- a/projects/client/src/lib/sections/media-actions/remove-from-history/RemoveFromHistoryAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/remove-from-history/RemoveFromHistoryAction.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import RemoveFromHistoryButton from "$lib/components/buttons/remove-from-history/RemoveFromHistoryButton.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { HistoryEntry } from "$lib/sections/lists/stores/useRecentlyWatchedList";
   import { useRemoveFromHistory } from "./useRemoveFromHistory";
 
@@ -20,16 +18,7 @@
   }: RemoveFromHistoryActionProps = $props();
 
   const { isRemoving, removeFromHistory } = $derived(
-    useRemoveFromHistory(entry),
-  );
-
-  const { confirm } = useConfirm();
-  const confirmRemoveFromHistory = $derived(
-    confirm({
-      type: ConfirmationType.RemoveFromHistory,
-      title,
-      onConfirm: removeFromHistory,
-    }),
+    useRemoveFromHistory({ ...entry, title }),
   );
 </script>
 
@@ -38,5 +27,5 @@
   {title}
   {size}
   isRemoving={$isRemoving}
-  onRemove={confirmRemoveFromHistory}
+  onRemove={removeFromHistory}
 />

--- a/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.spec.ts
@@ -56,6 +56,7 @@ describe('useRemoveFromHistory', () => {
     const props = {
       type: 'movie' as const,
       id: 1,
+      title: 'Some Movie',
     };
 
     runCommonTests(props, InvalidateAction.MarkAsWatched('movie'));
@@ -65,6 +66,7 @@ describe('useRemoveFromHistory', () => {
     const props = {
       type: 'episode' as const,
       id: 1,
+      title: 'Some Episode',
     };
 
     runCommonTests(props, InvalidateAction.MarkAsWatched('episode'));

--- a/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.ts
+++ b/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.ts
@@ -1,5 +1,7 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
+import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { removeWatchedRequest } from '$lib/requests/sync/removeWatchedRequest.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
@@ -8,12 +10,16 @@ import { writable } from 'svelte/store';
 export type UseRemoveFromHistoryProps = {
   id: number;
   type: 'movie' | 'episode';
+  title: string;
 };
 
-export function useRemoveFromHistory({ id, type }: UseRemoveFromHistoryProps) {
+export function useRemoveFromHistory(
+  { id, type, title }: UseRemoveFromHistoryProps,
+) {
   const isRemoving = writable(false);
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.RemoveFromHistory);
+  const { confirm } = useConfirm();
 
   const removeFromHistory = async () => {
     isRemoving.set(true);
@@ -27,6 +33,10 @@ export function useRemoveFromHistory({ id, type }: UseRemoveFromHistoryProps) {
 
   return {
     isRemoving,
-    removeFromHistory,
+    removeFromHistory: confirm({
+      type: ConfirmationType.RemoveFromHistory,
+      title,
+      onConfirm: removeFromHistory,
+    }),
   };
 }

--- a/projects/client/src/lib/sections/media-actions/restore/RestoreAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/restore/RestoreAction.svelte
@@ -19,6 +19,7 @@
   const { restore, isRestoring } = $derived(
     useRestore({
       ids: [target.id],
+      title,
     }),
   );
 </script>

--- a/projects/client/src/lib/sections/media-actions/restore/RestoreButton.svelte
+++ b/projects/client/src/lib/sections/media-actions/restore/RestoreButton.svelte
@@ -6,21 +6,10 @@
   import Button from "$lib/components/buttons/Button.svelte";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import RestoreIcon from "$lib/components/icons/RestoreIcon.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { RestoreButtonProps } from "./RestoreButtonProps";
 
   const { title, onRestore, isRestoring, style, ...props }: RestoreButtonProps =
     $props();
-
-  const { confirm } = useConfirm();
-  const confirmRestore = $derived(
-    confirm({
-      type: ConfirmationType.RestoreShow,
-      title,
-      onConfirm: onRestore,
-    }),
-  );
 
   const { color, variant, ...events } = $derived(
     useDangerButton({ isActive: false, color: "default" }),
@@ -30,7 +19,7 @@
     label: m.button_label_restore_show({ title }),
     color: $color,
     variant: $variant,
-    onclick: confirmRestore,
+    onclick: onRestore,
     disabled: isRestoring,
     ...events,
   });

--- a/projects/client/src/lib/sections/media-actions/restore/useRestore.ts
+++ b/projects/client/src/lib/sections/media-actions/restore/useRestore.ts
@@ -1,6 +1,8 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
+import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { restoreShowCalendarRequest } from '$lib/requests/queries/users/restoreShowCalendarRequest.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
@@ -11,6 +13,7 @@ import { toBulkPayload } from '../_internal/toBulkPayload.ts';
 
 export type RestoreStoreProps = {
   ids: number[];
+  title: string;
 };
 
 export function useRestore(
@@ -21,6 +24,7 @@ export function useRestore(
   const { user } = useUser();
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Restore);
+  const { confirm } = useConfirm();
 
   const restore = async () => {
     const current = await resolve(user);
@@ -48,6 +52,10 @@ export function useRestore(
 
   return {
     isRestoring,
-    restore,
+    restore: confirm({
+      type: ConfirmationType.RestoreShow,
+      title: props.title,
+      onConfirm: restore,
+    }),
   };
 }

--- a/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import WatchlistButton from "$lib/components/buttons/watchlist/WatchlistButton.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import { onMount } from "svelte";
   import { useWatchlist } from "./useWatchlist";
   import type { WatchlistActionProps } from "./WatchListActionProps";
@@ -19,7 +17,7 @@
     isWatchlistUpdating,
     isWatchlisted,
     removeFromWatchlist,
-  } = $derived(useWatchlist(target));
+  } = $derived(useWatchlist({ ...target, title }));
 
   onMount(() => {
     if (!isUpdating) {
@@ -34,15 +32,6 @@
       destroy: unsubscribe,
     };
   });
-
-  const { confirm } = useConfirm();
-  const confirmRemove = $derived(
-    confirm({
-      type: ConfirmationType.RemoveFromWatchList,
-      title,
-      onConfirm: removeFromWatchlist,
-    }),
-  );
 </script>
 
 <WatchlistButton
@@ -52,5 +41,5 @@
   isWatchlisted={$isWatchlisted}
   isWatchlistUpdating={$isWatchlistUpdating}
   onAdd={addToWatchlist}
-  onRemove={confirmRemove}
+  onRemove={removeFromWatchlist}
 />

--- a/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.spec.ts
@@ -25,7 +25,10 @@ describe('useWatchlist', () => {
       .mockReturnValueOnce({ invalidate }); // 3: in useWatchlist -> useIsWatchlisted -> useUser
   });
 
-  const runCommonTests = (props: MediaStoreProps, invalidation: string) => {
+  const runCommonTests = (
+    props: MediaStoreProps & { title: string },
+    invalidation: string,
+  ) => {
     it('should NOT be updating watchlist when first requested', async () => {
       const { isWatchlistUpdating } = await renderStore(() =>
         useWatchlist(props)
@@ -97,6 +100,7 @@ describe('useWatchlist', () => {
     const props = {
       type: 'movie' as const,
       media: { id: 1 },
+      title: 'Some Movie',
     };
 
     runCommonTests(props, InvalidateAction.Watchlisted('movie'));
@@ -114,6 +118,7 @@ describe('useWatchlist', () => {
     const props = {
       type: 'show' as const,
       media: { id: 1 },
+      title: 'Some Show',
     };
 
     runCommonTests(props, InvalidateAction.Watchlisted('show'));

--- a/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
+++ b/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
@@ -1,5 +1,7 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
+import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { addToWatchlistRequest } from '$lib/requests/sync/addToWatchlistRequest.ts';
@@ -9,12 +11,14 @@ import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { writable } from 'svelte/store';
 import { useIsWatchlisted } from './useIsWatchlisted.ts';
 
-export function useWatchlist(props: MediaStoreProps) {
+type UseWatchlistProps = MediaStoreProps & { title: string };
+export function useWatchlist(props: UseWatchlistProps) {
   const { type } = props;
   const media = Array.isArray(props.media) ? props.media : [props.media];
   const isWatchlistUpdating = writable(false);
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Watchlist);
+  const { confirm } = useConfirm();
 
   const ids = media.map(({ id }) => id);
 
@@ -59,6 +63,10 @@ export function useWatchlist(props: MediaStoreProps) {
     isWatchlistUpdating,
     isWatchlisted,
     addToWatchlist,
-    removeFromWatchlist,
+    removeFromWatchlist: confirm({
+      type: ConfirmationType.RemoveFromWatchList,
+      title: props.title,
+      onConfirm: removeFromWatchlist,
+    }),
   };
 }

--- a/projects/client/src/lib/sections/profile-banner/_internal/FollowUserButton.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/FollowUserButton.svelte
@@ -1,32 +1,21 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { DisplayableProfileProps } from "$lib/sections/profile/DisplayableProfileProps";
   import { toDisplayableName } from "$lib/utils/profile/toDisplayableName";
-  import { useFollowUserRequest } from "./useFollowUser";
+  import { useFollowUser } from "./useFollowUser";
 
   const { profile, slug }: DisplayableProfileProps = $props();
+
+  const displayName = $derived(toDisplayableName(profile));
   const { isRequestingFollow, isFollowed, followUser, unfollowUser } = $derived(
-    useFollowUserRequest(slug),
-  );
-
-  const userDisplayName = $derived(toDisplayableName(profile));
-
-  const { confirm } = useConfirm();
-  const confirmUnfollow = $derived(
-    confirm({
-      type: ConfirmationType.UnfollowUser,
-      username: userDisplayName,
-      onConfirm: unfollowUser,
-    }),
+    useFollowUser({ slug, displayName }),
   );
 
   const label = $derived(
     $isFollowed
-      ? m.button_label_unfollow({ username: userDisplayName })
-      : m.button_label_follow({ username: userDisplayName }),
+      ? m.button_label_unfollow({ username: displayName })
+      : m.button_label_follow({ username: displayName }),
   );
 
   const text = $derived(
@@ -40,7 +29,7 @@
   variant={$isFollowed ? "secondary" : "primary"}
   {label}
   onclick={(event) => {
-    $isFollowed ? confirmUnfollow(event) : followUser();
+    $isFollowed ? unfollowUser(event) : followUser();
   }}
   disabled={$isRequestingFollow}
 >

--- a/projects/client/src/lib/sections/profile-banner/_internal/useFollowUser.ts
+++ b/projects/client/src/lib/sections/profile-banner/_internal/useFollowUser.ts
@@ -1,16 +1,25 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
+import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { followUserRequest } from '$lib/requests/queries/users/followUserRequest.ts';
 import { unfollowUserRequest } from '$lib/requests/queries/users/unfollowUserRequest.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { derived, writable } from 'svelte/store';
 
-export function useFollowUserRequest(slug: string) {
+type UseFollowUserProps = {
+  slug: string;
+  displayName: string;
+};
+
+export function useFollowUser({ slug, displayName }: UseFollowUserProps) {
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Follow);
   const { network } = useUser();
+  const { confirm } = useConfirm();
+
   const isRequestingFollow = writable(false);
 
   const isFollowed = derived(network, ($network) => {
@@ -47,6 +56,10 @@ export function useFollowUserRequest(slug: string) {
     isRequestingFollow,
     isFollowed,
     followUser,
-    unfollowUser,
+    unfollowUser: confirm({
+      type: ConfirmationType.UnfollowUser,
+      username: displayName,
+      onConfirm: unfollowUser,
+    }),
   };
 }

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/DeleteCommentButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/DeleteCommentButton.svelte
@@ -2,8 +2,6 @@
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
   import DeleteIcon from "$lib/components/icons/DeleteIcon.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { ExtendedMediaType } from "$lib/requests/models/ExtendedMediaType";
@@ -14,25 +12,18 @@
     $props();
 
   const { user } = useUser();
-  const { confirm } = useConfirm();
   const { isDeleting, deleteComment } = $derived(
     useDeleteComment({ comment, type }),
   );
 
   const isOwnComment = $derived(comment.user.id === $user.id);
-  const confirmDelete = $derived(
-    confirm({
-      type: ConfirmationType.DeleteComment,
-      onConfirm: () => deleteComment(),
-    }),
-  );
 </script>
 
 <RenderFor audience="authenticated">
   {#if isOwnComment}
     <div class="trakt-delete-comment">
       <ActionButton
-        onclick={confirmDelete}
+        onclick={deleteComment}
         label={m.button_label_delete_comment()}
         style="ghost"
         size="small"

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/useDeleteComment.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/useDeleteComment.ts
@@ -1,5 +1,7 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
+import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
 import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaComment } from '$lib/requests/models/MediaComment.ts';
@@ -18,6 +20,7 @@ export function useDeleteComment(
   const isDeleting = writable(false);
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.DeleteComment);
+  const { confirm } = useConfirm();
 
   const invalidateAction = comment.parentId > 0
     ? InvalidateAction.Comment.Reply
@@ -34,7 +37,10 @@ export function useDeleteComment(
   };
 
   return {
-    deleteComment,
+    deleteComment: confirm({
+      type: ConfirmationType.DeleteComment,
+      onConfirm: deleteComment,
+    }),
     isDeleting: derived(isDeleting, ($isDeleting) => $isDeleting),
   };
 }

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/ListDropdown.svelte
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/ListDropdown.svelte
@@ -3,8 +3,6 @@
   import Button from "$lib/components/buttons/Button.svelte";
   import WatchlistButton from "$lib/components/buttons/watchlist/WatchlistButton.svelte";
   import BookmarkIcon from "$lib/components/icons/BookmarkIcon.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import * as m from "$lib/features/i18n/messages";
   import { useWatchlist } from "$lib/sections/media-actions/watchlist/useWatchlist";
   import { onMount } from "svelte";
@@ -29,6 +27,7 @@
   const { isListed } = $derived(
     useIsOnAnyList({
       lists: $lists,
+      title,
       ...target,
     }),
   );
@@ -38,16 +37,7 @@
     isWatchlistUpdating,
     isWatchlisted,
     removeFromWatchlist,
-  } = $derived(useWatchlist(target));
-
-  const { confirm } = useConfirm();
-  const confirmRemove = $derived(
-    confirm({
-      type: ConfirmationType.RemoveFromWatchList,
-      title,
-      onConfirm: removeFromWatchlist,
-    }),
-  );
+  } = $derived(useWatchlist({ ...target, title }));
 
   const isDisabled = $derived(
     $isLoading || $isUpdating || $isWatchlistUpdating,
@@ -68,7 +58,7 @@
         return;
       }
 
-      $isWatchlisted ? confirmRemove() : addToWatchlist();
+      $isWatchlisted ? removeFromWatchlist() : addToWatchlist();
     });
   });
 </script>
@@ -81,7 +71,7 @@
     isWatchlistUpdating={$isWatchlistUpdating}
     isWatchlisted={$isWatchlisted}
     onAdd={addToWatchlist}
-    onRemove={confirmRemove}
+    onRemove={removeFromWatchlist}
   />
 
   {#each $lists as list}

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItem.svelte
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItem.svelte
@@ -3,8 +3,6 @@
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import BookmarkIcon from "$lib/components/icons/BookmarkIcon.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import type { MediaStoreProps } from "$lib/models/MediaStoreProps";
   import LoadingIndicator from "$lib/sections/lists/drilldown/_internal/LoadingIndicator.svelte";
   import { onMount } from "svelte";
@@ -26,6 +24,7 @@
     $derived(
       useList({
         list,
+        title,
         ...target,
       }),
     );
@@ -42,17 +41,7 @@
     };
   });
 
-  const { confirm } = useConfirm();
-  const confirmRemove = $derived(
-    confirm({
-      type: ConfirmationType.RemoveFromList,
-      title,
-      name: list.name,
-      onConfirm: removeFromList,
-    }),
-  );
-
-  const handler = $derived($isListed ? confirmRemove : addToList);
+  const handler = $derived($isListed ? removeFromList : addToList);
   const { color, variant, isTouch, ...events } = $derived(
     useDangerButton({ isActive: $isListed, color: "default" }),
   );

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/useIsOnAnyList.ts
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/useIsOnAnyList.ts
@@ -6,14 +6,15 @@ import { useList } from './useList.ts';
 
 type UseListCountProps = {
   lists: MediaListSummary[];
+  title: string;
 } & MediaStoreProps;
 
 // FIXME: replace with new list check endpoint when available
-export function useIsOnAnyList({ lists, ...target }: UseListCountProps) {
-  const { isWatchlisted } = useWatchlist(target);
+export function useIsOnAnyList({ lists, title, ...target }: UseListCountProps) {
+  const { isWatchlisted } = useWatchlist({ ...target, title });
 
   const personalLists = lists
-    .map((list) => useList({ list, ...target }))
+    .map((list) => useList({ list, title, ...target }))
     .map(({ isListed }) => isListed);
 
   return {

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/useList.ts
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/useList.ts
@@ -1,5 +1,7 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
+import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
@@ -12,14 +14,14 @@ import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { writable } from 'svelte/store';
 import { useIsListed } from './useIsListed.ts';
 
-type UseListProps = { list: MediaListSummary } & MediaStoreProps;
+type UseListProps = { list: MediaListSummary; title: string } & MediaStoreProps;
 
 export function useList(props: UseListProps) {
   const { type } = props;
   const media = Array.isArray(props.media) ? props.media : [props.media];
   const isListUpdating = writable(false);
   const { invalidate } = useInvalidator();
-
+  const { confirm } = useConfirm();
   const { isListed, itemCount } = useIsListed(props);
 
   const { track } = useTrack(AnalyticsEvent.List);
@@ -64,7 +66,12 @@ export function useList(props: UseListProps) {
 
   return {
     addToList,
-    removeFromList,
+    removeFromList: confirm({
+      type: ConfirmationType.RemoveFromList,
+      title: props.title,
+      name: props.list.name,
+      onConfirm: removeFromList,
+    }),
     isListUpdating,
     isListed,
     itemCount,

--- a/projects/client/src/lib/sections/toast/_internal/StopButton.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/StopButton.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
   import CloseIcon from "$lib/components/icons/CloseIcon.svelte";
-  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
-  import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { NowPlayingItem } from "$lib/requests/models/NowPlayingItem";
   import { useStopNowPlaying } from "./useStopNowPlaying";
@@ -16,23 +14,14 @@
   } = $props();
 
   const { stop, isStopping, isStoppable } = $derived(
-    useStopNowPlaying(nowPlaying),
-  );
-
-  const { confirm } = useConfirm();
-  const confirmStop = $derived(
-    confirm({
-      type: ConfirmationType.StopCheckin,
-      title,
-      onConfirm: stop,
-    }),
+    useStopNowPlaying(nowPlaying, title),
   );
 </script>
 
 {#if isStoppable}
   <ActionButton
     disabled={$isStopping}
-    onclick={confirmStop}
+    onclick={stop}
     label={m.button_label_stop_playing({ title })}
     style="ghost"
     size="small"

--- a/projects/client/src/lib/sections/toast/_internal/useStopNowPlaying.ts
+++ b/projects/client/src/lib/sections/toast/_internal/useStopNowPlaying.ts
@@ -1,14 +1,17 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { ConfirmationType } from '$lib/features/confirmation/models/ConfirmationType.ts';
+import { useConfirm } from '$lib/features/confirmation/useConfirm.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { NowPlayingItem } from '$lib/requests/models/NowPlayingItem.ts';
 import { deleteCheckinRequest } from '$lib/requests/queries/checkin/deleteCheckinRequest.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { derived, writable } from 'svelte/store';
 
-export function useStopNowPlaying(nowPlaying: NowPlayingItem) {
+export function useStopNowPlaying(nowPlaying: NowPlayingItem, title: string) {
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.CheckIn);
+  const { confirm } = useConfirm();
 
   const isStopping = writable(false);
   const isStoppable = nowPlaying.action === 'checkin';
@@ -29,7 +32,11 @@ export function useStopNowPlaying(nowPlaying: NowPlayingItem) {
 
   return {
     isStopping: derived(isStopping, ($isStopping) => $isStopping),
-    stop: deleteCheckin,
+    stop: confirm({
+      type: ConfirmationType.StopCheckin,
+      title,
+      onConfirm: deleteCheckin,
+    }),
     isStoppable,
   };
 }

--- a/projects/client/test/beds/_internal/TestProvider.svelte
+++ b/projects/client/test/beds/_internal/TestProvider.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import AnalyticsProvider from "$lib/features/analytics/AnalyticsProvider.svelte";
   import AuthProvider from "$lib/features/auth/components/AuthProvider.svelte";
+  import ConfirmationProvider from "$lib/features/confirmation/ConfirmationProvider.svelte";
   import NavigationProvider from "$lib/features/navigation/NavigationProvider.svelte";
   import SearchProvider from "$lib/features/search/SearchProvider.svelte";
   import ToastProvider from "$lib/features/toast/ToastProvider.svelte";
@@ -14,22 +15,24 @@
 <!-- TODO: add more providers here as we expand test suite -->
 <AuthProvider isAuthorized={$isAuthorized} isAuthorizedLegacy={false}>
   <QueryClientProvider client={new QueryClient()}>
-    <ToastProvider>
-      <SearchProvider
-        config={{
-          keys: {
-            media: "",
-            people: "",
-          },
-          server: "",
-        }}
-      >
-        <NavigationProvider device="unknown">
-          <AnalyticsProvider>
-            {@render children()}
-          </AnalyticsProvider>
-        </NavigationProvider>
-      </SearchProvider>
-    </ToastProvider>
+    <ConfirmationProvider>
+      <ToastProvider>
+        <SearchProvider
+          config={{
+            keys: {
+              media: "",
+              people: "",
+            },
+            server: "",
+          }}
+        >
+          <NavigationProvider device="unknown">
+            <AnalyticsProvider>
+              {@render children()}
+            </AnalyticsProvider>
+          </NavigationProvider>
+        </SearchProvider>
+      </ToastProvider>
+    </ConfirmationProvider>
   </QueryClientProvider>
 </AuthProvider>

--- a/projects/client/test/mocks/useConfirm.mock.ts
+++ b/projects/client/test/mocks/useConfirm.mock.ts
@@ -1,0 +1,9 @@
+import { vi } from 'vitest';
+
+vi.mock('$lib/features/confirmation/useConfirm.ts', () => ({
+  useConfirm: vi.fn(() => ({
+    confirm: vi.fn((props) => async () => {
+      await props.onConfirm();
+    }),
+  })),
+}));

--- a/projects/client/vitest-setup.ts
+++ b/projects/client/vitest-setup.ts
@@ -11,6 +11,7 @@ import './test/mocks/navigator.mock.ts';
 import './test/mocks/oidc-client-ts.mock.ts';
 import './test/mocks/ResizeObserver.mock.ts';
 import './test/mocks/scrollTo.mock.ts';
+import './test/mocks/useConfirm.mock.ts';
 import './test/mocks/variables.mock.ts';
 
 import { setAuthorization } from '$test/beds/store/renderStore.ts';


### PR DESCRIPTION
## ⚠️ Warning ⚠️

- Drafted for now; need to dive a bit more into why this broken the app state mock 🤔

## 🎶 Notes 🎶

- Moves all confirmations to their respective stores.
  - When re-using stores, we non longer have to duplicate all the `useConfirm` usages.