### PR TITLE
feat(discover): portrait cards for start watching

### DIFF
--- a/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
@@ -21,6 +21,7 @@
     filter,
     metaInfo,
     drilldownLink,
+    variant,
   }: MediaListProps<T, M> = $props();
 
   const { list, isLoading } = $derived(
@@ -28,6 +29,8 @@
   );
 
   const defaultVariant = useDefaultCardVariant(type);
+  const height = $derived(mediaListHeightResolver(variant ?? $defaultVariant));
+
   const { hasActiveFilter } = useFilter();
 </script>
 
@@ -47,7 +50,7 @@
   {metaInfo}
   {drilldownLink}
   actions={externalActions ? actions : undefined}
-  --height-list={mediaListHeightResolver($defaultVariant)}
+  --height-list={height}
 >
   {#snippet empty()}
     {#if $isLoading}

--- a/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
@@ -14,4 +14,5 @@ export type MediaListProps<T, M> = {
   badge?: Snippet;
   metaInfo?: string;
   drilldownLink?: string;
+  variant?: 'portrait' | 'landscape';
 } & FilterParams;

--- a/projects/client/src/lib/sections/lists/progress/UpNextList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextList.svelte
@@ -10,7 +10,7 @@
   import CtaItem from "../components/cta/CtaItem.svelte";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
   import { useStablePaginated } from "../stores/useStablePaginated";
-  import { mediaListHeightResolver } from "../utils/mediaListHeightResolver";
+  import WatchlistItem from "../watchlist/WatchlistItem.svelte";
   import UpNextItem from "./UpNextItem.svelte";
   import { useHiddenShows } from "./useHiddenShows";
   import { useUpNextList } from "./useUpNextList";
@@ -28,7 +28,7 @@
   upNextIntent: "all" | "continue" | "start",
 )}
   <DrillableMediaList
-    type="episode"
+    {type}
     id={`up-next-list-${type}-${upNextIntent}`}
     source={{
       id: upNextIntent === "start" ? "start-watching" : "continue-watching",
@@ -50,16 +50,22 @@
         },
       })}
     urlBuilder={() =>
-      intent === "start"
+      upNextIntent === "start"
         ? UrlBuilder.startWatching($user?.slug ?? "")
         : UrlBuilder.progress($user?.slug ?? "")}
-    title={intent === "start"
+    title={upNextIntent === "start"
       ? m.list_title_start_watching()
       : m.list_title_up_next()}
-    --height-list={mediaListHeightResolver("landscape")}
+    variant={intent === "start" ? "portrait" : "landscape"}
   >
     {#snippet item(mediaItem)}
-      {#if "show" in mediaItem}
+      {#if upNextIntent === "start"}
+        <WatchlistItem
+          type={"show" in mediaItem ? "show" : "movie"}
+          media={"show" in mediaItem ? mediaItem.show : mediaItem}
+          mode={type === "media" ? "mixed" : "standalone"}
+        />
+      {:else if "show" in mediaItem}
         <UpNextItem
           style="cover"
           episode={mediaItem}

--- a/projects/client/src/lib/sections/lists/watchlist/WatchlistItem.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchlistItem.svelte
@@ -5,7 +5,8 @@
   import DefaultMediaItem from "../components/DefaultMediaItem.svelte";
   import type { MediaCardProps } from "../components/MediaCardProps";
 
-  const { type, media, style }: MediaCardProps<MediaInputDefault> = $props();
+  const { type, media, style, mode }: MediaCardProps<MediaInputDefault> =
+    $props();
 </script>
 
 {#snippet action()}
@@ -24,6 +25,7 @@
   {type}
   {media}
   {style}
+  {mode}
   action={media.status === "released" ? action : undefined}
   source="watchlist"
 />


### PR DESCRIPTION
## 🎶 Notes 🎶

- Switches back to portrait cards for `Start Watching`
  - Note: the footer for shows will change when I tackle the actions (e.g. it should show S1 E1, and the mark as watched action should mark the first ep as watched).

## 👀 Example 👀
<img width="429" height="928" alt="Screenshot 2025-10-27 at 12 49 27" src="https://github.com/user-attachments/assets/90668604-cb68-4da0-b922-baf96b9aa400" />
