### PR TITLE
fix(recommended): temporarily always hide watched from recommended

### DIFF
--- a/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
@@ -26,6 +26,8 @@ const recommendedMoviesRequest = (
         ignore_collected: true,
         limit,
         ...filter,
+        // FIXME: remove when we have tri-state filter toggles
+        ignore_watched: true,
       },
     });
 

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
@@ -27,6 +27,8 @@ const recommendedShowsRequest = (
         ignore_collected: true,
         limit,
         ...filter,
+        // FIXME: remove when we have tri-state filter toggles
+        ignore_watched: true,
       },
     });
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Temporarily always hide watched from recommended shows/movies (more details: https://github.com/trakt/trakt-web/issues/1180)
  - Will be removed when adding tri-state filter toggles.