### PR TITLE
fix(footer): multiline copyright notice on small devices

### DIFF
--- a/projects/client/src/lib/sections/footer/components/CopyRight.svelte
+++ b/projects/client/src/lib/sections/footer/components/CopyRight.svelte
@@ -1,16 +1,31 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
 
   const currentYear = new Date().getFullYear();
+  const copyright = $derived(`© 2010-${currentYear} trakt, inc.`);
 </script>
 
-<div class="trakt-copyright">
+{#snippet content(copyrightText: string, subtitleText: string)}
   <p class="secondary meta-info">
-    © 2010-{currentYear} trakt, inc. {m.text_copyright_notice()}
+    {copyrightText}
   </p>
-  <p class="secondary meta-info copyright-crafted-by">
-    {m.text_copyright_crafted_by()}
+  <p class="secondary meta-info">
+    {subtitleText}
   </p>
+{/snippet}
+
+<div class="trakt-copyright">
+  <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
+    {@render content(
+      `${copyright} ${m.text_copyright_notice()}`,
+      m.text_copyright_crafted_by(),
+    )}
+  </RenderFor>
+
+  <RenderFor audience="all" device={["tablet-sm", "mobile"]}>
+    {@render content(copyright, m.text_copyright_notice())}
+  </RenderFor>
 </div>
 
 <style lang="scss">
@@ -22,11 +37,5 @@
     gap: var(--ni-8);
 
     width: fit-content;
-
-    @include for-tablet-sm-and-below {
-      .copyright-crafted-by {
-        display: none;
-      }
-    }
   }
 </style>


### PR DESCRIPTION
## ♪ Note ♪

- Splits up the notice in the footer on small devices.
  - It already had its own translation 🤦

## 👀 Example 👀
<img width="429" height="186" alt="Screenshot 2025-10-27 at 18 43 49" src="https://github.com/user-attachments/assets/aa552fe1-e730-48ac-8f0e-d206108cf2b4" />
