### PR TITLE
fix: always sort lists by rank

### DIFF
--- a/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
@@ -57,6 +57,7 @@ const userListItemsRequest = (
         extended: 'full,images,colors',
         page,
         limit,
+        sort_by: 'rank',
         ...filter,
       },
     });


### PR DESCRIPTION
## ♪ Note ♪

- Always sort items by `rank`. The set order can't be trusted yet, since `random` is random per page and leads to duplicate items.