### PR TITLE
fix(comment): clamp preview on all browsers

### DIFF
--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentBody.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentBody.svelte
@@ -11,6 +11,8 @@
     spoilerExtension,
   } from "./spoilerExtension";
 
+  const MAX_PREVIEW_LINES = 3;
+
   type CommentBodyProps = {
     media: MediaEntry;
     comment: MediaComment;
@@ -49,12 +51,14 @@
     {#if type === "full"}
       {@render commentText()}
     {:else}
-      <button
-        class="trakt-comment-preview"
-        use:lineClamp={{ lines: 3 }}
-        onclick={onClick}
-      >
-        {@render commentText()}
+      <button class="trakt-comment-preview" onclick={onClick}>
+        <div
+          class="trakt-comment-preview-content"
+          use:lineClamp={{ lines: MAX_PREVIEW_LINES }}
+          style="--max-lines: {MAX_PREVIEW_LINES}"
+        >
+          {@render commentText()}
+        </div>
       </button>
     {/if}
   </div>
@@ -82,10 +86,18 @@
   }
 
   .trakt-comment-preview {
+    --preview-height: var(--ni-52);
+
     all: unset;
     -webkit-tap-highlight-color: transparent;
     cursor: pointer;
+    display: flex;
+    height: var(--preview-height);
 
-    min-height: var(--ni-52);
+    .trakt-comment-preview-content {
+      :global(p) {
+        line-height: calc(var(--preview-height) / var(--max-lines));
+      }
+    }
   }
 </style>


### PR DESCRIPTION
## ♪ Note ♪

- Fixes comment preview clamping on Safari.

## 👀 Example 👀

Before:
<img width="995" height="254" alt="Screenshot 2025-10-29 at 08 21 21" src="https://github.com/user-attachments/assets/94e97030-cb4a-4d5d-baa2-78a155884ce6" />


After:
<img width="995" height="254" alt="Screenshot 2025-10-29 at 08 21 12" src="https://github.com/user-attachments/assets/d4638cbe-83c2-4218-9100-f0c98f4a5810" />

