### PR TITLE
feat(summary): move header actions to popup menu

### DIFF
--- a/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
@@ -83,20 +83,26 @@
     </SummaryPoster>
   {/snippet}
 
-  <SummaryHeader>
-    {#snippet headerActions()}
+  <SummaryHeader {title}>
+    {#snippet popupActions()}
       <RenderFor audience="authenticated" navigation="default">
-        <CheckInAction
-          style="normal"
-          size="small"
-          {title}
+        <StreamOnButton
+          {streamOn}
           {type}
-          {show}
           {episode}
+          media={show}
+          style="dropdown-item"
         />
+        <CheckInAction style="dropdown-item" {title} {type} {show} {episode} />
       </RenderFor>
-      <SetCoverImageAction style="action" {type} id={episode.id} {title} />
+      <SetCoverImageAction
+        style="dropdown-item"
+        {type}
+        id={episode.id}
+        {title}
+      />
       <ShareButton
+        style="dropdown-item"
         {title}
         textFactory={({ title }) =>
           m.text_share_episode({

--- a/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaMetaInfo.svelte
@@ -5,9 +5,7 @@
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import WatchCountTag from "$lib/components/media/tags/WatchCountTag.svelte";
   import RatingList from "$lib/components/summary/RatingList.svelte";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { StreamOn } from "$lib/requests/models/StreamOn";
-  import StreamOnButton from "../stream/StreamOnButton.svelte";
   import { useMediaMetaInfo, type MetaInfoProps } from "./useMediaMetaInfo";
 
   type MediaMetaInfoProps = {
@@ -47,22 +45,6 @@
       {/if}
     </div>
   </div>
-  <div class="trakt-summary-watch-container">
-    <RenderFor
-      device={["tablet-lg", "desktop"]}
-      audience="all"
-      navigation="default"
-    >
-      <StreamOnButton {streamOn} {...target} style="normal" />
-    </RenderFor>
-    <RenderFor
-      device={["tablet-sm", "mobile"]}
-      audience="all"
-      navigation="default"
-    >
-      <StreamOnButton {streamOn} {...target} style="logo" />
-    </RenderFor>
-  </div>
 </div>
 
 <style>
@@ -83,7 +65,6 @@
     gap: var(--gap-xs);
   }
 
-  .trakt-summary-watch-container,
   .trakt-meta-tags {
     display: flex;
     align-items: center;

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -119,27 +119,24 @@
     </SummaryPoster>
   {/snippet}
 
-  <SummaryHeader>
-    {#snippet headerActions()}
+  <SummaryHeader {title}>
+    {#snippet popupActions()}
       <RenderFor audience="authenticated" navigation="default">
+        <StreamOnButton {streamOn} {type} {media} style="dropdown-item" />
+
         {#if media.type === "movie"}
-          <CheckInAction
-            size="small"
-            style="normal"
-            type="movie"
-            {title}
-            {media}
-          />
+          <CheckInAction style="dropdown-item" type="movie" {title} {media} />
         {/if}
       </RenderFor>
       <SetCoverImageAction
-        style="action"
+        style="dropdown-item"
         type={media.type}
         id={media.id}
         {title}
       />
       <ShareButton
         {title}
+        style="dropdown-item"
         textFactory={({ title }) => {
           switch (type) {
             case "movie":

--- a/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
@@ -16,7 +16,7 @@
     <SummaryPoster src={person.headshot.url.medium} alt={person.name} />
   {/snippet}
 
-  <SummaryHeader>
+  <SummaryHeader title={person.name}>
     {#snippet headerActions()}
       <ShareButton
         title={person.name}

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
@@ -1,14 +1,26 @@
 <script lang="ts">
+  import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
+  import * as m from "$lib/features/i18n/messages";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { Snippet } from "svelte";
 
   const {
     children,
     headerActions,
-  }: ChildrenProps & { headerActions?: Snippet } = $props();
+    popupActions,
+    title,
+  }: ChildrenProps & {
+    headerActions?: Snippet;
+    popupActions?: Snippet;
+    title: string;
+  } = $props();
 </script>
 
 <div class="trakt-summary-header">
+  <div class="trakt-summary-header-children">
+    {@render children()}
+  </div>
+
   {#if headerActions}
     <RenderFor audience="all" navigation="default">
       <div class="trakt-summary-action-header">
@@ -16,9 +28,18 @@
       </div>
     </RenderFor>
   {/if}
-  <div class="trakt-summary-header-children">
-    {@render children()}
-  </div>
+
+  {#if popupActions}
+    <RenderFor audience="all" navigation="default">
+      <div class="trakt-summary-action-header">
+        <PopupMenu label={m.button_label_popup_menu({ title })} size="normal">
+          {#snippet items()}
+            {@render popupActions()}
+          {/snippet}
+        </PopupMenu>
+      </div>
+    </RenderFor>
+  {/if}
 </div>
 
 <style lang="scss">
@@ -30,6 +51,8 @@
     display: flex;
     justify-content: flex-end;
     gap: var(--gap-xs);
+
+    flex: 1;
   }
 
   .trakt-summary-header-children {
@@ -40,7 +63,7 @@
 
   .trakt-summary-header {
     display: flex;
-    flex-direction: column;
     gap: var(--gap-xs);
+    justify-content: space-between;
   }
 </style>


### PR DESCRIPTION
## ♪ Note ♪

- Moves summary header actions to a popup menu.

## 👀 Example 👀

Before:
<img width="1453" height="1033" alt="Screenshot 2025-10-29 at 09 23 52" src="https://github.com/user-attachments/assets/e04cfd03-aee3-4a6f-957c-6a574e5408ba" />

After:

https://github.com/user-attachments/assets/24d8a242-be5b-44f8-9c69-3e4c4025b8d0


