### PR TITLE
fix: do not reset page data if still on first page

### DIFF
--- a/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
@@ -48,7 +48,7 @@
   });
 
   $effect(() => {
-    if ($initialType === type) {
+    if ($initialType === type || $currentPage === 1) {
       return;
     }
 


### PR DESCRIPTION
## ♪ Note ♪

- Do not reset page data if still on the first page of data.

## 👀 Example 👀
Before:


https://github.com/user-attachments/assets/502702dd-2876-44f0-b434-021662f258b1


After:

https://github.com/user-attachments/assets/017da395-bb1b-4b5d-b2e2-f84c1fbd2abb

