### PR TITLE
fix(comment): properly handle headings

### DIFF
--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentBody.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentBody.svelte
@@ -27,6 +27,9 @@
       extensions: [spoilerExtension()],
       renderer: {
         paragraph: createParagraphSpoilerRenderer(comment.isSpoiler),
+        heading: (tokens) => {
+          return `<h6 class="trakt-comment-heading">${tokens.text}</h6>`;
+        },
       },
     }),
   );
@@ -82,6 +85,11 @@
     :global(p),
     :global(li) {
       font-size: inherit;
+    }
+
+    :global(.trakt-comment-heading) {
+      text-transform: none;
+      text-decoration: underline;
     }
   }
 


### PR DESCRIPTION
## ♪ Note ♪

- Properly deal with comment headings

## 👀 Example 👀

before/after:
<img width="479" height="1017" alt="Screenshot 2025-11-03 at 11 15 00" src="https://github.com/user-attachments/assets/8628bf0e-8b6e-4121-a70f-8e11db004571" />

<img width="479" height="497" alt="Screenshot 2025-11-03 at 11 14 39" src="https://github.com/user-attachments/assets/f74bab41-3c5a-4f9c-99ab-9ad90555aeb4" />
