### PR TITLE
fix(summary): display half star ratings

### DIFF
--- a/projects/client/src/lib/sections/summary/components/rating/_internal/getStarFillPercentage.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/getStarFillPercentage.spec.ts
@@ -23,9 +23,9 @@ describe('getStarFillPercentage', () => {
     const star3 = { index: 3, value: 6, range: { min: 4, max: 6 } };
     const star4 = { index: 4, value: 8, range: { min: 6, max: 8 } };
 
-    const rating = 7.5;
+    const rating = 7;
     expect(getStarFillPercentage(star2, rating)).toBe(100);
     expect(getStarFillPercentage(star3, rating)).toBe(100);
-    expect(getStarFillPercentage(star4, rating)).toBe(100);
+    expect(getStarFillPercentage(star4, rating)).toBe(50);
   });
 });

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/getStarFillPercentage.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/getStarFillPercentage.ts
@@ -1,4 +1,3 @@
-import { STAR_RATINGS } from '../constants/index.ts';
 import type { StarRating } from '../models/StarRating.ts';
 
 export function getStarFillPercentage(
@@ -9,9 +8,14 @@ export function getStarFillPercentage(
     return 0;
   }
 
-  const step = 10 / STAR_RATINGS.length;
-  const roundedRating = Math.round(rating / step) * step;
-  const value = star.index * step;
+  const { min, max } = star.range;
 
-  return value <= roundedRating ? 100 : 0;
+  if (rating >= max) {
+    return 100;
+  }
+  if (rating <= min) {
+    return 0;
+  }
+
+  return ((rating - min) / (max - min)) * 100;
 }


### PR DESCRIPTION
## ♪ Note ♪

- Display ratings as is without rounding the stars.

## 👀 Example 👀
Before/after:

<img width="1118" height="670" alt="Screenshot 2025-11-03 at 17 57 16" src="https://github.com/user-attachments/assets/81a5caed-6ccf-4947-92e5-103784f980fc" />

<img width="1118" height="670" alt="Screenshot 2025-11-03 at 17 59 29" src="https://github.com/user-attachments/assets/c27aa4ed-c490-4ecc-9fc8-18a6fb81f13b" />
