### PR TITLE
Feat/single indicator tags

### DIFF
--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -123,7 +123,7 @@
       {media}
       {style}
       tag={rest.variant !== "next" ? tag : undefined}
-      indicators={canDeemphasize ? indicatorTags : undefined}
+      indicators={indicatorTags}
       {...rest}
       {popupActions}
     />


### PR DESCRIPTION
## 🎶 Notes 🎶

- Displays only a single indicator tag, in the following prio: `watched` -> `watchlisted`
- ~~Search results also indicate status now.~~
- Indicator tags are now always used in `DefaultMediaItem`

## 👀 Examples 👀
<img width="1445" height="838" alt="Screenshot 2025-11-04 at 11 47 53" src="https://github.com/user-attachments/assets/e7443848-091f-4ebd-a2ae-d505faf019c7" />

<img width="1445" height="814" alt="Screenshot 2025-11-04 at 11 48 01" src="https://github.com/user-attachments/assets/c3b2daf1-086a-4e4e-8b9d-7a4c7bdeb8c6" />

<img width="428" height="930" alt="Screenshot 2025-11-04 at 11 48 29" src="https://github.com/user-attachments/assets/cde6ca0c-641c-427c-becf-c0dc7b2d1451" />
