### PR TITLE
feat(activity): split up activity list in personal and social

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Социално"
     },
-    "button_label_social": {
-      "default": "Вижте социалната активност"
-    },
     "button_text_personal": {
       "default": "Лично"
-    },
-    "button_label_personal": {
-      "default": "Вижте личната активност"
     },
     "page_title_unexpected_error": {
       "default": "Нещо се обърка"

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Socialt"
     },
-    "button_label_social": {
-      "default": "Vis social aktivitet"
-    },
     "button_text_personal": {
       "default": "Personligt"
-    },
-    "button_label_personal": {
-      "default": "Vis personlig aktivitet"
     },
     "page_title_unexpected_error": {
       "default": "Noget gik galt"

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Sozial"
     },
-    "button_label_social": {
-      "default": "Soziale Aktivität ansehen"
-    },
     "button_text_personal": {
       "default": "Persönlich"
-    },
-    "button_label_personal": {
-      "default": "Persönliche Aktivität ansehen"
     },
     "page_title_unexpected_error": {
       "default": "Etwas ist schiefgelaufen"

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Social"
     },
-    "button_label_social": {
-      "default": "View social activity"
-    },
     "button_text_personal": {
       "default": "Personal"
-    },
-    "button_label_personal": {
-      "default": "View personal activity"
     },
     "page_title_unexpected_error": {
       "default": "Something went wrong"

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5093,26 +5093,10 @@
         "ios"
       ]
     },
-    "button_label_social": {
-      "default": "View social activity",
-      "description": "Aria-label for the button that allows users to view social activity.",
-      "exclude": [
-        "android",
-        "ios"
-      ]
-    },
     "button_text_personal": {
       "default": "Personal",
       "description": "Text for the button that allows users to view their own activity.",
       "exclude": [
-        "ios"
-      ]
-    },
-    "button_label_personal": {
-      "default": "View personal activity",
-      "description": "Aria-label for the button that allows users to view their own activity.",
-      "exclude": [
-        "android",
         "ios"
       ]
     },

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Social"
     },
-    "button_label_social": {
-      "default": "Ver actividad social"
-    },
     "button_text_personal": {
       "default": "Personal"
-    },
-    "button_label_personal": {
-      "default": "Ver actividad personal"
     },
     "page_title_unexpected_error": {
       "default": "Algo salió mal"

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Social"
     },
-    "button_label_social": {
-      "default": "Ver actividad social"
-    },
     "button_text_personal": {
       "default": "Personal"
-    },
-    "button_label_personal": {
-      "default": "Ver actividad personal"
     },
     "page_title_unexpected_error": {
       "default": "Algo salió mal"

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Social"
     },
-    "button_label_social": {
-      "default": "Voir l'activité sociale"
-    },
     "button_text_personal": {
       "default": "Personnel"
-    },
-    "button_label_personal": {
-      "default": "Voir votre activité"
     },
     "page_title_unexpected_error": {
       "default": "Quelque chose s'est mal passé"

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Social"
     },
-    "button_label_social": {
-      "default": "Voir l'activité sociale"
-    },
     "button_text_personal": {
       "default": "Personnel"
-    },
-    "button_label_personal": {
-      "default": "Voir l'activité personnelle"
     },
     "page_title_unexpected_error": {
       "default": "Un problème est survenu"

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Social"
     },
-    "button_label_social": {
-      "default": "Visualizza attività social"
-    },
     "button_text_personal": {
       "default": "Personale"
-    },
-    "button_label_personal": {
-      "default": "Visualizza attività personale"
     },
     "page_title_unexpected_error": {
       "default": "Qualcosa è andato storto"

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "ソーシャル"
     },
-    "button_label_social": {
-      "default": "ソーシャルアクティビティを表示"
-    },
     "button_text_personal": {
       "default": "パーソナル"
-    },
-    "button_label_personal": {
-      "default": "パーソナルアクティビティを表示"
     },
     "page_title_unexpected_error": {
       "default": "問題が発生しました"

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Sosialt"
     },
-    "button_label_social": {
-      "default": "Vis sosial aktivitet"
-    },
     "button_text_personal": {
       "default": "Personlig"
-    },
-    "button_label_personal": {
-      "default": "Vis personlig aktivitet"
     },
     "page_title_unexpected_error": {
       "default": "Noe gikk galt"

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Sociaal"
     },
-    "button_label_social": {
-      "default": "Bekijk sociale activiteit"
-    },
     "button_text_personal": {
       "default": "Persoonlijk"
-    },
-    "button_label_personal": {
-      "default": "Bekijk persoonlijke activiteit"
     },
     "page_title_unexpected_error": {
       "default": "Er is iets misgegaan"

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Społecznościowe"
     },
-    "button_label_social": {
-      "default": "Wyświetl aktywność społecznościową"
-    },
     "button_text_personal": {
       "default": "Osobiste"
-    },
-    "button_label_personal": {
-      "default": "Wyświetl aktywność osobistą"
     },
     "page_title_unexpected_error": {
       "default": "Coś poszło nie tak"

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Social"
     },
-    "button_label_social": {
-      "default": "Ver atividade social"
-    },
     "button_text_personal": {
       "default": "Pessoal"
-    },
-    "button_label_personal": {
-      "default": "Ver atividade pessoal"
     },
     "page_title_unexpected_error": {
       "default": "Algo deu errado"

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Social"
     },
-    "button_label_social": {
-      "default": "Vezi activitatea socială"
-    },
     "button_text_personal": {
       "default": "Personal"
-    },
-    "button_label_personal": {
-      "default": "Vezi activitatea personală"
     },
     "page_title_unexpected_error": {
       "default": "Ceva n-a mers bine"

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Socialt"
     },
-    "button_label_social": {
-      "default": "Visa social aktivitet"
-    },
     "button_text_personal": {
       "default": "Personligt"
-    },
-    "button_label_personal": {
-      "default": "Visa personlig aktivitet"
     },
     "page_title_unexpected_error": {
       "default": "Något gick fel"

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1846,14 +1846,8 @@
     "button_text_social": {
       "default": "Соціальне"
     },
-    "button_label_social": {
-      "default": "Переглянути соціальну активність"
-    },
     "button_text_personal": {
       "default": "Особисте"
-    },
-    "button_label_personal": {
-      "default": "Переглянути особисту активність"
     },
     "page_title_unexpected_error": {
       "default": "Щось пішло не так"

--- a/projects/client/src/lib/components/toggles/_internal/ToggleIcon.svelte
+++ b/projects/client/src/lib/components/toggles/_internal/ToggleIcon.svelte
@@ -7,11 +7,8 @@
   import PopularIcon from "$lib/components/icons/PopularIcon.svelte";
   import RecentIcon from "$lib/components/icons/RecentIcon.svelte";
   import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
-  import SocialIcon from "$lib/components/icons/SocialIcon.svelte";
   import type { ToggleOption } from "$lib/components/toggles/ToggleOption";
   import { useUser } from "$lib/features/auth/stores/useUser.ts";
-  import * as m from "$lib/features/i18n/messages.ts";
-  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
 
   interface ToggleIconProps {
     option: ToggleOption<T>;
@@ -34,17 +31,6 @@
 
 {#if option.value === "show"}
   <ShowIcon />
-{/if}
-
-{#if option.value === "social"}
-  <SocialIcon />
-{/if}
-
-{#if option.value === "personal"}
-  <CrossOriginImage
-    src={$user.avatar.url}
-    alt={m.image_alt_user_avatar({ username: $user.name.full })}
-  />
 {/if}
 
 {#if option.value === "people"}

--- a/projects/client/src/lib/components/toggles/_internal/constants.ts
+++ b/projects/client/src/lib/components/toggles/_internal/constants.ts
@@ -2,11 +2,9 @@ import type { DiscoverMode } from '$lib/features/discover/models/DiscoverMode.ts
 import * as m from '$lib/features/i18n/messages.ts';
 import type { CommentSortType } from '$lib/requests/models/CommentSortType.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
-import type { ActivityType } from '$lib/sections/lists/activity/models/ActivityType.ts';
 import type { ToggleOption } from '../ToggleOption.ts';
 
 export type TogglerId =
-  | 'activity'
   | 'media'
   | 'social'
   | 'discover'
@@ -24,7 +22,6 @@ type Toggler<T, K> = {
 };
 
 export type TogglerValueMap = {
-  activity: ActivityType;
   media: MediaToggleType;
   social: SocialToggleType;
   discover: DiscoverToggleType;
@@ -32,23 +29,6 @@ export type TogglerValueMap = {
 };
 
 type ToggleDefinition<K extends TogglerId> = Toggler<K, TogglerValueMap[K]>;
-
-const activity: ToggleDefinition<'activity'> = {
-  id: 'activity',
-  default: 'social',
-  options: [
-    {
-      value: 'social',
-      text: m.button_text_social,
-      label: m.button_label_social,
-    },
-    {
-      value: 'personal',
-      text: m.button_text_personal,
-      label: m.button_label_personal,
-    },
-  ],
-};
 
 const media: ToggleDefinition<'media'> = {
   id: 'media',
@@ -131,7 +111,6 @@ const comment: ToggleDefinition<'comment'> = {
 export const TOGGLERS: {
   [K in TogglerId]: Toggler<K, TogglerValueMap[K]>;
 } = {
-  activity,
   media,
   social,
   discover,

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -27,7 +27,8 @@
     <UpNextList intent="continue" />
     <UpNextList intent="start" />
     <UpcomingList />
-    <ActivityList />
+    <ActivityList activityType="personal" />
+    <ActivityList activityType="social" />
   </RenderFor>
 
   <RenderFor


### PR DESCRIPTION
## 🎶 Notes 🎶

- Splits up the activity list in two.
- Some translations keys are still left, since they're still used in the android app.

## 👀 Example 👀
<img width="431" height="927" alt="Screenshot 2025-11-04 at 11 39 51" src="https://github.com/user-attachments/assets/0b2f10bb-d52a-4116-b1f6-509c8d077640" />
