### PR TITLE
feat(rating): display imdb ratings as percentages

### DIFF
--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -44,7 +44,10 @@
     {/snippet}
   </RatingItem>
 
-  <RatingItem rating={imdb?.rating} url={imdb?.url}>
+  <RatingItem
+    rating={imdb?.rating && toPercentage(imdb.rating / 10, languageTag())}
+    url={imdb?.url}
+  >
     <IMDBIcon style={toVotesBasedRating(imdb?.votes)} />
     {#snippet superscript()}
       {i18n.voteText(imdb?.votes ?? 0)}


### PR DESCRIPTION
## ♪ Note ♪

- Display IMDB ratings as a percentage.

## 👀 Example 👀
Before/after:
<img width="428" height="930" alt="Screenshot 2025-11-04 at 11 55 29" src="https://github.com/user-attachments/assets/f0c75d66-267b-43a4-9af4-be1d108677a0" />

<img width="428" height="930" alt="Screenshot 2025-11-04 at 11 54 51" src="https://github.com/user-attachments/assets/7ab9678a-f8a2-4224-a735-f07cf5fc9d43" />
