### PR TITLE
fix(profile) / ensure unique user profiles from Trakt API

### DIFF
--- a/projects/client/src/lib/requests/queries/users/followersQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/followersQuery.ts
@@ -28,8 +28,18 @@ export const followersQuery = defineQuery({
     params: FollowersParams,
   ) => [params.slug],
   request: followersRequest,
-  mapper: (response) =>
-    response.body.map((follower) => mapToUserProfile(follower.user)),
+  mapper: (response) => {
+    /**
+     * FIXME: remove once Trakt API returns unique followers
+     */
+    const profiles = response.body.map((follower) =>
+      mapToUserProfile(follower.user)
+    );
+    const uniqueProfiles = Array.from(
+      new Map(profiles.map((profile) => [profile.slug, profile])).values(),
+    );
+    return uniqueProfiles;
+  },
   schema: z.array(UserProfileSchema),
   ttl: time.days(1),
 });

--- a/projects/client/src/lib/requests/queries/users/followingQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/followingQuery.ts
@@ -28,8 +28,18 @@ export const followingQuery = defineQuery({
     params: FollowingParams,
   ) => [params.slug],
   request: followingRequest,
-  mapper: (response) =>
-    response.body.map((following) => mapToUserProfile(following.user)),
+  mapper: (response) => {
+    /**
+     * FIXME: remove once Trakt API returns unique followings
+     */
+    const profiles = response.body.map((following) =>
+      mapToUserProfile(following.user)
+    );
+    const uniqueProfiles = Array.from(
+      new Map(profiles.map((profile) => [profile.slug, profile])).values(),
+    );
+    return uniqueProfiles;
+  },
   schema: z.array(UserProfileSchema),
   ttl: time.days(1),
 });


### PR DESCRIPTION
### Overview

This pull request addresses the issue of duplicate user profiles being returned by the Trakt API, specifically for followers and following lists. This was identified from the branch name and commit message.

### Changes

- Implements logic to ensure the uniqueness of user profiles retrieved from the Trakt API.
- Modified `followersQuery.ts` and `followingQuery.ts` to filter out duplicate user profiles based on their slug.
- Uses `Array.from` with a `Map` to efficiently remove duplicates, keeping only the first occurrence of each profile.
- Adds a `FIXME` comment in the code to indicate that this is a temporary fix, and should be removed once the Trakt API returns unique users.

### Technology

This change impacts the client-side code, specifically the queries used to fetch followers and following data. It does not use Hono, Cloudflare Workers, or Drizzle.

### Testing

No additional testing changes were made.