### PR TITLE
fix: use reactive param for stable paginated list

### DIFF
--- a/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
@@ -23,6 +23,7 @@
   useList={(params) =>
     useStablePaginated({
       ...params,
+      type: $mode,
       useList: (params) =>
         useUpNextList({
           limit: params.limit,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Possible fix for the media toggles in drilled down up next lists.
- Guesstimate: when built, the spread breaks the reactivity. Though not 100% sure, since I would've expected it to also happen in the preview build.