### PR TITLE
fix: do not trigger callback on destroyed element

### DIFF
--- a/projects/client/src/lib/utils/actions/whenInViewport.ts
+++ b/projects/client/src/lib/utils/actions/whenInViewport.ts
@@ -22,9 +22,7 @@ export function whenInViewport(
 
   return {
     destroy: () => {
-      if (element) {
-        observer.unobserve(element);
-      }
+      observer.disconnect();
     },
   };
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Possible fix for the unsafe mutation errors.
- Cause: intersection event is queued, Card is destroyed, callback is called, which tries to set the `isVisible` writable of that card to true.