### PR TITLE
feat(streaming): colorize logos in where to watch list

### DIFF
--- a/projects/client/src/lib/components/media/streaming-service/StreamingServiceLogo.svelte
+++ b/projects/client/src/lib/components/media/streaming-service/StreamingServiceLogo.svelte
@@ -6,9 +6,14 @@
   type StreamingServiceLogoProps = {
     source: string;
     i18n: StreamingServiceLogoIntl;
+    variant?: "monochrome" | "colored";
   };
 
-  const { source, i18n }: StreamingServiceLogoProps = $props();
+  const {
+    source,
+    i18n,
+    variant = "monochrome",
+  }: StreamingServiceLogoProps = $props();
   const { sources } = useStreamingServices();
 
   const service = $derived($sources.find((s) => s.source === source));
@@ -22,10 +27,16 @@
 
 <div
   class="trakt-streaming-service-logo"
+  class:is-colored={variant === "colored"}
   class:has-channel-logo={!!service?.channelLogoUrl}
+  style="--logo-color: {service?.color ?? 'var(--color-text-primary)'};"
 >
   {#if service?.logoUrl}
-    <CrossOriginImage src={service.logoUrl} alt={i18n.alt(displayName)} />
+    <CrossOriginImage
+      src={service.logoUrl}
+      alt={i18n.alt(displayName)}
+      classList="trakt-service-logo"
+    />
     {#if service?.channelLogoUrl}
       <div class="trakt-channel-separator"></div>
       <CrossOriginImage
@@ -44,6 +55,13 @@
     display: flex;
     align-items: center;
     gap: var(--gap-micro);
+
+    &.is-colored {
+      :global(img.trakt-service-logo) {
+        filter: drop-shadow(0 var(--ni-240) 0 var(--logo-color));
+        transform: translateY(var(--ni-neg-240));
+      }
+    }
 
     :global(img) {
       width: var(--ni-36);

--- a/projects/client/src/lib/requests/models/StreamingSource.ts
+++ b/projects/client/src/lib/requests/models/StreamingSource.ts
@@ -7,6 +7,7 @@ export const StreamingSourceSchema = z.object({
   isFree: z.boolean(),
   logoUrl: HttpsUrlSchema.nullish(),
   channelLogoUrl: HttpsUrlSchema.nullish(),
+  color: z.string().nullish(),
 });
 
 export type StreamingSource = z.infer<

--- a/projects/client/src/lib/requests/queries/services/streamingSourcesQuery.ts
+++ b/projects/client/src/lib/requests/queries/services/streamingSourcesQuery.ts
@@ -16,6 +16,17 @@ const StreamingSourceListSchema = z.map(
   StreamingSourceSchema.array(),
 );
 
+// FIXME: remove when API is fixed
+function mapToColor(color: string) {
+  const hexColorRegex = /^#[0-9A-Fa-f]{6}$/;
+
+  if (!hexColorRegex.test(color) || color === '#000000') {
+    return;
+  }
+
+  return color;
+}
+
 function mapStreamingSourceResponse(
   sourceResponse: WatchNowSourceResponse,
 ): StreamingSource {
@@ -25,6 +36,7 @@ function mapStreamingSourceResponse(
     isFree: sourceResponse.free,
     logoUrl: prependHttps(sourceResponse.images.logo),
     channelLogoUrl: prependHttps(sourceResponse.images.channel),
+    color: mapToColor(sourceResponse.color),
   };
 }
 

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchItem.svelte
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchItem.svelte
@@ -43,6 +43,7 @@
       <StreamingServiceLogo
         source={service.source}
         i18n={StreamingServiceLogoIntlProvider}
+        variant="colored"
       />
       <p class="meta-info">{text}</p>
     </div>
@@ -97,9 +98,6 @@
         width: 100%;
         height: 100%;
         object-fit: contain;
-
-        transition: filter var(--transition-increment) ease-in-out;
-        filter: var(--streaming-service-logo-filter);
       }
     }
 
@@ -114,6 +112,9 @@
         width: 75%;
         height: auto;
         max-height: 45%;
+
+        transition: filter var(--transition-increment) ease-in-out;
+        filter: var(--streaming-service-logo-filter);
       }
 
       :global(.trakt-channel-separator) {

--- a/projects/client/src/mocks/data/watchnow/mapped/StreamingSourcesMappedMock.ts
+++ b/projects/client/src/mocks/data/watchnow/mapped/StreamingSourcesMappedMock.ts
@@ -7,680 +7,763 @@ export const StreamingSourcesMappedMock: Map<
   [
     ['nl', [
       {
+        'channelLogoUrl': undefined,
+        'color': '#0978f9',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/amazon-prime-2acf46e84186be5ae29c2285fc305ab0e7d9b99c591ae3647b0bcc385585abd1.png.webp',
         'name': 'Amazon Prime Video',
-        'channelLogoUrl': undefined,
         'source': 'amazon_prime_video',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#ff9900',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/amazon-c7ce37c7d401baf5b6470a40250853decb6f6abcdac1673ee7c5217d9efe624c.png.webp',
         'name': 'Amazon Video',
-        'channelLogoUrl': undefined,
         'source': 'amazon_video',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/apple-tv-666c72c3b0e37f8ad861fb8d317e2160f46711ad8a4dd62ccf4d8afbe4c53c5a.png.webp',
         'name': 'Apple TV',
-        'channelLogoUrl': undefined,
         'source': 'apple_tv',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/apple-tv-plus-aeddf2e981277fca1567cc814d8f2d34d2ae00ff3913408d18a258a6190bedc3.png.webp',
         'name': 'Apple TV+',
-        'channelLogoUrl': undefined,
         'source': 'apple_tv_plus',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#19a590',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/broadwayhd-399a2acdbffb0d8c7f0a8c01acee20ad692a8f3dbeccd1e762a0cce06e8dc609.png.webp',
         'name': 'BroadwayHD',
-        'channelLogoUrl': undefined,
         'source': 'broadwayhd',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/canal-plus-bd23a920201a8c557333c9bd226e230c8c1d094fc4de582d79338b9cb4dbf8b0.png.webp',
         'name': 'Canal+',
-        'channelLogoUrl': undefined,
         'source': 'canal_plus',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/cinemember-b840d17961e9659b51efb65a4fdbb898757e391e2fa220cdefca3c0904de702b.png.webp',
         'name': 'CineMember',
-        'channelLogoUrl': undefined,
         'source': 'cinemember',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/amazon-channel-b5739028533271a9dde61e2a943ec4337a8952e13cdb32bf59947b0ced040f77.png.webp',
+        'color': '#002c38',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/crime-plus-investigation-play-62eb56f806bc6d2f4dfc2cf5ddb72109ae652b8636d9e78875209b9ac5d4eda5.png.webp',
         'name': 'Crime+Investigation Play (on Amazon) ',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/amazon-channel-b5739028533271a9dde61e2a943ec4337a8952e13cdb32bf59947b0ced040f77.png.webp',
         'source': 'crime_investigation_play_amazon_channel',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#f78b24',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/crunchyroll-183464596ec8e3da6849b2f895a428cdbdedd9af4ac2984587ca563fcb3cdfc5.png.webp',
         'name': 'Crunchyroll',
-        'channelLogoUrl': undefined,
         'source': 'crunchyroll',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/amazon-channel-b5739028533271a9dde61e2a943ec4337a8952e13cdb32bf59947b0ced040f77.png.webp',
+        'color': '#f78b24',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/crunchyroll-183464596ec8e3da6849b2f895a428cdbdedd9af4ac2984587ca563fcb3cdfc5.png.webp',
         'name': 'Crunchyroll (on Amazon)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/amazon-channel-b5739028533271a9dde61e2a943ec4337a8952e13cdb32bf59947b0ced040f77.png.webp',
         'source': 'crunchyroll_amazon_channel',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#fd284e',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/cultpix-4fc5f3598cf66fad878a4dea6e965bcdbef76a8f92f2362b83b104ce0e45a8d7.png.webp',
         'name': 'Cultpix',
-        'channelLogoUrl': undefined,
         'source': 'cultpix',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#3871dd',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/curiosity-stream-209c788baffeb3c27e3acba07557e232585cb1fb659bcb24f2a0e8b2f760ae76.png.webp',
         'name': 'Curiosity Stream',
-        'channelLogoUrl': undefined,
         'source': 'curiosity_stream',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#4dafcb',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/dekkoo-523bdbbd1b56506556c40dd759fa834693eba9e405a354f7785952ce8e693e56.png.webp',
         'name': 'Dekkoo',
-        'channelLogoUrl': undefined,
         'source': 'dekkoo',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#272c35',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/discovery-plus-baa5bd2f4664504eba877c4b7acb0929173fc6df008d8030f91e0dc1cdcec6b2.png.webp',
         'name': 'Discovery+',
-        'channelLogoUrl': undefined,
         'source': 'discovery_plus',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#063443',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/disney-plus-b1fb9207731691df042fa49c715f37f7381381d5396837d1987d10102b291cde.png.webp',
         'name': 'Disney+',
-        'channelLogoUrl': undefined,
         'source': 'disney_plus',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/amazon-channel-b5739028533271a9dde61e2a943ec4337a8952e13cdb32bf59947b0ced040f77.png.webp',
+        'color': '#512d85',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/dizi-b62e525fc4835d019fd1d6e42a3e01aeb405cc1b8b04d77f52607d3c7e647bca.png.webp',
         'name': 'Dizi (on Amazon)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/amazon-channel-b5739028533271a9dde61e2a943ec4337a8952e13cdb32bf59947b0ced040f77.png.webp',
         'source': 'dizi_amazon_channel',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/docalliance-films-da53173ec0ec7c026099ef5a2241af1c2eeae7f61ee6d72a11407b485401680d.png.webp',
         'name': 'DocAlliance Films',
-        'channelLogoUrl': undefined,
         'source': 'docalliance_films',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#ff4c00',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/docsville-c4a704d0aa5cacf4c550c2f74386fb1cfdfb4082799f9c5dc2ca6076b61e26c8.png.webp',
         'name': 'DOCSVILLE',
-        'channelLogoUrl': undefined,
         'source': 'docsville',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#0685d3',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/eventive-00256714f1f5bd45de968278ca2b0c19113980524301a7ccc5ccdee184972366.png.webp',
         'name': 'Eventive',
-        'channelLogoUrl': undefined,
         'source': 'eventive',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#002845',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/film1-bd9e26073f838144509a3cb3b9e27a20af1a5a37541ecbab49fe846d572e5ed2.png.webp',
         'name': 'Film1',
-        'channelLogoUrl': undefined,
         'source': 'film1',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#e30b13',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/filmbox-640c783d4bababe2e2f21d6f70cfa8ab1381ae235398fba2bf54838b82b8cf47.png.webp',
         'name': 'FilmBox+',
-        'channelLogoUrl': undefined,
         'source': 'filmbox_plus',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
+        'color': '#243c44',
         'isFree': true,
         'logoUrl':
           'https://trakt.tv/assets/channels/filmzie-98519b77cdfc74bb7f77a73729c3e878e64d0e9bb1c50667358c81d9f3b299cd.png.webp',
         'name': 'Filmzie (free)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
         'source': 'filmzie',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#607d8b',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/google-play-5131c8a11dbe90b6254a19b96a0ec9434c38c200e5e88af5263d2c9bd431116f.png.webp',
         'name': 'Google Play Movies',
-        'channelLogoUrl': undefined,
         'source': 'google_play_movies',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#0098db',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/guidedoc-81a6bcc348c01c31b1ffafe2a53ae7611cf28fbd3b6fd5c925e5910a99bd275f.png.webp',
         'name': 'GuideDoc',
-        'channelLogoUrl': undefined,
         'source': 'guidedoc',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#f40072',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/hayu-5e022757057b4911a6a6c82962956da56b9c314688a7dcd3b2e6fd261f7476fd.png.webp',
         'name': 'Hayu',
-        'channelLogoUrl': undefined,
         'source': 'hayu',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
+        'color': '#f81103',
         'isFree': true,
         'logoUrl':
           'https://trakt.tv/assets/channels/hoichoi-1e1772f73b09d147d855fe0c5f12485f06c263f315c3acb81025e0c460226260.png.webp',
         'name': 'Hoichoi (free)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
         'source': 'hoichoi',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#45e58a',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/iffr-9ef568c25f6308c7a00d791884544eb84d734d4d95dc4ccaaa91ad68ee59aa5e.png.webp',
         'name': 'IFFR Unleashed',
-        'channelLogoUrl': undefined,
         'source': 'iffr_unleashed',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
+        'color': undefined,
         'isFree': true,
         'logoUrl': undefined,
         'name': 'JustWatchTV (free)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
         'source': 'justwatchtv',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/kpn-41b115254d4c01056b1a14cdd9d105045ec2c1b2f228e31f9d8888da3237a28e.png.webp',
         'name': 'KPN',
-        'channelLogoUrl': undefined,
         'source': 'kpn',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#48c8f5',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/magellan-tv-3e75fdea3f4f422fab983fa7fcabd669d2d46cceeeb86ad355ae10a2f18b31ea.png.webp',
         'name': 'Magellan TV',
-        'channelLogoUrl': undefined,
         'source': 'magellan_tv',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#0f2ef2',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/max-277c156733fefbcb2b6769ad091788762e1eb253909840b019f116cd18d86309.png.webp',
         'name': 'Max',
-        'channelLogoUrl': undefined,
         'source': 'max',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#ef4722',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/mejane-b2b32a8d6c5da8c492b43e01a38d445c43edb95a0ccf36ecb12546a91e478ddf.png.webp',
         'name': 'meJane',
-        'channelLogoUrl': undefined,
         'source': 'mejane',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/amazon-channel-b5739028533271a9dde61e2a943ec4337a8952e13cdb32bf59947b0ced040f77.png.webp',
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/mgm-65f164f1135161a80c9f4ea8ebafab1bfc736dfe217c714b55a1c86f4a1c2712.png.webp',
         'name': 'MGM+ (on Amazon)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/amazon-channel-b5739028533271a9dde61e2a943ec4337a8952e13cdb32bf59947b0ced040f77.png.webp',
         'source': 'mgm_plus_amazon_channel',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#0c447f',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/microsoft-65f1941ea1f1ee09c832166d726e045a11cb5163963ea149d534cf4d5b3b1193.png.webp',
         'name': 'Microsoft Store',
-        'channelLogoUrl': undefined,
         'source': 'microsoft_store',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#009c7c',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/mubi-cb64f30c505e6b8986245d1dba61c6348569b887eb6d8b811e800af1b79315a2.png.webp',
         'name': 'MUBI',
-        'channelLogoUrl': undefined,
         'source': 'mubi',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#e50914',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/netflix-8a8f6cd4882e9305086ff41ce66d01913ffe500923d6939b3e60a176ab0fa38e.png.webp',
         'name': 'Netflix',
-        'channelLogoUrl': undefined,
         'source': 'netflix',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#e50914',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/netflix-kids-a9b8a5107e4ed28ae9985d3b88baf866710b995e097a4d7bac944bff7d356e82.png.webp',
         'name': 'Netflix Kids',
-        'channelLogoUrl': undefined,
         'source': 'netflix_kids',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#ff145a',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/nlziet-676eec2cdb9e101befc359192b90d8cd4cc915c93bc956792a8ea9eaa6f19d0f.png.webp',
         'name': 'NLZIET',
-        'channelLogoUrl': undefined,
         'source': 'nlziet',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
+        'color': '#fe6b00',
         'isFree': true,
         'logoUrl':
           'https://trakt.tv/assets/channels/npo-start-9a5e66cfe1db937f639ee668e7c71f26a3408a1695107bed9d761b4bfff25f08.png.webp',
         'name': 'NPO Start (free)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
         'source': 'npo_start',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#fd6b00',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/npo-plus-d9913b29c6e9709f56e9d8cb0fd75d99a5465e536f39a3643af3c904f01b2480.png.webp',
         'name': 'NPO+',
-        'channelLogoUrl': undefined,
         'source': 'npo_plus',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#fec139',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/pathe-thuis-3f437e58f2dff6f6dbe61e74cc0b9146286d36909e2ba186557bad3a54f8fe28.png.webp',
         'name': 'Pathé Thuis',
-        'channelLogoUrl': undefined,
         'source': 'pathe_thuis',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#ff9988',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/picl-8285aaed1afacd1ed1fa36da8556b7b0cbf1ff16f61226bd74a5ef6bde604b2f.png.webp',
         'name': 'Picl',
-        'channelLogoUrl': undefined,
         'source': 'picl',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/plex-5e7292839da5cdbdedb0f2806ec3fc8a6c5b436dd81ed7aeff825e68407c4ba2.png.webp',
         'name': 'Plex',
-        'channelLogoUrl': undefined,
         'source': 'plex',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#ba0000',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/rakuten-tv-fb85896ad802b7c7448bd3e6aa6e4486ef1d163eecba73fc4cb389e414012488.png.webp',
         'name': 'Rakuten TV',
-        'channelLogoUrl': undefined,
         'source': 'rakuten_tv',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/amazon-channel-b5739028533271a9dde61e2a943ec4337a8952e13cdb32bf59947b0ced040f77.png.webp',
+        'color': '#e01e26',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/shortstv-9ec24dbb7484c6350caa9a02db96a1cd1e14c992ddf5ee61faf0593606772100.png.webp',
         'name': 'ShortsTV (on Amazon)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/amazon-channel-b5739028533271a9dde61e2a943ec4337a8952e13cdb32bf59947b0ced040f77.png.webp',
         'source': 'shortstv_amazon_channel',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/skyshowtime-fe6d70edf1637c3f62a7e8bf5deb323cd462d1a3a02f3a818e11e99c0f9f3498.png.webp',
         'name': 'SkyShowtime',
-        'channelLogoUrl': undefined,
         'source': 'skyshowtime',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#153957',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/sooner-31ec5639ad30a112096475a2a36f112411e4255e2f84aae5ca4ddea947f23588.png.webp',
         'name': 'Sooner',
-        'channelLogoUrl': undefined,
         'source': 'sooner',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
+        'color': undefined,
         'isFree': true,
         'logoUrl':
           'https://trakt.tv/assets/channels/south-park-8439f017dfe552deaae611cd8af6c66bdb60df794c287a41981da7c9839f8274.png.webp',
         'name': 'South Park (free)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
         'source': 'south_park',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#3558f2',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/spamflix-134b61c485736b18d301fd6c7d149384e768d8bb0818a296f2cd2aaf8bf763e0.png.webp',
         'name': 'Spamflix',
-        'channelLogoUrl': undefined,
         'source': 'spamflix',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#990033',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/sun-nxt-8e0ce2107c545a768f89f4ea9432967451b7440a199ca8dbef5253906f664156.png.webp',
         'name': 'Sun Nxt',
-        'channelLogoUrl': undefined,
         'source': 'sun_nxt',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#9000ff',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/takflix-52b3083fc1c7d30ea77f6885695d0e1280f360c2bb87411690de5c9c57e0661e.png.webp',
         'name': 'Takflix',
-        'channelLogoUrl': undefined,
         'source': 'takflix',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/true-story-cbd06a0c03d7ba8e2fd43756a4280ae578e4d2c94977452b6fcf66cbe31e7d47.png.webp',
         'name': 'True Story',
-        'channelLogoUrl': undefined,
         'source': 'true_story',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#212d32',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/viaplay-66809130d159c3a7d7290a17964a374fa93ab8a5d2503a4110a296404c8914b7.png.webp',
         'name': 'Viaplay',
-        'channelLogoUrl': undefined,
         'source': 'viaplay',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#e61a23',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/videoland-1f559d0f4ca4dd00c3df32dd6d98e5911a2bd431a2e04c3865d30cde6e8bc9fd.png.webp',
         'name': 'Videoland',
-        'channelLogoUrl': undefined,
         'source': 'videoland',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#ff8101',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/wow-presents-plus-8fe89d8d116a8874f18d61ac55ebc4c50f51d1f13a3f1991d00b9d145fb275a8.png.webp',
         'name': 'WOW Presents+',
-        'channelLogoUrl': undefined,
         'source': 'wow_presents_plus',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#f48c00',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/ziggo-5d377ae14daecd058e02920323d1cafdcbdc7a0e2fd0dd77402d5c1c51db1385.png.webp',
         'name': 'Ziggo TV',
-        'channelLogoUrl': undefined,
         'source': 'ziggo_tv',
       },
     ]],
     ['ro', [
       {
+        'channelLogoUrl': undefined,
+        'color': '#0978f9',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/amazon-prime-2acf46e84186be5ae29c2285fc305ab0e7d9b99c591ae3647b0bcc385585abd1.png.webp',
         'name': 'Amazon Prime Video',
-        'channelLogoUrl': undefined,
         'source': 'amazon_prime_video',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#19a590',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/broadwayhd-399a2acdbffb0d8c7f0a8c01acee20ad692a8f3dbeccd1e762a0cce06e8dc609.png.webp',
         'name': 'BroadwayHD',
-        'channelLogoUrl': undefined,
         'source': 'broadwayhd',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#f78b24',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/crunchyroll-183464596ec8e3da6849b2f895a428cdbdedd9af4ac2984587ca563fcb3cdfc5.png.webp',
         'name': 'Crunchyroll',
-        'channelLogoUrl': undefined,
         'source': 'crunchyroll',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#fd284e',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/cultpix-4fc5f3598cf66fad878a4dea6e965bcdbef76a8f92f2362b83b104ce0e45a8d7.png.webp',
         'name': 'Cultpix',
-        'channelLogoUrl': undefined,
         'source': 'cultpix',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#3871dd',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/curiosity-stream-209c788baffeb3c27e3acba07557e232585cb1fb659bcb24f2a0e8b2f760ae76.png.webp',
         'name': 'Curiosity Stream',
-        'channelLogoUrl': undefined,
         'source': 'curiosity_stream',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#4dafcb',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/dekkoo-523bdbbd1b56506556c40dd759fa834693eba9e405a354f7785952ce8e693e56.png.webp',
         'name': 'Dekkoo',
-        'channelLogoUrl': undefined,
         'source': 'dekkoo',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#063443',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/disney-plus-b1fb9207731691df042fa49c715f37f7381381d5396837d1987d10102b291cde.png.webp',
         'name': 'Disney+',
-        'channelLogoUrl': undefined,
         'source': 'disney_plus',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/docalliance-films-da53173ec0ec7c026099ef5a2241af1c2eeae7f61ee6d72a11407b485401680d.png.webp',
         'name': 'DocAlliance Films',
-        'channelLogoUrl': undefined,
         'source': 'docalliance_films',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#ff4c00',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/docsville-c4a704d0aa5cacf4c550c2f74386fb1cfdfb4082799f9c5dc2ca6076b61e26c8.png.webp',
         'name': 'DOCSVILLE',
-        'channelLogoUrl': undefined,
         'source': 'docsville',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#0685d3',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/eventive-00256714f1f5bd45de968278ca2b0c19113980524301a7ccc5ccdee184972366.png.webp',
         'name': 'Eventive',
-        'channelLogoUrl': undefined,
         'source': 'eventive',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#e30b13',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/filmbox-640c783d4bababe2e2f21d6f70cfa8ab1381ae235398fba2bf54838b82b8cf47.png.webp',
         'name': 'FilmBox+',
-        'channelLogoUrl': undefined,
         'source': 'filmbox_plus',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
+        'color': '#243c44',
         'isFree': true,
         'logoUrl':
           'https://trakt.tv/assets/channels/filmzie-98519b77cdfc74bb7f77a73729c3e878e64d0e9bb1c50667358c81d9f3b299cd.png.webp',
         'name': 'Filmzie (free)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
         'source': 'filmzie',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#f40072',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/hayu-5e022757057b4911a6a6c82962956da56b9c314688a7dcd3b2e6fd261f7476fd.png.webp',
         'name': 'Hayu',
-        'channelLogoUrl': undefined,
         'source': 'hayu',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
+        'color': '#f81103',
         'isFree': true,
         'logoUrl':
           'https://trakt.tv/assets/channels/hoichoi-1e1772f73b09d147d855fe0c5f12485f06c263f315c3acb81025e0c460226260.png.webp',
         'name': 'Hoichoi (free)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
         'source': 'hoichoi',
       },
       {
+        'channelLogoUrl':
+          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
+        'color': undefined,
         'isFree': true,
         'logoUrl': undefined,
         'name': 'JustWatchTV (free)',
-        'channelLogoUrl':
-          'https://trakt.tv/assets/channels/free-07d99d3ee44e8f3ba937f71599f40306da3077110d5b51e08fc9d47cc6d72bc0.png.webp',
         'source': 'justwatchtv',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#48c8f5',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/magellan-tv-3e75fdea3f4f422fab983fa7fcabd669d2d46cceeeb86ad355ae10a2f18b31ea.png.webp',
         'name': 'Magellan TV',
-        'channelLogoUrl': undefined,
         'source': 'magellan_tv',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#0f2ef2',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/max-277c156733fefbcb2b6769ad091788762e1eb253909840b019f116cd18d86309.png.webp',
         'name': 'Max',
-        'channelLogoUrl': undefined,
         'source': 'max',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#009c7c',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/mubi-cb64f30c505e6b8986245d1dba61c6348569b887eb6d8b811e800af1b79315a2.png.webp',
         'name': 'MUBI',
-        'channelLogoUrl': undefined,
         'source': 'mubi',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#e50914',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/netflix-8a8f6cd4882e9305086ff41ce66d01913ffe500923d6939b3e60a176ab0fa38e.png.webp',
         'name': 'Netflix',
-        'channelLogoUrl': undefined,
         'source': 'netflix',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/plex-5e7292839da5cdbdedb0f2806ec3fc8a6c5b436dd81ed7aeff825e68407c4ba2.png.webp',
         'name': 'Plex',
-        'channelLogoUrl': undefined,
         'source': 'plex',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#ba0000',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/rakuten-tv-fb85896ad802b7c7448bd3e6aa6e4486ef1d163eecba73fc4cb389e414012488.png.webp',
         'name': 'Rakuten TV',
-        'channelLogoUrl': undefined,
         'source': 'rakuten_tv',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/skyshowtime-fe6d70edf1637c3f62a7e8bf5deb323cd462d1a3a02f3a818e11e99c0f9f3498.png.webp',
         'name': 'SkyShowtime',
-        'channelLogoUrl': undefined,
         'source': 'skyshowtime',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#3558f2',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/spamflix-134b61c485736b18d301fd6c7d149384e768d8bb0818a296f2cd2aaf8bf763e0.png.webp',
         'name': 'Spamflix',
-        'channelLogoUrl': undefined,
         'source': 'spamflix',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#990033',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/sun-nxt-8e0ce2107c545a768f89f4ea9432967451b7440a199ca8dbef5253906f664156.png.webp',
         'name': 'Sun Nxt',
-        'channelLogoUrl': undefined,
         'source': 'sun_nxt',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#9000ff',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/takflix-52b3083fc1c7d30ea77f6885695d0e1280f360c2bb87411690de5c9c57e0661e.png.webp',
         'name': 'Takflix',
-        'channelLogoUrl': undefined,
         'source': 'takflix',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': undefined,
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/true-story-cbd06a0c03d7ba8e2fd43756a4280ae578e4d2c94977452b6fcf66cbe31e7d47.png.webp',
         'name': 'True Story',
-        'channelLogoUrl': undefined,
         'source': 'true_story',
       },
       {
+        'channelLogoUrl': undefined,
+        'color': '#ff8101',
         'isFree': false,
         'logoUrl':
           'https://trakt.tv/assets/channels/wow-presents-plus-8fe89d8d116a8874f18d61ac55ebc4c50f51d1f13a3f1991d00b9d145fb275a8.png.webp',
         'name': 'WOW Presents+',
-        'channelLogoUrl': undefined,
         'source': 'wow_presents_plus',
       },
     ]],


### PR DESCRIPTION
## 🎶 Notes 🎶

- Colorizes the logos in the where to watch list.
- No color data for channel logos, they remain as is.
- Colors that were hardcoded to black (or are erroneous), are not mapped and default to the primary text color.

## 👀 Example 👀
Before:
<img width="885" height="170" alt="Screenshot 2025-11-11 at 16 14 28" src="https://github.com/user-attachments/assets/412099b6-100e-4983-a1cc-a19e04fb284b" />


After:
<img width="885" height="170" alt="Screenshot 2025-11-11 at 16 13 56" src="https://github.com/user-attachments/assets/35a970ae-1a4b-4de7-b1a2-f83218dfcf5f" />
