### PR TITLE
fix(navbar): add the vip upsell link back to the top navbar

### DIFF
--- a/projects/client/src/lib/sections/navbar/TopNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/TopNavbar.svelte
@@ -3,6 +3,7 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { trackWindowScroll } from "$lib/utils/actions/trackWindowScroll";
   import FilterButton from "./components/filter/FilterButton.svelte";
+  import GetVIPLink from "./components/GetVIPLink.svelte";
   import JoinTraktButton from "./components/JoinTraktButton.svelte";
   import { useNavbarState } from "./useNavbarState";
 
@@ -32,6 +33,7 @@
           {@render $state.seasonalActions?.()}
           <FilterButton size="small" isDisabled={!$state.hasFilters} />
         </RenderFor>
+        <RenderFor audience="free"><GetVIPLink /></RenderFor>
       </div>
     </nav>
 


### PR DESCRIPTION
## ♪ Note ♪

- Adds the vip upsell link back to the top navbar

## 👀 Example 👀
<img width="427" height="929" alt="Screenshot 2025-11-12 at 14 15 59" src="https://github.com/user-attachments/assets/744a4274-bc6c-44de-add9-667e164917aa" />
