### PR TITLE
fix(summary): makes action bar same width as the poster

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/Summary.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/Summary.svelte
@@ -46,17 +46,9 @@
   }
 
   .trakt-summary-main {
-    --side-action-bar-width: var(--ni-40);
-    --summary-gap: var(--gap-s);
-    --poster-side-distance: calc(
-      var(--layout-distance-side) + var(--side-action-bar-width) +
-        var(--summary-gap)
-    );
-    --poster-width: calc(100dvw - 2 * var(--poster-side-distance));
-
     display: grid;
     grid-template-columns: 1fr auto 1fr;
-    gap: var(--summary-gap);
+    gap: var(--summary-poster-gap);
 
     :global(.trakt-summary-poster-container) {
       grid-column-start: 2;
@@ -64,8 +56,8 @@
 
     :global(.trakt-summary-poster-container),
     :global(.trakt-summary-poster img) {
-      width: var(--poster-width);
-      height: calc(var(--poster-width) * 1.5);
+      width: var(--summary-poster-width);
+      height: calc(var(--summary-poster-width) * 1.5);
     }
 
     :global(.trakt-summary-poster img) {

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryActions.svelte
@@ -25,7 +25,7 @@
     position: relative;
 
     height: var(--ni-56);
-    width: var(--ni-320);
+    width: var(--summary-poster-width);
 
     padding: var(--ni-8) var(--ni-10);
     box-sizing: border-box;

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/SideActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/SideActions.svelte
@@ -15,16 +15,24 @@
   } = $props();
 </script>
 
-<ShareButton
-  {title}
-  {style}
-  textFactory={({ title }) => {
-    switch (type) {
-      case "movie":
-        return m.text_share_movie({ title });
-      case "show":
-        return m.text_share_show({ title });
-    }
-  }}
-  source={{ id: "media", type }}
-/>
+<div class="trakt-summary-side-actions">
+  <ShareButton
+    {title}
+    {style}
+    textFactory={({ title }) => {
+      switch (type) {
+        case "movie":
+          return m.text_share_movie({ title });
+        case "show":
+          return m.text_share_show({ title });
+      }
+    }}
+    source={{ id: "media", type }}
+  />
+</div>
+
+<style>
+  .trakt-summary-side-actions {
+    width: var(--summary-side-action-bar-width);
+  }
+</style>

--- a/projects/client/src/style/layout/index.css
+++ b/projects/client/src/style/layout/index.css
@@ -112,6 +112,17 @@
 
   --list-header-gap: var(--gap-s);
 
+  --summary-side-action-bar-width: var(--ni-40);
+  --summary-poster-gap: var(--gap-s);
+  --summary-poster-width: calc(
+    100dvw
+      - 2
+      * (
+      var(--layout-distance-side) + var(--summary-side-action-bar-width)
+        + var(--summary-poster-gap)
+    )
+  );
+
   @-moz-document url-prefix() {
     --layout-scrollbar-width: var(--ni-16);
   }


### PR DESCRIPTION
## ♪ Note ♪

- Makes the summary action bar have the same width as the poster.

## 👀 Examples 👀

Before/after:
<img width="427" height="931" alt="Screenshot 2025-11-13 at 12 39 50" src="https://github.com/user-attachments/assets/9c01b6ba-f509-4cce-8db6-f86b2bdc891f" />

<img width="427" height="931" alt="Screenshot 2025-11-13 at 13 22 47" src="https://github.com/user-attachments/assets/1cb7cb42-5939-4c57-b30d-495d7df30878" />
