### PR TITLE
revert: "fix: always sort lists by rank"

### DIFF
--- a/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userListItemsQuery.ts
@@ -57,7 +57,6 @@ const userListItemsRequest = (
         extended: 'full,images,colors',
         page,
         limit,
-        sort_by: 'rank',
         ...filter,
       },
     });


### PR DESCRIPTION
## ♪ Note ♪

- Revert back to default sorting of list items