### PR TITLE
fix(summary): colorize streaming service logos in all browsers

### DIFF
--- a/projects/client/src/lib/components/media/streaming-service/StreamingServiceLogo.svelte
+++ b/projects/client/src/lib/components/media/streaming-service/StreamingServiceLogo.svelte
@@ -35,6 +35,12 @@
       src={service.logoUrl}
       alt={i18n.alt(displayName)}
       classList="trakt-service-logo"
+      variant={variant === "monochrome"
+        ? { type: "default" }
+        : {
+            type: "masked",
+            color: service?.color ?? "var(--color-text-primary)",
+          }}
     />
     {#if service?.channelLogoUrl}
       <div class="trakt-channel-separator"></div>
@@ -54,13 +60,6 @@
     display: flex;
     align-items: center;
     gap: var(--gap-micro);
-
-    &.is-colored {
-      :global(img.trakt-service-logo) {
-        filter: drop-shadow(0 var(--ni-240) 0 var(--logo-color));
-        transform: translateY(var(--ni-neg-240));
-      }
-    }
 
     :global(img) {
       width: var(--ni-36);

--- a/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
+++ b/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
@@ -13,6 +13,7 @@
     onload: _onload,
     onerror: _onerror,
     classList = "",
+    variant = { type: "default" },
     ...rest
   }: ImageProps = $props();
 
@@ -20,6 +21,13 @@
   const isImageLoaded = $derived(writable(false));
 
   const isPlaceholder = $derived(PLACEHOLDERS.includes(src));
+
+  const style = $derived.by(() => {
+    if (variant.type === "masked") {
+      return `background-color: ${variant.color}; mask-image: url('${$response.uri}');`;
+    }
+    return "";
+  });
 </script>
 
 <img
@@ -27,8 +35,10 @@
   class:image-loaded={$isImageLoaded}
   class:image-animation-enabled={animate}
   class:image-placeholder={isPlaceholder}
+  class:has-mask={variant.type === "masked"}
   use:appendClassList={classList}
   src={$response.uri}
+  {style}
   {alt}
   onerror={(ev) => {
     resolveEnvironmentUri(src).then(response.set);
@@ -39,6 +49,13 @@
       isImageLoaded.set(true);
     }, 100);
     _onload?.(ev);
+
+    const shouldClearSrc =
+      variant.type === "masked" && ev.target instanceof HTMLImageElement;
+
+    if (shouldClearSrc) {
+      ev.target.src = "";
+    }
   }}
   {...rest}
 />
@@ -62,5 +79,13 @@
 
   img.image-placeholder {
     background-color: var(--shade-800);
+  }
+
+  img.has-mask {
+    content-visibility: hidden;
+    mask-size: contain;
+    mask-mode: alpha;
+    mask-repeat: no-repeat;
+    mask-position: center;
   }
 </style>

--- a/projects/client/src/lib/features/image/components/ImageProps.ts
+++ b/projects/client/src/lib/features/image/components/ImageProps.ts
@@ -1,4 +1,14 @@
+type Default = {
+  type: 'default';
+};
+
+type Masked = {
+  type: 'masked';
+  color: string;
+};
+
 export type ImageProps = HTMLImageElementProps & {
   animate?: boolean;
   classList?: string;
+  variant?: Default | Masked;
 };


### PR DESCRIPTION
## ♪ Note ♪

- Colorize streaming service logos using a mask instead of using a drop shadow.

## 👀 Example 👀

Top to bottom: Firefox, Safari, Chrome
<img width="787" height="498" alt="Screenshot 2025-11-17 at 13 04 24" src="https://github.com/user-attachments/assets/1cdfd3d2-3020-4bca-a3cc-817a8d692a94" />
