### PR TITLE
feat(queries): map more well known self and narrator roles

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToMediaCredits.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaCredits.ts
@@ -20,10 +20,10 @@ type EntryResponse = {
   show: ShowResponse;
 };
 
-const WELL_KNOWN_ROLES = [
-  'self',
-  'narrator',
-] as const;
+const WELL_KNOWN_ROLES: Record<string, string[]> = {
+  self: ['self (', 'self -'],
+  narrator: ['narrator ('],
+};
 
 function mapToMediaEntry(entryResponse: EntryResponse) {
   if ('movie' in entryResponse) {
@@ -39,9 +39,12 @@ export function mapToMediaCredits(
   const credits = new Map<CrewPosition, MediaEntry[]>();
 
   (response.cast ?? []).forEach((entry) => {
-    const wellKnownRole = WELL_KNOWN_ROLES.find((role) =>
-      entry.character.toLowerCase() === role
-    );
+    const character = entry.character.toLowerCase();
+
+    const wellKnownRole = Object.entries(WELL_KNOWN_ROLES)
+      .find(([role, patterns]) =>
+        character === role || patterns.some((p) => character.startsWith(p))
+      )?.[0];
 
     const key = wellKnownRole ?? 'acting';
     const entries = credits.get(key) ?? credits.set(key, []).get(key);

--- a/projects/client/src/lib/requests/queries/people/personMovieCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/personMovieCreditsQuery.ts
@@ -21,7 +21,7 @@ const personMovieCreditsRequest = (
     });
 
 export const personMovieCreditsQuery = defineQuery({
-  key: 'personMovieCredits:v2',
+  key: 'personMovieCredits:v3',
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: personMovieCreditsRequest,

--- a/projects/client/src/lib/requests/queries/people/personShowCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/personShowCreditsQuery.ts
@@ -21,7 +21,7 @@ const personShowCreditsRequest = (
     });
 
 export const personShowCreditsQuery = defineQuery({
-  key: 'personShowCredits:v2',
+  key: 'personShowCredits:v3',
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: personShowCreditsRequest,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Characters that start with `Self (` and `Self -` are now also grouped under `self`.
- Characters that start with `Narrator (voice)` are now also grouped under `narrator`.