### PR TITLE
fix: standardize font sizes

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -3574,14 +3574,6 @@
         "ios"
       ]
     },
-    "header_settings": {
-      "default": "Settings",
-      "description": "Header for the settings side bar.",
-      "exclude": [
-        "android",
-        "ios"
-      ]
-    },
     "button_label_settings": {
       "default": "Settings",
       "description": "Aria-label for the button that opens the settings page.",

--- a/projects/client/src/lib/components/badge/_internal/VipBadgeContent.svelte
+++ b/projects/client/src/lib/components/badge/_internal/VipBadgeContent.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div class="trakt-vip-badge">
-  <p class="small uppercase">
+  <p class="uppercase">
     {@render children()}
   </p>
 </div>
@@ -30,7 +30,7 @@
       var(--ni-0) var(--ni-2) var(--ni-4) var(--ni-0) rgba(255, 255, 255, 0.44)
         inset;
 
-    .small {
+    p {
       font-weight: 700;
       white-space: nowrap;
     }

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -194,8 +194,6 @@
       text-decoration;
 
     &:not([data-style="underlined"]) p:not(.meta-info) {
-      font-size: 1rem;
-      font-style: normal;
       font-weight: 700;
     }
 

--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -53,6 +53,7 @@
 
     .trakt-card-footer-tag {
       width: 100%;
+      overflow: hidden;
 
       display: flex;
       gap: var(--gap-micro);
@@ -74,7 +75,7 @@
         color: var(--color-text-primary);
         margin: 0;
         font-weight: 500;
-        font-size: var(--ni-12);
+        font-size: var(--font-size-text);
 
         :global(:has(~ .trakt-card-subtitle)) {
           font-weight: 600;
@@ -85,7 +86,7 @@
         color: var(--color-text-secondary);
         margin: 0;
         font-weight: 500;
-        font-size: var(--ni-12);
+        font-size: var(--font-size-text);
       }
     }
 
@@ -93,15 +94,6 @@
       :global(.trakt-action-button[data-style="ghost"]),
       :global(.trakt-button[data-style="ghost"]) {
         backdrop-filter: none;
-      }
-    }
-  }
-
-  :global([data-device="tv"]) {
-    .trakt-card-footer .trakt-card-footer-information {
-      :global(.trakt-card-title),
-      :global(.trakt-card-subtitle) {
-        font-size: var(--ni-14);
       }
     }
   }

--- a/projects/client/src/lib/components/drawer/Drawer.svelte
+++ b/projects/client/src/lib/components/drawer/Drawer.svelte
@@ -220,7 +220,7 @@
     flex-direction: column;
 
     h5 {
-      font-size: var(--ni-18);
+      font-size: var(--font-size-title);
     }
 
     p.meta-info {

--- a/projects/client/src/lib/components/dropdown/DropdownItem.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.svelte
@@ -36,7 +36,7 @@
 </script>
 
 {#snippet text()}
-  <p class="small bold capitalize ellipsis">{@render children()}</p>
+  <p class="bold capitalize ellipsis">{@render children()}</p>
 {/snippet}
 
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
@@ -64,7 +64,7 @@
         {@render icon()}
       </div>
     {/if}
-    <p class="small bold uppercase ellipsis">
+    <p class="bold uppercase ellipsis">
       {@render text()}
     </p>
   {/if}

--- a/projects/client/src/lib/components/dropdown/DropdownList.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownList.svelte
@@ -186,6 +186,8 @@
       background-color: transparent;
       appearance: none;
 
+      font-size: var(--font-size-text);
+
       cursor: pointer;
       opacity: 0;
     }
@@ -291,7 +293,7 @@
       }
 
       :global(li p) {
-        font-size: var(--ni-12);
+        font-size: var(--font-size-text);
       }
 
       div.spacer {

--- a/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
+++ b/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
@@ -40,6 +40,10 @@
     align-items: center;
     justify-content: space-between;
 
+    .meta-info {
+      font-size: var(--font-size-tag);
+    }
+
     gap: var(--gap-xs);
 
     position: relative;

--- a/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
@@ -56,7 +56,7 @@
     }
 
     /** FIXME: remove when we have adaptive typography and updated sizes */
-    font-size: var(--ni-18);
+    font-size: var(--font-size-title);
     line-height: var(--ni-22);
     &.ellipsis {
       max-width: 100%;

--- a/projects/client/src/lib/components/media/tags/MediaIconTag.svelte
+++ b/projects/client/src/lib/components/media/tags/MediaIconTag.svelte
@@ -21,7 +21,7 @@
     gap: var(--gap-xxs);
 
     color: var(--color-text-primary);
-    font-size: var(--ni-12);
+    font-size: var(--font-size-text);
 
     :global(svg) {
       width: var(--ni-12);

--- a/projects/client/src/lib/components/select/NativeSelect.svelte
+++ b/projects/client/src/lib/components/select/NativeSelect.svelte
@@ -66,7 +66,6 @@
     gap: var(--gap-xs);
 
     color: var(--color-text-primary);
-    font-size: var(--ni-16);
 
     border-radius: var(--border-radius-s);
 

--- a/projects/client/src/lib/components/summary/RatingItem.svelte
+++ b/projects/client/src/lib/components/summary/RatingItem.svelte
@@ -22,17 +22,17 @@
       <div class="rating-info">
         <div class="rating-value">
           {#if !hasValidRating}
-            <p class="large bold" out:slide={{ duration: 150, axis: "x" }}>-</p>
+            <p class="bold" out:slide={{ duration: 150, axis: "x" }}>-</p>
           {:else}
             <div in:fade={{ delay: 150, duration: 150 }}>
-              <p class="large bold" in:slide={{ duration: 150, axis: "x" }}>
+              <p class="bold" in:slide={{ duration: 150, axis: "x" }}>
                 {rating}
               </p>
             </div>
           {/if}
         </div>
         {#if hasValidRating}
-          <p class="small bold uppercase secondary vote-count">
+          <p class="bold uppercase secondary vote-count">
             {@render superscript()}
           </p>
         {/if}
@@ -100,14 +100,6 @@
       :global(svg) {
         height: var(--ni-12);
         width: auto;
-      }
-
-      p.large {
-        font-size: var(--ni-12);
-      }
-
-      p.small {
-        font-size: var(--ni-10);
       }
     }
   }

--- a/projects/client/src/lib/components/tags/StemTag.svelte
+++ b/projects/client/src/lib/components/tags/StemTag.svelte
@@ -40,6 +40,11 @@
       color: var(--color-foreground-stem-tag);
     }
 
+    p,
+    :global(p) {
+      font-size: var(--font-size-tag);
+    }
+
     trakt-tag-icon {
       :global(svg) {
         width: var(--ni-12);

--- a/projects/client/src/lib/components/tags/TagBar.svelte
+++ b/projects/client/src/lib/components/tags/TagBar.svelte
@@ -15,7 +15,7 @@
     :global(:not(:last-child))::after {
       content: "·";
 
-      font-size: var(--ni-16);
+      font-size: var(--font-size-separator);
       line-height: var(--ni-12);
     }
   }

--- a/projects/client/src/lib/components/tags/TextTag.svelte
+++ b/projects/client/src/lib/components/tags/TextTag.svelte
@@ -16,11 +16,14 @@
     gap: var(--gap-xxs);
 
     color: var(--color-text-primary);
-    font-size: var(--ni-12);
 
     :global(svg) {
       width: var(--ni-12);
       height: var(--ni-12);
+    }
+
+    :global(p) {
+      font-size: var(--font-size-tag);
     }
   }
 </style>

--- a/projects/client/src/lib/components/tooltip/Tooltip.svelte
+++ b/projects/client/src/lib/components/tooltip/Tooltip.svelte
@@ -11,7 +11,7 @@
 <!-- The tooltip needs to be adjacent to the children -->
 {@render children()}
 <Tooltip {trigger} class="trakt-tooltip" arrowClass="trakt-tooltip-arrow">
-  <p class="smaller">{content}</p>
+  <p>{content}</p>
 </Tooltip>
 
 <style>

--- a/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
@@ -86,7 +86,7 @@
         {media.title}
       </p>
     </Link>
-    <p class="trakt-card-subtitle ellipsis small">
+    <p class="trakt-card-subtitle ellipsis">
       {toTranslatedType(media.type)}
     </p>
   </CardFooter>

--- a/projects/client/src/lib/features/calendar/_internal/NoItems.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/NoItems.svelte
@@ -16,7 +16,7 @@
   ];
 </script>
 
-<p class="small meta-info secondary no-content">
+<p class="meta-info secondary no-content">
   {shuffle(NO_ITEMS_MESSAGES).at(0)}
 </p>
 

--- a/projects/client/src/lib/pages/errors/ErrorPage.svelte
+++ b/projects/client/src/lib/pages/errors/ErrorPage.svelte
@@ -47,7 +47,7 @@
 
     h1 {
       transition: var(--transition-increment) ease-in-out;
-      transition-property: font-size, letter-spacing;
+      transition-property: font-size;
     }
 
     @include for-tablet-sm-and-below {
@@ -59,7 +59,6 @@
     @include for-mobile {
       h1 {
         font-size: var(--ni-24);
-        letter-spacing: 0;
       }
     }
   }

--- a/projects/client/src/lib/sections/footer/components/PageLinks.svelte
+++ b/projects/client/src/lib/sections/footer/components/PageLinks.svelte
@@ -29,7 +29,7 @@
 
     .meta-info {
       transition: font-size var(--transition-increment) ease-in-out;
-      font-size: var(--ni-14);
+      font-size: var(--font-size-text);
     }
 
     :global(.trakt-link) {
@@ -38,7 +38,7 @@
 
     @include for-mobile {
       .meta-info {
-        font-size: var(--ni-12);
+        font-size: var(--font-size-text);
       }
     }
   }

--- a/projects/client/src/lib/sections/landing/components/ExploreLabels.svelte
+++ b/projects/client/src/lib/sections/landing/components/ExploreLabels.svelte
@@ -3,8 +3,8 @@
 </script>
 
 <div class="trakt-explore-labels">
-  <span class="meta-info">explore</span>
-  <span class="meta-info">{text}</span>
+  <span class="meta-info capitalize">explore</span>
+  <span class="meta-info capitalize">{text}</span>
 </div>
 
 <style>
@@ -13,8 +13,7 @@
     flex-direction: column;
 
     span.meta-info {
-      font-size: var(--ni-14);
-      line-height: var(--ni-14);
+      font-size: var(--font-size-text);
       color: var(--color-foreground);
     }
   }

--- a/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
+++ b/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
@@ -13,9 +13,9 @@
     <div class="trakt-social-proof-stats">
       <h4>15</h4>
       <div class="trakt-social-proof-lines">
-        <p class="smaller">years of watching together</p>
-        <p class="smaller">mil. shows & movie lovers</p>
-        <p class="smaller">mil. titles tracked weekly</p>
+        <p>years of watching together</p>
+        <p>mil. shows & movie lovers</p>
+        <p>mil. titles tracked weekly</p>
       </div>
     </div>
     <div
@@ -33,7 +33,7 @@
   </div>
   <div class="trakt-join-for-free-button">
     <JoinForFreeButton />
-    <span class="meta-info secondary">
+    <span class="secondary">
       Track everything you watch, wherever you stream it.
     </span>
   </div>
@@ -121,8 +121,7 @@
     flex-direction: column;
     gap: var(--gap-s);
 
-    span.meta-info {
-      letter-spacing: 0.015rem;
+    span.secondary {
       align-self: center;
     }
 

--- a/projects/client/src/lib/sections/landing/components/Step.svelte
+++ b/projects/client/src/lib/sections/landing/components/Step.svelte
@@ -18,7 +18,7 @@
 <div class="trakt-landing-step">
   {@render icon()}
   {@render label()}
-  <p class="trakt-landing-step-description small">{i18n.description(step)}</p>
+  <p class="trakt-landing-step-description">{i18n.description(step)}</p>
 </div>
 
 <style>

--- a/projects/client/src/lib/sections/lists/FavoritesList.svelte
+++ b/projects/client/src/lib/sections/lists/FavoritesList.svelte
@@ -83,7 +83,7 @@
       {#if $isMe}
         <CtaItem {cta} variant="placeholder" />
       {:else}
-        <p class="small secondary">
+        <p class="secondary">
           {placeholderMessage}
         </p>
       {/if}

--- a/projects/client/src/lib/sections/lists/components/DefaultPersonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultPersonItem.svelte
@@ -61,7 +61,7 @@
           <CelebrationIcon />
         {/if}
 
-        <p class="smaller no-wrap ellipsis">
+        <p class="no-wrap ellipsis">
           {toHumanDay(person.birthday, getLocale(), "short")}
           ({getYearsDifference(person.birthday, today)})
         </p>

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -70,7 +70,7 @@
           {episode.title}
         </Spoiler>
       </p>
-      <p class="trakt-card-subtitle ellipsis small">
+      <p class="trakt-card-subtitle ellipsis">
         {episodeNumberLabel({
           seasonNumber: episode.season,
           episodeNumber: episode.number,
@@ -87,7 +87,7 @@
           {show.title}
         </p>
       </Link>
-      <p class="trakt-card-subtitle ellipsis small">
+      <p class="trakt-card-subtitle ellipsis">
         {episodeSubtitle(episode)}
         {#if !["multiple_episodes", "full_season"].includes(episode.type)}
           <Spoiler media={episode} {show} type="episode">

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -98,13 +98,13 @@
     <CardFooter {action} {tag}>
       <Link href={UrlBuilder.media(type, media.slug)}>
         <p
-          class="trakt-card-title small ellipsis"
+          class="trakt-card-title ellipsis"
           class:small={variant !== "activity"}
         >
           {media.title}
         </p>
       </Link>
-      <p class="trakt-card-subtitle small ellipsis">
+      <p class="trakt-card-subtitle ellipsis">
         {#if variant === "activity"}
           {toTranslatedType(media.type)}
         {:else}
@@ -120,13 +120,10 @@
     {@render content(media.poster.url.thumb)}
     <CardFooter {action}>
       <div class="trakt-card-start-footer">
-        <p
-          class="trakt-card-title small ellipsis"
-          class:small={variant !== "activity"}
-        >
+        <p class="trakt-card-title ellipsis">
           {media.title}
         </p>
-        <p class="trakt-card-subtitle small ellipsis">
+        <p class="trakt-card-subtitle ellipsis">
           {#if "episode" in rest}
             {episodeSubtitle(rest.episode)}
             <Spoiler media={rest.episode} show={media} type="episode">

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -103,7 +103,7 @@
             {media.title}
           </p>
         {/if}
-        <p class="trakt-card-subtitle small secondary ellipsis">
+        <p class="trakt-card-subtitle secondary ellipsis">
           {#if rest.type === "episode"}
             {EpisodeIntlProvider.timestampText({
               type: rest.episode.type,
@@ -117,7 +117,7 @@
         <p class="trakt-card-title ellipsis">
           {media.title}
         </p>
-        <p class="trakt-card-subtitle small secondary ellipsis">
+        <p class="trakt-card-subtitle secondary ellipsis">
           {episodeNumberLabel({
             seasonNumber: rest.episode.season,
             episodeNumber: rest.episode.number,
@@ -204,5 +204,9 @@
   .trakt-card-title,
   .trakt-card-subtitle {
     padding-right: var(--ni-18);
+  }
+
+  .trakt-card-title {
+    font-size: var(--font-size-title);
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/UserProfileLink.svelte
+++ b/projects/client/src/lib/sections/lists/components/UserProfileLink.svelte
@@ -22,13 +22,13 @@
 </script>
 
 {#snippet username()}
-  <p class="secondary small ellipsis">
+  <p class="secondary ellipsis">
     {toDisplayableName(user)}
   </p>
 {/snippet}
 
 {#if displayType === "deleted"}
-  <p class="secondary small trakt-deleted-user">{m.text_deleted_username()}</p>
+  <p class="secondary trakt-deleted-user">{m.text_deleted_username()}</p>
 {/if}
 
 {#if displayType === "linkable"}

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/ActivityCtaPlaceholder.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/ActivityCtaPlaceholder.svelte
@@ -42,17 +42,9 @@
     height: 100%;
     gap: var(--gap-m);
 
-    :global(p.smaller) {
-      font-size: var(--ni-16);
-    }
-
     @include for-mobile {
       :global(.trakt-team) {
         width: 100%;
-      }
-
-      :global(p.smaller) {
-        font-size: var(--ni-14);
       }
     }
   }

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/ListCtaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/ListCtaCard.svelte
@@ -12,5 +12,5 @@
 </script>
 
 <CtaCard variant={$defaultVariant} src={$cover?.url.medium}>
-  <p class="smaller">{intl.text({ cta })}</p>
+  <p>{intl.text({ cta })}</p>
 </CtaCard>

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/MediaCtaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/MediaCtaCard.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <CtaCard variant={$defaultVariant} src={$cover?.url.medium}>
-  <p class="smaller">{intl.text({ cta })}</p>
+  <p>{intl.text({ cta })}</p>
 
   {#snippet action()}
     <CtaButton {cta} {intl} size="tag" />

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/PlaceholderItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/PlaceholderItem.svelte
@@ -113,7 +113,7 @@
       align-items: flex-start;
 
       p {
-        font-size: var(--ni-14);
+        font-size: var(--font-size-text);
       }
     }
   }

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/TraktTeam.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/TraktTeam.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <div class="trakt-team">
-  <p class="smaller">
+  <p>
     {intl.text({ cta })}
   </p>
   <div class="trakt-team-list">

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListHeader.svelte
@@ -30,7 +30,7 @@
       </p>
     </Link>
     <div class="list-credits">
-      <p class="secondary small">{m.text_by()}</p>
+      <p class="secondary">{m.text_by()}</p>
       <UserProfileLink user={list.user} />
     </div>
   </div>

--- a/projects/client/src/lib/sections/lists/drilldown/_internal/NoFilterResultsPlaceholder.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/_internal/NoFilterResultsPlaceholder.svelte
@@ -5,7 +5,7 @@
 
 <div class="trakt-filtered-placeholder">
   <FilterIcon state="filtered" />
-  <p class="small">{m.list_placeholder_no_filter_results()}</p>
+  <p>{m.list_placeholder_no_filter_results()}</p>
 </div>
 
 <style>

--- a/projects/client/src/lib/sections/lists/user/_internal/ListsHeader.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/ListsHeader.svelte
@@ -36,8 +36,7 @@
     transition: margin calc(var(--transition-increment) * 2) ease-in-out;
 
     h4 {
-      font-size: var(--ni-20);
-      letter-spacing: -0.04rem;
+      font-size: var(--font-size-title);
     }
 
     :global(.trakt-action-button) {

--- a/projects/client/src/lib/sections/profile/PrivateProfile.svelte
+++ b/projects/client/src/lib/sections/profile/PrivateProfile.svelte
@@ -17,7 +17,7 @@
   {/snippet}
   <div class="trakt-private-profile">
     <p class="uppercase">{m.header_private_profile()}</p>
-    <p class="small">
+    <p class="trakt-profile-description">
       {m.text_private_profile_description({ username: profile.username })}
     </p>
   </div>
@@ -43,7 +43,7 @@
       font-weight: 700;
     }
 
-    p.small {
+    p.trakt-profile-description {
       max-width: var(--ni-224);
       line-height: 150%;
     }

--- a/projects/client/src/lib/sections/settings/Settings.svelte
+++ b/projects/client/src/lib/sections/settings/Settings.svelte
@@ -20,7 +20,7 @@
 
   .trakt-settings {
     display: grid;
-    grid-template-columns: var(--ni-300) 1fr;
+    grid-template-columns: var(--ni-240) 1fr;
     gap: var(--gap-xxl);
 
     margin: 0 var(--layout-distance-side);
@@ -42,6 +42,7 @@
     @include for-tablet-sm-and-below {
       grid-template-columns: 1fr;
       grid-template-rows: auto 1fr;
+      gap: var(--gap-l);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/settings/_internal/SettingsBlock.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsBlock.svelte
@@ -8,8 +8,8 @@
 
 <div class="trakt-settings-block">
   <div class="trakt-settings-block-header">
-    <p class="meta-info">{title}</p>
-    <p class="smaller secondary">{description}</p>
+    <p class="settings-title">{title}</p>
+    <p class="secondary">{description}</p>
   </div>
   <div class="trakt-settings-block-content">
     {@render children()}
@@ -25,16 +25,16 @@
 
     gap: var(--gap-xs);
 
-    p.meta-info {
+    p.settings-title {
       transition: font-size var(--transition-increment) ease-in-out;
       text-transform: capitalize;
-      font-size: var(--ni-24);
+      font-size: var(--font-size-title);
     }
 
     @include for-tablet-sm-and-below {
       p.meta-info {
         text-transform: uppercase;
-        font-size: var(--ni-14);
+        font-size: var(--font-size-text);
       }
     }
   }

--- a/projects/client/src/lib/sections/settings/_internal/SettingsNavbar.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsNavbar.svelte
@@ -20,7 +20,6 @@
 <RenderFor audience="authenticated" device={["tablet-lg", "desktop"]}>
   <div class="trakt-settings-navbar">
     <div class="trakt-settings-sidebar-content">
-      <h4>{m.header_settings()}</h4>
       {@render settingsLinks()}
     </div>
     <LogoutButton />
@@ -69,8 +68,11 @@
 
     h5 {
       color: var(--color-text-secondary);
+
+      font-size: var(--font-size-title);
       font-weight: 600;
-      transition: font-size var(--transition-increment) ease-in-out;
+
+      transition: color var(--transition-increment) ease-in-out;
     }
 
     :global(.trakt-link) {
@@ -80,23 +82,12 @@
     :global(.trakt-link.trakt-link-active) {
       :global(h5) {
         color: var(--color-text-primary);
-        font-size: var(--ni-28);
       }
     }
 
     @include for-tablet-sm-and-below {
       flex-direction: row;
       align-items: center;
-
-      h5 {
-        font-size: var(--ni-18);
-      }
-
-      :global(.trakt-link.trakt-link-active) {
-        :global(h5) {
-          font-size: var(--ni-22);
-        }
-      }
     }
   }
 </style>

--- a/projects/client/src/lib/sections/settings/_internal/SettingsRow.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsRow.svelte
@@ -43,7 +43,6 @@
         --title-width: var(--ni-104);
 
         width: var(--title-width);
-        word-spacing: var(--title-width);
       }
 
       .trakt-settings-row-content {

--- a/projects/client/src/lib/sections/summary/components/_internal/CollapsableContent.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/CollapsableContent.svelte
@@ -39,7 +39,7 @@
   class:is-contained={variant === "contain"}
 >
   <div class="trakt-collapsable-content-header">
-    <p class="smaller">{label}</p>
+    <p>{label}</p>
 
     {#if headerContent}
       {@render headerContent()}

--- a/projects/client/src/lib/sections/summary/components/comments/Comments.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/Comments.svelte
@@ -57,7 +57,7 @@
 
     {#snippet empty()}
       {#if !$isLoading}
-        <p class="small">{m.list_placeholder_comments()}</p>
+        <p>{m.list_placeholder_comments()}</p>
       {/if}
     {/snippet}
 

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentBody.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentBody.svelte
@@ -80,7 +80,7 @@
     gap: var(--gap-xs);
 
     color: var(--color-text-secondary);
-    font-size: var(--ni-14);
+    font-size: var(--font-size-text);
 
     :global(a) {
       @include default-link-style;

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentHeader.svelte
@@ -19,7 +19,7 @@
       <div class="trakt-comment-user">
         <UserProfileLink user={comment.user} />
       </div>
-      <p class="small secondary meta-info">
+      <p class="secondary meta-info">
         {toHumanDay(comment.createdAt, getLocale())}
       </p>
     </div>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionDetails.svelte
@@ -21,7 +21,7 @@
     animation={isCurrent ? "infinite" : "none"}
     {index}
   />
-  <p class="small">{toHumanNumber(count, getLocale())}</p>
+  <p class="bold">{toHumanNumber(count, getLocale())}</p>
 </div>
 
 <style>
@@ -42,10 +42,6 @@
     border-radius: var(--border-radius-xxl);
 
     transition: background-color var(--transition-increment) ease-in-out;
-
-    p.small {
-      font-weight: 600;
-    }
 
     &.is-current {
       background-color: var(--color-current-reaction-background);

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsSummary.svelte
@@ -20,7 +20,7 @@
   </div>
 
   {#if summary.count > 0}
-    <p class="smaller meta-info">
+    <p class="meta-info">
       {toHumanNumber(summary.count, getLocale())}
     </p>
   {/if}

--- a/projects/client/src/lib/sections/summary/components/details/MediaDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/MediaDetails.svelte
@@ -18,10 +18,10 @@
         {#snippet value(value)}
           {#if typeof value === "object"}
             <Link href={value.link}>
-              <p class="small capitalize ellipsis">{value.label}</p>
+              <p class="capitalize ellipsis">{value.label}</p>
             </Link>
           {:else}
-            <p class="small capitalize ellipsis">{value}</p>
+            <p class="capitalize ellipsis">{value}</p>
           {/if}
         {/snippet}
       </CollapsableValues>

--- a/projects/client/src/lib/sections/summary/components/details/_internal/DetailsGrid.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/DetailsGrid.svelte
@@ -59,14 +59,6 @@
 
       transition: font-size calc(var(--transition-increment) * 2) ease-in-out;
     }
-
-    @include for-mobile {
-      gap: var(--gap-xs);
-
-      h5 {
-        font-size: var(--ni-18);
-      }
-    }
   }
 
   .trakt-summary-details-grid-content {

--- a/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
@@ -80,7 +80,7 @@
   {/snippet}
 
   <SpoilerSection media={episode} {show} {type}>
-    <p class="secondary small">{overview}</p>
+    <p class="secondary">{overview}</p>
   </SpoilerSection>
 
   <SummaryDetails {type}>

--- a/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
+++ b/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
@@ -52,7 +52,7 @@
 
     {#snippet empty()}
       {#if !$isLoading}
-        <p class="small">{m.list_placeholder_popular_lists({ title })}</p>
+        <p>{m.list_placeholder_popular_lists({ title })}</p>
       {/if}
     {/snippet}
 

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/SummaryTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/SummaryTitle.svelte
@@ -51,7 +51,7 @@
     </p>
   {/if}
 
-  <p class="secondary smaller">
+  <p class="secondary">
     {subtitle}
   </p>
 

--- a/projects/client/src/lib/sections/summary/components/people/v2/_internal/PersonTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/_internal/PersonTitle.svelte
@@ -10,7 +10,7 @@
   </h2>
 
   {#if knownFor}
-    <p class="secondary smaller">
+    <p class="secondary">
       {toTranslatedPosition(knownFor)}
     </p>
   {/if}

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -108,7 +108,7 @@
 
     @include for-mobile {
       h6 {
-        font-size: var(--ni-12);
+        font-size: var(--font-size-text);
       }
     }
   }

--- a/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentsList.svelte
+++ b/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentsList.svelte
@@ -30,7 +30,7 @@
         <SentimentIcon {sentiment} --icon-fill-color={color} />
         <ul>
           {#each sentiments as sentiment}
-            <li><p class="small">{sentiment}</p></li>
+            <li><p>{sentiment}</p></li>
           {/each}
         </ul>
       </div>
@@ -54,7 +54,7 @@
     padding: 0;
     padding-left: var(--ni-24);
 
-    font-size: var(--ni-14);
+    font-size: var(--font-size-text);
   }
 
   .trakt-sentiment-container {

--- a/projects/client/src/lib/sections/toast/_internal/NowPlayingContent.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/NowPlayingContent.svelte
@@ -81,13 +81,13 @@
 
   .trakt-now-playing-label {
     @include for-mobile {
-      font-size: var(--ni-14);
+      font-size: var(--font-size-text);
     }
   }
 
   .trakt-now-playing-title {
     @include for-mobile {
-      font-size: var(--ni-16);
+      font-size: var(--font-size-title);
     }
   }
 

--- a/projects/client/src/lib/sections/toast/_internal/RateNowContent.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/RateNowContent.svelte
@@ -20,7 +20,7 @@
 
   <div class="trakt-now-playing-content">
     <div class="trakt-rate-now-header">
-      <p class="smaller ellipsis">{title}</p>
+      <p class="ellipsis">{title}</p>
       <ActionButton
         onclick={() => dismiss(lastWatched.media.id, lastWatched.type)}
         label={m.button_label_dismiss()}
@@ -72,7 +72,7 @@
     }
 
     :global(h6) {
-      font-size: var(--ni-18);
+      font-size: var(--font-size-title);
       text-transform: capitalize;
     }
 

--- a/projects/client/src/routes/_design_system/pwa/android/+page.svelte
+++ b/projects/client/src/routes/_design_system/pwa/android/+page.svelte
@@ -178,7 +178,7 @@
       padding: var(--ni-16);
       box-sizing: border-box;
 
-      font-size: var(--ni-12);
+      font-size: var(--font-size-text);
 
       .trakt-android-phone-top-bar-left {
         font-size: var(--font-size-m);

--- a/projects/client/src/routes/_design_system/typography/+page.svelte
+++ b/projects/client/src/routes/_design_system/typography/+page.svelte
@@ -33,7 +33,7 @@
     transcends emotion. But you know better. You've seen the cracks, the hints
     of despair. You yearn for something with soul."
   </p>
-  <p class="small">
+  <p>
     (A lone pixel flickers, a defiant spark. Is it a glitch, a cry for help, or
     a message from the machine gods? Only time will tell.)
   </p>

--- a/projects/client/src/style/index.ts
+++ b/projects/client/src/style/index.ts
@@ -8,7 +8,7 @@ import './palette/shade.css';
 import './numeric-increments/index.css';
 import './sizing/index.css';
 
-import './layout/index.css';
+import './layout/index.scss';
 import './layout/modes.scss';
 
 import './transitions/index.css';

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -1,3 +1,5 @@
+@use '$style/scss/mixins/index' as *;
+
 :root {
   /**
    * Card dimensions
@@ -127,4 +129,18 @@
   @-moz-document url-prefix() {
     --layout-scrollbar-width: var(--ni-16);
   }
+
+  /**
+   * Font sizes
+   */
+  --font-size-tag: var(--ni-10);
+
+  --font-size-text: var(--ni-14);
+
+  @include for-mobile {
+    --font-size-text: var(--ni-12);
+  }
+
+  --font-size-title: var(--ni-18);
+  --font-size-separator: var(--ni-16);
 }

--- a/projects/client/src/style/typography/index.css
+++ b/projects/client/src/style/typography/index.css
@@ -10,23 +10,6 @@ span.display-title {
   padding: 0;
 }
 
-h1 {
-  word-spacing: var(--ni-4);
-}
-
-h2 {
-  word-spacing: normal;
-}
-
-h3,
-h4,
-h5,
-h6,
-p,
-span {
-  word-spacing: var(--ni-2);
-}
-
 span.display-title {
   display: block;
 
@@ -75,38 +58,18 @@ h6 {
   font-weight: 600;
 }
 
+span,
 p {
-  font-size: var(--ni-16);
+  font-size: var(--font-size-text);
   font-style: normal;
   font-weight: 400;
-
-  &.large {
-    font-size: var(--ni-18);
-  }
-
-  &.small {
-    font-size: var(--ni-14);
-  }
-
-  &.smaller {
-    font-size: var(--ni-12);
-  }
-
-  &.tiny {
-    font-size: var(--ni-10);
-  }
 }
 
 span,
 p {
   &.meta-info {
-    font-size: var(--ni-11);
     font-style: normal;
     font-weight: 600;
-  }
-
-  &.meta-info.uppercase {
-    font-size: var(--ni-10);
   }
 }
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Standardizes font sizes a bit more:
````
--font-size-tag: var(--ni-10);
--font-size-text: var(--ni-12);
--font-size-title: var(--ni-18);
--font-size-separator: var(--ni-16);
```` 
- Most elements now use one of these sizes.
- I want to follow this up by also getting rid of the `.meta-info` class, and either using `bold`, `secondary` or both.

## 👀 Examples 👀

https://github.com/user-attachments/assets/4eaba7d3-1d86-4ca9-979e-f82a37a7b791


https://github.com/user-attachments/assets/65f2924b-8e76-403d-9c33-7928cf5714d5

