### PR TITLE
fix(summary): remove extra bottom padding from poster

### DIFF
--- a/projects/client/src/lib/components/summary/SummaryPoster.svelte
+++ b/projects/client/src/lib/components/summary/SummaryPoster.svelte
@@ -54,7 +54,6 @@
 
 <style>
   .trakt-summary-poster-container {
-    --bottom-padding: var(--ni-12);
     --overlay-border-size: var(--ni-2);
 
     width: var(--ni-320);
@@ -62,8 +61,6 @@
     flex-direction: column;
     gap: var(--gap-m);
     position: relative;
-
-    padding-bottom: var(--bottom-padding);
   }
 
   .trakt-summary-poster :global(img),
@@ -122,7 +119,7 @@
     position: absolute;
     z-index: var(--layer-raised);
 
-    bottom: var(--bottom-padding);
+    bottom: 0;
     left: 0;
     right: 0;
 


### PR DESCRIPTION
## ♪ Note ♪

- Removes extra bottom padding from poster.

## 👀 Examples 👀
Before/after:
<img width="429" height="694" alt="before" src="https://github.com/user-attachments/assets/aa0c35b0-57d8-4e49-8b66-f1fdaa65d3ce" /> <img width="429" height="680" alt="after" src="https://github.com/user-attachments/assets/3c5ef7b9-7f53-4d64-948f-f7f457337205" />

Before/after:
<img width="429" height="672" alt="before_1" src="https://github.com/user-attachments/assets/0a2a841e-4bc3-45c9-8398-e494c48f72e2" /> <img width="429" height="672" alt="after_1" src="https://github.com/user-attachments/assets/1ef27db4-a9da-4407-a051-b82e75ce2a93" />

