### PR TITLE
fix(requests): sort start watching movies by airdate

### DIFF
--- a/projects/client/src/lib/requests/queries/sync/movieProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/movieProgressQuery.ts
@@ -50,7 +50,7 @@ const mapToStartWatchingMovie = (response: ListedMovieResponse) => {
     progress: NaN,
     minutesElapsed: 0,
     minutesLeft: movie.runtime ?? 0,
-    lastWatchedAt: null,
+    lastWatchedAt: new Date(movie.airDate),
   };
 };
 


### PR DESCRIPTION
## ♪ Note ♪

- Sort `start watching` movies by airDate instead of weaving.

## 👀 Example 👀
Before/after:
<img width="1282" height="314" alt="start_watching_before" src="https://github.com/user-attachments/assets/afb128f0-16d5-4fb0-a85d-ed7e897bf879" />

<img width="1282" height="314" alt="start_watching_after" src="https://github.com/user-attachments/assets/9a48efbf-3807-4260-8bcc-34cdc7f21d4f" />
