### PR TITLE
feat(errors): treat 500 as a well known server error

### DIFF
--- a/projects/client/src/lib/features/errors/_internal/mapToWellKnownError.ts
+++ b/projects/client/src/lib/features/errors/_internal/mapToWellKnownError.ts
@@ -6,6 +6,7 @@ import {
 
 function mapToWellKnownErrorType(statusCode: number) {
   switch (statusCode) {
+    case 500:
     case 502:
     case 503:
       return WellKnownErrorType.ServerError;


### PR DESCRIPTION
## ♪ Note ♪

- Treats 500 also as a well known server error.