### PR TITLE
fix(i18n): add normalize util and integrate it in translation functions

### DIFF
--- a/projects/client/src/lib/utils/formatting/string/normalizeTranslationKey.ts
+++ b/projects/client/src/lib/utils/formatting/string/normalizeTranslationKey.ts
@@ -1,0 +1,7 @@
+function normalizeString(input: string, separator: string): string {
+  return input.replace(/[^a-zA-Z0-9]/g, separator).toLowerCase();
+}
+
+export function normalizeTranslationKey(key: string): string {
+  return normalizeString(key, '_');
+}

--- a/projects/client/src/lib/utils/formatting/string/toTranslatedGenre.ts
+++ b/projects/client/src/lib/utils/formatting/string/toTranslatedGenre.ts
@@ -1,5 +1,7 @@
 import * as m from '$lib/features/i18n/messages.ts';
 
+import { normalizeTranslationKey } from './normalizeTranslationKey.ts';
+
 const GENRE_MAP = {
   horror: m.translated_value_genre_horror,
   comedy: m.translated_value_genre_comedy,
@@ -44,6 +46,6 @@ export function toTranslatedGenre(
   genre: string | (keyof typeof GENRE_MAP),
   data?: Record<string, unknown>,
 ): string {
-  const translationFn = GENRE_MAP[genre as keyof typeof GENRE_MAP];
+  const translationFn = GENRE_MAP[normalizeTranslationKey(genre) as keyof typeof GENRE_MAP];
   return translationFn?.(data) ?? genre;
 }

--- a/projects/client/src/lib/utils/formatting/string/toTranslatedJob.ts
+++ b/projects/client/src/lib/utils/formatting/string/toTranslatedJob.ts
@@ -1,5 +1,7 @@
 import * as m from '$lib/features/i18n/messages.ts';
 
+import { normalizeTranslationKey } from './normalizeTranslationKey.ts';
+
 const JOB_MAP = {
   action_director: m.translated_value_job_action_director,
   additional_second_assistant_director:
@@ -89,6 +91,7 @@ export function toTranslatedJob(
   job: string | (keyof typeof JOB_MAP),
   data?: Record<string, unknown>,
 ): string {
-  const translationFn = JOB_MAP[job as keyof typeof JOB_MAP];
+  const translationFn =
+    JOB_MAP[normalizeTranslationKey(job) as keyof typeof JOB_MAP];
   return translationFn?.(data) ?? job;
 }

--- a/projects/client/src/lib/utils/formatting/string/toTranslatedPosition.ts
+++ b/projects/client/src/lib/utils/formatting/string/toTranslatedPosition.ts
@@ -1,5 +1,7 @@
 import * as m from '$lib/features/i18n/messages.ts';
 
+import { normalizeTranslationKey } from './normalizeTranslationKey.ts';
+
 const POSITION_MAP = {
   acting: m.translated_value_position_acting,
   self: m.translated_value_position_self,
@@ -23,6 +25,9 @@ export function toTranslatedPosition(
   position: string | (keyof typeof POSITION_MAP),
   data?: Record<string, unknown>,
 ): string {
-  const translationFn = POSITION_MAP[position as keyof typeof POSITION_MAP];
+  const translationFn =
+    POSITION_MAP[
+      normalizeTranslationKey(position) as keyof typeof POSITION_MAP
+    ];
   return translationFn?.(data) ?? position;
 }

--- a/projects/client/src/lib/utils/formatting/string/toTranslatedVideoType.ts
+++ b/projects/client/src/lib/utils/formatting/string/toTranslatedVideoType.ts
@@ -1,5 +1,7 @@
 import * as m from '$lib/features/i18n/messages.ts';
 
+import { normalizeTranslationKey } from './normalizeTranslationKey.ts';
+
 const VIDEO_TYPE_MAP = {
   trailer: m.translated_value_video_type_trailer,
   clip: m.translated_value_video_type_clip,
@@ -15,6 +17,8 @@ export function toTranslatedVideoType(
   data?: Record<string, unknown>,
 ): string {
   const translationFn =
-    VIDEO_TYPE_MAP[videoType as keyof typeof VIDEO_TYPE_MAP];
+    VIDEO_TYPE_MAP[
+      normalizeTranslationKey(videoType) as keyof typeof VIDEO_TYPE_MAP
+    ];
   return translationFn?.(data) ?? videoType;
 }


### PR DESCRIPTION
This pull request introduces a utility function to standardize translation key formatting and applies it across multiple translation mapping functions. The main goal is to ensure that genre, job, position, and video type keys are consistently normalized before translation lookup, improving reliability and reducing mismatches due to formatting differences.

### Utility function addition

* Added `normalizeString` and `normalizeTranslationKey` functions in `normalizeTranslationKey.ts` to convert input strings into a normalized, lowercase, underscore-separated format.

### Refactoring translation mapping functions

* Updated `toTranslatedGenre`, `toTranslatedJob`, `toTranslatedPosition`, and `toTranslatedVideoType` to use `normalizeTranslationKey` for key lookup, ensuring consistent mapping regardless of input string formatting. [[1]](diffhunk://#diff-cbe04aa630b930cb9e1f3e4c1be141a129b487e6f711944577962db1889085ffL47-R49) [[2]](diffhunk://#diff-59bbde0c3a9b0d3043abe01db8e35ce3130a3e2795e117d33061dddd4c758821L92-R95) [[3]](diffhunk://#diff-4bb3773e7a05929c039a0c83b8b7317307f01bbe3f32fb49329192a038f92186L26-R31) [[4]](diffhunk://#diff-96960427521769b0cdf0e5799a3298f3aa89292663cb0eaa6ae1c879378ad75bL18-R22)

### Dependency updates

* Imported the new `normalizeTranslationKey` utility in all relevant translation mapping files to enable the normalization logic. [[1]](diffhunk://#diff-cbe04aa630b930cb9e1f3e4c1be141a129b487e6f711944577962db1889085ffR3-R4) [[2]](diffhunk://#diff-59bbde0c3a9b0d3043abe01db8e35ce3130a3e2795e117d33061dddd4c758821R3-R4) [[3]](diffhunk://#diff-4bb3773e7a05929c039a0c83b8b7317307f01bbe3f32fb49329192a038f92186R3-R4) [[4]](diffhunk://#diff-96960427521769b0cdf0e5799a3298f3aa89292663cb0eaa6ae1c879378ad75bR3-R4)