### PR TITLE
fix(watched): do not close drawer if it was already closed

### DIFF
--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/MarkAsWatchedDrawer.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/MarkAsWatchedDrawer.svelte
@@ -9,6 +9,7 @@
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MarkAsWatchedAt } from "$lib/models/MarkAsWatchedAt";
+  import { onDestroy } from "svelte";
   import { writable } from "svelte/store";
   import {
     useMarkAsWatched,
@@ -34,6 +35,11 @@
 
   const confirmedAction = writable<MarkAsWatchedAt | null>(null);
 
+  const isDestroyed = writable(false);
+  onDestroy(() => {
+    isDestroyed.set(true);
+  });
+
   const handler = async (watchedAt: MarkAsWatchedAt) => {
     const confirmMarkAsWatched = confirm({
       type: ConfirmationType.MarkAsWatched,
@@ -42,7 +48,10 @@
       onConfirm: async () => {
         confirmedAction.set(watchedAt);
         await markAsWatched(watchedAt);
-        onClose();
+
+        if (!$isDestroyed) {
+          onClose();
+        }
       },
     });
 


### PR DESCRIPTION
## ♪ Note ♪

- Woopsie. Users can also manually close the drawer while marking as watched 😅
  - Fixes https://trakt-tv.sentry.io/issues/78755609/?alert_rule_id=260231&alert_type=issue&notification_uuid=c22ffb65-fdd1-466c-b61a-54e261656210&project=4509870926463056&referrer=issue_alert-slack