### PR TITLE
fix(list): allow content to go under the navbar again

### DIFF
--- a/projects/client/src/lib/components/lists/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/SectionList.svelte
@@ -172,7 +172,6 @@
     );
 
     contain: layout;
-    content-visibility: auto;
 
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## ♪ Note ♪

- Lists can scroll all the way to the left again.
  - Downside, no `content-visibility: auto;` on the section list. If you don't agree with this change, close this and I'll try that different approach for the section list.

## 👀 Example 👀
<img width="833" height="920" alt="Screenshot 2025-11-21 at 19 29 18" src="https://github.com/user-attachments/assets/b550bcaf-5cdc-4c02-bac4-724ca9b48d48" />
