### PR TITLE
fix(summary): always show the watched label on poster

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/WatchCountTag.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/WatchCountTag.svelte
@@ -18,8 +18,8 @@
   >
     <TrackIcon />
 
+    <p class="bold uppercase no-wrap">{i18n.watchedLabel()}</p>
     {#if count > 1}
-      <p class="bold uppercase no-wrap">{i18n.watchedLabel()}</p>
       <p class="bold">·</p>
       <div transition:slide={{ axis: "x", duration: 150 }}>
         {#key count}


### PR DESCRIPTION
## ♪ Note ♪

- Always show the `watched` label

## 👀 Example 👀
<img width="425" height="651" alt="Screenshot 2025-11-24 at 15 37 46" src="https://github.com/user-attachments/assets/9eb60202-9def-43ca-88a3-a3fc14fac385" />
