### PR TITLE
fix(summary): update show progress episode cover on watch

### DIFF
--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -28,9 +28,8 @@
   }: EpisodeCardProps = $props();
 
   const isShowContext = $derived("context" in rest && rest.context === "show");
-  const isActivity = $derived(rest.variant === "activity");
 
-  const src = useEpisodeSpoilerImage({ episode, show });
+  const src = $derived(useEpisodeSpoilerImage({ episode, show }));
 
   const { track } = useTrack(AnalyticsEvent.SummaryDrilldown);
 </script>


### PR DESCRIPTION
## ♪ Note ♪

- Updates show progress episode card cover after marking it as watched.

## 👀 Example 👀

https://github.com/user-attachments/assets/dfe2b558-a7b7-46ca-bca3-4d39e15944d6

