### PR TITLE
fix(profile): place location below name

### DIFF
--- a/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
@@ -95,6 +95,13 @@
     }
   }
 
+  .profile-user-details {
+    display: flex;
+    flex-direction: column;
+
+    gap: var(--gap-micro);
+  }
+
   .profile-info {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## ♪ Note ♪

- Places location below user name.

## 👀 Example 👀

Before/after:
<img width="347" height="139" alt="Screenshot 2025-11-26 at 10 07 31" src="https://github.com/user-attachments/assets/0ef9ae45-b4d2-4a16-a43e-3b56362bd8f3" />

<img width="249" height="157" alt="Screenshot 2025-11-26 at 10 08 00" src="https://github.com/user-attachments/assets/21102a25-bcdd-4191-afd5-4cd1905894bc" />
