### PR TITLE
feat(cover): add overlay on main background cover types

### DIFF
--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -17,6 +17,9 @@
       src={$cover.data.src}
       alt={`Background for ${$cover.data.type}`}
     />
+    {#if $cover.data.type === "main"}
+      <div class="trakt-background-cover-image-overlay"></div>
+    {/if}
   </div>
 {/if}
 
@@ -79,6 +82,18 @@
         left: -60%;
       }
     }
+  }
+
+  .trakt-background-cover-image-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    width: 100%;
+    height: 100%;
+
+    background-color: var(--purple-700);
+    mix-blend-mode: color-dodge;
   }
 
   .trakt-background-cover-image {


### PR DESCRIPTION
## ♪ Note ♪

- Adds a color dodged purple overlay to `main` background cover images.
  - Had a chat with Magna, he also digs this 😎 

## 👀 Example 👀
Before/after:
<img width="1395" height="840" alt="Screenshot 2025-11-26 at 21 01 36" src="https://github.com/user-attachments/assets/870d9ddc-fa98-4bc4-8da8-ecf91e78509b" />

<img width="1395" height="840" alt="Screenshot 2025-11-26 at 21 01 22" src="https://github.com/user-attachments/assets/dfd63ad8-2624-4946-9578-f63f07875967" />
