### PR TITLE
fix(search): render trending results separately

### DIFF
--- a/projects/client/src/lib/components/lists/grid-list/GridList.svelte
+++ b/projects/client/src/lib/components/lists/grid-list/GridList.svelte
@@ -9,11 +9,13 @@
     empty?: Snippet;
     title?: string;
     metaInfo?: Snippet;
+    promotedItems?: T[];
     dimensionObserver?: (node: HTMLElement) => void;
   };
 
   const {
     items,
+    promotedItems = [],
     title,
     item,
     actions,
@@ -31,8 +33,10 @@
     isMounted.set(true);
   });
 
+  const promotedKeys = $derived(new Set(promotedItems.map(({ key }) => key)));
+
   const uniqueItems = $derived.by(() => {
-    const seenKeys = new Set<string>();
+    const seenKeys = new Set<string>(promotedKeys);
     return items.filter(({ key }) => !seenKeys.has(key) && seenKeys.add(key));
   });
 </script>
@@ -42,8 +46,11 @@
     <ListHeader {title} {metaInfo} {actions} {badge} inset="all" />
   {/if}
 
-  {#if uniqueItems.length > 0}
+  {#if uniqueItems.length > 0 || promotedItems.length > 0}
     <div class="trakt-list-item-container trakt-list-items" use:customAction>
+      {#each promotedItems as i (i.key)}
+        {@render item(i)}
+      {/each}
       {#each uniqueItems as i (i.key)}
         {@render item(i)}
       {/each}

--- a/projects/client/src/lib/features/search/SearchResultsGrid.svelte
+++ b/projects/client/src/lib/features/search/SearchResultsGrid.svelte
@@ -17,10 +17,18 @@
     title?: string;
     empty?: Snippet;
     items: Array<PersonSummary | MediaEntry>;
+    // FIXME: merge trending with regular items once we figure out the rendering issue
+    trendingItems?: Array<PersonSummary | MediaEntry>;
     onclick?: (item: PersonSummary | MediaEntry) => void;
   };
 
-  const { title, items, empty, onclick }: SearchResultsGridProps = $props();
+  const {
+    title,
+    items,
+    trendingItems,
+    empty,
+    onclick,
+  }: SearchResultsGridProps = $props();
 
   const { mode } = useSearch();
 
@@ -49,7 +57,8 @@
 <div class="search-results-grid">
   <GridList
     id={`search-grid-list-${id}`}
-    items={items as Array<PersonSummary | MediaEntry>}
+    {items}
+    promotedItems={trendingItems}
     {title}
     {empty}
     --width-item={`var(--width-override-card, var(${cardWidthVariable}))`}


### PR DESCRIPTION
## 🎶 Notes 🎶

- As a temporary fix, renders trending search results separately.
  - Pressing backspace on search query no longer should result in empty blocks.
- If there are trending search results, the first one is used for the cover image.

## 👀 Example 👀

https://github.com/user-attachments/assets/af9ccaed-4f3c-42fb-b77b-7382cd11141d

