### PR TITLE
feat(button): use danger colors only on hover

### DIFF
--- a/projects/client/src/lib/components/buttons/_internal/useDangerButton.spec.ts
+++ b/projects/client/src/lib/components/buttons/_internal/useDangerButton.spec.ts
@@ -29,15 +29,14 @@ describe('useDangerButton', () => {
     const button = useDangerButton({ color: 'blue', isActive: true });
 
     const color = await firstValueFrom(button.color);
-    expect(color).toBe('red');
+    expect(color).toBe('blue');
   });
 
-  it('should return correct variant based on touch and active state', async () => {
+  it('should return correct variant based active state', () => {
     vi.mocked(useMedia).mockReturnValue(of(false));
     const button = useDangerButton({ color: 'blue', isActive: true });
 
-    const variant = await firstValueFrom(button.variant);
-    expect(variant).toBe('primary');
+    expect(button.variant).toBe('primary');
   });
 
   it('should handle focus events', async () => {

--- a/projects/client/src/lib/components/buttons/_internal/useDangerButton.ts
+++ b/projects/client/src/lib/components/buttons/_internal/useDangerButton.ts
@@ -1,5 +1,4 @@
-import { useMedia, WellKnownMediaQuery } from '$lib/stores/css/useMedia.ts';
-import { BehaviorSubject, combineLatest, distinctUntilChanged } from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged } from 'rxjs';
 import { debounceTime, map } from 'rxjs/operators';
 import { time } from '../../../utils/timing/time.ts';
 import type { TraktButtonProps } from '../TraktButtonProps.ts';
@@ -14,30 +13,21 @@ export function useDangerButton({
   isActive,
 }: DangerProps) {
   const stateToColor = (isActive: boolean) => (isActive ? 'red' : seed);
-  const interactionToColor = (isTouch: boolean, isActive: boolean) =>
-    isTouch ? stateToColor(isActive) : seed;
-
-  const isTouch$ = useMedia(WellKnownMediaQuery.touch);
 
   const activeColor$ = new BehaviorSubject<ButtonColor | null>(null);
 
-  const color$ = combineLatest([isTouch$, activeColor$]).pipe(
-    map(([isTouch, activeColor]) =>
-      activeColor ?? interactionToColor(isTouch, isActive)
-    ),
+  const color$ = activeColor$.pipe(
+    map((activeColor) => activeColor ?? seed),
   );
 
-  const variant$ = isTouch$.pipe(
-    map((isTouch) => isActive && !isTouch ? 'primary' : 'secondary'),
-  );
+  const variant = isActive ? 'primary' : 'secondary';
 
   return {
     color: color$.pipe(
       debounceTime(time.fps(60)),
       distinctUntilChanged(),
     ),
-    variant: variant$,
-    isTouch: isTouch$,
+    variant,
     onmouseover: () => activeColor$.next(stateToColor(isActive)),
     onfocusin: () => activeColor$.next(stateToColor(isActive)),
     onfocusout: () => activeColor$.next(null),

--- a/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte
+++ b/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte
@@ -45,7 +45,7 @@
   const commonProps: Omit<ButtonProps, "children"> = $derived({
     label: i18n.label({ title, isWatched, isRewatching }),
     color: $color,
-    variant: mode === "ask" ? "primary" : $variant,
+    variant: mode === "ask" ? "primary" : variant,
     onclick: handler,
     disabled: isMarkingAsWatched,
     ...events,
@@ -68,7 +68,7 @@
 {/if}
 
 {#if style === "action"}
-  <ActionButton style="ghost" {...commonProps} {...props} variant="secondary">
+  <ActionButton style="ghost" {...commonProps} {...props}>
     <MarkAsWatchedIcon {state} />
   </ActionButton>
 {/if}

--- a/projects/client/src/lib/components/buttons/remove-from-history/RemoveFromHistoryButton.svelte
+++ b/projects/client/src/lib/components/buttons/remove-from-history/RemoveFromHistoryButton.svelte
@@ -23,7 +23,7 @@
   const commonProps: Omit<ButtonProps, "children"> = $derived({
     label: i18n.label({ title }),
     color: $color,
-    variant: $variant,
+    variant,
     onclick: onRemove,
     disabled: isRemoving,
     ...events,

--- a/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
+++ b/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
@@ -35,7 +35,7 @@
 
   const commonProps: Omit<ButtonProps, "children"> = $derived({
     color: $color,
-    variant: $variant,
+    variant,
     ...actionProps,
   });
 </script>

--- a/projects/client/src/lib/components/icons/MarkAsWatchedIcon.svelte
+++ b/projects/client/src/lib/components/icons/MarkAsWatchedIcon.svelte
@@ -92,18 +92,4 @@
   svg[data-size="small"] {
     transform: scale(0.75);
   }
-
-  @include for-touch {
-    svg {
-      &[data-state="watched"] {
-        .icon-state-active {
-          opacity: 1;
-        }
-
-        .icon-state-idle {
-          opacity: 0;
-        }
-      }
-    }
-  }
 </style>

--- a/projects/client/src/lib/sections/lists/user/_internal/RemoveFromListAction.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/RemoveFromListAction.svelte
@@ -26,7 +26,7 @@
   const commonProps: Omit<ButtonProps, "children"> = $derived({
     label: m.button_label_remove_from_list({ title }),
     color: $color,
-    variant: $variant,
+    variant,
     onclick: removeFromList,
     disabled: $isListUpdating,
     ...events,

--- a/projects/client/src/lib/sections/media-actions/drop/DropButton.svelte
+++ b/projects/client/src/lib/sections/media-actions/drop/DropButton.svelte
@@ -36,7 +36,7 @@
         ? m.button_label_drop_movie({ title })
         : m.button_label_drop_show({ title }),
     color: $color,
-    variant: $variant,
+    variant,
     onclick: confirmDrop,
     disabled: isDropping,
     ...events,

--- a/projects/client/src/lib/sections/media-actions/restore/RestoreButton.svelte
+++ b/projects/client/src/lib/sections/media-actions/restore/RestoreButton.svelte
@@ -29,7 +29,7 @@
   const commonProps: Omit<ButtonProps, "children"> = $derived({
     label: m.button_label_restore_show({ title }),
     color: $color,
-    variant: $variant,
+    variant,
     onclick: confirmRestore,
     disabled: isRestoring,
     ...events,

--- a/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItem.svelte
+++ b/projects/client/src/lib/sections/summary/components/list-dropdown/_internal/ListDropdownItem.svelte
@@ -55,7 +55,7 @@
   );
 
   const handler = $derived(isListed ? confirmRemove : addToList);
-  const { color, variant, isTouch, ...events } = $derived(
+  const { color, variant, ...events } = $derived(
     useDangerButton({ isActive: isListed, color: "default" }),
   );
   const state = $derived(isListed ? "added" : "missing");
@@ -64,7 +64,7 @@
     style: "flat",
     label: i18n.label({ isListed, listName: list.name, title }),
     color: $color,
-    variant: $isTouch && isListed ? $variant : "primary",
+    variant: isListed ? variant : "primary",
     onclick: handler,
     disabled: $isListUpdating || !isBelowLimit,
     ...events,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Less invasive `danger` buttons on touch.
  - Less red icons.
  - They all have warning prompts anyway.
  - Hovers will still update accordingly.

## 👀 Example 👀
<img width="429" height="930" alt="Screenshot 2025-12-01 at 08 34 16" src="https://github.com/user-attachments/assets/35848ad2-75f8-4fa1-b5aa-46e083aca726" />
