### PR TITLE
feat(cover): add overlay to cover image and background

### DIFF
--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -17,10 +17,11 @@
       src={$cover.data.src}
       alt={`Background for ${$cover.data.type}`}
     />
-    {#if $cover.data.type === "main"}
-      <div class="trakt-background-cover-image-overlay"></div>
-    {/if}
   </div>
+{/if}
+
+{#if $cover.state === "no-cover" || $cover.data?.type === "main"}
+  <div class="trakt-background-cover-image-overlay"></div>
 {/if}
 
 <style lang="scss">
@@ -85,15 +86,15 @@
   }
 
   .trakt-background-cover-image-overlay {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
 
     width: 100%;
     height: 100%;
 
-    background-color: var(--purple-700);
-    mix-blend-mode: color;
+    background-color: var(--purple-900);
+    mix-blend-mode: color-dodge;
   }
 
   .trakt-background-cover-image {


### PR DESCRIPTION
## 👀 Examples 👀

Before/after:
<img width="1361" height="1105" alt="Screenshot 2025-12-01 at 11 51 30" src="https://github.com/user-attachments/assets/4f040373-4a08-45be-8f3d-2a31dac813ce" />

<img width="1361" height="1105" alt="Screenshot 2025-12-01 at 11 51 19" src="https://github.com/user-attachments/assets/576622de-bf61-4e48-8462-952b853a3cf4" />
