### PR TITLE
fix(mir): use actual mir first play for background image

### DIFF
--- a/projects/client/src/lib/requests/queries/users/monthInReviewQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/monthInReviewQuery.ts
@@ -1,8 +1,11 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { mapToMovieEntry } from '$lib/requests/_internal/mapToMovieEntry.ts';
+import { mapToShowEntry } from '$lib/requests/_internal/mapToShowEntry.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { MonthInReviewResponse } from '@trakt/api';
 import { z } from 'zod';
+import { type MediaEntry, MediaEntrySchema } from '../../models/MediaEntry.ts';
 
 export type MonthInReviewParams = {
   slug: string;
@@ -15,9 +18,20 @@ export const UserMonthInReviewSchema = z.object({
   hoursWatched: z.number(),
   ratingsCount: z.number(),
   commentsCount: z.number(),
+  firstPlay: MediaEntrySchema.nullish(),
 });
 
 export type UserMonthInReview = z.infer<typeof UserMonthInReviewSchema>;
+
+function mapToFirstPlay(response: MonthInReviewResponse): MediaEntry | null {
+  if (!response.first_watched) {
+    return null;
+  }
+
+  return response.first_watched.type === 'episode'
+    ? mapToShowEntry(response.first_watched.show)
+    : mapToMovieEntry(response.first_watched.movie);
+}
 
 function mapToUserMonthInReview(
   response: MonthInReviewResponse,
@@ -27,6 +41,7 @@ function mapToUserMonthInReview(
     hoursWatched: Math.round(response.stats.all.minutes.total / 60),
     ratingsCount: response.stats.all.ratings_counts.total,
     commentsCount: response.stats.all.comments_counts.total,
+    firstPlay: mapToFirstPlay(response),
   };
 }
 
@@ -47,7 +62,7 @@ const monthInReviewRequest = (
     });
 
 export const monthInReviewQuery = defineQuery({
-  key: 'monthInReview',
+  key: 'monthInReview:v2',
   request: monthInReviewRequest,
   invalidations: [],
   dependencies: (params) => [params.slug, params.year, params.month],

--- a/projects/client/src/lib/sections/banner/month-in-review/MonthInReview.svelte
+++ b/projects/client/src/lib/sections/banner/month-in-review/MonthInReview.svelte
@@ -3,7 +3,7 @@
   import { useUser } from "$lib/features/auth/stores/useUser";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import ReviewContent from "$lib/sections/components/ReviewContent.svelte";
-  import { useMonthToDate } from "$lib/sections/profile/stores/useMonthToDate";
+  import { DEFAULT_COVER } from "$lib/utils/constants";
   import { slide } from "svelte/transition";
   import MonthInReviewLink from "../../components/MonthInReviewLink.svelte";
   import DismissButton from "../_internal/DismissButton.svelte";
@@ -20,16 +20,15 @@
       year: month.getFullYear(),
     }),
   );
-
-  const { monthToDate, isLoading: isLoadingMonthToDate } = $derived(
-    useMonthToDate({ slug: $user.slug }),
-  );
 </script>
 
 <RenderFor audience="vip">
-  {#if $review && !$isLoadingMonthToDate}
+  {#if $review}
     <div class="trakt-month-in-review" transition:slide={{ duration: 150 }}>
-      <ReviewContent coverSrc={$monthToDate.coverUrl} variant="gradient">
+      <ReviewContent
+        coverSrc={$review.firstPlay?.cover.url.medium ?? DEFAULT_COVER}
+        variant="gradient"
+      >
         {#snippet header()}
           <div class="trakt-mir-header-container">
             <div class="trakt-mir-header">

--- a/projects/client/src/mocks/data/users/mapped/UserMonthInReviewMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/UserMonthInReviewMappedMock.ts
@@ -1,8 +1,10 @@
 import type { UserMonthInReview } from '$lib/requests/queries/users/monthInReviewQuery.ts';
+import { MovieHereticMappedMock } from '../../summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
 
 export const UserMonthInReviewMappedMock: UserMonthInReview = {
   'commentsCount': 0,
   'hoursWatched': 12,
   'playCount': 7,
   'ratingsCount': 0,
+  'firstPlay': MovieHereticMappedMock,
 };

--- a/projects/client/src/mocks/data/users/response/UserMonthInReviewResponseMock.ts
+++ b/projects/client/src/mocks/data/users/response/UserMonthInReviewResponseMock.ts
@@ -1,4 +1,5 @@
 import type { MonthInReviewResponse } from '@trakt/api';
+import { MovieHereticResponseMock } from '../../summary/movies/heretic/response/MovieHereticResponseMock.ts';
 
 export const UserMonthInReviewResponseMock: MonthInReviewResponse = {
   'stats': {
@@ -130,34 +131,7 @@ export const UserMonthInReviewResponseMock: MonthInReviewResponse = {
   'first_watched': {
     'type': 'movie',
     'watched_at': '2025-05-07T14:42:04.000Z',
-    'movie': {
-      'title': 'Orphan',
-      'year': 2009,
-      'ids': {
-        'trakt': 13000,
-        'slug': 'orphan-2009',
-        'imdb': 'tt1148204',
-        'tmdb': 21208,
-      },
-      'images': {
-        'fanart': [
-          'walter-r2.trakt.tv/images/movies/000/013/000/fanarts/medium/01e98ac2be.jpg.webp',
-        ],
-        'poster': [
-          'walter-r2.trakt.tv/images/movies/000/013/000/posters/thumb/9ffc1c14b1.jpg.webp',
-        ],
-        'logo': [
-          'walter-r2.trakt.tv/images/movies/000/013/000/logos/medium/8b61f0a6a6.png.webp',
-        ],
-        'clearart': [],
-        'banner': [
-          'walter-r2.trakt.tv/images/movies/000/013/000/banners/medium/a4d9fb63f7.jpg.webp',
-        ],
-        'thumb': [
-          'walter-r2.trakt.tv/images/movies/000/013/000/thumbs/medium/efcacdd59e.jpg.webp',
-        ],
-      },
-    },
+    'movie': MovieHereticResponseMock,
   },
   'last_watched': {
     'type': 'movie',


### PR DESCRIPTION
## ♪ Note ♪

- Woops... The MIR was not using the response from the endpoint for the background image...

## 👀 Example 👀
Before/after:
<img width="428" height="925" alt="Screenshot 2025-12-01 at 18 51 49" src="https://github.com/user-attachments/assets/c7049fec-ad12-4b7a-a963-4b7a0b31501b" />

<img width="428" height="925" alt="Screenshot 2025-12-01 at 18 51 14" src="https://github.com/user-attachments/assets/b2241004-4860-42cc-887e-da18208071c8" />
