### PR TITLE
Fix/cover overlay fixes

### DIFF
--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -96,7 +96,7 @@
     height: 100%;
 
     background-color: var(--purple-900);
-    mix-blend-mode: color-dodge;
+    mix-blend-mode: var(--mix-blend-mode-cover-overlay);
   }
 
   .trakt-background-cover-image {

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -152,6 +152,11 @@
    */
   --streaming-service-logo-filter: brightness(0);
   --color-just-watch: #c79a00;
+
+  /*
+    * Cover image
+    */
+  --mix-blend-mode-cover-overlay: overlay;
 }
 
 // Define theme variables for dark mode
@@ -304,6 +309,11 @@
    */
   --streaming-service-logo-filter: brightness(1);
   --color-just-watch: #fcc405;
+
+  /*
+    * Cover image
+    */
+  --mix-blend-mode-cover-overlay: color-dodge;
 }
 
 // Apply themes to selectors


### PR DESCRIPTION
## 🎶 Notes 🎶

- Sets the zindex on the cover overlay.
- Quick fix for in light mode.
  - For now it makes it less annoying, but we should do a better follow-up to achieve the same effect in light mode.

## 👀 Example 👀
Before/after:
<img width="1403" height="925" alt="Screenshot 2025-12-01 at 20 02 33" src="https://github.com/user-attachments/assets/69d2f3ed-ffb4-4838-980d-7e9d963bea38" />

<img width="1403" height="925" alt="Screenshot 2025-12-01 at 20 02 30" src="https://github.com/user-attachments/assets/82cbb1d8-e95d-4e36-b1cf-496157c6c1cf" />
