### PR TITLE
fix(cover): improve contrasting summary cover image on large screens

### DIFF
--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -36,6 +36,8 @@
     width: 100%;
     background: var(--shade-900);
 
+    opacity: 0.5;
+
     @include color-mix-variable-with-fallback(
       --trakt-cover-primary-color-transparent,
       color-mix(
@@ -50,6 +52,10 @@
       ),
       color-mix(in srgb, var(--color-background) 25%, transparent)
     );
+
+    @include for-tablet-sm-and-below {
+      opacity: 1;
+    }
 
     &[data-cover-type="main"] {
       --color-transparent-background: transparent;
@@ -139,9 +145,18 @@
       background: linear-gradient(
         180deg,
         transparent 0%,
-        color-mix(in srgb, var(--color-background) 95%, transparent) 65%,
+        color-mix(in srgb, var(--color-background) 90%, transparent) 90%,
         var(--color-background) 100%
       );
+
+      @include for-tablet-sm-and-below {
+        background: linear-gradient(
+          180deg,
+          transparent 0%,
+          color-mix(in srgb, var(--color-background) 95%, transparent) 65%,
+          var(--color-background) 100%
+        );
+      }
     }
 
     &:not([data-cover-type="main"]) {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Played around a bit with the background and gradient with Magna to get a more readable result on desktop.

## 👀 Examples 👀
After/before:
<img width="2163" height="985" alt="Screenshot 2025-12-02 at 09 13 42" src="https://github.com/user-attachments/assets/47619f44-e17d-4ff3-8c6a-b6628f5a36df" />
