### PR TITLE
fix(mir): styling in firefox

### DIFF
--- a/projects/client/src/lib/sections/banner/_internal/DismissButton.svelte
+++ b/projects/client/src/lib/sections/banner/_internal/DismissButton.svelte
@@ -19,8 +19,9 @@
 
 <style>
   trakt-banner-dismiss-button {
-    :global(.trakt-action-button) {
+    :global(.trakt-action-button[data-style="ghost"]) {
       color: var(--shade-10);
+      backdrop-filter: none;
     }
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes the missing button & link in MIR in Firefox.
- No idea why the link also is not rendered when the background filter is set on the button... Not worth the time to investigate atm.

## 👀 Example 👀
Before/after:
<img width="555" height="161" alt="Screenshot 2025-12-02 at 17 48 01" src="https://github.com/user-attachments/assets/06c79984-d8bb-4db0-9345-0476055bed5a" />

<img width="555" height="161" alt="Screenshot 2025-12-02 at 17 47 52" src="https://github.com/user-attachments/assets/063b63be-977a-4260-bc5d-f2e5be50329d" />
