### PR TITLE
fix(profile): add missing about me

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Сортиране в низходящ ред"
+    },
+    "text_about_user": {
+      "default": "Относно {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Sorter faldende"
+    },
+    "text_about_user": {
+      "default": "Om {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Absteigend sortieren"
+    },
+    "text_about_user": {
+      "default": "Über {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Sort descending"
+    },
+    "text_about_user": {
+      "default": "About {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6244,6 +6244,19 @@
         "android",
         "ios"
       ]
+    },
+    "text_about_user": {
+      "default": "About {username}",
+      "description": "Text for the section that shows a specific users 'about me' description.",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
     }
   }
 }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Ordenar descendente"
+    },
+    "text_about_user": {
+      "default": "Acerca de {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Ordenar descendente"
+    },
+    "text_about_user": {
+      "default": "Acerca de {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Trier en ordre décroissant"
+    },
+    "text_about_user": {
+      "default": "À propos de {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Trier en ordre décroissant"
+    },
+    "text_about_user": {
+      "default": "À propos de {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Ordina decrescente"
+    },
+    "text_about_user": {
+      "default": "Su {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "降順で並べ替え"
+    },
+    "text_about_user": {
+      "default": "{username}さんのプロフィール",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Sorter synkende"
+    },
+    "text_about_user": {
+      "default": "Om {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Sorteren aflopend"
+    },
+    "text_about_user": {
+      "default": "Over {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Sortuj malejąco"
+    },
+    "text_about_user": {
+      "default": "O {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Ordenar decrescente"
+    },
+    "text_about_user": {
+      "default": "Sobre {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Ordonează descrescător"
+    },
+    "text_about_user": {
+      "default": "Despre {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Sortera fallande"
+    },
+    "text_about_user": {
+      "default": "Om {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -2360,6 +2360,14 @@
     },
     "button_label_sort_descending": {
       "default": "Сортувати за спаданням"
+    },
+    "text_about_user": {
+      "default": "Про {username}",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/src/lib/sections/profile/Profile.svelte
+++ b/projects/client/src/lib/sections/profile/Profile.svelte
@@ -34,7 +34,7 @@
     <VipUpsell />
   {/if}
 
-  <ProfileAbout about={profile.about} />
+  <ProfileAbout {profile} {slug} />
 </ProfileContainer>
 
 {#if $isMe}

--- a/projects/client/src/lib/sections/profile/components/ProfileAbout.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileAbout.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import ClampedText from "$lib/components/text/ClampedText.svelte";
+  import { useIsMe } from "$lib/features/auth/stores/useIsMe";
   import * as m from "$lib/features/i18n/messages";
 
   import { shuffle } from "$lib/utils/array/shuffle";
+  import { toDisplayableName } from "$lib/utils/profile/toDisplayableName";
+  import type { DisplayableProfileProps } from "../DisplayableProfileProps";
 
-  const { about }: { about: string | Nil } = $props();
+  const { profile, slug }: DisplayableProfileProps = $props();
 
   const ABOUT_MESSAGES = [
     m.text_about_placeholder_1(),
@@ -23,8 +26,29 @@
     m.text_about_placeholder_14(),
     m.text_about_placeholder_15(),
   ];
+
+  const { isMe } = $derived(useIsMe(slug));
+  const aboutText = $derived(
+    $isMe
+      ? m.text_about()
+      : m.text_about_user({ username: toDisplayableName(profile) }),
+  );
 </script>
 
-<ClampedText classList="trakt-profile-about" label={m.button_label_read_more()}>
-  {about ?? shuffle(ABOUT_MESSAGES).at(0)}
-</ClampedText>
+<div class="trakt-profile-about">
+  <span class="secondary bold">{aboutText}</span>
+  <ClampedText
+    classList="trakt-profile-about"
+    label={m.button_label_read_more()}
+  >
+    {profile.about ?? shuffle(ABOUT_MESSAGES).at(0)}
+  </ClampedText>
+</div>
+
+<style>
+  .trakt-profile-about {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+</style>


### PR DESCRIPTION
## ♪ Note ♪

- Adds missing `About me`/`About {username}` to profile

## 👀 Examples 👀
<img width="428" height="929" alt="Screenshot 2025-12-03 at 12 38 44" src="https://github.com/user-attachments/assets/f77c8348-4b3e-4a16-a520-4affd362e90f" />

<img width="428" height="929" alt="Screenshot 2025-12-03 at 12 33 44" src="https://github.com/user-attachments/assets/a7e3515e-fe31-49b7-afbb-a78a6f05ee09" />
