### PR TITLE
fix(settings): do not show top navbar on settings page

### DIFF
--- a/projects/client/src/routes/settings/+layout.svelte
+++ b/projects/client/src/routes/settings/+layout.svelte
@@ -2,6 +2,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import Settings from "$lib/sections/settings/Settings.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
 
@@ -13,6 +14,7 @@
   image={DEFAULT_SHARE_COVER}
   title={m.page_title_settings()}
 >
+  <NavbarStateSetter mode="minimal" />
   <TraktPageCoverSetter />
 
   <Settings>


### PR DESCRIPTION
## ♪ Note ♪

- Do not show the top navbar on settings page.

## 👀 Example 👀
Before/after:
<img width="428" height="540" alt="Screenshot 2025-12-03 at 14 50 52" src="https://github.com/user-attachments/assets/840012ba-8821-4e5d-b2e0-74edb5c5c1a6" />

<img width="428" height="514" alt="Screenshot 2025-12-03 at 14 50 10" src="https://github.com/user-attachments/assets/4b5b5d93-c4dc-4a40-a6a7-377ab969dae2" />
