### PR TITLE
feat(button): ghost are always transparent

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -166,9 +166,6 @@
     &[data-style="ghost"] {
       background-color: transparent;
 
-      /** This is required for improved readability when rendering over a cover image */
-      backdrop-filter: blur(var(--ni-16));
-
       @include for-mouse {
         &:hover {
           background-color: color-mix(

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -334,8 +334,6 @@
       margin: var(--ni-neg-4) var(--ni-neg-10);
       transform: scale(calc(var(--scale-factor-button) * 0.76925));
       background: transparent;
-      /** This is required for improved readability when rendering over a cover image */
-      backdrop-filter: blur(var(--ni-16));
 
       &:not([data-variant="secondary"]) {
         color: var(--color-foreground);

--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -86,12 +86,5 @@
         font-weight: 500;
       }
     }
-
-    .trakt-card-footer-action {
-      :global(.trakt-action-button[data-style="ghost"]),
-      :global(.trakt-button[data-style="ghost"]) {
-        backdrop-filter: none;
-      }
-    }
   }
 </style>

--- a/projects/client/src/lib/sections/banner/_internal/DismissButton.svelte
+++ b/projects/client/src/lib/sections/banner/_internal/DismissButton.svelte
@@ -21,7 +21,6 @@
   trakt-banner-dismiss-button {
     :global(.trakt-action-button[data-style="ghost"]) {
       color: var(--shade-10);
-      backdrop-filter: none;
     }
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/_internal/SummarySideActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummarySideActions.svelte
@@ -19,9 +19,6 @@
     width: var(--summary-side-action-bar-width);
 
     :global(.trakt-action-button) {
-      background: transparent;
-      backdrop-filter: none;
-
       :global(svg) {
         color: var(--color-foreground);
       }

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionPicker.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionPicker.svelte
@@ -72,9 +72,6 @@
 
       border-radius: 50%;
 
-      background-color: transparent;
-      backdrop-filter: none;
-
       opacity: 0;
 
       --delay-factor: calc(var(--animation-duration) / 6);

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RateActionButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RateActionButton.svelte
@@ -54,7 +54,6 @@
     :global(.trakt-action-button) {
       transition: color var(--transition-increment) ease-in-out;
       border-radius: 0;
-      backdrop-filter: none;
     }
 
     @include for-mouse() {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Removes the blur from ghost buttons; they're always transparent now.
- ~~Kept the blur in summary cards since it can clash with some background cover images.~~