### PR TITLE
fix(auth): keep server token in sync

### DIFF
--- a/projects/client/src/lib/features/auth/components/AuthProvider.svelte
+++ b/projects/client/src/lib/features/auth/components/AuthProvider.svelte
@@ -8,20 +8,24 @@
 
   type AuthProviderProps = {
     isAuthorized: boolean;
+    accessToken: string | null;
   } & ChildrenProps;
 
-  const { children, isAuthorized: isAuthorizedOidc }: AuthProviderProps =
-    $props();
+  const {
+    children,
+    isAuthorized: isAuthorizedOidc,
+    accessToken,
+  }: AuthProviderProps = $props();
 
   const { isAuthorized } = createAuthContext({
     isAuthorized: isAuthorizedOidc,
     token: null,
   });
 
-  const { isInitializing } = initializeUserManager();
+  const { isInitializing } = initializeUserManager(accessToken);
   const { user } = useUser();
 
-  beforeNavigate(({ from, to, cancel }) => {
+  beforeNavigate(({ from, to }) => {
     const isSamePage = from?.url.pathname === to?.url.pathname;
 
     if (get(isAuthorized) || isSamePage) {

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.spec.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.spec.ts
@@ -20,7 +20,7 @@ describe('initializeUserManager', () => {
 
   it('should initialize authorized users', async () => {
     setAuthorization(true);
-    await renderStore(() => initializeUserManager());
+    await renderStore(() => initializeUserManager(OidcUserMock.access_token));
     const { isAuthorized } = await renderStore(() => useAuth());
 
     const token = getToken();

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -18,7 +18,7 @@ function mapToToken(user: User | null): Token {
   };
 }
 
-export function initializeUserManager() {
+export function initializeUserManager(tokenFromServer?: string | null) {
   if (!browser) {
     return {
       isInitializing: readable(false),
@@ -32,6 +32,13 @@ export function initializeUserManager() {
     const manager = new UserManager(
       getOidcConfig(),
     );
+
+    const syncToken = (user: User | null) => {
+      if (!user) return;
+      if (user.access_token === tokenFromServer) return;
+
+      postToken(mapToToken(user));
+    };
 
     const setAuthState = (
       { token, isExpired }: { token: Token; isExpired: boolean },
@@ -59,6 +66,7 @@ export function initializeUserManager() {
 
       const token = mapToToken(user);
       setAuthState({ token, isExpired: user?.expired ?? true });
+      syncToken(user);
     };
 
     const checkTokenOnFocus = async () => {

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -128,7 +128,10 @@
 <ErrorProvider>
   <QueryClientProvider client={data.queryClient}>
     <GlobalParameterProvider>
-      <AuthProvider isAuthorized={data.oidcAuth.isAuthorized}>
+      <AuthProvider
+        isAuthorized={data.oidcAuth.isAuthorized}
+        accessToken={data.oidcAuth.token}
+      >
         <WSInvalidator />
         <FeatureFlagProvider>
           <CookieConsentProvider consent={data.cookieConsent}>

--- a/projects/client/test/beds/_internal/TestProvider.svelte
+++ b/projects/client/test/beds/_internal/TestProvider.svelte
@@ -5,6 +5,7 @@
   import NavigationProvider from "$lib/features/navigation/NavigationProvider.svelte";
   import SearchProvider from "$lib/features/search/SearchProvider.svelte";
   import ToastProvider from "$lib/features/toast/ToastProvider.svelte";
+  import { OidcUserMock } from "$mocks/data/auth/OidcUserMock.ts";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
   import type { Snippet } from "svelte";
   import { isAuthorized } from "./isAuthorized.ts";
@@ -14,7 +15,10 @@
 
 <!-- TODO: add more providers here as we expand test suite -->
 <QueryClientProvider client={new QueryClient()}>
-  <AuthProvider isAuthorized={$isAuthorized}>
+  <AuthProvider
+    isAuthorized={$isAuthorized}
+    accessToken={OidcUserMock.access_token}
+  >
     <FeatureFlagProvider>
       <ToastProvider>
         <SearchProvider


### PR DESCRIPTION
## ♪ Note ♪

- Do not rely on `postToken` to always work; if there is a mismatch, send the token to the server. This should reduce the landing page flash on page reloads.