### PR TITLE
fix(landing): keep steps in container

### DIFF
--- a/projects/client/src/lib/sections/landing/components/Steps.svelte
+++ b/projects/client/src/lib/sections/landing/components/Steps.svelte
@@ -35,8 +35,6 @@
 
     gap: var(--gap-s);
 
-    margin-top: calc(-1 * var(--gap-s));
-
     :global(svg) {
       width: var(--ni-32);
       height: var(--ni-32);


### PR DESCRIPTION
## ♪ Note ♪

- Removes the negating margin from the steps in the landing page. No idea why it was there to begin with...

## 👀 Example 👀
Before/after:
<img width="1177" height="281" alt="Screenshot 2025-12-04 at 13 26 12" src="https://github.com/user-attachments/assets/76556acb-954f-4b41-831a-f70492c3db4f" />

<img width="1177" height="281" alt="Screenshot 2025-12-04 at 13 42 51" src="https://github.com/user-attachments/assets/550c60c8-c63e-4fd0-b7f5-46912bb47746" />
