### PR TITLE
fix(list) / remove header inset options

### DIFF
--- a/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
@@ -8,7 +8,6 @@
     title,
     subtitle,
     metaInfo,
-    inset,
     titleAction,
     actions,
     badge,
@@ -24,7 +23,6 @@
     actions?: Snippet;
     badge?: Snippet;
     listActions?: Snippet;
-    inset: "all" | "title";
     navigationType?: DpadNavigationType;
     href?: string;
   } & HTMLElementProps = $props();
@@ -35,11 +33,7 @@
   );
 </script>
 
-<div
-  class:trakt-list-inset-title={inset === "title"}
-  class:trakt-inset-all={inset === "all"}
-  {...props}
->
+<div class="trakt-list-inset-title" {...props}>
   <div class="trakt-list-header">
     <div class="trakt-list-title-container">
       <div class="trakt-list-title">
@@ -81,15 +75,6 @@
 
     @include for-tablet-sm-and-below {
       margin-left: calc(var(--layout-distance-side));
-    }
-  }
-
-  .trakt-inset-all {
-    margin: 0 calc(var(--ni-72) + var(--layout-distance-side));
-    transition: margin calc(var(--transition-increment) * 2) ease-in-out;
-
-    @include for-tablet-sm-and-below {
-      margin: 0 calc(var(--layout-distance-side));
     }
   }
 

--- a/projects/client/src/lib/components/lists/grid-list/GridList.svelte
+++ b/projects/client/src/lib/components/lists/grid-list/GridList.svelte
@@ -45,14 +45,7 @@
 
 <section class="trakt-grid-list-container">
   {#if title}
-    <ListHeader
-      {title}
-      {metaInfo}
-      {actions}
-      {badge}
-      {listActions}
-      inset="all"
-    />
+    <ListHeader {title} {metaInfo} {actions} {badge} {listActions} />
   {/if}
 
   {#if uniqueItems.length > 0 || promotedItems.length > 0}

--- a/projects/client/src/lib/components/lists/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/SectionList.svelte
@@ -102,7 +102,6 @@
         {metaInfo}
         actions={$isCollapsed ? undefined : actions}
         {badge}
-        inset="title"
         navigationType={headerNavigationType}
         href={drilldownLink}
       />

--- a/projects/client/src/lib/sections/summary/components/_internal/CollapsableSection.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/CollapsableSection.svelte
@@ -55,7 +55,7 @@
   class:collapsable-section-container-mounted={$isMounted}
 >
   {#if $isVisible}
-    <ListHeader {title} {titleAction} inset="title" />
+    <ListHeader {title} {titleAction} />
 
     <div class="collapsable-section">
       {@render children()}


### PR DESCRIPTION
This pull request removes the `inset` prop and its related logic from the `ListHeader` component, simplifying its interface and usage across the codebase. The change affects how list headers are styled and used in several components.

**ListHeader component simplification:**

* Removed the `inset` prop (and its type) from the `ListHeader.svelte` component, as well as all logic and CSS classes related to it. (`projects/client/src/lib/components/lists/_internal/ListHeader.svelte`) [[1]](diffhunk://#diff-80f9a3a24aebab5ad68cc3bc85b5b2efd3462e85faa2087e268cdc70422a9971L11) [[2]](diffhunk://#diff-80f9a3a24aebab5ad68cc3bc85b5b2efd3462e85faa2087e268cdc70422a9971L27) [[3]](diffhunk://#diff-80f9a3a24aebab5ad68cc3bc85b5b2efd3462e85faa2087e268cdc70422a9971L38-R36) [[4]](diffhunk://#diff-80f9a3a24aebab5ad68cc3bc85b5b2efd3462e85faa2087e268cdc70422a9971L87-L95)

**Updates to component usage:**

* Updated all usages of `ListHeader` in `GridList.svelte`, `SectionList.svelte`, and `CollapsableSection.svelte` to remove the now-obsolete `inset` prop. (`projects/client/src/lib/components/lists/grid-list/GridList.svelte`, `projects/client/src/lib/components/lists/section-list/SectionList.svelte`, `projects/client/src/lib/sections/summary/components/_internal/CollapsableSection.svelte`) [[1]](diffhunk://#diff-eb93a4e560374d1209f1bcd7d96018f49881240ff73d41fdfd2cc180ba49cb48L48-R48) [[2]](diffhunk://#diff-91014e4138b47c75df0cdc011bf9994195372c41d60e3475553027b1d8a102f3L105) [[3]](diffhunk://#diff-53f4588a54afcc930feac92d9d62a520c4d1f10988dea3ce6b1a4979a4407905L58-R58)

Before / After:

<img width="300" height="666" alt="image" src="https://github.com/user-attachments/assets/0f229c2e-3b67-44be-b30c-92d6004160de" />
<img width="300" height="666" alt="image" src="https://github.com/user-attachments/assets/5b47ef40-509f-411e-bc7f-5627f3fb70ec" />
