### PR TITLE
feat(profile): new design for profile banner on mobile

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Опции на профила"
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Profilmuligheder"
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Profiloptionen"
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Profile options"
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -84,7 +84,8 @@
         }
       },
       "exclude": [
-        "ios"
+        "ios",
+        "web"
       ]
     },
     "list_title_up_next": {
@@ -6261,6 +6262,14 @@
           "type": "string"
         }
       },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "button_label_profile_options": {
+      "default": "Profile options",
+      "description": "Aria-label for the button that opens a popup menu or drawer for a users profile, where users can change settings and logout.",
       "exclude": [
         "android",
         "ios"

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Opciones del perfil"
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Opciones del perfil"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Options du profil"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Options du profil"
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Opzioni profilo"
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "プロフィールオプション"
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Profilinnstillinger"
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Profielopties"
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Opcje profilu"
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Opções do perfil"
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Opțiuni profil"
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Profilalternativ"
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -2371,6 +2371,9 @@
           "type": "string"
         }
       }
+    },
+    "button_label_profile_options": {
+      "default": "Опції профілю"
     }
   }
 }

--- a/projects/client/src/lib/components/buttons/logout/LogoutButton.svelte
+++ b/projects/client/src/lib/components/buttons/logout/LogoutButton.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import LogoutIcon from "$lib/components/icons/LogoutIcon.svelte";
   import { useAuth } from "$lib/features/auth/stores/useAuth";
   import * as m from "$lib/features/i18n/messages.ts";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import ActionButton from "../ActionButton.svelte";
 
-  const { style = "normal" }: { style?: "normal" | "action" } = $props();
+  const {
+    style = "normal",
+  }: { style?: "normal" | "action" | "dropdown-item" } = $props();
 
   const { logout } = useAuth();
 
@@ -33,4 +36,13 @@
   <ActionButton variant="secondary" {...commonProps}>
     <LogoutIcon />
   </ActionButton>
+{/if}
+
+{#if style === "dropdown-item"}
+  <DropdownItem {...commonProps} color="default" variant="primary" style="flat">
+    {m.button_text_logout()}
+    {#snippet icon()}
+      <LogoutIcon />
+    {/snippet}
+  </DropdownItem>
 {/if}

--- a/projects/client/src/lib/components/buttons/settings/SettingsButton.svelte
+++ b/projects/client/src/lib/components/buttons/settings/SettingsButton.svelte
@@ -1,16 +1,29 @@
 <script lang="ts">
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import GearIcon from "$lib/components/icons/GearIcon.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
-  const { style = "flat" }: { style?: "flat" | "ghost" } = $props();
+  const { style = "action" }: { style?: "action" | "dropdown-item" } = $props();
+
+  const commonProps = {
+    href: UrlBuilder.settings.general(),
+    label: m.button_label_settings(),
+  };
 </script>
 
-<ActionButton
-  {style}
-  href={UrlBuilder.settings.general()}
-  label={m.button_label_settings()}
->
-  <GearIcon />
-</ActionButton>
+{#if style === "action"}
+  <ActionButton style="ghost" {...commonProps}>
+    <GearIcon />
+  </ActionButton>
+{/if}
+
+{#if style === "dropdown-item"}
+  <DropdownItem style="flat" color="default" variant="primary" {...commonProps}>
+    Settings
+    {#snippet icon()}
+      <GearIcon />
+    {/snippet}
+  </DropdownItem>
+{/if}

--- a/projects/client/src/lib/components/icons/MoreIcon.svelte
+++ b/projects/client/src/lib/components/icons/MoreIcon.svelte
@@ -3,25 +3,48 @@
 
   type MoreIconProps = {
     shadowColor?: string;
+    size?: "small" | "normal";
   };
 
-  const { shadowColor }: MoreIconProps = $props();
+  const { shadowColor, size = "small" }: MoreIconProps = $props();
 
   const filterId = $derived(
     shadowColor ? `drop-shadow-${checksum(shadowColor)}` : undefined,
   );
+
+  const baseSize = $derived(size === "small" ? 16 : 24);
+  const halfBaseSize = $derived(baseSize / 2);
+  const radius = $derived(size === "small" ? 2 : 2.5);
 </script>
 
 {#snippet circles(filterUrl: string = "")}
-  <circle cx="8" cy="2" r="2" fill="currentColor" filter={filterUrl} />
-  <circle cx="8" cy="8" r="2" fill="currentColor" filter={filterUrl} />
-  <circle cx="8" cy="14" r="2" fill="currentColor" filter={filterUrl} />
+  <circle
+    cx={halfBaseSize}
+    cy={size === "small" ? 2 : 4}
+    r={radius}
+    fill="currentColor"
+    filter={filterUrl}
+  />
+  <circle
+    cx={halfBaseSize}
+    cy={halfBaseSize}
+    r={radius}
+    fill="currentColor"
+    filter={filterUrl}
+  />
+  <circle
+    cx={halfBaseSize}
+    cy={size === "small" ? 14 : 20}
+    r={radius}
+    fill="currentColor"
+    filter={filterUrl}
+  />
 {/snippet}
 
 <svg
-  width="16"
-  height="16"
-  viewBox="0 0 16 16"
+  width={baseSize}
+  height={baseSize}
+  viewBox="0 0 #{baseSize} #{baseSize}"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
   overflow="visible"

--- a/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import VipBadge from "$lib/components/badge/VipBadge.svelte";
-  import SettingsButton from "$lib/components/buttons/settings/SettingsButton.svelte";
   import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import { useIsMe } from "$lib/features/auth/stores/useIsMe";
   import { useUser } from "$lib/features/auth/stores/useUser";
@@ -10,6 +9,7 @@
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { DisplayableProfileProps } from "../profile/DisplayableProfileProps";
   import FollowUserButton from "./_internal/FollowUserButton.svelte";
+  import ProfileOptionsButton from "./_internal/ProfileOptionsButton.svelte";
   import ProfileImage from "./ProfileImage.svelte";
 
   const { profile, slug }: DisplayableProfileProps = $props();
@@ -17,11 +17,6 @@
   const { user } = useUser();
   const { isMe } = $derived(useIsMe(slug));
 
-  const nameLabel = $derived(
-    $isMe
-      ? m.header_profile_banner_greeting({ name: toDisplayableName(profile) })
-      : toDisplayableName(profile),
-  );
   const shareableSlug = $derived($isMe ? $user.slug : slug);
 </script>
 
@@ -36,33 +31,35 @@
     isVip={profile.isVip}
   >
     {#snippet badge()}
-      {#if profile.isVip}
-        <VipBadge isDirector={profile.isDirector} />
-      {/if}
+      <RenderFor audience="all" device={["tablet-sm", "desktop"]}>
+        {#if profile.isVip}
+          <VipBadge isDirector={profile.isDirector} />
+        {/if}
+      </RenderFor>
     {/snippet}
   </ProfileImage>
   <div class="profile-info" data-hj-suppress data-sentry-mask>
     <div class="profile-user-details">
       <span class="title">
-        {nameLabel}
+        {toDisplayableName(profile)}
       </span>
       <span class="user-location">{profile.location}</span>
     </div>
     <div class="profile-actions">
-      <RenderFor audience="authenticated">
-        {#if !$isMe}
-          <FollowUserButton {profile} {slug} />
-        {/if}
-        {#if $isMe}
-          <SettingsButton style="ghost" />
-        {/if}
-      </RenderFor>
       <ShareButton
         title={profile.name.first}
         urlOverride={UrlBuilder.profile.user(shareableSlug)}
         textFactory={({ title: name }) => m.text_share_profile({ name })}
         source={{ id: "profile", type: $isMe ? "own" : "other" }}
       />
+      <RenderFor audience="authenticated">
+        {#if !$isMe}
+          <FollowUserButton {profile} {slug} />
+        {/if}
+        {#if $isMe}
+          <ProfileOptionsButton />
+        {/if}
+      </RenderFor>
     </div>
   </div>
 </div>
@@ -76,6 +73,8 @@
     align-items: flex-start;
     gap: var(--gap-m);
 
+    transition: gap var(--transition-increment) ease-in-out;
+
     :global(.profile-image-container) {
       display: flex;
       flex-direction: column;
@@ -88,24 +87,27 @@
     }
 
     @include for-tablet-sm-and-below {
+      align-items: center;
       flex-direction: row;
-      align-items: flex-end;
+      gap: var(--gap-xs);
 
-      margin: 0;
+      :global(.profile-image-container) {
+        --width: var(--ni-40);
+        --height: var(--ni-40);
+        --border-width: var(--border-thickness-xs);
+      }
     }
   }
 
   .profile-user-details {
     display: flex;
     flex-direction: column;
-
     gap: var(--gap-micro);
   }
 
   .profile-info {
     display: flex;
     flex-direction: column;
-
     gap: var(--gap-m);
 
     .user-location {
@@ -114,9 +116,9 @@
 
     @include for-tablet-sm-and-below {
       width: 100%;
-      flex-direction: column-reverse;
-
-      gap: 0;
+      flex-direction: row;
+      gap: var(--gap-xs);
+      justify-content: space-between;
     }
   }
 
@@ -125,6 +127,11 @@
     align-items: center;
 
     gap: var(--gap-s);
+
+    :global(svg) {
+      width: var(--ni-24);
+      height: var(--ni-24);
+    }
 
     @include for-tablet-sm-and-below {
       align-self: flex-end;

--- a/projects/client/src/lib/sections/profile-banner/_internal/FollowUserButton.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/FollowUserButton.svelte
@@ -36,8 +36,8 @@
 
 <Button
   size={"small"}
-  color={$isFollowed ? "red" : "purple"}
-  variant={$isFollowed ? "secondary" : "primary"}
+  color={"default"}
+  variant={"primary"}
   {label}
   onclick={(event) => {
     $isFollowed ? confirmUnfollow(event) : followUser();

--- a/projects/client/src/lib/sections/profile-banner/_internal/ProfileOptionsButton.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/ProfileOptionsButton.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+
+  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import LogoutButton from "$lib/components/buttons/logout/LogoutButton.svelte";
+  import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
+  import SettingsButton from "$lib/components/buttons/settings/SettingsButton.svelte";
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import MoreIcon from "$lib/components/icons/MoreIcon.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { writable } from "svelte/store";
+
+  const isDrawerOpen = writable(false);
+</script>
+
+{#snippet content()}
+  <SettingsButton style="dropdown-item" />
+  <LogoutButton style="dropdown-item" />
+{/snippet}
+
+<RenderFor audience="authenticated" device={["mobile", "tablet-sm"]}>
+  <ActionButton
+    label={m.button_label_profile_options()}
+    onclick={() => isDrawerOpen.set(true)}
+    style="ghost"
+  >
+    <MoreIcon size="normal" />
+  </ActionButton>
+
+  {#if $isDrawerOpen}
+    <Drawer onClose={() => isDrawerOpen.set(false)} size="auto">
+      <div class="trakt-profile-options">
+        {@render content()}
+      </div>
+    </Drawer>
+  {/if}
+</RenderFor>
+
+<RenderFor audience="authenticated" device={["desktop", "tablet-lg"]}>
+  <PopupMenu label={m.button_label_profile_options()} size="normal">
+    {#snippet icon()}
+      <MoreIcon size="normal" />
+    {/snippet}
+
+    {#snippet items()}
+      {@render content()}
+    {/snippet}
+  </PopupMenu>
+</RenderFor>
+
+<style>
+  .trakt-profile-options {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+</style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- New design for profile banner


## 👀 Examples 👀
Before:
<img width="428" height="380" alt="Screenshot 2025-12-08 at 09 26 30" src="https://github.com/user-attachments/assets/18c605b4-a689-41aa-88ec-a15a20ef9484" />

After:

https://github.com/user-attachments/assets/1370f6ce-59c5-405f-9c4f-ee5bd4b414c2

