### PR TITLE
fix(summary): account for partial sentiments

### DIFF
--- a/projects/client/src/lib/sections/summary/components/sentiment/CommunitySentiments.svelte
+++ b/projects/client/src/lib/sections/summary/components/sentiment/CommunitySentiments.svelte
@@ -6,6 +6,17 @@
 
   const { sentiments, slug }: { sentiments: Sentiments | Nil; slug: string } =
     $props();
+
+  const hasPartialSentiments = $derived.by(() => {
+    if (!sentiments) return false;
+    return sentiments.good.length === 0 || sentiments.bad.length === 0;
+  });
+
+  const heightList = $derived(
+    hasPartialSentiments
+      ? "calc(0.5 * var(--height-sentiments-list))"
+      : "var(--height-sentiments-list)",
+  );
 </script>
 
 {#if sentiments}
@@ -13,10 +24,10 @@
     id={`community-sentiments-${slug}`}
     items={[{ ...sentiments, key: "sentiment" }]}
     title={m.header_community_sentiment()}
-    --height-list="var(--height-sentiments-list)"
+    --height-list={heightList}
   >
     {#snippet item(sentiments)}
-      <SentimentsCard {sentiments} />
+      <SentimentsCard {sentiments} isPartial={hasPartialSentiments} />
     {/snippet}
   </SectionList>
 {/if}

--- a/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentsCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentsCard.svelte
@@ -3,13 +3,22 @@
   import type { Sentiments } from "$lib/requests/models/Sentiments";
   import SentimentsList from "./SentimentsList.svelte";
 
-  const { sentiments }: { sentiments: Sentiments } = $props();
+  const {
+    sentiments,
+    isPartial,
+  }: { sentiments: Sentiments; isPartial: boolean } = $props();
+
+  const heightCard = $derived(
+    isPartial
+      ? "calc(0.5 * var(--height-sentiments-card))"
+      : "var(--height-sentiments-card)",
+  );
 </script>
 
 <div class="trakt-sentiments-card">
   <Card
     --width-card="var(--width-sentiments-card)"
-    --height-card="var(--height-sentiments-card)"
+    --height-card={heightCard}
     variant="transparent"
   >
     <div class="trakt-sentiments-container">

--- a/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentsList.svelte
+++ b/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentsList.svelte
@@ -26,17 +26,19 @@
 
 <div class="trakt-sentiment-body">
   {#each mappedSentiments as { sentiment, sentiments, backgroundColor }}
-    <div
-      class="trakt-sentiment-container"
-      style="--sentiment-background-color: {backgroundColor}"
-    >
-      <SentimentIcon {sentiment} />
-      <ul>
-        {#each sentiments as sentiment}
-          <li><p>{sentiment}</p></li>
-        {/each}
-      </ul>
-    </div>
+    {#if sentiments.length > 0}
+      <div
+        class="trakt-sentiment-container"
+        style="--sentiment-background-color: {backgroundColor}"
+      >
+        <SentimentIcon {sentiment} />
+        <ul>
+          {#each sentiments as sentiment}
+            <li><p>{sentiment}</p></li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
   {/each}
 </div>
 


### PR DESCRIPTION
## ♪ Note ♪

- Account for partial sentiments.

## 👀 Example 👀

Before/after:
<img width="907" height="1011" alt="Screenshot 2025-12-08 at 17 37 01" src="https://github.com/user-attachments/assets/a7087384-eb95-4504-ad3f-d7693bec8256" />

<img width="907" height="895" alt="Screenshot 2025-12-08 at 17 34 30" src="https://github.com/user-attachments/assets/9608d915-80e0-448b-960c-02795d45b26f" />
