### PR TITLE
feat(summary): show character or job in people summary

### DIFF
--- a/projects/client/src/lib/requests/models/MediaCredits.ts
+++ b/projects/client/src/lib/requests/models/MediaCredits.ts
@@ -1,10 +1,31 @@
 import { MediaEntrySchema } from '$lib/requests/models/MediaEntry.ts';
 import { z } from 'zod';
 
+const BaseCreditSchema = z.object({
+  media: MediaEntrySchema,
+  key: z.string(),
+});
+
+const CharacterSchema = BaseCreditSchema.extend({
+  character: z.string(),
+  type: z.literal('cast'),
+});
+
+const CrewSchema = BaseCreditSchema.extend({
+  job: z.string(),
+  type: z.literal('crew'),
+});
+
+const MediaCreditSchema = z.discriminatedUnion('type', [
+  CharacterSchema,
+  CrewSchema,
+]);
+
 export const MediaCreditsSchema = z
   .map(
     z.string(),
-    z.array(MediaEntrySchema),
+    MediaCreditSchema.array(),
   );
 
+export type MediaCredit = z.infer<typeof MediaCreditSchema>;
 export type MediaCredits = z.infer<typeof MediaCreditsSchema>;

--- a/projects/client/src/lib/requests/queries/people/personMovieCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/personMovieCreditsQuery.ts
@@ -21,7 +21,7 @@ const personMovieCreditsRequest = (
     });
 
 export const personMovieCreditsQuery = defineQuery({
-  key: 'personMovieCredits:v3',
+  key: 'personMovieCredits',
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: personMovieCreditsRequest,

--- a/projects/client/src/lib/requests/queries/people/personShowCreditsQuery.ts
+++ b/projects/client/src/lib/requests/queries/people/personShowCreditsQuery.ts
@@ -21,7 +21,7 @@ const personShowCreditsRequest = (
     });
 
 export const personShowCreditsQuery = defineQuery({
-  key: 'personShowCredits:v3',
+  key: 'personShowCredits',
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: personShowCreditsRequest,

--- a/projects/client/src/lib/sections/lists/CreditsList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsList.svelte
@@ -8,6 +8,7 @@
   import type { MediaType } from "$lib/requests/models/MediaType";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
   import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
+  import { toTranslatedJob } from "$lib/utils/formatting/string/toTranslatedJob";
   import { toTranslatedPosition } from "$lib/utils/formatting/string/toTranslatedPosition";
   import { writable } from "svelte/store";
   import DefaultMediaItem from "./components/DefaultMediaItem.svelte";
@@ -37,6 +38,16 @@
 
   const list = $derived(getPositionList($credits));
   const defaultVariant = $derived(useDefaultCardVariant(type));
+
+  const toCharacter = (character?: string) => {
+    return character || m.translated_value_status_unknown();
+  };
+
+  const toJob = (job?: string) => {
+    if (!job) return m.translated_value_status_unknown();
+
+    return toTranslatedJob(job);
+  };
 </script>
 
 <SectionList
@@ -45,8 +56,16 @@
   {title}
   --height-list={mediaListHeightResolver($defaultVariant)}
 >
-  {#snippet item(media)}
-    <DefaultMediaItem {type} {media} source="credits" />
+  {#snippet item(entry)}
+    <DefaultMediaItem
+      {type}
+      media={entry.media}
+      source="credits"
+      variant="credit"
+      role={entry.type === "cast"
+        ? toCharacter(entry.character)
+        : toJob(entry.job)}
+    />
   {/snippet}
 
   {#snippet dynamicActions()}

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -138,6 +138,18 @@
   </PortraitCard>
 {/if}
 
+{#if rest.variant === "credit"}
+  <PortraitCard>
+    {@render content(media.poster.url.thumb)}
+    <CardFooter {action}>
+      {@render tag?.()}
+      <p class="trakt-card-subtitle ellipsis">
+        {rest.role}
+      </p>
+    </CardFooter>
+  </PortraitCard>
+{/if}
+
 <style>
   .trakt-card-start-footer {
     :global(.trakt-media-icon-tag),

--- a/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/MediaCardProps.ts
@@ -11,7 +11,8 @@ export type MediaItemVariant<T> =
   | { variant?: Nil } & MediaInput<T>
   | { variant: 'activity'; date: Date } & MediaInput<T>
   | { variant: 'next'; progress: number; minutesLeft: number } & MediaInput<T>
-  | { variant: 'start' } & MediaInput<T>;
+  | { variant: 'start' } & MediaInput<T>
+  | { variant: 'credit'; role: string } & MediaInput<T>;
 
 type BaseItemProps<T> = MediaItemVariant<T> & {
   badge?: Snippet;

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -118,6 +118,13 @@
             - {rest.episode.title}
           </Spoiler>
         </p>
+      {:else if rest.variant === "credit"}
+        <p class="trakt-card-title ellipsis">
+          {media.title}
+        </p>
+        <p class="trakt-card-subtitle secondary ellipsis">
+          {rest.role}
+        </p>
       {:else}
         <p class="trakt-card-title ellipsis">
           {media.title}

--- a/projects/client/src/mocks/data/people/mapped/PersonFergusonShowCreditsMappedMock.ts
+++ b/projects/client/src/mocks/data/people/mapped/PersonFergusonShowCreditsMappedMock.ts
@@ -2,6 +2,16 @@ import type { MediaCredits } from '$lib/requests/models/MediaCredits.ts';
 import { ShowSiloMappedMock } from '../../summary/shows/silo/mapped/ShowSiloMappedMock.ts';
 
 export const PersonFergusonShowCreditsMappedMock: MediaCredits = new Map([
-  ['acting', [ShowSiloMappedMock]],
-  ['production', [ShowSiloMappedMock]],
+  ['acting', [{
+    type: 'cast',
+    media: ShowSiloMappedMock,
+    key: ShowSiloMappedMock.key,
+    character: 'Juliette Nichols',
+  }]],
+  ['production', [{
+    type: 'crew',
+    media: ShowSiloMappedMock,
+    key: ShowSiloMappedMock.key,
+    job: 'Executive Producer',
+  }]],
 ]);

--- a/projects/client/src/mocks/data/people/mapped/PersonGrantMovieCreditsMappedMock.ts
+++ b/projects/client/src/mocks/data/people/mapped/PersonGrantMovieCreditsMappedMock.ts
@@ -2,5 +2,10 @@ import type { MediaCredits } from '$lib/requests/models/MediaCredits.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
 
 export const PersonGrantMovieCreditsMappedMock: MediaCredits = new Map([
-  ['acting', [MovieHereticMappedMock]],
+  ['acting', [{
+    type: 'cast',
+    key: MovieHereticMappedMock.key,
+    media: MovieHereticMappedMock,
+    character: 'Mr. Reed',
+  }]],
 ]);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds character or jobs to items in people summary page.
  - Characters are shown as is.
  - Jobs are translated.

## 👀 Examples 👀
<img width="426" height="763" alt="Screenshot 2025-12-08 at 18 29 23" src="https://github.com/user-attachments/assets/3d703cf1-e857-4d37-9912-daf3d64938c8" />

<img width="426" height="763" alt="Screenshot 2025-12-08 at 18 29 43" src="https://github.com/user-attachments/assets/0ccb90eb-dc0f-4f89-a8db-1a08f12488b3" />
