### PR TITLE
fix(summary): fall back to show poster when there is no season poster

### DIFF
--- a/projects/client/src/lib/requests/models/Season.ts
+++ b/projects/client/src/lib/requests/models/Season.ts
@@ -10,6 +10,6 @@ export const SeasonSchema = z.object({
   }),
   poster: z.object({
     url: ImageUrlsSchema,
-  }),
+  }).optional(),
 });
 export type Season = z.infer<typeof SeasonSchema>;

--- a/projects/client/src/lib/requests/queries/shows/showSeasonsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSeasonsQuery.ts
@@ -3,6 +3,7 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { SeasonsResponse } from '@trakt/api';
 import { z } from 'zod';
+import { findDefined } from '../../../utils/string/findDefined.ts';
 import { mapToPoster } from '../../_internal/mapToPoster.ts';
 import { type Season, SeasonSchema } from '../../models/Season.ts';
 
@@ -24,15 +25,21 @@ const showSeasonsRequest = (
       },
     });
 
-const mapToSeason = (item: SeasonsResponse[0]): Season => ({
-  id: item.ids.trakt,
-  key: `season-${item.ids.trakt}`,
-  number: item.number,
-  episodes: {
-    count: item.episode_count ?? 0,
-  },
-  poster: mapToPoster(item.images),
-});
+const mapToSeason = (item: SeasonsResponse[0]): Season => {
+  const poster = findDefined(
+    ...(item.images?.poster ?? []),
+  );
+
+  return {
+    id: item.ids.trakt,
+    key: `season-${item.ids.trakt}`,
+    number: item.number,
+    episodes: {
+      count: item.episode_count ?? 0,
+    },
+    poster: poster ? mapToPoster(item.images) : undefined,
+  };
+};
 
 export const showSeasonsQuery = defineQuery({
   key: 'showSeasons',

--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -5,16 +5,22 @@
   import PortraitCard from "$lib/components/media/card/PortraitCard.svelte";
   import { lineClamp } from "$lib/components/text/lineClamp";
   import type { Season } from "$lib/requests/models/Season";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry";
   import { seasonLabel } from "$lib/utils/intl/seasonLabel";
 
   const SCROLL_OFFSET = 8;
 
   const {
     season,
+    show,
     urlBuilder,
     isCurrentSeason,
-  }: { season: Season; urlBuilder: () => string; isCurrentSeason: boolean } =
-    $props();
+  }: {
+    season: Season;
+    show: ShowEntry;
+    urlBuilder: () => string;
+    isCurrentSeason: boolean;
+  } = $props();
 
   const scrollToItem = (element: HTMLElement) => {
     if (!isCurrentSeason) return;
@@ -51,7 +57,7 @@
     <Link focusable={false} href={urlBuilder()} noscroll>
       <CardCover
         title={seasonLabel(season.number)}
-        src={season.poster.url.medium}
+        src={season.poster?.url.medium ?? show.poster.url.medium}
         alt={seasonLabel(season.number)}
       />
     </Link>

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
@@ -37,6 +37,7 @@
 >
   {#snippet item(season)}
     <SeasonItem
+      {show}
       {season}
       isCurrentSeason={season.number === currentSeason}
       urlBuilder={() => UrlBuilder.show(show.slug, { season: season.number })}

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts
@@ -40,11 +40,6 @@ export const ShowSiloSeasonsMappedMock: Season[] = [
     'episodes': {
       'count': 1,
     },
-    'poster': {
-      'url': {
-        'medium': '/placeholders/portrait_placeholder.png' as HttpsUrl,
-        'thumb': '/placeholders/portrait_placeholder.png' as HttpsUrl,
-      },
-    },
+    'poster': undefined,
   },
 ];


### PR DESCRIPTION
## 🎶 Notes 🎶

- Season posters are no longer mapped to the placeholder.
- Fall back to show poster when a season has no poster.


## 👀 Examples 👀
<img width="1041" height="343" alt="Screenshot 2025-12-08 at 20 42 57" src="https://github.com/user-attachments/assets/0503e653-8e8a-4138-b85e-48fac6deb7e3" />

<img width="853" height="511" alt="Screenshot 2025-12-08 at 20 43 00" src="https://github.com/user-attachments/assets/811fc034-fa3c-4a6e-93d7-72332e5aa285" />
