### PR TITLE
fix(card): correctly derive pending state of card cover images

### DIFF
--- a/projects/client/src/lib/components/card/CardCover.svelte
+++ b/projects/client/src/lib/components/card/CardCover.svelte
@@ -9,7 +9,7 @@
 
   const { src, overlaySrc, alt, badge, tag, title }: CardCoverProps = $props();
 
-  const isImagePending = $derived(writable(!isImageComplete(src)));
+  const isImagePending = writable(!isImageComplete(src));
   const id = $derived(checksum(`${src}-${title}`));
 
   const isPlaceholder = $derived(PLACEHOLDERS.includes(src));
@@ -40,7 +40,7 @@
       animate={false}
       {src}
       {alt}
-      onload={() => ($isImagePending = false)}
+      onload={() => isImagePending.set(false)}
       aria-labelledby={id}
     />
     {#if overlaySrc && !PLACEHOLDERS.includes(overlaySrc)}
@@ -49,7 +49,7 @@
         animate={false}
         src={overlaySrc}
         {alt}
-        onload={() => ($isImagePending = false)}
+        onload={() => isImagePending.set(false)}
         aria-labelledby={id}
       />
     {/if}


### PR DESCRIPTION
## ♪ Note ♪

- Fixes pending state of card covers.

## 👀 Example 👀

Before:

https://github.com/user-attachments/assets/c7a3fcef-ec28-4e2e-a19d-3c2fefbb91d2

After:

https://github.com/user-attachments/assets/e75d7acb-8983-4d2e-8b0d-7716a7e84ada

