### PR TITLE
fix(drawer): do not close on scroll

### DIFF
--- a/projects/client/src/lib/components/drawer/_internal/useDrawerPortal.ts
+++ b/projects/client/src/lib/components/drawer/_internal/useDrawerPortal.ts
@@ -1,5 +1,4 @@
 import { createUnderlay } from '$lib/features/portal/_internal/createUnderlay.ts';
-import { GlobalEventBus } from '$lib/utils/events/GlobalEventBus.ts';
 import { onMount } from 'svelte';
 
 type DrawerPortalProps = {
@@ -14,18 +13,15 @@ export function useDrawerPortal({ hasAutoClose, onClose }: DrawerPortalProps) {
         return;
       }
 
-      const instance = GlobalEventBus.getInstance();
       const newUnderlay = createUnderlay();
 
       document.body.appendChild(newUnderlay);
       document.body.appendChild(element);
 
       newUnderlay.addEventListener('click', onClose);
-      const destroyScroll = instance.register('scroll', onClose);
 
       return () => {
         newUnderlay.removeEventListener('click', onClose);
-        destroyScroll();
         newUnderlay.remove();
         element.remove();
       };


### PR DESCRIPTION
## 🎶 Notes 🎶

- Do not close drawer on scroll.
  - This behaviour is not compatible with having input fields in a drawer. The on screen keyboard triggers a scroll and closes it 😅
- To be fixed 'properly' in the futurel i.e, make it behave more like a modal.