### PR TITLE
Fix comparison for watched tag

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
@@ -13,6 +13,6 @@
   <PostCreditsTag count={postCreditsCount} i18n={TagIntlProvider} />
 {/if}
 
-{#if watchCount > 1}
+{#if watchCount > 0}
   <WatchCountTag count={watchCount} i18n={TagIntlProvider} />
 {/if}


### PR DESCRIPTION
The commit deee2507080ec337ec58fd0e282f5a72e2f0b694 changed the check for the `<WatchCountTag>` to only appear on items watched more than one time. I believe this was an accident, as items that you have watched (only once) don't have a watched tag on the website anymore.

If that was indeed not an error but an intended change, I'm sorry; feel free to close this PR.