### PR TITLE
Update scripts to use cross-env for Windows compatibility

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -29,6 +29,7 @@
     "npm:@vite-pwa/sveltekit@1.1.0": "1.1.0_@sveltejs+kit@2.49.1__@sveltejs+vite-plugin-svelte@6.2.1___svelte@5.45.6____acorn@8.15.0___vite@7.2.6____sass-embedded@1.93.3____picomatch@4.0.3___sass-embedded@1.93.3__svelte@5.45.6___acorn@8.15.0__vite@7.2.6___sass-embedded@1.93.3___picomatch@4.0.3__acorn@8.15.0__sass-embedded@1.93.3_@sveltejs+vite-plugin-svelte@6.2.1__svelte@5.45.6___acorn@8.15.0__vite@7.2.6___sass-embedded@1.93.3___picomatch@4.0.3__sass-embedded@1.93.3_svelte@5.45.6__acorn@8.15.0_vite@7.2.6__sass-embedded@1.93.3__picomatch@4.0.3_sass-embedded@1.93.3",
     "npm:@vitest/coverage-istanbul@3.2.4": "3.2.4_vitest@3.2.4__jsdom@26.1.0__msw@2.7.3___typescript@5.8.3__vite@7.2.6___sass-embedded@1.93.3___picomatch@4.0.3__sass-embedded@1.93.3__typescript@5.8.3_jsdom@26.1.0_msw@2.7.3__typescript@5.8.3_sass-embedded@1.93.3_typescript@5.8.3",
     "npm:concurrently@9.2.1": "9.2.1",
+    "npm:cross-env@10.1.0": "10.1.0",
     "npm:date-fns@4.1.0": "4.1.0",
     "npm:eslint-plugin-svelte@3.13.1": "3.13.1_eslint@9.39.1_svelte@5.45.6__acorn@8.15.0_postcss@8.5.6",
     "npm:eslint@9.39.1": "9.39.1",
@@ -1154,6 +1155,9 @@
       "dependencies": [
         "tslib"
       ]
+    },
+    "@epic-web/invariant@1.0.0": {
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA=="
     },
     "@esbuild/aix-ppc64@0.25.12": {
       "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
@@ -3947,6 +3951,14 @@
     },
     "core-util-is@1.0.3": {
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "cross-env@10.1.0": {
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dependencies": [
+        "@epic-web/invariant",
+        "cross-spawn"
+      ],
+      "bin": true
     },
     "cross-spawn@7.0.6": {
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
@@ -7593,6 +7605,7 @@
             "npm:@vite-pwa/sveltekit@1.1.0",
             "npm:@vitest/coverage-istanbul@3.2.4",
             "npm:concurrently@9.2.1",
+            "npm:cross-env@10.1.0",
             "npm:date-fns@4.1.0",
             "npm:eslint-plugin-svelte@3.13.1",
             "npm:eslint@9.39.1",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "pre:dev": "deno task i18n:web:watch",
     "dev": "concurrently 'deno task pre:dev' 'vite dev'",
-    "dev:staging": "concurrently 'deno task pre:dev' 'IS_STAGING=true vite dev'",
-    "dev:contrib": "concurrently 'deno task pre:dev' 'IS_CONTRIB=true vite dev'",
+    "dev:staging": "concurrently 'deno task pre:dev' 'cross-env IS_STAGING=true vite dev'",
+    "dev:contrib": "concurrently 'deno task pre:dev' 'cross-env  IS_CONTRIB=true vite dev'",
     "prebuild": "deno task i18n:web",
     "build": "vite build",
     "prebuild:preview": "deno task prebuild",
@@ -47,6 +47,7 @@
     "@vite-pwa/sveltekit": "1.1.0",
     "@vitest/coverage-istanbul": "3.2.4",
     "concurrently": "9.2.1",
+    "cross-env": "10.1.0",
     "eslint": "9.39.1",
     "eslint-plugin-svelte": "3.13.1",
     "globals": "16.5.0",


### PR DESCRIPTION
Enable development on Windows devices by updating scripts to use `cross-env` for setting environment variables; otherwise, the variables are treated as commands and fail on Windows shells.