### PR TITLE
Feat/full frame

### DIFF
--- a/projects/client/src/lib/components/frame/Frame.svelte
+++ b/projects/client/src/lib/components/frame/Frame.svelte
@@ -1,15 +1,22 @@
 <script lang="ts">
   import { useIsMe } from "$lib/features/auth/stores/useIsMe";
   import { useUser } from "$lib/features/auth/stores/useUser";
+  import Footer from "$lib/sections/footer/Footer.svelte";
   import { frameListener } from "./_internal/frameListener";
 
   type FrameProps = {
     slug: string;
     title: string;
     urlBuilder: (slug: string, token: string | Nil) => HttpsUrl;
+    mode?: "contain" | "cover";
   };
 
-  const { slug: userSlug, title, urlBuilder }: FrameProps = $props();
+  const {
+    slug: userSlug,
+    title,
+    urlBuilder,
+    mode = "contain",
+  }: FrameProps = $props();
 
   const { user } = useUser();
   const { isMe } = $derived(useIsMe(userSlug));
@@ -18,14 +25,43 @@
   const token = $derived($isMe ? $user.token : null);
 </script>
 
-<iframe
-  class="trakt-og-frame"
-  {title}
-  src={urlBuilder(slug, token)}
-  use:frameListener={slug}
-></iframe>
+<div class="trakt-frame-container" data-mode={mode}>
+  <iframe
+    class="trakt-og-frame"
+    {title}
+    src={urlBuilder(slug, token)}
+    use:frameListener={slug}
+  ></iframe>
 
-<style>
+  <Footer />
+  <div class="trakt-frame-spacer"></div>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-frame-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+
+    .trakt-frame-spacer {
+      height: 0;
+    }
+
+    &[data-mode="cover"] {
+      position: absolute;
+      top: 0;
+      left: 0;
+
+      @include for-tablet-sm-and-below {
+        .trakt-frame-spacer {
+          height: var(--mobile-navbar-height);
+        }
+      }
+    }
+  }
+
   iframe {
     width: 100%;
     height: 100dvh;

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -18,6 +18,7 @@
       runtime: number;
     };
     hasDynamicContent?: boolean;
+    mode?: "default" | "content-only";
   };
 
   const {
@@ -28,6 +29,7 @@
     image: _image,
     info: _info,
     hasDynamicContent = false,
+    mode = "default",
   }: ChildrenProps & TraktPageProps & AudienceProps = $props();
 
   const websiteName = "Trakt Web";
@@ -107,13 +109,17 @@
 </svelte:head>
 
 <RenderFor {audience}>
-  <NavbarStateSetter mode="full" />
+  {#if mode === "default"}
+    <NavbarStateSetter mode="full" />
+  {/if}
 
   <div class="trakt-content" {...dynamicContentProps}>
     {@render children()}
   </div>
 
-  <Footer />
+  {#if mode === "default"}
+    <Footer />
+  {/if}
 </RenderFor>
 
 {#if audience === "authenticated"}

--- a/projects/client/src/routes/users/[user]/mir/[year]/[month]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/mir/[year]/[month]/+page.svelte
@@ -17,6 +17,7 @@
   {audience}
   image={DEFAULT_SHARE_COVER}
   title={m.page_title_month_in_review()}
+  mode="content-only"
 >
   <NavbarStateSetter mode="minimal" />
 
@@ -33,5 +34,6 @@
       );
     }}
     title={m.page_title_month_in_review()}
+    mode="cover"
   />
 </TraktPage>

--- a/projects/client/src/routes/users/[user]/year/[year]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/year/[year]/+page.svelte
@@ -17,6 +17,7 @@
   {audience}
   image={DEFAULT_SHARE_COVER}
   title={m.page_title_year_to_date()}
+  mode="content-only"
 >
   <NavbarStateSetter mode="minimal" />
 
@@ -28,5 +29,6 @@
       return UrlBuilder.og.frame.yearToDate(slug, params.year, token);
     }}
     title={m.page_title_year_to_date()}
+    mode="cover"
   />
 </TraktPage>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Use minimal navbar mode for yir & mir pages
- Cover entire page with mir & yir
- ⚠️ Note ⚠️ section bar in the 2025 yir can be ignored; still has an issue I need to fix in OG.

## 👀 Example 👀
Before:
<img width="1453" height="794" alt="Screenshot 2025-12-18 at 09 51 28" src="https://github.com/user-attachments/assets/d3dfc7c6-bf6d-4b21-979f-0d84b5a24136" />


After:
<img width="1453" height="794" alt="Screenshot 2025-12-18 at 09 51 53" src="https://github.com/user-attachments/assets/8518d61c-b874-4b86-981b-f7f3f81eb8a5" />
