### PR TITLE
feat(theme): also show splash screen on larger screens

### DIFF
--- a/projects/client/src/lib/features/theme/components/SeasonalFlair.svelte
+++ b/projects/client/src/lib/features/theme/components/SeasonalFlair.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import RenderFor from "$lib/guards/RenderFor.svelte";
   import { useSeasonalTheme } from "../useSeasonalTheme";
   import SeasonalBackground from "./_internal/SeasonalBackground.svelte";
   import SeasonalSplashscreen from "./_internal/SeasonalSplashscreen.svelte";
@@ -19,11 +18,9 @@
 {#if $activeTheme}
   <SeasonalBackground themeId={$activeTheme} />
 
-  <RenderFor audience="all" device={["tablet-sm", "mobile"]}>
-    <SeasonalSplashscreen
-      hasSplashScreen={$hasSplashScreen}
-      themeId={$activeTheme}
-      {onDismiss}
-    />
-  </RenderFor>
+  <SeasonalSplashscreen
+    hasSplashScreen={$hasSplashScreen}
+    themeId={$activeTheme}
+    {onDismiss}
+  />
 {/if}


### PR DESCRIPTION
## ♪ Note ♪

- Had a quick chat with magna, for now we can just show the splash screen as is, in it's full sized glory.

## 👀 Example 👀
<img width="1609" height="1217" alt="Screenshot 2025-12-18 at 15 56 27" src="https://github.com/user-attachments/assets/f858716f-c35b-407e-a1eb-daab6313d353" />
