### PR TITLE
fix(theme): only show seasonal background if seasonal filters are enabled

### DIFF
--- a/projects/client/src/lib/features/theme/components/_internal/SeasonalBackground.svelte
+++ b/projects/client/src/lib/features/theme/components/_internal/SeasonalBackground.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
+  import { useDiscover } from "$lib/features/discover/useDiscover";
   import SnowBackground from "./christmas/SnowBackground.svelte";
 
   const { themeId }: { themeId: string } = $props();
+  const { useSeasonalFilters } = useDiscover();
 </script>
 
-{#if themeId === "christmas"}
-  <SnowBackground />
+{#if $useSeasonalFilters}
+  {#if themeId === "christmas"}
+    <SnowBackground />
+  {/if}
 {/if}


### PR DESCRIPTION
## ♪ Note ♪

- Do not show the seasonal background animation when seasonal filter is disabled.