### PR TITLE
fix(comment): show reactions distribution

### DIFF
--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsDistribution.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactionsDistribution.svelte
@@ -61,14 +61,14 @@
         opacity: 0.5;
       }
     }
+  }
 
-    @keyframes grow {
-      100% {
-        padding: var(--ni-16);
-        height: var(--ni-104);
-        margin: var(--ni-8);
-        opacity: 1;
-      }
+  @keyframes grow {
+    100% {
+      padding: var(--ni-16);
+      height: var(--ni-104);
+      margin: var(--ni-8);
+      opacity: 1;
     }
   }
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Reactions distributions are visible again.
- Fixes #1412

## 👀 Examples 👀
Before:

https://github.com/user-attachments/assets/fe981262-c40e-46bb-8fa9-fc0b0b144637

After:

https://github.com/user-attachments/assets/51616f7d-cf8b-4cd4-a245-11b687d8f108

