### PR TITLE
feat(colors): use better contrasting background colors

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -182,8 +182,6 @@
             var(--color-foreground) 10%,
             transparent
           );
-          /* color: var(--color-background); */
-          /* color: var(--color-text-primary); */
         }
       }
     }

--- a/projects/client/src/lib/components/date-time/DateTimePicker.svelte
+++ b/projects/client/src/lib/components/date-time/DateTimePicker.svelte
@@ -98,11 +98,7 @@
     font-size: var(--font-size-text);
 
     color: var(--color-text-primary);
-    background-color: color-mix(
-      in srgb,
-      var(--color-background) 25%,
-      transparent
-    );
+    background-color: var(--color-input-background);
 
     border: var(--ni-1) solid var(--color-border);
     border-radius: var(--date-time-border-radius);

--- a/projects/client/src/lib/components/dialogs/Dialog.svelte
+++ b/projects/client/src/lib/components/dialogs/Dialog.svelte
@@ -84,7 +84,7 @@
     max-width: 100dvw;
     max-height: var(--dialog-height);
 
-    background: color-mix(in srgb, var(--color-background) 88%, transparent);
+    background: var(--color-dialog-background);
     opacity: 0;
 
     backdrop-filter: blur(var(--ni-8));

--- a/projects/client/src/lib/components/drawer/Drawer.svelte
+++ b/projects/client/src/lib/components/drawer/Drawer.svelte
@@ -148,7 +148,7 @@
       var(--drawer-padding) + env(safe-area-inset-bottom, 0)
     );
 
-    background: color-mix(in srgb, var(--color-background) 70%, transparent);
+    background: var(--color-drawer-background);
 
     box-shadow: var(--ni-0) var(--ni-8) var(--ni-8) var(--ni-0)
       color-mix(in srgb, var(--color-shadow) 25%, transparent);

--- a/projects/client/src/lib/components/form/FormInput.svelte
+++ b/projects/client/src/lib/components/form/FormInput.svelte
@@ -88,7 +88,7 @@
     box-sizing: border-box;
 
     border-radius: var(--border-radius-m);
-    background: color-mix(in srgb, var(--color-background) 25%, transparent);
+    background: var(--color-input-background);
 
     outline: var(--border-thickness-xxs) solid var(--color-border);
     outline-offset: calc(-1 * var(--border-thickness-xxs));

--- a/projects/client/src/lib/features/search/SearchInput.svelte
+++ b/projects/client/src/lib/features/search/SearchInput.svelte
@@ -127,14 +127,15 @@
     position: relative;
 
     transition: outline var(--transition-increment) ease-in-out;
+    outline: var(--border-thickness-xxs) solid var(--color-border);
+
+    &,
+    .trakt-search-input {
+      border-radius: var(--border-radius-l);
+    }
 
     &:focus-within {
       outline: var(--border-thickness-xs) solid var(--purple-500);
-
-      &,
-      .trakt-search-input {
-        border-radius: var(--border-radius-l);
-      }
     }
 
     .trakt-search-icon {
@@ -157,7 +158,7 @@
       box-sizing: border-box;
 
       border-radius: var(--border-radius-l);
-      background: color-mix(in srgb, var(--color-background) 25%, transparent);
+      background: var(--color-input-background);
 
       transition: var(--transition-increment) ease-in-out;
       transition-property:
@@ -170,7 +171,6 @@
       }
 
       &:focus-within {
-        outline-color: var(--purple-600);
         opacity: 1;
       }
 

--- a/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
@@ -84,7 +84,11 @@
       align-items: center;
 
       padding-left: var(--ni-12);
-      background: color-mix(in srgb, var(--color-background) 50%, transparent);
+      background: color-mix(
+        in srgb,
+        var(--color-card-background) 50%,
+        transparent
+      );
       border-radius: var(--border-radius-l);
       overflow: hidden;
 

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/DateTimePickerDialog.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/DateTimePickerDialog.svelte
@@ -82,7 +82,7 @@
     padding: var(--ni-24);
     border-radius: var(--border-radius-l);
     border: none;
-    background-color: var(--color-card-background);
+    background-color: var(--color-dialog-background);
     color: var(--color-text-primary);
 
     max-width: var(--ni-480);

--- a/projects/client/src/lib/sections/profile/components/VipUpsell.svelte
+++ b/projects/client/src/lib/sections/profile/components/VipUpsell.svelte
@@ -34,7 +34,7 @@
     flex-direction: column;
     gap: var(--gap-m);
 
-    background: var(--color-background);
+    background: var(--color-card-background);
 
     border: var(--ni-2) solid var(--color-foreground-red);
     border-radius: var(--border-radius-l);

--- a/projects/client/src/lib/sections/profile/components/YearToDateLink.svelte
+++ b/projects/client/src/lib/sections/profile/components/YearToDateLink.svelte
@@ -51,5 +51,6 @@
     display: flex;
     align-items: center;
     gap: var(--gap-xs);
+    color: inherit;
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-input/CommentInput.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-input/CommentInput.svelte
@@ -118,6 +118,7 @@
     border: var(--ni-2) var(--purple-50) solid;
 
     color: var(--color-text-primary);
+    background-color: var(--color-input-background);
 
     transition: border-color var(--transition-increment) ease-in-out;
 

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -5,37 +5,40 @@
   /**
    * Theme-able variables
    */
+  --color-floating-background: var(--shade-60);
   --color-shadow: var(--shade-800);
 
   --color-foreground: var(--shade-920);
-  --color-background: var(--shade-10);
+  --color-background: color-mix(in srgb, var(--shade-300) 70%, var(--purple-50));
 
-  --color-text-primary: var(--shade-800);
-  --color-text-secondary: var(--shade-500);
+  --color-text-primary: var(--shade-900);
+  --color-text-secondary: var(--shade-800);
   --color-text-emphasis: var(--purple-700);
+
+  --color-input-background: color-mix(in srgb, var(--shade-20) 25%, transparent);
 
   /**
    * Navbar
    */
-  --color-background-navbar-base: var(--shade-50);
+  --color-background-navbar-base: var(--color-floating-background);
   --color-background-navbar: color-mix(in srgb,
       var(--color-background-navbar-base) 90%,
       transparent);
   --color-foreground-navbar: var(--color-foreground);
   --color-border: var(--shade-300);
-  --color-background-side-navbar: var(--shade-70);
+  --color-background-side-navbar: var(--color-background-navbar-base);
 
   /*
    * Card
    */
-  --color-card-background: var(--shade-20);
+  --color-card-background: var(--color-floating-background);
   --color-official-list-background: var(--purple-200);
   --list-poster-shadow: -4px 0px 16px 0px rgba(0, 0, 0, 0.25);
 
   /*
     * Actions bar
     */
-  --color-actions-bar-background: var(--shade-20);
+  --color-actions-bar-background: var(--color-floating-background);
 
   /*
    * Cta
@@ -75,7 +78,7 @@
   /*
    * Navbar
    */
-  --color-background-mobile-navbar: color-mix(in srgb, var(--color-background) 90%, transparent);
+  --color-background-mobile-navbar: color-mix(in srgb, var(--color-background-navbar-base) 90%, transparent);
 
   /*
    * Tooltip
@@ -119,7 +122,7 @@
   /**
     * Calendar
     */
-  --color-calendar-background: color-mix(in srgb, var(--color-background) 90%, transparent);
+  --color-calendar-background: color-mix(in srgb, var(--color-background-navbar-base) 90%, transparent);
   --color-calendar-inactive-background: var(--color-background-navbar-base);
   --color-calendar-active-background: var(--shade-200);
   --color-calendar-background-hover: var(--shade-100);
@@ -143,49 +146,51 @@
    * Where to watch
    */
   --streaming-service-logo-filter: brightness(0);
-  --color-just-watch: #c79a00;
-  --color-rank-positive: var(--green-700);
-  --color-rank-negative: var(--red-700);
+  --color-just-watch: var(--color-text-secondary);
 
   /*
-    * Cover image
-    */
-  --mix-blend-mode-cover-overlay: overlay;
+   * Dialogs & drawers
+   */
+  --color-drawer-background: color-mix(in srgb, var(--shade-70) 94%, transparent);
+  --color-dialog-background: var(--color-drawer-background);
 }
 
 // Define theme variables for dark mode
 @mixin dark-theme {
+  --color-floating-background: var(--shade-930);
   --color-shadow: var(--shade-940);
 
   --color-foreground: var(--shade-10);
-  --color-background: var(--shade-940);
+  --color-background: color-mix(in srgb, var(--shade-920) 90%, var(--purple-900));
 
   --color-text-primary: var(--shade-10);
   --color-text-secondary: var(--shade-300);
   --color-text-emphasis: var(--purple-300);
 
+  --color-input-background: color-mix(in srgb, var(--shade-800) 25%, transparent);
+
   /**
    * Navbar
    */
-  --color-background-navbar-base: var(--shade-920);
+  --color-background-navbar-base: var(--color-floating-background);
   --color-background-navbar: color-mix(in srgb,
       var(--color-background-navbar-base) 90%,
       transparent);
   --color-foreground-navbar: var(--shade-10);
   --color-border: var(--shade-700);
-  --color-background-side-navbar: var(--shade-900);
+  --color-background-side-navbar: var(--color-background-navbar-base);
 
   /*
    * Card
    */
-  --color-card-background: var(--shade-920);
+  --color-card-background: var(--color-floating-background);
   --color-official-list-background: var(--purple-800);
   --list-poster-shadow: -8px 0px 16px 0px rgba(0, 0, 0, 0.56);
 
   /*
     * Actions bar
     */
-  --color-actions-bar-background: var(--shade-920);
+  --color-actions-bar-background: var(--color-floating-background);
 
   /*
    * Cta
@@ -297,9 +302,10 @@
   --color-just-watch: #fcc405;
 
   /*
-    * Cover image
-    */
-  --mix-blend-mode-cover-overlay: color-dodge;
+   * Dialogs & drawers
+   */
+  --color-drawer-background: color-mix(in srgb, var(--shade-920) 94%, transparent);
+  --color-dialog-background: var(--color-drawer-background);
 }
 
 // Apply themes to selectors


### PR DESCRIPTION
## 🎶 Notes 🎶

- Uses better contrasting background colors.
- Still mixes in a bit of the main color; e.g. seasonal themes will still have effect on the background.
- inputs, dialogs, drawers have their own background variables now.

## 👀 Examples 👀
Before/after:
<img width="1461" height="1214" alt="light_before_1" src="https://github.com/user-attachments/assets/f9e8cd57-01c5-49af-90e8-fa1d1e45d1d9" />

<img width="1461" height="1214" alt="light_after_1" src="https://github.com/user-attachments/assets/bc0cc2c1-f822-45ff-af8e-adfb8b883da3" />

Before/after:
<img width="1461" height="1214" alt="light_before_2" src="https://github.com/user-attachments/assets/84f0aa13-283e-469f-a0ac-7696b41b41bc" />

<img width="1461" height="1214" alt="light_after_2" src="https://github.com/user-attachments/assets/4d45b4f1-04f8-4f35-8f0c-3875f28b569b" />

Before/after:
<img width="1461" height="1214" alt="dark_before_1" src="https://github.com/user-attachments/assets/1f04c30d-3785-4e83-bcd5-08648dd08190" />

<img width="1461" height="1214" alt="dark_after_1" src="https://github.com/user-attachments/assets/0df34369-ba60-404c-acda-b24edcbf0f83" />

Before/after:
<img width="1461" height="1214" alt="dark_before_2" src="https://github.com/user-attachments/assets/aba5081f-8f2a-42e8-8f96-d580fbe8835e" />

<img width="1461" height="1214" alt="dark_after_2" src="https://github.com/user-attachments/assets/66737640-94a2-4fe3-b9f7-d81dc54bbe35" />

Some random other examples:
<img width="1461" height="1214" alt="Screenshot 2025-12-20 at 17 47 24" src="https://github.com/user-attachments/assets/e3a8c01d-6d12-4681-81ce-ab50fb23a3d4" />

<img width="1461" height="1214" alt="Screenshot 2025-12-20 at 17 47 54" src="https://github.com/user-attachments/assets/91943cba-e811-43df-9fad-65e8032476b4" />

<img width="427" height="928" alt="Screenshot 2025-12-20 at 18 03 31" src="https://github.com/user-attachments/assets/4651bc0d-5362-4efc-aed3-195aa28bff15" />

<img width="1458" height="1224" alt="Screenshot 2025-12-20 at 18 04 04" src="https://github.com/user-attachments/assets/5f9b14a5-5597-4d8d-9257-586aabf50fb2" />

