### PR TITLE
fix(profile): use skeleton list while loading favorites and library items

### DIFF
--- a/projects/client/src/lib/sections/lists/FavoritesList.svelte
+++ b/projects/client/src/lib/sections/lists/FavoritesList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import SkeletonList from "$lib/components/lists/SkeletonList.svelte";
   import Toggler from "$lib/components/toggles/Toggler.svelte";
   import { useToggler } from "$lib/components/toggles/useToggler";
   import { useIsMe } from "$lib/features/auth/stores/useIsMe";
@@ -41,6 +42,8 @@
 
   const { isMe } = $derived(useIsMe(slug));
   const cta = $derived({ type: "favorites" as const, mediaType: type });
+
+  const listId = $derived(`favorites-list-${$selectedType.value}-${slug}`);
 </script>
 
 {#snippet metaInfo()}
@@ -48,7 +51,7 @@
 {/snippet}
 
 <SectionList
-  id={`favorites-list-${selectedType}-${slug}`}
+  id={listId}
   items={$list}
   {title}
   --height-list={mediaListHeightResolver($defaultVariant)}
@@ -87,6 +90,8 @@
           {placeholderMessage}
         </p>
       {/if}
+    {:else}
+      <SkeletonList id={listId} variant="portrait" />
     {/if}
   {/snippet}
 

--- a/projects/client/src/lib/sections/lists/library/LibraryList.svelte
+++ b/projects/client/src/lib/sections/lists/library/LibraryList.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import SkeletonList from "$lib/components/lists/SkeletonList.svelte";
+  import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import { DEFAULT_PAGE_SIZE } from "$lib/utils/constants";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
@@ -10,12 +12,19 @@
   import LibraryMediaItem from "./_internal/LibraryMediaItem.svelte";
   import { useLibraryList } from "./useLibraryList";
 
-  const { list, libraries, activeLibrary } = $derived(
+  const { list, libraries, activeLibrary, isLoading } = $derived(
     useLibraryList({ limit: DEFAULT_PAGE_SIZE }),
+  );
+
+  const { plexLibrary } = useUser();
+
+  const hasLibraryItems = $derived(
+    $plexLibrary &&
+      ($plexLibrary.movieIds.length > 0 || $plexLibrary.episodeIds.length > 0),
   );
 </script>
 
-{#if $list.length > 0}
+{#if hasLibraryItems}
   <div class="trakt-library-list" transition:slide={{ duration: 150 }}>
     <SectionList
       id="library-list"
@@ -41,6 +50,12 @@
           label={m.button_label_view_all_library_items()}
           source={{ id: "library" }}
         />
+      {/snippet}
+
+      {#snippet empty()}
+        {#if $isLoading}
+          <SkeletonList id="library-list" variant="portrait" />
+        {/if}
       {/snippet}
     </SectionList>
   </div>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Had a look at the library being loaded slow:
  - During the weekend it could take 2 to 3 seconds for some reason... But now its in the hundreds of ms.
  - Current endpoint doesn't have pagination support.
- The library list is now shown earlier; if we know the user has items, we show it already and use the skeleton list while loading.
- Same for favorites.

## 👀 Example 👀

https://github.com/user-attachments/assets/e1145f05-671a-4891-92a2-ae1efea17941

