### PR TITLE
fix(drawer): use correct unit for height

### DIFF
--- a/projects/client/src/lib/components/drawer/Drawer.svelte
+++ b/projects/client/src/lib/components/drawer/Drawer.svelte
@@ -191,7 +191,7 @@
 
       &:global(.is-fullscreen),
       &[data-size="large"] {
-        --mobile-drawer-height: calc(100vh - env(safe-area-inset-top, 0px));
+        --mobile-drawer-height: calc(100dvh - env(safe-area-inset-top, 0px));
       }
 
       &[data-size="auto"] {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Potential fix for drawer falling under the dynamic island on ios devices.
- Could not reproduce in simulated devices though 🥲
  - I did encounter it on several iOS devices