### PR TITLE
fix: use more subtle gradient on background cover image

### DIFF
--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -49,10 +49,6 @@
       color-mix(in srgb, var(--color-background) 25%, transparent)
     );
 
-    @include for-tablet-sm-and-below {
-      opacity: 1;
-    }
-
     &[data-cover-type="main"] {
       --color-transparent-background: transparent;
 
@@ -117,7 +113,7 @@
         background: linear-gradient(
           180deg,
           var(--trakt-cover-primary-color-transparent) 0%,
-          var(--trakt-cover-primary-color-transparent) 75%,
+          var(--trakt-cover-primary-color-transparent) 50%,
           transparent 100%
         );
       }


### PR DESCRIPTION
## ♪ Note ♪

- Use less 'in your face' gradient.

## 👀 Example 👀
Before:

<img width="425" height="928" alt="Screenshot 2025-12-23 at 09 17 22" src="https://github.com/user-attachments/assets/7c96d2a8-f113-4e5e-82c7-9201ad081c4d" />

After:
<img width="425" height="928" alt="Screenshot 2025-12-23 at 09 19 35" src="https://github.com/user-attachments/assets/00b398ce-ab00-404a-a665-7d8f24f222bc" />
