### PR TITLE
feat(summary): use episode covers for episode summary

### DIFF
--- a/projects/client/src/lib/components/summary/SummaryPoster.svelte
+++ b/projects/client/src/lib/components/summary/SummaryPoster.svelte
@@ -13,6 +13,7 @@
     hoverOverlay?: Snippet;
     actions?: Snippet;
     tags?: Snippet;
+    variant?: "portrait" | "landscape";
   };
 
   const {
@@ -23,12 +24,13 @@
     hoverOverlay,
     target = "_blank",
     tags,
+    variant = "portrait",
   }: SummaryPosterProps = $props();
 
   const activeOverlay = $derived(href && hoverOverlay);
 </script>
 
-<div class="trakt-summary-poster-container">
+<div class="trakt-summary-poster-container" data-variant={variant}>
   <div class="trakt-summary-poster" class:has-active-overlay={activeOverlay}>
     <Link {href} {target}>
       <CrossOriginImage {src} {alt} />
@@ -55,12 +57,20 @@
 <style>
   .trakt-summary-poster-container {
     --overlay-border-size: var(--ni-2);
+    --poster-aspect-ratio: 3 / 2;
 
-    width: var(--ni-320);
+    width: var(--summary-poster-width);
     display: flex;
     flex-direction: column;
     gap: var(--gap-m);
     position: relative;
+
+    &[data-variant="landscape"] {
+      .trakt-summary-poster :global(img),
+      .trakt-summary-poster-overlay {
+        --poster-aspect-ratio: 9 / 16;
+      }
+    }
   }
 
   .trakt-summary-poster :global(img),
@@ -69,8 +79,8 @@
 
     border-radius: var(--border-radius-xxl);
 
-    width: var(--ni-320);
-    height: var(--ni-480);
+    width: var(--summary-poster-width);
+    height: calc(var(--summary-poster-width) * var(--poster-aspect-ratio));
 
     object-fit: cover;
   }

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -2,6 +2,7 @@
   import * as m from "$lib/features/i18n/messages";
 
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
+  import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import SeasonList from "$lib/sections/lists/season/SeasonList.svelte";
   import CastList from "../lists/CastList.svelte";
@@ -24,13 +25,7 @@
     crew,
   }: EpisodeSummaryProps = $props();
 
-  // FIXME: move this to the summary component when merged with v2
-  const currentSeason = $derived(
-    seasons.find((s) => s.number === episode.season),
-  );
-  const posterSrc = $derived(
-    currentSeason?.poster?.url.medium ?? show.poster.url.medium,
-  );
+  const posterSrc = $derived(useEpisodeSpoilerImage({ episode, show }));
 </script>
 
 <!-- 
@@ -51,7 +46,7 @@
     {showIntl}
     {episodeIntl}
     {crew}
-    {posterSrc}
+    posterSrc={$posterSrc}
   />
 </RenderFor>
 
@@ -63,7 +58,7 @@
     {episodeIntl}
     {streamOn}
     {crew}
-    {posterSrc}
+    posterSrc={$posterSrc}
   />
 </RenderFor>
 

--- a/projects/client/src/lib/sections/summary/components/_internal/Summary.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/Summary.svelte
@@ -54,12 +54,6 @@
       grid-column-start: 2;
     }
 
-    :global(.trakt-summary-poster-container),
-    :global(.trakt-summary-poster img) {
-      width: var(--summary-poster-width);
-      height: calc(var(--summary-poster-width) * 1.5);
-    }
-
     :global(.trakt-summary-poster img) {
       box-shadow:
         var(--ni-0) var(--ni-11) var(--ni-24) var(--ni-0)

--- a/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
@@ -50,6 +50,7 @@
       alt={title}
       href={streamOn?.preferred?.link}
       {tags}
+      variant="landscape"
     >
       {#snippet hoverOverlay()}
         <StreamOnOverlay service={streamOn?.preferred} />

--- a/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
@@ -56,7 +56,7 @@
 
 <Summary>
   {#snippet poster()}
-    <SummaryPoster src={posterSrc} alt={title} {tags} />
+    <SummaryPoster src={posterSrc} alt={title} {tags} variant="landscape" />
   {/snippet}
 
   {#snippet sideActions()}

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
@@ -38,33 +38,13 @@
   {/if}
 </div>
 
-<style lang="scss">
-  @use "$style/scss/mixins/index" as *;
-
+<style>
   .trakt-summary-container {
     display: grid;
     gap: var(--gap-xl);
     grid-template-columns: minmax(var(--ni-320), 1fr) 2fr 1fr;
     margin: 0 var(--layout-distance-side);
-
-    @include for-mobile {
-      /* Poster is hidden in mobile layout. */
-      gap: initial;
-    }
-
-    @include for-tablet-sm-and-below {
-      grid-template-columns: 1fr;
-
-      .trakt-summary-content {
-        grid-column: 1;
-      }
-
-      :global(.trakt-summary-poster) {
-        height: var(--ni-120);
-        visibility: hidden;
-        pointer-events: none;
-      }
-    }
+    min-height: var(--ni-380);
   }
 
   .trakt-summary-content {
@@ -92,5 +72,10 @@
 
   .trakt-summary-actions {
     margin-left: var(--ni-neg-16);
+  }
+
+  .trakt-summary-poster {
+    display: flex;
+    align-items: center;
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- For episode summaries, uses the episode cover.
  - If it is a `spoiler`, it uses the show cover.
- Also done on desktop; could use some more loving layout wise, but for now it provides the same clarity that you're on an episode page.

## 👀 Examples 👀
Before/after:
<img width="425" height="928" alt="Screenshot 2025-12-23 at 09 47 05" src="https://github.com/user-attachments/assets/f52defb1-e0fa-432f-9870-accc3cdf1e85" />

<img width="429" height="928" alt="Screenshot 2025-12-23 at 09 47 39" src="https://github.com/user-attachments/assets/4481fec2-3bac-49cf-8dec-dc397fe8be12" />

Before/after:
<img width="1405" height="928" alt="Screenshot 2025-12-23 at 09 47 17" src="https://github.com/user-attachments/assets/ee358b4b-7174-41ef-9ae7-75d6a5cb0aa7" />

<img width="1405" height="928" alt="Screenshot 2025-12-23 at 09 47 24" src="https://github.com/user-attachments/assets/6b2b6b02-58db-41f5-a4eb-4507428cf8d0" />
