### PR TITLE
feat(trivia) / updates trivia data structure

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToTrivia.ts
+++ b/projects/client/src/lib/requests/_internal/mapToTrivia.ts
@@ -3,7 +3,7 @@ import type { TriviaResponse } from '../models/TriviaResponse.ts';
 
 export function mapToTrivia(
   key: string,
-  response: TriviaResponse,
+  response: TriviaResponse['items'][0],
 ): MediaTrivia {
   return {
     key,

--- a/projects/client/src/lib/requests/models/TriviaResponse.ts
+++ b/projects/client/src/lib/requests/models/TriviaResponse.ts
@@ -1,10 +1,22 @@
 import { z } from 'zod';
 
 export const TriviaResponseSchema = z.object({
-  id: z.string(),
-  spoiler: z.boolean(),
-  text: z.string(),
-  votes: z.number(),
+  items: z.array(
+    z.object({
+      fact_id: z.string(),
+      category: z.enum([
+        'bts',
+        'cast_n_crew',
+        'story_n_themes',
+        'impact_n_legacy',
+        'real_world_connections',
+      ]),
+      text: z.string(),
+      order: z.number(),
+      spoiler: z.boolean(),
+    }),
+  ),
+  summary: z.array(z.string()),
 });
 
 export type TriviaResponse = z.infer<

--- a/projects/client/src/lib/requests/queries/movies/movieTriviaQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTriviaQuery.ts
@@ -11,13 +11,13 @@ const movieTriviaRequest = async (
   { fetch, slug }: MovieTriviaParams,
 ) => {
   const response = await rawApiFetch(
-    { fetch, path: `/v3/media/movie/${slug}/info/1/version/1` },
+    { fetch, path: `/v3/media/movie/${slug}/info/5/version/1` },
   );
 
-  const body = response.ok ? await response.json() : [];
+  const body = response.ok ? await response.json() : { summary: [], items: [] };
 
   return {
-    body: body as TriviaResponse[],
+    body: body as TriviaResponse,
     status: 200,
   };
 };
@@ -28,8 +28,8 @@ export const movieTriviaQuery = defineQuery({
   dependencies: (params) => [params.slug],
   request: movieTriviaRequest,
   mapper: (response) =>
-    response.body.map((entry, index) =>
-      mapToTrivia(`movie_trivia_${index}`, entry)
+    response.body.items.map((entry) =>
+      mapToTrivia(`movie_trivia_${entry.fact_id}`, entry)
     ),
   schema: MediaTriviaSchema.array(),
   ttl: time.days(1),

--- a/projects/client/src/lib/requests/queries/shows/showTriviaQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTriviaQuery.ts
@@ -11,13 +11,13 @@ const showTriviaRequest = async (
   { fetch, slug }: ShowTriviaParams,
 ) => {
   const response = await rawApiFetch(
-    { fetch, path: `/v3/media/show/${slug}/info/1/version/1` },
+    { fetch, path: `/v3/media/show/${slug}/info/5/version/1` },
   );
 
-  const body = response.ok ? await response.json() : [];
+  const body = response.ok ? await response.json() : { summary: [], items: [] };
 
   return {
-    body: body as TriviaResponse[],
+    body: body as TriviaResponse,
     status: 200,
   };
 };
@@ -28,8 +28,8 @@ export const showTriviaQuery = defineQuery({
   dependencies: (params) => [params.slug],
   request: showTriviaRequest,
   mapper: (response) =>
-    response.body.map((entry, index) =>
-      mapToTrivia(`show_trivia_${index}`, entry)
+    response.body.items.map((entry) =>
+      mapToTrivia(`show_trivia_${entry.fact_id}`, entry)
     ),
   schema: MediaTriviaSchema.array(),
   ttl: time.days(1),

--- a/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaCard.svelte
@@ -3,14 +3,17 @@
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import type { MediaTrivia } from "$lib/requests/models/MediaTrivia";
+  import { Marked } from "marked";
   import ShadowScroller from "./ShadowScroller.svelte";
 
   const { trivia, media }: { trivia: MediaTrivia; media: MediaEntry } =
     $props();
+
+  const marked = new Marked();
 </script>
 
 {#snippet content()}
-  <p>{trivia.text}</p>
+  {@html marked.parse(trivia.text)}
 {/snippet}
 
 <Card


### PR DESCRIPTION
### Overview

This pull request updates the trivia data structure and rendering to enhance how trivia information is displayed and managed within the application. These changes refactor the trivia data model and improve the presentation of trivia content.

### Changes

*   Updates the `TriviaResponseSchema` to accommodate the new trivia format, which includes an array of items with specific fields like `fact_id`, `category`, `order`, etc.
*   Modifies the `mapToTrivia` function to correctly map the new trivia response data structure.
*   Updates the movie and show trivia queries to work with the updated data structure. The queries now target a different path and adjust the mapping to parse the new data.
*   Changes the component `TriviaCard.svelte` to render trivia text using `Marked` for improved formatting, supporting markdown.

### Testing

*   The changes were tested by manually verifying that trivia information is correctly fetched and rendered.

### TODO: @seferturan - implement trivia summary for free accounts