### PR TITLE
feat(favorite): allow favoriting without having to rate first

### DIFF
--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -73,7 +73,7 @@
         }}
       />
 
-      {#if props.type !== "episode" && ($current?.rating || $current?.isFavorited)}
+      {#if props.type !== "episode"}
         <div
           class="trakt-favorite-action"
           transition:slideFade={{ duration: 300, axis: "x" }}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1509
- Users can now favorite without having to rate first.
- The limitation of having to have watched it first remains.

## 👀 Examples 👀
<img width="500" height="119" alt="Screenshot 2026-01-14 at 10 55 09" src="https://github.com/user-attachments/assets/0fdd830d-5b1b-4f88-8c3f-957c78a49f4f" />

<img width="1017" height="548" alt="Screenshot 2026-01-14 at 10 55 22" src="https://github.com/user-attachments/assets/0d307ca5-6425-4e7f-a727-e31bcc03c1da" />
