### PR TITLE
feat(comment): always allow viewing reactions distribution

### DIFF
--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactButton.svelte
@@ -37,7 +37,7 @@
   }
 
   const isDisabled = $derived($isReacting);
-  const hasDistribution = $derived($currentReaction ?? $isReacting);
+  const hasDistribution = $derived($summary.count > 0 || $isReacting);
 </script>
 
 {#snippet content()}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1510
- Reaction distributions can now be viewed without having to react first.
- For now decided to keep it simple as a single button:
  - If there are no reactions yet, only the reaction picker is shown.
  - If there are, the picker and distribution are shown.

## 👀 Examples 👀
<img width="580" height="254" alt="Screenshot 2026-01-14 at 11 09 25" src="https://github.com/user-attachments/assets/7671fc6d-3d50-4b99-bac8-0e7a91107833" />

<img width="598" height="261" alt="Screenshot 2026-01-14 at 11 09 45" src="https://github.com/user-attachments/assets/213c59a8-1874-436f-9796-8f4f435f9ed0" />
