### PR TITLE
fix(profile): always show library items

### DIFF
--- a/projects/client/src/lib/sections/lists/library/LibraryList.svelte
+++ b/projects/client/src/lib/sections/lists/library/LibraryList.svelte
@@ -18,10 +18,13 @@
 
   const { plexLibrary } = useUser();
 
-  const hasLibraryItems = $derived(
+  const hasPlexItems = $derived(
     $plexLibrary &&
       ($plexLibrary.movieIds.length > 0 || $plexLibrary.episodeIds.length > 0),
   );
+
+  // FIXME: when we have native plex sync, always show skeleton + cta/upsell to sync plex
+  const hasLibraryItems = $derived($libraries.length > 0 || hasPlexItems);
 </script>
 
 {#if hasLibraryItems}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1515
- Library items are also shown if a user doesn't have a Plex collection.
- I left a `FIXME` in there for when we have native Plex Sync settings; this should get a CTA/Upsell.