### PR TITLE
feat(summary): new design and placement for social media links

### DIFF
--- a/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
@@ -42,7 +42,9 @@
   </div>
 
   <div class="person-meta-info">
-    <SocialMediaLinks {person} variant="compact" />
+    <div class="person-social-media-links">
+      <SocialMediaLinks {person} />
+    </div>
 
     <PersonDetails
       height={person.height}
@@ -66,5 +68,11 @@
     flex-direction: column;
     gap: var(--gap-l);
     flex: 1;
+  }
+
+  .person-social-media-links {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-s);
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
@@ -30,12 +30,11 @@
       textFactory={({ title: name }) => m.text_share_person({ name })}
       source={{ id: "person" }}
     />
+    <SocialMediaLinks {person} />
   {/snippet}
 
   {#snippet meta()}
     <PersonTitle name={person.name} knownFor={person.knownFor} />
-
-    <SocialMediaLinks {person} />
 
     <PersonDetails
       birthday={person.birthday}

--- a/projects/client/src/lib/sections/summary/components/people/v2/_internal/SocialMediaLinks.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/_internal/SocialMediaLinks.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
-  import SummaryActionsBar from "../../../_internal/SummaryActionsBar.svelte";
   import SocialMediaAction from "./SocialMediaAction.svelte";
 
-  const {
-    person,
-    variant = "default",
-  }: { person: PersonSummary; variant?: "default" | "compact" } = $props();
+  const { person }: { person: PersonSummary } = $props();
 
   const facebookUsername = $derived(person.socialMedia?.facebook);
   const xUsername = $derived(person.socialMedia?.x);
@@ -17,40 +13,16 @@
   );
 </script>
 
-<trakt-social-media-links data-variant={variant}>
-  {#if hasSocialMediaLinks}
-    <SummaryActionsBar>
-      {#if facebookUsername}
-        <SocialMediaAction username={facebookUsername} type="facebook" />
-      {/if}
-
-      {#if xUsername}
-        <SocialMediaAction username={xUsername} type="x" />
-      {/if}
-
-      {#if instagramUsername}
-        <SocialMediaAction username={instagramUsername} type="instagram" />
-      {/if}
-    </SummaryActionsBar>
+{#if hasSocialMediaLinks}
+  {#if facebookUsername}
+    <SocialMediaAction username={facebookUsername} type="facebook" />
   {/if}
-</trakt-social-media-links>
 
-<style>
-  trakt-social-media-links {
-    :global(.trakt-summary-actions) {
-      justify-content: center;
-      gap: var(--gap-l);
+  {#if xUsername}
+    <SocialMediaAction username={xUsername} type="x" />
+  {/if}
 
-      :global(svg) {
-        height: var(--ni-24);
-        width: auto;
-      }
-    }
-
-    &[data-variant="compact"] {
-      :global(.trakt-summary-actions) {
-        width: fit-content;
-      }
-    }
-  }
-</style>
+  {#if instagramUsername}
+    <SocialMediaAction username={instagramUsername} type="instagram" />
+  {/if}
+{/if}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1542
- Social media links are no longer placed in the action bar
  - On mobile view they're placed below the share button.
  - On larger screens the location is the same, but they're floating buttons.

## 👀 Examples 👀
<img width="426" height="662" alt="Screenshot 2026-01-15 at 16 43 09" src="https://github.com/user-attachments/assets/9c240ec7-740a-4a56-81eb-770d998c8e45" />

<img width="1384" height="557" alt="Screenshot 2026-01-15 at 16 44 35" src="https://github.com/user-attachments/assets/5af47731-47c1-4339-8031-0b5348a39491" />
