### PR TITLE
fix(summary): fixes sizing for poster overlay in safari

### DIFF
--- a/projects/client/src/lib/components/summary/SummaryPoster.svelte
+++ b/projects/client/src/lib/components/summary/SummaryPoster.svelte
@@ -57,7 +57,7 @@
 <style>
   .trakt-summary-poster-container {
     --overlay-border-size: var(--ni-2);
-    --poster-aspect-ratio: 2 / 3;
+    --poster-inverse-aspect-ratio: 3 / 2;
 
     width: var(--summary-poster-width);
     display: flex;
@@ -68,7 +68,7 @@
     &[data-variant="landscape"] {
       .trakt-summary-poster :global(img),
       .trakt-summary-poster-overlay {
-        --poster-aspect-ratio: 16 / 9;
+        --poster-inverse-aspect-ratio: 9 / 16;
       }
     }
   }
@@ -80,7 +80,10 @@
     border-radius: var(--border-radius-xxl);
 
     width: var(--summary-poster-width);
-    aspect-ratio: var(--poster-aspect-ratio);
+    /* Using aspect-ratio did not work in Safari, so we set the height explicitly */
+    height: calc(
+      var(--summary-poster-width) * var(--poster-inverse-aspect-ratio)
+    );
 
     object-fit: cover;
   }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Closes #1562
- Fixes the size of the hover overlay on posters in safari.

## 👀 Example 👀
Before:
<img width="885" height="592" alt="Screenshot 2026-01-20 at 13 43 54" src="https://github.com/user-attachments/assets/6f150035-c62b-4ea2-bbca-39b1d351ce37" />


After:
<img width="885" height="592" alt="Screenshot 2026-01-20 at 14 03 45" src="https://github.com/user-attachments/assets/3b6532c9-dc06-49ef-a5b5-a2e4276fdb09" />

