### PR TITLE
fix(search): fixes input size on mobile ios

### DIFF
--- a/projects/client/src/routes/search/+page.svelte
+++ b/projects/client/src/routes/search/+page.svelte
@@ -119,6 +119,7 @@
     align-content: center;
 
     gap: var(--gap-s);
+    padding: 0 var(--layout-distance-side);
 
     :global(.trakt-search-icon) {
       z-index: calc(var(--layer-overlay) - 1);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Closes #1564
- Input was missing the layout side distance.

## 👀 Example 👀
Before:

<img width="388" height="433" alt="Screenshot 2026-01-20 at 14 14 12" src="https://github.com/user-attachments/assets/8e8757b1-a76b-4154-b094-e75bf306f1a8" />

After:
<img width="388" height="433" alt="Screenshot 2026-01-20 at 14 14 01" src="https://github.com/user-attachments/assets/8f910c23-1dad-4164-8ac7-52e79d52a55c" />
