### PR TITLE
feat(card): use show cover for upcoming and up next episodes

### DIFF
--- a/projects/client/src/lib/features/spoilers/useEpisodeSpoilerImage.ts
+++ b/projects/client/src/lib/features/spoilers/useEpisodeSpoilerImage.ts
@@ -2,15 +2,21 @@ import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
 import { EpisodeComputedType } from '$lib/requests/models/EpisodeType.ts';
 import type { ShowEntry } from '$lib/requests/models/ShowEntry.ts';
 import { map } from 'rxjs';
+import type { EpisodeCardProps } from '../../sections/lists/components/models/EpisodeCardProps.ts';
 import { useMediaSpoiler } from './useMediaSpoiler.ts';
 
 type SpoilerImageProps = {
   episode: EpisodeEntry;
   show: ShowEntry;
-};
+} & Pick<EpisodeCardProps, 'variant'>;
+
+const SHOW_COVER_VARIANTS: readonly EpisodeCardProps['variant'][] = [
+  'next',
+  'upcoming',
+] as const;
 
 export function useEpisodeSpoilerImage(props: SpoilerImageProps) {
-  const { episode, show } = props;
+  const { episode, show, variant } = props;
 
   const { isSpoilerHidden } = useMediaSpoiler({
     show,
@@ -20,6 +26,10 @@ export function useEpisodeSpoilerImage(props: SpoilerImageProps) {
 
   return isSpoilerHidden.pipe(
     map(($isSpoilerHidden) => {
+      if (SHOW_COVER_VARIANTS.includes(variant)) {
+        return show.cover.url.thumb;
+      }
+
       switch (episode.type) {
         case EpisodeComputedType.full_season:
         case EpisodeComputedType.multiple_episodes:

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -33,7 +33,9 @@
 
   const isShowContext = $derived("context" in rest && rest.context === "show");
 
-  const src = $derived(useEpisodeSpoilerImage({ episode, show }));
+  const src = $derived(
+    useEpisodeSpoilerImage({ episode, show, variant: rest.variant }),
+  );
 
   const { track } = useTrack(AnalyticsEvent.SummaryDrilldown);
 </script>

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -25,7 +25,9 @@
     crew,
   }: EpisodeSummaryProps = $props();
 
-  const posterSrc = $derived(useEpisodeSpoilerImage({ episode, show }));
+  const posterSrc = $derived(
+    useEpisodeSpoilerImage({ episode, show, variant: "default" }),
+  );
 </script>
 
 <!-- 

--- a/projects/client/src/lib/sections/toast/_internal/ToastEpisodeCover.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/ToastEpisodeCover.svelte
@@ -12,7 +12,9 @@
   const { episode, show }: { episode: EpisodeEntry; show: ShowEntry } =
     $props();
 
-  const src = $derived(useEpisodeSpoilerImage({ episode, show }));
+  const src = $derived(
+    useEpisodeSpoilerImage({ episode, show, variant: "activity" }),
+  );
   const title = $derived(episodeActivityTitle(episode, show));
 </script>
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1571
- For `next` and `upcoming` episodes, uses the show cover

## 👀 Example 👀
Before:
<img width="1116" height="237" alt="Screenshot 2026-01-22 at 07 51 20" src="https://github.com/user-attachments/assets/9d5c1451-d71b-4fe3-8588-b1081b0194cc" />

After:
<img width="1116" height="237" alt="Screenshot 2026-01-22 at 07 51 12" src="https://github.com/user-attachments/assets/f37158eb-5f88-4219-b88e-8cbb3333aa3c" />

