### PR TITLE
feat(card): implements non mobile version of summary style cards

### DIFF
--- a/projects/client/src/lib/components/episode/tags/ShowProgressTag.spec.ts
+++ b/projects/client/src/lib/components/episode/tags/ShowProgressTag.spec.ts
@@ -1,47 +1,56 @@
 import { stretchedPercentage } from '$lib/utils/number/stretchedPercentage.ts';
+import { renderStore } from '$test/beds/store/renderStore.ts';
 import { render, screen } from '@testing-library/svelte';
 import { createRawSnippet } from 'svelte';
 import { describe, expect, it } from 'vitest';
 import ShowProgressTag from './ShowProgressTag.svelte';
 
-const children = createRawSnippet(() => ({
+const tags = createRawSnippet(() => ({
   render: () => '<span>Custom Text</span>',
 }));
 
 describe('ShowProgressTag', () => {
   const runtime = 25;
 
-  it('should set correct progress width with 0%', () => {
-    render(ShowProgressTag, {
-      props: { runtime, total: 100, progress: 0, children },
-    });
+  it('should set correct progress width with 0%', async () => {
+    await renderStore(() =>
+      render(ShowProgressTag, {
+        props: { runtime, total: 100, progress: 0, tags },
+      })
+    );
     const element = screen.getByRole('progressbar');
     expect(element.style.getPropertyValue('--progress-width')).toBe('0%');
   });
 
-  it('should set correct progress width with 50%', () => {
-    render(ShowProgressTag, {
-      props: { runtime, total: 100, progress: 50, children },
-    });
+  it('should set correct progress width with 50%', async () => {
+    await renderStore(() =>
+      render(ShowProgressTag, {
+        props: { runtime, total: 100, progress: 50, tags },
+      })
+    );
     const element = screen.getByRole('progressbar');
     expect(element.style.getPropertyValue('--progress-width')).toBe('50%');
   });
 
-  it('should set correct progress width with 100%', () => {
-    render(ShowProgressTag, {
-      props: { runtime, total: 100, progress: 100, children },
-    });
+  it('should set correct progress width with 100%', async () => {
+    await renderStore(() =>
+      render(ShowProgressTag, {
+        props: { runtime, total: 100, progress: 100, tags },
+      })
+    );
     const element = screen.getByRole('progressbar');
     expect(element.style.getPropertyValue('--progress-width')).toBe('100%');
   });
 
-  it('should handle decimal progress values', () => {
+  it('should handle decimal progress values', async () => {
     const progress = 33.33;
     const total = 100;
 
-    render(ShowProgressTag, {
-      props: { runtime, total, progress, children },
-    });
+    await renderStore(() =>
+      render(ShowProgressTag, {
+        props: { runtime, total, progress, tags },
+      })
+    );
     const expectedPercentage = stretchedPercentage({
       value: progress,
       total,

--- a/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
+++ b/projects/client/src/lib/components/episode/tags/ShowProgressTag.svelte
@@ -2,29 +2,65 @@
   import ProgressTag from "$lib/components/media/tags/ProgressTag.svelte";
   import type { TagIntl } from "$lib/components/media/tags/TagIntl";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import { stretchedPercentage } from "$lib/utils/number/stretchedPercentage";
+  import type { Snippet } from "svelte";
 
   type ShowProgressTagProps = {
     progress: number;
     total: number;
     runtime: number;
+    tags: Snippet;
     i18n?: TagIntl;
-  } & ChildrenProps;
+    style?: "summary" | "cover";
+  };
 
   const {
-    children,
+    tags: externalTags,
     progress,
     total,
     runtime,
     i18n = TagIntlProvider,
+    style,
   }: ShowProgressTagProps = $props();
 
   const percentage = $derived(stretchedPercentage({ value: progress, total }));
 </script>
 
-<ProgressTag progress={percentage} {total}>
-  {i18n.toDuration(runtime)}
-  {#snippet tags()}
-    {@render children()}
-  {/snippet}
-</ProgressTag>
+{#snippet tags()}
+  {#if style === "cover"}
+    {@render externalTags()}
+  {:else}
+    <RenderFor audience="all" device={["tablet-sm", "mobile"]}>
+      {@render externalTags()}
+    </RenderFor>
+  {/if}
+{/snippet}
+
+<div class="trakt-show-progress-tag">
+  <ProgressTag progress={percentage} {total} {tags}>
+    {i18n.toDuration(runtime)}
+  </ProgressTag>
+  <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
+    <div class="trakt-show-progress-tags">
+      {@render externalTags()}
+    </div>
+  </RenderFor>
+</div>
+
+<style>
+  .trakt-show-progress-tag {
+    width: 100%;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+
+  .trakt-show-progress-tags {
+    display: flex;
+    justify-content: space-around;
+    gap: var(--gap-micro);
+    flex-wrap: wrap;
+  }
+</style>

--- a/projects/client/src/lib/components/summary/GenreList.svelte
+++ b/projects/client/src/lib/components/summary/GenreList.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { appendClassList } from "$lib/utils/actions/appendClassList";
   import type { GenreIntl } from "./GenreIntl";
   import { GenreIntlProvider } from "./GenreIntlProvider";
@@ -17,9 +16,7 @@
     classList = "",
   }: GenreListProps = $props();
 
-  const isLargeDisplay = useMedia(WellKnownMediaQuery.desktop);
-  const genreCount = $derived($isLargeDisplay ? undefined : 3);
-  const visibleGenre = $derived(genres.slice(0, genreCount));
+  const visibleGenre = $derived(genres.slice(0, 1));
 </script>
 
 <p class="trakt-summary-genre ellipsis" use:appendClassList={classList}>

--- a/projects/client/src/lib/features/search/SearchResultsGrid.svelte
+++ b/projects/client/src/lib/features/search/SearchResultsGrid.svelte
@@ -3,7 +3,6 @@
   import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
   import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
   import EpisodeCountTag from "$lib/components/media/tags/EpisodeCountTag.svelte";
-  import MediaIconTag from "$lib/components/media/tags/MediaIconTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import { type MediaInputDefault } from "$lib/models/MediaInput";
   import { type MediaEntry } from "$lib/requests/models/MediaEntry";
@@ -31,10 +30,6 @@
 </script>
 
 {#snippet mediaTag(item: MediaInputDefault)}
-  {#if $mode === "media"}
-    <MediaIconTag mediaType={item.type} />
-  {/if}
-
   <AirDateTag i18n={TagIntlProvider} airDate={item.airDate} />
 
   {#if $mode === "movie"}
@@ -66,6 +61,7 @@
           style="cover"
           source="search"
           tag={mediaResultTag}
+          mode={$mode === "media" ? "mixed" : "standalone"}
           {onclick}
         />
       {:else}

--- a/projects/client/src/lib/sections/lists/activity/ActivityPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/activity/ActivityPaginatedList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { useDiscover } from "$lib/features/discover/useDiscover";
   import { useFilter } from "$lib/features/filters/useFilter";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { DEFAULT_ACTIVITY_PAGE_SIZE } from "$lib/utils/constants";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import SocialActivityItem from "./_internal/SocialActivityItem.svelte";
@@ -10,9 +9,6 @@
   type RecommendedListProps = { title: string };
 
   const { title }: RecommendedListProps = $props();
-
-  const isMobile = useMedia(WellKnownMediaQuery.mobile);
-  const style = $derived($isMobile ? "summary" : "cover");
 
   const { mode } = useDiscover();
   const { filterMap } = useFilter();
@@ -31,6 +27,6 @@
     })}
 >
   {#snippet item(activity)}
-    <SocialActivityItem {activity} {style} />
+    <SocialActivityItem {activity} style="summary" />
   {/snippet}
 </DrilledMediaList>

--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedListItem.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import AnticipatedTag from "$lib/components/media/tags/AnticipatedTag.svelte";
-  import MediaIconTag from "$lib/components/media/tags/MediaIconTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import DefaultMediaItem from "../components/DefaultMediaItem.svelte";
   import type { MediaCardProps } from "../components/models/MediaCardProps";
@@ -11,10 +10,6 @@
 </script>
 
 {#snippet tag()}
-  {#if mode === "mixed"}
-    <MediaIconTag mediaType={media.type} />
-  {/if}
-
   <AnticipatedTag i18n={TagIntlProvider} score={media.score} />
 {/snippet}
 
@@ -22,6 +17,7 @@
   {type}
   {media}
   {tag}
+  {mode}
   {style}
   source="anticipated"
   canDeemphasize

--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte
@@ -3,7 +3,6 @@
   import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import AnticipatedListItem from "./AnticipatedListItem.svelte";
   import { useAnticipatedList } from "./useAnticipatedList";
@@ -15,9 +14,6 @@
 
   const { title, type }: AnticipatedListProps = $props();
   const { filterMap } = useFilter();
-
-  const isMobile = useMedia(WellKnownMediaQuery.mobile);
-  const style = $derived($isMobile ? "summary" : "cover");
 </script>
 
 <DrilledMediaList
@@ -31,7 +27,7 @@
     <AnticipatedListItem
       type={media.type}
       {media}
-      {style}
+      style="summary"
       mode={type === "media" ? "mixed" : "standalone"}
     />
   {/snippet}

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -39,11 +39,13 @@
   const isSummary = $derived(style === "summary");
 </script>
 
-{#snippet defaultTag()}
+{#snippet contextualTag()}
   {#if mode === "mixed"}
     <MediaIconTag mediaType={media.type} />
   {/if}
+{/snippet}
 
+{#snippet defaultTag()}
   {#if "episode" in media}
     <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} />
     <EpisodeCountTag i18n={TagIntlProvider} count={media.episode.count} />
@@ -73,7 +75,16 @@
 
 {#snippet tag()}
   <TagBar>
+    {#if !isSummary}
+      {@render contextualTag()}
+    {/if}
+
     {#if isSummary}
+      {#if mode === "mixed"}
+        <RenderFor audience="all" device={["mobile", "tablet-sm"]}>
+          {@render contextualTag()}
+        </RenderFor>
+      {/if}
       {@render externalTag?.()}
       {@render defaultTag()}
     {:else if externalTag}
@@ -112,6 +123,7 @@
       {media}
       {style}
       tag={rest.variant !== "next" ? tag : undefined}
+      contextualTag={mode === "mixed" ? contextualTag : undefined}
       indicators={indicatorTags}
       {...rest}
       {popupActions}

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -65,17 +65,20 @@
           progress={props.episode.completed}
           total={props.episode.total}
           {runtime}
+          {style}
         >
-          <TextTag>
-            <p class="bold capitalize ellipsis">
-              {EpisodeIntlProvider.remainingText(props.episode.remaining)}
-            </p>
-          </TextTag>
-          <TextTag>
-            <p class="bold capitalize no-wrap">
-              {EpisodeIntlProvider.durationText(props.episode.minutesLeft)}
-            </p>
-          </TextTag>
+          {#snippet tags()}
+            <TextTag>
+              <p class="bold capitalize ellipsis">
+                {EpisodeIntlProvider.remainingText(props.episode.remaining)}
+              </p>
+            </TextTag>
+            <TextTag>
+              <p class="bold capitalize no-wrap">
+                {EpisodeIntlProvider.durationText(props.episode.minutesLeft)}
+              </p>
+            </TextTag>
+          {/snippet}
         </ShowProgressTag>
       {/if}
 

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -2,11 +2,15 @@
   import ActivityTag from "$lib/components/media/tags/ActivityTag.svelte";
   import ProgressTag from "$lib/components/media/tags/ProgressTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
+  import type { Snippet } from "svelte";
   import MediaCard from "./MediaCard.svelte";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
   import type { MediaCardProps } from "./models/MediaCardProps";
 
-  const props: MediaCardProps = $props();
+  const {
+    contextualTag,
+    ...props
+  }: MediaCardProps & { contextualTag?: Snippet } = $props();
   const style = $derived(props.style ?? "cover");
 
   const isCover = $derived(style === "cover");
@@ -46,6 +50,7 @@
   <MediaSummaryCard
     {...props}
     {style}
+    {contextualTag}
     action={props.action}
     popupActions={props.badge ? undefined : props.popupActions}
     tag={props.variant === "next" ? coverTag : props.tag}

--- a/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBottomBar.svelte
+++ b/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBottomBar.svelte
@@ -1,8 +1,33 @@
 <script lang="ts">
-  const { children }: ChildrenProps = $props();
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { Snippet } from "svelte";
+  import { fade } from "svelte/transition";
+
+  const {
+    children,
+    tag,
+    contextualTag,
+  }: ChildrenProps & { tag?: Snippet; contextualTag?: Snippet } = $props();
 </script>
 
-<div class="trakt-summary-card-bottom-bar">
+<div
+  class="trakt-summary-card-bottom-bar"
+  class:has-contextualTag={Boolean(contextualTag)}
+>
+  {#if contextualTag}
+    <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
+      {@render contextualTag()}
+    </RenderFor>
+  {/if}
+
+  {#if tag}
+    <RenderFor audience="all" device={["tablet-sm", "mobile"]}>
+      <div class="trakt-summary-bottom-bar-tags" in:fade={{ duration: 150 }}>
+        {@render tag()}
+      </div>
+    </RenderFor>
+  {/if}
+
   {@render children()}
 </div>
 
@@ -19,12 +44,23 @@
 
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     gap: var(--gap-xs);
 
     padding: var(--ni-12);
     box-sizing: border-box;
 
     z-index: var(--layer-floating);
+
+    &.has-contextualTag {
+      justify-content: space-between;
+    }
+  }
+
+  .trakt-summary-bottom-bar-tags {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    flex-grow: 1;
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/_internal/SummaryCardDetails.svelte
+++ b/projects/client/src/lib/sections/lists/components/_internal/SummaryCardDetails.svelte
@@ -1,18 +1,35 @@
 <script lang="ts">
-  const { children }: ChildrenProps = $props();
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { appendClassList } from "$lib/utils/actions/appendClassList";
+  import type { Snippet } from "svelte";
+  import { fade } from "svelte/transition";
+
+  const {
+    children,
+    tag,
+    classList = "",
+  }: { tag?: Snippet; classList?: string } & ChildrenProps = $props();
 </script>
 
-<div class="trakt-summary-card-details">
+<div class="trakt-summary-card-details" use:appendClassList={classList}>
   <div class="trakt-summary-card-titles">
     {@render children()}
   </div>
+
+  {#if tag}
+    <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
+      <div class="trakt-summary-card-tags" in:fade={{ duration: 150 }}>
+        {@render tag()}
+      </div>
+    </RenderFor>
+  {/if}
 </div>
 
 <style>
   .trakt-summary-card-details {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    gap: var(--gap-m);
 
     flex-grow: 1;
     z-index: var(--layer-raised);
@@ -26,6 +43,17 @@
       display: flex;
       flex-direction: column;
       gap: var(--gap-micro);
+    }
+  }
+
+  .trakt-summary-card-tags {
+    :global(.trakt-tag-bar) {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+
+      :global(:not(:last-child))::after {
+        display: none;
+      }
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
@@ -2,7 +2,6 @@
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
   import PaginatedList from "$lib/components/lists/PaginatedList.svelte";
   import type { Snippet } from "svelte";
-  import { mediaCardWidthResolver } from "../utils/mediaCardWidthResolver";
   import type { MediaListProps } from "./MediaListProps";
 
   type DrilledMediaListProps = MediaListProps<T, M> & {
@@ -32,7 +31,7 @@
       {actions}
       {items}
       {listActions}
-      --width-item={mediaCardWidthResolver(cardOrientation)}
+      --width-item="var(--width-summary-card)"
     >
       {#snippet empty()}
         {@render externalEmpty?.()}

--- a/projects/client/src/lib/sections/lists/history/PersonalHistoryPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/PersonalHistoryPaginatedList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import * as m from "$lib/features/i18n/messages";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import { useRecentlyWatchedList } from "../stores/useRecentlyWatchedList";
   import { toRecentlyWatchedType } from "./_internal/toRecentlyWatchedType";
@@ -10,9 +9,6 @@
   const { mode }: { mode?: DiscoverMode } = $props();
 
   const historyType = $derived(toRecentlyWatchedType(mode));
-
-  const isMobile = useMedia(WellKnownMediaQuery.mobile);
-  const style = $derived($isMobile ? "summary" : "cover");
 </script>
 
 <DrilledMediaList
@@ -28,6 +24,6 @@
     })}
 >
   {#snippet item(media)}
-    <RecentlyWatchedItem {media} {style} isActionable />
+    <RecentlyWatchedItem {media} style="summary" isActionable />
   {/snippet}
 </DrilledMediaList>

--- a/projects/client/src/lib/sections/lists/library/LibraryListPaginated.svelte
+++ b/projects/client/src/lib/sections/lists/library/LibraryListPaginated.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import LibraryMediaItem from "./_internal/LibraryMediaItem.svelte";
   import { useLibraryList } from "./useLibraryList";
 
   const { library }: { library: string } = $props();
-
-  const isMobile = useMedia(WellKnownMediaQuery.mobile);
-  const style = $derived($isMobile ? "summary" : "cover");
 </script>
 
 <DrilledMediaList
@@ -18,6 +14,6 @@
   useList={(params) => useLibraryList({ ...params, library })}
 >
   {#snippet item(item)}
-    <LibraryMediaItem {item} {style} />
+    <LibraryMediaItem {item} style="summary" />
   {/snippet}
 </DrilledMediaList>

--- a/projects/client/src/lib/sections/lists/popular/PopularPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/popular/PopularPaginatedList.svelte
@@ -4,7 +4,6 @@
   import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { decodeRecord } from "$lib/utils/url/UrlBuilder";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import PopularListItem from "./PopularListItem.svelte";
@@ -17,9 +16,6 @@
 
   const { title, type }: PopularListProps = $props();
   const { filterMap } = useFilter();
-
-  const isMobile = useMedia(WellKnownMediaQuery.mobile);
-  const style = $derived($isMobile ? "summary" : "cover");
 </script>
 
 <DrilledMediaList
@@ -37,7 +33,7 @@
     <PopularListItem
       type={media.type}
       {media}
-      {style}
+      style="summary"
       mode={type === "media" ? "mixed" : "standalone"}
     />
   {/snippet}

--- a/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
@@ -5,15 +5,11 @@
   import DrilledMediaList from "$lib/sections/lists/drilldown/DrilledMediaList.svelte";
   import { useUpNextList } from "$lib/sections/lists/progress/useUpNextList";
   import { useStablePaginated } from "$lib/sections/lists/stores/useStablePaginated";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import ContinueWatchingItem from "./_internal/ContinueWatchingItem.svelte";
   import StartWatchingItem from "./_internal/StartWatchingItem.svelte";
 
   const { intent }: { intent: "continue" | "start" } = $props();
 
-  const isMobile = useMedia(WellKnownMediaQuery.mobile);
-
-  const style = $derived($isMobile ? "summary" : "cover");
   const { mode } = useDiscover();
   const { filterMap } = useFilter();
 </script>
@@ -42,9 +38,9 @@
 >
   {#snippet item(progressEntry)}
     {#if intent === "start"}
-      <StartWatchingItem {style} entry={progressEntry} />
+      <StartWatchingItem style="summary" entry={progressEntry} />
     {:else}
-      <ContinueWatchingItem {style} entry={progressEntry} />
+      <ContinueWatchingItem style="summary" entry={progressEntry} />
     {/if}
   {/snippet}
 </DrilledMediaList>

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
@@ -2,7 +2,6 @@
   import { page } from "$app/state";
   import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import { extractWatchWindowParam } from "./extractWatchWindowParam";
   import RecommendedListItem from "./RecommendedListItem.svelte";
@@ -15,9 +14,6 @@
 
   const { title, type }: RecommendedListProps = $props();
   const { filterMap } = useFilter();
-
-  const isMobile = useMedia(WellKnownMediaQuery.mobile);
-  const style = $derived($isMobile ? "summary" : "cover");
 </script>
 
 <DrilledMediaList
@@ -34,7 +30,7 @@
     <RecommendedListItem
       type={media.type}
       {media}
-      {style}
+      style="summary"
       mode={type === "media" ? "mixed" : "standalone"}
     />
   {/snippet}

--- a/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingListItem.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import MediaIconTag from "$lib/components/media/tags/MediaIconTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import WatchersTag from "$lib/components/media/tags/WatchersTag.svelte";
   import DefaultMediaItem from "../components/DefaultMediaItem.svelte";
@@ -10,10 +9,6 @@
 </script>
 
 {#snippet tag()}
-  {#if mode === "mixed"}
-    <MediaIconTag mediaType={media.type} />
-  {/if}
-
   <WatchersTag i18n={TagIntlProvider} watchers={media.watchers} />
 {/snippet}
 
@@ -21,6 +16,7 @@
   {type}
   {media}
   {tag}
+  {mode}
   {style}
   source="trending"
   canDeemphasize

--- a/projects/client/src/lib/sections/lists/trending/TrendingPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingPaginatedList.svelte
@@ -4,7 +4,6 @@
   import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { decodeRecord } from "$lib/utils/url/UrlBuilder";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import TrendingListItem from "./TrendingListItem.svelte";
@@ -17,9 +16,6 @@
 
   const { title, type }: TrendingListProps = $props();
   const { filterMap } = useFilter();
-
-  const isMobile = useMedia(WellKnownMediaQuery.mobile);
-  const style = $derived($isMobile ? "summary" : "cover");
 </script>
 
 <DrilledMediaList
@@ -37,7 +33,7 @@
     <TrendingListItem
       type={media.type}
       {media}
-      {style}
+      style="summary"
       mode={type === "media" ? "mixed" : "standalone"}
     />
   {/snippet}

--- a/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
@@ -7,7 +7,6 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary";
   import type { MediaType } from "$lib/requests/models/MediaType";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import { useListSorting } from "./_internal/useListSorting";
   import UserListItem from "./_internal/UserListItem.svelte";
@@ -24,9 +23,6 @@
   const { title, type, list }: UserListProps = $props();
 
   const { user } = useUser();
-
-  const isMobile = useMedia(WellKnownMediaQuery.mobile);
-  const style = $derived($isMobile ? "summary" : "cover");
 
   const { filterMap } = useFilter();
   const { current, update, options, urlBuilder } = $derived(
@@ -81,7 +77,7 @@
     </div>
   {/snippet}
   {#snippet item(media)}
-    <UserListItem listedItem={media} {style} {list} />
+    <UserListItem listedItem={media} style="summary" {list} />
   {/snippet}
 
   {#snippet badge()}

--- a/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import DefaultMediaItem from "../components/DefaultMediaItem.svelte";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import { useWatchList } from "./useWatchList";
@@ -13,8 +12,6 @@
 
   const { title, type }: WatchListProps = $props();
 
-  const isMobile = useMedia(WellKnownMediaQuery.mobile);
-  const style = $derived($isMobile ? "summary" : "cover");
   const { filterMap } = useFilter();
 </script>
 
@@ -26,6 +23,11 @@
   useList={useWatchList}
 >
   {#snippet item(media)}
-    <DefaultMediaItem type={media.type} {media} {style} source="watchlist" />
+    <DefaultMediaItem
+      type={media.type}
+      {media}
+      style="summary"
+      source="watchlist"
+    />
   {/snippet}
 </DrilledMediaList>

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -48,8 +48,8 @@
   --height-person-card-cover: var(--ni-176);
   --height-person-card: calc(var(--height-person-card-cover) + var(--height-card-footer));
 
-  --width-summary-card: 100%;
-  --height-summary-card-cover: var(--ni-132);
+  --width-summary-card: var(--ni-276);
+  --height-summary-card-cover: var(--ni-208);
   --height-summary-card: var(--height-summary-card-cover);
 
   --width-list-card: var(--ni-480);
@@ -142,6 +142,11 @@
   @include for-mobile {
     --toggle-large-width: var(--ni-80);
     --font-size-text: var(--ni-12);
+  }
+
+  @include for-tablet-sm-and-below {
+    --width-summary-card: 100%;
+    --height-summary-card-cover: var(--ni-132);
   }
 
   --font-size-title: var(--ni-18);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1534
- Drilldowns on larger screens now show the same info as on mobile versions.
  - For small tablets, the mobile version is used for now; we might need to fine tune the card sizes a bit if we want these version on small tablets.

## 👀 Examples 👀
<img width="960" height="1056" alt="Screenshot 2026-01-26 at 08 48 33" src="https://github.com/user-attachments/assets/8286f56a-c42a-4598-9f90-e9c30ee2c28d" />

<img width="960" height="1056" alt="Screenshot 2026-01-26 at 08 48 40" src="https://github.com/user-attachments/assets/07c47c3d-a044-494e-9622-a67ddb21a478" />

<img width="960" height="1056" alt="Screenshot 2026-01-26 at 08 48 46" src="https://github.com/user-attachments/assets/367f5817-872c-4f92-8a52-ecfce66aa461" />

<img width="960" height="1056" alt="Screenshot 2026-01-26 at 08 48 52" src="https://github.com/user-attachments/assets/ad79647d-6061-4b30-82d1-3b2fc0e5558d" />

<img width="960" height="1056" alt="Screenshot 2026-01-26 at 08 48 59" src="https://github.com/user-attachments/assets/ecd4160f-766a-4dc3-be53-399a0399189a" />

<img width="960" height="1056" alt="Screenshot 2026-01-26 at 08 49 08" src="https://github.com/user-attachments/assets/f485dd65-9fe7-4151-92ab-0c6fa6e08332" />

<img width="960" height="1056" alt="Screenshot 2026-01-26 at 08 49 16" src="https://github.com/user-attachments/assets/311e8e87-897b-463c-800a-74d197a55754" />

<img width="960" height="1056" alt="Screenshot 2026-01-26 at 08 49 22" src="https://github.com/user-attachments/assets/a1f80a81-8f85-44dd-82ba-b5d7f92d056e" />

<img width="960" height="1056" alt="Screenshot 2026-01-26 at 08 49 32" src="https://github.com/user-attachments/assets/119441f8-199a-471c-a0dd-bfb6218b7d1b" />

<img width="960" height="1056" alt="Screenshot 2026-01-26 at 08 49 40" src="https://github.com/user-attachments/assets/a0eaa605-0ef6-4915-b8b5-417ffdea0508" />
