### PR TITLE
feat(summary): adds popup menu for season list

### DIFF
--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonPopupMenu.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonPopupMenu.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry";
+  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
+
+  type SeasonPopupMenuProps = {
+    title: string;
+    episodes: EpisodeEntry[];
+    show: ShowEntry;
+  };
+
+  const { title, episodes, show }: SeasonPopupMenuProps = $props();
+</script>
+
+<PopupMenu label={m.button_label_popup_menu({ title })} mode="standalone">
+  {#snippet items()}
+    <MarkAsWatchedAction
+      style="dropdown-item"
+      type="episode"
+      {title}
+      media={episodes}
+      {show}
+    />
+  {/snippet}
+</PopupMenu>

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { Season } from "$lib/requests/models/Season";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import SeasonItem from "$lib/sections/lists/components/SeasonItem.svelte";
   import { mediaListHeightResolver } from "$lib/sections/lists/utils/mediaListHeightResolver";
-  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import SeasonPopupMenu from "./SeasonPopupMenu.svelte";
 
   type SeasonListProps = {
     show: ShowEntry;
@@ -44,25 +43,6 @@
     />
   {/snippet}
   {#snippet actions()}
-    <RenderFor audience="authenticated" device={["desktop", "tablet-lg"]}>
-      <MarkAsWatchedAction
-        style="normal"
-        type="episode"
-        size="small"
-        title={subtitle}
-        media={episodes}
-        {show}
-      />
-    </RenderFor>
-    <RenderFor audience="authenticated" device={["mobile", "tablet-sm"]}>
-      <MarkAsWatchedAction
-        style="action"
-        type="episode"
-        size="small"
-        title={subtitle}
-        media={episodes}
-        {show}
-      />
-    </RenderFor>
+    <SeasonPopupMenu title={subtitle} {episodes} {show} />
   {/snippet}
 </SectionList>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1593
- Season lists now have a popup menu for the actions. Atm only the `track` action.

## 👀 Examples 👀
Before:

<img width="581" height="319" alt="Screenshot 2026-01-26 at 12 54 15" src="https://github.com/user-attachments/assets/cd9bb639-e490-4b81-b2d4-cbe024544486" />

After:
<img width="581" height="319" alt="Screenshot 2026-01-26 at 12 53 59" src="https://github.com/user-attachments/assets/fdf46c76-34c3-4315-83e7-6e32e0bb7368" />

<img width="581" height="319" alt="Screenshot 2026-01-26 at 12 54 03" src="https://github.com/user-attachments/assets/6ac9a127-5440-4f45-bedc-f9965909deee" />
