### PR TITLE
fix(summary): correctly size poster and overlay

### DIFF
--- a/projects/client/src/lib/components/summary/SummaryPoster.svelte
+++ b/projects/client/src/lib/components/summary/SummaryPoster.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { Snippet } from "svelte";
   import { fade } from "svelte/transition";
   import Link from "../link/Link.svelte";
@@ -35,15 +34,13 @@
     <Link {href} {target}>
       <CrossOriginImage {src} {alt} />
     </Link>
-  </div>
 
-  {#if activeOverlay}
-    <RenderFor audience="all">
+    {#if activeOverlay}
       <div class="trakt-summary-poster-overlay">
         {@render activeOverlay()}
       </div>
-    </RenderFor>
-  {/if}
+    {/if}
+  </div>
 
   {@render actions?.()}
 
@@ -57,7 +54,7 @@
 <style>
   .trakt-summary-poster-container {
     --overlay-border-size: var(--ni-2);
-    --poster-inverse-aspect-ratio: 3 / 2;
+    --poster-aspect-ratio: 2 / 3;
 
     width: var(--summary-poster-width);
     display: flex;
@@ -68,7 +65,7 @@
     &[data-variant="landscape"] {
       .trakt-summary-poster :global(img),
       .trakt-summary-poster-overlay {
-        --poster-inverse-aspect-ratio: 9 / 16;
+        --poster-aspect-ratio: 16 / 9;
       }
     }
   }
@@ -76,20 +73,20 @@
   .trakt-summary-poster :global(img),
   .trakt-summary-poster-overlay {
     overflow: hidden;
-
     border-radius: var(--border-radius-xxl);
-
-    width: var(--summary-poster-width);
-    /* Using aspect-ratio did not work in Safari, so we set the height explicitly */
-    height: calc(
-      var(--summary-poster-width) * var(--poster-inverse-aspect-ratio)
-    );
-
-    object-fit: cover;
   }
 
   .trakt-summary-poster {
+    position: relative;
+
     :global(img) {
+      display: block;
+
+      width: var(--summary-poster-width);
+      aspect-ratio: var(--poster-aspect-ratio);
+
+      object-fit: cover;
+
       align-self: stretch;
 
       box-shadow: 0px 7.673px 23.02px 0px rgba(0, 0, 0, 0.56);
@@ -102,13 +99,20 @@
 
   .trakt-summary-poster-overlay {
     position: absolute;
-    box-sizing: border-box;
+    z-index: var(--layer-raised);
+
+    --border-size: calc(2 * var(--overlay-border-size));
+    inset: 0;
+    margin: auto;
+    width: calc(100% - var(--border-size));
+    height: calc(100% - var(--border-size));
 
     opacity: 0;
     transition: opacity var(--transition-increment) ease-in-out;
 
     pointer-events: none;
 
+    box-sizing: border-box;
     border: var(--overlay-border-size) solid var(--color-overlay-foreground);
   }
 
@@ -118,7 +122,7 @@
       border: var(--overlay-border-size) solid transparent;
     }
 
-    & + .trakt-summary-poster-overlay {
+    .trakt-summary-poster-overlay {
       opacity: 1;
     }
   }

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
@@ -97,8 +97,7 @@
     display: flex;
     align-items: center;
 
-    :global(img),
-    :global(.trakt-summary-poster-overlay) {
+    :global(img) {
       width: 100%;
     }
   }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1608
- Correctly sizes the posters now.
  - Switch back to using aspect ratios.
  - Moved the overlay to the poster container to size it based on the parent; since it's non longer a div with an aspect-ratio this also works in safari.

## 👀 Example 👀
Before:
<img width="1074" height="720" alt="Screenshot 2026-01-27 at 07 12 48" src="https://github.com/user-attachments/assets/cc4943f6-af67-4439-b500-0c6e0294dba6" />

After:
Chrome:

https://github.com/user-attachments/assets/3d6a197e-1766-403d-9050-86f7044e9a5d

Safari:

https://github.com/user-attachments/assets/3b819aea-8387-4429-a5be-111caa4a4469

Firefox:

https://github.com/user-attachments/assets/efd4dcbe-4f1a-4277-b173-7512132248d1
