### PR TITLE
Fix/summary card link

### DIFF
--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -266,13 +266,6 @@
     }
   }
 
-  /* .trakt-summary-card-tags {
-    display: flex;
-    align-items: center;
-    gap: var(--gap-xs);
-    flex-grow: 1;
-  } */
-
   :global(.trakt-summary-card-titles) {
     height: var(--ni-66);
   }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1610
- Media summary cards now link to the correct pages (e.g. episodes link to the episode page).
- Also contains a small chore commit to remove dead code.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/13f4d84c-9866-43ed-b7ed-a18af5430f38

After:

https://github.com/user-attachments/assets/27bc970b-9d94-4e9b-ab8f-c1e745c23e21

