### PR TITLE
fix(card): do not render empty tags in season item

### DIFF
--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -69,6 +69,12 @@
   use:scrollToItem
 >
   {#if style === "cover"}
+    {#snippet tag()}
+      <TagBar>
+        <SeasonLabelTag seasonNumber={season.number} />
+      </TagBar>
+    {/snippet}
+
     <PortraitCard>
       {#if popupActions}
         <CardActionBar>
@@ -98,7 +104,7 @@
           alt={seasonLabel(season.number)}
         />
       </Link>
-      <CardFooter>
+      <CardFooter tag={variant === "list-item" ? tag : undefined}>
         {#if variant === "default"}
           <p
             use:lineClamp={{ lines: 2 }}
@@ -109,14 +115,6 @@
             {seasonLabel(season.number)}
           </p>
         {/if}
-
-        {#snippet tag()}
-          {#if variant === "list-item"}
-            <TagBar>
-              <SeasonLabelTag seasonNumber={season.number} />
-            </TagBar>
-          {/if}
-        {/snippet}
       </CardFooter>
     </PortraitCard>
   {/if}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1614
- Do not pass in a defined snippet if it's supposed to be empty 😅

## 👀 Example 👀

Before:
<img width="474" height="312" alt="Screenshot 2026-01-27 at 11 52 48" src="https://github.com/user-attachments/assets/f2ad206a-7532-4974-9267-aa116443b560" />

After:
<img width="474" height="312" alt="Screenshot 2026-01-27 at 11 52 08" src="https://github.com/user-attachments/assets/a079b9c5-978d-4e40-98be-e7d32ea1996c" />

