### PR TITLE
fix(list): emphasizes sort value better

### DIFF
--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -136,9 +136,9 @@
       popupActions={props.popupActions}
       {tag}
       badge={action}
+      {sortTag}
       type="episode"
       style="summary"
-      {sortTag}
     />
   {/if}
 

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -42,18 +42,18 @@
 
   type SummaryCardProps = {
     contextualTag?: Snippet;
-    sortTag?: Snippet;
     badge?: Snippet;
+    sortTag?: Snippet;
   } & DistributiveOmit<ItemCardProps, "badge" | "action">;
 
   const {
-    tag,
+    tag: externalTag,
     badge,
     popupActions,
     media,
     source,
-    sortTag,
     contextualTag,
+    sortTag,
     ...rest
   }: SummaryCardProps = $props();
 
@@ -90,6 +90,14 @@
       case "episode":
         return rest.episode;
     }
+  });
+
+  const tag = $derived.by(() => {
+    if (sortTag) {
+      return;
+    }
+
+    return externalTag;
   });
 </script>
 
@@ -194,16 +202,13 @@
           genres={media.genres}
         />
       {/if}
-      {#if sortTag}
-        <p class="trakt-card-subtitle">
-          {@render sortTag()}
-        </p>
-      {/if}
     </SummaryCardDetails>
   </Link>
 
   <SummaryCardBottomBar {contextualTag} {tag}>
-    {#if badge}
+    {#if sortTag}
+      {@render sortTag()}
+    {:else if badge}
       {@render badge()}
     {:else if rest.variant !== "activity" && rest.variant !== "next"}
       <SummaryCardRating item={ratedItem} />

--- a/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
@@ -71,12 +71,18 @@
       />
     </div>
   {/snippet}
+
   {#snippet item(media)}
-    <UserListItem listedItem={media} style="summary" {list}>
-      {#snippet sortTag()}
-        <SortValue item={media} sortBy={$current.sorting.value} />
-      {/snippet}
-    </UserListItem>
+    {#snippet sortTag()}
+      <SortValue item={media} sortBy={$current.sorting.value} />
+    {/snippet}
+
+    <UserListItem
+      listedItem={media}
+      style="summary"
+      {list}
+      sortTag={$current.sorting.value ? sortTag : undefined}
+    />
   {/snippet}
 
   {#snippet badge()}

--- a/projects/client/src/lib/sections/lists/user/_internal/SortValue.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SortValue.svelte
@@ -14,7 +14,7 @@
     <SortIcon {sortBy} />
   {/if}
 
-  <p class="tag secondary bold ellipsis">
+  <p class="bold ellipsis">
     {valueText}
   </p>
 </div>
@@ -26,8 +26,8 @@
     gap: var(--gap-micro);
 
     :global(svg) {
-      width: var(--ni-12);
-      height: var(--ni-12);
+      width: var(--ni-16);
+      height: var(--ni-16);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
@@ -14,35 +14,44 @@ function getEntry(item: ListItem) {
       return item.entry;
     case 'episode':
       return item.entry.episode;
-    default:
-      throw new Error(`Unsupported item type: ${item.type}`);
+    case 'season':
+      return item.entry.season;
+  }
+}
+
+function getRuntime(item: ListItem) {
+  switch (item.type) {
+    case 'movie':
+      return item.entry.runtime;
+    case 'show':
+      return item.entry.runtime * item.entry.episode.count;
+    case 'episode':
+      return item.entry.episode.runtime;
+    case 'season':
+      return item.entry.show.runtime * item.entry.season.episodes.count;
   }
 }
 
 export function formatSortValue(item: ListItem, sortBy?: SortBy) {
-  if (sortBy === 'added') {
-    return toHumanDay(item.listedAt, getLocale(), 'short');
-  }
-
-  if (!sortBy || item.type === 'season') {
+  if (!sortBy) {
     return;
   }
 
-  const entry = getEntry(item);
   switch (sortBy) {
+    case 'added':
+      return toHumanDay(item.listedAt, getLocale(), 'short');
     case 'runtime': {
-      const runtime = item.type === 'show'
-        ? item.entry.episode.count * item.entry.runtime
-        : entry.runtime;
-
+      const runtime = getRuntime(item);
       return toHumanDuration({ minutes: runtime }, languageTag());
     }
     case 'released': {
+      const entry = getEntry(item);
       return isMaxDate(entry.airDate)
         ? m.tag_text_tba()
         : toHumanDay(entry.airDate, getLocale(), 'short');
     }
     case 'percentage': {
+      const entry = getEntry(item);
       return entry.rating
         ? `${toTraktRating(entry.rating, getLocale())}`
         : undefined;

--- a/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
@@ -44,15 +44,16 @@
   {/snippet}
 
   {#snippet item(item)}
+    {#snippet sortTag()}
+      <SortValue {item} sortBy={$current.sorting.value} />
+    {/snippet}
+
     <DefaultMediaItem
       type={item.type}
       media={item.entry}
       style="summary"
       source="watchlist"
-    >
-      {#snippet sortTag()}
-        <SortValue {item} sortBy={$current.sorting.value} />
-      {/snippet}
-    </DefaultMediaItem>
+      sortTag={$current.sorting.value ? sortTag : undefined}
+    />
   {/snippet}
 </DrilledMediaList>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1622
- When sorting a list, the value is placed at the bottom right and the other meta info is not shown.

## 👀 Examples 👀
Before:
<img width="368" height="517" alt="Screenshot 2026-01-30 at 15 17 59" src="https://github.com/user-attachments/assets/bbcead31-5f20-4ef9-9e1e-e6ecadca6bf4" />


After:
<img width="368" height="517" alt="Screenshot 2026-01-30 at 15 37 38" src="https://github.com/user-attachments/assets/390081fe-d8ab-414a-9a40-f8b6b305c98e" />
