### PR TITLE
fix(requests): generates unique keys when mapping trivia responses

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToTrivia.ts
+++ b/projects/client/src/lib/requests/_internal/mapToTrivia.ts
@@ -2,9 +2,11 @@ import type { MediaTrivia } from '../models/MediaTrivia.ts';
 import type { TriviaResponse } from '../models/TriviaResponse.ts';
 
 export function mapToTrivia(
-  key: string,
+  keyPrefix: string,
   response: TriviaResponse['items'][0],
 ): MediaTrivia {
+  const key = `${keyPrefix}_${response.fact_id}_${response.order}`;
+
   return {
     key,
     text: response.text,

--- a/projects/client/src/lib/requests/queries/movies/movieTriviaQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTriviaQuery.ts
@@ -23,14 +23,12 @@ const movieTriviaRequest = async (
 };
 
 export const movieTriviaQuery = defineQuery({
-  key: 'movieSentiments',
+  key: 'movieTrivia',
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: movieTriviaRequest,
   mapper: (response) =>
-    response.body.items.map((entry) =>
-      mapToTrivia(`movie_trivia_${entry.fact_id}`, entry)
-    ),
+    response.body.items.map((entry) => mapToTrivia('movie_trivia', entry)),
   schema: MediaTriviaSchema.array(),
   ttl: time.hours(3),
 });

--- a/projects/client/src/lib/requests/queries/shows/showTriviaQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTriviaQuery.ts
@@ -23,14 +23,12 @@ const showTriviaRequest = async (
 };
 
 export const showTriviaQuery = defineQuery({
-  key: 'showSentiments',
+  key: 'showTrivia',
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: showTriviaRequest,
   mapper: (response) =>
-    response.body.items.map((entry) =>
-      mapToTrivia(`show_trivia_${entry.fact_id}`, entry)
-    ),
+    response.body.items.map((entry) => mapToTrivia('show_trivia', entry)),
   schema: MediaTriviaSchema.array(),
   ttl: time.hours(3),
 });


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1644
- Trivia entries now have a unique key
- Also changes the query keys
  - Needed to be changed anyway
  - And they were wrong to begin with 😅