### PR TITLE
fix(summary): uses correct font size for trivia

### DIFF
--- a/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaCard.svelte
@@ -53,9 +53,8 @@
       cursor: pointer;
     }
 
-    :global(p),
     :global(li) {
-      font-size: inherit;
+      font-size: var(--font-size-text);
     }
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1643
- Quick local fix for now to set the correct font-size.

## 👀 Example 👀
Before:
<img width="368" height="233" alt="Screenshot 2026-02-06 at 14 41 11" src="https://github.com/user-attachments/assets/530cb059-a9b3-4ad0-988e-fefa7518081c" />

After:
<img width="368" height="233" alt="Screenshot 2026-02-06 at 14 41 00" src="https://github.com/user-attachments/assets/2b478fae-469b-4438-ab3d-d3b2d5e57655" />
