### PR TITLE
iOS i18n updates including new missing key

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Гафове"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Начални надписи"
+    },
     "header_now_playing": {
       "default": "В ефир"
     },

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Bloopers"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Fortekster"
+    },
     "header_now_playing": {
       "default": "Spiller nu"
     },

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Pannen"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Vorspann"
+    },
     "header_now_playing": {
       "default": "Läuft jetzt"
     },

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Bloopers"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Opening Credits"
+    },
     "header_now_playing": {
       "default": "Now Playing"
     },

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -3409,6 +3409,13 @@
         "android"
       ]
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Opening Credits",
+      "description": "Value for the opening credits video type. The value is sent back from the Trakt API.",
+      "exclude": [
+        "android"
+      ]
+    },
     "header_now_playing": {
       "default": "Now Playing",
       "description": "Header for the 'now playing' toast that shows the movie or episode the user is currently watching.",

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Tomas Falsas"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Créditos de apertura"
+    },
     "header_now_playing": {
       "default": "En emisión"
     },

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Errores de grabación"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Créditos iniciales"
+    },
     "header_now_playing": {
       "default": "En emisión"
     },

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Bloopers"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Générique d'ouverture"
+    },
     "header_now_playing": {
       "default": "À l'affiche"
     },

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Bêtisier"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Générique de début"
+    },
     "header_now_playing": {
       "default": "En cours"
     },

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Errori sul set"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Titoli di testa"
+    },
     "header_now_playing": {
       "default": "In riproduzione"
     },

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "NG集"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "オープニングクレジット"
+    },
     "header_now_playing": {
       "default": "再生中"
     },

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Bloopers"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Fortekster"
+    },
     "header_now_playing": {
       "default": "Spilles nå"
     },

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Bloopers"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Openingscredits"
+    },
     "header_now_playing": {
       "default": "Nu bezig"
     },

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Wpadki"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Napisy początkowe"
+    },
     "header_now_playing": {
       "default": "Odtwarzane"
     },

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Erros de Gravação"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Créditos de abertura"
+    },
     "header_now_playing": {
       "default": "Em exibição"
     },

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Gafe"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Generic de început"
+    },
     "header_now_playing": {
       "default": "Rulează acum"
     },

--- a/projects/client/i18n/meta/ru-ru.json
+++ b/projects/client/i18n/meta/ru-ru.json
@@ -1548,6 +1548,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Ляпы"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Начальные титры"
+    },
     "header_now_playing": {
       "default": "Сейчас смотрю"
     },

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Bloopers"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Förtexter"
+    },
     "header_now_playing": {
       "default": "Spelas nu"
     },

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1281,6 +1281,9 @@
     "translated_value_video_type_bloopers": {
       "default": "Перли"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "Початкові титри"
+    },
     "header_now_playing": {
       "default": "Зараз в ефірі"
     },

--- a/projects/client/i18n/meta/zh-cn.json
+++ b/projects/client/i18n/meta/zh-cn.json
@@ -1547,6 +1547,9 @@
     "translated_value_video_type_bloopers": {
       "default": "NG 镜头"
     },
+    "translated_value_video_type_opening_credits": {
+      "default": "片头字幕"
+    },
     "header_now_playing": {
       "default": "正在播放"
     },

--- a/projects/client/src/lib/utils/formatting/string/toTranslatedVideoType.ts
+++ b/projects/client/src/lib/utils/formatting/string/toTranslatedVideoType.ts
@@ -10,15 +10,15 @@ const VIDEO_TYPE_MAP = {
   recap: m.translated_value_video_type_recap,
   behind_the_scenes: m.translated_value_video_type_behind_the_scenes,
   bloopers: m.translated_value_video_type_bloopers,
+  opening_credits: m.translated_value_video_type_opening_credits,
 } as const;
 
 export function toTranslatedVideoType(
   videoType: string | (keyof typeof VIDEO_TYPE_MAP),
   data?: Record<string, unknown>,
 ): string {
-  const translationFn =
-    VIDEO_TYPE_MAP[
-      normalizeTranslationKey(videoType) as keyof typeof VIDEO_TYPE_MAP
-    ];
+  const translationFn = VIDEO_TYPE_MAP[
+    normalizeTranslationKey(videoType) as keyof typeof VIDEO_TYPE_MAP
+  ];
   return translationFn?.(data) ?? videoType;
 }


### PR DESCRIPTION
Some more iOS i18n key updates, and added a missing key, `translated_value_video_type_opening_credits` based on this: https://github.com/trakt/trakt-api/blob/970c64d450addb59d5d68008051b9496d623856f/projects/api/src/contracts/_internal/response/videoTypeEnumSchema.ts#L10. @seferturan not sure if this is somehow missing from web or something, but I marked it as ignored in web by default. Feel free to change that if needed.