### PR TITLE
feat(summary): displays watched tag on first watch

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
@@ -13,6 +13,6 @@
   <PostCreditsTag count={postCreditsCount} i18n={TagIntlProvider} />
 {/if}
 
-{#if watchCount > 1}
+{#if watchCount > 0}
   <WatchCountTag count={watchCount} i18n={TagIntlProvider} />
 {/if}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1657
- Shows the `watched` also on the first watch.

## 👀 Example 👀
Before:
<img width="890" height="578" alt="Screenshot 2026-02-09 at 13 46 04" src="https://github.com/user-attachments/assets/297b7b20-dd71-4045-bf7b-321e86a2b1ef" />


After:
<img width="890" height="578" alt="Screenshot 2026-02-09 at 13 45 53" src="https://github.com/user-attachments/assets/f5f21655-3423-4f08-9963-edcd6d16cb72" />
