### PR TITLE
feat(summary): shows trivia summary for free users

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToTrivia.ts
+++ b/projects/client/src/lib/requests/_internal/mapToTrivia.ts
@@ -1,9 +1,12 @@
 import type { MediaTrivia } from '../models/MediaTrivia.ts';
 import type { TriviaResponse } from '../models/TriviaResponse.ts';
 
+type TriviaItemsResponse = TriviaResponse['items'][0];
+type TriviaSummaryResponse = TriviaResponse['summary'];
+
 export function mapToTrivia(
   keyPrefix: string,
-  response: TriviaResponse['items'][0],
+  response: TriviaItemsResponse,
 ): MediaTrivia {
   const key = `${keyPrefix}_${response.fact_id}_${response.order}`;
 
@@ -11,5 +14,17 @@ export function mapToTrivia(
     key,
     text: response.text,
     isSpoiler: response.spoiler,
+  };
+}
+
+export function mapToTriviaSummary(
+  keyPrefix: string,
+  response: TriviaSummaryResponse,
+): MediaTrivia {
+  const key = `${keyPrefix}_summary`;
+
+  return {
+    key,
+    text: response.map((item) => `- ${item}`).join('\n'),
   };
 }

--- a/projects/client/src/lib/requests/models/MediaTrivia.ts
+++ b/projects/client/src/lib/requests/models/MediaTrivia.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const MediaTriviaSchema = z.object({
   key: z.string(),
   text: z.string(),
-  isSpoiler: z.boolean(),
+  isSpoiler: z.boolean().optional(),
 });
 
 export type MediaTrivia = z.infer<

--- a/projects/client/src/lib/requests/queries/movies/movieTriviaQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTriviaQuery.ts
@@ -1,7 +1,11 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import { mapToTrivia } from '../../_internal/mapToTrivia.ts';
+import z from 'zod';
+import {
+  mapToTrivia,
+  mapToTriviaSummary,
+} from '../../_internal/mapToTrivia.ts';
 import { MediaTriviaSchema } from '../../models/MediaTrivia.ts';
 import { type TriviaResponse } from '../../models/TriviaResponse.ts';
 
@@ -27,8 +31,15 @@ export const movieTriviaQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: movieTriviaRequest,
-  mapper: (response) =>
-    response.body.items.map((entry) => mapToTrivia('movie_trivia', entry)),
-  schema: MediaTriviaSchema.array(),
+  mapper: (response) => ({
+    items: response.body.items.map((entry) =>
+      mapToTrivia('movie_trivia', entry)
+    ),
+    summary: mapToTriviaSummary('movie_trivia', response.body.summary),
+  }),
+  schema: z.object({
+    items: MediaTriviaSchema.array(),
+    summary: MediaTriviaSchema,
+  }),
   ttl: time.hours(3),
 });

--- a/projects/client/src/lib/requests/queries/shows/showTriviaQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTriviaQuery.ts
@@ -1,7 +1,11 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import { mapToTrivia } from '../../_internal/mapToTrivia.ts';
+import z from 'zod';
+import {
+  mapToTrivia,
+  mapToTriviaSummary,
+} from '../../_internal/mapToTrivia.ts';
 import { MediaTriviaSchema } from '../../models/MediaTrivia.ts';
 import { type TriviaResponse } from '../../models/TriviaResponse.ts';
 
@@ -27,8 +31,15 @@ export const showTriviaQuery = defineQuery({
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: showTriviaRequest,
-  mapper: (response) =>
-    response.body.items.map((entry) => mapToTrivia('show_trivia', entry)),
-  schema: MediaTriviaSchema.array(),
+  mapper: (response) => ({
+    items: response.body.items.map((entry) =>
+      mapToTrivia('show_trivia', entry)
+    ),
+    summary: mapToTriviaSummary('show_trivia', response.body.summary),
+  }),
+  schema: z.object({
+    items: MediaTriviaSchema.array(),
+    summary: MediaTriviaSchema,
+  }),
   ttl: time.hours(3),
 });

--- a/projects/client/src/lib/sections/summary/components/trivia/TriviaList.svelte
+++ b/projects/client/src/lib/sections/summary/components/trivia/TriviaList.svelte
@@ -5,6 +5,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import type { MediaTrivia } from "$lib/requests/models/MediaTrivia";
   import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
   import { slide } from "svelte/transition";
   import TriviaCard from "./_internal/TriviaCard.svelte";
@@ -20,7 +21,7 @@
     Math.max(...options.map((option) => option.text().length)),
   );
 
-  const { list, hasSpoilers } = $derived(
+  const { list, summary, hasSpoilers } = $derived(
     useTrivia({
       slug: media.slug,
       type: media.type,
@@ -36,26 +37,37 @@
   />
 {/snippet}
 
-<RenderFor audience="authenticated">
-  {#if $list.length > 0}
+{#snippet triviaList(items: MediaTrivia[], isVip = false)}
+  {#snippet actions()}
+    <Toggler value={$triviaType.value} onChange={set} {options} />
+  {/snippet}
+
+  {#if items.length > 0}
     <div class="trivia-list-container" transition:slide={{ duration: 150 }}>
       <SectionList
         id={`trivia-list-${media.slug}-${media.type}`}
-        items={$list}
+        {items}
         title={m.list_title_trivia()}
         --height-list="var(--height-trivia-list)"
-        metaInfo={$hasSpoilers ? metaInfo : undefined}
+        metaInfo={isVip && $hasSpoilers ? metaInfo : undefined}
+        actions={isVip && $hasSpoilers ? actions : undefined}
       >
-        {#snippet actions()}
-          {#if $hasSpoilers}
-            <Toggler value={$triviaType.value} onChange={set} {options} />
-          {/if}
-        {/snippet}
-
         {#snippet item(trivia)}
-          <TriviaCard {trivia} {media} />
+          <TriviaCard
+            {trivia}
+            {media}
+            variant={isVip ? undefined : "summary"}
+          />
         {/snippet}
       </SectionList>
     </div>
   {/if}
+{/snippet}
+
+<RenderFor audience="free">
+  {@render triviaList($summary)}
+</RenderFor>
+
+<RenderFor audience="vip">
+  {@render triviaList($list, true)}
 </RenderFor>

--- a/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaCard.svelte
@@ -6,8 +6,15 @@
   import { Marked } from "marked";
   import ShadowScroller from "./ShadowScroller.svelte";
 
-  const { trivia, media }: { trivia: MediaTrivia; media: MediaEntry } =
-    $props();
+  const {
+    trivia,
+    media,
+    variant = "default",
+  }: {
+    trivia: MediaTrivia;
+    media: MediaEntry;
+    variant?: "summary" | "default";
+  } = $props();
 
   const marked = new Marked();
 </script>
@@ -20,7 +27,7 @@
   --width-card="var(--width-trivia-card)"
   --height-card="var(--height-trivia-card)"
 >
-  <div class="trakt-trivia-container">
+  <div class="trakt-trivia-container" data-variant={variant}>
     <ShadowScroller>
       {#if !trivia.isSpoiler}
         {@render content()}
@@ -55,6 +62,13 @@
 
     :global(li) {
       font-size: var(--font-size-text);
+    }
+
+    &[data-variant="summary"] {
+      :global(ul) {
+        margin: 0;
+        padding-left: var(--font-size-text);
+      }
     }
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/trivia/useTrivia.ts
+++ b/projects/client/src/lib/sections/summary/components/trivia/useTrivia.ts
@@ -29,7 +29,7 @@ export function useTrivia(props: UseTriviaProps) {
         return false;
       }
 
-      return $query.data.some((trivia) => trivia.isSpoiler);
+      return $query.data.items.some((trivia) => trivia.isSpoiler);
     }),
   );
 
@@ -40,7 +40,7 @@ export function useTrivia(props: UseTriviaProps) {
           return [];
         }
 
-        return $query.data.filter((trivia) => {
+        return $query.data.items.filter((trivia) => {
           if (!$hasSpoilers) {
             return true;
           }
@@ -50,6 +50,9 @@ export function useTrivia(props: UseTriviaProps) {
             : !trivia.isSpoiler;
         });
       }),
+    ),
+    summary: query.pipe(
+      map(($query) => $query.data ? [$query.data.summary] : []),
     ),
     hasSpoilers,
   };


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1659
- On summary pages, free users are shown a summary of the trivia instead of all trivia.
- No query key changes needed since schemas changed.
- Everything is mapped to the same type so we can (largely) use the existing components as is.

## 👀 Examples 👀
<img width="370" height="234" alt="Screenshot 2026-02-09 at 16 18 46" src="https://github.com/user-attachments/assets/82afc55c-643a-476b-a318-fc56d49ced6d" />

<img width="509" height="250" alt="Screenshot 2026-02-09 at 16 27 53" src="https://github.com/user-attachments/assets/4ca47c8b-7479-4d84-8cec-61f608cd41c7" />
