### PR TITLE
fix: do not debounce first value update

### DIFF
--- a/projects/client/src/lib/stores/useDebouncedValue.ts
+++ b/projects/client/src/lib/stores/useDebouncedValue.ts
@@ -1,9 +1,25 @@
-import { BehaviorSubject, debounceTime } from 'rxjs';
+import {
+  BehaviorSubject,
+  concatMap,
+  debounceTime,
+  of,
+  pairwise,
+  startWith,
+} from 'rxjs';
+
+const INITIAL_VALUE = null;
 
 export function useDebouncedValue<T>(delay: number) {
-  const value = new BehaviorSubject<T | Nil>(null);
+  const value = new BehaviorSubject<T | Nil>(INITIAL_VALUE);
+
   const debounced = value.pipe(
-    debounceTime(delay),
+    startWith(INITIAL_VALUE),
+    pairwise(),
+    concatMap(([prevValue, newValue]) =>
+      prevValue === INITIAL_VALUE
+        ? of(newValue)
+        : of(newValue).pipe(debounceTime(delay))
+    ),
   );
 
   return {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1661
- Initial value being set when using `useDebouncedValue` is set right away now.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/c12ea4ce-d312-4da2-b659-ab1c86379c72



After:

https://github.com/user-attachments/assets/4b17966d-fd92-4cc6-972e-b6da970dd4b6

