### PR TITLE
chore: fixes svelte types handling in deno

### DIFF
--- a/projects/client/deno.json
+++ b/projects/client/deno.json
@@ -20,7 +20,8 @@
     "$app/server": "../../node_modules/@sveltejs/kit/types/index.d.ts",
     "$app/stores": "../../node_modules/@sveltejs/kit/types/index.d.ts",
     "@std/cli": "jsr:@std/cli@^1.0.24",
-    "@std/path": "jsr:@std/path@^1.1.3"
+    "@std/path": "jsr:@std/path@^1.1.3",
+    "$types/": "./.svelte-kit/types/src/routes/"
   },
   "lint": {
     "exclude": [

--- a/projects/client/src/routes/+layout.server.ts
+++ b/projects/client/src/routes/+layout.server.ts
@@ -1,8 +1,7 @@
+import type { OidcAuthToken } from '$lib/features/auth/models/OidcAuthToken.ts';
 import { getDeviceType } from '$lib/utils/devices/getDeviceType.ts';
 import { isBotAgent } from '$lib/utils/devices/isBotAgent.ts';
-
-import type { OidcAuthToken } from '$lib/features/auth/models/OidcAuthToken.ts';
-import type { LayoutServerLoad } from './$types.ts';
+import type { LayoutServerLoad } from '$types/$types.d.ts';
 
 const getAuth = (auth: Nil | OidcAuthToken) => {
   if (!auth) {

--- a/projects/client/src/routes/+layout.ts
+++ b/projects/client/src/routes/+layout.ts
@@ -1,8 +1,7 @@
-import type { LayoutLoad } from './$types.ts';
-
 import { browser } from '$app/environment';
 import { setToken } from '$lib/features/auth/token/index.ts';
 import { retryDelay } from '$lib/utils/retry/retryDelay.ts';
+import type { LayoutLoad } from '$types/$types.d.ts';
 import { QueryClient } from '@tanstack/svelte-query';
 
 export const load: LayoutLoad = ({ data }) => {

--- a/projects/client/src/routes/movies/[slug]/+page.ts
+++ b/projects/client/src/routes/movies/[slug]/+page.ts
@@ -1,6 +1,6 @@
 import { movieSummaryQuery } from '$lib/requests/queries/movies/movieSummaryQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
-import type { PageLoad } from './$types.ts';
+import type { PageLoad } from '$types/movies/[slug]/$types.d.ts';
 
 export const load: PageLoad = async ({ parent, params, fetch }) => {
   const { queryClient, isBot } = await parent();

--- a/projects/client/src/routes/people/[slug]/+page.ts
+++ b/projects/client/src/routes/people/[slug]/+page.ts
@@ -1,6 +1,6 @@
 import { peopleSummaryQuery } from '$lib/requests/queries/people/peopleSummaryQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
-import type { PageLoad } from './$types.ts';
+import type { PageLoad } from '$types/people/[slug]/$types.d.ts';
 
 export const load: PageLoad = async ({ parent, params, fetch }) => {
   const { queryClient, isBot } = await parent();

--- a/projects/client/src/routes/shows/[slug]/+page.ts
+++ b/projects/client/src/routes/shows/[slug]/+page.ts
@@ -1,6 +1,6 @@
 import { showSummaryQuery } from '$lib/requests/queries/shows/showSummaryQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
-import type { PageLoad } from './$types.ts';
+import type { PageLoad } from '$types/shows/[slug]/$types.d.ts';
 
 export const load: PageLoad = async ({ parent, params, fetch }) => {
   const { queryClient, isBot } = await parent();

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.ts
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.ts
@@ -1,6 +1,6 @@
 import { episodeSummaryQuery } from '$lib/requests/queries/episode/episodeSummaryQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
-import type { PageLoad } from './$types.ts';
+import type { PageLoad } from '$types/shows/[slug]/seasons/[season]/episodes/[episode]/$types.d.ts';
 
 export const load: PageLoad = async ({ parent, params, fetch }) => {
   const { queryClient, isBot } = await parent();

--- a/projects/client/svelte.config.js
+++ b/projects/client/svelte.config.js
@@ -41,6 +41,7 @@ const config = {
       '$test': './test',
       '$style': 'src/style',
       '$e2e': './e2e',
+      '$types': './.svelte-kit/types/src/routes',
     },
   },
 };


### PR DESCRIPTION
## 🎶 Notes 🎶

- Small chore to get deno to play along with svelte.

## 👀 Example 👀
Before:
<img width="795" height="552" alt="Screenshot 2026-02-10 at 12 08 23" src="https://github.com/user-attachments/assets/7621d712-2eb5-47ec-a484-8bc5d225fc27" />


After:
<img width="795" height="532" alt="Screenshot 2026-02-10 at 12 04 34" src="https://github.com/user-attachments/assets/82caf73d-484e-4545-bbdf-a20bb99aacaf" />
