### PR TITLE
feat: enable href rendering for legitimate bots

### DIFF
--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -193,6 +193,7 @@ declare global {
         | import('$lib/features/auth/models/OidcAuthToken.ts').OidcAuthToken
         | Nil;
       typesense: TypesenseConfig;
+      isLegitimateBot: boolean;
     }
     // interface PageData {}
     // interface PageState {}

--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -1,4 +1,5 @@
 import { handle as handleAuth } from '$lib/features/auth/handle.ts';
+import { handle as handleBotVerification } from '$lib/features/bot-verification/handle.ts';
 import { handle as handleCacheBust } from '$lib/features/cache-bust/handle.ts';
 import { handle as handleCookieConsent } from '$lib/features/cookie-consent/handle.ts';
 import { handle as handleDeployment } from '$lib/features/deployment/handle.ts';
@@ -52,6 +53,7 @@ export const handle: Handle = sequence(
     enableLogs: true,
   }),
   sentryHandle(),
+  handleBotVerification,
   handleDevice,
   handleLocale,
   handleTheme,

--- a/projects/client/src/lib/features/auth/stores/useGuardedHref.ts
+++ b/projects/client/src/lib/features/auth/stores/useGuardedHref.ts
@@ -1,10 +1,12 @@
 import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { useBotContext } from '../../bot-verification/stores/useBotContext.ts';
 import { UrlBuilder } from '../../../utils/url/UrlBuilder.ts';
 import { useAuth } from './useAuth.ts';
 
 export function useGuardedHref(href: string | Nil) {
   const originalHref = of(href);
+  const isLegitimateBot = useBotContext();
 
   try {
     const { isAuthorized } = useAuth();
@@ -12,6 +14,11 @@ export function useGuardedHref(href: string | Nil) {
     const guardedHref = isAuthorized.pipe(
       map((authorized) => {
         if (href == null) {
+          return href;
+        }
+
+        // Legitimate bots always see original href for SEO
+        if (isLegitimateBot) {
           return href;
         }
 

--- a/projects/client/src/lib/features/bot-verification/BotProvider.svelte
+++ b/projects/client/src/lib/features/bot-verification/BotProvider.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { iffy } from "$lib/utils/function/iffy";
+  import { setBotContext } from "./stores/useBotContext";
+
+  const {
+    children,
+    isLegitimateBot,
+  }: ChildrenProps & { isLegitimateBot: boolean } = $props();
+
+  iffy(() => setBotContext(isLegitimateBot));
+</script>
+
+{@render children()}

--- a/projects/client/src/lib/features/bot-verification/handle.ts
+++ b/projects/client/src/lib/features/bot-verification/handle.ts
@@ -1,0 +1,13 @@
+import type { Handle } from '@sveltejs/kit';
+import { isLegitimateBot } from './utils/isLegitimateBot.ts';
+
+export const handle: Handle = async ({ event, resolve }) => {
+  const userAgent = event.request.headers.get('user-agent') || '';
+  const ipAddress = event.getClientAddress();
+
+  // Verify if this is a legitimate bot via reverse DNS
+  const legitimate = await isLegitimateBot(userAgent, ipAddress);
+  event.locals.isLegitimateBot = legitimate;
+
+  return resolve(event);
+};

--- a/projects/client/src/lib/features/bot-verification/stores/useBotContext.ts
+++ b/projects/client/src/lib/features/bot-verification/stores/useBotContext.ts
@@ -1,0 +1,15 @@
+import { getContext, setContext } from 'svelte';
+
+const BOT_CONTEXT_KEY = Symbol('botContext');
+
+export function setBotContext(isLegitimateBot: boolean) {
+  setContext(BOT_CONTEXT_KEY, isLegitimateBot);
+}
+
+export function useBotContext(): boolean {
+  try {
+    return getContext<boolean>(BOT_CONTEXT_KEY) ?? false;
+  } catch {
+    return false;
+  }
+}

--- a/projects/client/src/lib/features/bot-verification/utils/isLegitimateBot.ts
+++ b/projects/client/src/lib/features/bot-verification/utils/isLegitimateBot.ts
@@ -1,0 +1,68 @@
+import { error } from '$lib/utils/console/print.ts';
+import { promises as dns } from 'node:dns';
+
+const LEGITIMATE_BOT_PATTERNS = {
+  googlebot: /\.google(bot)?\.com$/i,
+  bingbot: /\.search\.msn\.com$/i,
+  duckduckbot: /\.duckduckgo\.com$/i,
+  slackbot: /\.slack\.com$/i,
+  twitterbot: /\.twitter\.com$/i,
+  facebookexternalhit: /\.facebook\.com$/i,
+  linkedinbot: /\.linkedin\.com$/i,
+} as const;
+
+type BotType = keyof typeof LEGITIMATE_BOT_PATTERNS;
+
+function identifyBotType(userAgent: string): BotType | null {
+  const ua = userAgent.toLowerCase();
+  for (const bot of Object.keys(LEGITIMATE_BOT_PATTERNS)) {
+    if (ua.includes(bot)) {
+      return bot as BotType;
+    }
+  }
+
+  return null;
+}
+
+async function reverseIpLookup(ip: string): Promise<string> {
+  const hostnames = await dns.reverse(ip);
+  const hostname = hostnames.at(0);
+
+  if (!hostname) {
+    throw new Error(`No hostname found for IP: ${ip}`);
+  }
+
+  return hostname;
+}
+
+async function forwardDnsLookup(hostname: string): Promise<string> {
+  const result = await dns.lookup(hostname);
+  return result.address;
+}
+
+export async function isLegitimateBot(
+  userAgent: string,
+  ipAddress: string,
+): Promise<boolean> {
+  const botType = identifyBotType(userAgent);
+  if (!botType) return false;
+
+  try {
+    // Step 1: Reverse DNS lookup to get hostname from IP
+    const hostname = await reverseIpLookup(ipAddress);
+    const pattern = LEGITIMATE_BOT_PATTERNS[botType];
+
+    // Step 2: Verify hostname matches expected pattern
+    if (!pattern.test(hostname)) {
+      return false;
+    }
+
+    // Step 3: Forward DNS lookup to verify hostname resolves back to original IP
+    const resolvedIp = await forwardDnsLookup(hostname);
+    return resolvedIp === ipAddress;
+  } catch (e) {
+    // If DNS lookups fail, assume not a legitimate bot
+    error('Bot verification failed:', { userAgent, ipAddress, error: e });
+    return false;
+  }
+}

--- a/projects/client/src/routes/+layout.server.ts
+++ b/projects/client/src/routes/+layout.server.ts
@@ -25,6 +25,7 @@ export const load: LayoutServerLoad = (
   const defaultResponse = {
     theme: locals.theme,
     oidcAuth: getAuth(locals.oidcAuth),
+    isLegitimateBot: locals.isLegitimateBot,
     isBot: isBotAgent(request.headers.get('user-agent')),
     device: getDeviceType(request.headers.get('user-agent')),
     cookieConsent: locals.cookieConsent,

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
   import AnalyticsProvider from "$lib/features/analytics/AnalyticsProvider.svelte";
   import PageView from "$lib/features/analytics/PageView.svelte";
   import AuthProvider from "$lib/features/auth/components/AuthProvider.svelte";
+  import BotProvider from "$lib/features/bot-verification/BotProvider.svelte";
   import ConfirmationProvider from "$lib/features/confirmation/ConfirmationProvider.svelte";
   import CookieConsentProvider from "$lib/features/cookie-consent/CookieConsentProvider.svelte";
   import { DeploymentEndpoint } from "$lib/features/deployment/DeploymentEndpoint.js";
@@ -129,84 +130,86 @@
 <ErrorProvider>
   <QueryClientProvider client={data.queryClient}>
     <GlobalParameterProvider>
-      <AuthProvider
-        isAuthorized={data.oidcAuth.isAuthorized}
-        accessToken={data.oidcAuth.token}
-      >
-        <WSInvalidator />
-        <FeatureFlagProvider>
-          <CookieConsentProvider consent={data.cookieConsent}>
-            <PlayerProvider>
-              <AnalyticsProvider>
-                <RedirectProvider>
-                  <NavigationProvider>
-                    <LocaleProvider>
-                      <SearchProvider config={data.typesense}>
-                        <FilterProvider>
-                          <CoverProvider>
-                            <ToastProvider>
-                              <DiscoverProvider>
-                                <ConfirmationProvider>
-                                  <MarkAsWatchedDrawerProvider />
-                                  <CoverImage />
-                                  <SeasonalFlair />
+      <BotProvider isLegitimateBot={data.isLegitimateBot}>
+        <AuthProvider
+          isAuthorized={data.oidcAuth.isAuthorized}
+          accessToken={data.oidcAuth.token}
+        >
+          <WSInvalidator />
+          <FeatureFlagProvider>
+            <CookieConsentProvider consent={data.cookieConsent}>
+              <PlayerProvider>
+                <AnalyticsProvider>
+                  <RedirectProvider>
+                    <NavigationProvider>
+                      <LocaleProvider>
+                        <SearchProvider config={data.typesense}>
+                          <FilterProvider>
+                            <CoverProvider>
+                              <ToastProvider>
+                                <DiscoverProvider>
+                                  <ConfirmationProvider>
+                                    <MarkAsWatchedDrawerProvider />
+                                    <CoverImage />
+                                    <SeasonalFlair />
 
-                                  <ThemeProvider theme={data.theme}>
-                                    <ListScrollHistoryProvider>
-                                      <!--
+                                    <ThemeProvider theme={data.theme}>
+                                      <ListScrollHistoryProvider>
+                                        <!--
                                         All navbars are added in the layout to make sure they can
                                         persist during navigation. The state is set on a page level.
                                       -->
-                                      <RenderFor
-                                        audience="all"
-                                        device={["mobile", "tablet-sm"]}
-                                      >
-                                        <TopNavbar />
-                                      </RenderFor>
+                                        <RenderFor
+                                          audience="all"
+                                          device={["mobile", "tablet-sm"]}
+                                        >
+                                          <TopNavbar />
+                                        </RenderFor>
 
-                                      <RenderFor
-                                        audience="all"
-                                        device={["desktop", "tablet-lg"]}
-                                      >
-                                        <SideNavbar />
-                                      </RenderFor>
+                                        <RenderFor
+                                          audience="all"
+                                          device={["desktop", "tablet-lg"]}
+                                        >
+                                          <SideNavbar />
+                                        </RenderFor>
 
-                                      {@render children()}
+                                        {@render children()}
 
-                                      <RenderFor
-                                        audience="all"
-                                        device={["mobile", "tablet-sm"]}
-                                      >
-                                        <MobileNavbar />
-                                      </RenderFor>
+                                        <RenderFor
+                                          audience="all"
+                                          device={["mobile", "tablet-sm"]}
+                                        >
+                                          <MobileNavbar />
+                                        </RenderFor>
 
-                                      <RenderFor audience="authenticated">
-                                        <NavbarToastContent />
-                                      </RenderFor>
-                                      <SvelteQueryDevtools
-                                        buttonPosition="bottom-right"
-                                        styleNonce="opacity: 0.5"
-                                      />
-                                    </ListScrollHistoryProvider>
-                                  </ThemeProvider>
-                                </ConfirmationProvider>
-                              </DiscoverProvider>
-                            </ToastProvider>
-                          </CoverProvider>
-                        </FilterProvider>
-                      </SearchProvider>
-                    </LocaleProvider>
-                  </NavigationProvider>
+                                        <RenderFor audience="authenticated">
+                                          <NavbarToastContent />
+                                        </RenderFor>
+                                        <SvelteQueryDevtools
+                                          buttonPosition="bottom-right"
+                                          styleNonce="opacity: 0.5"
+                                        />
+                                      </ListScrollHistoryProvider>
+                                    </ThemeProvider>
+                                  </ConfirmationProvider>
+                                </DiscoverProvider>
+                              </ToastProvider>
+                            </CoverProvider>
+                          </FilterProvider>
+                        </SearchProvider>
+                      </LocaleProvider>
+                    </NavigationProvider>
 
-                  {#key page.url.pathname}
-                    <PageView />
-                  {/key}
-                </RedirectProvider>
-              </AnalyticsProvider>
-            </PlayerProvider>
-          </CookieConsentProvider>
-        </FeatureFlagProvider>
-      </AuthProvider>
+                    {#key page.url.pathname}
+                      <PageView />
+                    {/key}
+                  </RedirectProvider>
+                </AnalyticsProvider>
+              </PlayerProvider>
+            </CookieConsentProvider>
+          </FeatureFlagProvider>
+        </AuthProvider>
+      </BotProvider>
     </GlobalParameterProvider>
   </QueryClientProvider>
 </ErrorProvider>


### PR DESCRIPTION
# Bot Verification

This module provides reverse DNS verification for legitimate search engine bots to prevent scrapers from impersonating them.

## How It Works

### 1. Reverse DNS Verification

The system uses a two-step verification process recommended by Google and other search engines:

1. **Reverse DNS Lookup**: Get hostname from IP address
2. **Pattern Matching**: Verify hostname matches expected pattern (e.g., `.googlebot.com`)
3. **Forward DNS Lookup**: Verify hostname resolves back to original IP

This prevents scrapers from spoofing user agents since they can't fake DNS records.

### 2. Supported Bots

- **Googlebot**: `.google.com` or `.googlebot.com`
- **Bingbot**: `.search.msn.com`
- **DuckDuckBot**: `.duckduckgo.com`
- **Slackbot**: `.slack.com`
- **Twitterbot**: `.twitter.com`
- **FacebookExternalHit**: `.facebook.com`
- **LinkedInBot**: `.linkedin.com`

### 3. SEO Protection

When a legitimate bot is detected:
- `useGuardedHref` returns the original href instead of redirecting to home page
- This ensures search engines can properly crawl all pages for SEO
- Auth-protected links remain visible to crawlers for indexing

## Security

**Prevents**:
- Scrapers spoofing Googlebot user agent
- Unauthorized access via fake bot requests