### PR TITLE
fix: use derived states for guarded links

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -31,7 +31,7 @@
     (rest as TraktActionButtonAnchorProps).replacestate,
   );
 
-  const href = $guardedHref;
+  const href = $derived($guardedHref);
   const { isActive } = $derived(useActiveLink($originalHref));
 </script>
 

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -42,7 +42,7 @@
   const noscroll = $derived((rest as TraktButtonAnchorProps).noscroll);
   const replacestate = $derived((rest as TraktButtonAnchorProps).replacestate);
 
-  const href = $guardedHref;
+  const href = $derived($guardedHref);
   const { isActive } = $derived(useActiveLink($originalHref));
 
   const appendTestId = $derived((element: HTMLElement) => {

--- a/projects/client/src/lib/components/link/Link.svelte
+++ b/projects/client/src/lib/components/link/Link.svelte
@@ -26,7 +26,7 @@
   const { guardedHref, originalHref } = $derived(useGuardedHref(props.href));
   const { isActive } = $derived(useActiveLink($originalHref));
 
-  const href = $guardedHref;
+  const href = $derived($guardedHref);
 </script>
 
 <a


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1670
- Guarded hrefs were not derived.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/30910a56-c33c-4d22-b10d-e459578ba5b1

After:

https://github.com/user-attachments/assets/53aab2fa-6ad5-4096-b969-b12ecdb32ff7

