### PR TITLE
feat(ratings): distinguishes user ratings from trakt ratings

### DIFF
--- a/projects/client/src/lib/components/icons/RatingIcon.svelte
+++ b/projects/client/src/lib/components/icons/RatingIcon.svelte
@@ -4,9 +4,22 @@
 
   type RatingIconProps = {
     style?: VotesBasedRating;
+    variant?: "trakt" | "user";
   };
 
-  const { style = "rated" }: RatingIconProps = $props();
+  const { style = "rated", variant = "trakt" }: RatingIconProps = $props();
 </script>
 
-<StarIcon fill={style === "rated" ? "full" : "none"} />
+<div class="trakt-rating-icon" data-variant={variant}>
+  <StarIcon fill={style === "rated" ? "full" : "none"} />
+</div>
+
+<style>
+  .trakt-rating-icon {
+    display: contents;
+
+    &[data-variant="trakt"] {
+      color: var(--color-ratings-trakt);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/user/_internal/SortIcon.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SortIcon.svelte
@@ -2,12 +2,18 @@
   import CalendarIcon from "$lib/components/icons/CalendarIcon.svelte";
   import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
   import RatingIcon from "$lib/components/icons/RatingIcon.svelte";
+  import StarIcon from "$lib/components/icons/StarIcon.svelte";
   import type { SortBy } from "../models/SortBy";
 
-  const { sortBy }: { sortBy: SortBy } = $props();
+  const {
+    sortBy,
+    variant = "default",
+  }: { sortBy: SortBy; variant?: "default" | "value" } = $props();
 </script>
 
-{#if sortBy === "percentage"}
+{#if sortBy === "percentage" && variant === "default"}
+  <StarIcon fill="full" />
+{:else if sortBy === "percentage"}
   <RatingIcon />
 {/if}
 

--- a/projects/client/src/lib/sections/lists/user/_internal/SortValue.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SortValue.svelte
@@ -11,7 +11,7 @@
 
 <div class="trakt-sort-value">
   {#if valueText && sortBy}
-    <SortIcon {sortBy} />
+    <SortIcon {sortBy} variant="value" />
   {/if}
 
   <p class="bold ellipsis">

--- a/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.spec.ts
@@ -72,7 +72,7 @@ describe('formatSortValue', () => {
         type: 'movie',
         entry: { rating: 0.7 },
       } as unknown as ListItem;
-      expect(formatSortValue(ratedItem, 'percentage')).toBe('3.5');
+      expect(formatSortValue(ratedItem, 'percentage')).toBe('70%');
     });
 
     it('should return undefined if rating is missing', () => {

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommenterRating.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommenterRating.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import StarIcon from "$lib/components/icons/StarIcon.svelte";
+  import RatingIcon from "$lib/components/icons/RatingIcon.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import { getLocale } from "$lib/features/i18n";
   import type { MediaComment } from "$lib/requests/models/MediaComment";
-  import { toTraktRating } from "$lib/utils/formatting/number/toTraktRating";
+  import { toUserRating } from "$lib/utils/formatting/number/toUserRating";
 
   const { comment }: { comment: MediaComment } = $props();
 
@@ -14,14 +14,14 @@
     const rating = comment.user.stats.rating;
     if (!rating) return;
 
-    return toTraktRating(rating, getLocale());
+    return toUserRating(rating, getLocale());
   });
 </script>
 
 {#if !isOwnComment && rating}
   <div class="trakt-commenter-rating">
     <span>{rating}</span>
-    <StarIcon fill="full" />
+    <RatingIcon style="rated" variant="user" />
   </div>
 {/if}
 

--- a/projects/client/src/lib/utils/formatting/number/toTraktRating.spec.ts
+++ b/projects/client/src/lib/utils/formatting/number/toTraktRating.spec.ts
@@ -2,12 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { toTraktRating } from './toTraktRating.ts';
 
 describe('toTraktRating', () => {
-  it('will format ratings to star values', () => {
-    expect(toTraktRating(0)).toBe('0');
-    expect(toTraktRating(0.25)).toBe('1.3');
-    expect(toTraktRating(0.5)).toBe('2.5');
-    expect(toTraktRating(0.55)).toBe('2.8');
-    expect(toTraktRating(0.8)).toBe('4');
-    expect(toTraktRating(1)).toBe('5');
+  it('will format ratings to percentages', () => {
+    expect(toTraktRating(0.45)).toBe('45%');
+    expect(toTraktRating(0.99)).toBe('99%');
+    expect(toTraktRating(1)).toBe('100%');
   });
 });

--- a/projects/client/src/lib/utils/formatting/number/toTraktRating.ts
+++ b/projects/client/src/lib/utils/formatting/number/toTraktRating.ts
@@ -1,12 +1,5 @@
-import { STAR_RATINGS } from '../../../sections/summary/components/rating/constants/index.ts';
-import { toHumanNumber } from './toHumanNumber.ts';
-
-const MAX_RATING = 10;
+import { toPercentage } from './toPercentage.ts';
 
 export function toTraktRating(rating: number, locale = 'en') {
-  const factor = MAX_RATING / STAR_RATINGS.length;
-
-  const starRating = rating * 10 / factor;
-
-  return toHumanNumber(starRating, locale);
+  return toPercentage(rating, locale);
 }

--- a/projects/client/src/lib/utils/formatting/number/toUserRating.spec.ts
+++ b/projects/client/src/lib/utils/formatting/number/toUserRating.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { toUserRating } from './toUserRating.ts';
+
+describe('toUserRating', () => {
+  it('will format ratings to star values', () => {
+    expect(toUserRating(0)).toBe('0');
+    expect(toUserRating(0.25)).toBe('1.3');
+    expect(toUserRating(0.5)).toBe('2.5');
+    expect(toUserRating(0.55)).toBe('2.8');
+    expect(toUserRating(0.8)).toBe('4');
+    expect(toUserRating(1)).toBe('5');
+  });
+});

--- a/projects/client/src/lib/utils/formatting/number/toUserRating.ts
+++ b/projects/client/src/lib/utils/formatting/number/toUserRating.ts
@@ -1,0 +1,12 @@
+import { STAR_RATINGS } from '../../../sections/summary/components/rating/constants/index.ts';
+import { toHumanNumber } from './toHumanNumber.ts';
+
+const MAX_RATING = 10;
+
+export function toUserRating(rating: number, locale = 'en') {
+  const factor = MAX_RATING / STAR_RATINGS.length;
+
+  const starRating = rating * 10 / factor;
+
+  return toHumanNumber(starRating, locale);
+}

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -121,4 +121,9 @@
     var(--color-shadow) 1%,
     transparent
   ), var(--ni-0) var(--ni-96) var(--ni-32) var(--ni-0) transparent;
+
+  /**
+   * Ratings
+   */
+  --color-ratings-trakt: var(--purple-500);
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1672
- Trakt ratings now use a colored star and is shown as a percentage.
  - This now clearly distinguishes it from individual user ratings.

## 👀 Examples 👀
<img width="366" height="565" alt="Screenshot 2026-02-11 at 12 11 33" src="https://github.com/user-attachments/assets/708e97c6-b21c-4e0b-b104-02f49a08558e" />

<img width="370" height="234" alt="Screenshot 2026-02-11 at 12 11 44" src="https://github.com/user-attachments/assets/a931cf1d-c23b-4b21-98fe-81ea215da9cc" />

<img width="370" height="151" alt="Screenshot 2026-02-11 at 12 12 26" src="https://github.com/user-attachments/assets/97bdaaba-8aa3-4cc4-ba2d-6a5887a5b705" />
