### PR TITLE
fix(sentiment): deals with 404 responses

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToSentimentAnalyis.ts
+++ b/projects/client/src/lib/requests/_internal/mapToSentimentAnalyis.ts
@@ -6,11 +6,15 @@ function appendDot(text: string): string {
 }
 
 export function mapToSentimentAnalysis(
-  response: SentimentResponse,
-): SentimentAnalysis {
+  response?: SentimentResponse,
+): SentimentAnalysis | Nil {
+  if (!response) {
+    return null;
+  }
+
   return {
-    analysis: response.analysis,
-    highlight: response.highlight,
+    analysis: response?.analysis ?? '',
+    highlight: response?.highlight ?? '',
     aspect: {
       pros: response.aspect.pros.map((item) => appendDot(item.theme)),
       cons: response.aspect.cons.map((item) => appendDot(item.theme)),

--- a/projects/client/src/lib/requests/models/SentimentResponse.ts
+++ b/projects/client/src/lib/requests/models/SentimentResponse.ts
@@ -6,6 +6,10 @@ const AspectItemSchema = z.object({
 });
 
 export const SentimentResponseSchema = z.object({
+  aspect: z.object({
+    pros: z.array(AspectItemSchema),
+    cons: z.array(AspectItemSchema),
+  }),
   sentiment: z.object({
     overall: z.enum(['positive', 'negative', 'mixed']),
     score: z.number(),
@@ -14,12 +18,8 @@ export const SentimentResponseSchema = z.object({
       cons: z.array(z.string()),
     }),
   }),
-  analysis: z.string(),
-  aspect: z.object({
-    pros: z.array(AspectItemSchema),
-    cons: z.array(AspectItemSchema),
-  }),
-  highlight: z.string(),
+  analysis: z.string().optional(),
+  highlight: z.string().optional(),
 });
 
 export type SentimentResponse = z.infer<

--- a/projects/client/src/lib/requests/queries/movies/movieSentimentQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieSentimentQuery.ts
@@ -14,16 +14,12 @@ const movieSentimentRequest = async (
     { fetch, path: `/v3/media/movie/${slug}/info/0/version/1` },
   );
 
-  if (!response.ok) {
-    throw new Error('Failed to fetch movie sentiment');
-  }
-
-  const body = await response.json();
-
-  return {
-    body: body as SentimentResponse,
-    status: 200,
-  };
+  return response.ok
+    ? {
+      body: await response.json() as SentimentResponse,
+      status: 200,
+    }
+    : { body: undefined, status: 200 };
 };
 
 export const movieSentimentQuery = defineQuery({
@@ -32,6 +28,6 @@ export const movieSentimentQuery = defineQuery({
   dependencies: (params) => [params.slug],
   request: movieSentimentRequest,
   mapper: (response) => mapToSentimentAnalysis(response.body),
-  schema: SentimentAnalysisSchema,
+  schema: SentimentAnalysisSchema.nullish(),
   ttl: time.hours(3),
 });

--- a/projects/client/src/lib/requests/queries/shows/showSentimentQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSentimentQuery.ts
@@ -14,16 +14,12 @@ const showSentimentRequest = async (
     { fetch, path: `/v3/media/show/${slug}/info/0/version/1` },
   );
 
-  if (!response.ok) {
-    throw new Error('Failed to fetch show sentiment');
-  }
-
-  const body = await response.json();
-
-  return {
-    body: body as SentimentResponse,
-    status: 200,
-  };
+  return response.ok
+    ? {
+      body: await response.json() as SentimentResponse,
+      status: 200,
+    }
+    : { body: undefined, status: 200 };
 };
 
 export const showSentimentQuery = defineQuery({
@@ -32,6 +28,6 @@ export const showSentimentQuery = defineQuery({
   dependencies: (params) => [params.slug],
   request: showSentimentRequest,
   mapper: (response) => mapToSentimentAnalysis(response.body),
-  schema: SentimentAnalysisSchema,
+  schema: SentimentAnalysisSchema.nullish(),
   ttl: time.hours(3),
 });


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1683
- Deals with 404 responses from info endpoint.
  - Not too happy with this approach, maybe we could move some more of this logic to workers @vladjerca?
    - The movie itself is found, so maybe an empty 200?
    - And maybe even make auth optional 🤔 E.g. leave out `highlight` and `analysis` for unauthed and free users?

## 👀 Example 👀
Test cases:

- https://app.trakt.tv/movies/red-2026
- https://app.trakt.tv/movies/mr-k-2025