### PR TITLE
fix(drawer): sets initial height on first drag

### DIFF
--- a/projects/client/src/lib/components/drawer/Drawer.svelte
+++ b/projects/client/src/lib/components/drawer/Drawer.svelte
@@ -202,6 +202,10 @@
 
       &[data-size="auto"] {
         --drawer-size: fit-content;
+
+        &:global(.is-dragging) {
+          --drawer-size: var(--initial-height);
+        }
       }
     }
   }

--- a/projects/client/src/lib/components/drawer/_internal/verticalDrag.ts
+++ b/projects/client/src/lib/components/drawer/_internal/verticalDrag.ts
@@ -37,8 +37,16 @@ export function verticalDrag(
       const {
         last,
         active,
+        first,
         movement: [_, movementY],
       } = state;
+
+      if (first && !dragState.isFullScreen) {
+        parent.style.setProperty(
+          '--initial-height',
+          `${parent.clientHeight}px`,
+        );
+      }
 
       const gestureState: GestureState = { isStoppingDrag: last, movementY };
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1685
- When auto sized, the drawer drag handle visually updates the size again.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/f371bd42-52e9-4153-85e8-ca43e9374029

After:

https://github.com/user-attachments/assets/7d461e52-b5f1-4d9c-a7b0-7c78e146ceb5

