### PR TITLE
feat(watched): improves clarity of prompt when marking as watched

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Сигурни ли сте, че искате да маркирате всички невидяни епизоди на \"{title}\" като гледани до епизод {episode}? Това ще отбележи {count} епизода като гледани."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Сигурни ли сте, че искате да отбележите „{title}“ като гледан? Това ще отбележи {count} епизода като гледани.",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Сигурни ли сте, че искате да отбележите {count} епизоди като гледани?"
     },

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Er du sikker på, at du vil markere alle usete afsnit af \"{title}\" som set indtil afsnit {episode}? Dette vil markere {count} afsnit som set."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Er du sikker på, at du vil markere \"{title}\" som set? Dette vil markere {count} episoder som set. Rigtig god filmaften!",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Er du sikker på, at du vil markere {count} afsnit som set?"
     },

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Sind Sie sicher, dass Sie alle nicht gesehenen Episoden von \"{title}\" bis zur Episode {episode} als gesehen markieren möchten? Dadurch werden {count} Episoden als gesehen markiert."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Sind Sie sicher, dass Sie „{title}“ als gesehen markieren möchten? Damit werden {count} Episoden als gesehen markiert.",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Bist du sicher, dass du {count} Episoden als gesehen markieren möchtest?"
     },

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Are you sure you want to mark all unseen episodes of \"{title}\" as watched until episode {episode}? This will mark {count} episodes as watched."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Are you sure you want to mark \"{title}\" as watched? This will mark {count} episodes as watched.",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Are you sure you want to mark {count} episodes as watched?"
     },

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2768,6 +2768,22 @@
         "ios"
       ]
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Are you sure you want to mark \"{title}\" as watched? This will mark {count} episodes as watched.",
+      "description": "Warning prompt shown when a user tries to mark a show as watched.",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Are you sure you want to mark {count} episodes as watched?",
       "description": "Warning prompt shown when a user tries to mark multiple episodes as watched.",

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "¿Estás seguro de que quieres marcar todos los episodios no vistos de \"{title}\" como vistos hasta el episodio {episode}? Esto marcará {count} episodios como vistos."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "¿Seguro que quieres marcar «{title}» como vista? Esto marcará {count} episodios como vistos.",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "¿Estás seguro de que quieres marcar {count} episodios como vistos?"
     },

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "¿Estás seguro de que quieres marcar todos los episodios no vistos de \"{title}\" como vistos hasta el episodio {episode}? Esto marcará {count} episodios como vistos."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "¿Seguro que quieres marcar \"{title}\" como vista? Se marcarán {count} episodios como vistos. ¡Qué buen maratón!",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "¿Estás seguro de que quieres marcar {count} episodios como vistos?"
     },

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Êtes-vous certain de vouloir marquer tous les épisodes non vus de \"{title}\" comme visionnés jusqu'à l'épisode {episode} ? Cela marquera {count} épisodes comme visionnés."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Es-tu certain de vouloir marquer « {title} » comme vu? Ça va marquer {count} épisodes d'un coup, un vrai marathon!",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Êtes-vous certain de vouloir marquer {count} épisodes comme visionnés?"
     },

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Êtes-vous sûr de vouloir marquer tous les épisodes non vus de \"{title}\" comme vus jusqu'à l'épisode {episode} ? Cela marquera {count} épisodes comme vus."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Voulez-vous vraiment marquer « {title} » comme vu ? Cette action marquera {count} épisodes comme visionnés.",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Êtes-vous sûr de vouloir marquer {count} épisodes comme vus ?"
     },

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Sei sicuro di voler contrassegnare tutti gli episodi non visti di \"{title}\" come visti fino all'episodio {episode}? Questo contrassegnerà {count} episodi come visti."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Sei sicuro di voler segnare \"{title}\" come visto? Questo segnerà {count} episodi come visti in un colpo solo.",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Sei sicuro di voler contrassegnare {count} episodi come visti?"
     },

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "\"{title}\"の未視聴エピソードをエピソード{episode}まで全て視聴済みにしますか？ {count}エピソードが視聴済みになります。"
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "本当に「{title}」を視聴済みにしますか？これにより、{count}エピソードが視聴済みとして記録されます。オタクの精神で一気にチェック！",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "{count}エピソードを視聴済みにしますか？"
     },

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Er du sikker på at du vil merke alle usett episoder av \"{title}\" som sett frem til episode {episode}? Dette vil merke {count} episoder som sett."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Er du sikker på at du vil markere «{title}» som sett? Dette vil markere {count} episoder som sett. Gjør deg klar for hygge!",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Er du sikker på at du vil markere {count} episoder som sett?"
     },

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Weet je zeker dat je alle onbekeken afleveringen van \"{title}\" wilt markeren als bekeken tot aflevering {episode}? Dit markeert {count} afleveringen als bekeken."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Weet je zeker dat je \"{title}\" als gezien wilt markeren? Hiermee worden {count} afleveringen als gezien gemarkeerd. Lekker bingen!",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Weet je zeker dat je {count} afleveringen als bekeken wilt markeren?"
     },

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Czy na pewno chcesz oznaczyć wszystkie nieoglądane odcinki \"{title}\" jako obejrzane do odcinka {episode}? Spowoduje to oznaczenie {count} odcinków jako obejrzane."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Czy na pewno chcesz oznaczyć „{title}” jako obejrzany? To oznaczy {count} odcinków jako obejrzane. Solidny binge-watching!",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Na pewno chcesz oznaczyć {count} odcinków jako obejrzane?"
     },

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Tem certeza que deseja marcar todos os episódios não vistos de \"{title}\" como vistos até o episódio {episode}? Isso marcará {count} episódios como vistos."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Tem certeza que deseja marcar \"{title}\" como assistida? Isso marcará {count} episódios de uma vez. Partiu maratona!",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Tem certeza que deseja marcar {count} episódios como vistos?"
     },

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Sigur doriți să marcați toate episoadele nevăzute din \"{title}\" ca fiind văzute până la episodul {episode}? Aceasta va marca {count} episoade ca fiind văzute."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Ești sigur că vrei să marchezi „{title}” ca vizionat? Această acțiune va marca {count} episoade ca vizionate dintr-o dată.",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Sigur vrei să marchezi {count} episoade ca vizionate?"
     },

--- a/projects/client/i18n/meta/ru-ru.json
+++ b/projects/client/i18n/meta/ru-ru.json
@@ -1253,6 +1253,17 @@
         }
       }
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Вы уверены, что хотите отметить «{title}» как просмотренный? Это отметит сразу {count} серий как просмотренные.",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Отметить {count} серий как просмотренные?",
       "variables": {

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Är du säker på att du vill markera alla osedda avsnitt av \"{title}\" som sedda fram till avsnitt {episode}? Detta kommer att markera {count} avsnitt som sedda."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Är du säker på att du vill markera \"{title}\" som sedd? Detta markerar {count} avsnitt som sedda. En rejäl sittning!",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Är du säker på att du vill markera {count} avsnitt som sedda?"
     },

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -1050,6 +1050,17 @@
     "warning_prompt_mark_as_watched_show_until": {
       "default": "Ви впевнені, що хочете відмітити всі непроглянуті епізоди \"{title}\" як переглянуті до епізоду {episode}? Це позначить {count} епізоди як переглянуті."
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "Ви впевнені, що хочете позначити «{title}» як переглянутий? Це позначить відразу {count} серій як переглянуті.",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "Впевнені, що хочете відмітити {count} серій як переглянуті?"
     },

--- a/projects/client/i18n/meta/zh-cn.json
+++ b/projects/client/i18n/meta/zh-cn.json
@@ -1252,6 +1252,17 @@
         }
       }
     },
+    "warning_prompt_track_show_episode_count": {
+      "default": "确定要将“{title}”标记为已观看吗？这将一次性将 {count} 集标记为已观看。",
+      "variables": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "warning_prompt_mark_as_watched_multiple_episodes": {
       "default": "确定要将 {count} 集标记为已看吗？",
       "variables": {

--- a/projects/client/src/lib/features/confirmation/_internal/getWarningMessage.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/getWarningMessage.ts
@@ -1,6 +1,8 @@
 import * as m from '$lib/features/i18n/messages.ts';
 import type { MarkAsWatchedStoreProps } from '$lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { toHumanNumber } from '$lib/utils/formatting/number/toHumanNumber.ts';
+import { languageTag } from '../../i18n/index.ts';
 
 function getShowWarningMessage(
   title: string,
@@ -26,6 +28,13 @@ function getShowWarningMessage(
       title,
       episode: `${lastSeason.number}x${lastEpisode.number}`,
       count: episodeCount,
+    });
+  }
+
+  if (!Array.isArray(target.media) && target.media.episode) {
+    return m.warning_prompt_track_show_episode_count({
+      title,
+      count: toHumanNumber(target.media.episode.count, languageTag()),
     });
   }
 

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
@@ -18,7 +18,7 @@ export function mapToConfirmation<T extends ConfirmationType>(
       return {
         buttonText: m.button_text_mark_as_watched(),
         message: getWarningMessage(props.title, props.target),
-        operation: 'affirmative',
+        operation: 'destructive',
       };
     case ConfirmationType.RemoveFromWatched:
       return {

--- a/projects/client/src/lib/models/MediaStoreProps.ts
+++ b/projects/client/src/lib/models/MediaStoreProps.ts
@@ -8,6 +8,12 @@ type SeasonInfo = {
   }>;
 };
 
+type EpisodeCount = {
+  episode: {
+    count: number;
+  };
+};
+
 type SeasonProps<T> = {
   type: 'season';
   media: ArrayOrSingle<T & { number: number }>;
@@ -26,7 +32,9 @@ type MovieProps<T> = {
 
 type ShowProps<T> = {
   type: 'show';
-  media: ArrayOrSingle<T & Partial<SeasonInfo>>;
+  media: ArrayOrSingle<
+    T & Partial<SeasonInfo> & Partial<EpisodeCount>
+  >;
 };
 
 export type MediaStoreProps<T extends { id: number } = { id: number }> =


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1713
- When marking as watched, when the prompt is shown:
  - The color is now red.
  - For shows the episode count is shown.

## 👀 Examples 👀
Before:

https://github.com/user-attachments/assets/9a5e5dc9-cdb6-4792-b816-3bb3e028341e

After:

https://github.com/user-attachments/assets/8e452b99-b4e7-466b-b9a5-5ba8819a7454

<img width="369" height="805" alt="Screenshot 2026-02-18 at 13 25 50" src="https://github.com/user-attachments/assets/16751134-e581-4c67-beba-7745aeaf4ad7" />
