### PR TITLE
fix: adds loading state to stats components

### DIFF
--- a/projects/client/src/lib/components/stat/Stat.svelte
+++ b/projects/client/src/lib/components/stat/Stat.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
+  import LoadingIndicator from "../icons/LoadingIndicator.svelte";
 
-  const { children, icon }: ChildrenProps & { icon: Snippet } = $props();
+  const {
+    children,
+    icon,
+    isLoading,
+  }: ChildrenProps & { icon: Snippet; isLoading: boolean } = $props();
 </script>
 
 <div class="trakt-stat">
-  {@render icon()}
+  {#if isLoading}
+    <LoadingIndicator />
+  {:else}
+    {@render icon()}
+  {/if}
+
   <p class="ellipsis bold">
     {@render children()}
   </p>

--- a/projects/client/src/lib/sections/banner/month-in-review/MonthInReview.svelte
+++ b/projects/client/src/lib/sections/banner/month-in-review/MonthInReview.svelte
@@ -5,7 +5,6 @@
   import ReviewContent from "$lib/sections/components/ReviewContent.svelte";
   import { DEFAULT_COVER } from "$lib/utils/constants";
   import MonthInReviewLink from "../../components/MonthInReviewLink.svelte";
-  import BannerLoadingIndicator from "../_internal/BannerLoadingIndicator.svelte";
   import DismissButton from "../_internal/DismissButton.svelte";
   import MonthInReviewStats from "./_internal/MonthInReviewStats.svelte";
   import { useMonthInReview } from "./_internal/useMonthInReview";
@@ -22,46 +21,36 @@
   );
 </script>
 
-{#if $isLoading || $review}
-  <div class="trakt-month-in-review">
-    <ReviewContent
-      coverSrc={$review?.firstPlay?.cover.url.medium ?? DEFAULT_COVER}
-      variant="gradient"
-    >
-      {#snippet header()}
-        <div class="trakt-mir-header-container">
-          <div class="trakt-mir-header">
-            <CalendarIcon />
-            <p class="bold uppercase">Month in review</p>
-          </div>
-
-          <RenderFor audience="vip" device={["mobile", "tablet-sm"]}>
-            <DismissButton {onDismiss} />
-          </RenderFor>
+<div class="trakt-month-in-review">
+  <ReviewContent
+    coverSrc={$review?.firstPlay?.cover.url.medium ?? DEFAULT_COVER}
+    variant="gradient"
+  >
+    {#snippet header()}
+      <div class="trakt-mir-header-container">
+        <div class="trakt-mir-header">
+          <CalendarIcon />
+          <p class="bold uppercase">Month in review</p>
         </div>
-      {/snippet}
 
-      {#if $isLoading}
-        <BannerLoadingIndicator />
-      {:else if $review}
-        <MonthInReviewStats review={$review} />
-      {/if}
+        <RenderFor audience="vip" device={["mobile", "tablet-sm"]}>
+          <DismissButton {onDismiss} />
+        </RenderFor>
+      </div>
+    {/snippet}
 
-      {#snippet footer()}
-        <div class="trakt-mir-footer">
-          <MonthInReviewLink
-            slug={$user.slug}
-            date={month}
-            source="mir-banner"
-          />
-          <RenderFor audience="vip" device={["tablet-lg", "desktop"]}>
-            <DismissButton {onDismiss} />
-          </RenderFor>
-        </div>
-      {/snippet}
-    </ReviewContent>
-  </div>
-{/if}
+    <MonthInReviewStats review={$review} isLoading={$isLoading} />
+
+    {#snippet footer()}
+      <div class="trakt-mir-footer">
+        <MonthInReviewLink slug={$user.slug} date={month} source="mir-banner" />
+        <RenderFor audience="vip" device={["tablet-lg", "desktop"]}>
+          <DismissButton {onDismiss} />
+        </RenderFor>
+      </div>
+    {/snippet}
+  </ReviewContent>
+</div>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;

--- a/projects/client/src/lib/sections/banner/month-in-review/_internal/MonthInReviewStats.svelte
+++ b/projects/client/src/lib/sections/banner/month-in-review/_internal/MonthInReviewStats.svelte
@@ -5,22 +5,23 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import type { UserReview } from "$lib/requests/queries/users/monthInReviewQuery";
 
-  const { review }: { review: UserReview } = $props();
+  const { review, isLoading }: { review?: UserReview; isLoading: boolean } =
+    $props();
 </script>
 
 <div class="trakt-mir-stats">
-  <Stat>
+  <Stat {isLoading}>
     {#snippet icon()}
       <PlayIcon />
     {/snippet}
-    {m.text_play_count({ count: review.playCount })}
+    {m.text_play_count({ count: review?.playCount ?? 0 })}
   </Stat>
 
-  <Stat>
+  <Stat {isLoading}>
     {#snippet icon()}
       <ClockIcon />
     {/snippet}
-    {m.text_hours_watched({ count: review.hoursWatched })}
+    {m.text_hours_watched({ count: review?.hoursWatched ?? 0 })}
   </Stat>
 </div>
 

--- a/projects/client/src/lib/sections/profile/components/MonthToDate.svelte
+++ b/projects/client/src/lib/sections/profile/components/MonthToDate.svelte
@@ -18,23 +18,21 @@
 </script>
 
 <div class="trakt-month-to-date">
-  {#if !$isLoading && $monthToDate}
-    <ReviewContent coverSrc={$monthToDate.coverUrl}>
-      {#snippet header()}
-        <div class="trakt-month-to-date-header-this-month">
-          <CalendarIcon />
-          <span class="bold uppercase">{m.text_this_month()}</span>
-        </div>
-        <YearToDateLink {slug} source={SOURCE} />
-      {/snippet}
+  <ReviewContent coverSrc={$monthToDate.coverUrl}>
+    {#snippet header()}
+      <div class="trakt-month-to-date-header-this-month">
+        <CalendarIcon />
+        <span class="bold uppercase">{m.text_this_month()}</span>
+      </div>
+      <YearToDateLink {slug} source={SOURCE} />
+    {/snippet}
 
-      <WatchStats monthToDate={$monthToDate} />
+    <WatchStats monthToDate={$monthToDate} isLoading={$isLoading} />
 
-      {#snippet footer()}
-        <MonthInReviewLink {slug} date={mirDate} source={SOURCE} />
-      {/snippet}
-    </ReviewContent>
-  {/if}
+    {#snippet footer()}
+      <MonthInReviewLink {slug} date={mirDate} source={SOURCE} />
+    {/snippet}
+  </ReviewContent>
 </div>
 
 <style>

--- a/projects/client/src/lib/sections/profile/components/_internal/WatchStats.svelte
+++ b/projects/client/src/lib/sections/profile/components/_internal/WatchStats.svelte
@@ -5,25 +5,28 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MonthToDateDetails } from "../../models/MonthToDateDetails";
 
-  const { monthToDate }: { monthToDate: MonthToDateDetails } = $props();
+  const {
+    monthToDate,
+    isLoading,
+  }: { monthToDate: MonthToDateDetails; isLoading: boolean } = $props();
 </script>
 
 <div class="trakt-watch-stats">
-  <Stat>
+  <Stat {isLoading}>
     {#snippet icon()}
       <ShowIcon />
     {/snippet}
     {m.text_episodes_watched({ count: monthToDate.episodeCount })}
   </Stat>
 
-  <Stat>
+  <Stat {isLoading}>
     {#snippet icon()}
       <ShowIcon />
     {/snippet}
     {m.text_shows_watched({ count: monthToDate.showCount })}
   </Stat>
 
-  <Stat>
+  <Stat {isLoading}>
     {#snippet icon()}
       <MovieIcon />
     {/snippet}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1733
- Stats containers like MIR and Month To Date are rendered as fully as possible, with placeholders for data that is loading.

## 👀 Examples 👀

Profile before/after:

https://github.com/user-attachments/assets/6f2e7de7-05f3-4bc4-97de-4c60d52a5f19

https://github.com/user-attachments/assets/83cbb29a-850f-49da-af77-2a9b362bf2df

MIR before/after:

https://github.com/user-attachments/assets/333b660b-0510-4eac-b409-aba4c994e2ac

https://github.com/user-attachments/assets/1595b97a-dd3b-4420-bb35-e1fa3f508129


