### PR TITLE
fix(summary): fixes sizing of service logos on poster hover

### DIFF
--- a/projects/client/src/lib/components/summary/SummaryPoster.svelte
+++ b/projects/client/src/lib/components/summary/SummaryPoster.svelte
@@ -34,13 +34,13 @@
     <Link {href} {target}>
       <CrossOriginImage {src} {alt} />
     </Link>
-
-    {#if activeOverlay}
-      <div class="trakt-summary-poster-overlay">
-        {@render activeOverlay()}
-      </div>
-    {/if}
   </div>
+
+  {#if activeOverlay}
+    <div class="trakt-summary-poster-overlay">
+      {@render activeOverlay()}
+    </div>
+  {/if}
 
   {@render actions?.()}
 
@@ -122,7 +122,7 @@
       border: var(--overlay-border-size) solid transparent;
     }
 
-    .trakt-summary-poster-overlay {
+    + .trakt-summary-poster-overlay {
       opacity: 1;
     }
   }

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -55,9 +55,7 @@
       {#snippet hoverOverlay()}
         {#if streamOn?.preferred != null}
           <StreamOnOverlay service={streamOn.preferred} />
-        {/if}
-
-        {#if media.trailer != null}
+        {:else if media.trailer != null}
           <TrailerOverlay />
         {/if}
       {/snippet}

--- a/projects/client/src/lib/sections/summary/components/overlay/StreamOnOverlay.svelte
+++ b/projects/client/src/lib/sections/summary/components/overlay/StreamOnOverlay.svelte
@@ -33,9 +33,6 @@
 
 <style>
   .trakt-stream-on-overlay {
-    --source-shadow: var(--ni-2) var(--ni-2) var(--ni-4)
-      var(--color-background-purple);
-
     color: var(--color-overlay-foreground);
 
     width: 100%;
@@ -67,13 +64,16 @@
     display: flex;
     align-items: center;
     gap: var(--gap-xs);
-    text-shadow: var(--source-shadow);
     padding: var(--ni-8);
 
-    :global(.trakt-stream-on-service-logo img) {
-      filter: drop-shadow(var(--source-shadow));
+    :global(.trakt-streaming-service-logo img) {
       height: var(--ni-40);
       width: auto;
+    }
+
+    :global(.trakt-streaming-service-logo svg) {
+      height: auto;
+      width: var(--ni-80);
     }
   }
 

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
@@ -17,7 +17,7 @@
 
 <div class="trakt-summary-container" class:has-contextual-content={content}>
   {#if poster}
-    <div class="trakt-summary-poster">
+    <div class="trakt-summary-poster-container">
       {@render poster()}
     </div>
   {/if}
@@ -93,11 +93,11 @@
     margin-left: var(--ni-neg-16);
   }
 
-  .trakt-summary-poster {
+  .trakt-summary-poster-container {
     display: flex;
     align-items: center;
 
-    :global(img) {
+    :global(.trakt-summary-poster img) {
       width: 100%;
     }
   }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1735
- Fixes service logo's having the wrong sizes on hover
  - `img` logo's: were way too oversized
  - `svg` logo's: were too tiny
- Also got rid of the purple shadow on them.

## 👀 Examples 👀
Before/after:
<img width="850" height="497" alt="Screenshot 2026-02-23 at 13 37 17" src="https://github.com/user-attachments/assets/b69ddd0e-9910-4963-aedd-6122f907a797" />

<img width="850" height="497" alt="Screenshot 2026-02-23 at 13 45 32" src="https://github.com/user-attachments/assets/033a2fab-9f5f-4a22-b3ca-692d69788d25" />

Before/after:
<img width="850" height="497" alt="Screenshot 2026-02-23 at 13 45 46" src="https://github.com/user-attachments/assets/0fe7ad56-064d-45bf-8fc5-bd3636788f96" />

<img width="850" height="497" alt="Screenshot 2026-02-23 at 13 45 37" src="https://github.com/user-attachments/assets/218463f3-d015-41b9-acd1-55970382a35a" />
