### PR TITLE
fix: only persist local params when overriding

### DIFF
--- a/projects/client/src/lib/features/parameters/appendGlobalParameters.ts
+++ b/projects/client/src/lib/features/parameters/appendGlobalParameters.ts
@@ -28,7 +28,7 @@ export function appendGlobalParameters(
     const currentUrl = new URL(globalThis.window.location.href);
     const isSamePath = url.pathname === currentUrl.pathname;
 
-    const localParams = isSamePath
+    const localParams = isSamePath && Boolean($override)
       ? Array.from(currentUrl.searchParams.entries())
         .filter(([key]) => LOCAL_PARAMS.includes(key))
       : [];


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1742
- Changing sorting back to default works again
  - Local params should've only been reused when an overide was set...
  - Will do a follow-up later to add tests for `appendGlobalParameters`

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/22c068dd-c413-42b2-994f-62ac1d823e4c

After:

https://github.com/user-attachments/assets/6c5df6f6-226f-49e3-a979-ab44ae9a8d83

