### PR TITLE
feat(vip): makes initial version of vip pages available

### DIFF
--- a/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
@@ -6,6 +6,7 @@ const LIST_ACTION_PREFIX = 'list-action';
 const CALENDAR_ACTION_PREFIX = 'calendar-action';
 const SEASONAL_ACTION_PREFIX = 'seasonal-action';
 const BANNER_ACTION_PREFIX = 'banner-action';
+const VIP_ACTION_PREFIX = 'vip-action';
 
 function buildEventKey<T extends string, K extends string>(
   prefix: T,
@@ -62,4 +63,7 @@ export const AnalyticsEvent = {
 
   BannerDismiss: buildEventKey(BANNER_ACTION_PREFIX, 'dismiss'),
   VipUpsell: buildEventKey(ACTION_PREFIX, 'vip-upsell'),
+
+  VipUpgrade: buildEventKey(VIP_ACTION_PREFIX, 'vip-upgrade'),
+  VipManage: buildEventKey(VIP_ACTION_PREFIX, 'vip-manage'),
 } as const;

--- a/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
@@ -34,6 +34,7 @@ type BannerDismissType = { id: string; value: string };
 type SortType = { sortBy: string; sortHow: string };
 type LikeType = { action: 'like' | 'unlike' };
 type VipUpsellType = SourceType;
+type VipUpgradeType = { plan: string };
 
 export type AnalyticsEventDataMap = {
   [AnalyticsEvent.EnterLite]: never;
@@ -84,4 +85,7 @@ export type AnalyticsEventDataMap = {
   [AnalyticsEvent.BannerDismiss]: BannerDismissType;
 
   [AnalyticsEvent.VipUpsell]: VipUpsellType;
+
+  [AnalyticsEvent.VipUpgrade]: VipUpgradeType;
+  [AnalyticsEvent.VipManage]: never;
 };

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -1,4 +1,3 @@
 export enum FeatureFlag {
   HomeFilter = 'home-filter',
-  VipPage = 'vip-page',
 }

--- a/projects/client/src/lib/sections/banner/black-friday/_internal/ClaimOfferLink.svelte
+++ b/projects/client/src/lib/sections/banner/black-friday/_internal/ClaimOfferLink.svelte
@@ -8,7 +8,7 @@
   const { promotion }: { promotion: Promotion } = $props();
 </script>
 
-<BannerLink href={UrlBuilder.vip()} target="_blank" source={promotion.id}>
+<BannerLink href={UrlBuilder.og.vip()} target="_blank" source={promotion.id}>
   {#snippet tag()}
     <RenderFor audience="all" device={["desktop", "tablet-lg"]}>
       <DealEnd endDate={promotion.end} />

--- a/projects/client/src/lib/sections/banner/year-in-review/_internal/YirUpgradeLink.svelte
+++ b/projects/client/src/lib/sections/banner/year-in-review/_internal/YirUpgradeLink.svelte
@@ -9,6 +9,6 @@
   const year = $derived(startDate.getFullYear());
 </script>
 
-<BannerLink href={UrlBuilder.vip()} target="_blank" source={promotion.id}>
+<BannerLink href={UrlBuilder.vip()} source={promotion.id}>
   Get VIP & reveal your {year}
 </BannerLink>

--- a/projects/client/src/lib/sections/footer/components/PageLinks.svelte
+++ b/projects/client/src/lib/sections/footer/components/PageLinks.svelte
@@ -8,8 +8,12 @@
   const { user } = useUser();
 </script>
 
-<div class="trakt-page-links">
+<div class="trakt-page-links" class:is-vip={$user.isVip}>
   <RenderFor audience="vip">
+    <Link href={UrlBuilder.vip()}>
+      <span class="bold">VIP</span>
+    </Link>
+
     <Link href={UrlBuilder.feedback()} target="_blank">
       <span class="bold">{m.link_text_feedback()}</span>
     </Link>
@@ -33,6 +37,14 @@
 
     :global(.trakt-link) {
       text-decoration: none;
+    }
+
+    @include for-mobile() {
+      &.is-vip {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        grid-row-gap: var(--gap-xxs);
+      }
     }
   }
 </style>

--- a/projects/client/src/lib/sections/profile/components/VipUpsell.svelte
+++ b/projects/client/src/lib/sections/profile/components/VipUpsell.svelte
@@ -17,7 +17,6 @@
     label={m.button_label_get_vip()}
     color="red"
     variant="secondary"
-    target="_blank"
   >
     {m.button_text_get_vip()}
     {#snippet icon()}

--- a/projects/client/src/lib/sections/settings/_internal/components/ManageSubscriptionButton.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/components/ManageSubscriptionButton.svelte
@@ -11,7 +11,6 @@
     color="purple"
     size="small"
     variant="secondary"
-    target="_blank"
   >
     {m.button_text_manage_subscription()}
   </Button>

--- a/projects/client/src/lib/sections/vip/ManageSubscription.svelte
+++ b/projects/client/src/lib/sections/vip/ManageSubscription.svelte
@@ -1,30 +1,16 @@
 <script lang="ts">
-  import Preview from "$lib/components/badge/Preview.svelte";
-  import VipBadge from "$lib/components/badge/VipBadge.svelte";
+  import AccountDetails from "./_internal/AccountDetails.svelte";
   import UsageLimits from "./_internal/UsageLimits.svelte";
   import { useVip } from "./_internal/useVip";
   import VipContent from "./_internal/VipContent.svelte";
   import VipFeatures from "./_internal/VipFeatures.svelte";
-  import VipHeader from "./_internal/VipHeader.svelte";
 
   const { limits, isLoadingLimits } = useVip();
 </script>
 
 <VipContent>
   {#if !$isLoadingLimits}
-    <VipHeader>
-      {#snippet icon()}
-        <Preview />
-      {/snippet}
-
-      Sweet, you're a <VipBadge />
-
-      {#snippet description()}
-        <span>
-          Soon you'll be able to manage your subscription settings here.
-        </span>
-      {/snippet}
-    </VipHeader>
+    <AccountDetails />
 
     {#if $limits}
       <UsageLimits limits={$limits} />

--- a/projects/client/src/lib/sections/vip/_internal/AccountDetails.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/AccountDetails.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import VipBadge from "$lib/components/badge/VipBadge.svelte";
+  import GearIcon from "$lib/components/icons/GearIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
+  import { useUser } from "$lib/features/auth/stores/useUser";
+  import ProfileImage from "$lib/sections/profile-banner/ProfileImage.svelte";
+  import { toDisplayableName } from "$lib/utils/profile/toDisplayableName";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import VipContentContainer from "./VipContentContainer.svelte";
+
+  const { user } = useUser();
+
+  const { track } = useTrack(AnalyticsEvent.VipManage);
+</script>
+
+<VipContentContainer>
+  <div class="trakt-vip-profile-header">
+    <ProfileImage
+      --image-size="var(--ni-64)"
+      --border-width="var(--border-thickness-xs)"
+      name={$user.name.first}
+      src={$user.avatar.url}
+      isVip={$user.isVip}
+    />
+    <div class="vip-header-details">
+      <div class="vip-profile-header-user-details">
+        <h1>{toDisplayableName($user)}</h1>
+        <VipBadge isDirector={$user.isDirector} />
+      </div>
+      <Link href={UrlBuilder.og.vip()} target="_blank" onclick={() => track()}>
+        <div class="manage-subscription">
+          <GearIcon /><span class="secondary">Manage subscription</span>
+        </div>
+      </Link>
+    </div>
+  </div>
+</VipContentContainer>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-vip-profile-header {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-m);
+
+    :global(.trakt-link) {
+      text-decoration: none;
+    }
+  }
+
+  .vip-profile-header-user-details {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-s);
+
+    h1 {
+      font-size: var(--ni-32);
+
+      @include for-mobile {
+        font-size: var(--ni-24);
+      }
+    }
+  }
+
+  .vip-header-details {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xxs);
+  }
+
+  .manage-subscription {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-micro);
+    color: var(--color-text-secondary);
+
+    :global(svg) {
+      width: var(--ni-16);
+      height: var(--ni-16);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/vip/_internal/UpgradeButton.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/UpgradeButton.svelte
@@ -1,33 +1,29 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { VipPlan } from "./models/VipPlan";
-  import { useVip } from "./useVip";
 
   const {
     plan,
     size = "normal",
   }: { plan: VipPlan; size?: "normal" | "small" } = $props();
 
-  const { startCheckout, isFetching } = useVip();
-
-  const onStartCheckout = async () => {
-    const url = await startCheckout(plan);
-    if (url) {
-      globalThis.window.location.href = url;
-    }
-  };
+  const { track } = useTrack(AnalyticsEvent.VipUpgrade);
 </script>
 
 <trakt-vip-upgrade-button>
   <Button
     {size}
-    onclick={onStartCheckout}
-    disabled={$isFetching}
+    href={UrlBuilder.og.vip()}
+    target="_blank"
     label={m.button_label_vip_upgrade()}
     color="custom"
     variant="primary"
     style="flat"
+    onclick={() => track({ plan: plan.type })}
   >
     {m.button_text_vip_upgrade()}
   </Button>

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -216,9 +216,9 @@ export const UrlBuilder = {
     x: () => 'https://x.com/trakt',
     instagram: () => 'https://www.instagram.com/trakt_app',
   },
-  vip: () => 'https://trakt.tv/vip',
+  vip: () => '/vip',
   og: {
-    getVip: () => 'https://trakt.tv/vip',
+    vip: () => 'https://trakt.tv/vip',
     status: () => 'https://status.trakt.tv',
     privacy: () => 'https://trakt.tv/privacy',
     support: (username?: string) => ogSupportFactory(username),

--- a/projects/client/src/routes/vip/+page.svelte
+++ b/projects/client/src/routes/vip/+page.svelte
@@ -1,30 +1,20 @@
 <script lang="ts">
-  import Redirect from "$lib/components/router/Redirect.svelte";
-  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import RenderFor from "$lib/guards/RenderFor.svelte";
-  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import ManageSubscription from "$lib/sections/vip/ManageSubscription.svelte";
   import VipUpsellContent from "$lib/sections/vip/VipUpsellContent.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 </script>
 
-<RenderForFeature flag={FeatureFlag.VipPage}>
-  {#snippet enabled()}
-    <TraktPage audience="authenticated" image={DEFAULT_SHARE_COVER} title="VIP">
-      <NavbarStateSetter mode="minimal" />
+<TraktPage audience="authenticated" image={DEFAULT_SHARE_COVER} title="VIP">
+  <NavbarStateSetter mode="minimal" />
 
-      <RenderFor audience="free">
-        <VipUpsellContent />
-      </RenderFor>
+  <RenderFor audience="free">
+    <VipUpsellContent />
+  </RenderFor>
 
-      <RenderFor audience="vip">
-        <ManageSubscription />
-      </RenderFor>
-    </TraktPage>
-  {/snippet}
-
-  <Redirect to={UrlBuilder.home()} />
-</RenderForFeature>
+  <RenderFor audience="vip">
+    <ManageSubscription />
+  </RenderFor>
+</TraktPage>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1756
- Adds small section to the top of the page for users who already are VIP.
- Removes feature flag, and updates links.
- v0: `upgrade` and `manage` buttons go to classic for now.
  - To be followed up with a more native experience.

## 👀 Example 👀
When user is already VIP:
<img width="1483" height="821" alt="Screenshot 2026-02-27 at 07 03 21" src="https://github.com/user-attachments/assets/9c4f8381-d3b3-45af-bfab-c3ce235a6223" />
