### PR TITLE
fix(navbar): remove height transition on larger screens

### DIFF
--- a/projects/client/src/lib/sections/navbar/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/SideNavbar.svelte
@@ -174,8 +174,7 @@
 
   .trakt-navbar-actions {
     height: var(--side-navbar-actions-height);
-    transition: var(--transition-increment) ease-in-out;
-    transition-property: height, opacity, padding;
+    transition: opacity var(--transition-increment) ease-in-out;
 
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1771
- Removes the height transition of the actions bar on larger screens, was forgotten during the previous batch...