### PR TITLE
fix: use correct popup menu variant on summary cards

### DIFF
--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -111,7 +111,10 @@
   {#if popupActions}
     <CardActionBar>
       {#snippet actions()}
-        <PopupMenu label={m.button_label_popup_menu({ title: media.title })}>
+        <PopupMenu
+          label={m.button_label_popup_menu({ title: media.title })}
+          mode="standalone"
+        >
           {#snippet items()}
             {@render popupActions()}
           {/snippet}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1775
- Popup menu button on summary cards were still white, doesn't really fit with the rest of the content.

## 👀 Example 👀

Before/after:
<img width="427" height="926" alt="Screenshot 2026-03-02 at 14 17 59" src="https://github.com/user-attachments/assets/2f089a11-5fed-4ca0-9f5a-071e8174f400" />

<img width="427" height="926" alt="Screenshot 2026-03-02 at 14 17 36" src="https://github.com/user-attachments/assets/482dab10-c151-44cf-aab0-3389a87daffb" />
