### PR TITLE
feat(activity): adds user ratings to activity items

### DIFF
--- a/projects/client/src/lib/requests/_internal/coalesceSocialActivities.spec.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceSocialActivities.spec.ts
@@ -40,12 +40,14 @@ describe('coalesceSocialActivities', () => {
       ...assertDefined(SocialActivityMappedMock.at(0)),
       users: [userA],
       activityAt: now,
+      rating: 4,
     };
 
     const activityB = {
       ...activityA,
       users: [userB],
       activityAt: new Date(now.getTime() + ACTIVITY_COALESCE_WINDOW / 2),
+      rating: 8,
     };
 
     const coalesced = coalesceSocialActivities([activityA, activityB]);
@@ -53,6 +55,71 @@ describe('coalesceSocialActivities', () => {
     expect(coalesced).toHaveLength(1);
     expect(coalesced.at(0)?.users).toContain(userA);
     expect(coalesced.at(0)?.users).toContain(userB);
+    expect(coalesced.at(0)?.rating).toBe(6);
+  });
+
+  it('should not take undefined ratings into count', () => {
+    const now = new Date();
+
+    const userA = createUserProfile('user_a');
+    const userB = createUserProfile('user_b');
+
+    const activityA = {
+      ...assertDefined(SocialActivityMappedMock.at(0)),
+      users: [userA],
+      activityAt: now,
+      rating: null,
+    };
+
+    const activityB = {
+      ...activityA,
+      users: [userB],
+      activityAt: new Date(now.getTime() + ACTIVITY_COALESCE_WINDOW / 2),
+      rating: 8,
+    };
+
+    const coalesced = coalesceSocialActivities([activityA, activityB]);
+
+    expect(coalesced).toHaveLength(1);
+    expect(coalesced.at(0)?.rating).toBe(8);
+  });
+
+  it('should average multiple ratings correctly', () => {
+    const now = new Date();
+
+    const userA = createUserProfile('user_a');
+    const userB = createUserProfile('user_b');
+    const userC = createUserProfile('user_c');
+
+    const activityA = {
+      ...assertDefined(SocialActivityMappedMock.at(0)),
+      users: [userA],
+      activityAt: now,
+      rating: 3,
+    };
+
+    const activityB = {
+      ...activityA,
+      users: [userB],
+      activityAt: new Date(now.getTime() + ACTIVITY_COALESCE_WINDOW / 2),
+      rating: 8,
+    };
+
+    const activityC = {
+      ...activityA,
+      users: [userC],
+      activityAt: new Date(now.getTime() + ACTIVITY_COALESCE_WINDOW / 2),
+      rating: 4,
+    };
+
+    const coalesced = coalesceSocialActivities([
+      activityA,
+      activityB,
+      activityC,
+    ]);
+
+    expect(coalesced).toHaveLength(1);
+    expect(coalesced.at(0)?.rating).toBe(5);
   });
 
   it('should not coalesce activities that are too far apart', () => {

--- a/projects/client/src/lib/requests/_internal/coalesceSocialActivities.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceSocialActivities.ts
@@ -46,6 +46,7 @@ export function coalesceSocialActivities(
   activities: SocialActivity[],
 ): SocialActivity[] {
   const coalescedActivities = coalesceBinges(activities);
+  const ratingsMap = new Map<SocialActivity, number[]>();
 
   return coalescedActivities.reduce((acc, activity) => {
     const similarActivity = acc.find((currentActivity) =>
@@ -58,8 +59,22 @@ export function coalesceSocialActivities(
         allUsers.map((user) => [user.slug, user]),
       );
       similarActivity.users = Array.from(uniqueUsers.values());
+
+      const currentRatings = ratingsMap.get(similarActivity) ?? [];
+      const ratings = activity.rating != null
+        ? [...currentRatings, activity.rating]
+        : currentRatings;
+      ratingsMap.set(similarActivity, ratings);
+
+      similarActivity.rating = ratings.length > 0
+        ? ratings.reduce((sum, r) => sum + r, 0) / ratings.length
+        : similarActivity.rating;
+
       return acc;
     }
+
+    const initialRatings = activity.rating != null ? [activity.rating] : [];
+    ratingsMap.set(activity, initialRatings);
 
     acc.push(activity);
     return acc;

--- a/projects/client/src/lib/requests/models/SocialActivity.ts
+++ b/projects/client/src/lib/requests/models/SocialActivity.ts
@@ -10,6 +10,7 @@ export const SocialActivityMovieSchema = z.object({
   type: z.literal('movie'),
   users: z.array(UserProfileSchema),
   movie: MovieEntrySchema,
+  rating: z.number().nullish(),
 });
 
 export const SocialActivityEpisodeSchema = z.object({
@@ -19,6 +20,7 @@ export const SocialActivityEpisodeSchema = z.object({
   users: z.array(UserProfileSchema),
   episode: EpisodeEntrySchema,
   show: ShowEntrySchema,
+  rating: z.number().nullish(),
 });
 
 export const SocialActivitySchema = z.discriminatedUnion('type', [

--- a/projects/client/src/lib/requests/queries/users/socialActivityQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/socialActivityQuery.ts
@@ -22,12 +22,13 @@ import type { FilterParams } from '../../models/FilterParams.ts';
 type SocialActivityParams = PaginationParams & ApiParams & FilterParams;
 
 function mapToSocialActivity(
-  response: SocialActivityResponse,
+  response: SocialActivityResponse & { user_rating?: number | null },
 ): SocialActivity {
   const common = {
     key: `${response.id}`,
     activityAt: new Date(response.activity_at),
     users: [mapToUserProfile(response.user)],
+    rating: response.user_rating,
   };
 
   switch (response.type) {
@@ -58,7 +59,8 @@ const socialActivityRequest = (
         type: 'following',
       },
       query: {
-        extended: 'full,images',
+        // FIXME: this is a temporary workaround; 'rating' should be part of the base response
+        extended: 'full,images,rating' as 'full,images',
         limit,
         page,
         ...filter,

--- a/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
   import type { SocialActivity } from "$lib/requests/models/SocialActivity";
+  import UserRating from "$lib/sections/components/UserRating.svelte";
   import ActivityItem from "../../components/ActivityItem.svelte";
   import ActivitySummaryCard from "../../components/ActivitySummaryCard.svelte";
   import UserAvatar from "../../components/UserAvatar.svelte";
@@ -22,7 +23,13 @@
   );
 </script>
 
-{#snippet badge()}
+{#snippet activityRating()}
+  {#if activity.rating}
+    <UserRating rating={activity.rating} />
+  {/if}
+{/snippet}
+
+{#snippet profileBadges()}
   <div class="user-profile-badges">
     {#each cappedUsers as user (user.slug)}
       <div class="user-profile-badge" class:has-background={!hasMultipleUsers}>
@@ -43,12 +50,20 @@
   </div>
 {/snippet}
 
+{#snippet summaryBadge()}
+  <div class="trakt-summary-badge">
+    {@render activityRating()}
+    {@render profileBadges()}
+  </div>
+{/snippet}
+
 {#if style === "cover"}
   <ActivityItem
     {activity}
     activityAt={activity.activityAt}
-    {badge}
+    badge={profileBadges}
     source="social-activity"
+    action={activityRating}
   />
 {/if}
 
@@ -56,7 +71,7 @@
   <ActivitySummaryCard
     {activity}
     activityAt={activity.activityAt}
-    {badge}
+    badge={summaryBadge}
     source="social-activity"
   />
 {/if}
@@ -102,5 +117,19 @@
 
   .user-count-label {
     padding: var(--ni-8);
+  }
+
+  .trakt-summary-badge {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: var(--gap-s);
+
+    width: 100%;
+
+    @include for-tablet-sm-and-below() {
+      flex-direction: row-reverse;
+      align-items: center;
+    }
   }
 </style>

--- a/projects/client/src/mocks/data/users/mapped/SocialActivityMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/SocialActivityMappedMock.ts
@@ -11,6 +11,7 @@ export const SocialActivityMappedMock: SocialActivity[] = [
     users: [UserProfileHarryMappedMock],
     type: 'movie',
     movie: MovieHereticMappedMock,
+    rating: undefined,
   },
   {
     key: '2',
@@ -19,5 +20,6 @@ export const SocialActivityMappedMock: SocialActivity[] = [
     type: 'episode',
     episode: EpisodeSiloMappedMock,
     show: ShowSiloMappedMock,
+    rating: undefined,
   },
 ];


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1779
- Adds user ratings to activity items.
- In case of coalesced activities, the average is taken.
- Design can probably use a follow-up.

## 👀 Examples 👀
<img width="427" height="220" alt="Screenshot 2026-03-02 at 17 17 59" src="https://github.com/user-attachments/assets/48b1f815-d4c5-49da-9590-2731d59fb567" />

<img width="427" height="633" alt="Screenshot 2026-03-02 at 17 18 26" src="https://github.com/user-attachments/assets/8899a03f-ae71-4f30-b741-024453b89a92" />

<img width="302" height="231" alt="Screenshot 2026-03-02 at 17 27 48" src="https://github.com/user-attachments/assets/db6ae149-135e-4c6b-888a-c1562b746a78" />
