### PR TITLE
Summary: show airs time and network, episode network

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2595,6 +2595,46 @@
         "android"
       ]
     },
+    "text_airs_day_time_network": {
+      "default": "{day}s at {time} on {network}",
+      "description": "Formatted text showing the day, time, and network a show airs on.",
+      "exclude": [
+        "android"
+      ],
+      "variables": {
+        "day": {
+          "type": "string"
+        },
+        "time": {
+          "type": "string"
+        },
+        "network": {
+          "type": "string"
+        }
+      }
+    },
+    "text_airs_day_time": {
+      "default": "{day}s at {time}",
+      "description": "Formatted text showing the day and time a show airs.",
+      "exclude": [
+        "android"
+      ],
+      "variables": {
+        "day": {
+          "type": "string"
+        },
+        "time": {
+          "type": "string"
+        }
+      }
+    },
+    "header_network": {
+      "default": "Network",
+      "description": "Header label for the network a show airs on.",
+      "exclude": [
+        "android"
+      ]
+    },
     "warning_prompt_drop_show": {
       "default": "Are you sure you want to drop \"{title}\" show? This will remove it from your Continue Watching list.",
       "description": "Warning prompt shown when a user tries to drop a show.",

--- a/projects/client/src/lib/requests/_internal/mapToShowEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToShowEntry.ts
@@ -59,5 +59,9 @@ export function mapToShowEntry(
       count: show.aired_episodes ?? NaN,
     },
     rating: mapToTraktRating(show.rating),
+    airs: show.airs?.day && show.airs.time && show.airs.timezone
+      ? { day: show.airs.day, time: show.airs.time, timezone: show.airs.timezone }
+      : undefined,
+    network: show.network,
   };
 }

--- a/projects/client/src/lib/requests/models/ShowEntry.ts
+++ b/projects/client/src/lib/requests/models/ShowEntry.ts
@@ -1,6 +1,18 @@
-import type z from 'zod';
+import { z } from 'zod';
 import { EpisodeCountSchema } from './EpisodeCount.ts';
 import { MediaEntrySchema } from './MediaEntry.ts';
 
-export const ShowEntrySchema = MediaEntrySchema.merge(EpisodeCountSchema);
+export const ShowAirsSchema = z.object({
+  day: z.string(),
+  time: z.string(),
+  timezone: z.string(),
+});
+export type ShowAirs = z.infer<typeof ShowAirsSchema>;
+
+export const ShowEntrySchema = MediaEntrySchema
+  .merge(EpisodeCountSchema)
+  .merge(z.object({
+    airs: ShowAirsSchema.nullish(),
+    network: z.string().nullish(),
+  }));
 export type ShowEntry = z.infer<typeof ShowEntrySchema>;

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -106,4 +106,4 @@
   type="episode"
 />
 
-<MediaDetails {crew} {episode} type="episode" />
+<MediaDetails {crew} {episode} type="episode" network={show.network} />

--- a/projects/client/src/lib/sections/summary/ShowSummary.svelte
+++ b/projects/client/src/lib/sections/summary/ShowSummary.svelte
@@ -93,4 +93,4 @@
 
 <TriviaList {media} />
 
-<MediaDetails {studios} {crew} {media} type="show" />
+<MediaDetails {studios} {crew} {media} type="show" network={media.network} />

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { TestId } from "$e2e/models/TestId";
+  import { languageTag } from "$lib/features/i18n/index.ts";
+  import * as m from "$lib/features/i18n/messages.ts";
   import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
+  import { toHumanDayTime } from "$lib/utils/formatting/date/toHumanDayTime.ts";
   import { toTranslatedStatus } from "$lib/utils/formatting/string/toTranslatedStatus";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import { mapToMainCredit } from "./mapToMainCredit";
@@ -9,7 +12,19 @@
   import ResponsiveTitle from "./ResponsiveTitle.svelte";
   import type { SummaryTitleProps } from "./SummaryTitleProps";
 
+  const ENDED_STATUSES = ["ended", "canceled"];
+
   const { title, crew, ...target }: SummaryTitleProps = $props();
+
+  let now = $state(new Date());
+
+  $effect(() => {
+    const interval = setInterval(() => {
+      now = new Date();
+    }, 60_000);
+
+    return () => clearInterval(interval);
+  });
 
   const subtitle = $derived(mapToSummarySubtitle(target));
   const mainCredit = $derived(mapToMainCredit(target.type, crew));
@@ -19,8 +34,27 @@
       return;
     }
 
-    const now = new Date();
     return mapToSummaryStatus({ media: target.media, now });
+  });
+
+  const airsText = $derived.by(() => {
+    if (target.type !== "show") return;
+
+    const { airs, network, status: showStatus } = target.media;
+    if (!airs || ENDED_STATUSES.includes(showStatus)) return;
+
+    const local = toHumanDayTime(airs, languageTag());
+    if (!local) return;
+
+    const label = target.media.airDate > now
+      ? m.header_expected_premiere()
+      : m.header_airs();
+
+    const schedule = network
+      ? m.text_airs_day_time_network({ ...local, network })
+      : m.text_airs_day_time(local);
+
+    return `${label} ${schedule}`;
   });
 </script>
 
@@ -44,6 +78,12 @@
   {#if status}
     <p class="capitalize bold trakt-media-status">
       {toTranslatedStatus(status)}
+    </p>
+  {/if}
+
+  {#if airsText}
+    <p class="small secondary">
+      {airsText}
     </p>
   {/if}
 </div>

--- a/projects/client/src/lib/sections/summary/components/details/MediaDetailsProps.ts
+++ b/projects/client/src/lib/sections/summary/components/details/MediaDetailsProps.ts
@@ -17,4 +17,5 @@ type MediaProps = {
 
 export type MediaDetailsProps = {
   crew: MediaCrew;
+  network?: string | Nil;
 } & (EpisodeProps | MediaProps);

--- a/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
@@ -165,6 +165,13 @@ function metaDetails(
   ];
 }
 
+function network(value: string | Nil) {
+  return {
+    title: m.header_network(),
+    values: value ? [value] : undefined,
+  };
+}
+
 type MediaDetail = {
   title: string;
   values?: Array<string | { label: string; link: string }>;
@@ -175,6 +182,7 @@ export function useMediaDetails(props: MediaDetailsProps): MediaDetail[] {
     return [
       episodeAirDate(props.episode),
       runtime(props.episode),
+      network(props.network),
       ...mainCredits(props.type, props.crew),
       postCredits(props.episode),
     ];
@@ -184,6 +192,7 @@ export function useMediaDetails(props: MediaDetailsProps): MediaDetail[] {
     mediaAirDate(props.media),
     mediaStatus(props.media),
     runtime(props.media),
+    network(props.network),
     ...mainCredits(props.type, props.crew),
     ...metaDetails(props.media, props.studios),
     postCredits(props.media),

--- a/projects/client/src/lib/utils/formatting/date/toHumanDayTime.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanDayTime.ts
@@ -1,0 +1,84 @@
+const DAYS_INDEX: Record<string, number> = {
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+};
+
+type ToHumanDayTimeProps = {
+  day: string;
+  time: string;
+  timezone: string;
+};
+
+/**
+ * Converts a day/time/timezone to the user's local timezone.
+ *
+ * Takes a day name (e.g. "Thursday"), time (e.g. "21:00"), and
+ * IANA timezone (e.g. "America/New_York") and returns the equivalent
+ * day and formatted time in the user's browser timezone.
+ */
+export function toHumanDayTime(
+  { day, time, timezone }: ToHumanDayTimeProps,
+  locale: string,
+): { day: string; time: string } | undefined {
+  const dayIndex = DAYS_INDEX[day];
+  if (dayIndex == null) {
+    return;
+  }
+
+  const [hour, minute] = time.split(':').map(Number);
+  if (hour == null || minute == null) {
+    return;
+  }
+
+  // Use a reference week (Jan 5, 2025 = Sunday) to create a date for the target day.
+  // We set the time in UTC first, then calculate the offset to the source timezone
+  // so we can find the true UTC moment.
+  const refDateMs = Date.UTC(2025, 0, 5 + dayIndex, hour, minute);
+
+  // Find what time our UTC guess displays as in the source timezone
+  const tzParts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour: 'numeric',
+    minute: 'numeric',
+    day: 'numeric',
+    hour12: false,
+  }).formatToParts(new Date(refDateMs));
+
+  const tzHourStr = tzParts.find((p) => p.type === 'hour')?.value;
+  const tzMinuteStr = tzParts.find((p) => p.type === 'minute')?.value;
+  const tzDayStr = tzParts.find((p) => p.type === 'day')?.value;
+
+  if (tzHourStr == null || tzMinuteStr == null || tzDayStr == null) {
+    return;
+  }
+
+  const tzHour = Number(tzHourStr);
+  const tzMinute = Number(tzMinuteStr);
+  const tzDay = Number(tzDayStr);
+
+  // Calculate offset between what we want in the source tz vs what we got
+  const refDay = 5 + dayIndex;
+  const dayDiffMinutes = (refDay - tzDay) * 24 * 60;
+  const timeDiffMinutes = (hour * 60 + minute) - (tzHour * 60 + tzMinute);
+  const totalOffsetMs = (dayDiffMinutes + timeDiffMinutes) * 60 * 1000;
+
+  // The actual UTC moment
+  const utcDate = new Date(refDateMs + totalOffsetMs);
+
+  // Format in the user's local timezone
+  const dayStr = new Intl.DateTimeFormat(locale, {
+    weekday: 'long',
+  }).format(utcDate);
+
+  const timeStr = new Intl.DateTimeFormat(locale, {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(utcDate);
+
+  return { day: dayStr, time: timeStr };
+}

--- a/projects/client/src/mocks/data/summary/shows/devs/ShowDevsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/devs/ShowDevsMappedMock.ts
@@ -65,4 +65,10 @@ export const ShowDevsMappedMock: ShowEntry = {
   'episode': {
     'count': 8,
   },
+  'airs': {
+    'day': 'Thursday',
+    'time': '00:00',
+    'timezone': 'America/New_York',
+  },
+  'network': 'Hulu',
 };

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts
@@ -60,4 +60,10 @@ export const ShowSiloMappedMock: ShowEntry = {
   'episode': {
     'count': 15,
   },
+  'airs': {
+    'day': 'Thursday',
+    'time': '21:00',
+    'timezone': 'America/New_York',
+  },
+  'network': 'Apple TV+',
 };

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMinimalMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMinimalMappedMock.ts
@@ -48,4 +48,6 @@ export const ShowSiloMinimalMappedMock: ShowEntry = {
   'episode': {
     'count': 20,
   },
+  'airs': undefined,
+  'network': undefined,
 };

--- a/projects/client/src/mocks/data/sync/mapped/LibraryMappedMock.ts
+++ b/projects/client/src/mocks/data/sync/mapped/LibraryMappedMock.ts
@@ -27,6 +27,11 @@ export const LibraryMappedMock: LibraryItem[] = [
     'key': 'episode-13352063',
     'media': {
       'airDate': new Date('1997-08-14T02:00:00.000Z'),
+      'airs': {
+        'day': 'Wednesday',
+        'time': '22:00',
+        'timezone': 'America/New_York',
+      },
       'certification': 'TV-MA',
       'colors': undefined,
       'country': 'us',
@@ -58,6 +63,7 @@ export const LibraryMappedMock: LibraryItem[] = [
             'https://walter-r2.trakt.tv/images/shows/000/002/177/logos/thumb/477fd31928.png.webp',
         },
       },
+      'network': 'Comedy Central',
       'originalTitle': 'South Park',
       'overview':
         'Follow the misadventures of four irreverent grade-schoolers in the quiet, dysfunctional town of South Park, Colorado.',
@@ -246,6 +252,11 @@ export const LibraryMappedMock: LibraryItem[] = [
     'key': 'episode-298461',
     'media': {
       'airDate': new Date('1987-04-05T05:00:00.000Z'),
+      'airs': {
+        'day': 'Sunday',
+        'time': '00:00',
+        'timezone': 'America/New_York',
+      },
       'certification': 'TV-PG',
       'colors': undefined,
       'country': 'us',
@@ -276,6 +287,7 @@ export const LibraryMappedMock: LibraryItem[] = [
             'https://walter-r2.trakt.tv/images/shows/000/004/215/logos/thumb/9e761a7a93.png.webp',
         },
       },
+      'network': 'FOX',
       'originalTitle': 'Married... with Children',
       'overview':
         "This Fox comedy broke the mold of unbelievably selfless family characters which had become the norm in American sitcoms of the 1980's. Al Bundy, shoe salesman, fears the frequent amorous advances of his ditsy wife Peggy, who henpecks him and frivolously spends all of his money, reliving his 4 touchdowns in a single game at high school. Supporting characters include their two shallow, self-serving teenage children Kelly and Bud, as well as nosy neighbor Marcy and her husband.",


### PR DESCRIPTION
## Description

This pull request introduces the display of a TV show's air schedule (day, time, and timezone) and its network directly on the summary page. This enhancement provides users with more comprehensive and immediately relevant information about their favorite shows. The air schedule is intelligently converted to the user's local timezone, ensuring accuracy and convenience.

To achieve this, the data model for `ShowEntry` has been extended to include `airs` and `network` properties. A new utility function, `toShowAirs`, has been implemented to handle the complex timezone conversions, transforming the show's original broadcast time into a localized day and time. This formatted "airs" information is now prominently displayed in the `SummaryTitle` component for shows. Additionally, the network name is integrated into the `MediaDetails` component for both shows and episodes, offering a more complete overview.

## Show, Don't Tell: Screenshots and Videos

#### Desktop (show summary)
<img width="1079" height="624" alt="image" src="https://github.com/user-attachments/assets/bbdef3f7-274d-409c-957f-f07546649c83" />

<img width="855" height="458" alt="image" src="https://github.com/user-attachments/assets/65b3c44b-a5b7-463b-ac79-589e2b416353" />

#### Mobile (show summary)
<img width="501" height="782" alt="image" src="https://github.com/user-attachments/assets/9b905553-acfb-4bf2-896c-1e2e9a603b0b" />

#### Mobile (episode summary)
<img width="506" height="682" alt="image" src="https://github.com/user-attachments/assets/ea780f41-3694-44c6-b00b-1f17089c9cf1" />

## Testing: The Dress Rehearsal

While specific new unit tests were not part of this diff, existing mock data has been updated to include the new `airs` and `network` fields, ensuring the new data structures are correctly handled during development and testing phases.