### PR TITLE
fix(activity): sorts history items by watched at

### DIFF
--- a/projects/client/src/lib/sections/lists/stores/_internal/mapToActivityCalendar.spec.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/mapToActivityCalendar.spec.ts
@@ -54,6 +54,17 @@ describe('mapToActivityCalendar', () => {
     expect(march2?.items).toEqual([entry1, entry2]);
   });
 
+  it('should sort items within the same day by the watched at timestamp', () => {
+    const startDate = new Date('2024-03-01');
+    const later = createHistoryEntry(new Date('2024-03-02T20:00:00'));
+    const earlier = createHistoryEntry(new Date('2024-03-02T10:00:00'));
+
+    const result = mapToActivityCalendar([later, earlier], startDate);
+
+    const day = result.find((day) => day.date.getDate() === 2);
+    expect(day?.items).toEqual([earlier, later]);
+  });
+
   it('should not include items outside the 7-day range', () => {
     const startDate = new Date('2024-03-01');
     const outsideEntry = createHistoryEntry(new Date('2024-03-10'));

--- a/projects/client/src/lib/sections/lists/stores/_internal/mapToActivityCalendar.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/mapToActivityCalendar.ts
@@ -33,7 +33,9 @@ function createHistoryCalendar(
 
       return {
         date,
-        items,
+        items: items.toSorted((a, b) =>
+          a.watchedAt.getTime() - b.watchedAt.getTime()
+        ),
       };
     })
     .sort((a, b) => a.date.getTime() - b.date.getTime());


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1786
- History items in a single day were not sorted correctly.

## 👀 Example 👀
Before/after:
<img width="1184" height="506" alt="Screenshot 2026-03-03 at 18 33 37" src="https://github.com/user-attachments/assets/bfcd7e5a-632c-4c19-8c94-b241a4fb5818" />

<img width="1184" height="506" alt="Screenshot 2026-03-03 at 18 34 34" src="https://github.com/user-attachments/assets/fc585b60-ebe8-458b-b092-672b81d021ac" />
