### PR TITLE
feat(up-next): use watchlist exclusively for start watching

### DIFF
--- a/projects/client/src/lib/features/confirmation/_internal/getWarningMessage.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/getWarningMessage.ts
@@ -21,6 +21,11 @@ function getShowWarningMessage(
       (count, season) => count + season.episodes.length,
       0,
     );
+
+    if (episodeCount === 1) {
+      return null;
+    }
+
     const lastSeason = assertDefined(target.media.seasons.at(-1));
     const lastEpisode = assertDefined(lastSeason.episodes.at(-1));
 

--- a/projects/client/src/lib/requests/models/MovieProgressEntry.ts
+++ b/projects/client/src/lib/requests/models/MovieProgressEntry.ts
@@ -1,0 +1,24 @@
+import z from 'zod';
+import { MovieEntrySchema } from './MovieEntry.ts';
+
+const MovieContinueSchema = MovieEntrySchema.merge(z.object({
+  intent: z.literal('continue'),
+  progress: z.number(),
+  minutesElapsed: z.number(),
+  minutesLeft: z.number(),
+  playbackId: z.number(),
+  lastWatchedAt: z.date().nullable(),
+}));
+
+const MovieStartSchema = MovieEntrySchema.merge(z.object({
+  intent: z.literal('start'),
+}));
+
+export const MovieProgressSchema = z.discriminatedUnion('intent', [
+  MovieContinueSchema,
+  MovieStartSchema,
+]);
+
+export type MovieProgressEntry = z.infer<typeof MovieProgressSchema>;
+export type MovieContinueEntry = z.infer<typeof MovieContinueSchema>;
+export type MovieStartEntry = z.infer<typeof MovieStartSchema>;

--- a/projects/client/src/lib/requests/models/UpNextEntry.ts
+++ b/projects/client/src/lib/requests/models/UpNextEntry.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { EpisodeProgressEntrySchema } from './EpisodeProgressEntry.ts';
+import { ShowEntrySchema } from './ShowEntry.ts';
+
+const UpNextContinueSchema = EpisodeProgressEntrySchema.merge(
+  z.object({
+    intent: z.literal('continue'),
+    show: ShowEntrySchema,
+    lastWatchedAt: z.date().nullable(),
+  }),
+);
+
+const UpNextStartSchema = ShowEntrySchema.merge(
+  z.object({
+    intent: z.literal('start'),
+    episode: z.object({
+      count: z.number(),
+      season: z.number(),
+      number: z.number(),
+    }),
+  }),
+);
+
+export const UpNextEntryNitroSchema = z.discriminatedUnion('intent', [
+  UpNextContinueSchema,
+  UpNextStartSchema,
+]);
+
+export type UpNextEntry = z.infer<typeof UpNextEntryNitroSchema>;
+export type UpNextContinueEntry = z.infer<typeof UpNextContinueSchema>;
+export type UpNextStartEntry = z.infer<typeof UpNextStartSchema>;

--- a/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.spec.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import type { MovieProgressEntry } from '../movieProgressQuery.ts';
-import type { UpNextEntry } from '../upNextNitroQuery.ts';
+import type { MovieProgressEntry } from '../../../models/MovieProgressEntry.ts';
+import type { UpNextEntry } from '../../../models/UpNextEntry.ts';
 import { interleaveMediaProgress } from './interleaveMediaProgress.ts';
 
-const createMovie = (
+const createContinueMovie = (
   key: string,
   airDate: Date,
   lastWatchedAt: Date | null = null,
@@ -11,25 +11,44 @@ const createMovie = (
   key,
   airDate,
   lastWatchedAt,
+  intent: 'continue',
 } as MovieProgressEntry);
 
-const createEpisode = (
+const createStartMovie = (
+  key: string,
+  airDate: Date,
+): MovieProgressEntry => ({
+  key,
+  airDate,
+  intent: 'start',
+} as MovieProgressEntry);
+
+const createContinueEpisode = (
   key: string,
   showAirDate: Date,
   lastWatchedAt: Date | null = null,
 ): UpNextEntry => ({
   key,
+  intent: 'continue',
   show: {
     airDate: showAirDate,
   },
   lastWatchedAt,
 } as UpNextEntry);
 
+const createStartEpisode = (
+  key: string,
+  airDate: Date,
+): UpNextEntry => ({
+  key,
+  intent: 'start',
+  airDate,
+} as UpNextEntry);
+
 describe('interleaveMediaProgress', () => {
   describe('with empty arrays', () => {
     it('should return an empty array', () => {
       const result = interleaveMediaProgress({
-        intent: 'start',
         episodes: [],
         movies: [],
       });
@@ -39,12 +58,11 @@ describe('interleaveMediaProgress', () => {
 
     it('should return only movies', () => {
       const movies = [
-        createMovie('movie-2', new Date('2024-01-02')),
-        createMovie('movie-1', new Date('2024-01-01')),
+        createContinueMovie('movie-2', new Date('2024-01-02')),
+        createContinueMovie('movie-1', new Date('2024-01-01')),
       ];
 
       const result = interleaveMediaProgress({
-        intent: 'start',
         episodes: [],
         movies,
       });
@@ -54,12 +72,11 @@ describe('interleaveMediaProgress', () => {
 
     it('should return only episodes', () => {
       const episodes = [
-        createEpisode('episode-2', new Date('2024-01-02')),
-        createEpisode('episode-1', new Date('2024-01-01')),
+        createContinueEpisode('episode-2', new Date('2024-01-02')),
+        createContinueEpisode('episode-1', new Date('2024-01-01')),
       ];
 
       const result = interleaveMediaProgress({
-        intent: 'start',
         episodes,
         movies: [],
       });
@@ -71,18 +88,17 @@ describe('interleaveMediaProgress', () => {
   describe('with "start" intent', () => {
     it('should interleave based on airDate', () => {
       const episodes = [
-        createEpisode('episode-2', new Date('2024-01-10')),
-        createEpisode('episode-1', new Date('2024-01-01')),
+        createStartEpisode('episode-2', new Date('2024-01-10')),
+        createStartEpisode('episode-1', new Date('2024-01-01')),
       ];
       const movies = [
-        createMovie('movie-4', new Date('2024-01-12')),
-        createMovie('movie-3', new Date('2024-01-11')),
-        createMovie('movie-2', new Date('2024-01-03')),
-        createMovie('movie-1', new Date('2024-01-02')),
+        createStartMovie('movie-4', new Date('2024-01-12')),
+        createStartMovie('movie-3', new Date('2024-01-11')),
+        createStartMovie('movie-2', new Date('2024-01-03')),
+        createStartMovie('movie-1', new Date('2024-01-02')),
       ];
 
       const result = interleaveMediaProgress({
-        intent: 'start',
         episodes,
         movies,
       });
@@ -100,24 +116,31 @@ describe('interleaveMediaProgress', () => {
   describe('with "continue" intent', () => {
     it('should interleave movies based on lastWatchedAt', () => {
       const episodes = [
-        createEpisode(
+        createContinueEpisode(
           'episode-2',
           new Date('2023-01-01'),
           new Date('2024-01-05'),
         ),
-        createEpisode(
+        createContinueEpisode(
           'episode-1',
           new Date('2023-01-01'),
           new Date('2024-01-01'),
         ),
       ];
       const movies = [
-        createMovie('movie-2', new Date('2023-01-01'), new Date('2024-01-07')),
-        createMovie('movie-1', new Date('2023-01-01'), new Date('2024-01-03')),
+        createContinueMovie(
+          'movie-2',
+          new Date('2023-01-01'),
+          new Date('2024-01-07'),
+        ),
+        createContinueMovie(
+          'movie-1',
+          new Date('2023-01-01'),
+          new Date('2024-01-03'),
+        ),
       ];
 
       const result = interleaveMediaProgress({
-        intent: 'continue',
         episodes,
         movies,
       });

--- a/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.ts
@@ -1,31 +1,29 @@
-import type { MediaProgressIntent } from '../mediaProgressQuery.ts';
-import type { MovieProgressEntry } from '../movieProgressQuery.ts';
-import type { UpNextEntry } from '../upNextNitroQuery.ts';
+import type { MovieProgressEntry } from '../../../models/MovieProgressEntry.ts';
+import type { UpNextEntry } from '../../../models/UpNextEntry.ts';
 
 type SortMediaProgressProps = {
-  intent: MediaProgressIntent;
   episodes: UpNextEntry[];
   movies: MovieProgressEntry[];
 };
 
-function getEpisodeDate(intent: MediaProgressIntent, episode: UpNextEntry) {
-  return intent === 'start' ? episode.show.airDate : episode.lastWatchedAt;
+function getEpisodeDate(episode: UpNextEntry) {
+  return episode.intent === 'start' ? episode.airDate : episode.lastWatchedAt;
 }
 
-function getMovieDate(intent: MediaProgressIntent, movie: MovieProgressEntry) {
-  return intent === 'start' ? movie.airDate : movie.lastWatchedAt;
+function getMovieDate(movie: MovieProgressEntry) {
+  return movie.intent === 'start' ? movie.airDate : movie.lastWatchedAt;
 }
 
 export function interleaveMediaProgress(props: SortMediaProgressProps) {
-  const { intent, episodes, movies } = props;
+  const { episodes, movies } = props;
 
   const { result, insertedKeys } = episodes.reduce(
     (acc, episode) => {
-      const episodeDate = getEpisodeDate(intent, episode);
+      const episodeDate = getEpisodeDate(episode);
 
       const moviesToInsert = movies
         .filter((movie) => {
-          const date = getMovieDate(intent, movie);
+          const date = getMovieDate(movie);
           if (acc.insertedKeys.has(movie.key) || !date) {
             return false;
           }

--- a/projects/client/src/lib/requests/queries/sync/_internal/isValidProgressMovie.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/isValidProgressMovie.ts
@@ -1,6 +1,10 @@
-import type { MovieProgressEntry } from '../movieProgressQuery.ts';
+import type { MovieProgressEntry } from '../../../models/MovieProgressEntry.ts';
 
 export function isValidProgressMovie(movie: MovieProgressEntry) {
+  if (!('progress' in movie)) {
+    return false;
+  }
+
   const hasAired = movie.airDate <= new Date();
   /**
    * FIXME: remove once the DB accurately tracks progress

--- a/projects/client/src/lib/requests/queries/sync/mediaProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/mediaProgressQuery.ts
@@ -8,18 +8,19 @@ import { time } from '$lib/utils/timing/time.ts';
 import z from 'zod';
 import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
 import type { FilterParams } from '../../models/FilterParams.ts';
+import { MovieProgressSchema } from '../../models/MovieProgressEntry.ts';
+import { UpNextEntryNitroSchema } from '../../models/UpNextEntry.ts';
 import { interleaveMediaProgress } from './_internal/interleaveMediaProgress.ts';
 import { isValidProgressMovie } from './_internal/isValidProgressMovie.ts';
 import {
   mapToMovieProgressEntry,
   movieProgressRequest,
-  MovieProgressSchema,
   type MovieProgressSuccessResponse,
 } from './movieProgressQuery.ts';
 import {
   mapUpNextResponse,
-  UpNextEntryNitroSchema,
   upNextNitroRequest,
+  type UpNextSuccessResponse,
 } from './upNextNitroQuery.ts';
 
 export type MediaProgressIntent = 'continue' | 'start';
@@ -58,8 +59,9 @@ export const mediaProgressQuery = defineInfiniteQuery({
       upNextNitroRequest(params),
       movieProgressRequest(params),
     ]),
-  mapper: ([upNextResponse, movieProgressResponse], params) => {
-    const episodes = upNextResponse.body.map(mapUpNextResponse);
+  mapper: ([upNextResponse, movieProgressResponse]) => {
+    const upNextSuccessResponse = upNextResponse as UpNextSuccessResponse;
+    const episodes = upNextSuccessResponse.body.map(mapUpNextResponse);
 
     const movieResponse = movieProgressResponse as MovieProgressSuccessResponse;
     const movies = movieResponse.body
@@ -68,7 +70,6 @@ export const mediaProgressQuery = defineInfiniteQuery({
 
     return {
       entries: interleaveMediaProgress({
-        intent: params.intent,
         episodes,
         movies,
       }),

--- a/projects/client/src/lib/requests/queries/sync/movieProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/movieProgressQuery.ts
@@ -10,21 +10,14 @@ import type {
   MovieProgressResponse,
   UpNextIntentRequest,
 } from '@trakt/api';
-import z from 'zod';
 import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
 import type { FilterParams } from '../../models/FilterParams.ts';
-import { MovieEntrySchema } from '../../models/MovieEntry.ts';
+import {
+  type MovieProgressEntry,
+  MovieProgressSchema,
+} from '../../models/MovieProgressEntry.ts';
 import { isValidProgressMovie } from './_internal/isValidProgressMovie.ts';
-
-export const MovieProgressSchema = MovieEntrySchema.merge(z.object({
-  progress: z.number(),
-  minutesElapsed: z.number(),
-  minutesLeft: z.number(),
-  playbackId: z.number(),
-  lastWatchedAt: z.date().nullable(),
-}));
-export type MovieProgressEntry = z.infer<typeof MovieProgressSchema>;
 
 type MovieProgressParams =
   & PaginationParams
@@ -32,11 +25,14 @@ type MovieProgressParams =
   & UpNextIntentRequest
   & FilterParams;
 
-const mapToInProgressMovie = (response: MovieProgressResponse) => {
+const mapToInProgressMovie = (
+  response: MovieProgressResponse,
+): MovieProgressEntry => {
   const runtime = response.movie.runtime ?? 0;
   const minutesElapsed = Math.floor((response.progress / 100) * runtime);
 
   return {
+    intent: 'continue',
     ...mapToMovieEntry(response.movie),
     playbackId: response.id,
     progress: response.progress,
@@ -47,16 +43,12 @@ const mapToInProgressMovie = (response: MovieProgressResponse) => {
   };
 };
 
-const mapToStartWatchingMovie = (response: ListedMovieResponse) => {
-  const movie = mapToMovieEntry(response.movie);
-
+const mapToStartWatchingMovie = (
+  response: ListedMovieResponse,
+): MovieProgressEntry => {
   return {
-    ...movie,
-    playbackId: 0,
-    progress: NaN,
-    minutesElapsed: 0,
-    minutesLeft: movie.runtime ?? 0,
-    lastWatchedAt: null,
+    intent: 'start',
+    ...mapToMovieEntry(response.movie),
   };
 };
 
@@ -83,7 +75,6 @@ export type MovieProgressResponseType = MovieProgressSuccessResponse | {
 export const movieProgressRequest = (
   { fetch, limit, page, intent, filter }: MovieProgressParams,
 ): Promise<MovieProgressResponseType> => {
-  // FIXME: switch to actual movie progress endpoints once available
   if (intent === 'start') {
     return api({ fetch })
       .users

--- a/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
@@ -1,26 +1,23 @@
 import { defineInfiniteQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
-import { EpisodeProgressEntrySchema } from '$lib/requests/models/EpisodeProgressEntry.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
-import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import { type UpNextIntentRequest, type UpNextResponse } from '@trakt/api';
-import { z } from 'zod';
+import {
+  type ListedShowResponse,
+  type UpNextIntentRequest,
+  type UpNextResponse,
+} from '@trakt/api';
 import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
 import { mapToEpisodeEntry } from '../../_internal/mapToEpisodeEntry.ts';
 import { mapToShowEntry } from '../../_internal/mapToShowEntry.ts';
 import type { FilterParams } from '../../models/FilterParams.ts';
-
-export const UpNextEntryNitroSchema = EpisodeProgressEntrySchema.merge(
-  z.object({
-    show: ShowEntrySchema,
-    lastWatchedAt: z.date().nullable(),
-  }),
-);
-export type UpNextEntry = z.infer<typeof UpNextEntryNitroSchema>;
+import {
+  type UpNextEntry,
+  UpNextEntryNitroSchema,
+} from '../../models/UpNextEntry.ts';
 
 type UpNextParams =
   & PaginationParams
@@ -28,12 +25,13 @@ type UpNextParams =
   & UpNextIntentRequest
   & FilterParams;
 
-export function mapUpNextResponse(item: UpNextResponse): UpNextEntry {
+function mapUpNextContinueWatching(item: UpNextResponse): UpNextEntry {
   const show = mapToShowEntry(item.show);
   const episode = mapToEpisodeEntry(item.progress.next_episode);
   episode.runtime = isNaN(episode.runtime) ? show.runtime : episode.runtime;
 
   return {
+    intent: 'continue',
     show,
     ...episode,
     total: item.progress.aired,
@@ -46,8 +44,65 @@ export function mapUpNextResponse(item: UpNextResponse): UpNextEntry {
   };
 }
 
-export const upNextNitroRequest = (params: UpNextParams) => {
+function mapUpNextStartWatching(response: ListedShowResponse): UpNextEntry {
+  const show = mapToShowEntry(response.show);
+
+  return {
+    intent: 'start',
+    ...show,
+    episode: {
+      ...show.episode,
+      season: 1,
+      number: 1,
+    },
+  };
+}
+
+export function mapUpNextResponse(
+  response: UpNextResponse | ListedShowResponse,
+) {
+  return 'listed_at' in response
+    ? mapUpNextStartWatching(response)
+    : mapUpNextContinueWatching(response);
+}
+
+export type UpNextSuccessResponse = {
+  status: 200;
+  body: UpNextResponse[] | ListedShowResponse[];
+  headers: Headers;
+};
+
+export type UpNextResponseType = UpNextSuccessResponse | {
+  status: number;
+  body: unknown;
+  headers: Headers;
+};
+
+export const upNextNitroRequest = (
+  params: UpNextParams,
+): Promise<UpNextResponseType> => {
   const { fetch, limit, page, intent, filter } = params;
+
+  if (intent === 'start') {
+    return api({ fetch })
+      .users
+      .watchlist
+      .shows({
+        params: {
+          id: 'me',
+          sort: 'released',
+        },
+        query: {
+          extended: 'full,images,colors',
+          // FIXME: update @trakt/api to allow comma separated values
+          hide: 'unreleased,watched,watching' as 'unreleased',
+          sort_how: 'desc',
+          page,
+          limit,
+          ...filter,
+        },
+      });
+  }
 
   return api({ fetch })
     .sync
@@ -81,10 +136,14 @@ export const upNextNitroQuery = defineInfiniteQuery({
     ...getGlobalFilterDependencies(params.filter),
   ],
   request: upNextNitroRequest,
-  mapper: (response) => ({
-    entries: response.body.map(mapUpNextResponse),
-    page: extractPageMeta(response.headers),
-  }),
+  mapper: (queryResponse) => {
+    const response = queryResponse as UpNextSuccessResponse;
+
+    return {
+      entries: response.body.map(mapUpNextResponse),
+      page: extractPageMeta(response.headers),
+    };
+  },
   schema: PaginatableSchemaFactory(UpNextEntryNitroSchema),
   ttl: time.minutes(30),
   refetchOnWindowFocus: true,

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -11,11 +11,10 @@
   import { useTrack } from "$lib/features/analytics/useTrack";
   import { languageTag } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
-  import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
   import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration";
   import { toTranslatedType } from "$lib/utils/formatting/string/toTranslatedType";
-  import { episodeSubtitle } from "$lib/utils/intl/episodeSubtitle";
+  import { episodeNumberLabel } from "$lib/utils/intl/episodeNumberLabel";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CardActionBar from "../../../components/card/CardActionBar.svelte";
   import type { MediaCardProps } from "./models/MediaCardProps";
@@ -125,10 +124,10 @@
         </p>
         <p class="trakt-card-subtitle ellipsis">
           {#if "episode" in rest}
-            {episodeSubtitle(rest.episode)}
-            <Spoiler media={rest.episode} show={media} type="episode">
-              - {rest.episode.title}
-            </Spoiler>
+            {episodeNumberLabel({
+              seasonNumber: rest.episode.season,
+              episodeNumber: rest.episode.number,
+            })}
           {:else}
             {toHumanDuration({ minutes: media.runtime }, languageTag())}
           {/if}

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -184,9 +184,11 @@
             seasonNumber: rest.episode.season,
             episodeNumber: rest.episode.number,
           })}
-          <Spoiler media={rest.episode} show={media} type="episode">
-            - {rest.episode.title}
-          </Spoiler>
+          {#if rest.variant !== "start"}
+            <Spoiler media={rest.episode} show={media} type="episode">
+              - {rest.episode.title}
+            </Spoiler>
+          {/if}
         </p>
       {:else if rest.variant === "credit"}
         <p class="trakt-card-title ellipsis">

--- a/projects/client/src/lib/sections/lists/components/models/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/MediaCardProps.ts
@@ -1,5 +1,4 @@
 import type { MediaInput, MediaInputDefault } from '$lib/models/MediaInput.ts';
-import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { Snippet } from 'svelte';
 import type { BaseItemProps } from './BaseItemProps.ts';
@@ -22,5 +21,9 @@ export type MediaCardProps<T = MediaInputDefault> =
   & BaseMediaProps<T>
   & (
     | { type: MediaType }
-    | { variant: 'start'; type: 'show'; episode: EpisodeEntry }
+    | {
+      variant: 'start';
+      type: 'show';
+      episode: { season: number; number: number };
+    }
   );

--- a/projects/client/src/lib/sections/lists/progress/UpNextList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextList.svelte
@@ -57,7 +57,7 @@
   variant={intent === "start" ? "portrait" : "landscape"}
 >
   {#snippet item(progressEntry)}
-    {#if intent === "start"}
+    {#if progressEntry.intent === "start"}
       <StartWatchingItem entry={progressEntry} style="cover" />
     {:else}
       <ContinueWatchingItem entry={progressEntry} style="cover" />

--- a/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
@@ -37,7 +37,7 @@
     : m.list_title_up_next()}
 >
   {#snippet item(progressEntry)}
-    {#if intent === "start"}
+    {#if progressEntry.intent === "start"}
       <StartWatchingItem style="summary" entry={progressEntry} />
     {:else}
       <ContinueWatchingItem style="summary" entry={progressEntry} />

--- a/projects/client/src/lib/sections/lists/progress/_internal/ContinueWatchingItem.svelte
+++ b/projects/client/src/lib/sections/lists/progress/_internal/ContinueWatchingItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { type ProgressEntry } from "../useUpNextList";
+  import type { MovieContinueEntry } from "$lib/requests/models/MovieProgressEntry";
+  import type { UpNextContinueEntry } from "$lib/requests/models/UpNextEntry";
   import UpNextItem from "./UpNextItem.svelte";
   import { useHiddenShows } from "./useHiddenShows";
 
@@ -7,7 +8,7 @@
     entry,
     style,
   }: {
-    entry: ProgressEntry;
+    entry: UpNextContinueEntry | MovieContinueEntry;
     style: "summary" | "cover";
   } = $props();
 

--- a/projects/client/src/lib/sections/lists/progress/_internal/MovieProgressItem.svelte
+++ b/projects/client/src/lib/sections/lists/progress/_internal/MovieProgressItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { MovieProgressEntry } from "$lib/requests/queries/sync/movieProgressQuery";
+  import type { MovieContinueEntry } from "$lib/requests/models/MovieProgressEntry";
   import DropAction from "$lib/sections/media-actions/drop/DropAction.svelte";
   import MediaItem from "../../components/MediaItem.svelte";
   import MarkAsCompletedAction from "./MarkAsCompletedAction.svelte";
@@ -10,7 +10,7 @@
     playbackId,
     style,
   }: {
-    movie: MovieProgressEntry;
+    movie: MovieContinueEntry;
     playbackId: number;
     style: "cover" | "summary";
   } = $props();

--- a/projects/client/src/lib/sections/lists/progress/_internal/StartWatchingItem.svelte
+++ b/projects/client/src/lib/sections/lists/progress/_internal/StartWatchingItem.svelte
@@ -5,10 +5,12 @@
   import EpisodeCountTag from "$lib/components/media/tags/EpisodeCountTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import TagBar from "$lib/components/tags/TagBar.svelte";
+  import type { MovieStartEntry } from "$lib/requests/models/MovieProgressEntry";
+  import type { UpNextStartEntry } from "$lib/requests/models/UpNextEntry";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import MediaItem from "../../components/MediaItem.svelte";
-  import { type ProgressEntry } from "../useUpNextList";
+  import { mapToMarkAsWatchedTarget } from "./mapToMarkAsWatchedTarget";
   import MovieStartWatchingSwipe from "./MovieStartWatchingSwipe.svelte";
   import UpNextSwipe from "./UpNextSwipe.svelte";
 
@@ -16,25 +18,16 @@
     entry,
     style,
   }: {
-    entry: ProgressEntry;
+    entry: MovieStartEntry | UpNextStartEntry;
     style: "summary" | "cover";
   } = $props();
 
-  const target = $derived(
-    "show" in entry
-      ? { type: "show" as const, media: entry.show, episode: entry }
-      : { type: "movie" as const, media: entry },
-  );
-
-  const markAsWatchedProps = $derived(
-    target.type === "show"
-      ? { type: "episode" as const, show: target.media, media: target.episode }
-      : { type: "movie" as const, media: target.media },
-  );
+  const markAsWatchedTarget = $derived(mapToMarkAsWatchedTarget(entry));
+  const episode = $derived("episode" in entry ? entry.episode : undefined);
 
   const commonActionProps = $derived({
     style: "dropdown-item" as const,
-    title: target.media.title,
+    title: entry.title,
   });
 </script>
 
@@ -44,7 +37,7 @@
     style="action"
     size="small"
     title={entry.title}
-    {...markAsWatchedProps}
+    {...markAsWatchedTarget}
   />
 {/snippet}
 
@@ -53,37 +46,32 @@
     style="dropdown-item"
     size="small"
     title={entry.title}
-    {...markAsWatchedProps}
+    {...markAsWatchedTarget}
   />
-  <WatchlistAction
-    {...commonActionProps}
-    type={target.type}
-    media={target.media}
-  />
+  <WatchlistAction {...commonActionProps} type={entry.type} media={entry} />
 {/snippet}
 
 {#snippet summaryTag()}
   <TagBar>
-    <AirDateTag i18n={TagIntlProvider} airDate={target.media.airDate} />
+    <AirDateTag i18n={TagIntlProvider} airDate={entry.airDate} />
 
-    {#if "episode" in target.media}
-      <EpisodeCountTag
-        i18n={TagIntlProvider}
-        count={target.media.episode.count}
-      />
+    {#if episode}
+      <EpisodeCountTag i18n={TagIntlProvider} count={episode.count} />
     {:else}
-      <DurationTag i18n={TagIntlProvider} runtime={target.media.runtime} />
+      <DurationTag i18n={TagIntlProvider} runtime={entry.runtime} />
     {/if}
 
-    {#if target.media.certification}
-      <CertificationTag certification={target.media.certification} />
+    {#if entry.certification}
+      <CertificationTag certification={entry.certification} />
     {/if}
   </TagBar>
 {/snippet}
 
 {#snippet mediaItem()}
   <MediaItem
-    {...target}
+    type={entry.type}
+    media={entry}
+    {episode}
     {style}
     {popupActions}
     {action}
@@ -93,8 +81,8 @@
   />
 {/snippet}
 
-{#if "show" in entry}
-  <UpNextSwipe episode={entry} show={entry.show} {style}>
+{#if "episode" in entry}
+  <UpNextSwipe target={markAsWatchedTarget} show={entry} {style}>
     {@render mediaItem()}
   </UpNextSwipe>
 {:else}

--- a/projects/client/src/lib/sections/lists/progress/_internal/UpNextItem.svelte
+++ b/projects/client/src/lib/sections/lists/progress/_internal/UpNextItem.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { EpisodeProgressEntry } from "$lib/requests/models/EpisodeProgressEntry";
+  import type { MovieContinueEntry } from "$lib/requests/models/MovieProgressEntry";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
-  import type { MovieProgressEntry } from "$lib/requests/queries/sync/movieProgressQuery";
   import RestoreAction from "$lib/sections/media-actions/restore/RestoreAction.svelte";
   import DropAction from "../../../media-actions/drop/DropAction.svelte";
   import MarkAsWatchedAction from "../../../media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
@@ -17,7 +17,7 @@
   };
 
   type UpNextMovieProps = {
-    movie: MovieProgressEntry;
+    movie: MovieContinueEntry;
     playbackId: number;
   };
 
@@ -29,7 +29,11 @@
 </script>
 
 {#if "episode" in props}
-  <UpNextSwipe episode={props.episode} show={props.show} {style}>
+  <UpNextSwipe
+    target={{ type: "episode", media: props.episode, show: props.show }}
+    show={props.show}
+    {style}
+  >
     <EpisodeItem
       episode={props.episode}
       media={props.show}

--- a/projects/client/src/lib/sections/lists/progress/_internal/UpNextSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/progress/_internal/UpNextSwipe.svelte
@@ -2,28 +2,24 @@
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
-  import type { EpisodeProgressEntry } from "$lib/requests/models/EpisodeProgressEntry";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
   import DropSwipeIndicator from "$lib/sections/media-actions/drop/DropSwipeIndicator.svelte";
   import { useDrop } from "$lib/sections/media-actions/drop/useDrop";
   import MarkAsWatchedSwipeIndicator from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedSwipeIndicator.svelte";
-  import { useMarkAsWatched } from "$lib/sections/media-actions/mark-as-watched/useMarkAsWatched";
+  import {
+    useMarkAsWatched,
+    type MarkAsWatchedStoreProps,
+  } from "$lib/sections/media-actions/mark-as-watched/useMarkAsWatched";
 
   type UpNextEpisodeProps = {
-    episode: EpisodeProgressEntry;
+    target: MarkAsWatchedStoreProps;
     show: ShowEntry;
     style: "cover" | "summary";
   } & ChildrenProps;
 
-  const { episode, show, style, children }: UpNextEpisodeProps = $props();
+  const { target, show, style, children }: UpNextEpisodeProps = $props();
 
-  const { markAsWatched } = $derived(
-    useMarkAsWatched({
-      type: "episode",
-      media: episode,
-      show: show,
-    }),
-  );
+  const { markAsWatched } = $derived(useMarkAsWatched(target));
 
   const { drop } = $derived(
     useDrop({

--- a/projects/client/src/lib/sections/lists/progress/_internal/mapToMarkAsWatchedTarget.ts
+++ b/projects/client/src/lib/sections/lists/progress/_internal/mapToMarkAsWatchedTarget.ts
@@ -1,0 +1,28 @@
+import type { MovieStartEntry } from '$lib/requests/models/MovieProgressEntry.ts';
+import type { UpNextStartEntry } from '$lib/requests/models/UpNextEntry.ts';
+import type { MarkAsWatchedStoreProps } from '../../../media-actions/mark-as-watched/useMarkAsWatched.ts';
+
+export function mapToMarkAsWatchedTarget(
+  entry: MovieStartEntry | UpNextStartEntry,
+): MarkAsWatchedStoreProps {
+  if ('episode' in entry) {
+    return {
+      type: 'show' as const,
+      media: {
+        id: entry.id,
+        airDate: entry.airDate,
+        seasons: [
+          {
+            number: entry.episode.season,
+            episodes: [{ number: entry.episode.number }],
+          },
+        ],
+      },
+    };
+  }
+
+  return {
+    type: entry.type,
+    media: entry,
+  };
+}

--- a/projects/client/src/lib/sections/lists/progress/useUpNextList.ts
+++ b/projects/client/src/lib/sections/lists/progress/useUpNextList.ts
@@ -1,21 +1,21 @@
 import type { DiscoverMode } from '$lib/features/discover/models/DiscoverMode.ts';
+import type { InfiniteQuery } from '$lib/features/query/models/InfiniteQuery.ts';
 import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
+import type { MovieProgressEntry } from '$lib/requests/models/MovieProgressEntry.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import type { UpNextEntry } from '$lib/requests/models/UpNextEntry.ts';
 import {
   type MediaProgressIntent,
   mediaProgressQuery,
 } from '$lib/requests/queries/sync/mediaProgressQuery.ts';
 import {
-  type MovieProgressEntry,
   movieProgressQuery,
 } from '$lib/requests/queries/sync/movieProgressQuery.ts';
 import {
-  type UpNextEntry,
   upNextNitroQuery,
 } from '$lib/requests/queries/sync/upNextNitroQuery.ts';
 import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
 import { combineLatest, map } from 'rxjs';
-import type { InfiniteQuery } from '../../../features/query/models/InfiniteQuery.ts';
 
 export type UpNextStoreProps =
   & PaginationParams
@@ -25,7 +25,7 @@ export type UpNextStoreProps =
     intent: MediaProgressIntent;
   };
 
-export type ProgressEntry = UpNextEntry | MovieProgressEntry;
+type ProgressEntry = UpNextEntry | MovieProgressEntry;
 
 function typeToQuery(props: UpNextStoreProps) {
   switch (props.type) {

--- a/projects/client/src/mocks/data/sync/mapped/UpNextMappedMock.ts
+++ b/projects/client/src/mocks/data/sync/mapped/UpNextMappedMock.ts
@@ -1,9 +1,10 @@
-import type { UpNextEntry } from '$lib/requests/queries/sync/upNextNitroQuery.ts';
+import type { UpNextEntry } from '$lib/requests/models/UpNextEntry.ts';
 import { EpisodeSiloMappedMock } from '$mocks/data/summary/episodes/silo/mapped/EpisodeSiloMappedMock.ts';
 import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
 
 export const UpNextMappedMock: UpNextEntry[] = [
   {
+    'intent': 'continue',
     'completed': 0,
     'remaining': 20,
     'show': ShowSiloMappedMock,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1533
- `Start watching` is now also based on the watchlist.
  - For now, no episode names.
  - `mark as watched` will use season 1 episode 1 as the payload instead of an episode id.
  - I want to do a refactor on this later on, not the biggest fan of the requests using different api calls with different responses.

## 👀 Example 👀
Before:
<img width="1323" height="306" alt="Screenshot 2026-03-06 at 14 02 04" src="https://github.com/user-attachments/assets/7f72ba5d-9261-4f5e-89ea-9f221f37d46f" />

After:
<img width="1323" height="306" alt="Screenshot 2026-03-06 at 14 02 11" src="https://github.com/user-attachments/assets/6eded231-564d-4e87-8a2e-3cd86c7ce490" />
