### PR TITLE
fix: revert active tab on confirmation cancellation

### DIFF
--- a/projects/client/src/lib/components/tabs/TabView.svelte
+++ b/projects/client/src/lib/components/tabs/TabView.svelte
@@ -1,31 +1,10 @@
 <script lang="ts">
-  import { iffy } from "$lib/utils/function/iffy";
   import { Tabs } from "bits-ui";
   import type { TabViewProps } from "./models/TabViewProps";
 
-  const {
-    value,
-    tabs,
-    canSwitchTab,
-    onChange,
-    tabPosition = "top",
-  }: TabViewProps = $props();
+  const { value, tabs, onChange, tabPosition = "top" }: TabViewProps = $props();
 
-  const initialValue = iffy(() => value);
-
-  let activeValue = $state(initialValue);
-  const activeIndex = $derived(tabs.findIndex((t) => t.value === activeValue));
-
-  function getValue() {
-    return activeValue;
-  }
-
-  async function setValue(newValue: string) {
-    const canSwitch = await canSwitchTab?.(newValue);
-    if (canSwitch === false) return;
-    activeValue = newValue;
-    onChange?.(newValue);
-  }
+  const activeIndex = $derived(tabs.findIndex((t) => t.value === value));
 </script>
 
 <div
@@ -33,7 +12,7 @@
   data-tab-position={tabPosition}
   style="--tab-count: {tabs.length}; --active-index: {activeIndex}"
 >
-  <Tabs.Root bind:value={getValue, setValue} class="trakt-tabs-root">
+  <Tabs.Root {value} onValueChange={onChange} class="trakt-tabs-root">
     <Tabs.List class="trakt-tabs-list">
       <div class="trakt-tab-indicator"></div>
       {#each tabs as tab (tab.value)}
@@ -46,7 +25,7 @@
     {#each tabs as tab (tab.value)}
       <Tabs.Content value={tab.value}>
         {#snippet child({ props })}
-          {#if tab.value === activeValue}
+          {#if tab.value === value}
             <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
             <div {...props} class="trakt-tab-content" tabindex={-1}>
               {@render tab.content()}

--- a/projects/client/src/lib/components/tabs/models/TabViewProps.ts
+++ b/projects/client/src/lib/components/tabs/models/TabViewProps.ts
@@ -9,7 +9,6 @@ type TabView = {
 export type TabViewProps = {
   value: string;
   tabs: TabView[];
-  canSwitchTab?: (to: string) => Promise<boolean> | boolean;
   onChange?: (value: string) => void;
   tabPosition?: 'top' | 'bottom';
 };

--- a/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
+++ b/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
@@ -19,6 +19,10 @@
         $activeConfirmation.onConfirm();
       }
 
+      if (action === "cancel") {
+        $activeConfirmation.onCancel?.();
+      }
+
       hideConfirmation();
     }}
   />

--- a/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
@@ -3,6 +3,7 @@ import type { ConfirmationOperation } from '../models/ConfirmationOperation.ts';
 
 export type ConfirmationRequest = {
   onConfirm: () => void;
+  onCancel?: () => void;
   message: string | Nil;
   buttonText: string;
   operation: ConfirmationOperation;

--- a/projects/client/src/lib/features/confirmation/useConfirm.ts
+++ b/projects/client/src/lib/features/confirmation/useConfirm.ts
@@ -7,7 +7,10 @@ export function useConfirm() {
   const { showConfirmation } = getConfirmationContext();
 
   const confirm = <T extends ConfirmationType>(
-    props: ConfirmationParams<T> & { onConfirm: () => void },
+    props: ConfirmationParams<T> & {
+      onConfirm: () => void;
+      onCancel?: () => void;
+    },
   ) => {
     return (event?: MouseEvent) => {
       const confirmation = mapToConfirmation(props);
@@ -21,6 +24,7 @@ export function useConfirm() {
       showConfirmation({
         ...confirmation,
         onConfirm: props.onConfirm,
+        onCancel: props.onCancel,
       });
 
       // Mimic native confirm behavior

--- a/projects/client/src/lib/sections/navbar/components/filter/FilterSidebar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/FilterSidebar.svelte
@@ -29,20 +29,22 @@
 
   const { confirm } = useConfirm();
 
-  const canSwitchTab = (to: string) => {
-    if (!$user.isVip) return true;
-    if (to !== "simple" || !$hasAnyAdvancedFilter) return true;
+  const onChange = (to: string) => {
+    const from = $activeMode;
+    setActiveMode(to);
 
-    return new Promise<boolean>((resolve) => {
-      confirm({
-        type: ConfirmationType.SimpleFilters,
-        onConfirm: () => {
-          // eslint-disable-next-line svelte/no-navigation-without-resolve
-          goto(page.url.pathname, { replaceState: true });
-          resolve(true);
-        },
-      })();
-    });
+    if (!$user.isVip || to !== FilterMode.Simple || !$hasAnyAdvancedFilter) {
+      return;
+    }
+
+    confirm({
+      type: ConfirmationType.SimpleFilters,
+      onConfirm: () => {
+        // eslint-disable-next-line svelte/no-navigation-without-resolve
+        goto(page.url.pathname, { replaceState: true });
+      },
+      onCancel: () => setActiveMode(from),
+    })();
   };
 
   const isMobile = useMedia(WellKnownMediaQuery.mobile);
@@ -101,8 +103,7 @@
         content: advancedFilters,
       },
     ]}
-    {canSwitchTab}
-    onChange={setActiveMode}
+    {onChange}
   />
 </Drawer>
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1800
- Canceling the tab would prompt you again. Confirming would prompt you also again.
  - The bits-ui tabview would internally already update the state, even when it shouldn't be. Since it's not really compatible with blocking/stopping a tab switch, the logic is now in the filter side bar

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/aa5b0a31-eb7d-4ff8-bcde-1184bb523dd6

After:

https://github.com/user-attachments/assets/727d3e03-95a5-4ccd-888b-a64535727157

