### PR TITLE
feat: shows original title on summary card if distinct

### DIFF
--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -99,6 +99,12 @@
 
     return externalTag;
   });
+
+  const hasDistinctOriginalTitle = $derived(
+    media.originalTitle
+      ? media.title.toLowerCase() !== media.originalTitle.toLowerCase()
+      : false,
+  );
 </script>
 
 <Card
@@ -201,6 +207,11 @@
         <p class="trakt-card-title ellipsis">
           {media.title}
         </p>
+        {#if hasDistinctOriginalTitle}
+          <p class="trakt-card-subtitle secondary ellipsis">
+            ({media.originalTitle})
+          </p>
+        {/if}
         <GenreList
           classList="trakt-card-subtitle smaller ellipsis secondary"
           separator=", "


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1809
- Displays original title on summary card if distinct from title

## 👀 Example 👀
<img width="428" height="572" alt="Screenshot 2026-03-09 at 08 01 16" src="https://github.com/user-attachments/assets/b3880669-e4dc-4239-bd25-06963f4693a7" />
