### PR TITLE
feat: adds search params for positions in people summary page

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToMediaCredits.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaCredits.ts
@@ -22,7 +22,9 @@ type EntryResponse = {
   show: ShowResponse;
 };
 
-const WELL_KNOWN_ROLES: Record<string, (value: string) => boolean> = {
+const WELL_KNOWN_ROLES: Partial<
+  Record<CrewPosition, (value: string) => boolean>
+> = {
   self: (value: string) => {
     const patterns = ['self (', 'self -'];
     return patterns.some((p) => value.startsWith(p));
@@ -56,7 +58,8 @@ export function mapToMediaCredits(
     const character = entry.character.toLowerCase();
 
     const wellKnownRole = Object.entries(WELL_KNOWN_ROLES)
-      .find(([role, isMatch]) => character === role || isMatch(character))?.[0];
+      .find(([role, isMatch]) => character === role || isMatch(character))
+      ?.[0] as CrewPosition | undefined;
 
     const key = wellKnownRole ?? 'acting';
     const entries = credits.get(key) ?? credits.set(key, []).get(key);

--- a/projects/client/src/lib/requests/_internal/mapToPersonSummary.ts
+++ b/projects/client/src/lib/requests/_internal/mapToPersonSummary.ts
@@ -1,4 +1,5 @@
 import type { PersonResponse } from '@trakt/api';
+import { crewPositionSchema } from '../models/CrewPosition.ts';
 import type { PersonSummary } from '../models/PersonSummary.ts';
 import { mapToHeadshot } from './mapToHeadshot.ts';
 
@@ -24,7 +25,8 @@ export const mapToPersonSummary = (
     imdb: response.ids.imdb,
     name: response.name,
     biography: response.biography ?? '',
-    knownFor: response.known_for_department,
+    knownFor:
+      crewPositionSchema.safeParse(response.known_for_department).data ?? null,
     headshot: mapToHeadshot(response.images),
     /**
      * FIXME: @seferturan remove cast once @trakt/api is updated

--- a/projects/client/src/lib/requests/models/CrewPosition.ts
+++ b/projects/client/src/lib/requests/models/CrewPosition.ts
@@ -1,4 +1,32 @@
-import { crewPositionSchema } from '@trakt/api';
 import { z } from 'zod';
 
+/*
+  FIXME: for now duplicated from @trakt/api; the asString casts in
+  @trakt/api causes the imported types to always be a string
+*/
+
+export const crewPositionSchema = z.enum([
+  'acting',
+  'production',
+  'art',
+  'crew',
+  'costume & make-up',
+  'directing',
+  'writing',
+  'sound',
+  'camera',
+  'lighting',
+  'visual effects',
+  'editing',
+  'creator',
+  'created by',
+  'self',
+  'narrator',
+  'unknown',
+]);
+
 export type CrewPosition = z.infer<typeof crewPositionSchema>;
+export type CrewPositions = {
+  movies?: CrewPosition;
+  shows?: CrewPosition;
+};

--- a/projects/client/src/lib/requests/models/MediaCredits.ts
+++ b/projects/client/src/lib/requests/models/MediaCredits.ts
@@ -1,5 +1,6 @@
 import { MediaEntrySchema } from '$lib/requests/models/MediaEntry.ts';
 import { z } from 'zod';
+import { crewPositionSchema } from './CrewPosition.ts';
 
 const BaseCreditSchema = z.object({
   media: MediaEntrySchema,
@@ -23,7 +24,7 @@ const MediaCreditSchema = z.discriminatedUnion('type', [
 
 export const MediaCreditsSchema = z
   .map(
-    z.string(),
+    crewPositionSchema,
     MediaCreditSchema.array(),
   );
 

--- a/projects/client/src/lib/requests/models/PersonSummary.ts
+++ b/projects/client/src/lib/requests/models/PersonSummary.ts
@@ -1,5 +1,5 @@
-import { crewPositionSchema } from '@trakt/api';
 import { z } from 'zod';
+import { crewPositionSchema } from './CrewPosition.ts';
 import { ImageUrlsSchema } from './ImageUrlsSchema.ts';
 
 export const PersonSummarySchema = z.object({

--- a/projects/client/src/lib/requests/queries/search/searchPeopleQuery.ts
+++ b/projects/client/src/lib/requests/queries/search/searchPeopleQuery.ts
@@ -33,7 +33,7 @@ function isGarbage(value: PersonSummary): boolean {
     'production',
   ];
 
-  return !relevantPositions.includes(value?.knownFor ?? '');
+  return !relevantPositions.includes(value?.knownFor ?? 'unknown');
 }
 
 function mapToSearchResultEntry(

--- a/projects/client/src/lib/sections/lists/CastList.svelte
+++ b/projects/client/src/lib/sections/lists/CastList.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import type { CastMember } from "$lib/requests/models/MediaCrew";
+  import type { MediaType } from "$lib/requests/models/MediaType";
   import CastMemberItem from "./components/CastMemberItem.svelte";
 
   type CastListProps = {
     title: string;
     cast: CastMember[];
     slug: string;
+    type: MediaType;
   };
 
-  const { title, cast, slug }: CastListProps = $props();
+  const { title, cast, slug, type }: CastListProps = $props();
 </script>
 
 <SectionList
@@ -19,6 +21,6 @@
   --height-list="var(--height-person-list)"
 >
   {#snippet item(castMember)}
-    <CastMemberItem {castMember} />
+    <CastMemberItem {castMember} {type} />
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/lists/CreditsList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsList.svelte
@@ -3,13 +3,16 @@
   import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import * as m from "$lib/features/i18n/messages";
-  import type { CrewPosition } from "$lib/requests/models/CrewPosition";
+  import type {
+    CrewPosition,
+    CrewPositions,
+  } from "$lib/requests/models/CrewPosition";
   import type { MediaCredits } from "$lib/requests/models/MediaCredits";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
   import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
   import { toTranslatedPosition } from "$lib/utils/formatting/string/toTranslatedPosition";
-  import { writable } from "$lib/utils/store/WritableSubject.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CreditMediaItem from "./components/CreditMediaItem.svelte";
   import { useCreditsList } from "./stores/useCreditsList";
   import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
@@ -18,29 +21,41 @@
     title: string;
     type: MediaType;
     person: PersonSummary;
+    positions?: CrewPositions;
   };
 
-  const { title, type, person }: CreditsListProps = $props();
+  const { title, type, person, positions }: CreditsListProps = $props();
 
-  const currentPosition = $derived(
-    writable<CrewPosition>(person.knownFor ?? "acting"),
-  );
+  const selectedPosition = $derived.by(() => {
+    const defaultPosition = person.knownFor ?? "acting";
+    const position = positions?.[`${type}s`];
 
-  const { credits, positions } = $derived(
+    return position ?? defaultPosition;
+  });
+
+  const { credits, positions: allPositions } = $derived(
     useCreditsList({ type, slug: person.slug }),
   );
 
   const getPositionList = (mediaCredits?: MediaCredits) => {
     if (!mediaCredits) return [];
-    return mediaCredits.get($currentPosition) ?? [];
+    return mediaCredits.get(selectedPosition) ?? [];
   };
 
   const list = $derived(getPositionList($credits));
   const defaultVariant = $derived(useDefaultCardVariant(type));
+
+  const buildPositionHref = (position: CrewPosition) => {
+    const params = positions ?? {};
+    return UrlBuilder.people(person.slug, {
+      ...params,
+      [`${type}s`]: position,
+    });
+  };
 </script>
 
 <SectionList
-  id={`credits-list-${person.slug}-${type}-${$currentPosition}`}
+  id={`credits-list-${person.slug}-${type}-${selectedPosition}`}
   items={list}
   {title}
   --height-list={mediaListHeightResolver($defaultVariant)}
@@ -57,14 +72,15 @@
       variant="primary"
       color="blue"
       size="small"
-      disabled={$positions.length <= 1}
+      disabled={$allPositions.length <= 1}
     >
-      {toTranslatedPosition($currentPosition)}
+      {toTranslatedPosition(selectedPosition)}
       {#snippet items()}
-        {#each $positions as position}
+        {#each $allPositions as position (position)}
           <DropdownItem
             color="blue"
-            onclick={() => currentPosition.set(position)}
+            href={buildPositionHref(position)}
+            noscroll
           >
             {toTranslatedPosition(position)}
           </DropdownItem>

--- a/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
@@ -5,17 +5,23 @@
   import PersonCard from "$lib/components/people/card/PersonCard.svelte";
   import * as m from "$lib/features/i18n/messages";
   import type { CastMember } from "$lib/requests/models/MediaCrew";
+  import type { MediaType } from "$lib/requests/models/MediaType";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
   type CastMemberCardProps = {
     castMember: CastMember;
+    type: MediaType;
   };
 
-  const { castMember }: CastMemberCardProps = $props();
+  const { castMember, type }: CastMemberCardProps = $props();
+
+  const params = $derived({
+    [`${type}s`]: "acting" as const,
+  });
 </script>
 
 <PersonCard>
-  <Link focusable={false} href={UrlBuilder.people(castMember.key)}>
+  <Link focusable={false} href={UrlBuilder.people(castMember.key, params)}>
     <CardCover
       title={castMember.name}
       src={castMember.headshot.url.thumb}

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -76,7 +76,12 @@
   <WhereToWatchList type="episode" {episode} media={show} {streamOn} />
 </RenderFor>
 
-<CastList title={m.list_title_actors()} cast={crew.cast} slug={show.slug} />
+<CastList
+  title={m.list_title_actors()}
+  cast={crew.cast}
+  slug={show.slug}
+  type="show"
+/>
 
 <Comments
   media={show}

--- a/projects/client/src/lib/sections/summary/MovieSummary.svelte
+++ b/projects/client/src/lib/sections/summary/MovieSummary.svelte
@@ -59,7 +59,12 @@
   <CommunitySentiment {sentiment} slug={media.slug} />
 </RenderFor>
 
-<CastList title={m.list_title_actors()} cast={crew.cast} slug={media.slug} />
+<CastList
+  title={m.list_title_actors()}
+  cast={crew.cast}
+  slug={media.slug}
+  type={media.type}
+/>
 
 <Comments {media} type="movie" />
 

--- a/projects/client/src/lib/sections/summary/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/PeopleSummary.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { CrewPositions } from "$lib/requests/models/CrewPosition";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
   import CreditsList from "../lists/CreditsList.svelte";
   import CreditsHistoryList from "../lists/history/CreditsHistoryList.svelte";
@@ -9,8 +10,10 @@
 
   const {
     person,
+    positions,
   }: {
     person: PersonSummary;
+    positions?: CrewPositions;
   } = $props();
 </script>
 
@@ -22,6 +25,16 @@
   <PeopleSummary {person} />
 </RenderFor>
 
-<CreditsList title={m.list_title_movie_credits()} type="movie" {person} />
-<CreditsList title={m.list_title_show_credits()} type="show" {person} />
+<CreditsList
+  title={m.list_title_movie_credits()}
+  type="movie"
+  {person}
+  {positions}
+/>
+<CreditsList
+  title={m.list_title_show_credits()}
+  type="show"
+  {person}
+  {positions}
+/>
 <CreditsHistoryList {person} />

--- a/projects/client/src/lib/sections/summary/ShowSummary.svelte
+++ b/projects/client/src/lib/sections/summary/ShowSummary.svelte
@@ -67,7 +67,12 @@
   <Sentiment {sentiment} slug={media.slug} />
 </RenderFor>
 
-<CastList title={m.list_title_actors()} cast={crew.cast} slug={media.slug} />
+<CastList
+  title={m.list_title_actors()}
+  cast={crew.cast}
+  slug={media.slug}
+  type={media.type}
+/>
 
 <Comments {media} type="show" />
 

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { TestId } from "$e2e/models/TestId";
   import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
-  import * as m from "$lib/features/i18n/messages.ts";
   import { toTranslatedStatus } from "$lib/utils/formatting/string/toTranslatedStatus";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { mapToMainCredit } from "./mapToMainCredit";
   import { mapToSummaryStatus } from "./mapToSummaryStatus";
   import { mapToSummarySubtitle } from "./mapToSummarySubtitle";
   import ResponsiveTitle from "./ResponsiveTitle.svelte";
@@ -12,28 +12,7 @@
   const { title, crew, ...target }: SummaryTitleProps = $props();
 
   const subtitle = $derived(mapToSummarySubtitle(target));
-
-  const mainCredit = $derived.by(() => {
-    if (target.type === "show") {
-      const creator = crew.creators?.at(0);
-      return (
-        creator && {
-          text: m.text_created_by({ name: creator.name }),
-          key: creator.key,
-        }
-      );
-    }
-
-    const director = crew.directors?.find((director) =>
-      director.jobs.map((job) => job.toLowerCase()).includes("director"),
-    );
-    return (
-      director && {
-        text: m.text_directed_by({ name: director.name }),
-        key: director.key,
-      }
-    );
-  });
+  const mainCredit = $derived(mapToMainCredit(target.type, crew));
 
   const status = $derived.by(() => {
     if (target.type === "episode") {
@@ -52,7 +31,7 @@
     <p class="tiny trakt-media-main-credit">
       <MessageWithLink
         message={mainCredit.text}
-        href={UrlBuilder.people(mainCredit.key)}
+        href={UrlBuilder.people(mainCredit.key, mainCredit.positions)}
         target="_self"
       />
     </p>

--- a/projects/client/src/lib/sections/summary/components/_internal/mapToMainCredit.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/mapToMainCredit.ts
@@ -1,0 +1,48 @@
+import * as m from '$lib/features/i18n/messages.ts';
+import type { CrewPositions } from '$lib/requests/models/CrewPosition.ts';
+import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
+import type { MediaCrew } from '$lib/requests/models/MediaCrew.ts';
+
+type MainCredit = {
+  text: string;
+  key: string;
+  positions?: CrewPositions;
+};
+
+function mapToCreator(crew: MediaCrew): MainCredit | null {
+  const creator = crew.creators?.at(0);
+  if (!creator) return null;
+
+  return {
+    text: m.text_created_by({ name: creator.name }),
+    key: creator.key,
+    positions: { shows: 'created by' },
+  };
+}
+
+function mapToDirector(
+  type: 'movie' | 'episode',
+  crew: MediaCrew,
+): MainCredit | null {
+  const director = crew.directors?.find((person) =>
+    person.jobs.some((job) => job.toLowerCase() === 'director')
+  );
+  if (!director) return null;
+
+  const positions = type === 'movie'
+    ? { movies: 'directing' as const }
+    : { shows: 'directing' as const };
+
+  return {
+    text: m.text_directed_by({ name: director.name }),
+    key: director.key,
+    positions,
+  };
+}
+
+export function mapToMainCredit(
+  type: ExtendedMediaType,
+  crew: MediaCrew,
+): MainCredit | null {
+  return type === 'show' ? mapToCreator(crew) : mapToDirector(type, crew);
+}

--- a/projects/client/src/lib/sections/summary/components/details/_internal/toCrewMemberWithJob.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/toCrewMemberWithJob.ts
@@ -1,0 +1,26 @@
+import type { CrewPosition } from '$lib/requests/models/CrewPosition.ts';
+import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
+import type { CrewMember } from '$lib/requests/models/MediaCrew.ts';
+import { toTranslatedJob } from '$lib/utils/formatting/string/toTranslatedJob.ts';
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
+
+type ToCrewMemberWithJobProps = {
+  type: ExtendedMediaType;
+  person: CrewMember;
+  position: CrewPosition;
+};
+
+export function toCrewMemberWithJob(
+  { type, person, position }: ToCrewMemberWithJobProps,
+) {
+  const jobs = person.jobs.map((job) => toTranslatedJob(job));
+  const positions = {
+    movies: type === 'movie' ? position : undefined,
+    shows: type !== 'movie' ? position : undefined,
+  };
+
+  return {
+    label: `${person.name} (${jobs.join(', ')})`,
+    link: UrlBuilder.people(person.key, positions),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
@@ -15,10 +15,9 @@ import { toHumanDay } from '$lib/utils/formatting/date/toHumanDay.ts';
 import { toHumanDuration } from '$lib/utils/formatting/date/toHumanDuration.ts';
 import { toCountryName } from '$lib/utils/formatting/intl/toCountryName.ts';
 import { toLanguageName } from '$lib/utils/formatting/intl/toLanguageName.ts';
-import { toTranslatedJob } from '$lib/utils/formatting/string/toTranslatedJob.ts';
 import { toTranslatedStatus } from '$lib/utils/formatting/string/toTranslatedStatus.ts';
-import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
 import type { MediaDetailsProps } from '../MediaDetailsProps.ts';
+import { toCrewMemberWithJob } from './toCrewMemberWithJob.ts';
 
 function originalTitle(media: MediaEntry) {
   if (!media.originalTitle || media.originalTitle === media.title) {
@@ -84,14 +83,6 @@ function postCredits(entry: MediaEntry | EpisodeEntry) {
 }
 
 function mainCredits(type: ExtendedMediaType, crew: MediaCrew) {
-  const toCrewMemberWithJob = (person: CrewMember) => {
-    const jobs = person.jobs.map((job) => toTranslatedJob(job));
-    return {
-      label: `${person.name} (${jobs.join(', ')})`,
-      link: UrlBuilder.people(person.key),
-    };
-  };
-
   const onJob = (crewMember: CrewMember, job: Job) =>
     crewMember.jobs.includes(job);
 
@@ -103,14 +94,26 @@ function mainCredits(type: ExtendedMediaType, crew: MediaCrew) {
           title: m.header_director(),
           values: crew.directors
             .filter((director) => onJob(director, 'Director'))
-            .map(toCrewMemberWithJob),
+            .map((director) =>
+              toCrewMemberWithJob({
+                person: director,
+                position: 'directing',
+                type,
+              })
+            ),
         };
       case 'show':
         return {
           title: m.header_creator(),
           values: crew.creators
             .filter((creator) => onJob(creator, 'Creator'))
-            .map(toCrewMemberWithJob),
+            .map((creator) =>
+              toCrewMemberWithJob({
+                person: creator,
+                position: 'created by',
+                type,
+              })
+            ),
         };
     }
   };
@@ -119,7 +122,13 @@ function mainCredits(type: ExtendedMediaType, crew: MediaCrew) {
     creatorOrDirector(),
     {
       title: m.header_writer(),
-      values: crew.writers.map(toCrewMemberWithJob),
+      values: crew.writers.map((writer) =>
+        toCrewMemberWithJob({
+          person: writer,
+          position: 'writing',
+          type,
+        })
+      ),
     },
   ];
 }

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -2,6 +2,7 @@ import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.t
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { SearchParams } from '$lib/requests/models/SearchParams.ts';
 import type { PersonalListType } from '$lib/sections/lists/user/models/PersonalListType.ts';
+import type { CrewPositions } from '../../requests/models/CrewPosition.ts';
 import { buildParamString } from './buildParamString.ts';
 
 type TypeParams = {
@@ -165,7 +166,8 @@ export const UrlBuilder = {
     `/shows/${id}${buildParamString(params)}`,
   movies: () => '/movies',
   movie: (id: string) => `/movies/${id}`,
-  people: (id: string) => `/people/${id}`,
+  people: (id: string, positions?: CrewPositions) =>
+    `/people/${id}${buildParamString(positions ?? {})}`,
   episode: (id: string, season: number, episode: number) =>
     `/shows/${id}/seasons/${season}/episodes/${episode}`,
   profile: {

--- a/projects/client/src/routes/people/[slug]/+page.svelte
+++ b/projects/client/src/routes/people/[slug]/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { crewPositionSchema } from "$lib/requests/models/CrewPosition";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import PeopleSummary from "$lib/sections/summary/PeopleSummary.svelte";
@@ -9,6 +11,17 @@
   const { params }: PageProps = $props();
 
   const { person, isLoading } = $derived(usePerson(params.slug));
+
+  const mapToCrewPosition = (value: string | Nil) => {
+    return crewPositionSchema.safeParse(value?.toLowerCase()).data;
+  };
+
+  const positions = $derived.by(() => {
+    const movies = mapToCrewPosition(page.url.searchParams.get("movies"));
+    const shows = mapToCrewPosition(page.url.searchParams.get("shows"));
+
+    return { movies, shows };
+  });
 </script>
 
 <TraktPage
@@ -21,7 +34,7 @@
   </RenderFor>
 
   {#if !$isLoading}
-    <PeopleSummary person={$person!} />
+    <PeopleSummary person={$person!} {positions} />
   {:else}
     <!-- TODO: remove this when we have empty state, currently prevents content jumps -->
     <RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1815
- Dropdowns in people summary page now use search params.
  - When clicking on a person link within a certain context, the params are set. E.g. when clicking on a director, `directing` will be selected.

## 👀 Example 👀

https://github.com/user-attachments/assets/334ceea9-b2e6-47bb-a799-a48a27a74075

