### PR TITLE
fix(card): prevent title overflow in media summary cards

### DIFF
--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -208,7 +208,7 @@
           {media.title}
         </p>
         {#if hasDistinctOriginalTitle}
-          <p class="trakt-card-subtitle secondary ellipsis">
+          <p class="secondary ellipsis">
             ({media.originalTitle})
           </p>
         {/if}
@@ -280,7 +280,7 @@
   }
 
   :global(.trakt-summary-card-titles) {
-    height: var(--ni-66);
+    min-height: var(--ni-66);
   }
 
   .trakt-card-title,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1821
- Quick fix to deal with titles overflowing.
  - As a follow-up, we should improve the sizing/layout of summary cards on desktop.


## 👀 Example 👀
Before:
<img width="294" height="222" alt="Screenshot 2026-03-09 at 19 28 33" src="https://github.com/user-attachments/assets/35a965f5-1bdb-4a06-9f09-cbe5c9bec523" />


After:
<img width="294" height="222" alt="Screenshot 2026-03-09 at 19 27 01" src="https://github.com/user-attachments/assets/0b0c992d-ddf4-4ab6-8140-9382d7cf4256" />
