### PR TITLE
feat(list): sorts lists in drawer based on if an entry is listed

### DIFF
--- a/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItem.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItem.svelte
@@ -18,12 +18,10 @@
     onLoading,
     i18n = ListDropdownItemIntlProvider,
     media,
-    listedOnIds,
+    isListed,
   }: ListDropdownItemProps = $props();
 
   const { user } = useUser();
-
-  const isListed = $derived(listedOnIds.some((listId) => listId === list.id));
 
   const { addToList, removeFromList, isListUpdating } = $derived(
     useList({

--- a/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItemProps.ts
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItemProps.ts
@@ -9,6 +9,6 @@ export type ListDropdownItemProps = {
   };
   onLoading?: (isLoading: boolean) => void;
   title: string;
-  listedOnIds: number[];
+  isListed: boolean;
   i18n?: ListDropdownItemIntl;
 };

--- a/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.svelte
@@ -30,6 +30,16 @@
     useListedOnIds({ media }),
   );
 
+  const listedOnIdsSet = $derived(new Set($listedOnIds));
+  const sortedLists = $derived(
+    $lists.toSorted((a, b) => {
+      const aListed = listedOnIdsSet.has(a.id);
+      const bListed = listedOnIdsSet.has(b.id);
+      if (aListed === bListed) return 0;
+      return aListed ? -1 : 1;
+    }),
+  );
+
   const {
     addToWatchlist,
     isWatchlistUpdating,
@@ -69,13 +79,13 @@
     {#if isEmpty && isLoading}
       <LoadingIndicator />
     {:else}
-      {#each $lists as list}
+      {#each sortedLists as list (list.id)}
         <ListDropdownItem
           title={title ?? media.title}
           {list}
           {onLoading}
           {media}
-          listedOnIds={$listedOnIds}
+          isListed={listedOnIdsSet.has(list.id)}
         />
       {/each}
     {/if}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1823
- When managing lists, lists that already contain a movie/show will be placed at the top.

## 👀 Example 👀
Before:
<img width="418" height="898" alt="Screenshot 2026-03-10 at 09 33 19" src="https://github.com/user-attachments/assets/94380c4f-9d1d-42bc-9858-d215e715d28e" />


After:
<img width="418" height="898" alt="Screenshot 2026-03-10 at 09 35 39" src="https://github.com/user-attachments/assets/28b28a87-3a4e-4328-ad1f-1dfaffc44fca" />
