### PR TITLE
chore(a11y): enhances accessibility across multiple components

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -30,6 +30,7 @@ module.exports = {
       RuleConfigSeverity.Error,
       'always',
       [
+        'a11y',
         'activity',
         'analytics',
         'anticipated',

--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Отбележи \"{title}\" като гледано дотук"
     },
+    "date_time_label_watched": {
+      "default": "Изберете дата и час, на които сте гледали „{title}“"
+    },
     "translated_value_genre_horror": {
       "default": "Хорър"
     },

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Marker \"{title}\" som set indtil her"
     },
+    "date_time_label_watched": {
+      "default": "Vælg dato og tidspunkt for, hvornår du så \"{title}\""
+    },
     "translated_value_genre_horror": {
       "default": "Gyser"
     },

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "\"{title}\" bis hier als gesehen markieren"
     },
+    "date_time_label_watched": {
+      "default": "Wählen Sie Datum und Uhrzeit, zu denen Sie „{title}“ gesehen haben"
+    },
     "translated_value_genre_horror": {
       "default": "Horror"
     },

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Mark \"{title}\" as watched until here"
     },
+    "date_time_label_watched": {
+      "default": "Pick a date and time when you watched \"{title}\""
+    },
     "translated_value_genre_horror": {
       "default": "Horror"
     },

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -193,6 +193,19 @@
         "ios"
       ]
     },
+    "date_time_label_watched": {
+      "default": "Pick a date and time when you watched \"{title}\"",
+      "description": "Aria-label for the button that allows users to pick a date and time when they watched a movie, episode, or show.",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "translated_value_genre_horror": {
       "default": "Horror",
       "description": "Text for the horror genre. The value is sent back from the Trakt API.",

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Marcar \"{title}\" como visto hasta aquí"
     },
+    "date_time_label_watched": {
+      "default": "Seleccione la fecha y la hora en la que vio «{title}»"
+    },
     "translated_value_genre_horror": {
       "default": "Terror"
     },

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Marcar \"{title}\" como visto hasta aquí"
     },
+    "date_time_label_watched": {
+      "default": "Elige la fecha y hora en que viste \"{title}\""
+    },
     "translated_value_genre_horror": {
       "default": "Terror"
     },

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Marquer \"{title}\" comme vu jusqu'ici"
     },
+    "date_time_label_watched": {
+      "default": "Choisissez la date et l'heure où vous avez écouté « {title} »"
+    },
     "translated_value_genre_horror": {
       "default": "Horreur"
     },

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Marquer \"{title}\" comme regardé jusqu'ici"
     },
+    "date_time_label_watched": {
+      "default": "Choisissez la date et l'heure auxquelles vous avez regardé « {title} »"
+    },
     "translated_value_genre_horror": {
       "default": "Horreur"
     },

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Segna \"{title}\" come visto fino a qui"
     },
+    "date_time_label_watched": {
+      "default": "Scegli la data e l'ora in cui hai guardato \"{title}\""
+    },
     "translated_value_genre_horror": {
       "default": "Horror"
     },

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "\"{title}\"をここまで視聴済みにする"
     },
+    "date_time_label_watched": {
+      "default": "「{title}」を鑑賞した日時を選択してください"
+    },
     "translated_value_genre_horror": {
       "default": "ホラー"
     },

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Merk \"{title}\" som sett hit"
     },
+    "date_time_label_watched": {
+      "default": "Velg dato og tidspunkt for når du så \"{title}\""
+    },
     "translated_value_genre_horror": {
       "default": "Skrekk"
     },

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "\"{title}\" tot hier als bekeken markeren"
     },
+    "date_time_label_watched": {
+      "default": "Kies de datum en tijd waarop je naar \"{title}\" hebt gekeken"
+    },
     "translated_value_genre_horror": {
       "default": "Horror"
     },

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Oznacz \"{title}\" jako obejrzane do tego miejsca"
     },
+    "date_time_label_watched": {
+      "default": "Wybierz datę i godzinę, kiedy obejrzałeś „{title}”"
+    },
     "translated_value_genre_horror": {
       "default": "Horror"
     },

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Marcar \"{title}\" como assistido até aqui"
     },
+    "date_time_label_watched": {
+      "default": "Escolha a data e a hora em que você assistiu a \"{title}\""
+    },
     "translated_value_genre_horror": {
       "default": "Terror"
     },

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Marchează \"{title}\" ca urmărit până aici"
     },
+    "date_time_label_watched": {
+      "default": "Alege data și ora la care ai vizionat „{title}”"
+    },
     "translated_value_genre_horror": {
       "default": "Horror"
     },

--- a/projects/client/i18n/meta/ru-ru.json
+++ b/projects/client/i18n/meta/ru-ru.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Отметить «{title}» как просмотренное до этого момента"
     },
+    "date_time_label_watched": {
+      "default": "Выберите дату и время, когда вы посмотрели «{title}»"
+    },
     "translated_value_genre_horror": {
       "default": "Ужасы"
     },

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Markera \"{title}\" som sett hit"
     },
+    "date_time_label_watched": {
+      "default": "Välj datum och tid när du såg \"{title}\""
+    },
     "translated_value_genre_horror": {
       "default": "Skräck"
     },

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -81,6 +81,9 @@
     "button_label_watched_until_here": {
       "default": "Відмітити \"{title}\" як переглянуте до цього місця"
     },
+    "date_time_label_watched": {
+      "default": "Оберіть дату та час, коли ви подивилися «{title}»"
+    },
     "translated_value_genre_horror": {
       "default": "Жахи"
     },

--- a/projects/client/i18n/meta/zh-cn.json
+++ b/projects/client/i18n/meta/zh-cn.json
@@ -80,6 +80,9 @@
     "button_label_watched_until_here": {
       "default": "标记“{title}”看到这里"
     },
+    "date_time_label_watched": {
+      "default": "选择您观看“{title}”的日期和时间"
+    },
     "translated_value_genre_horror": {
       "default": "恐怖"
     },

--- a/projects/client/src/lib/components/date-time/DateTimePicker.svelte
+++ b/projects/client/src/lib/components/date-time/DateTimePicker.svelte
@@ -3,12 +3,14 @@
   import CalendarIcon from "../icons/CalendarIcon.svelte";
   import { toDateTimeLocal } from "./_internal/toDateTimeLocal";
 
-  const {
-    value,
-    maxDate,
-    onChange,
-  }: { value?: Date; maxDate?: Date; onChange: (date?: Date) => void } =
-    $props();
+  type DateTimePickerProps = {
+    value?: Date;
+    maxDate?: Date;
+    label: string;
+    onChange: (date?: Date) => void;
+  };
+
+  const { value, maxDate, label, onChange }: DateTimePickerProps = $props();
 
   const { language } = getLanguageAndRegion();
 
@@ -38,6 +40,7 @@
     bind:this={inputElement}
     class="trakt-date-time-input"
     type="datetime-local"
+    aria-label={label}
     value={toDateTimeLocal(value)}
     max={toDateTimeLocal(maxDate)}
     lang={language}

--- a/projects/client/src/lib/components/dropdown/DropdownItem.spec.ts
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.spec.ts
@@ -98,7 +98,7 @@ describe('DropdownItem', () => {
     });
 
     await waitFor(() => {
-      const listItemElement = screen.getByRole('listitem');
+      const listItemElement = screen.getByRole('button');
       expect(listItemElement).toHaveAttribute('tabindex', '0');
     });
   });

--- a/projects/client/src/lib/components/dropdown/DropdownItem.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.svelte
@@ -29,6 +29,7 @@
   );
   const tabIndex = $derived(hasHandler ? 0 : -1);
   const href = $derived((props as DropdownItemAnchorProps).href);
+  const itemRole = $derived(hasHandler && !href ? "button" : undefined);
   const noscroll = $derived((props as DropdownItemAnchorProps).noscroll);
   const replacestate = $derived(
     (props as DropdownItemAnchorProps).replacestate,
@@ -46,6 +47,7 @@
 <li
   use:triggerWithKeyboard
   use:disableNavigation={props.disabled}
+  role={itemRole}
   tabindex={tabIndex}
   data-color={color}
   data-style={style}

--- a/projects/client/src/lib/components/form/FormInput.svelte
+++ b/projects/client/src/lib/components/form/FormInput.svelte
@@ -13,6 +13,7 @@
     placeholder,
     value,
     autofocus = false,
+    required,
     validation,
   }: FormInputProps = $props();
 
@@ -51,6 +52,7 @@
     type="text"
     {placeholder}
     {disabled}
+    {required}
     {value}
     oninput={handleInput}
     aria-invalid={hasError ? "true" : "false"}

--- a/projects/client/src/lib/components/form/models/FormInputProps.ts
+++ b/projects/client/src/lib/components/form/models/FormInputProps.ts
@@ -6,5 +6,6 @@ export type FormInputProps = {
   value?: string;
   disabled: boolean;
   placeholder: string;
+  required?: boolean;
   validation?: ValidationProps;
 };

--- a/projects/client/src/lib/features/image/components/EditableImage.svelte
+++ b/projects/client/src/lib/features/image/components/EditableImage.svelte
@@ -37,6 +37,7 @@
 <div
   tabindex="0"
   role="button"
+  aria-label={alt}
   class="trakt-editable-image"
   use:dropzone
   onfiles={(ev) => readImage(ev.detail.files)}

--- a/projects/client/src/lib/sections/banner/black-friday/BlackFriday.svelte
+++ b/projects/client/src/lib/sections/banner/black-friday/BlackFriday.svelte
@@ -25,8 +25,7 @@
       </RenderFor>
     </div>
 
-    <!-- svelte-ignore a11y_img_redundant_alt -->
-    <img src={gift} class="trakt-black-friday-gift" alt="Gift image" />
+    <img src={gift} class="trakt-black-friday-gift" alt="" />
   </div>
 </RenderFor>
 

--- a/projects/client/src/lib/sections/cookie/CookieNotice.svelte
+++ b/projects/client/src/lib/sections/cookie/CookieNotice.svelte
@@ -37,7 +37,7 @@
     class="trakt-cookie-notice"
     transition:slide={{ duration: NOTICE_TRANSITION_DURATION }}
   >
-    <div class="trakt-cookie">🍪</div>
+    <div class="trakt-cookie" aria-hidden="true">🍪</div>
     <p>
       <MessageWithLink
         message={m.text_cookie_notice()}

--- a/projects/client/src/lib/sections/landing/Landing.svelte
+++ b/projects/client/src/lib/sections/landing/Landing.svelte
@@ -64,8 +64,7 @@
     {/snippet}
   </LandingColumns>
 
-  <!-- svelte-ignore a11y_img_redundant_alt -->
-  <img src={popcorn} class="trakt-popcorn" alt="Popcorn image" />
+  <img src={popcorn} class="trakt-popcorn" alt="" />
 </div>
 
 <style lang="scss">

--- a/projects/client/src/lib/sections/landing/MobileLanding.svelte
+++ b/projects/client/src/lib/sections/landing/MobileLanding.svelte
@@ -22,8 +22,7 @@
 
   <TraktApps />
 
-  <!-- svelte-ignore a11y_img_redundant_alt -->
-  <img src={popcorn} class="trakt-popcorn" alt="Popcorn image" />
+  <img src={popcorn} class="trakt-popcorn" alt="" />
 </div>
 
 <style>

--- a/projects/client/src/lib/sections/lists/user/_internal/SaveListDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SaveListDrawer.svelte
@@ -118,6 +118,7 @@
         disabled={$isSaving}
         value={$name}
         autofocus
+        required
         validation={{
           isValid: (value) => value.trim().length > 0,
           errorText: m.validation_text_list_name(),

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/DateTimePickerDialog.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/DateTimePickerDialog.svelte
@@ -5,15 +5,15 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import { writable } from "$lib/utils/store/WritableSubject.ts";
 
-  const {
-    onConfirm,
-    onCancel,
-    buttonText,
-  }: {
+  type DateTimePickerDialogProps = {
     onConfirm: (date: Date) => void;
     onCancel: () => void;
     buttonText: string;
-  } = $props();
+    title: string;
+  };
+
+  const { onConfirm, onCancel, buttonText, title }: DateTimePickerDialogProps =
+    $props();
 
   const now = new Date();
 
@@ -31,6 +31,7 @@
     value={$selectedDate}
     maxDate={now}
     onChange={(date) => selectedDate.set(date)}
+    label={m.date_time_label_watched({ title })}
   />
 
   {#snippet footer()}

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/MarkAsWatchedDrawer.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/MarkAsWatchedDrawer.svelte
@@ -149,6 +149,7 @@
 
 {#if $showDateTimePicker}
   <DateTimePickerDialog
+    {title}
     buttonText={m.button_text_mark_as_watched()}
     onCancel={() => showDateTimePicker.set(false)}
     onConfirm={(date) => {

--- a/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
@@ -4,6 +4,7 @@
   import ListIcon from "$lib/components/icons/mobile/ListIcon.svelte";
   import SearchIcon from "$lib/components/icons/SearchIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
@@ -43,20 +44,23 @@
     {/if}
 
     <div class="trakt-mobile-navbar-links">
-      <Link href={UrlBuilder.home()}>
+      <Link href={UrlBuilder.home()} label={m.button_label_home()}>
         <HomeIcon />
       </Link>
 
       <RenderFor audience="authenticated">
-        <Link href={UrlBuilder.discover()}>
+        <Link href={UrlBuilder.discover()} label={m.button_label_discover()}>
           <DiscoverIcon />
         </Link>
 
-        <Link href={UrlBuilder.lists.user("me")}>
+        <Link
+          href={UrlBuilder.lists.user("me")}
+          label={m.button_label_browse_lists()}
+        >
           <ListIcon />
         </Link>
 
-        <Link href={UrlBuilder.search()}>
+        <Link href={UrlBuilder.search()} label={m.button_label_search()}>
           <SearchIcon />
         </Link>
 

--- a/projects/client/src/lib/sections/smart-lists/SmartListCreator.svelte
+++ b/projects/client/src/lib/sections/smart-lists/SmartListCreator.svelte
@@ -99,6 +99,7 @@
           disabled={isDisabled}
           value={listName}
           autofocus
+          required
           validation={{
             isValid: (value) => value.trim().length > 0,
             errorText: m.validation_text_list_name(),

--- a/projects/client/src/lib/sections/toast/Toast.svelte
+++ b/projects/client/src/lib/sections/toast/Toast.svelte
@@ -10,6 +10,9 @@
 
 <div
   class="trakt-toast"
+  role="status"
+  aria-live="polite"
+  aria-atomic="true"
   style="--distance-from-bottom: {$distanceFromBottom}px; --footer-height: {$footerHeight}px"
   transition:fade={{ duration: 300 }}
 >


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1841
- Adds `aria-label` to interactive elements like date pickers and editable images.
- Sets explicit `role="button"` for interactive dropdown items that are not links.
- Incorporates `required` attribute for form inputs.
- Hides purely decorative images and elements from screen readers using empty `alt` attributes or `aria-hidden`.
- Provides accessible `label` attributes for icon-only navigation links in the mobile navbar.
- Configures toast notifications with `role="status"`, `aria-live="polite"`, and `aria-atomic="true"` for screen reader announcements.