### PR TITLE
fix(calendar): reverses historic calendar layouts

### DIFF
--- a/projects/client/src/lib/features/calendar/CalendarLayout.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarLayout.svelte
@@ -21,6 +21,7 @@
     layout = "grid",
     empty,
     maxDate,
+    order = "chronological",
   }: CalendarLayoutProps<T> = $props();
 
   let activeScrollDate = $state<Date | null>(null);
@@ -39,6 +40,10 @@
   );
   const currentDate = $derived(activeScrollDate ?? activeDate);
   const selectedDate = $derived(isInCurrentPeriod ? currentDate : activeDate);
+
+  const orderedCalendar = $derived(
+    order === "chronological" ? calendar : calendar.toReversed(),
+  );
 </script>
 
 <div class="calendar-layout-container">
@@ -73,7 +78,7 @@
       initialId={dateKey(activeDate)}
       onUpdate={handleScrollSpyUpdate}
     >
-      <CalendarItems {calendar} {item} {layout} {empty} />
+      <CalendarItems calendar={orderedCalendar} {item} {layout} {empty} />
     </ScrollSpy>
   {/if}
 </div>

--- a/projects/client/src/lib/features/calendar/models/CalendarLayoutProps.ts
+++ b/projects/client/src/lib/features/calendar/models/CalendarLayoutProps.ts
@@ -8,4 +8,5 @@ export type CalendarLayoutProps<T> = {
   item: Snippet<[T]>;
   layout?: 'list' | 'grid';
   empty?: Snippet;
+  order?: 'chronological' | 'reverse-chronological';
 } & CalendarNavigationProps;

--- a/projects/client/src/lib/sections/lists/activity/ActivityPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/activity/ActivityPaginatedList.svelte
@@ -7,8 +7,6 @@
   import SocialActivityItem from "./_internal/SocialActivityItem.svelte";
   import { useActivityList } from "./_internal/useActivityList";
 
-  type RecommendedListProps = { title: string };
-
   const { mode } = useDiscover();
   const { filterMap } = useFilter();
 
@@ -39,6 +37,7 @@
   onReset={reset}
   layout="list"
   maxDate={now}
+  order="reverse-chronological"
 >
   {#snippet item(activity)}
     <SocialActivityItem {activity} style="summary" />

--- a/projects/client/src/lib/sections/lists/history/PersonalHistoryPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/PersonalHistoryPaginatedList.svelte
@@ -42,6 +42,7 @@
   onReset={reset}
   layout="list"
   maxDate={now}
+  order="reverse-chronological"
 >
   {#snippet item(media)}
     <RecentlyWatchedItem {media} style="summary" isActionable />


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1848
- Reverses historic calendar layouts.

## 👀 Example 👀
Before:
<img width="431" height="933" alt="Screenshot 2026-03-15 at 14 42 57" src="https://github.com/user-attachments/assets/7691f38e-7fc7-42e6-af02-27ea76b413ea" />

After:
<img width="431" height="933" alt="Screenshot 2026-03-15 at 14 42 45" src="https://github.com/user-attachments/assets/f409adbc-6568-40e3-a69a-77750237797a" />
