### PR TITLE
feat(summary): shows dropped tag on dropped shows

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Гледано"
     },
+    "tag_text_dropped": {
+      "default": "Прекратено"
+    },
     "header_height": {
       "default": "Ръст"
     },

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Set"
     },
+    "tag_text_dropped": {
+      "default": "Droppet"
+    },
     "header_height": {
       "default": "Højde"
     },

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Gesehen"
     },
+    "tag_text_dropped": {
+      "default": "Abgebrochen"
+    },
     "header_height": {
       "default": "Größe"
     },

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Watched"
     },
+    "tag_text_dropped": {
+      "default": "Dropped"
+    },
     "header_height": {
       "default": "Height"
     },

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5953,6 +5953,14 @@
         "ios"
       ]
     },
+    "tag_text_dropped": {
+      "default": "Dropped",
+      "description": "Text for the tag that is shown for dropped shows. This should be as short as possible.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "header_height": {
       "default": "Height",
       "description": "Header for the section that displays the person's height.",

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Visto"
     },
+    "tag_text_dropped": {
+      "default": "Abandonada"
+    },
     "header_height": {
       "default": "Altura"
     },

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Vista"
     },
+    "tag_text_dropped": {
+      "default": "Abandonada"
+    },
     "header_height": {
       "default": "Altura"
     },

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Vu"
     },
+    "tag_text_dropped": {
+      "default": "Abandonné"
+    },
     "header_height": {
       "default": "Taille"
     },

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Vu"
     },
+    "tag_text_dropped": {
+      "default": "Abandonné"
+    },
     "header_height": {
       "default": "Taille"
     },

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Visto"
     },
+    "tag_text_dropped": {
+      "default": "Abbandonato"
+    },
     "header_height": {
       "default": "Altezza"
     },

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "視聴済み"
     },
+    "tag_text_dropped": {
+      "default": "リタイア"
+    },
     "header_height": {
       "default": "身長"
     },

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Sett"
     },
+    "tag_text_dropped": {
+      "default": "Droppet"
+    },
     "header_height": {
       "default": "Høyde"
     },

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Bekeken"
     },
+    "tag_text_dropped": {
+      "default": "Gestopt"
+    },
     "header_height": {
       "default": "Lengte"
     },

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Obejrzano"
     },
+    "tag_text_dropped": {
+      "default": "Porzucone"
+    },
     "header_height": {
       "default": "Wzrost"
     },

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Visto"
     },
+    "tag_text_dropped": {
+      "default": "Abandonado"
+    },
     "header_height": {
       "default": "Altura"
     },

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Vizionat"
     },
+    "tag_text_dropped": {
+      "default": "Abandonat"
+    },
     "header_height": {
       "default": "Înălțime"
     },

--- a/projects/client/i18n/meta/ru-ru.json
+++ b/projects/client/i18n/meta/ru-ru.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Просмотрено"
     },
+    "tag_text_dropped": {
+      "default": "Брошено"
+    },
     "header_height": {
       "default": "Рост"
     },

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Sedda"
     },
+    "tag_text_dropped": {
+      "default": "Avbruten"
+    },
     "header_height": {
       "default": "Längd"
     },

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -2187,6 +2187,9 @@
     "tag_text_watched": {
       "default": "Переглянуто"
     },
+    "tag_text_dropped": {
+      "default": "Кинуто"
+    },
     "header_height": {
       "default": "Зріст"
     },

--- a/projects/client/i18n/meta/zh-cn.json
+++ b/projects/client/i18n/meta/zh-cn.json
@@ -2186,6 +2186,9 @@
     "tag_text_watched": {
       "default": "已看"
     },
+    "tag_text_dropped": {
+      "default": "已弃"
+    },
     "header_height": {
       "default": "身高"
     },

--- a/projects/client/src/lib/components/media/tags/TagIntl.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntl.ts
@@ -13,4 +13,5 @@ export type TagIntl = {
   toDay: (date: Date) => string;
   watchedLabel: () => string;
   toRemainingDuration: (duration: number) => string;
+  droppedLabel: () => string;
 };

--- a/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
@@ -32,4 +32,5 @@ export const TagIntlProvider: TagIntl = {
     m.tag_text_remaining_duration({
       duration: toHumanDuration({ minutes: duration }, languageTag()),
     }),
+  droppedLabel: () => m.tag_text_dropped(),
 };

--- a/projects/client/src/lib/features/auth/queries/currentUserDroppedQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserDroppedQuery.ts
@@ -1,0 +1,36 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { z } from 'zod';
+
+export const UserDroppedHistorySchema = z.object({
+  shows: z.set(z.number()),
+});
+
+export type UserDroppedHistory = z.infer<typeof UserDroppedHistorySchema>;
+
+const currentUserDroppedRequest = async ({ fetch }: ApiParams) => {
+  const response = await rawApiFetch({
+    fetch,
+    path: '/v3/users/me/dropped/minimal',
+  });
+
+  return response.ok
+    ? { body: (await response.json()) as number[], status: 200 }
+    : { body: [] as number[], status: 200 };
+};
+
+export const currentUserDroppedQuery = defineQuery({
+  key: 'currentUserDropped',
+  invalidations: [
+    InvalidateAction.Drop('show'),
+  ],
+  dependencies: [],
+  request: currentUserDroppedRequest,
+  mapper: (response) => ({
+    shows: new Set(response.body),
+  }),
+  schema: UserDroppedHistorySchema,
+  ttl: time.hours(3),
+});

--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -7,6 +7,10 @@ import {
   currentUserCommentReactionsQuery,
   type UserReactions,
 } from '../queries/currentUserCommentReactionsQuery.ts';
+import {
+  currentUserDroppedQuery,
+  type UserDroppedHistory,
+} from '../queries/currentUserDroppedQuery.ts';
 import { currentUserFavoritesQuery } from '../queries/currentUserFavoritesQuery.ts';
 import {
   currentUserHistoryQuery,
@@ -116,6 +120,7 @@ export function useUser() {
   const likesQuerySignal = useQuery(currentUserLikesQuery());
   const limitsQuerySignal = useQuery(userLimitsQuery());
   const notesQuerySignal = useQuery(currentUserNotesQuery());
+  const droppedQuerySignal = useQuery(currentUserDroppedQuery());
 
   // Create a stream that switches between authorized and anonymous state
   const userContext$ = isAuthorized.pipe(
@@ -158,6 +163,9 @@ export function useUser() {
             movies: new Map(),
             shows: new Map(),
           }),
+          dropped: of<UserDroppedHistory>({
+            shows: new Set(),
+          }),
         });
       }
 
@@ -195,6 +203,9 @@ export function useUser() {
         notes: notesQuerySignal.pipe(
           map((notes) => notes.data),
         ),
+        dropped: droppedQuerySignal.pipe(
+          map((dropped) => dropped.data),
+        ),
       });
     }),
     shareReplay(1),
@@ -212,5 +223,6 @@ export function useUser() {
     likes: userContext$.pipe(switchMap((ctx) => ctx.likes)),
     limits: userContext$.pipe(switchMap((ctx) => ctx.limits)),
     notes: userContext$.pipe(switchMap((ctx) => ctx.notes)),
+    dropped: userContext$.pipe(switchMap((ctx) => ctx.dropped)),
   };
 }

--- a/projects/client/src/lib/sections/summary/components/_internal/DroppedTag.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/DroppedTag.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import DropIcon from "$lib/components/icons/DropIcon.svelte";
+  import type { TagIntl } from "$lib/components/media/tags/TagIntl";
+  import StemTag from "$lib/components/tags/StemTag.svelte";
+
+  const { i18n }: { i18n: TagIntl } = $props();
+</script>
+
+<StemTag
+  --color-background-stem-tag="var(--shade-10)"
+  --color-foreground-stem-tag="var(--shade-920)"
+>
+  {#snippet icon()}
+    <DropIcon />
+  {/snippet}
+
+  <p class="bold uppercase no-wrap">{i18n.droppedLabel()}</p>
+</StemTag>

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
   import PostCreditsTag from "$lib/components/media/tags/PostCreditsTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
+  import DroppedTag from "./DroppedTag.svelte";
   import WatchCountTag from "./WatchCountTag.svelte";
 
   const {
     postCreditsCount,
     watchCount,
-  }: { postCreditsCount: number; watchCount: number } = $props();
+    isDropped,
+  }: { postCreditsCount: number; watchCount: number; isDropped?: boolean } =
+    $props();
 </script>
+
+{#if isDropped}
+  <DroppedTag i18n={TagIntlProvider} />
+{/if}
 
 {#if postCreditsCount > 0 && watchCount === 0}
   <PostCreditsTag count={postCreditsCount} i18n={TagIntlProvider} />

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -14,6 +14,7 @@
   import SummaryContainer from "../summary/SummaryContainer.svelte";
   import SummaryHeader from "../summary/SummaryHeader.svelte";
   import SummaryOverview from "../summary/SummaryOverview.svelte";
+  import { useIsDropped } from "./_internal/useIsDropped";
   import type { MediaSummaryProps } from "./MediaSummaryProps";
   import { useMediaMetaInfo } from "./useMediaMetaInfo";
   import MediaActions from "./v2/_internal/MediaActions.svelte";
@@ -34,12 +35,17 @@
   const postCreditsCount = $derived(media.postCredits?.length ?? 0);
 
   const { ratings } = $derived(useMediaMetaInfo(target));
+  const { isDropped } = $derived(useIsDropped(media));
 
   const posterUrl = $derived(streamOn?.preferred?.link ?? media.trailer);
 </script>
 
 {#snippet tags()}
-  <SummaryPosterTags {postCreditsCount} watchCount={$watchCount} />
+  <SummaryPosterTags
+    {postCreditsCount}
+    watchCount={$watchCount}
+    isDropped={$isDropped}
+  />
 {/snippet}
 
 <SummaryCover src={media.cover.url.medium} colors={media.colors} {type} />

--- a/projects/client/src/lib/sections/summary/components/media/_internal/useIsDropped.ts
+++ b/projects/client/src/lib/sections/summary/components/media/_internal/useIsDropped.ts
@@ -1,0 +1,21 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import { map } from 'rxjs';
+
+export function useIsDropped(media: MediaEntry) {
+  const { dropped } = useUser();
+
+  const isDropped = dropped.pipe(
+    map(($dropped) => {
+      if (!$dropped) {
+        return false;
+      }
+
+      return $dropped.shows.has(media.id);
+    }),
+  );
+
+  return {
+    isDropped,
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -14,6 +14,7 @@
   import SummaryRateNow from "../../_internal/SummaryRateNow.svelte";
   import SummaryTitle from "../../_internal/SummaryTitle.svelte";
   import { useIsRateable } from "../../rating/_internal/useIsRateable";
+  import { useIsDropped } from "../_internal/useIsDropped";
   import type { MediaSummaryEntry } from "../models/MediaSummaryEntry";
   import { useMediaMetaInfo } from "../useMediaMetaInfo";
   import MediaActions from "./_internal/MediaActions.svelte";
@@ -38,10 +39,15 @@
   const postCreditsCount = $derived(media.postCredits?.length ?? 0);
 
   const { isRateable } = $derived(useIsRateable(target));
+  const { isDropped } = $derived(useIsDropped(media));
 </script>
 
 {#snippet tags()}
-  <SummaryPosterTags {postCreditsCount} watchCount={$watchCount} />
+  <SummaryPosterTags
+    {postCreditsCount}
+    watchCount={$watchCount}
+    isDropped={$isDropped}
+  />
 {/snippet}
 
 <CoverImageSetter


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1531
- Shows a `dropped` tag on the poster for dropped shows.

## 👀 Example 👀
<img width="427" height="724" alt="Screenshot 2026-03-15 at 21 09 51" src="https://github.com/user-attachments/assets/a4627b49-6dd2-49b9-a8fd-8e9eeaa3ba77" />
