### PR TITLE
fix: uses correct direction for collapse icon

### DIFF
--- a/projects/client/src/lib/components/lists/section-list/CollapseIcon.svelte
+++ b/projects/client/src/lib/components/lists/section-list/CollapseIcon.svelte
@@ -19,9 +19,10 @@
 <style>
   .trakt-collapse-icon {
     transition: transform var(--transition-increment) ease-in-out;
+    transform: rotate(-180deg);
   }
 
   .trakt-collapse-icon.is-collapsed {
-    transform: rotate(-180deg);
+    transform: rotate(0deg);
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1857
- Flips collapse icon direction.

## 👀 Example 👀
Before:


https://github.com/user-attachments/assets/4f927af7-bcb0-48f7-bfbe-3c9b46ea549e


After:

https://github.com/user-attachments/assets/c469b7f4-25df-4f2b-a983-6c625888b285

