### PR TITLE
feat(list) / add pinned list and oscars 2026 promotion

### DIFF
--- a/projects/client/src/lib/sections/lists/user/PinnedList.svelte
+++ b/projects/client/src/lib/sections/lists/user/PinnedList.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode.ts";
+  import { useQuery } from "$lib/features/query/useQuery.ts";
+  import { userListSummaryQuery } from "$lib/requests/queries/users/userListSummaryQuery.ts";
+  import UserList from "./UserList.svelte";
+
+  type PinnedListProps = {
+    userId: string;
+    listId: string;
+    mode?: DiscoverMode;
+  };
+
+  const { userId, listId, mode }: PinnedListProps = $props();
+
+  const query = useQuery(userListSummaryQuery({ userId, listId }));
+</script>
+
+{#if $query && $query.data}
+  <div class="trakt-pinned-list">
+    <UserList list={$query.data} type={mode} />
+  </div>
+{/if}
+
+<style>
+  .trakt-pinned-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-micro);
+  }
+</style>

--- a/projects/client/src/routes/users/[user]/lists/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/+page.svelte
@@ -9,6 +9,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import SmartLists from "$lib/sections/lists/smart/SmartLists.svelte";
   import PersonalLists from "$lib/sections/lists/user/PersonalLists.svelte";
+  import PinnedList from "$lib/sections/lists/user/PinnedList.svelte";
   import WatchList from "$lib/sections/lists/watchlist/WatchList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
@@ -21,6 +22,8 @@
   const { user } = useUser();
 
   const { isMe } = $derived(useIsMe(params.user));
+
+  const showOscarsList = new Date() < new Date("2026-04-01");
 </script>
 
 <TraktPage
@@ -44,6 +47,11 @@
     drilldownLabel={m.button_label_view_all_watchlist_items()}
     type={$mode}
   />
+
+  <!-- TODO: improve / make dynamic -->
+  {#if showOscarsList}
+    <PinnedList mode={$mode} userId="visualcortex" listId="2026-oscar-winners" />
+  {/if}
 
   <SmartLists mode={$mode} />
 


### PR DESCRIPTION
## Overview
Introduces a new reusable component to feature specific user lists and adds a promotional display for the 2026 Oscars winners list on the user lists page.

## Changes
- Created a `PinnedList` component that fetches and displays list summaries using the user list summary query.
- Integrated the pinned list section into the main user lists route.
- Implemented a time-based conditional check to display the 2026 Oscar winners list until April 2026.
- Styled the pinned list container for consistent layout within the lists view.

## Testing
- Verified the component correctly fetches and renders list data when provided with a valid user and list ID.
- Manually tested the date-based conditional logic to ensure the pinned list displays correctly before the expiration date.