### PR TITLE
refactor / move asset placeholders to dedicated file

### DIFF
--- a/projects/client/src/lib/components/card/CardCover.svelte
+++ b/projects/client/src/lib/components/card/CardCover.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
-  import { PLACEHOLDERS } from "$lib/utils/constants";
+  import { PLACEHOLDERS } from "$lib/utils/assets";
   import { isImageComplete } from "$lib/utils/image/isImageComplete";
   import { checksum } from "$lib/utils/string/checksum";
   import { lineClamp } from "../text/lineClamp";

--- a/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
+++ b/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { appendClassList } from "$lib/utils/actions/appendClassList";
-  import { PLACEHOLDERS } from "$lib/utils/constants";
+  import { PLACEHOLDERS } from "$lib/utils/assets";
   import { writable } from "$lib/utils/store/WritableSubject.ts";
   import type { ImageProps } from "./ImageProps";
   import { resolveEnvironmentUri } from "./resolveEnvironmentUri";

--- a/projects/client/src/lib/requests/_internal/mapToCover.ts
+++ b/projects/client/src/lib/requests/_internal/mapToCover.ts
@@ -1,7 +1,7 @@
 import {
   MEDIA_COVER_LARGE_PLACEHOLDER,
   MEDIA_COVER_THUMB_PLACEHOLDER,
-} from '$lib/utils/constants.ts';
+} from '$lib/utils/assets.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import type { MovieResponse, ShowResponse } from '@trakt/api';

--- a/projects/client/src/lib/requests/_internal/mapToHeadshot.ts
+++ b/projects/client/src/lib/requests/_internal/mapToHeadshot.ts
@@ -1,4 +1,4 @@
-import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/constants.ts';
+import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/assets.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import type { PersonResponse } from '@trakt/api';

--- a/projects/client/src/lib/requests/_internal/mapToLogo.ts
+++ b/projects/client/src/lib/requests/_internal/mapToLogo.ts
@@ -1,7 +1,7 @@
 import {
   MEDIA_COVER_LARGE_PLACEHOLDER,
   MEDIA_COVER_THUMB_PLACEHOLDER,
-} from '$lib/utils/constants.ts';
+} from '$lib/utils/assets.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import type { MovieResponse, ShowResponse } from '@trakt/api';

--- a/projects/client/src/lib/requests/_internal/mapToPoster.ts
+++ b/projects/client/src/lib/requests/_internal/mapToPoster.ts
@@ -1,4 +1,4 @@
-import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/constants.ts';
+import { MEDIA_POSTER_PLACEHOLDER } from '$lib/utils/assets.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import type { MediaEntry } from '../models/MediaEntry.ts';

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -3,7 +3,7 @@
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaType } from "$lib/requests/models/MediaType";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import Redirect from "../../components/router/Redirect.svelte";
   import Footer from "../footer/Footer.svelte";

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -14,7 +14,7 @@
   import {
     EPISODE_COVER_PLACEHOLDER,
     MEDIA_POSTER_PLACEHOLDER,
-  } from "$lib/utils/constants";
+  } from "$lib/utils/assets";
   import { episodeNumberLabel } from "$lib/utils/intl/episodeNumberLabel";
   import { episodeSubtitle } from "$lib/utils/intl/episodeSubtitle";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -12,7 +12,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
-  import { EPISODE_COVER_PLACEHOLDER } from "$lib/utils/constants";
+  import { EPISODE_COVER_PLACEHOLDER } from "$lib/utils/assets";
   import { toRelativeHumanDay } from "$lib/utils/formatting/date/toRelativeHumanDay";
   import { episodeNumberLabel } from "$lib/utils/intl/episodeNumberLabel";
   import { episodeSubtitle } from "$lib/utils/intl/episodeSubtitle";

--- a/projects/client/src/lib/sections/toast/_internal/ToastEpisodeCover.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/ToastEpisodeCover.svelte
@@ -5,7 +5,7 @@
   import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
-  import { EPISODE_COVER_PLACEHOLDER } from "$lib/utils/constants";
+  import { EPISODE_COVER_PLACEHOLDER } from "$lib/utils/assets";
   import { episodeActivityTitle } from "$lib/utils/intl/episodeActivityTitle";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 

--- a/projects/client/src/lib/utils/assets.ts
+++ b/projects/client/src/lib/utils/assets.ts
@@ -1,0 +1,41 @@
+import { assets } from '$app/paths';
+import { shuffle } from '$lib/utils/array/shuffle.ts';
+import { assertDefined } from './assert/assertDefined.ts';
+
+export const EPISODE_COVER_PLACEHOLDER =
+  `${assets}/placeholders/landscape_placeholder.png` as HttpsUrl;
+
+export const MEDIA_COVER_LARGE_PLACEHOLDER =
+  `${assets}/placeholders/purple_placeholder.png` as HttpsUrl;
+
+export const MEDIA_COVER_THUMB_PLACEHOLDER =
+  `${assets}/placeholders/landscape_placeholder.png` as HttpsUrl;
+
+export const MEDIA_POSTER_PLACEHOLDER =
+  `${assets}/placeholders/portrait_placeholder.png` as HttpsUrl;
+
+export const PLACEHOLDERS: string[] = [
+  EPISODE_COVER_PLACEHOLDER,
+  MEDIA_COVER_LARGE_PLACEHOLDER,
+  MEDIA_COVER_THUMB_PLACEHOLDER,
+  MEDIA_POSTER_PLACEHOLDER,
+];
+
+const generateShareCover = (type: 'show' | 'movie') =>
+  assertDefined(
+    shuffle(
+      [1, 2, 3, 4, 5].map((n) => `${assets}/trakt_share_${type}_${n}.webp`),
+    ).at(0),
+    `${type} share cover is required`,
+  );
+
+export const DEFAULT_SHARE_SHOW_COVER = generateShareCover('show');
+export const DEFAULT_SHARE_MOVIE_COVER = generateShareCover('movie');
+
+export const DEFAULT_SHARE_COVER = assertDefined(
+  shuffle([
+    DEFAULT_SHARE_SHOW_COVER,
+    DEFAULT_SHARE_MOVIE_COVER,
+  ]).at(0),
+  'Default share cover is required',
+);

--- a/projects/client/src/lib/utils/constants.ts
+++ b/projects/client/src/lib/utils/constants.ts
@@ -1,56 +1,14 @@
-import { assets } from '$app/paths';
-import { shuffle } from '$lib/utils/array/shuffle.ts';
-import { assertDefined } from './assert/assertDefined.ts';
-
 /**
  * This cover is the Alien Isolation cover.
  */
 export const DEFAULT_COVER =
   'https://walter-r2.trakt.tv/images/movies/000/759/944/fanarts/full/a12a59d031.jpg.webp';
 
-export const EPISODE_COVER_PLACEHOLDER =
-  `${assets}/placeholders/landscape_placeholder.png` as HttpsUrl;
-
-export const MEDIA_COVER_LARGE_PLACEHOLDER =
-  `${assets}/placeholders/purple_placeholder.png` as HttpsUrl;
-
-export const MEDIA_COVER_THUMB_PLACEHOLDER =
-  `${assets}/placeholders/landscape_placeholder.png` as HttpsUrl;
-
-export const MEDIA_POSTER_PLACEHOLDER =
-  `${assets}/placeholders/portrait_placeholder.png` as HttpsUrl;
-
-export const PLACEHOLDERS: string[] = [
-  EPISODE_COVER_PLACEHOLDER,
-  MEDIA_COVER_LARGE_PLACEHOLDER,
-  MEDIA_COVER_THUMB_PLACEHOLDER,
-  MEDIA_POSTER_PLACEHOLDER,
-];
-
 export const DEFAULT_AVATAR =
   'https://walter-r2.trakt.tv/hotlink-ok/placeholders/medium/zoidberg.png' as HttpsUrl;
 
 export const MAX_DATE = new Date('9999-12-31T23:59:59.999Z');
 export const MIN_DATE = new Date('0000-01-01T00:00:00.000Z');
-
-const generateShareCover = (type: 'show' | 'movie') =>
-  assertDefined(
-    shuffle(
-      [1, 2, 3, 4, 5].map((n) => `${assets}/trakt_share_${type}_${n}.webp`),
-    ).at(0),
-    `${type} share cover is required`,
-  );
-
-export const DEFAULT_SHARE_SHOW_COVER = generateShareCover('show');
-export const DEFAULT_SHARE_MOVIE_COVER = generateShareCover('movie');
-
-export const DEFAULT_SHARE_COVER = assertDefined(
-  shuffle([
-    DEFAULT_SHARE_SHOW_COVER,
-    DEFAULT_SHARE_MOVIE_COVER,
-  ]).at(0),
-  'Default share cover is required',
-);
 
 export const NOOP_FN = () => {
   // noop

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -13,7 +13,7 @@
   import UpNextList from "$lib/sections/lists/progress/UpNextList.svelte";
   import UpcomingList from "$lib/sections/lists/UpcomingList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   // FIXME: move to PersonalHistoryList when Profile also supports discover mode
   const { mode } = useDiscover();

--- a/projects/client/src/routes/_design_system/assets/+page.svelte
+++ b/projects/client/src/routes/_design_system/assets/+page.svelte
@@ -12,7 +12,7 @@
   import { usePopularList } from "$lib/sections/lists/popular/usePopularList";
   import { useTrendingList } from "$lib/sections/lists/trending/useTrendingList";
   import { shuffle } from "$lib/utils/array/shuffle";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import DownloadIcon from "./DownloadIcon.svelte";
 
   const total = $derived(parseInt(page.url.searchParams.get("limit") ?? "70"));

--- a/projects/client/src/routes/about/+page.svelte
+++ b/projects/client/src/routes/about/+page.svelte
@@ -2,7 +2,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import About from "$lib/sections/about/About.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/branding/+page.svelte
+++ b/projects/client/src/routes/branding/+page.svelte
@@ -2,7 +2,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import Branding from "$lib/sections/branding/Branding.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/calendar/+page.svelte
+++ b/projects/client/src/routes/calendar/+page.svelte
@@ -6,7 +6,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
 
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/discover/+page.svelte
+++ b/projects/client/src/routes/discover/+page.svelte
@@ -12,7 +12,7 @@
   import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
   import TrendingList from "$lib/sections/lists/trending/TrendingList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 
   const { mode: type, useSeasonalFilters } = useDiscover();
   const { themeFilters } = useSeasonalTheme();

--- a/projects/client/src/routes/history/+page.svelte
+++ b/projects/client/src/routes/history/+page.svelte
@@ -8,7 +8,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import PersonalHistoryPaginatedList from "$lib/sections/lists/history/PersonalHistoryPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   const { mode } = useDiscover();
   const { history } = useUser();

--- a/projects/client/src/routes/lists/official/[list]/+page.svelte
+++ b/projects/client/src/routes/lists/official/[list]/+page.svelte
@@ -3,7 +3,7 @@
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import UserListPaginatedList from "$lib/sections/lists/user/UserListPaginatedList.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import { mapToMediaType } from "../../../users/[user]/lists/[list]/_internal/mapToMediaType";
   import type { PageProps } from "../[list]/$types";
   import { useListSummary } from "./useListSummary";

--- a/projects/client/src/routes/lists/smart/create/+page.svelte
+++ b/projects/client/src/routes/lists/smart/create/+page.svelte
@@ -6,7 +6,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import SmartListCreator from "$lib/sections/smart-lists/SmartListCreator.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   const { mode } = useDiscover();
 

--- a/projects/client/src/routes/lists/smart/view/+page.svelte
+++ b/projects/client/src/routes/lists/smart/view/+page.svelte
@@ -6,7 +6,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import SmartListRenderer from "$lib/sections/lists/smart/SmartListRenderer.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   const { mode } = useDiscover();
 </script>

--- a/projects/client/src/routes/lists/smart/view/[list]/+page.svelte
+++ b/projects/client/src/routes/lists/smart/view/[list]/+page.svelte
@@ -6,10 +6,8 @@
   import SmartListPaginatedRenderer from "$lib/sections/lists/smart/SmartListPaginatedRenderer.svelte";
   import { useSmartLists } from "$lib/sections/lists/smart/useSmartLists.ts";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import {
-    DEFAULT_SHARE_COVER,
-    UPPER_SMART_LIST_LIMIT,
-  } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
+  import { UPPER_SMART_LIST_LIMIT } from "$lib/utils/constants";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
   import type { PageProps } from "./$types";
 

--- a/projects/client/src/routes/media/anticipated/+page.svelte
+++ b/projects/client/src/routes/media/anticipated/+page.svelte
@@ -5,7 +5,7 @@
 
   import AnticipatedPaginatedList from "$lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/media/popular/+page.svelte
+++ b/projects/client/src/routes/media/popular/+page.svelte
@@ -5,7 +5,7 @@
   import PopularPaginatedList from "$lib/sections/lists/popular/PopularPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
 
-  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/media/recommended/+page.svelte
+++ b/projects/client/src/routes/media/recommended/+page.svelte
@@ -5,7 +5,7 @@
 
   import RecommendedPaginatedList from "$lib/sections/lists/recommended/RecommendedPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/media/trending/+page.svelte
+++ b/projects/client/src/routes/media/trending/+page.svelte
@@ -5,7 +5,7 @@
 
   import TrendingPaginatedList from "$lib/sections/lists/trending/TrendingPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/movies/+page.svelte
+++ b/projects/client/src/routes/movies/+page.svelte
@@ -7,7 +7,7 @@
   import PopularList from "$lib/sections/lists/popular/PopularList.svelte";
   import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
   import TrendingList from "$lib/sections/lists/trending/TrendingList.svelte";
-  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 
   const type = "movie";
 </script>

--- a/projects/client/src/routes/movies/anticipated/+page.svelte
+++ b/projects/client/src/routes/movies/anticipated/+page.svelte
@@ -5,7 +5,7 @@
 
   import AnticipatedPaginatedList from "$lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/movies/popular/+page.svelte
+++ b/projects/client/src/routes/movies/popular/+page.svelte
@@ -5,7 +5,7 @@
   import PopularPaginatedList from "$lib/sections/lists/popular/PopularPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
 
-  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/movies/recommended/+page.svelte
+++ b/projects/client/src/routes/movies/recommended/+page.svelte
@@ -5,7 +5,7 @@
 
   import RecommendedPaginatedList from "$lib/sections/lists/recommended/RecommendedPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/movies/trending/+page.svelte
+++ b/projects/client/src/routes/movies/trending/+page.svelte
@@ -5,7 +5,7 @@
 
   import TrendingPaginatedList from "$lib/sections/lists/trending/TrendingPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/privacy/+page.svelte
+++ b/projects/client/src/routes/privacy/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import Privacy from "$lib/sections/privacy/Privacy.svelte";
 </script>
 

--- a/projects/client/src/routes/profile/[slug]/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/+page.svelte
@@ -7,7 +7,7 @@
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import PrivateProfile from "$lib/sections/profile/PrivateProfile.svelte";
   import Profile from "$lib/sections/profile/Profile.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import type { PageProps } from "./$types";
   import { useProfile } from "./useProfile";
 

--- a/projects/client/src/routes/profile/me/+page.svelte
+++ b/projects/client/src/routes/profile/me/+page.svelte
@@ -7,7 +7,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import Profile from "$lib/sections/profile/Profile.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   const { user } = useUser();
 </script>

--- a/projects/client/src/routes/search/+page.svelte
+++ b/projects/client/src/routes/search/+page.svelte
@@ -12,7 +12,7 @@
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import { isMobileAppleDevice } from "$lib/utils/devices/isMobileAppleDevice";
 
   const query = $derived(page.url.searchParams.get("q")?.trim());

--- a/projects/client/src/routes/settings/+layout.svelte
+++ b/projects/client/src/routes/settings/+layout.svelte
@@ -4,7 +4,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import Settings from "$lib/sections/settings/Settings.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   const { children } = $props();
 </script>

--- a/projects/client/src/routes/shows/+page.svelte
+++ b/projects/client/src/routes/shows/+page.svelte
@@ -9,7 +9,7 @@
   import TrendingList from "$lib/sections/lists/trending/TrendingList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
 
-  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 
   const type = "show";
 </script>

--- a/projects/client/src/routes/shows/anticipated/+page.svelte
+++ b/projects/client/src/routes/shows/anticipated/+page.svelte
@@ -5,7 +5,7 @@
 
   import AnticipatedPaginatedList from "$lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/shows/popular/+page.svelte
+++ b/projects/client/src/routes/shows/popular/+page.svelte
@@ -5,7 +5,7 @@
 
   import PopularPaginatedList from "$lib/sections/lists/popular/PopularPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/shows/recommended/+page.svelte
+++ b/projects/client/src/routes/shows/recommended/+page.svelte
@@ -5,7 +5,7 @@
 
   import RecommendedPaginatedList from "$lib/sections/lists/recommended/RecommendedPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/shows/trending/+page.svelte
+++ b/projects/client/src/routes/shows/trending/+page.svelte
@@ -5,7 +5,7 @@
 
   import TrendingPaginatedList from "$lib/sections/lists/trending/TrendingPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/social/activity/+page.svelte
+++ b/projects/client/src/routes/social/activity/+page.svelte
@@ -9,7 +9,7 @@
 
   import ActivityPaginatedList from "$lib/sections/lists/activity/ActivityPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   const { mode } = useDiscover();
 

--- a/projects/client/src/routes/terms/+page.svelte
+++ b/projects/client/src/routes/terms/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import Terms from "$lib/sections/terms/Terms.svelte";
 </script>
 

--- a/projects/client/src/routes/users/[user]/library/+page.svelte
+++ b/projects/client/src/routes/users/[user]/library/+page.svelte
@@ -9,7 +9,7 @@
   import LibraryListPaginated from "$lib/sections/lists/library/LibraryListPaginated.svelte";
   import type { Library } from "$lib/sections/lists/library/models/Library";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { PageProps } from "./$types";
 

--- a/projects/client/src/routes/users/[user]/lists/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/+page.svelte
@@ -12,7 +12,7 @@
   import PinnedList from "$lib/sections/lists/user/PinnedList.svelte";
   import WatchList from "$lib/sections/lists/watchlist/WatchList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { PageProps } from "./$types";
 

--- a/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
@@ -5,7 +5,7 @@
   import UserListPaginatedList from "$lib/sections/lists/user/UserListPaginatedList.svelte";
   import { useUserListSummary } from "$lib/sections/lists/user/useUserListSummary.ts";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import type { PageProps } from "./$types";
   import { mapToMediaType } from "./_internal/mapToMediaType";
 

--- a/projects/client/src/routes/users/[user]/lists/view/collaborations/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/view/collaborations/+page.svelte
@@ -5,7 +5,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import PersonalListsPaginated from "$lib/sections/lists/user/PersonalListsPaginated.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import type { PageProps } from "./$types";
 
   const { params }: PageProps = $props();

--- a/projects/client/src/routes/users/[user]/lists/view/liked/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/view/liked/+page.svelte
@@ -8,7 +8,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import PersonalListsPaginated from "$lib/sections/lists/user/PersonalListsPaginated.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { PageProps } from "./$types";
 

--- a/projects/client/src/routes/users/[user]/lists/view/personal/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/view/personal/+page.svelte
@@ -5,7 +5,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import PersonalListsPaginated from "$lib/sections/lists/user/PersonalListsPaginated.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import type { PageProps } from "./$types";
 
   const { params }: PageProps = $props();

--- a/projects/client/src/routes/users/[user]/mir/[year]/[month]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/mir/[year]/[month]/+page.svelte
@@ -4,7 +4,7 @@
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { PageProps } from "./$types";
 

--- a/projects/client/src/routes/users/[user]/progress/+page.svelte
+++ b/projects/client/src/routes/users/[user]/progress/+page.svelte
@@ -6,7 +6,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import UpNextPaginatedList from "$lib/sections/lists/progress/UpNextPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/users/[user]/start-watching/+page.svelte
+++ b/projects/client/src/routes/users/[user]/start-watching/+page.svelte
@@ -6,7 +6,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import UpNextPaginatedList from "$lib/sections/lists/progress/UpNextPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage

--- a/projects/client/src/routes/users/[user]/watchlist/+page.svelte
+++ b/projects/client/src/routes/users/[user]/watchlist/+page.svelte
@@ -6,7 +6,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import WatchlistPaginatedList from "$lib/sections/lists/watchlist/WatchlistPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 
   const { mode } = useDiscover();
 </script>

--- a/projects/client/src/routes/vip/+page.svelte
+++ b/projects/client/src/routes/vip/+page.svelte
@@ -4,7 +4,7 @@
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import VipManage from "$lib/sections/vip/VipManage.svelte";
   import VipSubscribe from "$lib/sections/vip/VipSubscribe.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 </script>
 
 <TraktPage audience="authenticated" image={DEFAULT_SHARE_COVER} title="VIP">

--- a/projects/client/src/routes/vip/renew/+page.svelte
+++ b/projects/client/src/routes/vip/renew/+page.svelte
@@ -4,7 +4,7 @@
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { useVip } from "$lib/sections/vip/_internal/useVip";
   import VipSubscribe from "$lib/sections/vip/VipSubscribe.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/constants";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
   const { subscription, isLoading } = useVip();


### PR DESCRIPTION
### Overview
Relocates asset-related constants and placeholder generation logic into a dedicated utility file to improve project structure and ensure better path resolution for static assets.

### Changes
- Creates a new `assets.ts` utility file to house media placeholders and share cover generation logic.
- Moves placeholder constants and the `PLACEHOLDERS` array from the general constants file to the new assets utility.
- Updates imports in the image components and request mapping logic to reference the new file location.
- Integrates `$app/paths` within the asset utility to handle base path resolution more effectively.

### Testing
Verified that image components and media mappers correctly resolve placeholder paths by updating all relevant import references and ensuring the client builds without resolution errors.