### PR TITLE
feat(layout) / add canonical link and sanitize og:url

### DIFF
--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -73,6 +73,10 @@
       : _info,
   );
 
+  const canonicalUrl = $derived(
+    `${page.url.origin}${page.url.pathname}`,
+  );
+
   const dynamicContentProps = $derived(
     hasDynamicContent
       ? {
@@ -84,9 +88,10 @@
 
 <svelte:head>
   <title>{displayTitle}</title>
+  <link rel="canonical" href={canonicalUrl} />
   <meta property="og:site_name" content={websiteName} />
   <meta property="og:type" content={ogType} />
-  <meta property="og:url" content={page.url.toString()} />
+  <meta property="og:url" content={canonicalUrl} />
   <meta property="og:image" content={image} />
   <meta property="og:title" content={ogTitle} />
   <meta property="og:locale" content="en_US" />


### PR DESCRIPTION
### Overview
Improves search engine optimization and ensures consistent social media sharing by implementing canonical URLs and sanitizing metadata.

### Changes
- Derives a canonical URL from the page origin and pathname to exclude query parameters and fragments.
- Adds a `rel="canonical"` link tag to the document head for better indexing.
- Updates the `og:url` property to use the sanitized canonical URL instead of the full raw URL.

### Testing
Verified by inspecting the rendered HTML head in a browser environment to ensure that query strings are correctly stripped from the canonical and Open Graph URL tags.