### PR TITLE
iOS i18n updates + duplicate 'terms of use' key fix

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Сигурни ли сте, че искате да премахнете това гледне на \"{title}\" от наблюдавани?"
     },
+    "list_title_episodes": {
+      "default": "Епизоди"
+    },
     "list_title_seasons": {
       "default": "Сезони"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Управление на списъци"
     },
+    "button_text_view_history": {
+      "default": "Виж историята"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Добави или премахни \"{title}\" от списъци"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Десетилетие"
+    },
+    "header_ratings": {
+      "default": "Оценки"
     },
     "button_label_view_all_items_in": {
       "default": "Виж всички в \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Обзор на месеца"
     },
     "page_title_settings": {
+      "default": "Настройки"
+    },
+    "button_text_settings": {
       "default": "Настройки"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "За мен"
     },
+    "page_title_automatic_tracking": {
+      "default": "Автоматично проследяване"
+    },
     "text_automatic_tracking": {
       "default": "Автоматично Проследяване"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Изтриване на акаунт"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Диагностика и кеш"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Споделяне на логовете за автентикация"
+    },
+    "button_text_view_cache_size": {
+      "default": "Виж размера на кеша"
+    },
+    "button_text_clear_cache": {
+      "default": "Изчисти кеша"
+    },
+    "text_analytics": {
+      "default": "Анализ"
     },
     "header_calendar": {
       "default": "Календар"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "Тази година"
     },
+    "filter_label_before_year": {
+      "default": "Преди {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Наскоро актуализирани"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Спри проверка"
+    },
+    "button_text_edit_comment": {
+      "default": "Редактирай"
     },
     "button_text_delete_comment": {
       "default": "Изтрий ревюто"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Режисьор: <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Режисьор: {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Режисьор:"
     },
     "text_created_by": {
       "default": "Създадено от <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Създадено от {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Създател:"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Прекратено"
+    },
+    "tag_text_started": {
+      "default": "Започнат"
     },
     "header_height": {
       "default": "Ръст"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Искате ли да спрете да бъдете питани за оценка на това, което наскоро сте гледали?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Възстанови подканите за оценка"
+    },
     "text_billing_month_for_free": {
       "default": "Опитайте 1 месец безплатно и след това:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Надграждане до VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Неограничено проследяване и още."
+      "default": "Обзор на годината и още."
     },
     "button_label_like_list": {
       "default": "Харесва ми {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Условия за ползване"
+    },
+    "button_text_block_comments": {
+      "default": "Блокиране на коментарите от {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Готово"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Отхвърляне на промените?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Сигурни ли сте, че искате да отхвърлите това? Всички незапазени промени ще бъдат загубени."
+    },
+    "button_text_discard": {
+      "default": "Отхвърляне"
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Er du sikker på, at du vil fjerne denne afspilning af \"{title}\" fra din set-liste?"
     },
+    "list_title_episodes": {
+      "default": "Afsnit"
+    },
     "list_title_seasons": {
       "default": "Sæsoner"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Administrer lister"
     },
+    "button_text_view_history": {
+      "default": "Se historik"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Tilføj eller fjern \"{title}\" fra lister"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Årti"
+    },
+    "header_ratings": {
+      "default": "Bedømmelser"
     },
     "button_label_view_all_items_in": {
       "default": "Se alle i \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Månedens overblik"
     },
     "page_title_settings": {
+      "default": "Indstillinger"
+    },
+    "button_text_settings": {
       "default": "Indstillinger"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "Om mig"
     },
+    "page_title_automatic_tracking": {
+      "default": "Automatisk sporing"
+    },
     "text_automatic_tracking": {
       "default": "Automatisk Sporing"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Slet konto"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnosticering og cache"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Del godkendelseslogfiler"
+    },
+    "button_text_view_cache_size": {
+      "default": "Se cache-størrelse"
+    },
+    "button_text_clear_cache": {
+      "default": "Ryd cache"
+    },
+    "text_analytics": {
+      "default": "Analyse"
     },
     "header_calendar": {
       "default": "Kalender"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "I år"
     },
+    "filter_label_before_year": {
+      "default": "Før {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Senest opdateret"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Stop check-in"
+    },
+    "button_text_edit_comment": {
+      "default": "Rediger"
     },
     "button_text_delete_comment": {
       "default": "Slet anmeldelse"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Instrueret af <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Instrueret af {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Instrueret af"
     },
     "text_created_by": {
       "default": "Skabt af <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Skabt af {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Skabt af"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Droppet"
+    },
+    "tag_text_started": {
+      "default": "Påbegyndt"
     },
     "header_height": {
       "default": "Højde"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Vil du stoppe med at blive spurgt om at bedømme det, du for nylig har set?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Gendan vurderingsanmodninger"
+    },
     "text_billing_month_for_free": {
       "default": "Prøv 1 måned gratis og derefter:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Opgrader til VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Ubegrænset sporing og meget mere."
+      "default": "Året der gik & meget mere."
     },
     "button_label_like_list": {
       "default": "Synes godt om {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Brugsvilkår"
+    },
+    "button_text_block_comments": {
+      "default": "Bloker kommentarer fra {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Færdig"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Annuller ændringer?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Er du sikker på, at du vil annullere dette? Alle ikke-gemte ændringer vil gå tabt."
+    },
+    "button_text_discard": {
+      "default": "Annuller"
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Möchten Sie diese Wiedergabe von \"{title}\" wirklich von Ihrer Gesehen-Liste entfernen?"
     },
+    "list_title_episodes": {
+      "default": "Episoden"
+    },
     "list_title_seasons": {
       "default": "Staffeln"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Listen verwalten"
     },
+    "button_text_view_history": {
+      "default": "Verlauf anzeigen"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "\"{title}\" zu Listen hinzufügen oder entfernen"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Dekade"
+    },
+    "header_ratings": {
+      "default": "Bewertungen"
     },
     "button_label_view_all_items_in": {
       "default": "Alle \"{title}\" ansehen"
@@ -1261,6 +1270,9 @@
       "default": "Monatsrückblick"
     },
     "page_title_settings": {
+      "default": "Einstellungen"
+    },
+    "button_text_settings": {
       "default": "Einstellungen"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "Über mich"
     },
+    "page_title_automatic_tracking": {
+      "default": "Automatisches Tracking"
+    },
     "text_automatic_tracking": {
       "default": "Automatische Verfolgung"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Konto löschen"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnose & Cache"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Authentifizierungsprotokolle teilen"
+    },
+    "button_text_view_cache_size": {
+      "default": "Cache-Größe anzeigen"
+    },
+    "button_text_clear_cache": {
+      "default": "Cache leeren"
+    },
+    "text_analytics": {
+      "default": "Analysen"
     },
     "header_calendar": {
       "default": "Kalender"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "Dieses Jahr"
     },
+    "filter_label_before_year": {
+      "default": "Vor {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Kürzlich aktualisiert"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Check-in beenden"
+    },
+    "button_text_edit_comment": {
+      "default": "Bearbeiten"
     },
     "button_text_delete_comment": {
       "default": "Bewertung löschen"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Regie: <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Regie: {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Regie:"
     },
     "text_created_by": {
       "default": "Erstellt von <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Erstellt von {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Erstellt von:"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Abgebrochen"
+    },
+    "tag_text_started": {
+      "default": "Begonnen"
     },
     "header_height": {
       "default": "Größe"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Möchten Sie nicht mehr gefragt werden, was Sie kürzlich gesehen haben?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Bewertungsaufforderungen wiederherstellen"
+    },
     "text_billing_month_for_free": {
       "default": "1 Monat gratis testen und dann:"
     },
@@ -2404,7 +2462,7 @@
       "default": "VIP aufwerten!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Unbegrenztes Tracking und mehr."
+      "default": "Jahresrückblick & mehr."
     },
     "button_label_like_list": {
       "default": "{name} gefällt mir"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Nutzungsbedingungen"
+    },
+    "button_text_block_comments": {
+      "default": "Kommentare von {user} blockieren"
+    },
+    "button_text_keyboard_done": {
+      "default": "Fertig"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Änderungen verwerfen?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Sind Sie sicher, dass Sie dies verwerfen möchten? Alle ungespeicherten Änderungen gehen verloren."
+    },
+    "button_text_discard": {
+      "default": "Verwerfen"
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Are you sure you want to remove this play of \"{title}\" from your Watched list?"
     },
+    "list_title_episodes": {
+      "default": "Episodes"
+    },
     "list_title_seasons": {
       "default": "Seasons"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Manage lists"
     },
+    "button_text_view_history": {
+      "default": "View History"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Add or remove \"{title}\" from lists"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Decade"
+    },
+    "header_ratings": {
+      "default": "Ratings"
     },
     "button_label_view_all_items_in": {
       "default": "View all items in \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Month in review"
     },
     "page_title_settings": {
+      "default": "Settings"
+    },
+    "button_text_settings": {
       "default": "Settings"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "About me"
     },
+    "page_title_automatic_tracking": {
+      "default": "Automatic Tracking"
+    },
     "text_automatic_tracking": {
       "default": "Automatic Tracking"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Delete Account"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnostics & Cache"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Share Authentication Logs"
+    },
+    "button_text_view_cache_size": {
+      "default": "View Cache Size"
+    },
+    "button_text_clear_cache": {
+      "default": "Clear Cache"
+    },
+    "text_analytics": {
+      "default": "Analytics"
     },
     "header_calendar": {
       "default": "Calendar"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "This year"
     },
+    "filter_label_before_year": {
+      "default": "Before {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Recently updated"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Stop check in"
+    },
+    "button_text_edit_comment": {
+      "default": "Edit"
     },
     "button_text_delete_comment": {
       "default": "Delete Review"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Directed by <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Directed by {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Directed by"
     },
     "text_created_by": {
       "default": "Created by <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Created by {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Created by"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Dropped"
+    },
+    "tag_text_started": {
+      "default": "Started"
     },
     "header_height": {
       "default": "Height"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Do you want to stop being asked to rate what you recently watched?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Restore Rating Prompts"
+    },
     "text_billing_month_for_free": {
       "default": "Try 1 month for free and then:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Upgrade to VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Unlimited tracking and more."
+      "default": "Year in Review & more."
     },
     "button_label_like_list": {
       "default": "Like {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Terms of Use"
+    },
+    "button_text_block_comments": {
+      "default": "Block comments from {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Done"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Discard Changes?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Are you sure you want to discard this? Any unsaved changes will be lost."
+    },
+    "button_text_discard": {
+      "default": "Discard"
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -128,16 +128,12 @@
     "button_text_watchlist": {
       "default": "Watchlist",
       "description": "Text for the button that allows users to add/remove a movie or show to/from their watchlist.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_text_mark_as_watched": {
       "default": "Mark as Watched",
       "description": "Text for the button that allows users to mark a movie, episode, or show as watched.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_text_watched_until_here": {
       "default": "Watched until here",
@@ -150,9 +146,7 @@
     "button_text_watch_again": {
       "default": "Watch again",
       "description": "Text for the button that allows users to mark a movie, episode, or show as re-watched.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_add_to_watchlist": {
       "default": "Add \"{title}\" to your Watchlist",
@@ -210,296 +204,259 @@
       "default": "Horror",
       "description": "Text for the horror genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_comedy": {
       "default": "Comedy",
       "description": "Text for the comedy genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_action": {
       "default": "Action",
       "description": "Text for the action genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_adventure": {
       "default": "Adventure",
       "description": "Text for the adventure genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_animation": {
       "default": "Animation",
       "description": "Text for the animation genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_biography": {
       "default": "Biography",
       "description": "Text for the biography genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_children": {
       "default": "Children",
       "description": "Text for the children genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_crime": {
       "default": "Crime",
       "description": "Text for the crime genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_documentary": {
       "default": "Documentary",
       "description": "Text for the documentary genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_drama": {
       "default": "Drama",
       "description": "Text for the drama genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_family": {
       "default": "Family",
       "description": "Text for the family genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_fantasy": {
       "default": "Fantasy",
       "description": "Text for the fantasy genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_game_show": {
       "default": "Game Show",
       "description": "Text for the game show genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_history": {
       "default": "History",
       "description": "Text for the history genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_home_and_garden": {
       "default": "Home and Garden",
       "description": "Text for the home and garden genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_holiday": {
       "default": "Holiday",
       "description": "Text for the holiday genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_music": {
       "default": "Music",
       "description": "Text for the music genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_musical": {
       "default": "Musical",
       "description": "Text for the musical genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_mystery": {
       "default": "Mystery",
       "description": "Text for the mystery genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_news": {
       "default": "News",
       "description": "Text for the news genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_none": {
       "default": "None",
       "description": "Text for the none genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_reality": {
       "default": "Reality",
       "description": "Text for the reality genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_romance": {
       "default": "Romance",
       "description": "Text for the romance genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_short": {
       "default": "Short",
       "description": "Text for the short genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_soap": {
       "default": "Soap",
       "description": "Text for the soap genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_special_interest": {
       "default": "Special Interest",
       "description": "Text for the special interest genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_sporting_event": {
       "default": "Sporting Event",
       "description": "Text for the sporting event genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_suspense": {
       "default": "Suspense",
       "description": "Text for the suspense genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_talk_show": {
       "default": "Talk Show",
       "description": "Text for the talk show genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_thriller": {
       "default": "Thriller",
       "description": "Text for the thriller genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_war": {
       "default": "War",
       "description": "Text for the war genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_western": {
       "default": "Western",
       "description": "Text for the western genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_anime": {
       "default": "Anime",
       "description": "Text for the anime genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_superhero": {
       "default": "Superhero",
       "description": "Text for the superhero genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_donghua": {
       "default": "Donghua",
       "description": "Text for the donghua genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_mini_series": {
       "default": "Mini-Series",
       "description": "Text for the mini-series genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_genre_science_fiction": {
       "default": "Science Fiction",
       "description": "Text for the science fiction genre. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_label_remove_from_watchlist": {
@@ -523,16 +480,12 @@
     "input_placeholder_search_movies": {
       "default": "Search movies...",
       "description": "Placeholder text for the search input field. This should be a short and concise message that indicates what users can search for.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "input_placeholder_search_shows": {
       "default": "Search shows...",
       "description": "Placeholder text for the search input field. This should be a short and concise message that indicates what users can search for.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_text_join_trakt": {
       "default": "Join Trakt",
@@ -672,9 +625,7 @@
     "badge_text_get_vip": {
       "default": "Get VIP",
       "description": "Text for the VIP upsell badge. This is shown in a badge and should be as short as possible.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_get_vip": {
       "default": "Unlock VIP features",
@@ -800,8 +751,7 @@
       "default": "TBA",
       "description": "Text for the tag that indicates that something has no release date yet. This should be as short as possible.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "list_title_related_movies": {
@@ -1118,600 +1068,524 @@
       "default": "Action Director",
       "description": "Job title for the action director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_additional_second_assistant_director": {
       "default": "Additional Second Assistant Director",
       "description": "Job title for the additional second assistant director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_additional_third_assistant_director": {
       "default": "Additional Third Assistant Director",
       "description": "Job title for the additional third assistant director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_assistant_director": {
       "default": "Assistant Director",
       "description": "Job title for the assistant director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_assistant_director_trainee": {
       "default": "Assistant Director Trainee",
       "description": "Job title for the assistant director trainee. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_co_director": {
       "default": "Co-Director",
       "description": "Job title for the co-director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_continuity": {
       "default": "Continuity",
       "description": "Job title for the continuity supervisor. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_crowd_assistant_director": {
       "default": "Crowd Assistant Director",
       "description": "Job title for the crowd assistant director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_director": {
       "default": "Director",
       "description": "Job title for the director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_field_director": {
       "default": "Field Director",
       "description": "Job title for the field director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_first_assistant_director": {
       "default": "First Assistant Director",
       "description": "Job title for the first assistant director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_first_assistant_director_trainee_prep": {
       "default": "First Assistant Director (Prep)",
       "description": "Job title for the first assistant director trainee (prep). The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_first_assistant_director_trainee": {
       "default": "First Assistant Director Trainee",
       "description": "Job title for the first assistant director trainee. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_insert_unit_director": {
       "default": "Insert Unit Director",
       "description": "Job title for the insert unit director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_insert_unit_first_assistant_director": {
       "default": "Insert Unit First Assistant Director",
       "description": "Job title for the insert unit first assistant director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_layout": {
       "default": "Layout",
       "description": "Job title for the layout artist. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_other": {
       "default": "Other",
       "description": "Job title that is used when no specific job is known. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_script_coordinator": {
       "default": "Script Coordinator",
       "description": "Job title for the script coordinator. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_script_supervisor": {
       "default": "Script Supervisor",
       "description": "Job title for the script supervisor. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_second_assistant_director": {
       "default": "Second Assistant Director",
       "description": "Job title for the second assistant director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_second_assistant_director_trainee": {
       "default": "Second Assistant Director Trainee",
       "description": "Job title for the second assistant director trainee. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_second_second_assistant_director": {
       "default": "Second Second Assistant Director",
       "description": "Job title for the second second assistant director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_second_unit_director": {
       "default": "Second Unit Director",
       "description": "Job title for the second unit director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_second_unit_first_assistant_director": {
       "default": "Second Unit First Assistant Director",
       "description": "Job title for the second unit first assistant director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_series_director": {
       "default": "Series Director",
       "description": "Job title for the series director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_series_guest_director": {
       "default": "Special Guest Director",
       "description": "Job title for the special guest director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_stage_director": {
       "default": "Stage Director",
       "description": "Job title for the stage director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_third_assistant_director": {
       "default": "Third Assistant Director",
       "description": "Job title for the third assistant director. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_adaptation": {
       "default": "Adaptation",
       "description": "Job title for the person who adapted an existing work of literature. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_author": {
       "default": "Author",
       "description": "Job title for the author. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_book": {
       "default": "Book",
       "description": "Job title for the person who wrote the book a media item is based on. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_characters": {
       "default": "Characters",
       "description": "Job title for the person who wrote the characters. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_co_writer": {
       "default": "Co-Writer",
       "description": "Job title for the co-writer. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_comic_book": {
       "default": "Comic Book",
       "description": "Job title for the person who wrote the comic book a media item is based on. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_creative_producer": {
       "default": "Creative Producer",
       "description": "Job title for the creative producer. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_dialogue": {
       "default": "Dialogue",
       "description": "Job title for the dialogue writer. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_executive_story_editor": {
       "default": "Executive Story Editor",
       "description": "Job title for the executive story editor. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_graphic_novel": {
       "default": "Graphic Novel",
       "description": "Job title for the who wrote the graphic novel a media item is based on. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_head_of_story": {
       "default": "Head of Story",
       "description": "Job title for the head of story. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_idea": {
       "default": "Idea",
       "description": "Job title for the person who's idea a media item is based on. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_junior_story_editor": {
       "default": "Junior Story Editor",
       "description": "Job title for the junior story editor. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_lyricist": {
       "default": "Lyricist",
       "description": "Job title for the lyricist. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_musical": {
       "default": "Musical",
       "description": "Job title for the person who made the musical a media item is based on. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_novel": {
       "default": "Novel",
       "description": "Job title for the person who wrote the novel a media item is based on. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_opera": {
       "default": "Opera",
       "description": "Job title for the person who made the opera a media item is based on. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_original_concept": {
       "default": "Original Concept",
       "description": "Job title for the person who came up with the original concept. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_original_film_writer": {
       "default": "Original Film Writer",
       "description": "Job title for the original film writer. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_original_series_creator": {
       "default": "Original Series Creator",
       "description": "Job title for the original series creator. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_original_original_story": {
       "default": "Original Story",
       "description": "Job title for the person who's story a media item is originally based on. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_scenario_writer": {
       "default": "Scenario Writer",
       "description": "Job title for the scenario writer. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_screenplay": {
       "default": "Screenplay",
       "description": "Job title for the screenplay writer. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_screenstory": {
       "default": "Screenstory",
       "description": "Job title for the screenstory writer. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_script_consultant": {
       "default": "Script Consultant",
       "description": "Job title for the script consultant. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_script_editor": {
       "default": "Script Editor",
       "description": "Job title for the script editor. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_senior_story_editor": {
       "default": "Senior Story Editor",
       "description": "Job title for the senior story editor. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_series_composition": {
       "default": "Series Composition",
       "description": "Job title for the person responsible for the series composition. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_short_story": {
       "default": "Short Story",
       "description": "Job title for the person who's short story a media item is based on. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_staff_writer": {
       "default": "Staff Writer",
       "description": "Job title for the staff writer. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_story": {
       "default": "Story",
       "description": "Job title for the person who wrote the story. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_story_story_artist": {
       "default": "Story Artist",
       "description": "Job title for the story artist. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_story_story_consultant": {
       "default": "Story Consultant",
       "description": "Job title for the story consultant. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_story_story_coordinator": {
       "default": "Story Coordinator",
       "description": "Job title for the story coordinator. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_story_story_developer": {
       "default": "Story Developer",
       "description": "Job title for the story developer. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_story_story_editor": {
       "default": "Story Editor",
       "description": "Job title for the story editor. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_story_story_manager": {
       "default": "Story Manager",
       "description": "Job title for the story manager. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_story_story_supervisor": {
       "default": "Story Supervisor",
       "description": "Job title for the story supervisor. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_storyboard": {
       "default": "Storyboard",
       "description": "Job title for the person who worked on the storyboard. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_teleplay": {
       "default": "Teleplay",
       "description": "Job title for the teleplay writer. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_texte": {
       "default": "Texte",
       "description": "Job title for the texte. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_theatre_play": {
       "default": "Theatre Play",
       "description": "Job title for the person who created theatre play a media item is based on. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_writer": {
       "default": "Writer",
       "description": "Job title for the writer. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_writers_assistant": {
       "default": "Writers' Assistant",
       "description": "Job title for the writers' assistant. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_writers_production": {
       "default": "Writers' Production",
       "description": "Job title for the writers' production. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "translated_value_job_creator": {
       "default": "Creator",
       "description": "Job title for the creator. The value is sent back from the Trakt API.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_text_remove_from_history": {
       "default": "Remove from Watched",
       "description": "Text for the button that allows users to remove a movie or episode from their watch history.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_remove_from_watched": {
       "default": "Remove \"{title}\" from your Watched list",
@@ -1734,9 +1608,7 @@
           "type": "string"
         }
       },
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_remove_from_history": {
       "default": "Remove this play of \"{title}\" from your Watched list",
@@ -1759,16 +1631,20 @@
           "type": "string"
         }
       },
+      "exclude": []
+    },
+    "list_title_episodes": {
+      "default": "Episodes",
+      "description": "Title for lists containing episodes of a season. This title should be as short and concise as possible.",
       "exclude": [
-        "ios"
+        "web",
+        "android"
       ]
     },
     "list_title_seasons": {
       "default": "Seasons",
       "description": "Title for lists containing seasons of a show. This title should be as short and concise as possible.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "text_season_number": {
       "default": "Season {number}",
@@ -1778,16 +1654,12 @@
           "type": "number"
         }
       },
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "text_season_specials": {
       "default": "Specials",
       "description": "Text for the specials season of a show. This should be as short and concise as possible.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_expand_media_overview": {
       "default": "Expand \"{title}\" overview",
@@ -1833,9 +1705,7 @@
     "button_text_share": {
       "default": "Share",
       "description": "Text for the button that allows users to share a movie, show, episode, person, profile, etc.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_text_trailer": {
       "default": "Trailer",
@@ -2006,9 +1876,7 @@
           "type": "string"
         }
       },
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_view_all_recommended_movies": {
       "default": "View all recommended movies",
@@ -2090,8 +1958,7 @@
       "default": "Rate",
       "description": "Header for the section that allows users to rate a movie, show, or episode.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_text_add_to_favorites": {
@@ -2212,8 +2079,7 @@
       "default": "Availability",
       "description": "Header for the section that shows streaming services for a movie, show, or episode.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_label_popup_menu": {
@@ -2232,9 +2098,7 @@
     "list_title_popular_lists": {
       "default": "Popular Lists",
       "description": "Title for lists containing popular lists of movies or shows. This title should be as short and concise as possible.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "list_placeholder_popular_lists": {
       "default": "\"{title}\" does not appear on any popular lists.",
@@ -2285,9 +2149,7 @@
     "list_placeholder_comments": {
       "default": "No reviews yet.",
       "description": "Placeholder text shown when there are no reviews in a list.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "list_placeholder_replies": {
       "default": "No replies yet.",
@@ -2616,9 +2478,7 @@
           "type": "string"
         }
       },
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_drop_show": {
       "default": "Flag show \"{title}\" as dropped",
@@ -2636,9 +2496,7 @@
     "button_text_drop_show": {
       "default": "Drop show",
       "description": "Text for the button that allows a user to drop a show. Indicating that a user is no longer actively tracking this show.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "warning_prompt_drop_movie": {
       "default": "Are you sure you want to drop \"{title}\"? This will remove it from your Continue Watching list.",
@@ -2751,8 +2609,7 @@
         }
       },
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "warning_prompt_mark_as_watched_multiple_episodes": {
@@ -2824,9 +2681,7 @@
           "type": "number"
         }
       },
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "list_title_comments": {
       "default": "Reviews",
@@ -2844,22 +2699,17 @@
     "dialog_title_comment": {
       "default": "Review",
       "description": "Title for the review dialog, which is used when a user is adding a new review.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_text_add_review": {
       "default": "Add Review",
       "description": "Button action label used when a user is submitting a review.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_text_add_reply": {
       "default": "Add Reply",
       "description": "Button action label used when a user is submitting a reply.",
       "exclude": [
-        "ios",
         "web"
       ]
     },
@@ -2895,9 +2745,7 @@
     "textarea_placeholder_comment": {
       "default": "Add a review...",
       "description": "Placeholder text for the review textarea when adding a new review.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "switch_label_mark_as_spoiler": {
       "default": "Mark as spoiler",
@@ -2910,9 +2758,7 @@
     "text_spoiler": {
       "default": "Spoiler",
       "description": "Text used to indicate that something is a spoiler.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_close_error": {
       "default": "Close error",
@@ -2933,9 +2779,7 @@
     "translated_value_error_comment_invalid_content": {
       "default": "Reviews must be at least 5 words.",
       "description": "Error message shown when a review is invalid due to content length.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "translated_value_error_reply_invalid_content": {
       "default": "Replies must be at least 5 words.",
@@ -3047,9 +2891,7 @@
     "button_text_retry": {
       "default": "Retry",
       "description": "Text for the retry button. Used for things like error pages and failed authentications.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_retry": {
       "default": "Retry",
@@ -3068,8 +2910,15 @@
       "default": "Manage lists",
       "description": "Text for the button that opens the lists drawer. This allows users to add or remove a movie or show from their lists.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
+      ]
+    },
+    "button_text_view_history": {
+      "default": "View History",
+      "description": "Text for the button that opens the full page of the user's plays for a particular media item.",
+      "exclude": [
+        "web",
+        "android"
       ]
     },
     "dropdown_label_add_remove_from_lists": {
@@ -3136,24 +2985,21 @@
       "default": "Light",
       "description": "Text for the light theme option in the theme selection dropdown.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "option_text_theme_dark": {
       "default": "Dark",
       "description": "Text for the dark theme option in the theme selection dropdown.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "option_text_theme_system": {
       "default": "System",
       "description": "Text for the system theme option in the theme selection dropdown.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_label_filters": {
@@ -3168,8 +3014,7 @@
       "default": "Reset",
       "description": "Aria-label for the button that resets a single filter to its initial value.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_search_results_for": {
@@ -3241,48 +3086,50 @@
       "default": "Hide Watched",
       "description": "Header for the filter that allows users to hide watched items in their lists.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "header_hide_watchlisted": {
       "default": "Hide Watchlisted",
       "description": "Header for the filter that allows users to hide watchlisted items in their lists.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "option_text_my_favorites": {
       "default": "My favorites",
       "description": "Text for the option that filters items to show only those that are in the user's favorites.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "option_text_all_digital_releases": {
       "default": "All digital releases",
       "description": "Text for the option that filters items to show all digital releases.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "option_text_streaming_now": {
       "default": "Streaming now",
       "description": "Text for the option that filters items to show only those that are currently streaming.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "header_decade": {
       "default": "Decade",
       "description": "Header for the filter that allows users to select a decade.",
       "exclude": [
+        "android"
+      ]
+    },
+    "header_ratings": {
+      "default": "Ratings",
+      "description": "Header for the filter that allows users to select a rating.",
+      "exclude": [
         "android",
-        "ios"
+        "web"
       ]
     },
     "button_label_view_all_items_in": {
@@ -3302,8 +3149,7 @@
       "default": "Reset all",
       "description": "Text for the button that resets all filters to their initial values.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_label_reset_all_filters": {
@@ -3388,9 +3234,7 @@
     "button_text_checkin": {
       "default": "Now watching",
       "description": "Text for the button that allows users to indicate that they are starting to watch a movie or episode.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_checkin": {
       "default": "Now watching \"{title}\"",
@@ -3477,8 +3321,14 @@
     "page_title_settings": {
       "default": "Settings",
       "description": "Title for the settings page.",
+      "exclude": []
+    },
+    "button_text_settings": {
+      "default": "Settings",
+      "description": "Text for the button that allows users to open the settings page.",
       "exclude": [
-        "ios"
+        "android",
+        "web"
       ]
     },
     "button_label_settings": {
@@ -3493,8 +3343,7 @@
       "default": "Show spoilers",
       "description": "Text for the section that allows users to toggle spoilers.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "switch_label_spoilers": {
@@ -3938,16 +3787,12 @@
     "button_text_create": {
       "default": "Create",
       "description": "Text for the button that allows users to create a new list, review, rating etc.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_text_apply": {
       "default": "Apply",
       "description": "Text for the button that allows users to apply changes that are currently being edited.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_apply": {
       "default": "Apply changes",
@@ -3977,16 +3822,13 @@
       "default": "Create list",
       "description": "Text for the button that allows users to create a new list.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "page_title_create_list": {
       "default": "Create List",
       "description": "Title for a screen that allows users to create a new list.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "page_description_create_list": {
       "default": "Enter a name and description for your list.",
@@ -4007,9 +3849,7 @@
     "page_title_edit_list": {
       "default": "Edit List",
       "description": "Title for a screen that allows users to edit an existing list.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "list_placeholder_personal_list_empty": {
       "default": "There is nothing in this list yet.",
@@ -4124,9 +3964,7 @@
     "text_display_name": {
       "default": "Display name",
       "description": "Text for the section that allows users to change their display name.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "text_display_email": {
       "default": "Email",
@@ -4155,9 +3993,7 @@
     "text_location": {
       "default": "Location",
       "description": "Text for the section that allows users to change their location.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_change_location": {
       "default": "Change location",
@@ -4170,15 +4006,20 @@
     "text_about": {
       "default": "About me",
       "description": "Text for the section that allows users to change their 'about me' description.",
+      "exclude": []
+    },
+    "page_title_automatic_tracking": {
+      "default": "Automatic Tracking",
+      "description": "Title for the automatic tracking page.",
       "exclude": [
-        "ios"
+        "web",
+        "android"
       ]
     },
     "text_automatic_tracking": {
       "default": "Automatic Tracking",
       "description": "Text for the section that allows users to manage automatic shows and movies tracking.",
       "exclude": [
-        "ios",
         "web"
       ]
     },
@@ -4231,8 +4072,7 @@
       "default": "Favorite genres",
       "description": "Header for the section that allows users to change their favorite genres.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_label_toggle_genre": {
@@ -4448,24 +4288,21 @@
       "default": "Movies",
       "description": "Text for the tag that indicates a movie.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "tag_text_shows": {
       "default": "Shows",
       "description": "Text for the tag that indicates a show. This should be as short and concise as possible.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "tag_text_episodes": {
       "default": "Episodes",
       "description": "Text for the tag that indicates an episode. This should be as short and concise as possible.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "tag_text_released": {
@@ -4506,9 +4343,7 @@
     "button_text_toggle_search_media": {
       "default": "Media",
       "description": "Text for the button that allows users to toggle the search mode to media.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_toggle_search_people": {
       "default": "Search for people",
@@ -4520,16 +4355,12 @@
     "button_text_toggle_search_people": {
       "default": "People",
       "description": "Text for the button that allows users to toggle the search mode to people.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "input_placeholder_search_people": {
       "default": "Search people...",
       "description": "Placeholder text for the search input field. This should be a short and concise message that indicates what users can search for.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_toggle_search_lists": {
       "default": "Search for lists",
@@ -4542,16 +4373,12 @@
     "button_text_toggle_search_lists": {
       "default": "Lists",
       "description": "Text for the button that allows users to toggle the search mode to lists.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "input_placeholder_search_lists": {
       "default": "Search lists...",
       "description": "Placeholder text for the search input field. This should be a short and concise message that indicates what users can search for.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "link_text_forums": {
       "default": "Forums",
@@ -4593,12 +4420,51 @@
         "web"
       ]
     },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnostics & Cache",
+      "description": "Text for the button that allows users to diagnose some issues or clear some cached values.",
+      "exclude": [
+        "android",
+        "web"
+      ]
+    },
+    "button_text_share_auth_logs": {
+      "default": "Share Authentication Logs",
+      "description": "Text for the button that allows users to export their authentication logs for debugging.",
+      "exclude": [
+        "android",
+        "web"
+      ]
+    },
+    "button_text_view_cache_size": {
+      "default": "View Cache Size",
+      "description": "Text for the button that allows users to view the size of their cache.",
+      "exclude": [
+        "android",
+        "web"
+      ]
+    },
+    "button_text_clear_cache": {
+      "default": "Clear Cache",
+      "description": "Text for the button that allows users to clear their cache.",
+      "exclude": [
+        "android",
+        "web"
+      ]
+    },
+    "text_analytics": {
+      "default": "Analytics",
+      "description": "Text for the section where users can toggle their analytics setting.",
+      "exclude": [
+        "android",
+        "web"
+      ]
+    },
     "header_calendar": {
       "default": "Calendar",
       "description": "Header for the calendar section, where users can choose days/weeks to see what movies or episodes are available on their calendar.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_label_previous_calendar_period": {
@@ -4620,9 +4486,7 @@
     "button_text_reset_calendar_period": {
       "default": "Today",
       "description": "Text for the button that resets the calendar view to today.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_reset_calendar_period": {
       "default": "Today",
@@ -4649,88 +4513,76 @@
       "default": "Nothing for you on this day. Take a day off, enjoy the weather.",
       "description": "Placeholder text shown when there are no movies or episodes available on a specific day in the calendar.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_calendar_placeholder_2": {
       "default": "No items found for this date. Maybe try another day?",
       "description": "Placeholder text shown when there are no movies or episodes available on a specific day in the calendar.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_calendar_placeholder_3": {
       "default": "Looks like there's nothing scheduled for this day. Relax and take it easy.",
       "description": "Placeholder text shown when there are no movies or episodes available on a specific day in the calendar.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_calendar_placeholder_4": {
       "default": "Your calendar is empty on this day. Perfect time to catch up on some rest.",
       "description": "Placeholder text shown when there are no movies or episodes available on a specific day in the calendar.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_calendar_placeholder_5": {
       "default": "This day is wide open. Maybe start something new?",
       "description": "Placeholder text shown when there are no movies or episodes available on a specific day in the calendar.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_calendar_placeholder_6": {
       "default": "No plans here. Time to do something spontaneous.",
       "description": "Placeholder text shown when there are no movies or episodes available on a specific day in the calendar.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_calendar_placeholder_7": {
       "default": "Nothing scheduled. Enjoy some free time.",
       "description": "Placeholder text shown when there are no movies or episodes available on a specific day in the calendar.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_calendar_placeholder_8": {
       "default": "Your schedule is clear. Make the most of it.",
       "description": "Placeholder text shown when there are no movies or episodes available on a specific day in the calendar.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_calendar_placeholder_9": {
       "default": "No events this day. Maybe revisit an old favorite.",
       "description": "Placeholder text shown when there are no movies or episodes available on a specific day in the calendar.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_calendar_placeholder_10": {
       "default": "All clear. Time to explore something different.",
       "description": "Placeholder text shown when there are no movies or episodes available on a specific day in the calendar.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "page_title_calendar": {
       "default": "Calendar",
       "description": "Title for the calendar page, where users can see what movies or episodes are available on their calendar.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_calendar": {
       "default": "Calendar",
@@ -4744,47 +4596,40 @@
       "default": "Your shows and movies. Your pace. Jump back in exactly where you left off. What are you currently watching?",
       "description": "Call to action text shown in the Up Next list, encouraging users to add their favorite shows and movies.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_cta_up_next": {
       "default": "Your shows. Your pace. Jump back in exactly where you left off. What are you currently watching?",
       "description": "Call to action text shown in the Up Next list, encouraging users to add their favorite shows.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "text_cta_up_next_movies": {
       "default": "Your movies. Your pace. Jump back in exactly where you left off. What are you currently watching?",
       "description": "Call to action text shown in the Up Next list, encouraging users to add their favorite movies.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_cta_start_watching_media": {
       "default": "Your queue awaits. Add the shows and movies you're excited to start watching. What's next?",
       "description": "Call to action text shown in the Start Watching list, encouraging users to add their favorite shows and movies.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_cta_start_watching_shows": {
       "default": "Your queue awaits. Add the shows you're excited to start watching. What's next?",
       "description": "Call to action text shown in the Start Watching list, encouraging users to add their favorite shows.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_cta_start_watching_movies": {
       "default": "Your queue awaits. Add the movies you're excited to start watching. What's next?",
       "description": "Call to action text shown in the Start Watching list, encouraging users to add their favorite movies.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_cta_watchlist_released": {
@@ -4798,23 +4643,19 @@
       "default": "Your timeline. See what's dropping next with a full list of upcoming episodes and movies you care about.",
       "description": "Call to action text shown in the Upcoming list, encouraging users to follow shows for upcoming episodes and movies.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_cta_upcoming": {
       "default": "Your timeline. See what's dropping next with a full list of upcoming episodes you care about.",
       "description": "Call to action text shown in the Upcoming list, encouraging users to follow shows for upcoming episodes.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "text_cta_upcoming_movies": {
       "default": "Your timeline. See what's dropping next with a full list of upcoming movies you care about.",
       "description": "Call to action text shown in the Upcoming list, encouraging users to follow movies for upcoming releases.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_cta_watchlist_unreleased": {
@@ -4837,23 +4678,19 @@
       "default": "Watch it. Track it. Your viewing history updates in real time, right here.",
       "description": "Call to action text shown in the personal activity list, encouraging users to mark their watched content.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_cta_activity_list": {
       "default": "Start making friends quickly by following the Trakt Team and explore what they are watching.",
       "description": "Call to action text shown in the social activity list, encouraging users to follow members of the Trakt Team.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "text_cta_watchlist": {
       "default": "See it. Save it. Watch it later. Start curating your personal watchlist.",
       "description": "Call to action text shown in the Watchlist, encouraging users to add movies and shows to their watchlist.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_cta_watchlist_movies": {
@@ -4875,9 +4712,7 @@
     "text_cta_personal_lists": {
       "default": "Your lists. Your rules. Collect and organize movies and shows your way.",
       "description": "Call to action text shown in the empty personal lists screen, encouraging users to create a custom list for organizing their shows and movies.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "text_cta_smart_lists": {
       "default": "Set the filters. Skip the curation. Your list builds and updates itself automatically.",
@@ -4951,8 +4786,7 @@
       "default": "Discover media",
       "description": "Link text for discovering media content. Meant to entice users to find new content.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "link_label_discover_media": {
@@ -4966,9 +4800,7 @@
     "link_text_discover_shows": {
       "default": "Discover shows",
       "description": "Link text for discovering shows. Meant to entice users to find new content.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "link_label_discover_shows": {
       "default": "Discover shows",
@@ -4981,9 +4813,7 @@
     "link_text_discover_movies": {
       "default": "Discover movies",
       "description": "Link text for discovering movies. Meant to entice users to find new content.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "link_label_discover_movies": {
       "default": "Discover movies",
@@ -4997,8 +4827,7 @@
       "default": "Review reactions",
       "description": "Header for the review reactions section.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_label_close_reaction": {
@@ -5038,9 +4867,7 @@
     "header_account_details": {
       "default": "Account details",
       "description": "Header for the section that allows users to change their account details.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "description_account_details": {
       "default": "Change your photo, name and other details.",
@@ -5103,8 +4930,7 @@
       "default": "Bummer, no hits. Your filter may have been a little too selective.",
       "description": "Placeholder text shown when there are no results for a filter.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "error_text_unexpected_error_short": {
@@ -5119,7 +4945,6 @@
       "default": "Where to Watch",
       "description": "Title for the all available streaming services page where user can see where to watch movie/show.",
       "exclude": [
-        "ios",
         "web"
       ]
     },
@@ -5127,7 +4952,6 @@
       "default": "Subscription",
       "description": "Text used to indicate the list of all streaming services where media is available to watch in subscription model.",
       "exclude": [
-        "ios",
         "web"
       ]
     },
@@ -5135,7 +4959,6 @@
       "default": "Free",
       "description": "Text used to indicate the list of all streaming services where media is available to watch for free.",
       "exclude": [
-        "ios",
         "web"
       ]
     },
@@ -5143,7 +4966,6 @@
       "default": "Purchase",
       "description": "Text used to indicate the list of all streaming services where media is available to watch for one time purchase.",
       "exclude": [
-        "ios",
         "web"
       ]
     },
@@ -5151,7 +4973,6 @@
       "default": "Rent",
       "description": "Text used to indicate the list of all streaming services where media is available to rent.",
       "exclude": [
-        "ios",
         "web"
       ]
     },
@@ -5159,7 +4980,6 @@
       "default": "Favorite",
       "description": "Text used to indicate the list of all favorite streaming services of a user.",
       "exclude": [
-        "ios",
         "web"
       ]
     },
@@ -5363,9 +5183,7 @@
     "button_text_no_services": {
       "default": "No services",
       "description": "Text for the button that indicates there are no streaming services available for a movie or show.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "header_get_trakt_app": {
       "default": "Get the trakt app",
@@ -5440,9 +5258,7 @@
     "link_text_general_settings": {
       "default": "General",
       "description": "Text for the link to the general settings page.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "link_text_data_settings": {
       "default": "Data",
@@ -5516,8 +5332,20 @@
       "default": "This year",
       "description": "Label for the 'this year' filter which filters items to only show those from the current year.",
       "exclude": [
+        "android"
+      ]
+    },
+    "filter_label_before_year": {
+      "default": "Before {year}",
+      "description": "Label for the filter which filters items to only show those from before the given year. e.g. 'Before 1960'.",
+      "variables": {
+        "year": {
+          "type": "number"
+        }
+      },
+      "exclude": [
         "android",
-        "ios"
+        "web"
       ]
     },
     "text_sort_recently_updated": {
@@ -5579,22 +5407,17 @@
     "input_placeholder_lists_name": {
       "default": "Name",
       "description": "Placeholder text for name input field. This is displayed when users opens a form and sees empty form fields to be filled in.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "input_placeholder_lists_description": {
       "default": "Description (optional)",
       "description": "Placeholder text for optional description input field. This is displayed when users opens a form and sees empty form fields to be filled in.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_text_view_description": {
       "default": "View Description",
       "description": "Text for the button that allows users to show full details of certain show or movie.",
       "exclude": [
-        "ios",
         "android"
       ]
     },
@@ -5602,7 +5425,6 @@
       "default": "Hide Description",
       "description": "Text for the button that allows users to hide full details of certain show or movie.",
       "exclude": [
-        "ios",
         "android"
       ]
     },
@@ -5610,7 +5432,6 @@
       "default": "Spoiler Alert",
       "description": "Text for the spoiler alert label that warns users about potential spoilers in the content they are about to see.",
       "exclude": [
-        "ios",
         "android"
       ]
     },
@@ -5618,7 +5439,6 @@
       "default": "Remove from watchlist",
       "description": "Text for the button that allows a user to remove a show or movie from their watchlist.",
       "exclude": [
-        "ios",
         "android"
       ]
     },
@@ -5629,12 +5449,18 @@
         "android"
       ]
     },
+    "button_text_edit_comment": {
+      "default": "Edit",
+      "description": "Text for the button that allows a user to edit a review.",
+      "exclude": [
+        "android",
+        "web"
+      ]
+    },
     "button_text_delete_comment": {
       "default": "Delete Review",
       "description": "Text for the button that allows a user to delete a review.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_text_delete_reply": {
       "default": "Delete Reply",
@@ -5655,9 +5481,7 @@
     "warning_prompt_delete_comment": {
       "default": "Are you sure you want to delete your review?",
       "description": "Text for the warning prompt that appears when a user attempts to delete a review.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "warning_prompt_delete_reply": {
       "default": "Are you sure you want to delete your reply?",
@@ -5778,32 +5602,28 @@
       "default": "Stream",
       "description": "Text label indicating that the media can be streamed. If there is no short translation available, Anglicism is fine.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_rent": {
       "default": "Rent",
       "description": "Text label indicating that the media can be rented.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_buy": {
       "default": "Buy",
       "description": "Text label indicating that the media can be bought.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_on_demand": {
       "default": "On demand",
       "description": "Text label indicating that the media can be streamed on demand.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "list_title_where_to_watch": {
@@ -5877,8 +5697,7 @@
       "default": "Theme",
       "description": "Text for the section that allows users to change the theme.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "text_language": {
@@ -5928,9 +5747,7 @@
     "translated_value_library_custom": {
       "default": "Custom",
       "description": "Value for the custom library name. This is the category for library items that are not in a specific category like Plex.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "page_title_library": {
       "default": "Library",
@@ -5973,6 +5790,19 @@
         "android"
       ]
     },
+    "text_directed_by_plain": {
+      "default": "Directed by {name}",
+      "description": "Text to indicate the director of a movie.",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "web",
+        "android"
+      ]
+    },
     "text_directed_by_short": {
       "default": "Directed by",
       "description": "Text to indicate the director of a movie.",
@@ -5994,6 +5824,19 @@
         "android"
       ]
     },
+    "text_created_by_plain": {
+      "default": "Created by {name}",
+      "description": "Text to indicate the creator of a show.",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "web",
+        "android"
+      ]
+    },
     "text_created_by_short": {
       "default": "Created by",
       "description": "Text to indicate the creator of a show.",
@@ -6005,16 +5848,21 @@
     "tag_text_watched": {
       "default": "Watched",
       "description": "Text for the tag that is shown before the movie or show watch count. This should be as short as possible.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "tag_text_dropped": {
       "default": "Dropped",
       "description": "Text for the tag that is shown for dropped shows. This should be as short as possible.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
+      ]
+    },
+    "tag_text_started": {
+      "default": "Started",
+      "description": "Text for the tag that is shown to indicate a show is started but not completed. This should be as short as possible.",
+      "exclude": [
+        "web",
+        "android"
       ]
     },
     "header_height": {
@@ -6057,9 +5905,7 @@
     "button_text_mark_as_watched_now": {
       "default": "Just now",
       "description": "Text for the button that allows users to mark a movie or episode as watched just now.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_mark_as_watched_now": {
       "default": "Just now",
@@ -6072,9 +5918,7 @@
     "button_text_mark_as_watched_release_date": {
       "default": "Release date",
       "description": "Text for the button that allows users to mark a movie or episode as watched on the release date.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_mark_as_watched_release_date": {
       "default": "Release date",
@@ -6087,9 +5931,7 @@
     "button_text_mark_as_watched_other_date": {
       "default": "Other date",
       "description": "Text for the button that allows users to mark a movie or episode as watched on a custom date.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_mark_as_watched_other_date": {
       "default": "Other date",
@@ -6102,9 +5944,7 @@
     "button_text_mark_as_watched_unknown_date": {
       "default": "Unknown date",
       "description": "Text for the button that allows users to mark a movie or episode as watched on an unknown date.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "button_label_mark_as_watched_unknown_date": {
       "default": "Unknown date",
@@ -6117,9 +5957,7 @@
     "text_this_month": {
       "default": "This month",
       "description": "Text shown to indicate the users stats of the current month.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "text_this_year": {
       "default": "This year",
@@ -6286,8 +6124,7 @@
         }
       },
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_label_profile_options": {
@@ -6310,8 +6147,7 @@
       "default": "Private",
       "description": "Text used to indicate that something is private.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "switch_label_toggle_list_privacy": {
@@ -6346,8 +6182,7 @@
       "default": "Streaming service has been linked.",
       "description": "Text to indicate that linking a streaming service via Younify is completed.",
       "exclude": [
-        "web",
-        "ios"
+        "web"
       ]
     },
     "text_info_younify_service_unlinked": {
@@ -6362,16 +6197,14 @@
       "default": "Fix",
       "description": "Text for the button that allows users to fix issues with their Younify linked streaming services.",
       "exclude": [
-        "web",
-        "ios"
+        "web"
       ]
     },
     "button_text_younify_unlink": {
       "default": "Unlink",
       "description": "Text for the button that allows users to unlink their Younify linked streaming services.",
       "exclude": [
-        "web",
-        "ios"
+        "web"
       ]
     },
     "button_text_data_sync_yes": {
@@ -6386,16 +6219,14 @@
       "default": "Ignore existing data",
       "description": "Text for button that allows users to ignore syncing existing data when linking Younify streaming services.",
       "exclude": [
-        "web",
-        "ios"
+        "web"
       ]
     },
     "button_text_younify_send_logs": {
       "default": "Send Logs",
       "description": "Text for the button that allows users to send logs for Younify troubleshooting.",
       "exclude": [
-        "web",
-        "ios"
+        "web"
       ]
     },
     "text_younify_status_linked": {
@@ -6439,8 +6270,7 @@
       "default": "Sync Existing Data",
       "description": "Title for the dialog that appears when a user links a Younify streaming service.",
       "exclude": [
-        "web",
-        "ios"
+        "web"
       ]
     },
     "dialog_prompt_younify_data_sync": {
@@ -6507,6 +6337,14 @@
         "android"
       ]
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Restore Rating Prompts",
+      "description": "Text for the button that allows users to reset their suppressed rating prompts.",
+      "exclude": [
+        "android",
+        "web"
+      ]
+    },
     "text_billing_month_for_free": {
       "default": "Try 1 month for free and then:",
       "description": "Text used to inform user about billing and subscription options.",
@@ -6535,8 +6373,7 @@
       "default": "Upgrade to VIP",
       "description": "Text used to inform user about billing and subscription options.",
       "exclude": [
-        "web",
-        "ios"
+        "web"
       ]
     },
     "text_billing_disclaimer": {
@@ -6571,31 +6408,25 @@
     "text_vip_upsell_default": {
       "default": "Enhance your Trakt experience",
       "description": "Text used to promote a VIP package for the user.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "text_vip_upsell_default_description": {
       "default": "Upgrade to VIP and unlock the full Trakt experience, packed with features built for TV Shows and Movies lovers.",
       "description": "Description used to promote a VIP package for the user.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "text_vip_upsell_default_2": {
       "default": "Upgrade to VIP!",
       "description": "Text used to promote a VIP package for the user.",
       "exclude": [
-        "web",
-        "ios"
+        "web"
       ]
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Unlimited tracking and more.",
+      "default": "Year in Review & more.",
       "description": "Description used to promote a VIP package for the user.",
       "exclude": [
-        "web",
-        "ios"
+        "web"
       ]
     },
     "button_label_like_list": {
@@ -6717,9 +6548,7 @@
     "button_text_track": {
       "default": "Track",
       "description": "Do not translate this.",
-      "exclude": [
-        "ios"
-      ]
+      "exclude": []
     },
     "filter_label_runtime": {
       "default": "{range} minutes",
@@ -6730,16 +6559,14 @@
         }
       },
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "header_behavior": {
       "default": "Behavior",
       "description": "Header for the section that allows users to change the behavior, i.e. spoiler settings and watch again behavior.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "description_behavior": {
@@ -6754,8 +6581,7 @@
       "default": "Enable multiple watches",
       "description": "Text for the section that allows users to enable or disable multiple watches.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "switch_label_multiple_watches": {
@@ -6770,8 +6596,7 @@
       "default": "Add to list",
       "description": "Header for the section that allows users to add/remove a movie or show to/from a list.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "header_sentiment_highlight": {
@@ -7396,8 +7221,7 @@
       "default": "Notifications",
       "description": "Header for the section that allows users to manage their notification settings.",
       "exclude": [
-        "web",
-        "ios"
+        "web"
       ]
     },
     "text_settings_adjust_delivery": {
@@ -7793,16 +7617,14 @@
       "default": "Note",
       "description": "Title for the drawer that allows users to add a note to a movie or show. This should be as short and concise as possible.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_text_add_note": {
       "default": "Add Note",
       "description": "Button text for adding a note to a show or movie.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "button_label_add_note": {
@@ -7822,8 +7644,7 @@
       "default": "Why did you favorite this title?",
       "description": "Placeholder text for the input field when adding a note about why a user favorited a title.",
       "exclude": [
-        "android",
-        "ios"
+        "android"
       ]
     },
     "input_placeholder_note_drop": {
@@ -8265,6 +8086,51 @@
       "exclude": [
         "android",
         "ios"
+      ]
+    },
+    "button_text_block_comments": {
+      "default": "Block comments from {user}",
+      "description": "Text for the button that allows users to block comments from a particular user.",
+      "variables": {
+        "user": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "web",
+        "android"
+      ]
+    },
+    "button_text_keyboard_done": {
+      "default": "Done",
+      "description": "Text for the button that allows users to indicate they are done with the keyboard and want to dismiss it. This should be as short and concise as possible.",
+      "exclude": [
+        "web",
+        "android"
+      ]
+    },
+    "dialog_title_discard_changes": {
+      "default": "Discard Changes?",
+      "description": "Title for the alert dialog that appears when a user attempts to dismiss a view with unsaved changes.",
+      "exclude": [
+        "web",
+        "android"
+      ]
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Are you sure you want to discard this? Any unsaved changes will be lost.",
+      "description": "Text for the warning prompt that appears when a user attempts to dismiss a view with unsaved input, warning them of data loss.",
+      "exclude": [
+        "web",
+        "android"
+      ]
+    },
+    "button_text_discard": {
+      "default": "Discard",
+      "description": "Text for the destructive button that confirms the discarding of unsaved changes.",
+      "exclude": [
+        "web",
+        "android"
       ]
     }
   }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "¿Seguro que quieres eliminar esta reproducción de \"{title}\" de tu lista de Vistos?"
     },
+    "list_title_episodes": {
+      "default": "Episodios"
+    },
     "list_title_seasons": {
       "default": "Temporadas"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Gestionar listas"
     },
+    "button_text_view_history": {
+      "default": "Ver historial"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Añadir o quitar \"{title}\" de las listas"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Década"
+    },
+    "header_ratings": {
+      "default": "Valoraciones"
     },
     "button_label_view_all_items_in": {
       "default": "Ver todo en \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Mes en revisión"
     },
     "page_title_settings": {
+      "default": "Ajustes"
+    },
+    "button_text_settings": {
       "default": "Ajustes"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "Sobre mí"
     },
+    "page_title_automatic_tracking": {
+      "default": "Seguimiento automático"
+    },
     "text_automatic_tracking": {
       "default": "Seguimiento Automático"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Eliminar cuenta"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnóstico y caché"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Compartir registros de autenticación"
+    },
+    "button_text_view_cache_size": {
+      "default": "Ver tamaño de caché"
+    },
+    "button_text_clear_cache": {
+      "default": "Borrar caché"
+    },
+    "text_analytics": {
+      "default": "Analítica"
     },
     "header_calendar": {
       "default": "Calendario"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "Este año"
     },
+    "filter_label_before_year": {
+      "default": "Antes de {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Recientemente actualizado"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Detener el registro"
+    },
+    "button_text_edit_comment": {
+      "default": "Editar"
     },
     "button_text_delete_comment": {
       "default": "Eliminar reseña"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Dirigida por <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Dirigida por {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Dirigida por"
     },
     "text_created_by": {
       "default": "Creada por <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Creada por {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Creada por"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Abandonada"
+    },
+    "tag_text_started": {
+      "default": "Empezada"
     },
     "header_height": {
       "default": "Altura"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "¿Quieres dejar de que te pregunten para valorar lo que has visto recientemente?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Restablecer avisos de puntuación"
+    },
     "text_billing_month_for_free": {
       "default": "Prueba 1 mes gratis y luego:"
     },
@@ -2404,7 +2462,7 @@
       "default": "¡Mejorar a VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Seguimiento ilimitado y más."
+      "default": "Tu resumen del año y mucho más."
     },
     "button_label_like_list": {
       "default": "Me gusta {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Condiciones de uso"
+    },
+    "button_text_block_comments": {
+      "default": "Bloquear comentarios de {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Hecho"
+    },
+    "dialog_title_discard_changes": {
+      "default": "¿Descartar Cambios?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "¿Seguro que quieres descartar esto? Los cambios sin guardar se perderán."
+    },
+    "button_text_discard": {
+      "default": "Descartar"
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "¿Estás seguro de que quieres eliminar esta reproducción de \"{title}\" de tu lista de Vistos?"
     },
+    "list_title_episodes": {
+      "default": "Episodios"
+    },
     "list_title_seasons": {
       "default": "Temporadas"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Administrar listas"
     },
+    "button_text_view_history": {
+      "default": "Ver historial"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Añadir o quitar \"{title}\" de listas"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Década"
+    },
+    "header_ratings": {
+      "default": "Calificaciones"
     },
     "button_label_view_all_items_in": {
       "default": "Ver todos en \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Mes en revisión"
     },
     "page_title_settings": {
+      "default": "Configuración"
+    },
+    "button_text_settings": {
       "default": "Configuración"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "Acerca de mí"
     },
+    "page_title_automatic_tracking": {
+      "default": "Seguimiento automático"
+    },
     "text_automatic_tracking": {
       "default": "Seguimiento Automático"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Eliminar cuenta"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnóstico y caché"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Compartir registros de autenticación"
+    },
+    "button_text_view_cache_size": {
+      "default": "Ver tamaño del caché"
+    },
+    "button_text_clear_cache": {
+      "default": "Limpiar caché"
+    },
+    "text_analytics": {
+      "default": "Análisis"
     },
     "header_calendar": {
       "default": "Calendario"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "Este año"
     },
+    "filter_label_before_year": {
+      "default": "Antes de {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Actualizado recientemente"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Detener el registro"
+    },
+    "button_text_edit_comment": {
+      "default": "Editar"
     },
     "button_text_delete_comment": {
       "default": "Eliminar reseña"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Dirigida por <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Dirigida por {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Dirigida por"
     },
     "text_created_by": {
       "default": "Creada por <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Creada por {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Creada por"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Abandonada"
+    },
+    "tag_text_started": {
+      "default": "Empezada"
     },
     "header_height": {
       "default": "Altura"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "¿Quieres que dejemos de preguntarte para que califiques lo que viste recientemente?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Restaurar avisos de calificación"
+    },
     "text_billing_month_for_free": {
       "default": "Prueba 1 mes gratis y después:"
     },
@@ -2404,7 +2462,7 @@
       "default": "¡Hazte VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Seguimiento ilimitado y más."
+      "default": "Resumen del año y más."
     },
     "button_label_like_list": {
       "default": "Me gusta {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Términos de uso"
+    },
+    "button_text_block_comments": {
+      "default": "Bloquear comentarios de {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Listo"
+    },
+    "dialog_title_discard_changes": {
+      "default": "¿Descartar cambios?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "¿Seguro que quieres descartar esto? Cualquier cambio no guardado se perderá."
+    },
+    "button_text_discard": {
+      "default": "Descartar"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Êtes-vous sûr de vouloir supprimer cette lecture de \"{title}\" de votre liste Vu ?"
     },
+    "list_title_episodes": {
+      "default": "Épisodes"
+    },
     "list_title_seasons": {
       "default": "Saisons"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Gérer mes listes"
     },
+    "button_text_view_history": {
+      "default": "Voir l'historique"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Ajouter ou retirer \"{title}\" des listes"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Décennie"
+    },
+    "header_ratings": {
+      "default": "Évaluations"
     },
     "button_label_view_all_items_in": {
       "default": "Voir tous les titres dans \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Bilan du mois"
     },
     "page_title_settings": {
+      "default": "Paramètres"
+    },
+    "button_text_settings": {
       "default": "Paramètres"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "À mon sujet"
     },
+    "page_title_automatic_tracking": {
+      "default": "Suivi automatique"
+    },
     "text_automatic_tracking": {
       "default": "Suivi automatique"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Supprimer mon compte"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnostics et cache"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Partager les journaux d'authentification"
+    },
+    "button_text_view_cache_size": {
+      "default": "Voir l'espace cache"
+    },
+    "button_text_clear_cache": {
+      "default": "Vider la cache"
+    },
+    "text_analytics": {
+      "default": "Analytique"
     },
     "header_calendar": {
       "default": "Calendrier"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "Cette année"
     },
+    "filter_label_before_year": {
+      "default": "Avant {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Mis à jour récemment"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Arrêter l'enregistrement"
+    },
+    "button_text_edit_comment": {
+      "default": "Modifier"
     },
     "button_text_delete_comment": {
       "default": "Supprimer l'avis"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Réalisé par <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Réalisé par {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Réalisé par"
     },
     "text_created_by": {
       "default": "Créé par <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Créée par {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Créé par"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Abandonné"
+    },
+    "tag_text_started": {
+      "default": "Commencée"
     },
     "header_height": {
       "default": "Taille"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Veux-tu arrêter qu'on te demande d'évaluer ce que tu as vu récemment ?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Rétablir les demandes d'évaluation"
+    },
     "text_billing_month_for_free": {
       "default": "Essaie 1 mois gratuit, puis :"
     },
@@ -2404,7 +2462,7 @@
       "default": "Deviens VIP !"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Suivi illimité et plus encore."
+      "default": "Revue de l'année et bien plus."
     },
     "button_label_like_list": {
       "default": "Aimer {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Conditions d'utilisation"
+    },
+    "button_text_block_comments": {
+      "default": "Bloquer les commentaires de {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Terminé"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Annuler les changements?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Es-tu sûr de vouloir annuler ça? Tous les changements non sauvegardés seront perdus."
+    },
+    "button_text_discard": {
+      "default": "Annuler"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Voulez-vous vraiment supprimer cette lecture de \"{title}\" de votre liste Vu ?"
     },
+    "list_title_episodes": {
+      "default": "Épisodes"
+    },
     "list_title_seasons": {
       "default": "Saisons"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Gérer les listes"
     },
+    "button_text_view_history": {
+      "default": "Consulter l'historique"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Ajouter ou retirer \"{title}\" des listes"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Décennie"
+    },
+    "header_ratings": {
+      "default": "Notes"
     },
     "button_label_view_all_items_in": {
       "default": "Voir tous les titres dans \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Bilan du mois"
     },
     "page_title_settings": {
+      "default": "Paramètres"
+    },
+    "button_text_settings": {
       "default": "Paramètres"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "À propos de moi"
     },
+    "page_title_automatic_tracking": {
+      "default": "Suivi automatique"
+    },
     "text_automatic_tracking": {
       "default": "Suivi automatique"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Supprimer votre compte"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnostics et cache"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Partager les journaux d'authentification"
+    },
+    "button_text_view_cache_size": {
+      "default": "Afficher la taille du cache"
+    },
+    "button_text_clear_cache": {
+      "default": "Vider le cache"
+    },
+    "text_analytics": {
+      "default": "Analyses"
     },
     "header_calendar": {
       "default": "Calendrier"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "Cette année"
     },
+    "filter_label_before_year": {
+      "default": "Avant {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Récemment mis à jour"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Arrêter l'enregistrement"
+    },
+    "button_text_edit_comment": {
+      "default": "Modifier"
     },
     "button_text_delete_comment": {
       "default": "Supprimer l'avis"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Réalisé par <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Réalisé par {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Réalisé par"
     },
     "text_created_by": {
       "default": "Créé par <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Créée par {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Créé par"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Abandonné"
+    },
+    "tag_text_started": {
+      "default": "Commencée"
     },
     "header_height": {
       "default": "Taille"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Voulez-vous arrêter d'être sollicité pour noter ce que vous avez regardé récemment ?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Rétablir les invites de notation"
+    },
     "text_billing_month_for_free": {
       "default": "Essayez 1 mois gratuitement, puis :"
     },
@@ -2404,7 +2462,7 @@
       "default": "Passez VIP !"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Suivi illimité et plus encore."
+      "default": "Rétrospective de l'année et bien plus."
     },
     "button_label_like_list": {
       "default": "Aimer {name}"
@@ -3004,7 +3062,22 @@
       "default": "Faites glisser l'image pour l'ajuster"
     },
     "link_text_terms_of_use": {
-      "default": "Terms of Use"
+      "default": "Conditions d'utilisation"
+    },
+    "button_text_block_comments": {
+      "default": "Bloquer les commentaires de {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Terminé"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Ignorer les modifications ?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Êtes-vous sûr de vouloir ignorer ceci ? Toutes les modifications non enregistrées seront perdues."
+    },
+    "button_text_discard": {
+      "default": "Ignorer"
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Sei sicuro di voler rimuovere questa visione di \"{title}\" dalla tua lista Visti?"
     },
+    "list_title_episodes": {
+      "default": "Episodi"
+    },
     "list_title_seasons": {
       "default": "Stagioni"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Gestisci le liste"
     },
+    "button_text_view_history": {
+      "default": "Vedi cronologia"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Aggiungi o rimuovi \"{title}\" dalle liste"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Decennio"
+    },
+    "header_ratings": {
+      "default": "Valutazioni"
     },
     "button_label_view_all_items_in": {
       "default": "Vedi tutti gli elementi in \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Mese in rassegna"
     },
     "page_title_settings": {
+      "default": "Impostazioni"
+    },
+    "button_text_settings": {
       "default": "Impostazioni"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "Su di me"
     },
+    "page_title_automatic_tracking": {
+      "default": "Monitoraggio automatico"
+    },
     "text_automatic_tracking": {
       "default": "Tracciamento Automatico"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Elimina account"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnostica e cache"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Condividi i log di autenticazione"
+    },
+    "button_text_view_cache_size": {
+      "default": "Visualizza dimensione cache"
+    },
+    "button_text_clear_cache": {
+      "default": "Svuota la cache"
+    },
+    "text_analytics": {
+      "default": "Analisi"
     },
     "header_calendar": {
       "default": "Calendario"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "Quest'anno"
     },
+    "filter_label_before_year": {
+      "default": "Prima del {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Aggiornato di recente"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Interrompi il check-in"
+    },
+    "button_text_edit_comment": {
+      "default": "Modifica"
     },
     "button_text_delete_comment": {
       "default": "Elimina recensione"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Regia di <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Regia di {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Diretto da"
     },
     "text_created_by": {
       "default": "Creata da <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Creata da {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Creato da"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Abbandonato"
+    },
+    "tag_text_started": {
+      "default": "Iniziata"
     },
     "header_height": {
       "default": "Altezza"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Vuoi smettere di ricevere richieste di valutazione per ciò che hai guardato di recente?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Ripristina i prompt di valutazione"
+    },
     "text_billing_month_for_free": {
       "default": "Prova 1 mese gratis e poi:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Passa a VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Tracciamento illimitato e altro ancora."
+      "default": "Riassunto dell'anno e molto altro."
     },
     "button_label_like_list": {
       "default": "Mi piace {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Condizioni d'uso"
+    },
+    "button_text_block_comments": {
+      "default": "Blocca i commenti di {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Fatto"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Annullare le modifiche?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Sei sicuro di voler annullare? Tutte le modifiche non salvate andranno perse."
+    },
+    "button_text_discard": {
+      "default": "Annulla"
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "\"{title}\"の視聴記録を視聴済みリストから削除してもよろしいですか？"
     },
+    "list_title_episodes": {
+      "default": "エピソード"
+    },
     "list_title_seasons": {
       "default": "シーズン"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "リストを管理"
     },
+    "button_text_view_history": {
+      "default": "履歴を表示"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "\"{title}\" をリストに追加または削除"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "年代"
+    },
+    "header_ratings": {
+      "default": "評価"
     },
     "button_label_view_all_items_in": {
       "default": "\"{title}\" のアイテムをすべて表示"
@@ -1261,6 +1270,9 @@
       "default": "今月のレビュー"
     },
     "page_title_settings": {
+      "default": "設定"
+    },
+    "button_text_settings": {
       "default": "設定"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "自己紹介"
     },
+    "page_title_automatic_tracking": {
+      "default": "自動トラッキング"
+    },
     "text_automatic_tracking": {
       "default": "自動追跡"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "アカウントを削除する"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "診断とキャッシュ"
+    },
+    "button_text_share_auth_logs": {
+      "default": "認証ログを共有"
+    },
+    "button_text_view_cache_size": {
+      "default": "キャッシュサイズを表示"
+    },
+    "button_text_clear_cache": {
+      "default": "キャッシュをクリア"
+    },
+    "text_analytics": {
+      "default": "分析"
     },
     "header_calendar": {
       "default": "カレンダー"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "今年"
     },
+    "filter_label_before_year": {
+      "default": "{year}年より前"
+    },
     "text_sort_recently_updated": {
       "default": "最近更新"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "チェックインを停止"
+    },
+    "button_text_edit_comment": {
+      "default": "編集"
     },
     "button_text_delete_comment": {
       "default": "レビューを削除"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "<a>{name}</a> 監督"
     },
+    "text_directed_by_plain": {
+      "default": "監督: {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "監督:"
     },
     "text_created_by": {
       "default": "<a>{name}</a> 制作"
+    },
+    "text_created_by_plain": {
+      "default": "制作：{name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "制作:"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "リタイア"
+    },
+    "tag_text_started": {
+      "default": "視聴中"
     },
     "header_height": {
       "default": "身長"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "最近視聴したコンテンツの評価を求めるのをやめますか？"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "評価プロンプトを復元"
+    },
     "text_billing_month_for_free": {
       "default": "まず1ヶ月無料でお試しください。その後:"
     },
@@ -2404,7 +2462,7 @@
       "default": "VIPにアップグレード！"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "無制限の追跡機能など。"
+      "default": "1年の振り返りとその他の特典。"
     },
     "button_label_like_list": {
       "default": "{name} をいいね！"
@@ -2443,7 +2501,7 @@
       "default": "エクスポートが完了しました。"
     },
     "button_text_track": {
-      "default": "追跡"
+      "default": "Track"
     },
     "filter_label_runtime": {
       "default": "{range} 分"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "利用規約"
+    },
+    "button_text_block_comments": {
+      "default": "{user} のコメントをブロック"
+    },
+    "button_text_keyboard_done": {
+      "default": "完了"
+    },
+    "dialog_title_discard_changes": {
+      "default": "変更を破棄しますか？"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "本当に破棄しますか？ 保存されていない変更はすべて失われます。"
+    },
+    "button_text_discard": {
+      "default": "破棄"
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Er du sikker på at du vil fjerne denne visningen av \"{title}\" fra din Sett-liste?"
     },
+    "list_title_episodes": {
+      "default": "Episoder"
+    },
     "list_title_seasons": {
       "default": "Sesonger"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Administrer lister"
     },
+    "button_text_view_history": {
+      "default": "Se historikk"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Legg til eller fjern \"{title}\" fra lister"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Tiår"
+    },
+    "header_ratings": {
+      "default": "Vurderinger"
     },
     "button_label_view_all_items_in": {
       "default": "Vis alle i \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Månedens oversikt"
     },
     "page_title_settings": {
+      "default": "Innstillinger"
+    },
+    "button_text_settings": {
       "default": "Innstillinger"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "Om meg"
     },
+    "page_title_automatic_tracking": {
+      "default": "Automatisk sporing"
+    },
     "text_automatic_tracking": {
       "default": "Automatisk Sporing"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Slett konto"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnostikk og hurtigbuffer"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Del autentiseringslogger"
+    },
+    "button_text_view_cache_size": {
+      "default": "Se størrelse på hurtigbuffer"
+    },
+    "button_text_clear_cache": {
+      "default": "Tøm hurtigbuffer"
+    },
+    "text_analytics": {
+      "default": "Analyse"
     },
     "header_calendar": {
       "default": "Kalender"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "I år"
     },
+    "filter_label_before_year": {
+      "default": "Før {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Nylig oppdatert"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Stopp sjekk inn"
+    },
+    "button_text_edit_comment": {
+      "default": "Rediger"
     },
     "button_text_delete_comment": {
       "default": "Slett anmeldelse"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Regi: <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Regissert av {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Regi:"
     },
     "text_created_by": {
       "default": "Laget av <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Skapt av {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Skapt av:"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Droppet"
+    },
+    "tag_text_started": {
+      "default": "Påbegynt"
     },
     "header_height": {
       "default": "Høyde"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Vil du slutte å bli spurt om å vurdere det du nylig har sett?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Gjenopprett vurderingsmeldinger"
+    },
     "text_billing_month_for_free": {
       "default": "Prøv 1 måned gratis og deretter:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Oppgrader til VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Ubegrenset sporing og mer."
+      "default": "Årsoppsummering og mer."
     },
     "button_label_like_list": {
       "default": "Liker {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Brukervilkår"
+    },
+    "button_text_block_comments": {
+      "default": "Blokker kommentarer fra {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Ferdig"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Forkast endringer?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Er du sikker på at du vil forkaste dette? Alle ulagrede endringer vil gå tapt."
+    },
+    "button_text_discard": {
+      "default": "Forkast"
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Weet je zeker dat je deze afspeelbeurt van \"{title}\" uit je Bekeken lijst wilt verwijderen?"
     },
+    "list_title_episodes": {
+      "default": "Afleveringen"
+    },
     "list_title_seasons": {
       "default": "Seizoenen"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Lijsten beheren"
     },
+    "button_text_view_history": {
+      "default": "Geschiedenis bekijken"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "\"{title}\" toevoegen of verwijderen van lijsten"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Decennium"
+    },
+    "header_ratings": {
+      "default": "Beoordelingen"
     },
     "button_label_view_all_items_in": {
       "default": "Bekijk alle items in \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Maandoverzicht"
     },
     "page_title_settings": {
+      "default": "Instellingen"
+    },
+    "button_text_settings": {
       "default": "Instellingen"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "Over mij"
     },
+    "page_title_automatic_tracking": {
+      "default": "Automatisch bijhouden"
+    },
     "text_automatic_tracking": {
       "default": "Automatisch Volgen"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Account verwijderen"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnose & cache"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Verificatielogboeken delen"
+    },
+    "button_text_view_cache_size": {
+      "default": "Cachegrootte bekijken"
+    },
+    "button_text_clear_cache": {
+      "default": "Cache wissen"
+    },
+    "text_analytics": {
+      "default": "Analyses"
     },
     "header_calendar": {
       "default": "Kalender"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "Dit jaar"
     },
+    "filter_label_before_year": {
+      "default": "Vóór {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Recent bijgewerkt"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Check-in stoppen"
+    },
+    "button_text_edit_comment": {
+      "default": "Bewerken"
     },
     "button_text_delete_comment": {
       "default": "Beoordeling verwijderen"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Geregisseerd door <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Geregisseerd door {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Regie:"
     },
     "text_created_by": {
       "default": "Gemaakt door <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Gemaakt door {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Gemaakt door:"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Gestopt"
+    },
+    "tag_text_started": {
+      "default": "Begonnen"
     },
     "header_height": {
       "default": "Lengte"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Wil je niet meer gevraagd worden om te beoordelen wat je onlangs hebt bekeken?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Beoordelingsprompts herstellen"
+    },
     "text_billing_month_for_free": {
       "default": "Probeer 1 maand gratis en dan:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Upgrade naar VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Onbeperkt volgen en meer."
+      "default": "Jaaroverzicht & meer."
     },
     "button_label_like_list": {
       "default": "Vind {name} leuk"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Gebruiksvoorwaarden"
+    },
+    "button_text_block_comments": {
+      "default": "Reacties van {user} blokkeren"
+    },
+    "button_text_keyboard_done": {
+      "default": "Klaar"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Wijzigingen negeren?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Weet je zeker dat je dit wilt negeren? Alle onopgeslagen wijzigingen gaan verloren."
+    },
+    "button_text_discard": {
+      "default": "Negeren"
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Na pewno chcesz usunąć to odtworzenie \"{title}\" z listy Obejrzanych?"
     },
+    "list_title_episodes": {
+      "default": "Odcinki"
+    },
     "list_title_seasons": {
       "default": "Sezony"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Zarządzaj listami"
     },
+    "button_text_view_history": {
+      "default": "Zobacz historię"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Dodaj lub usuń \"{title}\" z list"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Dekada"
+    },
+    "header_ratings": {
+      "default": "Oceny"
     },
     "button_label_view_all_items_in": {
       "default": "Zobacz wszystko w \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Przegląd miesiąca"
     },
     "page_title_settings": {
+      "default": "Ustawienia"
+    },
+    "button_text_settings": {
       "default": "Ustawienia"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "O mnie"
     },
+    "page_title_automatic_tracking": {
+      "default": "Automatyczne śledzenie"
+    },
     "text_automatic_tracking": {
       "default": "Automatyczne Śledzenie"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Usuń konto"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnostyka i pamięć podręczna"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Udostępnij logi uwierzytelniania"
+    },
+    "button_text_view_cache_size": {
+      "default": "Zobacz rozmiar pamięci podręcznej"
+    },
+    "button_text_clear_cache": {
+      "default": "Wyczyść pamięć podręczną"
+    },
+    "text_analytics": {
+      "default": "Analityka"
     },
     "header_calendar": {
       "default": "Kalendarz"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "W tym roku"
     },
+    "filter_label_before_year": {
+      "default": "Przed {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Ostatnio zaktualizowane"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Zatrzymaj meldowanie"
+    },
+    "button_text_edit_comment": {
+      "default": "Edytuj"
     },
     "button_text_delete_comment": {
       "default": "Usuń recenzję"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Reżyseria: <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Reżyseria: {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Reżyseria:"
     },
     "text_created_by": {
       "default": "Stworzone przez <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Twórca: {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Twórca:"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Porzucone"
+    },
+    "tag_text_started": {
+      "default": "Rozpoczęte"
     },
     "header_height": {
       "default": "Wzrost"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Czy chcesz przestać być proszonym o ocenę tego, co ostatnio oglądałeś?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Przywróć prośby o ocenę"
+    },
     "text_billing_month_for_free": {
       "default": "Wypróbuj 1 miesiąc za darmo, a potem:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Uaktualnij do VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Nieograniczone śledzenie i więcej."
+      "default": "Podsumowanie roku i wiele więcej."
     },
     "button_label_like_list": {
       "default": "Lubię {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Regulamin"
+    },
+    "button_text_block_comments": {
+      "default": "Zablokuj komentarze od {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Gotowe"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Odrzucić zmiany?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Czy na pewno chcesz to odrzucić? Wszelkie niezapisane zmiany zostaną utracone."
+    },
+    "button_text_discard": {
+      "default": "Odrzuć"
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Tem certeza de que deseja remover esta reprodução de \"{title}\" da sua lista de Vistos?"
     },
+    "list_title_episodes": {
+      "default": "Episódios"
+    },
     "list_title_seasons": {
       "default": "Temporadas"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Gerenciar listas"
     },
+    "button_text_view_history": {
+      "default": "Ver histórico"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Adicionar ou remover \"{title}\" das listas"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Década"
+    },
+    "header_ratings": {
+      "default": "Avaliações"
     },
     "button_label_view_all_items_in": {
       "default": "Ver tudo em \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Resumo do mês"
     },
     "page_title_settings": {
+      "default": "Configurações"
+    },
+    "button_text_settings": {
       "default": "Configurações"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "Sobre mim"
     },
+    "page_title_automatic_tracking": {
+      "default": "Rastreamento Automático"
+    },
     "text_automatic_tracking": {
       "default": "Rastreamento Automático"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Excluir conta"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnóstico e Cache"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Compartilhar logs de autenticação"
+    },
+    "button_text_view_cache_size": {
+      "default": "Ver Tamanho do Cache"
+    },
+    "button_text_clear_cache": {
+      "default": "Limpar Cache"
+    },
+    "text_analytics": {
+      "default": "Análises"
     },
     "header_calendar": {
       "default": "Calendário"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "Este ano"
     },
+    "filter_label_before_year": {
+      "default": "Antes de {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Atualizado recentemente"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Parar check-in"
+    },
+    "button_text_edit_comment": {
+      "default": "Editar"
     },
     "button_text_delete_comment": {
       "default": "Excluir Avaliação"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Direção de <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Dirigido por {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Dirigido por"
     },
     "text_created_by": {
       "default": "Criação de <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Criada por {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Criado por"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Abandonado"
+    },
+    "tag_text_started": {
+      "default": "Iniciada"
     },
     "header_height": {
       "default": "Altura"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Você quer parar de ser perguntado para avaliar o que assistiu recentemente?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Restaurar Pedidos de Avaliação"
+    },
     "text_billing_month_for_free": {
       "default": "Experimente 1 mês grátis e depois:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Upgrade para VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Acompanhamento ilimitado e muito mais."
+      "default": "Retrospectiva do ano e muito mais."
     },
     "button_label_like_list": {
       "default": "Curtir {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Termos de Uso"
+    },
+    "button_text_block_comments": {
+      "default": "Bloquear comentários de {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Pronto"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Descartar Alterações?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Tem certeza de que deseja descartar isso? Quaisquer alterações não salvas serão perdidas."
+    },
+    "button_text_discard": {
+      "default": "Descartar"
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Sigur vrei să ștergi această vizionare a \"{title}\" din lista ta de vizionate?"
     },
+    "list_title_episodes": {
+      "default": "Episoade"
+    },
     "list_title_seasons": {
       "default": "Sezoane"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Gestionează listele"
     },
+    "button_text_view_history": {
+      "default": "Vezi istoricul"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Adaugă sau elimină \"{title}\" din liste"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Deceniu"
+    },
+    "header_ratings": {
+      "default": "Evaluări"
     },
     "button_label_view_all_items_in": {
       "default": "Vezi toate în \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Luna în revistă"
     },
     "page_title_settings": {
+      "default": "Setări"
+    },
+    "button_text_settings": {
       "default": "Setări"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "Despre mine"
     },
+    "page_title_automatic_tracking": {
+      "default": "Monitorizare automată"
+    },
     "text_automatic_tracking": {
       "default": "Urmărire Automată"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Șterge contul"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnostic și cache"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Partajează jurnalele de autentificare"
+    },
+    "button_text_view_cache_size": {
+      "default": "Vezi dimensiunea cache-ului"
+    },
+    "button_text_clear_cache": {
+      "default": "Șterge cache-ul"
+    },
+    "text_analytics": {
+      "default": "Analize"
     },
     "header_calendar": {
       "default": "Calendar"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "Anul acesta"
     },
+    "filter_label_before_year": {
+      "default": "Înainte de {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Actualizat recent"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Oprește check-in-ul"
+    },
+    "button_text_edit_comment": {
+      "default": "Editează"
     },
     "button_text_delete_comment": {
       "default": "Șterge Recenzia"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Regizat de <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Regizat de {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Regizat de"
     },
     "text_created_by": {
       "default": "Creat de <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Creat de {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Creat de"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Abandonat"
+    },
+    "tag_text_started": {
+      "default": "Început"
     },
     "header_height": {
       "default": "Înălțime"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Dorești să nu mai fii întrebat să evaluezi ce ai urmărit recent?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Restabilește solicitările de evaluare"
+    },
     "text_billing_month_for_free": {
       "default": "Încearcă 1 lună gratuit și apoi:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Fă upgrade la VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Urmărire nelimitată și multe altele."
+      "default": "Retrospectiva anului și multe altele."
     },
     "button_label_like_list": {
       "default": "Apreciază {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Termeni de utilizare"
+    },
+    "button_text_block_comments": {
+      "default": "Blochează comentariile de la {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Gata"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Renunți la modificări?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Ești sigur că vrei să renunți la asta? Orice modificare nesalvată se va pierde."
+    },
+    "button_text_discard": {
+      "default": "Renunță"
     }
   }
 }

--- a/projects/client/i18n/meta/ru-ru.json
+++ b/projects/client/i18n/meta/ru-ru.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Вы уверены, что хотите удалить этот просмотр «{title}»?"
     },
+    "list_title_episodes": {
+      "default": "Эпизоды"
+    },
     "list_title_seasons": {
       "default": "Сезоны"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Управлять списками"
     },
+    "button_text_view_history": {
+      "default": "Посмотреть историю"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Добавить или удалить «{title}» из списков"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Десятилетие"
+    },
+    "header_ratings": {
+      "default": "Рейтинги"
     },
     "button_label_view_all_items_in": {
       "default": "Посмотреть всё в «{title}»"
@@ -1261,6 +1270,9 @@
       "default": "Итоги месяца"
     },
     "page_title_settings": {
+      "default": "Настройки"
+    },
+    "button_text_settings": {
       "default": "Настройки"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "О себе"
     },
+    "page_title_automatic_tracking": {
+      "default": "Автоматическое отслеживание"
+    },
     "text_automatic_tracking": {
       "default": "Авто-трекинг"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Удалить аккаунт"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Диагностика и кэш"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Поделиться журналами аутентификации"
+    },
+    "button_text_view_cache_size": {
+      "default": "Размер кэша"
+    },
+    "button_text_clear_cache": {
+      "default": "Очистить кэш"
+    },
+    "text_analytics": {
+      "default": "Аналитика"
     },
     "header_calendar": {
       "default": "Календарь"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "В этом году"
     },
+    "filter_label_before_year": {
+      "default": "До {year} года"
+    },
     "text_sort_recently_updated": {
       "default": "Обновлено недавно"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Остановить отметку"
+    },
+    "button_text_edit_comment": {
+      "default": "Изменить"
     },
     "button_text_delete_comment": {
       "default": "Удалить отзыв"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Режиссер: <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Режиссёр: {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Режиссер"
     },
     "text_created_by": {
       "default": "Создатель: <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Создатель: {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Создатель"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Брошено"
+    },
+    "tag_text_started": {
+      "default": "Начато"
     },
     "header_height": {
       "default": "Рост"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Перестать предлагать оценку после просмотра?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Восстановить запросы оценки"
+    },
     "text_billing_month_for_free": {
       "default": "1 месяц бесплатно, затем:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Стань VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Безлимитный трекинг и многое другое."
+      "default": "Итоги года и многое другое."
     },
     "button_label_like_list": {
       "default": "Лайк списку {name}"
@@ -2443,7 +2501,7 @@
       "default": "Готово."
     },
     "button_text_track": {
-      "default": "Отследить"
+      "default": "Track"
     },
     "filter_label_runtime": {
       "default": "{range} мин."
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Условия использования"
+    },
+    "button_text_block_comments": {
+      "default": "Заблокировать комментарии от {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Готово"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Отменить изменения?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Вы уверены, что хотите отменить это? Все несохраненные изменения будут потеряны."
+    },
+    "button_text_discard": {
+      "default": "Отменить"
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Är du säker på att du vill ta bort den här visningen av \"{title}\" från din Sedda-lista?"
     },
+    "list_title_episodes": {
+      "default": "Avsnitt"
+    },
     "list_title_seasons": {
       "default": "Säsonger"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Hantera listor"
     },
+    "button_text_view_history": {
+      "default": "Visa historik"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Lägg till eller ta bort \"{title}\" från listor"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Årtionde"
+    },
+    "header_ratings": {
+      "default": "Betyg"
     },
     "button_label_view_all_items_in": {
       "default": "Visa alla i \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Månadens överblick"
     },
     "page_title_settings": {
+      "default": "Inställningar"
+    },
+    "button_text_settings": {
       "default": "Inställningar"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "Om mig"
     },
+    "page_title_automatic_tracking": {
+      "default": "Automatisk spårning"
+    },
     "text_automatic_tracking": {
       "default": "Automatisk Spårning"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Radera konto"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Diagnostik och cache"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Dela autentiseringsloggar"
+    },
+    "button_text_view_cache_size": {
+      "default": "Visa cachestorlek"
+    },
+    "button_text_clear_cache": {
+      "default": "Rensa cache"
+    },
+    "text_analytics": {
+      "default": "Analys"
     },
     "header_calendar": {
       "default": "Kalender"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "I år"
     },
+    "filter_label_before_year": {
+      "default": "Före {year}"
+    },
     "text_sort_recently_updated": {
       "default": "Senast uppdaterad"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Stoppa check-in"
+    },
+    "button_text_edit_comment": {
+      "default": "Redigera"
     },
     "button_text_delete_comment": {
       "default": "Radera recension"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Regi: <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Regisserad av {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Regi:"
     },
     "text_created_by": {
       "default": "Skapad av <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Skapad av {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Skapad av:"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Avbruten"
+    },
+    "tag_text_started": {
+      "default": "Påbörjad"
     },
     "header_height": {
       "default": "Längd"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Vill du sluta bli ombedd att betygsätta det du nyligen har sett?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Återställ betygsförfrågningar"
+    },
     "text_billing_month_for_free": {
       "default": "Testa 1 månad gratis och sedan:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Uppgradera till VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Obegränsad spårning och mer."
+      "default": "Årssammanfattning med mera."
     },
     "button_label_like_list": {
       "default": "Gilla {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Användarvillkor"
+    },
+    "button_text_block_comments": {
+      "default": "Blockera kommentarer från {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Klar"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Avbryt ändringar?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Är du säker på att du vill avbryta detta? Alla osparade ändringar kommer att gå förlorade."
+    },
+    "button_text_discard": {
+      "default": "Avbryt"
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -675,6 +675,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "Ви впевнені, що хочете видалити це відтворення \"{title}\" зі списку Переглянуто?"
     },
+    "list_title_episodes": {
+      "default": "Епізоди"
+    },
     "list_title_seasons": {
       "default": "Сезони"
     },
@@ -1122,6 +1125,9 @@
     "button_text_manage_lists": {
       "default": "Керувати списками"
     },
+    "button_text_view_history": {
+      "default": "Переглянути історію"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "Додати або видалити \"{title}\" зі списків"
     },
@@ -1190,6 +1196,9 @@
     },
     "header_decade": {
       "default": "Десятиліття"
+    },
+    "header_ratings": {
+      "default": "Рейтинги"
     },
     "button_label_view_all_items_in": {
       "default": "Переглянути все у \"{title}\""
@@ -1261,6 +1270,9 @@
       "default": "Огляд місяця"
     },
     "page_title_settings": {
+      "default": "Налаштування"
+    },
+    "button_text_settings": {
       "default": "Налаштування"
     },
     "button_label_settings": {
@@ -1491,6 +1503,9 @@
     "text_about": {
       "default": "Про мене"
     },
+    "page_title_automatic_tracking": {
+      "default": "Автоматичне відстеження"
+    },
     "text_automatic_tracking": {
       "default": "Автоматичне Відстеження"
     },
@@ -1646,6 +1661,21 @@
     },
     "button_text_delete_account": {
       "default": "Видалити акаунт"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "Діагностика та кеш"
+    },
+    "button_text_share_auth_logs": {
+      "default": "Поділитися журналами автентифікації"
+    },
+    "button_text_view_cache_size": {
+      "default": "Переглянути розмір кешу"
+    },
+    "button_text_clear_cache": {
+      "default": "Очистити кеш"
+    },
+    "text_analytics": {
+      "default": "Аналітика"
     },
     "header_calendar": {
       "default": "Календар"
@@ -1998,6 +2028,9 @@
     "filter_label_this_year": {
       "default": "Цього року"
     },
+    "filter_label_before_year": {
+      "default": "До {year} року"
+    },
     "text_sort_recently_updated": {
       "default": "Нещодавно оновлено"
     },
@@ -2039,6 +2072,9 @@
     },
     "button_text_stop_check_in": {
       "default": "Зупинити відмітку перегляду"
+    },
+    "button_text_edit_comment": {
+      "default": "Редагувати"
     },
     "button_text_delete_comment": {
       "default": "Видалити відгук"
@@ -2175,11 +2211,27 @@
     "text_directed_by": {
       "default": "Режисер: <a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "Режисер: {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "Режисер:"
     },
     "text_created_by": {
       "default": "Створено <a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "Створено {name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "Створено:"
@@ -2189,6 +2241,9 @@
     },
     "tag_text_dropped": {
       "default": "Кинуто"
+    },
+    "tag_text_started": {
+      "default": "Розпочато"
     },
     "header_height": {
       "default": "Зріст"
@@ -2373,6 +2428,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "Чи бажаєте ви припинити запитання щодо оцінки того, що ви нещодавно переглянули?"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "Відновити запити оцінювання"
+    },
     "text_billing_month_for_free": {
       "default": "Спробуйте 1 місяць безкоштовно, а потім:"
     },
@@ -2404,7 +2462,7 @@
       "default": "Оновити до VIP!"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "Необмежене відстеження та більше."
+      "default": "Підсумки року та багато іншого."
     },
     "button_label_like_list": {
       "default": "Сподобалось {name}"
@@ -3005,6 +3063,21 @@
     },
     "link_text_terms_of_use": {
       "default": "Умови використання"
+    },
+    "button_text_block_comments": {
+      "default": "Заблокувати коментарі від {user}"
+    },
+    "button_text_keyboard_done": {
+      "default": "Готово"
+    },
+    "dialog_title_discard_changes": {
+      "default": "Відкинути зміни?"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "Ви впевнені, що хочете відкинути це? Усі незбережені зміни буде втрачено."
+    },
+    "button_text_discard": {
+      "default": "Відкинути"
     }
   }
 }

--- a/projects/client/i18n/meta/zh-cn.json
+++ b/projects/client/i18n/meta/zh-cn.json
@@ -674,6 +674,9 @@
     "warning_prompt_remove_single_watched": {
       "default": "确定要从已看列表中移除“{title}”的这条播放记录吗？"
     },
+    "list_title_episodes": {
+      "default": "剧集"
+    },
     "list_title_seasons": {
       "default": "季"
     },
@@ -1121,6 +1124,9 @@
     "button_text_manage_lists": {
       "default": "管理列表"
     },
+    "button_text_view_history": {
+      "default": "查看历史"
+    },
     "dropdown_label_add_remove_from_lists": {
       "default": "添加或移除“{title}”于片单"
     },
@@ -1189,6 +1195,9 @@
     },
     "header_decade": {
       "default": "年代"
+    },
+    "header_ratings": {
+      "default": "评分"
     },
     "button_label_view_all_items_in": {
       "default": "查看“{title}”中的所有项目"
@@ -1260,6 +1269,9 @@
       "default": "月度回顾"
     },
     "page_title_settings": {
+      "default": "设置"
+    },
+    "button_text_settings": {
       "default": "设置"
     },
     "button_label_settings": {
@@ -1490,6 +1502,9 @@
     "text_about": {
       "default": "关于我"
     },
+    "page_title_automatic_tracking": {
+      "default": "自动追踪"
+    },
     "text_automatic_tracking": {
       "default": "自动记录"
     },
@@ -1645,6 +1660,21 @@
     },
     "button_text_delete_account": {
       "default": "删除账户"
+    },
+    "button_text_diagnostics_and_cache": {
+      "default": "诊断与缓存"
+    },
+    "button_text_share_auth_logs": {
+      "default": "分享身份验证日志"
+    },
+    "button_text_view_cache_size": {
+      "default": "查看缓存大小"
+    },
+    "button_text_clear_cache": {
+      "default": "清除缓存"
+    },
+    "text_analytics": {
+      "default": "分析"
     },
     "header_calendar": {
       "default": "日历"
@@ -1997,6 +2027,9 @@
     "filter_label_this_year": {
       "default": "今年"
     },
+    "filter_label_before_year": {
+      "default": "{year}年之前"
+    },
     "text_sort_recently_updated": {
       "default": "最近更新"
     },
@@ -2038,6 +2071,9 @@
     },
     "button_text_stop_check_in": {
       "default": "停止签到"
+    },
+    "button_text_edit_comment": {
+      "default": "编辑"
     },
     "button_text_delete_comment": {
       "default": "删除评论"
@@ -2174,11 +2210,27 @@
     "text_directed_by": {
       "default": "导演：<a>{name}</a>"
     },
+    "text_directed_by_plain": {
+      "default": "导演：{name}",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "text_directed_by_short": {
       "default": "导演"
     },
     "text_created_by": {
       "default": "主创：<a>{name}</a>"
+    },
+    "text_created_by_plain": {
+      "default": "由 {name} 创作",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "text_created_by_short": {
       "default": "主创"
@@ -2188,6 +2240,9 @@
     },
     "tag_text_dropped": {
       "default": "已弃"
+    },
+    "tag_text_started": {
+      "default": "已开始"
     },
     "header_height": {
       "default": "身高"
@@ -2372,6 +2427,9 @@
     "warning_prompt_suppress_ratings_toast": {
       "default": "你要停止被询问最近观看内容的评分吗？"
     },
+    "button_text_restore_rating_prompts": {
+      "default": "恢复评分提示"
+    },
     "text_billing_month_for_free": {
       "default": "免费试用 1 个月，之后："
     },
@@ -2403,7 +2461,7 @@
       "default": "升级到 VIP！"
     },
     "text_vip_upsell_default_description_2": {
-      "default": "无限记录以及更多功能。"
+      "default": "年度回顾及更多专属特权。"
     },
     "button_label_like_list": {
       "default": "点赞 {name}"
@@ -2442,7 +2500,7 @@
       "default": "导出完成。"
     },
     "button_text_track": {
-      "default": "记录"
+      "default": "Track"
     },
     "filter_label_runtime": {
       "default": "{range} 分钟"
@@ -3004,6 +3062,21 @@
     },
     "link_text_terms_of_use": {
       "default": "使用条款"
+    },
+    "button_text_block_comments": {
+      "default": "屏蔽来自 {user} 的评论"
+    },
+    "button_text_keyboard_done": {
+      "default": "完成"
+    },
+    "dialog_title_discard_changes": {
+      "default": "要放弃更改吗？"
+    },
+    "warning_prompt_discard_changes": {
+      "default": "确定要放弃这些更改吗？未保存的更改将会丢失。"
+    },
+    "button_text_discard": {
+      "default": "丢弃"
     }
   }
 }


### PR DESCRIPTION
Because I tried to add things to similar spots this is a bit messy but hopefully moving forward will not be as massive of a set of changes.

Note as part of this I've also fixed a duplicate key with terms of use: `"link_text_terms"`. @michaldrabik if you regenerate after this with no changes it will likely cause Android to show "Terms" instead of "Terms of Use" until you switch to the new `"link_text_terms_of_use"` key from `"link_text_terms"`.

---

- Update VIP upgrade translations removing reference to 'unlimited tracking'.
- Add keys for comment dismissal warning prompt.
- Add keys for diagnostics and cache options, including restoring rating prompt when suppressed
- Add rating header key back while still in use on iOS
- Add key to dismiss the system keyboard
- Add key for 'edit review' button
- Add key to block another user's comments
- Add key to open the full page of a user's plays for a media item
- Add key for episodes list title
- Add key for 'before certain year' filter option
- Add key for automatic tracking screen
- Add 'button_text_settings' key
- Add 'tag_text_started' for shows started but not yet completed
- Add extra 'created by' and 'directed by' keys that exclude HTML tags
- Fix: Remove translated "Track" value which isn't meant to be translated

Actual changes to check in `en.json`:
L1636 list_title_episodes
L2916 button_text_view_history
L3127 header_ratings
L3326 button_text_settings
L3964 page_title_automatic_tracking
L4346 link_text_feedback
L4353 link_text_terms_of_use
L4368 button_text_delete_account
L4376 button_text_diagnostics_and_cache
L4384 button_text_share_auth_logs
L4392 button_text_view_cache_size
L4400 button_text_clear_cache
L4408 text_analytics
L5313 filter_label_before_year
L5431 button_text_edit_comment
L5772 text_directed_by_plain
L5806 text_created_by_plain
L5839 tag_text_started
L6320 button_text_restore_rating_prompts
L6405 text_vip_upsell_default_description_2
L8077 button_text_block_comments
L8090 button_text_keyboard_done
L8092 dialog_title_discard_changes
L8100 warning_prompt_discard_changes
L8108 button_text_discard