### PR TITLE
fix(calendar) / focus end of week in reverse-chronological order

### DIFF
--- a/projects/client/src/lib/features/calendar/context/useCalendarPeriod.ts
+++ b/projects/client/src/lib/features/calendar/context/useCalendarPeriod.ts
@@ -1,11 +1,13 @@
 import { getLocale } from '$lib/features/i18n/index.ts';
 import { getStartOfWeek } from '$lib/utils/date/getStartOfWeek.ts';
 import { isCurrentWeek } from '$lib/utils/date/isCurrentWeek.ts';
+import { addDays } from 'date-fns/addDays';
 import { addWeeks } from 'date-fns/addWeeks';
 import { subWeeks } from 'date-fns/subWeeks';
 import { map } from 'rxjs';
 import { AnalyticsEvent } from '../../analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '../../analytics/useTrack.ts';
+import type { CalendarOrder } from '../models/CalendarOrder.ts';
 import { getCalendarContext } from './getCalendarContext.ts';
 
 type Direction = 'next' | 'previous';
@@ -19,8 +21,21 @@ function getNextOrPreviousPeriod(date: Date, direction: Direction) {
   return getStartOfWeek(targetWeek, getLocale());
 }
 
+const LAST_DAY_OF_WEEK_OFFSET = 6;
+
+function getActiveDate(weekStart: Date, order: CalendarOrder): Date {
+  if (order === 'reverse-chronological') {
+    return addDays(weekStart, LAST_DAY_OF_WEEK_OFFSET);
+  }
+
+  return weekStart;
+}
+
 // FIXME: calendar navigation should be reflected in url
-export function useCalendarPeriod() {
+export function useCalendarPeriod(
+  options?: { order?: CalendarOrder },
+) {
+  const { order = 'chronological' } = options ?? {};
   const { startDate, activeDate } = getCalendarContext();
   const { track } = useTrack(AnalyticsEvent.CalendarPeriod);
 
@@ -29,7 +44,7 @@ export function useCalendarPeriod() {
     const date = startDate.value;
     const newStart = getNextOrPreviousPeriod(date, direction);
 
-    activeDate.next(newStart);
+    activeDate.next(getActiveDate(newStart, order));
     startDate.next(newStart);
   };
 

--- a/projects/client/src/lib/features/calendar/models/CalendarLayoutProps.ts
+++ b/projects/client/src/lib/features/calendar/models/CalendarLayoutProps.ts
@@ -1,6 +1,7 @@
 import type { Snippet } from 'svelte';
 import type { Calendar } from './Calendar.ts';
 import type { CalendarNavigationProps } from './CalendarNavigationProps.ts';
+import type { CalendarOrder } from './CalendarOrder.ts';
 
 export type CalendarLayoutProps<T> = {
   calendar: Calendar<T>;
@@ -8,5 +9,5 @@ export type CalendarLayoutProps<T> = {
   item: Snippet<[T]>;
   layout?: 'list' | 'grid';
   empty?: Snippet;
-  order?: 'chronological' | 'reverse-chronological';
+  order?: CalendarOrder;
 } & CalendarNavigationProps;

--- a/projects/client/src/lib/features/calendar/models/CalendarOrder.ts
+++ b/projects/client/src/lib/features/calendar/models/CalendarOrder.ts
@@ -1,0 +1,1 @@
+export type CalendarOrder = 'chronological' | 'reverse-chronological';

--- a/projects/client/src/lib/sections/lists/activity/ActivityPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/activity/ActivityPaginatedList.svelte
@@ -11,7 +11,7 @@
   const { filterMap } = useFilter();
 
   const { startDate, endDate, activeDate, next, previous, reset } =
-    useCalendarPeriod();
+    useCalendarPeriod({ order: 'reverse-chronological' });
 
   const now = new Date();
 

--- a/projects/client/src/lib/sections/lists/history/PersonalHistoryPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/PersonalHistoryPaginatedList.svelte
@@ -11,7 +11,7 @@
   const { mode }: { mode?: DiscoverMode } = $props();
 
   const { startDate, endDate, activeDate, next, previous, reset } =
-    useCalendarPeriod();
+    useCalendarPeriod({ order: 'reverse-chronological' });
 
   const historyType = $derived(toRecentlyWatchedType(mode));
 


### PR DESCRIPTION
## Overview
Ensures that calendar navigation focuses on the most relevant day when browsing in reverse-chronological order. In lists such as personal history or activity, navigating between weeks now correctly sets the active focus to the end of the week instead of the beginning, aligning with the expected visual flow of most-recent items first.

## Changes
- Introduces a shared `CalendarOrder` type to standardize chronological and reverse-chronological ordering across the calendar feature.
- Updates the `useCalendarPeriod` hook to accept an `order` option, defaulting to `chronological`.
- Implements logic within `useCalendarPeriod` to calculate the active date based on the specified order, applying a 6-day offset for reverse-chronological views.
- Updates `ActivityPaginatedList` and `PersonalHistoryPaginatedList` to utilize the reverse-chronological configuration.

## Testing
Manual verification was performed in the activity and history sections to confirm that navigating to previous or next weeks focuses the end of the week when reverse-chronological order is active.