### PR TITLE
feat(profile) / implement custom profile photo management with cropping

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Имате въпроси относно използването на нашия бранд? Свържете се с нас."
+    },
+    "button_text_view_photo": {
+      "default": "Виж снимката"
+    },
+    "button_text_upload_photo": {
+      "default": "Качи снимка"
+    },
+    "button_text_remove_photo": {
+      "default": "Премахни снимката"
+    },
+    "button_label_view_photo": {
+      "default": "Виж профилната си снимка"
+    },
+    "button_label_upload_photo": {
+      "default": "Качи нова профилна снимка"
+    },
+    "button_label_remove_photo": {
+      "default": "Премахни профилната си снимка"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Плъзни изображението, за да го наместиш идеално за големия екран"
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Har du spørgsmål om brugen af vores brand? Kontakt os endelig."
+    },
+    "button_text_view_photo": {
+      "default": "Se billede"
+    },
+    "button_text_upload_photo": {
+      "default": "Upload billede"
+    },
+    "button_text_remove_photo": {
+      "default": "Fjern billede"
+    },
+    "button_label_view_photo": {
+      "default": "Se dit profilbillede"
+    },
+    "button_label_upload_photo": {
+      "default": "Upload et nyt profilbillede"
+    },
+    "button_label_remove_photo": {
+      "default": "Fjern dit profilbillede"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Træk i billedet for at justere det – så er du helt klar til din næste hyggelige filmaften."
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Haben Sie Fragen zur Verwendung unserer Marke? Kontaktieren Sie uns."
+    },
+    "button_text_view_photo": {
+      "default": "Foto ansehen"
+    },
+    "button_text_upload_photo": {
+      "default": "Foto hochladen"
+    },
+    "button_text_remove_photo": {
+      "default": "Foto entfernen"
+    },
+    "button_label_view_photo": {
+      "default": "Ihr Profilfoto ansehen"
+    },
+    "button_label_upload_photo": {
+      "default": "Ein neues Profilfoto hochladen"
+    },
+    "button_label_remove_photo": {
+      "default": "Ihr Profilfoto entfernen"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Bild zum Anpassen ziehen"
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Have questions about using our brand? Reach out."
+    },
+    "button_text_view_photo": {
+      "default": "View photo"
+    },
+    "button_text_upload_photo": {
+      "default": "Upload photo"
+    },
+    "button_text_remove_photo": {
+      "default": "Remove photo"
+    },
+    "button_label_view_photo": {
+      "default": "View your profile photo"
+    },
+    "button_label_upload_photo": {
+      "default": "Upload a new profile photo"
+    },
+    "button_label_remove_photo": {
+      "default": "Remove your profile photo"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Drag the image to adjust"
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4041,6 +4041,62 @@
         "ios"
       ]
     },
+    "button_text_view_photo": {
+      "default": "View photo",
+      "description": "Text for the menu item that allows users to view their current profile photo.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "button_text_upload_photo": {
+      "default": "Upload photo",
+      "description": "Text for the menu item and confirm button that allows users to upload a new profile photo.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "button_text_remove_photo": {
+      "default": "Remove photo",
+      "description": "Text for the menu item that allows users to remove their current profile photo.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "button_label_view_photo": {
+      "default": "View your profile photo",
+      "description": "Aria-label for the button that opens the full-size profile photo viewer.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "button_label_upload_photo": {
+      "default": "Upload a new profile photo",
+      "description": "Aria-label for the button that opens the photo upload and crop dialog.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "button_label_remove_photo": {
+      "default": "Remove your profile photo",
+      "description": "Aria-label for the button that removes the current profile photo.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Drag the image to adjust",
+      "description": "Hint label in the profile photo crop dialog instructing users to drag to reposition.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "text_private_account": {
       "default": "Private account",
       "description": "Text for the section that allows users to toggle privacy.",

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "¿Tiene alguna duda sobre el uso de nuestra marca? Contacte con nosotros."
+    },
+    "button_text_view_photo": {
+      "default": "Ver foto"
+    },
+    "button_text_upload_photo": {
+      "default": "Subir foto"
+    },
+    "button_text_remove_photo": {
+      "default": "Eliminar foto"
+    },
+    "button_label_view_photo": {
+      "default": "Ver tu foto de perfil"
+    },
+    "button_label_upload_photo": {
+      "default": "Subir una nueva foto de perfil"
+    },
+    "button_label_remove_photo": {
+      "default": "Eliminar tu foto de perfil"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Arrastra la imagen para ajustarla"
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "¿Alguna pregunta sobre el uso de nuestra marca? Escríbenos."
+    },
+    "button_text_view_photo": {
+      "default": "Ver foto"
+    },
+    "button_text_upload_photo": {
+      "default": "Subir foto"
+    },
+    "button_text_remove_photo": {
+      "default": "Quitar foto"
+    },
+    "button_label_view_photo": {
+      "default": "Ver tu foto de perfil"
+    },
+    "button_label_upload_photo": {
+      "default": "Subir una nueva foto de perfil"
+    },
+    "button_label_remove_photo": {
+      "default": "Eliminar tu foto de perfil"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Arrastra la imagen para ajustarla, ¡que quede de película!"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Besoin d'aide avec notre image de marque? Écrivez-nous."
+    },
+    "button_text_view_photo": {
+      "default": "Voir la photo"
+    },
+    "button_text_upload_photo": {
+      "default": "Téléverser"
+    },
+    "button_text_remove_photo": {
+      "default": "Supprimer"
+    },
+    "button_label_view_photo": {
+      "default": "Voir votre photo de profil"
+    },
+    "button_label_upload_photo": {
+      "default": "Téléverser une nouvelle photo de profil"
+    },
+    "button_label_remove_photo": {
+      "default": "Supprimer votre photo de profil"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Glissez l'image pour ajuster le cadrage, comme au cinéma d'ici !"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Vous avez des questions sur l'utilisation de notre marque ? Contactez-nous."
+    },
+    "button_text_view_photo": {
+      "default": "Voir la photo"
+    },
+    "button_text_upload_photo": {
+      "default": "Charger une photo"
+    },
+    "button_text_remove_photo": {
+      "default": "Supprimer la photo"
+    },
+    "button_label_view_photo": {
+      "default": "Voir votre photo de profil"
+    },
+    "button_label_upload_photo": {
+      "default": "Charger une nouvelle photo de profil"
+    },
+    "button_label_remove_photo": {
+      "default": "Supprimer votre photo de profil"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Faites glisser l'image pour l'ajuster"
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Hai domande sull'uso del nostro marchio? Contattaci."
+    },
+    "button_text_view_photo": {
+      "default": "Vedi foto"
+    },
+    "button_text_upload_photo": {
+      "default": "Carica foto"
+    },
+    "button_text_remove_photo": {
+      "default": "Rimuovi foto"
+    },
+    "button_label_view_photo": {
+      "default": "Visualizza la tua foto profilo"
+    },
+    "button_label_upload_photo": {
+      "default": "Carica una nuova foto profilo"
+    },
+    "button_label_remove_photo": {
+      "default": "Rimuovi la tua foto profilo"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Trascina l'immagine per l'inquadratura perfetta"
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "ブランドの使用についてご不明な点がありますか？ぜひお問い合わせください。"
+    },
+    "button_text_view_photo": {
+      "default": "写真を表示"
+    },
+    "button_text_upload_photo": {
+      "default": "写真をアップロード"
+    },
+    "button_text_remove_photo": {
+      "default": "写真を削除"
+    },
+    "button_label_view_photo": {
+      "default": "プロフィール写真を表示"
+    },
+    "button_label_upload_photo": {
+      "default": "新しいプロフィール写真をアップロード"
+    },
+    "button_label_remove_photo": {
+      "default": "プロフィール写真を削除"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "画像をドラッグして位置を調整"
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Har du spørsmål om bruk av merkevaren vår? Ta kontakt."
+    },
+    "button_text_view_photo": {
+      "default": "Se bilde"
+    },
+    "button_text_upload_photo": {
+      "default": "Last opp bilde"
+    },
+    "button_text_remove_photo": {
+      "default": "Fjern bilde"
+    },
+    "button_label_view_photo": {
+      "default": "Se profilbildet ditt"
+    },
+    "button_label_upload_photo": {
+      "default": "Last opp et nytt profilbilde"
+    },
+    "button_label_remove_photo": {
+      "default": "Fjern profilbildet ditt"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Dra i bildet for å tilpasse – finn din beste vinkel før kveldens premiere!"
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Heb je vragen over het gebruik van ons merk? Neem contact op."
+    },
+    "button_text_view_photo": {
+      "default": "Bekijk foto"
+    },
+    "button_text_upload_photo": {
+      "default": "Foto uploaden"
+    },
+    "button_text_remove_photo": {
+      "default": "Foto verwijderen"
+    },
+    "button_label_view_photo": {
+      "default": "Bekijk je profielfoto"
+    },
+    "button_label_upload_photo": {
+      "default": "Upload een nieuwe profielfoto"
+    },
+    "button_label_remove_photo": {
+      "default": "Verwijder je profielfoto"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Sleep de afbeelding om aan te passen"
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Masz pytania dotyczące korzystania z naszej marki? Skontaktuj się z nami."
+    },
+    "button_text_view_photo": {
+      "default": "Zobacz zdjęcie"
+    },
+    "button_text_upload_photo": {
+      "default": "Prześlij zdjęcie"
+    },
+    "button_text_remove_photo": {
+      "default": "Usuń zdjęcie"
+    },
+    "button_label_view_photo": {
+      "default": "Zobacz swoje zdjęcie profilowe"
+    },
+    "button_label_upload_photo": {
+      "default": "Prześlij nowe zdjęcie profilowe"
+    },
+    "button_label_remove_photo": {
+      "default": "Usuń swoje zdjęcie profilowe"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Przeciągnij obraz, aby dopasować kadr przed premierą!"
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Tem perguntas sobre o uso da nossa marca? Entre em contato!"
+    },
+    "button_text_view_photo": {
+      "default": "Ver foto"
+    },
+    "button_text_upload_photo": {
+      "default": "Enviar foto"
+    },
+    "button_text_remove_photo": {
+      "default": "Remover foto"
+    },
+    "button_label_view_photo": {
+      "default": "Ver sua foto de perfil"
+    },
+    "button_label_upload_photo": {
+      "default": "Enviar uma nova foto de perfil"
+    },
+    "button_label_remove_photo": {
+      "default": "Remover sua foto de perfil"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Arraste a imagem para ajustar"
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Ai întrebări despre utilizarea brandului nostru? Contactează-ne."
+    },
+    "button_text_view_photo": {
+      "default": "Vezi fotografia"
+    },
+    "button_text_upload_photo": {
+      "default": "Încarcă fotografia"
+    },
+    "button_text_remove_photo": {
+      "default": "Elimină fotografia"
+    },
+    "button_label_view_photo": {
+      "default": "Vezi fotografia de profil"
+    },
+    "button_label_upload_photo": {
+      "default": "Încarcă o nouă fotografie de profil"
+    },
+    "button_label_remove_photo": {
+      "default": "Elimină fotografia de profil"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Trage imaginea pentru a fixa cadrul perfect, exact ca un regizor!"
     }
   }
 }

--- a/projects/client/i18n/meta/ru-ru.json
+++ b/projects/client/i18n/meta/ru-ru.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Есть вопросы по использованию нашего бренда? Свяжитесь с нами."
+    },
+    "button_text_view_photo": {
+      "default": "Посмотреть фото"
+    },
+    "button_text_upload_photo": {
+      "default": "Загрузить фото"
+    },
+    "button_text_remove_photo": {
+      "default": "Удалить фото"
+    },
+    "button_label_view_photo": {
+      "default": "Посмотреть фото профиля"
+    },
+    "button_label_upload_photo": {
+      "default": "Загрузить новое фото профиля"
+    },
+    "button_label_remove_photo": {
+      "default": "Удалить ваше фото профиля"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Перетащите изображение, чтобы настроить"
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Har du frågor om hur du använder vårt varumärke? Hör av dig."
+    },
+    "button_text_view_photo": {
+      "default": "Visa bild"
+    },
+    "button_text_upload_photo": {
+      "default": "Ladda upp bild"
+    },
+    "button_text_remove_photo": {
+      "default": "Ta bort bild"
+    },
+    "button_label_view_photo": {
+      "default": "Visa din profilbild"
+    },
+    "button_label_upload_photo": {
+      "default": "Ladda upp en ny profilbild"
+    },
+    "button_label_remove_photo": {
+      "default": "Ta bort din profilbild"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Dra i bilden för att justera"
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -2981,6 +2981,27 @@
     },
     "text_branding_questions_intro": {
       "default": "Маєте запитання щодо використання нашого бренду? Зв’яжіться з нами."
+    },
+    "button_text_view_photo": {
+      "default": "Переглянути фото"
+    },
+    "button_text_upload_photo": {
+      "default": "Завантажити фото"
+    },
+    "button_text_remove_photo": {
+      "default": "Видалити фото"
+    },
+    "button_label_view_photo": {
+      "default": "Переглянути фото вашого профілю"
+    },
+    "button_label_upload_photo": {
+      "default": "Завантажити нове фото профілю"
+    },
+    "button_label_remove_photo": {
+      "default": "Видалити фото вашого профілю"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "Перетягніть зображення для налаштування"
     }
   }
 }

--- a/projects/client/i18n/meta/zh-cn.json
+++ b/projects/client/i18n/meta/zh-cn.json
@@ -2980,6 +2980,27 @@
     },
     "text_branding_questions_intro": {
       "default": "对使用我们的品牌有疑问？请联系我们。"
+    },
+    "button_text_view_photo": {
+      "default": "查看照片"
+    },
+    "button_text_upload_photo": {
+      "default": "上传照片"
+    },
+    "button_text_remove_photo": {
+      "default": "移除照片"
+    },
+    "button_label_view_photo": {
+      "default": "查看您的个人资料照片"
+    },
+    "button_label_upload_photo": {
+      "default": "上传新的个人资料照片"
+    },
+    "button_label_remove_photo": {
+      "default": "移除您的个人资料照片"
+    },
+    "label_drag_image_to_adjust": {
+      "default": "拖动图像以调整位置"
     }
   }
 }

--- a/projects/client/src/lib/sections/profile-banner/ProfileImage.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfileImage.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
+  import LoaderIcon from "$lib/components/icons/LoaderIcon.svelte";
+  import RenameIcon from "$lib/components/icons/RenameIcon.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
-  import EditableImage from "$lib/features/image/components/EditableImage.svelte";
   import { InvalidateAction } from "$lib/requests/models/InvalidateAction";
   import { uploadAvatarRequest } from "$lib/requests/queries/users/uploadAvatarRequest";
   import { useInvalidator } from "$lib/stores/useInvalidator";
   import type { Snippet } from "svelte";
-
+  import { fade } from "svelte/transition";
+  import ProfileImageContextMenu from "./_internal/ProfileImageContextMenu.svelte";
+  import ProfileImageCropDialog from "./_internal/ProfileImageCropDialog.svelte";
+  import ProfileImageViewDialog from "./_internal/ProfileImageViewDialog.svelte";
   const {
     name,
     src,
@@ -23,13 +27,68 @@
 
   const { invalidate } = useInvalidator();
 
-  async function handleImageUploaded(ev: any) {
-    const success = await uploadAvatarRequest({ avatar: ev.base64 });
+  type Dialog = "none" | "view" | "crop";
 
-    if (!success) {
-      return;
-    }
+  const imageEdit = $state<{
+    dialog: Dialog;
+    pendingBase64: string | null;
+    isUploading: boolean;
+  }>({
+    dialog: "none",
+    pendingBase64: null,
+    isUploading: false,
+  });
 
+  function openFilePicker() {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "image/*";
+    input.onchange = () => {
+      if (!input.files?.length) return;
+      readFile(input.files[0]);
+    };
+    input.click();
+  }
+
+  function readFile(file: File) {
+    if (!file.type.startsWith("image/")) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      imageEdit.pendingBase64 = ev.target?.result as string;
+      imageEdit.dialog = "crop";
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function handleFilesDropped(files: FileList) {
+    const [file] = files;
+    if (file) readFile(file);
+  }
+
+  async function handleCropConfirmed(base64: string) {
+    imageEdit.dialog = "none";
+    imageEdit.pendingBase64 = null;
+    imageEdit.isUploading = true;
+    const success = await uploadAvatarRequest({ avatar: base64 });
+    imageEdit.isUploading = false;
+    if (!success) return;
+    invalidate(InvalidateAction.User.Avatar);
+  }
+
+  function generateTransparentAvatar(): string {
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    return canvas.toDataURL("image/png");
+  }
+
+  async function handleRemovePhoto() {
+    imageEdit.isUploading = true;
+    const success = await uploadAvatarRequest({
+      avatar: generateTransparentAvatar(),
+    });
+    imageEdit.isUploading = false;
+    if (!success) return;
     invalidate(InvalidateAction.User.Avatar);
   }
 </script>
@@ -42,11 +101,40 @@
     </figcaption>
 
     {#if isEditable}
-      <EditableImage
-        {src}
-        alt={m.image_alt_user_avatar({ username: name })}
-        onchange={handleImageUploaded}
-      />
+      <ProfileImageContextMenu
+        onViewPhoto={() => (imageEdit.dialog = "view")}
+        onUploadPhoto={openFilePicker}
+        onRemovePhoto={handleRemovePhoto}
+      >
+        {#snippet trigger(props)}
+          <div
+            {...props}
+            class="editable-image-wrapper"
+            role="button"
+            tabindex="0"
+            aria-label={m.button_label_upload_photo()}
+            ondragover={(ev) => {
+              ev.preventDefault();
+              ev.currentTarget.classList.add("dragover");
+            }}
+            ondragleave={(ev) => ev.currentTarget.classList.remove("dragover")}
+            ondrop={(ev) => {
+              ev.preventDefault();
+              ev.currentTarget.classList.remove("dragover");
+              const { files } = ev.dataTransfer ?? {};
+              if (files?.length) handleFilesDropped(files);
+            }}
+          >
+            <CrossOriginImage
+              {src}
+              alt={m.image_alt_user_avatar({ username: name })}
+            />
+          </div>
+        {/snippet}
+      </ProfileImageContextMenu>
+      <div class="edit-badge" aria-hidden="true">
+        <RenameIcon />
+      </div>
     {:else}
       <CrossOriginImage
         {src}
@@ -55,8 +143,35 @@
     {/if}
   </figure>
 
+  {#if imageEdit.isUploading}
+    <div class="upload-overlay" transition:fade={{ duration: 150 }}>
+      <div class="upload-spinner">
+        <LoaderIcon />
+      </div>
+    </div>
+  {/if}
+
   {@render badge?.()}
 </div>
+
+{#if imageEdit.dialog === "view"}
+  <ProfileImageViewDialog
+    {src}
+    alt={m.image_alt_user_avatar({ username: name })}
+    onClose={() => (imageEdit.dialog = "none")}
+  />
+{/if}
+
+{#if imageEdit.dialog === "crop" && imageEdit.pendingBase64}
+  <ProfileImageCropDialog
+    src={imageEdit.pendingBase64}
+    onConfirm={handleCropConfirmed}
+    onClose={() => {
+      imageEdit.dialog = "none";
+      imageEdit.pendingBase64 = null;
+    }}
+  />
+{/if}
 
 <style>
   .visually-hidden {
@@ -102,18 +217,94 @@
     padding: var(--border-width);
     box-sizing: border-box;
 
-    :global(.trakt-editable-image img) {
-      transition: outline-color var(--transition-increment) ease-in-out;
-    }
-
-    :global(.trakt-editable-image.dragover img) {
-      outline-color: var(--purple-500);
-    }
-
     :global(img) {
       width: 100%;
       height: 100%;
       border-radius: 50%;
+    }
+  }
+
+  .editable-image-wrapper {
+    position: relative;
+    display: block;
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+    border-radius: 50%;
+    overflow: hidden;
+
+    &:focus-visible {
+      outline: var(--border-thickness-xs) solid var(--color-foreground);
+      outline-offset: 2px;
+    }
+  }
+
+  .edit-badge {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    transform: translate(15%, 15%);
+
+    width: var(--ni-24);
+    height: var(--ni-24);
+    border-radius: 50%;
+    background-color: var(--color-modal-background);
+    box-shadow: var(--shadow-dialog);
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+
+    opacity: 0;
+    transition:
+      opacity var(--transition-increment) ease-in-out,
+      transform var(--transition-increment) ease-in-out;
+
+    :global(svg) {
+      width: var(--ni-12);
+      height: var(--ni-12);
+      color: var(--color-text-primary);
+    }
+  }
+
+  .profile-image-container:has(.editable-image-wrapper:hover) .edit-badge,
+  .profile-image-container:has(.editable-image-wrapper:focus-visible)
+    .edit-badge {
+    opacity: 1;
+    transform: translate(15%, 15%) scale(1.1);
+  }
+
+  .upload-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: var(--image-size);
+    height: var(--image-size);
+    border-radius: 50%;
+    overflow: hidden;
+    background-color: color-mix(in srgb, var(--shade-900) 55%, transparent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: calc(var(--layer-raised) + 1);
+    cursor: wait;
+  }
+
+  .upload-spinner {
+    display: flex;
+    animation: upload-spin 1.2s linear infinite;
+
+    :global(svg) {
+      width: var(--ni-28);
+      height: var(--ni-28);
+      color: white;
+    }
+  }
+
+  @keyframes upload-spin {
+    to {
+      transform: rotate(1turn);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/profile-banner/_internal/ProfileImageContextMenu.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/ProfileImageContextMenu.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  import CoverImageIcon from "$lib/components/icons/CoverImageIcon.svelte";
+  import DeleteIcon from "$lib/components/icons/DeleteIcon.svelte";
+  import ProfileIcon from "$lib/components/icons/ProfileIcon.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { Popover } from "bits-ui";
+  import type { Snippet } from "svelte";
+
+  const {
+    trigger,
+    onViewPhoto,
+    onUploadPhoto,
+    onRemovePhoto,
+  }: {
+    trigger: Snippet<[Record<string, unknown>]>;
+    onViewPhoto: () => void;
+    onUploadPhoto: () => void;
+    onRemovePhoto: () => void;
+  } = $props();
+
+  let open = $state(false);
+
+  const closeAnd = (action: () => void) => () => {
+    open = false;
+    action();
+  };
+</script>
+
+<Popover.Root bind:open>
+  <Popover.Trigger>
+    {#snippet child({ props })}
+      {@render trigger(props)}
+    {/snippet}
+  </Popover.Trigger>
+  <Popover.Portal>
+    <Popover.Content
+      class="profile-image-context-menu"
+      sideOffset={8}
+      align="center"
+    >
+      <button
+        class="menu-item"
+        onclick={closeAnd(onViewPhoto)}
+        aria-label={m.button_label_view_photo()}
+      >
+        <ProfileIcon />
+        <span>{m.button_text_view_photo()}</span>
+      </button>
+
+      <button
+        class="menu-item"
+        onclick={closeAnd(onUploadPhoto)}
+        aria-label={m.button_label_upload_photo()}
+      >
+        <CoverImageIcon />
+        <span>{m.button_text_upload_photo()}</span>
+      </button>
+
+      <hr class="menu-divider" />
+
+      <button
+        class="menu-item menu-item--destructive"
+        onclick={closeAnd(onRemovePhoto)}
+        aria-label={m.button_label_remove_photo()}
+      >
+        <DeleteIcon />
+        <span>{m.button_text_remove_photo()}</span>
+      </button>
+    </Popover.Content>
+  </Popover.Portal>
+</Popover.Root>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  :global(.profile-image-context-menu) {
+    z-index: var(--layer-top);
+    background-color: var(--color-modal-background);
+    border-radius: var(--border-radius-l);
+    box-shadow: var(--shadow-menu);
+    padding: var(--ni-8);
+    min-width: var(--ni-200);
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-2);
+
+    animation: menuIn var(--transition-increment) ease-out forwards;
+  }
+
+  @keyframes menuIn {
+    from {
+      opacity: 0;
+      transform: scale(0.95) translateY(-4px);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1) translateY(0);
+    }
+  }
+
+  .menu-item {
+    all: unset;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: var(--ni-12);
+    padding: var(--ni-12) var(--ni-16);
+    border-radius: var(--border-radius-m);
+    color: var(--color-text-primary);
+    font-size: var(--font-size-m);
+    font-weight: var(--font-weight-normal);
+    transition: background-color var(--transition-increment) ease-in-out;
+
+    @include for-mouse {
+      &:hover {
+        background-color: color-mix(
+          in srgb,
+          var(--color-foreground) 8%,
+          transparent
+        );
+      }
+
+      &:focus-visible {
+        outline: var(--border-thickness-xs) solid var(--color-foreground);
+        outline-offset: -2px;
+      }
+    }
+
+    &--destructive {
+      color: var(--color-background-red);
+    }
+
+    :global(svg) {
+      width: var(--ni-20);
+      height: var(--ni-20);
+      flex-shrink: 0;
+    }
+  }
+
+  .menu-divider {
+    all: unset;
+    display: block;
+    height: 1px;
+    background-color: color-mix(
+      in srgb,
+      var(--color-foreground) 10%,
+      transparent
+    );
+    margin: var(--ni-4) var(--ni-8);
+  }
+</style>

--- a/projects/client/src/lib/sections/profile-banner/_internal/ProfileImageCropDialog.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/ProfileImageCropDialog.svelte
@@ -1,0 +1,338 @@
+<script lang="ts">
+  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import Button from "$lib/components/buttons/Button.svelte";
+  import Modal from "$lib/components/dialogs/Modal.svelte";
+  import CloseIcon from "$lib/components/icons/CloseIcon.svelte";
+  import CoverImageIcon from "$lib/components/icons/CoverImageIcon.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+
+  const {
+    src,
+    onConfirm,
+    onClose,
+  }: {
+    src: string;
+    onConfirm: (base64: string) => void;
+    onClose: () => void;
+  } = $props();
+
+  const CANVAS_DIMENSION = 440;
+  const MIN_ZOOM_SCALE = 1;
+  const MAX_ZOOM_SCALE = 4;
+  const ZOOM_SCALE_STEP = 0.3;
+  const WHEEL_ZOOM_SENSITIVITY = 0.005;
+  const WHEEL_ZOOM_LINE_HEIGHT_PX = 20;
+  const WHEEL_ZOOM_MAX_DELTA = 0.2;
+
+  const refs = $state<{ canvas?: HTMLCanvasElement; img?: HTMLImageElement }>(
+    {},
+  );
+
+  const crop = $state({
+    scale: 1,
+    offsetX: 0,
+    offsetY: 0,
+    isDragging: false,
+    isImageLoaded: false,
+    zoomTransition: false,
+  });
+
+  const dragAnchor = { x: 0, y: 0, offsetX: 0, offsetY: 0 };
+
+  function clampOffsets(x: number, y: number, currentScale: number) {
+    const { img } = refs;
+    if (!img) return { x, y };
+
+    const renderedW = img.naturalWidth * currentScale;
+    const renderedH = img.naturalHeight * currentScale;
+    const maxX = Math.max(0, (renderedW - CANVAS_DIMENSION) / 2);
+    const maxY = Math.max(0, (renderedH - CANVAS_DIMENSION) / 2);
+
+    return {
+      x: Math.min(maxX, Math.max(-maxX, x)),
+      y: Math.min(maxY, Math.max(-maxY, y)),
+    };
+  }
+
+  function draw() {
+    const { canvas, img } = refs;
+    if (!canvas || !img || !crop.isImageLoaded) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, CANVAS_DIMENSION, CANVAS_DIMENSION);
+
+    const naturalAspect = img.naturalWidth / img.naturalHeight;
+    const [baseW, baseH] =
+      naturalAspect >= 1
+        ? [CANVAS_DIMENSION * naturalAspect, CANVAS_DIMENSION]
+        : [CANVAS_DIMENSION, CANVAS_DIMENSION / naturalAspect];
+
+    const drawW = baseW * crop.scale;
+    const drawH = baseH * crop.scale;
+    const drawX = (CANVAS_DIMENSION - drawW) / 2 + crop.offsetX;
+    const drawY = (CANVAS_DIMENSION - drawH) / 2 + crop.offsetY;
+
+    ctx.drawImage(img, drawX, drawY, drawW, drawH);
+  }
+
+  $effect(() => {
+    draw();
+  });
+
+  function onImageLoad() {
+    if (!refs.img) return;
+    crop.isImageLoaded = true;
+    crop.scale = 1;
+    crop.offsetX = 0;
+    crop.offsetY = 0;
+    draw();
+  }
+
+  function onPointerDown(ev: PointerEvent) {
+    crop.isDragging = true;
+    dragAnchor.x = ev.clientX;
+    dragAnchor.y = ev.clientY;
+    dragAnchor.offsetX = crop.offsetX;
+    dragAnchor.offsetY = crop.offsetY;
+    (ev.target as HTMLElement).setPointerCapture(ev.pointerId);
+  }
+
+  function onPointerMove(ev: PointerEvent) {
+    if (!crop.isDragging) return;
+
+    const dx = ev.clientX - dragAnchor.x;
+    const dy = ev.clientY - dragAnchor.y;
+    const clamped = clampOffsets(
+      dragAnchor.offsetX + dx,
+      dragAnchor.offsetY + dy,
+      crop.scale,
+    );
+    crop.offsetX = clamped.x;
+    crop.offsetY = clamped.y;
+  }
+
+  const onPointerUp = () => {
+    crop.isDragging = false;
+  };
+
+  function onWheel(ev: WheelEvent) {
+    ev.preventDefault();
+    crop.zoomTransition = false;
+    const rawPixels =
+      ev.deltaMode === 1 ? ev.deltaY * WHEEL_ZOOM_LINE_HEIGHT_PX : ev.deltaY;
+    const delta = Math.max(
+      -WHEEL_ZOOM_MAX_DELTA,
+      Math.min(WHEEL_ZOOM_MAX_DELTA, -(rawPixels * WHEEL_ZOOM_SENSITIVITY)),
+    );
+    zoom(delta);
+  }
+
+  function zoom(delta: number) {
+    const newScale = Math.min(
+      MAX_ZOOM_SCALE,
+      Math.max(MIN_ZOOM_SCALE, crop.scale + delta),
+    );
+    const clamped = clampOffsets(crop.offsetX, crop.offsetY, newScale);
+    crop.scale = newScale;
+    crop.offsetX = clamped.x;
+    crop.offsetY = clamped.y;
+  }
+
+  const exportCroppedBase64 = () =>
+    refs.canvas?.toDataURL("image/jpeg", 0.9) ?? "";
+
+  const handleConfirm = () => onConfirm(exportCroppedBase64());
+</script>
+
+<!-- Hidden image element used for drawing -->
+<img
+  bind:this={refs.img}
+  {src}
+  alt=""
+  aria-hidden="true"
+  style="display:none"
+  onload={onImageLoad}
+  crossorigin="anonymous"
+/>
+
+<Modal {onClose}>
+  <div class="crop-dialog">
+    <div class="crop-header">
+      <ActionButton
+        label={m.button_text_cancel()}
+        color="default"
+        style="ghost"
+        onclick={onClose}
+      >
+        <CloseIcon />
+      </ActionButton>
+      <span class="crop-hint">{m.label_drag_image_to_adjust()}</span>
+      <Button
+        label={m.button_text_upload_photo()}
+        color="default"
+        style="ghost"
+        size="small"
+        onclick={handleConfirm}
+      >
+        {#snippet icon()}
+          <CoverImageIcon />
+        {/snippet}
+        {m.button_text_upload_photo()}
+      </Button>
+    </div>
+
+    <div class="crop-canvas-wrapper">
+      <canvas
+        bind:this={refs.canvas}
+        width={CANVAS_DIMENSION}
+        height={CANVAS_DIMENSION}
+        class="crop-canvas"
+        class:is-dragging={crop.isDragging}
+        onpointerdown={onPointerDown}
+        onpointermove={onPointerMove}
+        onpointerup={onPointerUp}
+        onpointercancel={onPointerUp}
+        onwheel={onWheel}
+        style="touch-action: none;"
+      ></canvas>
+    </div>
+
+    <div class="crop-zoom-controls">
+      <button
+        class="zoom-btn"
+        aria-label="Zoom out"
+        onclick={() => {
+          crop.zoomTransition = true;
+          zoom(-ZOOM_SCALE_STEP);
+        }}
+        disabled={crop.scale <= MIN_ZOOM_SCALE}
+      >
+        &minus;
+      </button>
+      <div class="zoom-track">
+        <div
+          class="zoom-fill"
+          class:animated={crop.zoomTransition}
+          style="width: {((crop.scale - MIN_ZOOM_SCALE) /
+            (MAX_ZOOM_SCALE - MIN_ZOOM_SCALE)) *
+            100}%"
+        ></div>
+      </div>
+      <button
+        class="zoom-btn"
+        aria-label="Zoom in"
+        onclick={() => {
+          crop.zoomTransition = true;
+          zoom(ZOOM_SCALE_STEP);
+        }}
+        disabled={crop.scale >= MAX_ZOOM_SCALE}
+      >
+        +
+      </button>
+    </div>
+  </div>
+</Modal>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .crop-dialog {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-16);
+    padding: 0;
+  }
+
+  .crop-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--ni-8);
+  }
+
+  .crop-hint {
+    font-size: var(--font-size-text);
+    color: var(--color-text-secondary);
+    flex: 1;
+    text-align: center;
+  }
+
+  .crop-canvas-wrapper {
+    position: relative;
+    border-radius: var(--border-radius-m);
+    overflow: hidden;
+    aspect-ratio: 1;
+    width: 100%;
+    background-color: var(--shade-900);
+  }
+
+  .crop-canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+
+    &.is-dragging {
+      cursor: grabbing;
+    }
+  }
+
+  .crop-zoom-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--ni-12);
+  }
+
+  .zoom-btn {
+    all: unset;
+    cursor: pointer;
+    width: var(--ni-28);
+    height: var(--ni-28);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--border-radius-s);
+    font-size: var(--font-size-l);
+    color: var(--color-text-primary);
+    transition: background-color var(--transition-increment) ease-in-out;
+
+    @include for-mouse {
+      &:hover:not(:disabled) {
+        background-color: color-mix(
+          in srgb,
+          var(--color-foreground) 10%,
+          transparent
+        );
+      }
+    }
+
+    &:disabled {
+      opacity: 0.3;
+      cursor: not-allowed;
+    }
+  }
+
+  .zoom-track {
+    flex: 1;
+    height: var(--ni-4);
+    border-radius: var(--border-radius-s);
+    background-color: color-mix(
+      in srgb,
+      var(--color-foreground) 15%,
+      transparent
+    );
+    overflow: hidden;
+  }
+
+  .zoom-fill {
+    height: 100%;
+    background-color: var(--color-foreground);
+    border-radius: var(--border-radius-s);
+
+    &.animated {
+      transition: width calc(var(--transition-increment) * 2) ease-out;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/profile-banner/_internal/ProfileImageViewDialog.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/ProfileImageViewDialog.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import Modal from "$lib/components/dialogs/Modal.svelte";
+  import CloseIcon from "$lib/components/icons/CloseIcon.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+
+  const {
+    src,
+    alt,
+    onClose,
+  }: {
+    src: string;
+    alt: string;
+    onClose: () => void;
+  } = $props();
+</script>
+
+<Modal {onClose}>
+  <div class="view-dialog">
+    <div class="view-header">
+      <ActionButton
+        label={m.button_text_cancel()}
+        color="default"
+        style="ghost"
+        onclick={onClose}
+      >
+        <CloseIcon />
+      </ActionButton>
+    </div>
+    <div class="view-image-wrapper">
+      <img {src} {alt} class="view-image" />
+    </div>
+  </div>
+</Modal>
+
+<style>
+  .view-dialog {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-16);
+    padding: 0;
+  }
+
+  .view-header {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  .view-image-wrapper {
+    border-radius: var(--border-radius-m);
+    overflow: hidden;
+    aspect-ratio: 1;
+    width: 100%;
+    background-color: var(--shade-900);
+  }
+
+  .view-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+</style>


### PR DESCRIPTION
### Overview
This PR enhances the profile image management experience by introducing a comprehensive suite of tools for user avatars. It replaces the basic upload functionality with an interactive system that allows users to view their current photo in full size, crop new uploads for a perfect fit, and manage their profile photo through a dedicated context menu.

### Changes
- Replaces the basic editable image component with a custom implementation featuring an interactive edit badge and hover/focus states.
- Implements a `ProfileImageContextMenu` providing quick access to view, upload, and remove actions.
- Adds a `ProfileImageCropDialog` that utilizes the Canvas API to allow users to scale and reposition images before uploading.
- Introduces a `ProfileImageViewDialog` for inspecting the current profile photo in a modal view.
- Supports drag-and-drop file interactions for streamlined photo updates.
- Updates internationalization files with new strings for accessibility (aria-labels), button text, and user guidance.
- Refactors the image upload logic to handle base64 data produced by the cropping tool and triggers state invalidation upon successful updates.

### Testing
- Verified the cropping tool functionality, including zoom (mouse wheel and buttons) and drag-to-adjust behavior.
- Tested the context menu triggers across different interaction methods (hover and focus).
- Confirmed that image removal and upload requests correctly update the user profile state.

https://github.com/user-attachments/assets/f972214d-0b20-4acc-8ff0-b2f143c2caf0
