### PR TITLE
feat(seo) / improve metadata and search engine discovery

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -103,6 +103,7 @@ module.exports = {
         'share',
         'search',
         'sentiment',
+        'seo',
         'settings',
         'show',
         'smart-list',

--- a/projects/client/src/app.html
+++ b/projects/client/src/app.html
@@ -51,6 +51,13 @@
       href="%sveltekit.assets%/pwa/ios/apple-touch-icon.png"
     />
 
+    <!-- SEO defaults (overridden per-page by TraktPage) -->
+    <meta
+      name="description"
+      content="Trakt Web: Track Your Shows &amp; Movies"
+    />
+    <meta name="theme-color" content="#ed1c24" />
+
     %sveltekit.head%
   </head>
   <body

--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -28,22 +28,22 @@ const WHITELISTED_HEADERS = new Set([
 export const handleCacheControl: Handle = async ({ event, resolve }) => {
   const response = await resolve(event);
 
-  if (response.headers.get('content-type')?.includes('text/html')) {
-    const clonedHeaders = new Headers(response.headers);
-
-    clonedHeaders.set(
-      'Cache-Control',
-      'private, no-store, no-cache, must-revalidate',
-    );
-
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: clonedHeaders,
-    });
+  if (!response.headers.get('content-type')?.includes('text/html')) {
+    return response;
   }
 
-  return response;
+  const clonedHeaders = new Headers(response.headers);
+  const cacheControl = event.locals.isLegitimateBot
+    ? 'public, max-age=3600, s-maxage=3600'
+    : 'private, no-store, no-cache, must-revalidate';
+
+  clonedHeaders.set('Cache-Control', cacheControl);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: clonedHeaders,
+  });
 };
 
 export const handle: Handle = sequence(

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import { getLanguageAndRegion } from "$lib/features/i18n";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaType } from "$lib/requests/models/MediaType";
@@ -73,9 +74,53 @@
       : _info,
   );
 
-  const canonicalUrl = $derived(
-    `${page.url.origin}${page.url.pathname}`,
-  );
+  const canonicalUrl = $derived(`${page.url.origin}${page.url.pathname}`);
+
+  const ogLocale = $derived.by(() => {
+    const { language, region } = getLanguageAndRegion();
+    return `${language}_${region.toUpperCase()}`;
+  });
+
+  const isIndexable = $derived(audience === "all" || audience === "public");
+
+  const createWebsiteLd = (url: string) =>
+    JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: websiteName,
+      url,
+      description: websiteTitle,
+    });
+
+  const createMovieLd = (title: string, url: string) => {
+    const duration = _info?.runtime;
+    return JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Movie",
+      name: title,
+      description: _info?.overview,
+      image: _image,
+      url,
+      ...(duration && duration > 0 ? { duration: `PT${duration}M` } : {}),
+    });
+  };
+
+  const createShowLd = (title: string, url: string) =>
+    JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "TVSeries",
+      name: title,
+      description: _info?.overview,
+      image: _image,
+      url,
+    });
+
+  const jsonLd = $derived.by(() => {
+    if (type === "home") return createWebsiteLd(canonicalUrl);
+    if (type === "movie" && _title) return createMovieLd(_title, canonicalUrl);
+    if (type === "show" && _title) return createShowLd(_title, canonicalUrl);
+    return null;
+  });
 
   const dynamicContentProps = $derived(
     hasDynamicContent
@@ -89,12 +134,17 @@
 <svelte:head>
   <title>{displayTitle}</title>
   <link rel="canonical" href={canonicalUrl} />
+  <meta
+    name="robots"
+    content={isIndexable ? "index, follow" : "noindex, nofollow"}
+  />
   <meta property="og:site_name" content={websiteName} />
   <meta property="og:type" content={ogType} />
   <meta property="og:url" content={canonicalUrl} />
   <meta property="og:image" content={image} />
+  <meta property="og:image:alt" content={ogTitle} />
   <meta property="og:title" content={ogTitle} />
-  <meta property="og:locale" content="en_US" />
+  <meta property="og:locale" content={ogLocale} />
   <meta property="og:updated_time" content={new Date().toISOString()} />
 
   {#if info != null}
@@ -111,6 +161,10 @@
   <meta name="twitter:title" content={ogTitle} />
   <meta name="twitter:image" content={image} />
   <meta name="twitter:creator" content={twitterHandle} />
+
+  {#if jsonLd != null}
+    {@html `<script type="application/ld+json">${jsonLd}</script>`}
+  {/if}
 </svelte:head>
 
 <RenderFor {audience}>

--- a/projects/client/src/routes/sitemap.xml/+server.ts
+++ b/projects/client/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,73 @@
+import type { RequestHandler } from '@sveltejs/kit';
+
+const ORIGIN = 'https://app.trakt.tv';
+
+type SitemapEntry = {
+  path: string;
+  priority: string;
+  changefreq:
+    | 'always'
+    | 'hourly'
+    | 'daily'
+    | 'weekly'
+    | 'monthly'
+    | 'yearly'
+    | 'never';
+};
+
+const STATIC_ROUTES: ReadonlyArray<SitemapEntry> = [
+  { path: '/', priority: '1.0', changefreq: 'daily' },
+  { path: '/movies', priority: '0.9', changefreq: 'daily' },
+  { path: '/movies/popular', priority: '0.8', changefreq: 'daily' },
+  { path: '/movies/trending', priority: '0.8', changefreq: 'hourly' },
+  { path: '/movies/anticipated', priority: '0.7', changefreq: 'weekly' },
+  { path: '/movies/recommended', priority: '0.7', changefreq: 'daily' },
+  { path: '/shows', priority: '0.9', changefreq: 'daily' },
+  { path: '/shows/popular', priority: '0.8', changefreq: 'daily' },
+  { path: '/shows/trending', priority: '0.8', changefreq: 'hourly' },
+  { path: '/shows/anticipated', priority: '0.7', changefreq: 'weekly' },
+  { path: '/shows/recommended', priority: '0.7', changefreq: 'daily' },
+  { path: '/media/popular', priority: '0.7', changefreq: 'daily' },
+  { path: '/media/trending', priority: '0.7', changefreq: 'hourly' },
+  { path: '/media/anticipated', priority: '0.7', changefreq: 'weekly' },
+  { path: '/media/recommended', priority: '0.7', changefreq: 'daily' },
+  { path: '/discover', priority: '0.8', changefreq: 'daily' },
+  { path: '/search', priority: '0.6', changefreq: 'monthly' },
+  { path: '/vip', priority: '0.5', changefreq: 'monthly' },
+  { path: '/about', priority: '0.4', changefreq: 'monthly' },
+  { path: '/privacy', priority: '0.3', changefreq: 'monthly' },
+  { path: '/terms', priority: '0.3', changefreq: 'monthly' },
+];
+
+const buildUrl = (
+  { path, priority, changefreq }: SitemapEntry,
+  lastmod: string,
+) =>
+  `  <url>
+    <loc>${ORIGIN}${path}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>${changefreq}</changefreq>
+    <priority>${priority}</priority>
+  </url>`;
+
+const buildSitemap = (lastmod: string) => {
+  const urls = STATIC_ROUTES.map((entry) => buildUrl(entry, lastmod)).join(
+    '\n',
+  );
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>`;
+};
+
+export const GET: RequestHandler = () => {
+  const lastmod = new Date().toISOString().split('T')[0]!;
+
+  return new Response(buildSitemap(lastmod), {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  });
+};

--- a/projects/client/static/robots.txt
+++ b/projects/client/static/robots.txt
@@ -1,2 +1,12 @@
 User-agent: *
 Allow: /
+Disallow: /calendar
+Disallow: /history
+Disallow: /settings
+Disallow: /social
+Disallow: /callback
+Disallow: /silent-redirect
+Disallow: /api/
+Disallow: /_design_system
+
+Sitemap: https://app.trakt.tv/sitemap.xml


### PR DESCRIPTION
### Overview
Enhances the application's visibility and data structure for search engines and social platforms by implementing structured data, a sitemap, and optimized crawler configurations.

### Changes
- Adds default SEO meta tags for description and theme color to the base HTML template.
- Modifies server hooks to serve public cache-control headers to legitimate bots, improving crawling efficiency.
- Updates the page layout component to dynamically generate JSON-LD (Schema.org) structured data for the homepage, movies, and shows.
- Implements a robots meta tag to automatically manage page indexing based on audience visibility settings.
- Refines Open Graph metadata by dynamically setting locales and adding image accessibility tags.
- Creates a new `sitemap.xml` route that lists primary static paths with defined priorities and change frequencies.
- Updates `robots.txt` to reference the sitemap and exclude private or utility routes from search results.

### Testing
- Validated the generated XML structure of the sitemap endpoint.
- Inspected the document head across different route types to ensure correct meta tag and JSON-LD injection.
- Verified server response headers to confirm conditional cache-control logic for crawlers.