### PR TITLE
Consolidate AI agent instructions into cross-tool AGENTS.md

### DIFF
--- a/.agents/.impeccable.md
+++ b/.agents/.impeccable.md
@@ -1,0 +1,32 @@
+## Design Context
+
+### Users
+Trakt users are entertainment enthusiasts who track movies, TV shows, and their viewing habits. They range from casual viewers managing a watchlist to data-driven cinephiles who want stats, trends, and discovery tools. They use the app across devices — desktop for deep browsing, mobile for quick logging and checking what's next. The job to be done: stay organized, discover great content, and feel on top of their entertainment life.
+
+### Brand Personality
+**Clean, confident, modern.** Trakt is a polished, well-built tool that feels premium without being flashy. It respects the user's time and attention — UI elements are purposeful, not decorative. The purple brand color adds personality without being loud.
+
+### Emotional Goals
+- **Delight & discovery**: Browsing should feel exciting — surfacing new shows, trending content, and unexpected recommendations should spark curiosity and satisfaction.
+- **Control & clarity**: Users should feel organized and informed. Progress tracking, watchlists, and stats should provide a sense of mastery over their viewing life.
+
+### Aesthetic Direction
+- **Visual tone**: Clean and confident. Strong hierarchy, generous whitespace, purposeful color accents. Content (posters, artwork) should be the visual star — UI chrome stays out of the way.
+- **Theme**: Full light/dark support with subtle purple tinting in dark mode. Seasonal theme overrides (Halloween → orange, Christmas → red) add moments of delight.
+- **Anti-references**: Avoid cluttered dashboards, overly gamified UI, or anything that feels like a spreadsheet. Avoid generic streaming-app aesthetics (Netflix dark-and-red). Avoid overly playful/childish design — this is a confident, modern tool.
+
+### Design Principles
+
+1. **Content is king** — Posters, artwork, and media metadata are the visual centerpiece. UI chrome should recede and let content breathe.
+2. **Purposeful color** — Purple is the brand anchor. Red, blue, green, and orange serve specific semantic roles (actions, trends, status). Never use color purely for decoration.
+3. **Consistent rhythm** — Use the `--ni-X` spacing scale and `--gap-*` variables religiously. Consistent spacing creates the feeling of polish that separates good from great.
+4. **Respect the user** — Reduced motion support, clear focus states, WCAG AA contrast. No auto-playing anything. No dark patterns. The user is in control.
+5. **Themed by design** — Every color choice must work across light, dark, and seasonal themes. Use semantic CSS variables, never raw hex values in components.
+
+### Technical Design Constraints
+- **Styling**: SCSS with scoped Svelte `<style lang="scss">` blocks. No Tailwind, no CSS-in-JS.
+- **Components**: Bits UI v2 headless primitives with custom styling. Color variants via `color` prop (purple, red, blue, orange, default).
+- **Tokens**: All values via CSS custom properties (`--ni-*`, `--color-*`, `--gap-*`, `--border-radius-*`).
+- **Responsive**: Mobile-first with breakpoints at 480px, 768px, 1024px. Use SCSS mixins (`for-mobile`, `for-tablet-sm`, `for-desktop`, `for-mouse`, `for-touch`).
+- **Typography**: System font stack, 3 size tiers (tag: 10px, text: 14px, title: 18px).
+- **Accessibility**: WCAG AA compliance. All animations respect `prefers-reduced-motion`.

--- a/.agents/rules/code-principles.md
+++ b/.agents/rules/code-principles.md
@@ -1,0 +1,132 @@
+---
+trigger: glob
+globs: "**"
+description: "Functional programming, immutability, simplicity, and function design principles (Single Responsibility, Object Parameters, Dependency Injection)."
+applyTo: "**"
+---
+
+# Code Principles
+
+## Functional Programming
+
+- **Write functional code**: Prefer pure functions that avoid side effects when possible.
+  - Functions should return consistent output for the same input.
+  - Minimize state mutation and favor immutable data structures.
+  - Keep Svelte stores minimal; use `$derived()` for computed values.
+- **Separation of Concerns**: Keep core logic pure and deterministic.
+  - API calls, local storage, and DOM manipulation are side effects.
+  - Pure functions should handle data transformation only.
+  - Side effects should live in the outer layers (components, hooks, server functions).
+
+## Immutability
+
+- **Prefer `const` over `let`**: Use `const` whenever possible.
+- Avoid reassigning variables.
+- Use array methods like `map`, `filter`, and `reduce` instead of mutating loops.
+- Use TypeScript's `readonly` types: `Readonly<T>`, `ReadonlyArray<T>`, `ReadonlyMap`, `ReadonlySet`.
+
+**Bad:**
+```typescript
+let result = [];
+for (let i = 0; i < items.length; i++) {
+  result.push(transform(items[i]));
+}
+```
+
+**Good:**
+```typescript
+const result = items.map(transform);
+```
+
+## Early Exits
+
+- **Use guard clauses and early returns**: Check error conditions first and return early.
+- Avoid deep nesting by handling edge cases at the start of functions.
+
+**Bad:**
+```typescript
+function processData(data: Data | null) {
+  if (data) {
+    if (data.isValid) {
+      if (data.hasPermission) {
+        return transform(data);
+      }
+    }
+  }
+  return null;
+}
+```
+
+**Good:**
+```typescript
+function processData(data: Data | null) {
+  if (!data) return null;
+  if (!data.isValid) return null;
+  if (!data.hasPermission) return null;
+
+  return transform(data);
+}
+```
+
+## Code Smells to Avoid
+
+- **No nested if statements**: Nested conditionals indicate poor architecture.
+  - Refactor into separate functions with clear responsibilities.
+  - Use guard clauses and early returns instead.
+- **No abstraction leaks**: Ensure abstractions hide implementation details completely.
+- **No "god functions"**: Each function should have a single, clear responsibility.
+
+## Function Design
+
+- **Single Responsibility Principle**: Each function should do one thing well.
+- Function names should clearly describe what they do.
+- When a function takes 3+ parameters, use a single object parameter.
+
+**Bad:**
+```typescript
+fetchData(url, token, retry, timeout);
+```
+
+**Good:**
+```typescript
+fetchData({ url, token, retry, timeout });
+```
+
+## Dependency Injection
+
+- **Pass dependencies as parameters**: Don't instantiate external services inside functions.
+- Makes functions testable without mocking.
+- Use interface types to define the shape of dependencies.
+
+**Bad:**
+```typescript
+export function fetchUser(id: string) {
+  const api = new ApiClient();
+  return api.get(`/users/${id}`);
+}
+```
+
+**Good:**
+```typescript
+interface FetchUserParams {
+  api: ApiClient;
+  id: string;
+}
+
+export function fetchUser({ api, id }: FetchUserParams) {
+  return api.get(`/users/${id}`);
+}
+```
+
+## Simplicity
+
+- **Keep it simple**: Simple code is maintainable code.
+- Suggestions should be simple and functional with low visual complexity.
+- Split up into smaller functions when needed.
+- Favor readability over cleverness.
+- If a solution feels complex, step back and reconsider the approach.
+
+## Iteration Patterns
+
+- **Prefer functional methods over imperative loops**: Use `map`, `filter`, `reduce`.
+- Avoid mutable loop counters when possible.

--- a/.agents/rules/components.md
+++ b/.agents/rules/components.md
@@ -1,0 +1,322 @@
+---
+trigger: glob
+globs: 'projects/client/src/lib/{components,features,sections,guards}/**'
+description: 'Architecture, patterns, and conventions for lib/components, lib/features, lib/sections, and lib/guards.'
+applyTo: 'projects/client/src/lib/{components,features,sections,guards}/**'
+---
+
+# Components, Features & Sections Guidelines
+
+## Overview
+
+UI code is split across four directories, each with a distinct role:
+
+| Directory        | Role                                                          |
+| ---------------- | ------------------------------------------------------------- |
+| `lib/components` | Generic, reusable UI primitives — zero domain knowledge       |
+| `lib/features`   | Stateful feature modules: providers, contexts, store hooks    |
+| `lib/sections`   | Page-level composition — orchestrates features + components   |
+| `lib/guards`     | Conditional rendering gates (`RenderFor`, `RenderForFeature`) |
+
+---
+
+## Directory Structure
+
+### `lib/components/`
+
+Purely presentational, reusable across the entire app. No awareness of API
+shapes or app state.
+
+### `lib/features/`
+
+Each subdirectory is a self-contained feature. Features own their state,
+providers, contexts, and domain-specific sub-components.
+
+### `lib/sections/`
+
+Page-level composition components. Sections know about domain data shapes and
+compose features and `lib/components` together to form page regions.
+
+### `lib/guards/`
+
+Thin conditional-rendering wrappers — use these instead of inline `{#if}` for
+auth / feature / audience / device gating.
+
+---
+
+## The `_internal/` Rule
+
+`_internal/` folders enforce file-private visibility. The rule is strict:
+
+> **A file inside `folderA/_internal/` may only be imported by files inside
+> `folderA/` or `folderA/_internal/` itself.**
+
+If a helper, sub-component, or context factory is needed outside its parent
+folder, it must be **uplifted** — moved to `folderA/` (and exported) or to a
+higher-level shared location.
+
+**Never import from another folder's `_internal/`.**
+
+```
+features/
+  search/
+    _internal/
+      createSearchContext.ts  ← only used inside search/
+    SearchProvider.svelte     ← imports _internal/createSearchContext ✔
+    index.ts                  ← re-exports public API
+
+sections/
+  summary/
+    components/
+      _internal/
+        SummaryTitleMapper.ts ← only used inside summary/components/
+      SummaryTitle.svelte     ← imports _internal/SummaryTitleMapper ✔
+
+# WRONG — do not do this:
+features/upsell/UpsellCta.svelte  ← importing search/_internal/createSearchContext ✗
+```
+
+---
+
+## Svelte 5 Runes
+
+All components use Svelte 5 runes mode. Never use `export let`, `$:`, or
+`createEventDispatcher`.
+
+```svelte
+<script lang="ts">
+  import type { ButtonProps } from './_internal/ButtonProps.ts';
+
+  const { variant = 'primary', onclick, children }: ButtonProps = $props();
+
+  const isDisabled = $derived(variant === 'ghost' && !onclick);
+</script>
+```
+
+Key runes:
+
+| Rune            | Use                                                                                    |
+| --------------- | -------------------------------------------------------------------------------------- |
+| `$props()`      | Declare component props (replaces `export let`)                                        |
+| `$derived`      | Computed value (cached, replaces `$:`)                                                 |
+| `$derived.by()` | Computed value with multi-line logic                                                   |
+| `$effect`       | Side effect that re-runs on dependency change (do not use unless absolutely necessary) |
+| `$effect.pre`   | Side effect that runs before DOM updates (do not use unless absolutely necessary)      |
+
+---
+
+## Props Type Files
+
+For components with more than 2-3 props, define a separate
+`ComponentNameProps.ts` file (usually inside the component folder or
+`_internal/`).
+
+```typescript
+// buttons/_internal/TraktButtonProps.ts
+import type { Snippet } from 'svelte';
+
+export type TraktButtonProps = {
+  variant?: 'primary' | 'secondary' | 'ghost';
+  icon?: Snippet;
+  children: Snippet;
+  onclick?: () => void;
+};
+```
+
+Use `Snippet` (from `svelte`) for slot-like composition — never use the legacy
+slot API.
+
+---
+
+## Snippets for Composition
+
+Use `{#snippet}` and the `Snippet` type for flexible content injection.
+
+```svelte
+<!-- In the component -->
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  const { children, footer }: { children: Snippet; footer?: Snippet } = $props();
+</script>
+
+<div class="modal">
+  {@render children()}
+  {#if footer}
+    <footer>{@render footer()}</footer>
+  {/if}
+</div>
+```
+
+```svelte
+<!-- At the call site -->
+<Modal>
+  <p>Content here</p>
+  {#snippet footer()}<button>Close</button>{/snippet}
+</Modal>
+```
+
+---
+
+## Provider Pattern
+
+Feature providers are thin shells that call a context factory from `_internal/`.
+
+```svelte
+<!-- features/search/SearchProvider.svelte -->
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { iffy } from '$lib/utils/function/iffy.ts';
+  import { createSearchContext } from './_internal/createSearchContext.ts';
+
+  const { children }: { children: Snippet } = $props();
+
+  iffy(createSearchContext);
+</script>
+
+{@render children()}
+```
+
+The matching `getXxxContext()` function is called by child components to access
+the shared state:
+
+```typescript
+// features/search/_internal/getSearchContext.ts
+import { getContext } from 'svelte';
+import type { SearchContext } from './SearchContext.ts';
+
+export function getSearchContext(): SearchContext {
+  return getContext<SearchContext>('search');
+}
+```
+
+Naming conventions:
+
+| File                            | Purpose                                    |
+| ------------------------------- | ------------------------------------------ |
+| `XxxProvider.svelte`            | Provider shell component                   |
+| `_internal/createXxxContext.ts` | Calls `setContext`, returns context object |
+| `_internal/getXxxContext.ts`    | Wraps `getContext` with proper typing      |
+| `_internal/XxxContext.ts`       | TypeScript type for the context object     |
+
+---
+
+## `use*` Hooks (Feature Stores)
+
+Feature state is often exposed via `use*` composable functions that return
+reactive RxJS-based state.
+
+```typescript
+// features/auth/stores/useUser.ts
+export function useUser() {
+  const query = useQuery(userQuery({ fetch }));
+
+  return {
+    user: $derived(query.data),
+    isLoading: $derived(query.isLoading),
+  };
+}
+```
+
+- Live in `features/{domain}/stores/` (or `features/{domain}/stores/_internal/`)
+- Name always starts with `use` (e.g., `useUser`, `useTheme`, `useFilters`)
+- Return `$derived` values, not raw observables
+- Do **not** import across feature boundaries — if sharing is needed, expose via
+  context or a shared section
+
+---
+
+## Guard Components
+
+Use guards instead of inline `{#if auth.isLoggedIn}` or `{#if isDesktop}`:
+
+```svelte
+<RenderFor audience="member">
+  <WatchlistButton />
+</RenderFor>
+
+<RenderFor device="desktop">
+  <DesktopSidebar />
+</RenderFor>
+
+<RenderForFeature flag="notes">
+  <NotesPanel />
+</RenderForFeature>
+```
+
+`RenderFor` props: `audience`, `device`, `input` (can be combined).
+
+---
+
+## `data-*` Attributes for Variants
+
+Components use `data-*` attributes for styling variants instead of class
+concatenation.
+
+```svelte
+<button data-variant="primary" data-style="filled">
+  {@render children()}
+</button>
+```
+
+```scss
+button[data-variant='primary'] { … }
+button[data-style='filled'] { … }
+```
+
+Common attributes:
+
+| Attribute      | Purpose                                |
+| -------------- | -------------------------------------- |
+| `data-variant` | Visual variant (primary, secondary, …) |
+| `data-style`   | Style modifier (filled, outlined, …)   |
+
+---
+
+## Lazy Rendering on Cards
+
+Cards that render below the fold should defer rendering until visible:
+
+```svelte
+<script lang="ts">
+  import { whenInViewport } from '$lib/utils/actions/whenInViewport.ts';
+  let isVisible = $state(false);
+</script>
+
+<div use:whenInViewport={{ onVisible: () => (isVisible = true) }}>
+  {#if isVisible}
+    <CardContent />
+  {/if}
+</div>
+```
+
+---
+
+## Where to Place a New Component
+
+| Question                                              | Place in                                     |
+| ----------------------------------------------------- | -------------------------------------------- |
+| Is it a generic UI primitive with no app state?       | `lib/components/{domain}/`                   |
+| Does it manage state or provide context?              | `lib/features/{feature}/`                    |
+| Does it compose multiple features into a page region? | `lib/sections/{section}/`                    |
+| Is it a private implementation detail of folder X?    | `lib/{...}/X/_internal/`                     |
+| Is it used by 2+ sibling folders in `_internal/`?     | Uplift to parent folder or `lib/components/` |
+
+---
+
+## Quick Checklist
+
+- [ ] Correct layer: primitive → `components`, stateful/context → `features`,
+      composition → `sections`
+- [ ] Never import from another folder's `_internal/` — uplift if needed
+- [ ] Using Svelte 5 runes (`$props`, `$derived`, `$effect`) — no `export let`
+      or `$:`
+- [ ] Snippets used for slot-like composition, not legacy `<slot>`
+- [ ] Props type file created for components with 3+ props
+- [ ] Provider delegates to `_internal/createXxxContext` via `iffy()`
+- [ ] `use*` hooks live in `features/{domain}/stores/` and return `$derived`
+      values
+- [ ] Guards (`RenderFor`, `RenderForFeature`) used instead of raw `{#if}` for
+      auth/feature/device gating
+- [ ] Variants expressed via `data-*` attributes, not dynamic class strings
+- [ ] SCSS uses CSS custom properties (`--ni-*`, `--color-*`) — no raw hex
+      values

--- a/.agents/rules/implementation.md
+++ b/.agents/rules/implementation.md
@@ -1,0 +1,38 @@
+---
+trigger: glob
+globs: "**"
+description: "General implementation approach for all source code in this project."
+applyTo: "**"
+---
+
+# Implementation Guidelines
+
+## Before Writing Code
+
+- **Search for existing patterns first.** This codebase has conventions — follow them.
+- Check how similar functionality is implemented elsewhere in the project before creating something new.
+- Prefer referencing real files as examples over abstract descriptions.
+
+## When Establishing New Patterns
+
+- When you establish a new pattern that diverges from or extends existing conventions, note it so documentation can be updated.
+- If you find yourself writing a helper used in 2+ places, consider whether it belongs in `lib/utils/`.
+- If you refactor shared logic, document the new pattern.
+
+## Naming Conventions
+
+- **PascalCase**: Component names, interfaces, and type aliases
+- **camelCase**: Variables, functions, and methods
+- **ALL_CAPS**: Constants
+- Components: PascalCase files (e.g., `ClampedText.svelte`, `MoreButton.svelte`)
+- Utilities/helpers: camelCase files (e.g., `lineClamp.ts`, `clickOutside.ts`)
+- Type definitions: PascalCase files (e.g., `MediaStoreProps.ts`, `FilterParams.ts`)
+
+## TypeScript Standards
+
+- Always use TypeScript with strict mode.
+- No `any` types; use specific types or utility types.
+- Use Zod for runtime validation and type inference. Define schema first, then derive type with `z.infer`.
+- Use `Nil` type for `null | undefined`.
+- Use `.nullish()` in Zod schemas for optional nullable fields.
+- Use optional chaining (`?.`) and nullish coalescing (`??`).

--- a/.agents/rules/project.md
+++ b/.agents/rules/project.md
@@ -1,0 +1,83 @@
+---
+trigger: glob
+globs: "**"
+description: "Core project overview, structure, architecture patterns, styling conventions, and tooling. Apply to all files."
+applyTo: "**"
+---
+
+# Project Guidelines
+
+## Tech Stack
+
+SvelteKit + TypeScript app (Svelte 5, runes mode) deployed to Cloudflare Pages. Monorepo using Deno workspaces with the app at `projects/client/`.
+
+## Project Structure
+
+```
+projects/client/src/
+  routes/          # SvelteKit file-based routing
+  lib/
+    components/    # Reusable UI components (buttons, forms, dialogs, media, etc.)
+    features/      # Feature modules — self-contained domains (auth, calendar, theme, i18n, etc.)
+    sections/      # Page composition — navbar, lists, profile, layout shells
+    guards/        # Conditional rendering (RenderFor, RenderForFeature, RenderForAudience)
+    requests/      # API request mappers and query definitions
+    stores/        # Reactive state (RxJS BehaviorSubject + localStorage)
+    models/        # TypeScript type definitions
+    utils/         # Utility functions organized by domain (actions/, array/, date/, string/, etc.)
+    pages/         # Page-specific logic and error pages
+    paraglide/     # Generated i18n messages (do not edit — auto-generated)
+    pwa/           # PWA manifest and service worker config
+  style/           # Global SCSS — design tokens, theme, animations
+  mocks/           # MSW request mocking (handlers + test data)
+```
+
+## Commit Standards
+
+- **Follow Conventional Commits**: All commits must adhere to the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+  - Use types: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:`, etc.
+  - Example: `feat: add user profile component`
+  - Example: `fix: correct date formatting in calendar view`
+
+## Architecture Patterns
+
+### Pages are thin shells
+Route pages compose features and sections. Business logic lives in `lib/features/`, not in route files. Layouts wrap children with providers (e.g., `CalendarProvider`).
+
+### Features are self-contained
+Each feature directory in `lib/features/` owns its state, components, and queries. Features expose a public API and keep internals in `_internal/` subdirectories.
+
+### Components use data attributes for variants
+Components use `data-variant`, `data-style`, `data-color` attributes for styling variants rather than prop-driven class concatenation.
+
+### Snippets for flexible content
+Use Svelte 5 `{#snippet}` for reusable template fragments and component slot alternatives.
+
+### Guards for conditional rendering
+Use `RenderFor`, `RenderForFeature`, `RenderForAudience` components instead of inline `{#if}` blocks for auth/feature/audience gating.
+
+### Stores use RxJS + localStorage
+State management uses `BehaviorSubject` from RxJS, often backed by `localStorage` for persistence. Prefer `$derived()` for computed values over additional stores.
+
+### API requests use mappers
+`lib/requests/` contains query definitions via `defineQuery()` and pure mapper functions that transform API responses to domain models. Zod validates at the boundary.
+
+### i18n via Paraglide
+Internationalization uses Paraglide JS (Inlang). Messages are type-safe functions: `m.page_title_home()`. Source definitions live in `i18n/meta/`, generated output in `lib/paraglide/`. Never edit generated files.
+
+## Styling
+
+- SCSS with scoped Svelte `<style lang="scss">` blocks.
+- All values via CSS custom properties (`--ni-*`, `--color-*`, `--gap-*`, `--border-radius-*`).
+- Responsive mixins: `for-mobile`, `for-tablet-sm`, `for-desktop`, `for-mouse`, `for-touch`.
+- Import mixins as: `@use "$style/scss/mixins/index" as *;`
+- Full light/dark theme support. Never use raw hex values — use semantic CSS variables.
+- Use kebab-case for CSS class names.
+- Component-scoped styles preferred.
+
+## Tooling
+
+- **Formatter**: Use `deno fmt`, not prettier.
+- **Linter**: ESLint with TypeScript + Svelte plugins. Config at `eslint.config.js`.
+- **Build**: Vite + SvelteKit adapter-cloudflare. Paraglide generates i18n before build.
+- **Dev**: `deno task client:dev` starts the dev server.

--- a/.agents/rules/requests.md
+++ b/.agents/rules/requests.md
@@ -1,0 +1,356 @@
+---
+trigger: glob
+globs: 'projects/client/src/lib/requests/**'
+description: 'How to implement API queries and mutation requests in lib/requests.'
+applyTo: 'projects/client/src/lib/requests/**'
+---
+
+# API Requests Guidelines
+
+## Overview
+
+`lib/requests/` integrates with two sources:
+
+- **`@trakt/api`** — Typed SDK for the Trakt v2 REST API. Use `api({ fetch })`
+  to call it.
+- **`v3/` endpoints** — Untyped internal endpoints accessed via `rawApiFetch`.
+  Always define a local Zod schema for their response.
+
+---
+
+## Naming Conventions
+
+| File type       | Convention                  | Example                                      |
+| --------------- | --------------------------- | -------------------------------------------- |
+| Query file      | `{name}Query.ts`            | `movieSummaryQuery.ts`                       |
+| Mutation file   | `{name}Request.ts`          | `addToWatchlistRequest.ts`                   |
+| Mapper function | `mapTo{Entity}.ts`          | `mapToMovieEntry.ts`                         |
+| Model / schema  | `{EntityName}.ts`           | `MediaEntry.ts`                              |
+| Export name     | camelCase matching filename | `movieSummaryQuery`, `addToWatchlistRequest` |
+
+---
+
+## Pattern 1 — `@trakt/api` Query (`defineQuery`)
+
+Use this for standard single-fetch queries backed by the typed SDK.
+
+```ts
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import { SomeSchema } from '$lib/requests/models/SomeModel.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import type { SomeApiResponse } from '@trakt/api'; // only if you need the raw type in the mapper
+
+type SomeParams = {
+  slug: string;
+} & ApiParams;
+
+const someRequest = (
+  { fetch, slug }: SomeParams,
+) =>
+  api({ fetch })
+    .category
+    .method({
+      params: { id: slug },
+      query: { extended: 'full,images' },
+    });
+
+export const someQuery = defineQuery({
+  key: 'someKey',
+  invalidations: [],
+  dependencies: (params) => [params.slug],
+  request: someRequest,
+  mapper: (response) => mapToSomething(response.body),
+  schema: SomeSchema,
+  ttl: time.hours(3),
+});
+```
+
+### Key rules
+
+- The `request` function receives the full `params` object — destructure only
+  what you need.
+- `mapper` transforms `response.body` (typed by the SDK) into the domain model.
+- `schema` is the Zod schema for the **output** — it validates what `mapper`
+  returns.
+- `dependencies` must list every param that, when changed, should refetch. Use
+  spread helpers for filters/search (see below).
+- `invalidations` lists `InvalidateAction.*` tokens that bust this cache when
+  mutations fire.
+
+---
+
+## Pattern 2 — `@trakt/api` Paginated Query (`defineInfiniteQuery`)
+
+Use this for list endpoints that support pagination.
+
+```ts
+import { defineInfiniteQuery } from '$lib/features/query/defineQuery.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
+import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+
+type SomeListParams =
+  & { slug: string }
+  & PaginationParams
+  & ApiParams;
+
+const someListRequest = (
+  { fetch, slug, limit, page }: SomeListParams,
+) =>
+  api({ fetch })
+    .category
+    .list({
+      params: { id: slug },
+      query: { extended: 'full,images', page, limit },
+    });
+
+export const someListQuery = defineInfiniteQuery({
+  key: 'someList',
+  invalidations: [],
+  dependencies: (params) => [params.slug, params.page, params.limit],
+  request: someListRequest,
+  mapper: (response) => ({
+    entries: response.body.map(mapToEntry),
+    page: extractPageMeta(response.headers),
+  }),
+  schema: PaginatableSchemaFactory(EntrySchema),
+  ttl: time.hours(1),
+});
+```
+
+### Key rules
+
+- Always use `PaginatableSchemaFactory(EntrySchema)` for the schema.
+- Always call `extractPageMeta(response.headers)` to populate the `page` field.
+- Include `params.page` and `params.limit` in `dependencies`.
+
+---
+
+## Pattern 3 — `v3/` Endpoint Query
+
+`v3/` endpoints are not covered by `@trakt/api`'s type system. **Always** define
+a Zod schema locally for their response, and parse with it before returning from
+the request function.
+
+```ts
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import z from 'zod';
+
+// 1. Define the raw response schema inline (v3 responses have no SDK types)
+export const SomeV3ResponseSchema = z.object({
+  field_name: z.string(),
+  nested: z.object({
+    value: z.number(),
+  }),
+});
+
+type SomeV3Response = z.infer<typeof SomeV3ResponseSchema>;
+
+type SomeParams = { slug: string } & ApiParams;
+
+// 2. Use rawApiFetch and parse the response body with the schema
+const someRequest = async (
+  { fetch, slug }: SomeParams,
+) => {
+  const response = await rawApiFetch(
+    { fetch, path: `/v3/some/endpoint/${slug}` },
+  );
+
+  return response.ok
+    ? {
+      body: SomeV3ResponseSchema.parse(await response.json()),
+      status: 200,
+    }
+    : { body: undefined, status: 200 };
+};
+
+// 3. Map from the raw response to the domain model
+export const someV3Query = defineQuery({
+  key: 'someV3',
+  invalidations: [],
+  dependencies: (params) => [params.slug],
+  request: someRequest,
+  mapper: (response) => mapToSomeDomainModel(response.body),
+  schema: SomeDomainSchema,
+  ttl: time.hours(3),
+});
+```
+
+### Key rules
+
+- **Always** `.parse()` the raw JSON — never trust unvalidated `v3/` responses.
+- If the endpoint can return an empty/error body, guard with `response.ok` and
+  return `{ body: undefined, status: 200 }` as the fallback so `mapper` receives
+  `undefined` and can handle it gracefully.
+- Export the `ResponseSchema` when other files need to reference it.
+- Keep the raw response schema (`...ResponseSchema`) and domain schema
+  (`...Schema`) separate.
+
+---
+
+## Pattern 4 — Mutation Request
+
+Use for write operations (add, remove, update). These are plain async functions
+— not queries.
+
+```ts
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import type { SomeApiRequestBody } from '@trakt/api';
+
+type SomeActionParams = {
+  body: SomeApiRequestBody;
+} & ApiParams;
+
+export function someActionRequest(
+  { body, fetch }: SomeActionParams,
+): Promise<boolean> {
+  return api({ fetch })
+    .category
+    .action({ body })
+    .then(({ status }) => status === 201); // or 200, 204 depending on the endpoint
+}
+```
+
+For `v3/` mutations use `rawApiFetch` with `method: 'POST'` / `'DELETE'` and
+validate with Zod if the response body matters.
+
+---
+
+## Mapper Functions
+
+- Pure functions — no side effects, no API calls.
+- Named `mapTo{DomainType}(apiResponse): DomainType`.
+- Live in `_internal/` if reused across queries; inline or exported from the
+  query file if used only once or twice.
+- When extending an existing mapper (e.g., adding a field), prefer `.extend()`
+  on the schema rather than duplicating.
+
+```ts
+// _internal/mapToEntry.ts
+export function mapToEntry(response: EntryResponse): Entry {
+  return {
+    id: response.ids.trakt,
+    key: `entry-${response.ids.trakt}`,
+    title: response.title,
+  };
+}
+```
+
+---
+
+## Models
+
+- Define Zod schema first; derive the TypeScript type with `z.infer`.
+- Use `.nullish()` for optional nullable fields, `.optional()` for fields that
+  may be absent.
+- Export both the schema (`EntitySchema`) and the type (`Entity`) from the same
+  file.
+
+```ts
+// models/Entry.ts
+import { z } from 'zod';
+
+export const EntrySchema = z.object({
+  id: z.number(),
+  key: z.string(),
+  title: z.string(),
+  description: z.string().nullish(),
+});
+
+export type Entry = z.infer<typeof EntrySchema>;
+```
+
+---
+
+## Invalidations
+
+Use `InvalidateAction.*` to declare which mutations should bust a query's cache.
+
+```ts
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+
+invalidations: [
+  InvalidateAction.Watchlisted('movie'),
+  InvalidateAction.MarkAsWatched('episode'),
+  InvalidateAction.List.Created,
+],
+```
+
+Leave `invalidations: []` for queries that never need external cache busting.
+
+---
+
+## TTL Reference
+
+`Infinity` should never be used used for TTL.
+
+| Data freshness                    | Value                                    |
+| --------------------------------- | ---------------------------------------- |
+| Very stable (people, studios)     | `time.days(7)`                           |
+| Stable (summaries, translations)  | `time.days(1)`                           |
+| Normal (lists, ratings)           | `time.hours(3)` or `time.hours(6)`       |
+| Frequently changing               | `time.minutes(30)` or `time.minutes(15)` |
+| Real-time (watchers, now playing) | `time.minutes(5)` or lower               |
+
+---
+
+## Filter & Search Dependencies
+
+When a query accepts `FilterParams` or `SearchParams`, spread the helper
+functions in `dependencies`:
+
+```ts
+import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
+import { getRecordDependencies } from '$lib/requests/_internal/getRecordDependencies.ts';
+
+dependencies: (params) => [
+  params.limit,
+  params.page,
+  ...getGlobalFilterDependencies(params.filterOverride?.movie ?? params.filter),
+  ...getRecordDependencies(params.search),
+],
+```
+
+---
+
+## Conditional Queries
+
+Use `enabled` to skip fetching when required params are absent:
+
+```ts
+export const someQuery = defineQuery({
+  // ...
+  enabled: (params) => Boolean(params.slug),
+});
+```
+
+---
+
+## Authenticated vs Unauthenticated
+
+| Client                         | When to use                                          |
+| ------------------------------ | ---------------------------------------------------- |
+| `api({ fetch })`               | Default — attaches Bearer token if user is signed in |
+| `unauthorizedApi({ fetch })`   | Public endpoints that must not send auth headers     |
+| `rawApiFetch({ fetch, path })` | `v3/` and other non-SDK endpoints — authenticated    |
+
+---
+
+## Quick Checklist
+
+Before submitting a new query or request, verify:
+
+- [ ] File is in the correct subfolder (`queries/{domain}/`, `sync/`, `vip/`)
+- [ ] File name matches the exported symbol (`movieSummaryQuery.ts` →
+      `movieSummaryQuery`)
+- [ ] Params type intersects `ApiParams`
+- [ ] `@trakt/api` endpoint: SDK chain via `api({ fetch })`
+- [ ] `v3/` endpoint: `rawApiFetch` + local `ResponseSchema.parse()`
+- [ ] `schema` matches the **output** of `mapper`, not the raw API response
+- [ ] `dependencies` lists every param that should trigger a refetch
+- [ ] `invalidations` lists relevant `InvalidateAction.*` tokens
+- [ ] Mapper is a pure function — no side effects
+- [ ] `ttl` is appropriate for the data's freshness requirements

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -1,0 +1,34 @@
+---
+trigger: glob
+globs: "**/*.{test,spec}.ts"
+description: "Testing philosophy, file organization, test beds, and MSW mocking guidelines."
+applyTo: "**/*.{test,spec}.ts"
+---
+
+# Testing Guidelines
+
+## Framework
+
+Vitest + `@testing-library/svelte` in jsdom environment.
+
+## File Organization
+
+- **Colocated tests**: Place `*.spec.ts` or `*.test.ts` next to the source file being tested.
+- **Test beds**: `test/beds/` has factories for queries, stores, and component renders.
+- **Mocks**: MSW for request mocking (`src/mocks/`), environment mocks in `test/mocks/`.
+- **Setup**: `vitest-setup.ts` initializes MSW, mocks browser APIs (IntersectionObserver, matchMedia, localStorage, etc.).
+
+## Running Tests
+
+```bash
+deno task client:test    # from project root
+vitest                   # from projects/client/
+```
+
+## Testing Philosophy
+
+- **Test pure functions**: Focus testing on business logic and data transformations.
+- **Test behavior, not implementation**: Tests should verify what code does, not how it does it.
+- Pure functions are easy to test without mocks.
+- Side effects should be tested at integration level, not unit level.
+- Use MSW to mock API responses rather than mocking fetch directly.

--- a/.agents/rules/utils.md
+++ b/.agents/rules/utils.md
@@ -1,0 +1,240 @@
+---
+trigger: glob
+globs: 'projects/client/src/lib/utils/**'
+description: 'Conventions and patterns for everything in lib/utils.'
+applyTo: 'projects/client/src/lib/utils/**'
+---
+
+# Utils Guidelines
+
+## Overview
+
+`lib/utils/` contains pure helper functions, browser-specific utilities, Svelte
+actions, and shared constants. Everything is organized by domain. Before writing
+a new helper, check whether the domain folder already has something equivalent.
+
+---
+
+## Pure Functions (most of `utils/`)
+
+All utilities that do not touch the DOM or external state must be pure — same
+input always produces the same output.
+
+```ts
+// Good
+export function getDayKey(date: Date): string {
+  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+}
+
+// Bad — side effect inside a utility
+export function getDayKey(date: Date): string {
+  console.log(date); // ← side effect, belongs at the call site
+  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+}
+```
+
+---
+
+## Svelte Actions (`actions/`)
+
+Svelte actions manage DOM lifecycle. They always receive an `HTMLElement` as the
+first argument and return a destroy object.
+
+```ts
+export function myAction(node: HTMLElement, param?: SomeType) {
+  // setup
+  const handler = () => {/* ... */};
+  node.addEventListener('click', handler);
+
+  return {
+    update(newParam: SomeType) {
+      // optional: called when param changes
+    },
+    destroy() {
+      node.removeEventListener('click', handler);
+    },
+  };
+}
+```
+
+**Rules:**
+
+- Actions that need global window events must register through
+  `GlobalEventBus.getInstance().register()` — never attach listeners to `window`
+  directly.
+- Actions should dispatch semantic `CustomEvent`s rather than imperatively
+  mutating state.
+- Clean up all listeners in `destroy()`.
+
+---
+
+## GlobalEventBus (`events/GlobalEventBus.ts`)
+
+Use for shared window-level event handling inside actions or utilities. Never
+instantiate directly — always use `GlobalEventBus.getInstance()`.
+
+```ts
+const unregister = GlobalEventBus.getInstance().register('scroll', handler);
+// later:
+unregister();
+```
+
+---
+
+## Formatting (`formatting/`)
+
+Formatting functions are locale-aware and always accept a locale parameter
+(last, optional, defaults to `'en'`).
+
+```ts
+// date
+toHumanDate(today, date, localeKey);
+toHumanDay(date, localeKey, 'short' | 'long');
+toHumanDuration({ days, hours, minutes, clampAt }, locale);
+toHumanETA(today, targetDate, locale);
+toRelativeHumanDay(today, date, localeKey);
+
+// number
+toHumanNumber(value, locale); // compact notation: 1.2k, 4.5M
+toPercentage(value, locale); // 0.75 → "75%"
+toTraktRating(rating, locale); // alias for toPercentage
+toHumanCurrency({ price, currency, locale });
+
+// intl (Intl.DisplayNames)
+toLanguageName(code, languageTag);
+toCountryName(code, languageTag);
+```
+
+**Rules:**
+
+- Import `LOCALE_MAP` and resolve a `date-fns` locale object when using
+  `date-fns` functions.
+- Use `Intl.*` APIs for runtime locale resolution — never hard-code locale
+  strings inside functions.
+
+---
+
+## Translation Lookup Maps (`formatting/string/toTranslated*.ts`)
+
+When an API value needs to be surfaced as translated UI text, use a lookup map
+of i18n message functions.
+
+```ts
+const FOO_MAP = {
+  bar: m.translated_value_foo_bar,
+  baz: m.translated_value_foo_baz,
+} as const;
+
+export function toTranslatedFoo(
+  value: string | (keyof typeof FOO_MAP),
+  data?: Record<string, unknown>,
+): string {
+  const fn = FOO_MAP[value as keyof typeof FOO_MAP];
+  return fn?.(data) ?? value; // fall back to raw value when unknown
+}
+```
+
+Normalize API strings to map keys with `normalizeTranslationKey(key)` before
+lookup when keys may differ in case or separators.
+
+---
+
+## Time Constants (`timing/time.ts`)
+
+Use the `time` helper for all millisecond values — never write raw numbers.
+
+```ts
+import { time } from '$lib/utils/timing/time.ts';
+
+time.seconds(30); // 30_000
+time.minutes(5); // 300_000
+time.hours(3); // 10_800_000
+time.days(1); // 86_400_000
+```
+
+---
+
+## Assertions (`assert/`)
+
+Use `assertDefined` at boundaries where `null | undefined` would be a
+programming error.
+
+```ts
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+
+const value = assertDefined(map.get(key), 'Expected key to be present');
+```
+
+Never use `assertDefined` to validate external data (use Zod instead). It is
+only for internal invariants.
+
+---
+
+## Store Utilities (`store/`)
+
+| Export                     | Purpose                                                                   |
+| -------------------------- | ------------------------------------------------------------------------- |
+| `WritableSubject<T>`       | `BehaviorSubject` with `.set()` / `.update()` like Svelte writable stores |
+| `writable<T>(initial)`     | Factory shorthand for `new WritableSubject(initial)`                      |
+| `resolve(stream, timeout)` | Await the first defined value from an RxJS `Observable`                   |
+| `toObservable(store)`      | Bridge a Svelte-compatible readable store into an RxJS `Observable`       |
+
+---
+
+## Safe Storage (`storage/safeStorage.ts`)
+
+Always use `safeLocalStorage` / `safeSessionStorage` instead of `localStorage` /
+`sessionStorage` to avoid SSR crashes.
+
+```ts
+import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
+
+safeLocalStorage.getItem('key');
+safeLocalStorage.setItem('key', value);
+```
+
+---
+
+## URL Utilities (`url/`)
+
+| Export                            | Purpose                                                               |
+| --------------------------------- | --------------------------------------------------------------------- |
+| `UrlBuilder`                      | Centralised app route factory — use for all internal navigation paths |
+| `buildParamString(params)`        | Serialise a record into a query string (`?foo=bar&baz=1`)             |
+| `prependHttps(url, placeholder?)` | Ensure a URL starts with `https://`                                   |
+| `prependHttpOrHttps(url)`         | Same, but allows `http://` for localhost                              |
+| `setCacheBuster(url)`             | Append `_cb` timestamp to bust CDN caches                             |
+| `buildOAuthUrl(clientId, origin)` | Construct the OAuth redirect URL                                      |
+
+**Rules:**
+
+- All internal app routes must go through `UrlBuilder` — do not construct path
+  strings by hand.
+- Never hard-code `https://` prefixes on URLs coming from the API; always pass
+  them through `prependHttps`.
+
+---
+
+## Constants (`constants.ts`, `assets.ts`)
+
+- `constants.ts` — global values (dates, sizes, limits, `NOOP_FN`). Add new
+  global constants here.
+- `assets.ts` — placeholder image URLs derived from `$app/paths`. Do not
+  hard-code placeholder paths elsewhere.
+
+---
+
+## Quick Checklist
+
+Before adding a new utility:
+
+- [ ] Check for an existing equivalent in the relevant domain folder first
+- [ ] File name and exported function name are camelCase and match each other
+- [ ] Function is pure (unless it's an action or intentional side-effect helper)
+- [ ] Internal helpers that don't need to be public live in `_internal/`
+- [ ] Locale-aware formatters accept `locale` as an optional last parameter,
+      defaulting to `'en'`
+- [ ] No direct `window.addEventListener` — use `GlobalEventBus` instead
+- [ ] No direct `localStorage` / `sessionStorage` — use `safeLocalStorage` /
+      `safeSessionStorage`
+- [ ] Time values use `time.seconds/minutes/hours/days(n)`, not raw numbers

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,74 +1,39 @@
-# Code Review Style Guide
+# Project Coding Standards
 
-This style guide outlines coding standards and best practices for the Trakt Web
-project (SvelteKit + TypeScript with Svelte 5 in runes mode).
+## Tech Stack
+- SvelteKit + TypeScript project, using Svelte 5 in runes mode.
+
+## Naming Conventions
+
+### General Rules
+- **PascalCase**: Component names, interfaces, and type aliases
+- **camelCase**: Variables, functions, and methods
+- **ALL_CAPS**: Constants
+
+### File Naming
+- Components: PascalCase (e.g., `ClampedText.svelte`, `MoreButton.svelte`)
+- Utilities/helpers: camelCase (e.g., `lineClamp.ts`, `clickOutside.ts`)
+- Type definitions: PascalCase (e.g., `MediaStoreProps.ts`, `FilterParams.ts`)
 
 ## Commit Standards
-
 - **Follow Conventional Commits**: All commits must adhere to the [Conventional Commits](https://www.conventionalcommits.org/) specification.
   - Use types: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:`, etc.
   - Example: `feat: add user profile component`
   - Example: `fix: correct date formatting in calendar view`
 
-## General Principles
+## Code Principles
 
 ### Functional Programming
-
-- **Write functional code**: Prefer pure functions that avoid side effects when possible
-- Functions should return consistent output for the same input
-- Minimize state mutation and favor immutable data structures
-- Keep Svelte stores minimal; use `$derived()` for computed values
-
-### Simplicity and Functionality
-
-- **Keep it simple**: Suggestions should be simple and functional
-- **Low visual complexity**: Avoid over-engineered solutions
-- **Function decomposition**: Split suggestions into smaller functions when needed
-- **Avoid over-engineering**: Solutions should not be unnecessarily complex
-- Favor readability over cleverness
-- If a solution feels complex, step back and reconsider the approach
-
-### Response Style
-
-- Responses should be concise and to the point
-- Focus on functional implementation rather than theoretical discussions
-
-## Naming Conventions
-
-### General Rules
-
-- **PascalCase**: Component names, interfaces, and type aliases
-  ```typescript
-  type LineClampProps = { ... }
-  interface MediaIntl extends EpisodeIntl { ... }
-  ```
-
-- **camelCase**: Variables, functions, and methods
-  ```typescript
-  const isClamped = writable(false);
-  function findRegionalIntl(props: ToMediaOrEpisodeIntlProps) { ... }
-  ```
-
-- **ALL_CAPS**: Constants
-  ```typescript
-  const DEFAULT_SHARE_COVER = '...';
-  const NOOP_FN = () => {};
-  ```
-
-### File Naming
-
-- Components: PascalCase (e.g., `ClampedText.svelte`, `MoreButton.svelte`)
-- Utilities/helpers: camelCase (e.g., `lineClamp.ts`, `clickOutside.ts`)
-- Type definitions: PascalCase (e.g., `MediaStoreProps.ts`, `FilterParams.ts`)
-
-## Code Quality Principles
+- **Write functional code**: Prefer pure functions that avoid side effects when possible.
+- Functions should return consistent output for the same input.
+- Minimize state mutation and favor immutable data structures.
+- Keep Svelte stores minimal; use `$derived()` for computed values.
 
 ### Immutability
-
-- **Prefer `const` over `let`**: Use `const` whenever possible typed
-- **Strict mode enabled**: `"strict": true` in tsconfig.json
-- **No `any` types**: Use specific types or appropriate utility types
-- **Use `readonly` types**: Enforce immutability at compile time with `Readonly<T>`, `ReadonlyArray<T>`, `ReadonlyMap`, `ReadonlySet``, `ReadonlyMap`, `ReadonlySet`
+- **Prefer `const` over `let`**: Use `const` whenever possible.
+- Avoid reassigning variables.
+- Use array methods like `map`, `filter`, and `reduce` instead of mutating loops.
+- Use TypeScript's `readonly` types: `Readonly<T>`, `ReadonlyArray<T>`, `ReadonlyMap`, `ReadonlySet`.
 
 **Bad:**
 ```typescript
@@ -84,9 +49,8 @@ const result = items.map(transform);
 ```
 
 ### Early Exits
-
-- **Use guard clauses and early returns**: Check error conditions first and return early
-- Avoid deep nesting by handling edge cases at the start of functions
+- **Use guard clauses and early returns**: Check error conditions first and return early.
+- Avoid deep nesting by handling edge cases at the start of functions.
 
 **Bad:**
 ```typescript
@@ -108,55 +72,85 @@ function processData(data: Data | null) {
   if (!data) return null;
   if (!data.isValid) return null;
   if (!data.hasPermission) return null;
-  
+
   return transform(data);
 }
 ```
 
 ### Code Smells to Avoid
+- **No nested if statements**: Nested conditionals indicate poor architecture.
+  - Refactor into separate functions with clear responsibilities.
+  - Use guard clauses and early returns instead.
+- **No abstraction leaks**: Ensure abstractions hide implementation details completely.
+- **No "god functions"**: Each function should have a single, clear responsibility.
 
-- **No nested if statements**: Nested conditionals indicate poor architecture
-  - Refactor into separate functions with clear responsibilities
-  - Use guard clauses and early returns instead
-- **No abstraction leaks**: Ensure abstractions hide implementation details completely
-- **No "god functions"**: Each function should have a single, clear responsibility
-
-### Iteration Patterns
-
-- **Prefer functional methods over imperative loops**: Use `map`, `filter`, `reduce`
-- Avoid mutable loop counters when possible
-- Use recursion for complex accumulation patterns
+### Function Design
+- **Single Responsibility Principle**: Each function should do one thing well.
+- Function names should clearly describe what they do.
+- When a function takes 3+ parameters, use a single object parameter.
+- Pass dependencies as parameters (dependency injection).
 
 **Bad:**
 ```typescript
-let acc = [];
-let i = 0;
-while (i < items.length) {
-  acc.push(transform(items[i]));
-  i++;
+fetchData(url, token, retry, timeout);
+```
+
+**Good:**
+```typescript
+fetchData({ url, token, retry, timeout });
+```
+
+### Dependency Injection
+- **Pass dependencies as parameters**: Don't instantiate external services inside functions.
+- Makes functions testable without mocking.
+- Use interface types to define the shape of dependencies.
+
+**Bad:**
+```typescript
+export function fetchUser(id: string) {
+  const api = new ApiClient();
+  return api.get(`/users/${id}`);
 }
 ```
 
 **Good:**
 ```typescript
-const acc = items.map(transform);
+interface FetchUserParams {
+  api: ApiClient;
+  id: string;
+}
+
+export function fetchUser({ api, id }: FetchUserParams) {
+  return api.get(`/users/${id}`);
+}
 ```
+
+### Separation of Concerns
+- **Push side effects to the edges**: Keep core logic pure and deterministic.
+- API calls, local storage, and DOM manipulation are side effects.
+- Pure functions should handle data transformation only.
+- Side effects should live in the outer layers (components, hooks, server functions).
+
+### Simplicity
+- **Keep it simple**: Simple code is maintainable code.
+- Suggestions should be simple and functional with low visual complexity.
+- Split up into smaller functions when needed.
+- Favor readability over cleverness.
+- If a solution feels complex, step back and reconsider the approach.
+
+### Iteration Patterns
+- **Prefer functional methods over imperative loops**: Use `map`, `filter`, `reduce`.
+- Avoid mutable loop counters when possible.
 
 ## TypeScript Standards
 
 ### Type Safety
-
-- **Always use TypeScript**: All `.ts` and `.svelte` files should be strongly
-  typed
-- **Strict mode enabled**: `"strict": true` in tsconfig.json
-- **No `any` types**: Use specific types or appropriate utility types
+- Always use TypeScript with strict mode.
+- No `any` types; use specific types or utility types.
 
 ### Type Definitions
 
 #### Props Types
-
-Define props types inline or as separate types:
-
 ```typescript
 type LineClampProps = {
   label: string;
@@ -167,9 +161,6 @@ const { children, label, classList = '' }: LineClampProps = $props();
 ```
 
 #### Union Types
-
-Use discriminated unions for complex type scenarios:
-
 ```typescript
 export type MediaStoreProps<T extends { id: number } = { id: number }> =
   | EpisodeProps<T>
@@ -178,9 +169,6 @@ export type MediaStoreProps<T extends { id: number } = { id: number }> =
 ```
 
 #### Utility Types
-
-Leverage TypeScript utility types:
-
 ```typescript
 type FilterParams = DeepPartial<{
   filter: FilterParam;
@@ -189,8 +177,7 @@ type FilterParams = DeepPartial<{
 ```
 
 ### Zod Schemas
-
-- Use Zod for runtime validation and type inference
+- Use Zod for runtime validation and type inference.
 - Define schema first, then derive type:
 
 ```typescript
@@ -201,88 +188,58 @@ export type MediaIntl = z.infer<typeof MediaIntlSchema>;
 ```
 
 ### Null Handling
-
-- Use `Nil` type for `null | undefined`
-- Use `.nullish()` in Zod schemas for optional nullable fields
-- Use optional chaining (`?.`) and nullish coalescing (`??`)
+- Use `Nil` type for `null | undefined`.
+- Use `.nullish()` in Zod schemas for optional nullable fields.
+- Use optional chaining (`?.`) and nullish coalescing (`??`).
 
 ## Svelte 5 Runes Mode
 
 ### Reactive State with Runes
 
 #### `$props()`
-
-Define component props:
-
 ```typescript
 const { children, label, classList = '' }: LineClampProps = $props();
 ```
 
 #### `$derived()`
-
-Create derived reactive values:
-
 ```typescript
 const isExpanded = $derived($lines === 1337);
 const hasValidRating = $derived(rating !== undefined);
 const title = $derived(intl?.title ?? media?.title ?? '');
-```
 
-- Use for computed values that depend on reactive state
-- Can destructure from functions/objects:
-
-```typescript
+// Destructure from functions/objects:
 const { isCollapsed, toggle } = $derived(useCollapsedList(id));
 ```
 
-## Component Structure
-
-### Script Block
+### Component Structure
 
 ```typescript
 <script lang="ts">
   // 1. Imports (grouped logically)
   import Component from "$lib/components/Component.svelte";
   import { utility } from "$lib/utils/utility";
-  
+
   // 2. Type definitions
   type ComponentProps = {
     prop: string;
   } & ChildrenProps;
-  
+
   // 3. Props destructuring
   const { children, prop }: ComponentProps = $props();
-  
+
   // 4. Reactive state (stores)
   const state = writable(initialValue);
-  
+
   // 5. Derived values
   const derived = $derived($state > 0);
   const { value } = $derived(useHook());
-  
+
   // 6. Functions
   function handleClick() { ... }
 </script>
 ```
 
-### Template
-
-```svelte
-<!-- Use proper hierarchy and semantic HTML -->
-<div class="container">
-  <p use:action={params} use:anotherAction class="content">
-    {@render children()}
-  </p>
-  
-  {#if condition}
-    <Component />
-  {/if}
-</div>
-```
-
 ### Snippets
-
-Use snippets for reusable template fragments:
 
 ```svelte
 {#snippet navbarState(hasFilters: boolean)}
@@ -296,26 +253,7 @@ Use snippets for reusable template fragments:
 {@render navbarState(true)}
 ```
 
-### Style Block
-
-```svelte
-<style lang="scss">
-  @use "$style/scss/mixins/index" as *;
-
-  .container {
-    display: flex;
-    gap: var(--gap-xs);
-    
-    @include for-tablet-sm-and-below {
-      flex-direction: column;
-    }
-  }
-</style>
-```
-
 ### Custom Hooks Pattern
-
-Create composable functions that return reactive state:
 
 ```typescript
 function useFeatureFlag(flag: FeatureFlag) {
@@ -329,65 +267,22 @@ const { isEnabled } = $derived(useFeatureFlag(flag));
 ```
 
 ## Styling
-- Use object parameters for functions with 3+ arguments
-- Pass dependencies as parameters (dependency injection)
 
-**Simple function:**
-```typescript
-export function findRegionalIntl(props: ToMediaOrEpisodeIntlProps) {
-  const { region } = getLanguageAndRegion();
-  // ... implementation
-  return result;
-}
-```
+### SCSS with Scoped Styles
 
-**Object parameters (3+ args):**
-```typescript
-// Bad
-function fetchData(url: string, token: string, retry: number, timeout: number) { }
+```svelte
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
 
-// Good
-interface FetchDataParams {
-  url: string;
-  token: string;
-  retry: number;
-  timeout: number;
-}
+  .container {
+    display: flex;
+    gap: var(--gap-xs);
 
-function fetchData({ url, token, retry, timeout }: FetchDataParams) { }
-```
-
-**Dependency injection:**
-```typescript
-// Bad - instantiates dependency inside
-export function fetchUser(id: string) {
-  const api = new ApiClient();
-  return api.get(`/users/${id}`);
-}
-
-// Good - dependency passed as parameter
-interface FetchUserParams {
-  api: ApiClient;
-  id: string;
-}
-
-export function fetchUser({ api, id }: FetchUserParams) {
-  return api.get(`/users/${id}`);
-}
-```
-
-### Separation of Concerns
-
-- **Push side effects to the edges**: Keep core logic pure and deterministic
-- API calls, local storage, and DOM manipulation are side effects
-- Pure functions should handle data transformation only
-- Side effects should live in the outer layers (components, server functions, hooks)isplay: flex;
-  gap: var(--gap-xs);
-
-  @include for-tablet-sm-and-below {
-    flex-direction: column;
+    @include for-tablet-sm-and-below {
+      flex-direction: column;
+    }
   }
-}
+</style>
 ```
 
 ### CSS Variables
@@ -404,10 +299,9 @@ Use CSS custom properties for theming:
 ```
 
 ### Class Naming
-
-- Use kebab-case for CSS classes
-- Descriptive, semantic names
-- Component-scoped styles preferred
+- Use kebab-case for CSS classes.
+- Descriptive, semantic names.
+- Component-scoped styles preferred.
 
 ### Dynamic Classes
 
@@ -425,24 +319,15 @@ Use CSS custom properties for theming:
 
 ### Svelte Actions
 
-Actions follow a consistent pattern:
-
 ```typescript
 export function actionName(node: HTMLElement, params?: ActionParams) {
-  // Setup logic
-
-  function handler(event: Event) {
-    // Handle event
-  }
+  function handler(event: Event) { ... }
 
   node.addEventListener('event', handler);
 
   return {
-    update(newParams?: ActionParams) {
-      // Update logic
-    },
+    update(newParams?: ActionParams) { ... },
     destroy() {
-      // Cleanup
       node.removeEventListener('event', handler);
     },
   };
@@ -450,87 +335,41 @@ export function actionName(node: HTMLElement, params?: ActionParams) {
 ```
 
 ### Utility Functions
-
-- Pure functions when possible
-- Single responsibility
-- Well-typed inputs and outputs
-- Include `.ts` extension in imports
-
-```typescript
-export function findRegionalIntl(props: ToMediaOrEpisodeIntlProps) {
-  const { region } = getLanguageAndRegion();
-  // ... implementation
-  return result;
-}
-```
+- Pure functions when possible.
+- Single responsibility.
+- Well-typed inputs and outputs.
+- Include `.ts` extension in imports.
 
 ## Code Quality
 
-### ESLint Configuration
-
-- Use TypeScript ESLint recommended rules
-
-## Summary Checklist
-
-Key principles for clean, maintainable code:
-
-1. ✅ Follow Conventional Commits
-2. ✅ Write functional, pure code when possible
-3. ✅ Avoid nested if statements (code smell)
-4. ✅ Use early exits with guard clauses
-5. ✅ Prefer `const` over `let` for immutability
-6. ✅ Keep solutions simple and readable
-7. ✅ Prevent abstraction leaks
-8. ✅ Single Responsibility Principle for functions
-9. ✅ Use dependency injection for testability
-10. ✅ Push side effects to the edges
-11. ✅ Use TypeScript readonly types
-12. ✅ Use object parameters for functions with 3+ arguments
-13. ✅ Prefer functional iteration over imperative loops
-14. ✅ Use `$derived()` for computed values in Svelte
-15. ✅ Keep components focused and single-purpose
-- Svelte plugin enabled
-- Unused variables prefixed with `_` are allowed:
-
-```typescript
-const { _unused, used } = props;
-```
+### ESLint
+- TypeScript ESLint recommended rules.
+- Svelte plugin enabled.
+- Unused variables prefixed with `_` are allowed.
 
 ### Best Practices
 
 #### Prefer Composition
-
 ```typescript
-// Good
 <Button onclick={handleClick} label={label} />
-
-// Avoid complex inline handlers
-<button onclick={() => { /* complex logic */ }}>
 ```
 
 #### Type Guards
-
 ```typescript
 if (props.type === 'episode') {
-  // TypeScript narrows the type
   const episodes = props.media.episodes;
 }
 ```
 
 #### Conditional Rendering
-
 ```svelte
-<!-- Prefer {#if} over && -->
 {#if condition}
   <Component />
 {/if}
-
-<!-- Not: {condition && <Component />} -->
 ```
 
-### Performance Considerations
-
-- Use `$derived()` for computed values (cached)
-- Lazy load components when appropriate
-- Avoid unnecessary reactive statements
-- Use actions for DOM manipulation instead of reactive statements
+### Performance
+- Use `$derived()` for computed values (cached).
+- Lazy load components when appropriate.
+- Avoid unnecessary reactive statements.
+- Use actions for DOM manipulation instead of reactive statements.

--- a/.github/instructions/code-principles.instructions.md
+++ b/.github/instructions/code-principles.instructions.md
@@ -1,0 +1,1 @@
+../../.agents/rules/code-principles.md

--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -1,0 +1,1 @@
+../../.agents/rules/components.md

--- a/.github/instructions/implementation.instructions.md
+++ b/.github/instructions/implementation.instructions.md
@@ -1,0 +1,1 @@
+../../.agents/rules/implementation.md

--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -1,0 +1,1 @@
+../../.agents/rules/project.md

--- a/.github/instructions/requests.instructions.md
+++ b/.github/instructions/requests.instructions.md
@@ -1,0 +1,1 @@
+../../.agents/rules/requests.md

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,1 @@
+../../.agents/rules/testing.md

--- a/.github/instructions/utils.instructions.md
+++ b/.github/instructions/utils.instructions.md
@@ -1,0 +1,1 @@
+../../.agents/rules/utils.md

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ vite.config.ts.timestamp-*
 
 # Vitest
 coverage
+
+# ai junk
+.todos
+.superpowers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+@.agents/rules/project.md
+@.agents/rules/code-principles.md
+@.agents/rules/implementation.md
+@.agents/rules/testing.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Scene Setting

Our team uses multiple AI coding tools (Claude Code, Copilot, Antigravity, Gemini Code Assist, Codex, Cursor), but we had no shared project instructions for agents — architecture patterns,  testing conventions, implementation guidelines, etc. lived only in the code review style guides, which serve a different purpose. This PR adds a proper agent instruction layer with `.agents/rules/` as the canonical source, matching the pattern established in `trakt-workers`.

### Architecture

`.agents/rules/` is the canonical source, matching the pattern established in `trakt-workers`.  Everything else points to it or stands alone intentionally.

.agents/rules/                               ← Single source of truth
  project.md                                   Project overview, architecture, tooling
  code-principles.md                           Functional programming, immutability, DI
  implementation.md                            Naming, TypeScript standards, patterns
  testing.md                                   Vitest, test beds, MSW

AGENTS.md                                    ← @ includes to rules
CLAUDE.md → AGENTS.md                        ← Symlink

.github/copilot-instructions.md              ← Standalone (Copilot PR reviews)
.github/instructions/*.instructions.md       ← Symlinks to .agents/rules/

.gemini/styleguide.md                        ← Standalone (Gemini code reviews)

### Why this shape?

- **`.agents/rules/`** is the format Antigravity reads natively
- **`AGENTS.md`** uses `@` includes so Claude resolves the full content. Tools that don't support `@` includes (Codex, Cursor) won't get the content — accepted trade-off over maintaining duplicate files
- **Review bot files are intentionally independent.** `.gemini/styleguide.md` and `.github/copilot-instructions.md` are standalone so they act as a defensive check — if someone loosens a rule in the agent instructions, the review bots still catch it
- **`.github/instructions/`** symlinks give Copilot path-scoped rules from the same canonical source

### What changed

- Created `.agents/rules/` with four foundation rule files
- Created `AGENTS.md` with `@` includes and `CLAUDE.md` symlink
- Cleaned up `.gemini/styleguide.md` (fixed corrupted content where CSS bled into markdown,
removed duplicate sections)
- `.github/copilot-instructions.md` left unchanged
- Added `.github/instructions/` with symlinks for Copilot path-scoped rules
- Added `.agents/.impeccable.md` with design context for AI design skills
- Added `.todos/` to `.gitignore`