### PR TITLE
Home page stat blocks!

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -109,6 +109,7 @@ module.exports = {
         'smart-list',
         'social',
         'spoiler',
+        'stats',
         'streaming',
         'summary',
         'tags',

--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Плъзни изображението, за да го наместиш идеално за големия екран"
+    },
+    "text_stats_today": {
+      "default": "Днес"
+    },
+    "text_stats_time_morning": {
+      "default": "Сутрин"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Следобед"
+    },
+    "text_stats_time_evening": {
+      "default": "Вечер"
+    },
+    "text_stats_time_late_night": {
+      "default": "Късно вечер"
+    },
+    "text_stats_weeks_ago": {
+      "default": "преди {count} седм."
+    },
+    "text_stats_weeks_short": {
+      "default": "{count} седм."
+    },
+    "text_stats_this_week": {
+      "default": "Тази седмица"
+    },
+    "text_stats_was_last_week": {
+      "default": "беше {day} миналата седмица"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "без промяна"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} епизода"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} филма"
+    },
+    "text_stats_day_count": {
+      "default": "{count} ден"
+    },
+    "text_stats_days_count": {
+      "default": "{count} дни"
+    },
+    "text_stats_watching_streak": {
+      "default": "поредица"
+    },
+    "text_stats_watch_today": {
+      "default": "Гледай днес,"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "за да продължиш лентата!"
+    },
+    "text_stats_genre_other": {
+      "default": "Други"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Вечен"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Митичен"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Легендарен"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Обсебен"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Инферно"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Пламтящ"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "В стихията си"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Загрявка"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Искра"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Всеки. Един. Ден."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Другите само мечтаят"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Това вече е начин на живот"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Без почивни дни"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "В зоната"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Поддържай огъня жив"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Става ти навик"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Продължавай напред"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Цяла година!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Половин година!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 поредни дни!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 поредни дни!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "Цял месец!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Две силни седмици!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "Цяла седмица!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Трети пореден ден!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Започва се!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} месец"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} месеца"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} седмица"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} седмици"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} ден"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} дни"
+    },
+    "label_stats_plays": {
+      "default": "Гледания"
+    },
+    "label_stats_episodes": {
+      "default": "Епизоди"
+    },
+    "label_stats_movies": {
+      "default": "Филми"
+    },
+    "label_stats_shows": {
+      "default": "Сериали"
+    },
+    "label_stats_active_days": {
+      "default": "Активни дни"
+    },
+    "label_stats_busiest_day": {
+      "default": "Най-натоварен ден"
+    },
+    "label_stats_best_day": {
+      "default": "Най-добър ден"
+    },
+    "label_stats_hours": {
+      "default": "Часове"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "По жанрове"
+    },
+    "header_stats_this_week": {
+      "default": "Тази седмица"
+    },
+    "header_stats_graph_daily": {
+      "default": "Дневна активност"
+    },
+    "header_stats_graph_trend": {
+      "default": "Седмичен тренд"
+    },
+    "header_stats_graph_peak": {
+      "default": "Пикови часове"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Сериали срещу Филми"
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Træk i billedet for at justere det – så er du helt klar til din næste hyggelige filmaften."
+    },
+    "text_stats_today": {
+      "default": "I dag"
+    },
+    "text_stats_time_morning": {
+      "default": "Morgen"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Eftermiddag"
+    },
+    "text_stats_time_evening": {
+      "default": "Aften"
+    },
+    "text_stats_time_late_night": {
+      "default": "Sent om natten"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count} u. siden"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count} u."
+    },
+    "text_stats_this_week": {
+      "default": "Denne uge"
+    },
+    "text_stats_was_last_week": {
+      "default": "var {day} i sidste uge"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "samme"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} episoder"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} film"
+    },
+    "text_stats_day_count": {
+      "default": "{count} dag"
+    },
+    "text_stats_days_count": {
+      "default": "{count} dage"
+    },
+    "text_stats_watching_streak": {
+      "default": "seerrække"
+    },
+    "text_stats_watch_today": {
+      "default": "Se noget i dag"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "for at holde din seerrække i live!"
+    },
+    "text_stats_genre_other": {
+      "default": "Andet"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Evig"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mytisk"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legendarisk"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Besat"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Inferno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Flammende"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "I brand"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Opvarmning"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Gnist"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Hver. Eneste. Dag."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Andre kan kun drømme"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Det er en livsstil nu"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Ingen fridage"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Fuldstændig opslugt"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Hold ilden kørende"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "En god vane"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Bliv ved"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Et helt år!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Et halvt år!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 dage i træk!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 dage i træk!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "En hel måned!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "To stærke uger!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "En hel uge!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Tre dage inde!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Det begynder!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} måned"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} måneder"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} uge"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} uger"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} dag"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} dage"
+    },
+    "label_stats_plays": {
+      "default": "Afspilninger"
+    },
+    "label_stats_episodes": {
+      "default": "Afsnit"
+    },
+    "label_stats_movies": {
+      "default": "Film"
+    },
+    "label_stats_shows": {
+      "default": "Serier"
+    },
+    "label_stats_active_days": {
+      "default": "Aktive dage"
+    },
+    "label_stats_busiest_day": {
+      "default": "Travleste dag"
+    },
+    "label_stats_best_day": {
+      "default": "Bedste dag"
+    },
+    "label_stats_hours": {
+      "default": "Timer"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genrefordeling"
+    },
+    "header_stats_this_week": {
+      "default": "Denne uge"
+    },
+    "header_stats_graph_daily": {
+      "default": "Daglig aktivitet"
+    },
+    "header_stats_graph_trend": {
+      "default": "Ugentlig tendens"
+    },
+    "header_stats_graph_peak": {
+      "default": "Mest aktive timer"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Serier vs Film"
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Bild zum Anpassen ziehen"
+    },
+    "text_stats_today": {
+      "default": "Heute"
+    },
+    "text_stats_time_morning": {
+      "default": "Vormittag"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Nachmittag"
+    },
+    "text_stats_time_evening": {
+      "default": "Abend"
+    },
+    "text_stats_time_late_night": {
+      "default": "Nacht"
+    },
+    "text_stats_weeks_ago": {
+      "default": "vor {count}W"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count}W"
+    },
+    "text_stats_this_week": {
+      "default": "Diese Woche"
+    },
+    "text_stats_was_last_week": {
+      "default": "war letzte Woche {day}"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "gleich"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} Episoden"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} Filme"
+    },
+    "text_stats_day_count": {
+      "default": "{count} Tag"
+    },
+    "text_stats_days_count": {
+      "default": "{count} Tage"
+    },
+    "text_stats_watching_streak": {
+      "default": "Watching-Streak"
+    },
+    "text_stats_watch_today": {
+      "default": "Schauen Sie heute etwas,"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "um die Streak am Leben zu halten!"
+    },
+    "text_stats_genre_other": {
+      "default": "Sonstige"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Ewig"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mythisch"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legendär"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Besessen"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Inferno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Lodernd"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "Heißgelaufen"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Aufwärmen"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Funke"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Jeden. Einzelnen. Tag."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Davon träumt Hollywood nur"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Filmreifer Lifestyle"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Keine Drehpause"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Fokus wie ein Regisseur"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Licht aus, Spot an!"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Gewohnheitssache"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Dranbleiben"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Ein ganzes Jahr im Kinosessel!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Ein halbes Jahr Cineastik!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 Tage am Stück!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 Tage am Stück!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "Ein voller Monat!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Zwei Wochen stark!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "Eine ganze Woche!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Drei Tage geschafft!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Es beginnt!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} Monat"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} Monate"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} Woche"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} Wochen"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} Tag"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} Tage"
+    },
+    "label_stats_plays": {
+      "default": "Wiedergaben"
+    },
+    "label_stats_episodes": {
+      "default": "Episoden"
+    },
+    "label_stats_movies": {
+      "default": "Filme"
+    },
+    "label_stats_shows": {
+      "default": "Serien"
+    },
+    "label_stats_active_days": {
+      "default": "Aktive Tage"
+    },
+    "label_stats_busiest_day": {
+      "default": "Aktivster Tag"
+    },
+    "label_stats_best_day": {
+      "default": "Bester Tag"
+    },
+    "label_stats_hours": {
+      "default": "Stunden"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genre-Verteilung"
+    },
+    "header_stats_this_week": {
+      "default": "Diese Woche"
+    },
+    "header_stats_graph_daily": {
+      "default": "Tägliche Aktivität"
+    },
+    "header_stats_graph_trend": {
+      "default": "Wochentrend"
+    },
+    "header_stats_graph_peak": {
+      "default": "Spitzenzeiten"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Serien vs. Filme"
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Drag the image to adjust"
+    },
+    "text_stats_today": {
+      "default": "Today"
+    },
+    "text_stats_time_morning": {
+      "default": "Morning"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Afternoon"
+    },
+    "text_stats_time_evening": {
+      "default": "Evening"
+    },
+    "text_stats_time_late_night": {
+      "default": "Late Night"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count}w ago"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count}w"
+    },
+    "text_stats_this_week": {
+      "default": "This week"
+    },
+    "text_stats_was_last_week": {
+      "default": "was {day} last week"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "same"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} episodes"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} movies"
+    },
+    "text_stats_day_count": {
+      "default": "{count} day"
+    },
+    "text_stats_days_count": {
+      "default": "{count} days"
+    },
+    "text_stats_watching_streak": {
+      "default": "watching streak"
+    },
+    "text_stats_watch_today": {
+      "default": "Watch today"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "to keep your streak alive!"
+    },
+    "text_stats_genre_other": {
+      "default": "Other"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Eternal"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mythical"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legendary"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Obsessed"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Inferno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Blazing"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "On Fire"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Warm Up"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Spark"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Every. Single. Day."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Others can only dream"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "It's a lifestyle now"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "No days off"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Locked in"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Keep that fire going"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Habit forming"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Keep going"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "A full year!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Half a year!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 days straight!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 days straight!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "A full month!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Two weeks strong!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "A whole week!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Three days in!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "It begins!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} month"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} months"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} week"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} weeks"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} day"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} days"
+    },
+    "label_stats_plays": {
+      "default": "Plays"
+    },
+    "label_stats_episodes": {
+      "default": "Episodes"
+    },
+    "label_stats_movies": {
+      "default": "Movies"
+    },
+    "label_stats_shows": {
+      "default": "Shows"
+    },
+    "label_stats_active_days": {
+      "default": "Active Days"
+    },
+    "label_stats_busiest_day": {
+      "default": "Busiest Day"
+    },
+    "label_stats_best_day": {
+      "default": "Best Day"
+    },
+    "label_stats_hours": {
+      "default": "Hours"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genre Breakdown"
+    },
+    "header_stats_this_week": {
+      "default": "This Week"
+    },
+    "header_stats_graph_daily": {
+      "default": "Daily Activity"
+    },
+    "header_stats_graph_trend": {
+      "default": "Week Trend"
+    },
+    "header_stats_graph_peak": {
+      "default": "Peak Hours"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Shows vs Movies"
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4572,10 +4572,11 @@
       ]
     },
     "link_text_terms": {
-      "default": "Terms of Use",
-      "description": "Text for the link that takes users to the support page or triggers a mailto url.",
+      "default": "Terms",
+      "description": "Text for the terms link in the footer.",
       "exclude": [
-        "web"
+        "android",
+        "ios"
       ]
     },
     "link_text_policy": {
@@ -7996,14 +7997,6 @@
         "ios"
       ]
     },
-    "link_text_terms": {
-      "default": "Terms",
-      "description": "Text for the terms link in the footer.",
-      "exclude": [
-        "android",
-        "ios"
-      ]
-    },
     "link_text_privacy": {
       "default": "Privacy",
       "description": "Text for the privacy link in the footer.",
@@ -8263,6 +8256,534 @@
     "text_branding_questions_intro": {
       "default": "Have questions about using our brand? Reach out.",
       "description": "Intro text for the questions/contact section on the Branding page.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_today": {
+      "default": "Today",
+      "description": "Label for the current day in stats charts.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_time_morning": {
+      "default": "Morning",
+      "description": "Label for morning time bucket (5am-12pm) in watch clock chart.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_time_afternoon": {
+      "default": "Afternoon",
+      "description": "Label for afternoon time bucket (12pm-5pm) in watch clock chart.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_time_evening": {
+      "default": "Evening",
+      "description": "Label for evening time bucket (5pm-10pm) in watch clock chart.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_time_late_night": {
+      "default": "Late Night",
+      "description": "Label for late night time bucket (10pm-5am) in watch clock chart.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count}w ago",
+      "description": "Week trend label for weeks in the past, e.g. '4w ago'.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_weeks_short": {
+      "default": "{count}w",
+      "description": "Abbreviated week trend label, e.g. '3w'.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_this_week": {
+      "default": "This week",
+      "description": "Label for the current week in week trend chart.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_was_last_week": {
+      "default": "was {day} last week",
+      "description": "Note indicating the busiest day last week, e.g. 'was Monday last week'.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}",
+      "description": "Positive delta indicator for week-over-week change.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}",
+      "description": "Negative delta indicator for week-over-week change.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_delta_same": {
+      "default": "same",
+      "description": "Label shown when week-over-week change is zero.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} episodes",
+      "description": "Episode count label in shows vs movies breakdown.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_movies_count": {
+      "default": "{count} movies",
+      "description": "Movie count label in shows vs movies breakdown.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_day_count": {
+      "default": "{count} day",
+      "description": "Singular day count for watching streak.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_days_count": {
+      "default": "{count} days",
+      "description": "Plural day count for watching streak.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_watching_streak": {
+      "default": "watching streak",
+      "description": "Label following the streak count, e.g. '5 days watching streak'.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_watch_today": {
+      "default": "Watch today",
+      "description": "Call to action when streak is at risk.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "to keep your streak alive!",
+      "description": "Motivational text following 'Watch today' when streak is at risk.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_genre_other": {
+      "default": "Other",
+      "description": "Label for the 'other' genre bucket in genre breakdown.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Eternal",
+      "description": "Streak tier name for 365+ day streaks.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mythical",
+      "description": "Streak tier name for 180+ day streaks.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legendary",
+      "description": "Streak tier name for 90+ day streaks.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Obsessed",
+      "description": "Streak tier name for 60+ day streaks.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Inferno",
+      "description": "Streak tier name for 30+ day streaks.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Blazing",
+      "description": "Streak tier name for 14+ day streaks.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "On Fire",
+      "description": "Streak tier name for 7+ day streaks.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Warm Up",
+      "description": "Streak tier name for 3+ day streaks.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Spark",
+      "description": "Streak tier name for 1 day streaks.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Every. Single. Day.",
+      "description": "Motivational message for 180+ day streak tiers.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Others can only dream",
+      "description": "Motivational message for 90+ day streak tier.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "It's a lifestyle now",
+      "description": "Motivational message for 60+ day streak tier.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "No days off",
+      "description": "Motivational message for 30+ day streak tier.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Locked in",
+      "description": "Motivational message for 14+ day streak tier.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Keep that fire going",
+      "description": "Motivational message for 7+ day streak tier.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Habit forming",
+      "description": "Motivational message for 3+ day streak tier.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Keep going",
+      "description": "Motivational message for 1 day streak tier.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_exact_year": {
+      "default": "A full year!",
+      "description": "Message shown when streak is exactly 365 days.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Half a year!",
+      "description": "Message shown when streak is exactly 180 days.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 days straight!",
+      "description": "Message shown when streak is exactly 90 days.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 days straight!",
+      "description": "Message shown when streak is exactly 60 days.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_exact_month": {
+      "default": "A full month!",
+      "description": "Message shown when streak is exactly 30 days.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Two weeks strong!",
+      "description": "Message shown when streak is exactly 14 days.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_exact_week": {
+      "default": "A whole week!",
+      "description": "Message shown when streak is exactly 7 days.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Three days in!",
+      "description": "Message shown when streak is exactly 3 days.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "It begins!",
+      "description": "Message shown when streak is exactly 1 day.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_month": {
+      "default": "{count} month",
+      "description": "Singular month label in streak accumulator.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_months": {
+      "default": "{count} months",
+      "description": "Plural months label in streak accumulator.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_week": {
+      "default": "{count} week",
+      "description": "Singular week label in streak accumulator.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} weeks",
+      "description": "Plural weeks label in streak accumulator.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_day": {
+      "default": "{count} day",
+      "description": "Singular day label in streak accumulator.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_streak_days": {
+      "default": "{count} days",
+      "description": "Plural days label in streak accumulator.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "label_stats_plays": {
+      "default": "Plays",
+      "description": "Label for total plays stat in weekly pulse.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "label_stats_episodes": {
+      "default": "Episodes",
+      "description": "Label for episodes stat in weekly pulse.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "label_stats_movies": {
+      "default": "Movies",
+      "description": "Label for movies stat in weekly pulse.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "label_stats_shows": {
+      "default": "Shows",
+      "description": "Label for shows stat in weekly pulse.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "label_stats_active_days": {
+      "default": "Active Days",
+      "description": "Label for active days stat in weekly pulse.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "label_stats_busiest_day": {
+      "default": "Busiest Day",
+      "description": "Label for busiest day of week stat in weekly pulse.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "label_stats_best_day": {
+      "default": "Best Day",
+      "description": "Label for best performing day stat in weekly pulse.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "label_stats_hours": {
+      "default": "Hours",
+      "description": "Label for total hours watched stat in weekly pulse.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genre Breakdown",
+      "description": "Section header for the 14-day genre breakdown chart.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "header_stats_this_week": {
+      "default": "This Week",
+      "description": "Section header for the weekly pulse stats block.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "header_stats_graph_daily": {
+      "default": "Daily Activity",
+      "description": "Title for the daily bars graph in weekly pulse.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "header_stats_graph_trend": {
+      "default": "Week Trend",
+      "description": "Title for the week-over-week trend graph in weekly pulse.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "header_stats_graph_peak": {
+      "default": "Peak Hours",
+      "description": "Title for the watch clock graph in weekly pulse.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Shows vs Movies",
+      "description": "Title for the shows/movies breakdown graph in weekly pulse.",
       "exclude": [
         "android",
         "ios"

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Arrastra la imagen para ajustarla"
+    },
+    "text_stats_today": {
+      "default": "Hoy"
+    },
+    "text_stats_time_morning": {
+      "default": "Mañana"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Tarde"
+    },
+    "text_stats_time_evening": {
+      "default": "Noche"
+    },
+    "text_stats_time_late_night": {
+      "default": "Madrugada"
+    },
+    "text_stats_weeks_ago": {
+      "default": "Hace {count} sem."
+    },
+    "text_stats_weeks_short": {
+      "default": "{count} sem."
+    },
+    "text_stats_this_week": {
+      "default": "Esta semana"
+    },
+    "text_stats_was_last_week": {
+      "default": "fue el {day} pasado"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "igual"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} episodios"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} películas"
+    },
+    "text_stats_day_count": {
+      "default": "{count} día"
+    },
+    "text_stats_days_count": {
+      "default": "{count} días"
+    },
+    "text_stats_watching_streak": {
+      "default": "racha de visionado"
+    },
+    "text_stats_watch_today": {
+      "default": "Mira algo hoy"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "¡para mantener viva tu racha!"
+    },
+    "text_stats_genre_other": {
+      "default": "Otros"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Eterno"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mítico"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legendario"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Obsesión"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Infierno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Ardiente"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "Fuego"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Calentando"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Chispa"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Día. Tras. Día."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Lo que otros solo sueñan"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Ya es un estilo de vida"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Sin días de descanso"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Concentración total"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Que no se apague la llama"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Creando hábito"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Sigue así"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "¡Un año entero!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "¡Medio año!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "¡90 días seguidos!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "¡60 días seguidos!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "¡Un mes completo!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "¡Dos semanas a tope!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "¡Una semana entera!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "¡Ya van tres días!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "¡Comienza la aventura!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} mes"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} meses"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} semana"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} semanas"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} día"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} días"
+    },
+    "label_stats_plays": {
+      "default": "Reproducciones"
+    },
+    "label_stats_episodes": {
+      "default": "Episodios"
+    },
+    "label_stats_movies": {
+      "default": "Películas"
+    },
+    "label_stats_shows": {
+      "default": "Series"
+    },
+    "label_stats_active_days": {
+      "default": "Días activos"
+    },
+    "label_stats_busiest_day": {
+      "default": "Día más activo"
+    },
+    "label_stats_best_day": {
+      "default": "Mejor día"
+    },
+    "label_stats_hours": {
+      "default": "Horas"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Desglose por géneros"
+    },
+    "header_stats_this_week": {
+      "default": "Esta semana"
+    },
+    "header_stats_graph_daily": {
+      "default": "Actividad diaria"
+    },
+    "header_stats_graph_trend": {
+      "default": "Tendencia semanal"
+    },
+    "header_stats_graph_peak": {
+      "default": "Horas punta"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Series vs Películas"
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Arrastra la imagen para ajustarla, ¡que quede de película!"
+    },
+    "text_stats_today": {
+      "default": "Hoy"
+    },
+    "text_stats_time_morning": {
+      "default": "Mañana"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Tarde"
+    },
+    "text_stats_time_evening": {
+      "default": "Noche"
+    },
+    "text_stats_time_late_night": {
+      "default": "Madrugada"
+    },
+    "text_stats_weeks_ago": {
+      "default": "Hace {count} sem"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count} sem"
+    },
+    "text_stats_this_week": {
+      "default": "Esta semana"
+    },
+    "text_stats_was_last_week": {
+      "default": "fue el {day} pasado"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "igual"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} episodios"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} películas"
+    },
+    "text_stats_day_count": {
+      "default": "{count} día"
+    },
+    "text_stats_days_count": {
+      "default": "{count} días"
+    },
+    "text_stats_watching_streak": {
+      "default": "de racha"
+    },
+    "text_stats_watch_today": {
+      "default": "Mira algo hoy"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "¡para que no muera tu racha!"
+    },
+    "text_stats_genre_other": {
+      "default": "Otro"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Eterno"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mítico"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legendario"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Obsesión total"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Infierno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Fuego puro"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "Encendido"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Calentamiento"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Chispa"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Día tras día. Sin falta."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Lo que otros solo sueñan"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Ya es un estilo de vida"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Aquí no hay descansos"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Bien clavado"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Que no se apague la flama"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Creando el hábito"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "¡Sigue así!"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "¡Un año completito!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "¡Medio año ya!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "¡90 días al hilo!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "¡60 días al hilo!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "¡Un mes entero!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "¡Dos semanas dándole duro!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "¡Toda una semana!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "¡Ya van tres días!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "¡Apenas empieza!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} mes"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} meses"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} semana"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} semanas"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} día"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} días"
+    },
+    "label_stats_plays": {
+      "default": "Reproducciones"
+    },
+    "label_stats_episodes": {
+      "default": "Episodios"
+    },
+    "label_stats_movies": {
+      "default": "Películas"
+    },
+    "label_stats_shows": {
+      "default": "Series"
+    },
+    "label_stats_active_days": {
+      "default": "Días activos"
+    },
+    "label_stats_busiest_day": {
+      "default": "Día más movido"
+    },
+    "label_stats_best_day": {
+      "default": "Mejor día"
+    },
+    "label_stats_hours": {
+      "default": "Horas"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Desglose de géneros"
+    },
+    "header_stats_this_week": {
+      "default": "Esta semana"
+    },
+    "header_stats_graph_daily": {
+      "default": "Actividad diaria"
+    },
+    "header_stats_graph_trend": {
+      "default": "Tendencia semanal"
+    },
+    "header_stats_graph_peak": {
+      "default": "Horas pico"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Series vs Películas"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Glissez l'image pour ajuster le cadrage, comme au cinéma d'ici !"
+    },
+    "text_stats_today": {
+      "default": "Aujourd'hui"
+    },
+    "text_stats_time_morning": {
+      "default": "Matin"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Après-midi"
+    },
+    "text_stats_time_evening": {
+      "default": "Soirée"
+    },
+    "text_stats_time_late_night": {
+      "default": "Fin de soirée"
+    },
+    "text_stats_weeks_ago": {
+      "default": "Il y a {count} s."
+    },
+    "text_stats_weeks_short": {
+      "default": "{count} s."
+    },
+    "text_stats_this_week": {
+      "default": "Cette semaine"
+    },
+    "text_stats_was_last_week": {
+      "default": "était {day} dernier"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "identique"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} épisodes"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} films"
+    },
+    "text_stats_day_count": {
+      "default": "{count} jour"
+    },
+    "text_stats_days_count": {
+      "default": "{count} jours"
+    },
+    "text_stats_watching_streak": {
+      "default": "de visionnage consécutif"
+    },
+    "text_stats_watch_today": {
+      "default": "Regarde quelque chose"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "pour garder ta séquence en vie!"
+    },
+    "text_stats_genre_other": {
+      "default": "Autre"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Éternel"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mythique"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Légendaire"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Accro"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Brasier"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "En feu"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "En flammes"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Échauffement"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Étincelle"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Chaque. Saint. Jour."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Un rêve pour les autres"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "C'est rendu un mode de vie"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Pas de congé"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Bien concentré"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Lâche pas la patate!"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Une vraie habitude"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Continue comme ça"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Un an pile!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Six mois déjà!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 jours d'affilée!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 jours d'affilée!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "Un mois complet!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Deux semaines de feu!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "Une semaine entière!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Trois jours de faits!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Ça commence!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} mois"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} mois"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} semaine"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} semaines"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} jour"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} jours"
+    },
+    "label_stats_plays": {
+      "default": "Visionnements"
+    },
+    "label_stats_episodes": {
+      "default": "Épisodes"
+    },
+    "label_stats_movies": {
+      "default": "Films"
+    },
+    "label_stats_shows": {
+      "default": "Séries"
+    },
+    "label_stats_active_days": {
+      "default": "Jours actifs"
+    },
+    "label_stats_busiest_day": {
+      "default": "Journée record"
+    },
+    "label_stats_best_day": {
+      "default": "Meilleure journée"
+    },
+    "label_stats_hours": {
+      "default": "Heures"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Répartition par genre"
+    },
+    "header_stats_this_week": {
+      "default": "Cette semaine"
+    },
+    "header_stats_graph_daily": {
+      "default": "Activité quotidienne"
+    },
+    "header_stats_graph_trend": {
+      "default": "Tendance hebdo"
+    },
+    "header_stats_graph_peak": {
+      "default": "Heures de pointe"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Séries vs Films"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Faites glisser l'image pour l'ajuster"
+    },
+    "text_stats_today": {
+      "default": "Today"
+    },
+    "text_stats_time_morning": {
+      "default": "Morning"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Afternoon"
+    },
+    "text_stats_time_evening": {
+      "default": "Evening"
+    },
+    "text_stats_time_late_night": {
+      "default": "Late Night"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count}w ago"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count}w"
+    },
+    "text_stats_this_week": {
+      "default": "This week"
+    },
+    "text_stats_was_last_week": {
+      "default": "was {day} last week"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "same"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} episodes"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} movies"
+    },
+    "text_stats_day_count": {
+      "default": "{count} day"
+    },
+    "text_stats_days_count": {
+      "default": "{count} days"
+    },
+    "text_stats_watching_streak": {
+      "default": "watching streak"
+    },
+    "text_stats_watch_today": {
+      "default": "Watch today"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "to keep your streak alive!"
+    },
+    "text_stats_genre_other": {
+      "default": "Other"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Eternal"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mythical"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legendary"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Obsessed"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Inferno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Blazing"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "On Fire"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Warm Up"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Spark"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Every. Single. Day."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Others can only dream"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "It's a lifestyle now"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "No days off"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Locked in"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Keep that fire going"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Habit forming"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Keep going"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "A full year!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Half a year!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 days straight!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 days straight!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "A full month!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Two weeks strong!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "A whole week!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Three days in!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "It begins!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} month"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} months"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} week"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} weeks"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} jour"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} jours"
+    },
+    "label_stats_plays": {
+      "default": "Lectures"
+    },
+    "label_stats_episodes": {
+      "default": "Épisodes"
+    },
+    "label_stats_movies": {
+      "default": "Films"
+    },
+    "label_stats_shows": {
+      "default": "Séries"
+    },
+    "label_stats_active_days": {
+      "default": "Jours actifs"
+    },
+    "label_stats_busiest_day": {
+      "default": "Jour le plus actif"
+    },
+    "label_stats_best_day": {
+      "default": "Meilleur jour"
+    },
+    "label_stats_hours": {
+      "default": "Heures"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Répartition par genre"
+    },
+    "header_stats_this_week": {
+      "default": "Cette semaine"
+    },
+    "header_stats_graph_daily": {
+      "default": "Activité quotidienne"
+    },
+    "header_stats_graph_trend": {
+      "default": "Tendance hebdomadaire"
+    },
+    "header_stats_graph_peak": {
+      "default": "Heures de pointe"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Séries vs Films"
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Trascina l'immagine per l'inquadratura perfetta"
+    },
+    "text_stats_today": {
+      "default": "Oggi"
+    },
+    "text_stats_time_morning": {
+      "default": "Mattina"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Pomeriggio"
+    },
+    "text_stats_time_evening": {
+      "default": "Sera"
+    },
+    "text_stats_time_late_night": {
+      "default": "Notte fonda"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count} sett. fa"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count} sett."
+    },
+    "text_stats_this_week": {
+      "default": "Questa sett."
+    },
+    "text_stats_was_last_week": {
+      "default": "era {day} scorsa settimana"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "uguale"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} episodi"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} film"
+    },
+    "text_stats_day_count": {
+      "default": "{count} giorno"
+    },
+    "text_stats_days_count": {
+      "default": "{count} giorni"
+    },
+    "text_stats_watching_streak": {
+      "default": "di fila"
+    },
+    "text_stats_watch_today": {
+      "default": "Guarda oggi"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "per non interrompere la serie!"
+    },
+    "text_stats_genre_other": {
+      "default": "Altro"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Eterno"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mitico"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Leggendario"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Ossessionato"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Inferno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Ardente"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "In fiamme"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Riscaldamento"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Scintilla"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Ogni. Singolo. Giorno."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Un sogno per gli altri"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Ormai è uno stile di vita"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Senza sosta"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Sintonizzato"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Mantieni vivo il fuoco"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Sta diventando un'abitudine"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Continua così"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Un anno intero!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Mezzo anno!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 giorni di fila!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 giorni di fila!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "Un mese intero!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Due settimane alla grande!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "Una settimana intera!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Tre giorni fatti!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Si comincia!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} mese"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} mesi"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} settimana"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} settimane"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} giorno"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} giorni"
+    },
+    "label_stats_plays": {
+      "default": "Visioni"
+    },
+    "label_stats_episodes": {
+      "default": "Episodi"
+    },
+    "label_stats_movies": {
+      "default": "Film"
+    },
+    "label_stats_shows": {
+      "default": "Serie TV"
+    },
+    "label_stats_active_days": {
+      "default": "Giorni attivi"
+    },
+    "label_stats_busiest_day": {
+      "default": "Giorno di punta"
+    },
+    "label_stats_best_day": {
+      "default": "Miglior giorno"
+    },
+    "label_stats_hours": {
+      "default": "Ore"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Analisi generi"
+    },
+    "header_stats_this_week": {
+      "default": "Questa settimana"
+    },
+    "header_stats_graph_daily": {
+      "default": "Attività quotidiana"
+    },
+    "header_stats_graph_trend": {
+      "default": "Trend settimanale"
+    },
+    "header_stats_graph_peak": {
+      "default": "Picchi di visione"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Serie TV vs Film"
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "画像をドラッグして位置を調整"
+    },
+    "text_stats_today": {
+      "default": "今日"
+    },
+    "text_stats_time_morning": {
+      "default": "朝"
+    },
+    "text_stats_time_afternoon": {
+      "default": "午後"
+    },
+    "text_stats_time_evening": {
+      "default": "夜"
+    },
+    "text_stats_time_late_night": {
+      "default": "深夜"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count}週間前"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count}週"
+    },
+    "text_stats_this_week": {
+      "default": "今週"
+    },
+    "text_stats_was_last_week": {
+      "default": "先週は{day}が最多でした"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "変化なし"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} エピソード"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} 映画"
+    },
+    "text_stats_day_count": {
+      "default": "{count}日"
+    },
+    "text_stats_days_count": {
+      "default": "{count}日"
+    },
+    "text_stats_watching_streak": {
+      "default": "連続視聴"
+    },
+    "text_stats_watch_today": {
+      "default": "今日も観よう"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "連続記録を更新しよう！"
+    },
+    "text_stats_genre_other": {
+      "default": "その他"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "エターナル"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "神話級"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "伝説級"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "夢中"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "インフェルノ"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "ブレイジング"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "絶好調"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "ウォームアップ"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "スパーク"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "毎日、欠かさず。"
+    },
+    "text_stats_streak_others_dream": {
+      "default": "誰もが憧れる境地"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "もはや生活の一部"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "365日休みなし"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "全集中で視聴中"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "その調子でいこう"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "習慣化してきた！"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "継続は力なり"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "丸1年達成！"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "半年達成！"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90日連続！"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60日連続！"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "丸1ヶ月！"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "2週間突破！"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "丸1週間！"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "3日目突入！"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "全てはここから！"
+    },
+    "text_stats_streak_month": {
+      "default": "{count}ヶ月"
+    },
+    "text_stats_streak_months": {
+      "default": "{count}ヶ月"
+    },
+    "text_stats_streak_week": {
+      "default": "{count}週間"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count}週間"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} 日"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} 日"
+    },
+    "label_stats_plays": {
+      "default": "視聴数"
+    },
+    "label_stats_episodes": {
+      "default": "エピソード"
+    },
+    "label_stats_movies": {
+      "default": "映画"
+    },
+    "label_stats_shows": {
+      "default": "ドラマ"
+    },
+    "label_stats_active_days": {
+      "default": "アクティブ日数"
+    },
+    "label_stats_busiest_day": {
+      "default": "最多視聴日"
+    },
+    "label_stats_best_day": {
+      "default": "ベスト視聴日"
+    },
+    "label_stats_hours": {
+      "default": "時間"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "ジャンル内訳"
+    },
+    "header_stats_this_week": {
+      "default": "今週"
+    },
+    "header_stats_graph_daily": {
+      "default": "日別アクティビティ"
+    },
+    "header_stats_graph_trend": {
+      "default": "週間トレンド"
+    },
+    "header_stats_graph_peak": {
+      "default": "ピーク時間帯"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "ドラマ vs 映画"
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Dra i bildet for å tilpasse – finn din beste vinkel før kveldens premiere!"
+    },
+    "text_stats_today": {
+      "default": "I dag"
+    },
+    "text_stats_time_morning": {
+      "default": "Morgen"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Ettermiddag"
+    },
+    "text_stats_time_evening": {
+      "default": "Kveld"
+    },
+    "text_stats_time_late_night": {
+      "default": "Natt"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count} u. siden"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count}u"
+    },
+    "text_stats_this_week": {
+      "default": "Denne uken"
+    },
+    "text_stats_was_last_week": {
+      "default": "var {day} forrige uke"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "likt"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} episoder"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} filmer"
+    },
+    "text_stats_day_count": {
+      "default": "{count} dag"
+    },
+    "text_stats_days_count": {
+      "default": "{count} dager"
+    },
+    "text_stats_watching_streak": {
+      "default": "seerekke"
+    },
+    "text_stats_watch_today": {
+      "default": "Se noe i dag"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "for å holde seerekken (og hyggen) i live!"
+    },
+    "text_stats_genre_other": {
+      "default": "Annet"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Evig"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mytisk"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legendarisk"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Besatt"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Inferno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Brennende"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "I fyr og flamme"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Oppvarming"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Gnist"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Hver. Eneste. Dag."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Andre kan bare drømme"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Det er en livsstil nå"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Ingen fridager"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Helt fokusert"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Hold fyr i peisen"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "En god vane"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Fortsett slik"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Et helt år!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Et halvt år!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 dager på rad!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 dager på rad!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "En hel måned!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "To sterke uker!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "En hel uke!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Tre dager i boks!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Det begynner!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} måned"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} måneder"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} uke"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} uker"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} dag"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} dager"
+    },
+    "label_stats_plays": {
+      "default": "Avspillinger"
+    },
+    "label_stats_episodes": {
+      "default": "Episoder"
+    },
+    "label_stats_movies": {
+      "default": "Filmer"
+    },
+    "label_stats_shows": {
+      "default": "Serier"
+    },
+    "label_stats_active_days": {
+      "default": "Aktive dager"
+    },
+    "label_stats_busiest_day": {
+      "default": "Travleste dag"
+    },
+    "label_stats_best_day": {
+      "default": "Beste dag"
+    },
+    "label_stats_hours": {
+      "default": "Timer"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Sjangerfordeling"
+    },
+    "header_stats_this_week": {
+      "default": "Denne uken"
+    },
+    "header_stats_graph_daily": {
+      "default": "Daglig aktivitet"
+    },
+    "header_stats_graph_trend": {
+      "default": "Ukestrend"
+    },
+    "header_stats_graph_peak": {
+      "default": "Topptimer"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Serier vs. filmer"
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Sleep de afbeelding om aan te passen"
+    },
+    "text_stats_today": {
+      "default": "Vandaag"
+    },
+    "text_stats_time_morning": {
+      "default": "Ochtend"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Middag"
+    },
+    "text_stats_time_evening": {
+      "default": "Avond"
+    },
+    "text_stats_time_late_night": {
+      "default": "Nacht"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count}w geleden"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count}w"
+    },
+    "text_stats_this_week": {
+      "default": "Deze week"
+    },
+    "text_stats_was_last_week": {
+      "default": "was vorige week {day}"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "gelijk"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} afleveringen"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} films"
+    },
+    "text_stats_day_count": {
+      "default": "{count} dag"
+    },
+    "text_stats_days_count": {
+      "default": "{count} dagen"
+    },
+    "text_stats_watching_streak": {
+      "default": "kijk-streak"
+    },
+    "text_stats_watch_today": {
+      "default": "Kijk vandaag nog"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "om je streak levend te houden!"
+    },
+    "text_stats_genre_other": {
+      "default": "Overig"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Eeuwig"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mythisch"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legendarisch"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Geobsedeerd"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Inferno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Laaiend"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "In vuur en vlam"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Opwarmertje"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Vonk"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Elke. Dag. Weer."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Anderen kunnen er alleen van dromen"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Het is nu een lifestyle"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Geen rustdagen"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Helemaal in de zone"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Houd het vuur brandend"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Een echte gewoonte"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Lekker bezig"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Een heel jaar!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Een half jaar!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 dagen op rij!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 dagen op rij!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "Een volle maand!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Al twee weken!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "Een volle week!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Drie dagen onderweg!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Het begin is er!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} maand"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} maanden"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} week"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} weken"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} dag"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} dagen"
+    },
+    "label_stats_plays": {
+      "default": "Kijkbeurten"
+    },
+    "label_stats_episodes": {
+      "default": "Afleveringen"
+    },
+    "label_stats_movies": {
+      "default": "Films"
+    },
+    "label_stats_shows": {
+      "default": "Series"
+    },
+    "label_stats_active_days": {
+      "default": "Actieve dagen"
+    },
+    "label_stats_busiest_day": {
+      "default": "Drukste dag"
+    },
+    "label_stats_best_day": {
+      "default": "Beste dag"
+    },
+    "label_stats_hours": {
+      "default": "Uren"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genreoverzicht"
+    },
+    "header_stats_this_week": {
+      "default": "Deze week"
+    },
+    "header_stats_graph_daily": {
+      "default": "Dagelijkse activiteit"
+    },
+    "header_stats_graph_trend": {
+      "default": "Weektrend"
+    },
+    "header_stats_graph_peak": {
+      "default": "Piektijden"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Series vs. Films"
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Przeciągnij obraz, aby dopasować kadr przed premierą!"
+    },
+    "text_stats_today": {
+      "default": "Dzisiaj"
+    },
+    "text_stats_time_morning": {
+      "default": "Rano"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Popołudnie"
+    },
+    "text_stats_time_evening": {
+      "default": "Wieczór"
+    },
+    "text_stats_time_late_night": {
+      "default": "Późna noc"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count} tyg. temu"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count} tyg."
+    },
+    "text_stats_this_week": {
+      "default": "W tym tygodniu"
+    },
+    "text_stats_was_last_week": {
+      "default": "to {day} w zeszłym tygodniu"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "bez zmian"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} odcinków"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} filmów"
+    },
+    "text_stats_day_count": {
+      "default": "{count} dzień"
+    },
+    "text_stats_days_count": {
+      "default": "{count} dni"
+    },
+    "text_stats_watching_streak": {
+      "default": "oglądania z rzędu"
+    },
+    "text_stats_watch_today": {
+      "default": "Obejrzyj coś dziś"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "aby podtrzymać swoją serię!"
+    },
+    "text_stats_genre_other": {
+      "default": "Inne"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Wieczność"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mityczny"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legenda"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Obsesja"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Inferno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Żar"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "W ogniu"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Rozgrzewka"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Iskra"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Dzień. Po. Dniu."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Inni mogą tylko pomarzyć"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "To już styl życia"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Bez dni wolnych"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "W trybie maratonu"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Podtrzymuj ten ogień"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "To wchodzi w krew"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Tak trzymaj"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Okrągły rok!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Pół roku za Tobą!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 dni z rzędu!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 dni z rzędu!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "Pełny miesiąc!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Mocne dwa tygodnie!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "Cały tydzień!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Trzeci dzień!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Zaczyna się!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} miesiąc"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} mies."
+    },
+    "text_stats_streak_week": {
+      "default": "{count} tydzień"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} tyg."
+    },
+    "text_stats_streak_day": {
+      "default": "{count} dzień"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} dni"
+    },
+    "label_stats_plays": {
+      "default": "Odtworzenia"
+    },
+    "label_stats_episodes": {
+      "default": "Odcinki"
+    },
+    "label_stats_movies": {
+      "default": "Filmy"
+    },
+    "label_stats_shows": {
+      "default": "Seriale"
+    },
+    "label_stats_active_days": {
+      "default": "Aktywne dni"
+    },
+    "label_stats_busiest_day": {
+      "default": "Najbardziej aktywny dzień"
+    },
+    "label_stats_best_day": {
+      "default": "Najlepszy dzień"
+    },
+    "label_stats_hours": {
+      "default": "Godziny"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Podział na gatunki"
+    },
+    "header_stats_this_week": {
+      "default": "W tym tygodniu"
+    },
+    "header_stats_graph_daily": {
+      "default": "Aktywność dzienna"
+    },
+    "header_stats_graph_trend": {
+      "default": "Trend tygodniowy"
+    },
+    "header_stats_graph_peak": {
+      "default": "Godziny szczytu"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Seriale vs Filmy"
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Arraste a imagem para ajustar"
+    },
+    "text_stats_today": {
+      "default": "Hoje"
+    },
+    "text_stats_time_morning": {
+      "default": "Manhã"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Tarde"
+    },
+    "text_stats_time_evening": {
+      "default": "Noite"
+    },
+    "text_stats_time_late_night": {
+      "default": "Madrugada"
+    },
+    "text_stats_weeks_ago": {
+      "default": "há {count} sem"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count} sem"
+    },
+    "text_stats_this_week": {
+      "default": "Esta semana"
+    },
+    "text_stats_was_last_week": {
+      "default": "foi {day} semana passada"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "igual"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} episódios"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} filmes"
+    },
+    "text_stats_day_count": {
+      "default": "{count} dia"
+    },
+    "text_stats_days_count": {
+      "default": "{count} dias"
+    },
+    "text_stats_watching_streak": {
+      "default": "em sequência"
+    },
+    "text_stats_watch_today": {
+      "default": "Assista hoje"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "para manter sua maratona viva!"
+    },
+    "text_stats_genre_other": {
+      "default": "Outro"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Eterno"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mítico"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Lendário"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Obcecado"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Inferno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Bombando"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "Pegando Fogo"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Aquecimento"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Faísca"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Todo. Santo. Dia."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "O resto só sonha com isso"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Virou estilo de vida"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Sem folga da telinha"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Foco total"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Mantém essa chama acesa"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Virando hábito"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Continua assim"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Um ano inteirinho!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Meio ano de maratona!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 dias sem parar!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 dias seguidos!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "Um mês completo!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Duas semanas firmes!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "Uma semana cheia!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Três dias já!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Começou!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} mês"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} meses"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} semana"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} semanas"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} dia"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} dias"
+    },
+    "label_stats_plays": {
+      "default": "Reproduções"
+    },
+    "label_stats_episodes": {
+      "default": "Episódios"
+    },
+    "label_stats_movies": {
+      "default": "Filmes"
+    },
+    "label_stats_shows": {
+      "default": "Séries"
+    },
+    "label_stats_active_days": {
+      "default": "Dias Ativos"
+    },
+    "label_stats_busiest_day": {
+      "default": "Dia Mais Agitado"
+    },
+    "label_stats_best_day": {
+      "default": "Melhor Dia"
+    },
+    "label_stats_hours": {
+      "default": "Horas"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Divisão por Gênero"
+    },
+    "header_stats_this_week": {
+      "default": "Nesta Semana"
+    },
+    "header_stats_graph_daily": {
+      "default": "Atividade Diária"
+    },
+    "header_stats_graph_trend": {
+      "default": "Tendência Semanal"
+    },
+    "header_stats_graph_peak": {
+      "default": "Horários de Pico"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Séries vs Filmes"
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Trage imaginea pentru a fixa cadrul perfect, exact ca un regizor!"
+    },
+    "text_stats_today": {
+      "default": "Astăzi"
+    },
+    "text_stats_time_morning": {
+      "default": "Dimineață"
+    },
+    "text_stats_time_afternoon": {
+      "default": "După-amiază"
+    },
+    "text_stats_time_evening": {
+      "default": "Seară"
+    },
+    "text_stats_time_late_night": {
+      "default": "Noapte târziu"
+    },
+    "text_stats_weeks_ago": {
+      "default": "acum {count} săpt."
+    },
+    "text_stats_weeks_short": {
+      "default": "{count} săpt."
+    },
+    "text_stats_this_week": {
+      "default": "Săptămâna aceasta"
+    },
+    "text_stats_was_last_week": {
+      "default": "a fost {day} săptămâna trecută"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "la fel"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} episoade"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} filme"
+    },
+    "text_stats_day_count": {
+      "default": "{count} zi"
+    },
+    "text_stats_days_count": {
+      "default": "{count} zile"
+    },
+    "text_stats_watching_streak": {
+      "default": "serie consecutivă"
+    },
+    "text_stats_watch_today": {
+      "default": "Vizionează ceva azi"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "pentru a menține seria activă!"
+    },
+    "text_stats_genre_other": {
+      "default": "Altele"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Etern"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mitic"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legendar"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Obsedat"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Infern"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Arzător"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "În flăcări"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Încălzire"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Scânteie"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "În. Fiecare. Zi."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Alții pot doar să viseze"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "E deja un stil de viață"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Fără zile de pauză"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Conectat total"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Ține flacăra aprinsă"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Se formează un obicei"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Continuă tot așa"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Un an întreg de povești!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "O jumătate de an!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 de zile neîntrerupte!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 de zile neîntrerupte!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "O lună întreagă!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Două săptămâni în forță!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "O săptămână plină!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Deja de trei zile!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "A început!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} lună"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} luni"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} săptămână"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} săptămâni"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} zi"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} zile"
+    },
+    "label_stats_plays": {
+      "default": "Vizionări"
+    },
+    "label_stats_episodes": {
+      "default": "Episoade"
+    },
+    "label_stats_movies": {
+      "default": "Filme"
+    },
+    "label_stats_shows": {
+      "default": "Seriale"
+    },
+    "label_stats_active_days": {
+      "default": "Zile active"
+    },
+    "label_stats_busiest_day": {
+      "default": "Cea mai plină zi"
+    },
+    "label_stats_best_day": {
+      "default": "Cea mai bună zi"
+    },
+    "label_stats_hours": {
+      "default": "Ore"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Distribuția pe genuri"
+    },
+    "header_stats_this_week": {
+      "default": "Săptămâna aceasta"
+    },
+    "header_stats_graph_daily": {
+      "default": "Activitate zilnică"
+    },
+    "header_stats_graph_trend": {
+      "default": "Evoluția săptămânii"
+    },
+    "header_stats_graph_peak": {
+      "default": "Ore de vârf"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Seriale vs Filme"
     }
   }
 }

--- a/projects/client/i18n/meta/ru-ru.json
+++ b/projects/client/i18n/meta/ru-ru.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Перетащите изображение, чтобы настроить"
+    },
+    "text_stats_today": {
+      "default": "Сегодня"
+    },
+    "text_stats_time_morning": {
+      "default": "Утро"
+    },
+    "text_stats_time_afternoon": {
+      "default": "День"
+    },
+    "text_stats_time_evening": {
+      "default": "Вечер"
+    },
+    "text_stats_time_late_night": {
+      "default": "Ночь"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count}н назад"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count}н"
+    },
+    "text_stats_this_week": {
+      "default": "На этой неделе"
+    },
+    "text_stats_was_last_week": {
+      "default": "был в {day} на прошлой неделе"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "так же"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} эпизодов"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} фильмов"
+    },
+    "text_stats_day_count": {
+      "default": "{count} день"
+    },
+    "text_stats_days_count": {
+      "default": "{count} дней"
+    },
+    "text_stats_watching_streak": {
+      "default": "серия просмотров"
+    },
+    "text_stats_watch_today": {
+      "default": "Посмотри что-нибудь сегодня"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "чтобы не прерывать серию!"
+    },
+    "text_stats_genre_other": {
+      "default": "Другое"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Вечность"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Мифический"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Легендарный"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Одержимый"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Инферно"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Пылающий"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "В огне"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Разминка"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Искра"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Каждый. Божий. День."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Другим такое только снится"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Это уже стиль жизни"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Без выходных"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Полное погружение"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Поддерживай огонь"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Привычка формируется"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Так держать"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Целый год!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Полгода!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 дней подряд!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 дней подряд!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "Целый месяц!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Две недели в ударе!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "Целая неделя!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Три дня позади!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Начало положено!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} месяц"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} мес."
+    },
+    "text_stats_streak_week": {
+      "default": "{count} неделя"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} нед."
+    },
+    "text_stats_streak_day": {
+      "default": "{count} день"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} дн."
+    },
+    "label_stats_plays": {
+      "default": "Просмотры"
+    },
+    "label_stats_episodes": {
+      "default": "Серии"
+    },
+    "label_stats_movies": {
+      "default": "Фильмы"
+    },
+    "label_stats_shows": {
+      "default": "Сериалы"
+    },
+    "label_stats_active_days": {
+      "default": "Активные дни"
+    },
+    "label_stats_busiest_day": {
+      "default": "Пиковый день"
+    },
+    "label_stats_best_day": {
+      "default": "Лучший день"
+    },
+    "label_stats_hours": {
+      "default": "Часы"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Статистика по жанрам"
+    },
+    "header_stats_this_week": {
+      "default": "На этой неделе"
+    },
+    "header_stats_graph_daily": {
+      "default": "Дневная активность"
+    },
+    "header_stats_graph_trend": {
+      "default": "Тренд недели"
+    },
+    "header_stats_graph_peak": {
+      "default": "Часы пик"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Сериалы vs фильмы"
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Dra i bilden för att justera"
+    },
+    "text_stats_today": {
+      "default": "Idag"
+    },
+    "text_stats_time_morning": {
+      "default": "Morgon"
+    },
+    "text_stats_time_afternoon": {
+      "default": "Eftermiddag"
+    },
+    "text_stats_time_evening": {
+      "default": "Kväll"
+    },
+    "text_stats_time_late_night": {
+      "default": "Sen natt"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count}v sedan"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count}v"
+    },
+    "text_stats_this_week": {
+      "default": "Denna vecka"
+    },
+    "text_stats_was_last_week": {
+      "default": "var {day} förra veckan"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "samma"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} avsnitt"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} filmer"
+    },
+    "text_stats_day_count": {
+      "default": "{count} dag"
+    },
+    "text_stats_days_count": {
+      "default": "{count} dagar"
+    },
+    "text_stats_watching_streak": {
+      "default": "tittarsvit"
+    },
+    "text_stats_watch_today": {
+      "default": "Se något idag"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "för att hålla din svit vid liv!"
+    },
+    "text_stats_genre_other": {
+      "default": "Övrigt"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Evig"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Mytisk"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Legendarisk"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Besatt"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Inferno"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Glödande"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "Brinnande"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Uppvärmning"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Gnistra"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Varje. Endaste. Dag."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Andra kan bara drömma"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Det är en livsstil nu"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Inga lediga dagar"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Fokuserad"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Håll elden vid liv"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Vanebildande"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Fortsätt så"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Ett helt år!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Ett halvår!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 dagar i sträck!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 dagar i sträck!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "En hel månad!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Två starka veckor!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "En hel vecka!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Tre dagar avklarade!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Det börjar!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} månad"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} månader"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} vecka"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} veckor"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} dag"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} dagar"
+    },
+    "label_stats_plays": {
+      "default": "Tittningar"
+    },
+    "label_stats_episodes": {
+      "default": "Avsnitt"
+    },
+    "label_stats_movies": {
+      "default": "Filmer"
+    },
+    "label_stats_shows": {
+      "default": "Serier"
+    },
+    "label_stats_active_days": {
+      "default": "Aktiva dagar"
+    },
+    "label_stats_busiest_day": {
+      "default": "Mest aktiv"
+    },
+    "label_stats_best_day": {
+      "default": "Bästa dagen"
+    },
+    "label_stats_hours": {
+      "default": "Timmar"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genrefördelning"
+    },
+    "header_stats_this_week": {
+      "default": "Denna vecka"
+    },
+    "header_stats_graph_daily": {
+      "default": "Daglig aktivitet"
+    },
+    "header_stats_graph_trend": {
+      "default": "Veckotrend"
+    },
+    "header_stats_graph_peak": {
+      "default": "Topptider"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Serier vs Filmer"
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -3002,6 +3002,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "Перетягніть зображення для налаштування"
+    },
+    "text_stats_today": {
+      "default": "Сьогодні"
+    },
+    "text_stats_time_morning": {
+      "default": "Ранок"
+    },
+    "text_stats_time_afternoon": {
+      "default": "День"
+    },
+    "text_stats_time_evening": {
+      "default": "Вечір"
+    },
+    "text_stats_time_late_night": {
+      "default": "Пізня ніч"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count}т. тому"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count}т."
+    },
+    "text_stats_this_week": {
+      "default": "Цього тижня"
+    },
+    "text_stats_was_last_week": {
+      "default": "був у {day} минулого тижня"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "без змін"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} серій"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} фільмів"
+    },
+    "text_stats_day_count": {
+      "default": "{count} день"
+    },
+    "text_stats_days_count": {
+      "default": "{count} днів"
+    },
+    "text_stats_watching_streak": {
+      "default": "днів поспіль"
+    },
+    "text_stats_watch_today": {
+      "default": "Подивіться щось сьогодні"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "щоб вогонь не згас!"
+    },
+    "text_stats_genre_other": {
+      "default": "Інше"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "Вічний"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "Міфічний"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "Легендарний"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "Одержимий"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "Пекельний"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "Палкий"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "У вогні"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "Розігрів"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "Іскра"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "Кожен. Божий. День."
+    },
+    "text_stats_streak_others_dream": {
+      "default": "Інші лише мріють про таке"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "Тепер це ваш стиль життя"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "Жодних вихідних"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "Повне занурення"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "Не збавляйте темп"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "Звичка формується"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "Тільки вперед"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "Цілий рік кіномарафону!"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "Пів року історій!"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "90 днів незламності!"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "60 днів у ритмі Trakt!"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "Цілий місяць разом!"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "Два тижні витримки!"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "Цілий тиждень!"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "Вже три дні!"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "Пригоди починаються!"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} місяць"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} місяців"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} тиждень"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} тижні"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} день"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} днів"
+    },
+    "label_stats_plays": {
+      "default": "Перегляди"
+    },
+    "label_stats_episodes": {
+      "default": "Серії"
+    },
+    "label_stats_movies": {
+      "default": "Фільми"
+    },
+    "label_stats_shows": {
+      "default": "Серіали"
+    },
+    "label_stats_active_days": {
+      "default": "Активні дні"
+    },
+    "label_stats_busiest_day": {
+      "default": "Найактивніший день"
+    },
+    "label_stats_best_day": {
+      "default": "Найкращий день"
+    },
+    "label_stats_hours": {
+      "default": "Години"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Жанровий розподіл"
+    },
+    "header_stats_this_week": {
+      "default": "Цього тижня"
+    },
+    "header_stats_graph_daily": {
+      "default": "Щоденна активність"
+    },
+    "header_stats_graph_trend": {
+      "default": "Тижневий тренд"
+    },
+    "header_stats_graph_peak": {
+      "default": "Пікові години"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "Серіали та фільми"
     }
   }
 }

--- a/projects/client/i18n/meta/zh-cn.json
+++ b/projects/client/i18n/meta/zh-cn.json
@@ -3001,6 +3001,204 @@
     },
     "label_drag_image_to_adjust": {
       "default": "拖动图像以调整位置"
+    },
+    "text_stats_today": {
+      "default": "今天"
+    },
+    "text_stats_time_morning": {
+      "default": "上午"
+    },
+    "text_stats_time_afternoon": {
+      "default": "下午"
+    },
+    "text_stats_time_evening": {
+      "default": "晚上"
+    },
+    "text_stats_time_late_night": {
+      "default": "深夜"
+    },
+    "text_stats_weeks_ago": {
+      "default": "{count}周前"
+    },
+    "text_stats_weeks_short": {
+      "default": "{count}周"
+    },
+    "text_stats_this_week": {
+      "default": "本周"
+    },
+    "text_stats_was_last_week": {
+      "default": "上周是{day}"
+    },
+    "text_stats_delta_up": {
+      "default": "+{count}"
+    },
+    "text_stats_delta_down": {
+      "default": "-{count}"
+    },
+    "text_stats_delta_same": {
+      "default": "持平"
+    },
+    "text_stats_episodes_count": {
+      "default": "{count} 集"
+    },
+    "text_stats_movies_count": {
+      "default": "{count} 部电影"
+    },
+    "text_stats_day_count": {
+      "default": "{count} 天"
+    },
+    "text_stats_days_count": {
+      "default": "{count} 天"
+    },
+    "text_stats_watching_streak": {
+      "default": "连胜记录"
+    },
+    "text_stats_watch_today": {
+      "default": "今天开看"
+    },
+    "text_stats_keep_streak_alive": {
+      "default": "让你的连胜记录延续下去！"
+    },
+    "text_stats_genre_other": {
+      "default": "其他"
+    },
+    "text_stats_streak_tier_eternal": {
+      "default": "永恒"
+    },
+    "text_stats_streak_tier_mythical": {
+      "default": "神话"
+    },
+    "text_stats_streak_tier_legendary": {
+      "default": "传奇"
+    },
+    "text_stats_streak_tier_obsessed": {
+      "default": "痴迷"
+    },
+    "text_stats_streak_tier_inferno": {
+      "default": "烈焰"
+    },
+    "text_stats_streak_tier_blazing": {
+      "default": "炽热"
+    },
+    "text_stats_streak_tier_on_fire": {
+      "default": "火热"
+    },
+    "text_stats_streak_tier_warm_up": {
+      "default": "热身"
+    },
+    "text_stats_streak_tier_spark": {
+      "default": "星火"
+    },
+    "text_stats_streak_every_single_day": {
+      "default": "日。复。一。日。"
+    },
+    "text_stats_streak_others_dream": {
+      "default": "他人梦寐以求"
+    },
+    "text_stats_streak_lifestyle": {
+      "default": "这已经是一种生活方式"
+    },
+    "text_stats_streak_no_days_off": {
+      "default": "全年无休"
+    },
+    "text_stats_streak_locked_in": {
+      "default": "全身心投入"
+    },
+    "text_stats_streak_keep_fire": {
+      "default": "保持那股火热"
+    },
+    "text_stats_streak_habit_forming": {
+      "default": "习惯成自然"
+    },
+    "text_stats_streak_keep_going": {
+      "default": "继续前进"
+    },
+    "text_stats_streak_exact_year": {
+      "default": "整整一年！"
+    },
+    "text_stats_streak_exact_half_year": {
+      "default": "半年了！"
+    },
+    "text_stats_streak_exact_90": {
+      "default": "连续 90 天！"
+    },
+    "text_stats_streak_exact_60": {
+      "default": "连续 60 天！"
+    },
+    "text_stats_streak_exact_month": {
+      "default": "整整一个月！"
+    },
+    "text_stats_streak_exact_two_weeks": {
+      "default": "坚持了两周！"
+    },
+    "text_stats_streak_exact_week": {
+      "default": "足足一周！"
+    },
+    "text_stats_streak_exact_three_days": {
+      "default": "连续三天！"
+    },
+    "text_stats_streak_exact_it_begins": {
+      "default": "开始了！"
+    },
+    "text_stats_streak_month": {
+      "default": "{count} 个月"
+    },
+    "text_stats_streak_months": {
+      "default": "{count} 个月"
+    },
+    "text_stats_streak_week": {
+      "default": "{count} 周"
+    },
+    "text_stats_streak_weeks": {
+      "default": "{count} 周"
+    },
+    "text_stats_streak_day": {
+      "default": "{count} 天"
+    },
+    "text_stats_streak_days": {
+      "default": "{count} 天"
+    },
+    "label_stats_plays": {
+      "default": "观看次数"
+    },
+    "label_stats_episodes": {
+      "default": "分集"
+    },
+    "label_stats_movies": {
+      "default": "电影"
+    },
+    "label_stats_shows": {
+      "default": "剧集"
+    },
+    "label_stats_active_days": {
+      "default": "活跃天数"
+    },
+    "label_stats_busiest_day": {
+      "default": "最忙碌的一天"
+    },
+    "label_stats_best_day": {
+      "default": "表现最佳的一天"
+    },
+    "label_stats_hours": {
+      "default": "小时"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "类型分布"
+    },
+    "header_stats_this_week": {
+      "default": "本周"
+    },
+    "header_stats_graph_daily": {
+      "default": "每日动态"
+    },
+    "header_stats_graph_trend": {
+      "default": "周趋势图"
+    },
+    "header_stats_graph_peak": {
+      "default": "高峰时段"
+    },
+    "header_stats_graph_shows_movies": {
+      "default": "剧集 vs 电影"
     }
   }
 }

--- a/projects/client/src/lib/sections/stats/GenreBreakdown.svelte
+++ b/projects/client/src/lib/sections/stats/GenreBreakdown.svelte
@@ -2,14 +2,16 @@
   import { useUser } from "$lib/features/auth/stores/useUser";
   import { languageTag } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
-  import { useGenreBreakdown } from "./_internal/useGenreBreakdown";
+  import { DAY_COUNT, useGenreBreakdown } from "./_internal/useGenreBreakdown";
+
+  const GENRE_MID_INDEX = Math.floor(DAY_COUNT / 2);
 
   const { user } = useUser();
   const { data, isLoading } = $derived(useGenreBreakdown({ slug: $user.slug }));
 
   const dateRange = $derived.by(() => {
     const now = new Date();
-    const rangeStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 13);
+    const rangeStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - (DAY_COUNT - 1));
     return `${rangeStart.toLocaleString(languageTag(), { month: "short", day: "numeric" })} – ${now.toLocaleString(languageTag(), { month: "short", day: "numeric" })}`;
   });
 
@@ -17,7 +19,7 @@
 
   const midDate = $derived.by(() => {
     if (!$data) return "";
-    const mid = $data.days[7];
+    const mid = $data.days[GENRE_MID_INDEX];
     if (!mid) return "";
     return mid.date.toLocaleString(languageTag(), { month: "short", day: "numeric" });
   });
@@ -85,40 +87,48 @@
 <style lang="scss">
   .trakt-genre-breakdown {
     margin: 0 var(--layout-distance-side);
-    padding: var(--ni-16) var(--ni-24);
-    background: var(--shade-930);
-    border: 1px solid var(--shade-910);
-    border-radius: var(--border-radius-l);
+    padding: var(--ni-24) var(--ni-28);
+    background: linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.04) 0%,
+      rgba(255, 255, 255, 0.01) 100%
+    );
+    backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 20px;
+    box-shadow:
+      0 8px 32px rgba(0, 0, 0, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
   }
 
   .trakt-genre-header {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
-    margin-bottom: var(--ni-16);
+    margin-bottom: var(--ni-20);
   }
 
   .trakt-genre-title {
     display: flex;
     align-items: center;
-    gap: var(--ni-8);
-    color: var(--shade-400);
-    font-size: var(--ni-12);
+    gap: 10px;
+    color: rgba(255, 255, 255, 0.5);
+    font-size: var(--ni-13);
     font-weight: 600;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
+    letter-spacing: 0.04em;
   }
 
   .trakt-genre-dot {
-    width: var(--ni-8);
-    height: var(--ni-8);
+    width: 6px;
+    height: 6px;
     border-radius: 50%;
     background: var(--green-500);
+    box-shadow: 0 0 8px rgba(74, 222, 128, 0.5);
     flex-shrink: 0;
   }
 
   .trakt-genre-range {
-    color: var(--shade-500);
+    color: rgba(255, 255, 255, 0.25);
     font-size: var(--ni-12);
   }
 
@@ -135,7 +145,7 @@
   .trakt-genre-bars {
     display: flex;
     align-items: flex-end;
-    gap: var(--ni-4);
+    gap: 6px;
     height: var(--ni-120);
   }
 
@@ -150,14 +160,16 @@
     width: 100%;
     display: flex;
     flex-direction: column;
-    border-radius: var(--ni-2) var(--ni-2) 0 0;
+    border-radius: 6px 6px 0 0;
     overflow: hidden;
-    gap: 1px;
+    gap: 2px;
     min-height: 0;
   }
 
   .trakt-genre-segment {
     min-height: var(--ni-2);
+    border-radius: 1px;
+    opacity: 0.85;
   }
 
   .trakt-genre-date-labels {
@@ -167,40 +179,41 @@
   }
 
   .trakt-genre-date-label {
-    color: var(--shade-500);
-    font-size: var(--ni-12);
+    color: rgba(255, 255, 255, 0.2);
+    font-size: var(--ni-11);
   }
 
   .trakt-genre-legend {
     display: flex;
     flex-direction: column;
-    gap: var(--ni-8);
+    gap: 10px;
     justify-content: center;
     flex-shrink: 0;
-    min-width: var(--ni-120);
+    min-width: 130px;
   }
 
   .trakt-genre-legend-item {
     display: flex;
     align-items: center;
-    gap: var(--ni-8);
+    gap: 10px;
   }
 
   .trakt-genre-legend-dot {
-    width: var(--ni-8);
-    height: var(--ni-8);
-    border-radius: 50%;
+    width: 10px;
+    height: 10px;
+    border-radius: 4px;
+    opacity: 0.85;
     flex-shrink: 0;
   }
 
   .trakt-genre-legend-label {
-    color: var(--shade-400);
+    color: rgba(255, 255, 255, 0.45);
     font-size: var(--ni-12);
     flex: 1;
   }
 
   .trakt-genre-legend-pct {
-    color: var(--shade-300);
+    color: rgba(255, 255, 255, 0.7);
     font-size: var(--ni-12);
     font-weight: 600;
   }

--- a/projects/client/src/lib/sections/stats/GenreBreakdown.svelte
+++ b/projects/client/src/lib/sections/stats/GenreBreakdown.svelte
@@ -16,7 +16,7 @@
 
   const midDate = $derived.by(() => {
     if (!$data) return "";
-    const mid = $data.days[6];
+    const mid = $data.days[7];
     if (!mid) return "";
     return mid.date.toLocaleString(languageTag(), { month: "short", day: "numeric" });
   });
@@ -42,12 +42,12 @@
     <div class="trakt-genre-body">
       <div class="trakt-genre-chart-area">
         <div class="trakt-genre-bars">
-          {#each $data!.days as day}
+          {#each $data!.days as day, di (di)}
             <div class="trakt-genre-bar-col">
               <div class="trakt-genre-bar" style:height="{$data!.maxDayTotal > 0 ? (day.total / $data!.maxDayTotal) * 100 : 0}%">
-                {#each [...day.segments].reverse() as segment}
+                {#each [...day.segments].reverse() as segment, ri (ri)}
                   {#if segment.count > 0}
-                    {@const segIndex = day.segments.indexOf(segment)}
+                    {@const segIndex = day.segments.length - 1 - ri}
                     {@const legendEntry = $data!.legend[segIndex]}
                     <div
                       class="trakt-genre-segment"
@@ -69,7 +69,7 @@
       </div>
 
       <div class="trakt-genre-legend">
-        {#each $data!.legend as entry}
+        {#each $data!.legend as entry (entry.genre)}
           <div class="trakt-genre-legend-item">
             <span class="trakt-genre-legend-dot" style:background-color={entry.color}></span>
             <span class="trakt-genre-legend-label">{entry.label}</span>
@@ -156,7 +156,7 @@
   }
 
   .trakt-genre-segment {
-    min-height: 2px;
+    min-height: var(--ni-2);
   }
 
   .trakt-genre-date-labels {
@@ -176,7 +176,7 @@
     gap: var(--ni-8);
     justify-content: center;
     flex-shrink: 0;
-    min-width: 120px;
+    min-width: var(--ni-120);
   }
 
   .trakt-genre-legend-item {

--- a/projects/client/src/lib/sections/stats/GenreBreakdown.svelte
+++ b/projects/client/src/lib/sections/stats/GenreBreakdown.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+  import { useUser } from "$lib/features/auth/stores/useUser";
+  import { languageTag } from "$lib/features/i18n";
+  import { useGenreBreakdown } from "./_internal/useGenreBreakdown";
+
+  const { user } = useUser();
+  const { data, isLoading } = $derived(useGenreBreakdown({ slug: $user.slug }));
+
+  const dateRange = $derived.by(() => {
+    const now = new Date();
+    const rangeStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 13);
+    return `${rangeStart.toLocaleString(languageTag(), { month: "short", day: "numeric" })} – ${now.toLocaleString(languageTag(), { month: "short", day: "numeric" })}`;
+  });
+
+  const shouldShow = $derived(!$isLoading && $data && $data.days.some(d => d.total > 0));
+
+  const midDate = $derived.by(() => {
+    if (!$data) return "";
+    const mid = $data.days[6];
+    if (!mid) return "";
+    return mid.date.toLocaleString(languageTag(), { month: "short", day: "numeric" });
+  });
+
+  const startLabel = $derived.by(() => {
+    if (!$data) return "";
+    const first = $data.days[0];
+    if (!first) return "";
+    return first.date.toLocaleString(languageTag(), { month: "short", day: "numeric" });
+  });
+</script>
+
+{#if shouldShow}
+  <div class="trakt-genre-breakdown">
+    <div class="trakt-genre-header">
+      <p class="trakt-genre-title">
+        <span class="trakt-genre-dot"></span>
+        LAST 14 DAYS — GENRE BREAKDOWN
+      </p>
+      <p class="trakt-genre-range">{dateRange}</p>
+    </div>
+
+    <div class="trakt-genre-body">
+      <div class="trakt-genre-chart-area">
+        <div class="trakt-genre-bars">
+          {#each $data!.days as day}
+            <div class="trakt-genre-bar-col">
+              <div class="trakt-genre-bar" style:height="{$data!.maxDayTotal > 0 ? (day.total / $data!.maxDayTotal) * 100 : 0}%">
+                {#each [...day.segments].reverse() as segment}
+                  {#if segment.count > 0}
+                    {@const segIndex = day.segments.indexOf(segment)}
+                    {@const legendEntry = $data!.legend[segIndex]}
+                    <div
+                      class="trakt-genre-segment"
+                      style:background-color={legendEntry?.color ?? '#555555'}
+                      style:flex-grow={segment.count}
+                    ></div>
+                  {/if}
+                {/each}
+              </div>
+            </div>
+          {/each}
+        </div>
+
+        <div class="trakt-genre-date-labels">
+          <span class="trakt-genre-date-label">{startLabel}</span>
+          <span class="trakt-genre-date-label">{midDate}</span>
+          <span class="trakt-genre-date-label">Today</span>
+        </div>
+      </div>
+
+      <div class="trakt-genre-legend">
+        {#each $data!.legend as entry}
+          <div class="trakt-genre-legend-item">
+            <span class="trakt-genre-legend-dot" style:background-color={entry.color}></span>
+            <span class="trakt-genre-legend-label">{entry.label}</span>
+            <span class="trakt-genre-legend-pct">{entry.percentage}%</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style lang="scss">
+  .trakt-genre-breakdown {
+    margin: 0 var(--layout-distance-side);
+    padding: var(--ni-16) var(--ni-24);
+    background: var(--shade-930);
+    border: 1px solid var(--shade-910);
+    border-radius: var(--border-radius-l);
+  }
+
+  .trakt-genre-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: var(--ni-16);
+  }
+
+  .trakt-genre-title {
+    display: flex;
+    align-items: center;
+    gap: var(--ni-8);
+    color: var(--shade-400);
+    font-size: var(--ni-12);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .trakt-genre-dot {
+    width: var(--ni-8);
+    height: var(--ni-8);
+    border-radius: 50%;
+    background: var(--green-500);
+    flex-shrink: 0;
+  }
+
+  .trakt-genre-range {
+    color: var(--shade-500);
+    font-size: var(--ni-12);
+  }
+
+  .trakt-genre-body {
+    display: flex;
+    gap: var(--ni-24);
+  }
+
+  .trakt-genre-chart-area {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .trakt-genre-bars {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--ni-4);
+    height: var(--ni-120);
+  }
+
+  .trakt-genre-bar-col {
+    flex: 1;
+    display: flex;
+    align-items: flex-end;
+    height: 100%;
+  }
+
+  .trakt-genre-bar {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    border-radius: var(--ni-2) var(--ni-2) 0 0;
+    overflow: hidden;
+    gap: 1px;
+    min-height: 0;
+  }
+
+  .trakt-genre-segment {
+    min-height: 2px;
+  }
+
+  .trakt-genre-date-labels {
+    display: flex;
+    justify-content: space-between;
+    margin-top: var(--ni-8);
+  }
+
+  .trakt-genre-date-label {
+    color: var(--shade-500);
+    font-size: var(--ni-12);
+  }
+
+  .trakt-genre-legend {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-8);
+    justify-content: center;
+    flex-shrink: 0;
+    min-width: 120px;
+  }
+
+  .trakt-genre-legend-item {
+    display: flex;
+    align-items: center;
+    gap: var(--ni-8);
+  }
+
+  .trakt-genre-legend-dot {
+    width: var(--ni-8);
+    height: var(--ni-8);
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .trakt-genre-legend-label {
+    color: var(--shade-400);
+    font-size: var(--ni-12);
+    flex: 1;
+  }
+
+  .trakt-genre-legend-pct {
+    color: var(--shade-300);
+    font-size: var(--ni-12);
+    font-weight: 600;
+  }
+</style>

--- a/projects/client/src/lib/sections/stats/GenreBreakdown.svelte
+++ b/projects/client/src/lib/sections/stats/GenreBreakdown.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { useUser } from "$lib/features/auth/stores/useUser";
   import { languageTag } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
   import { useGenreBreakdown } from "./_internal/useGenreBreakdown";
 
   const { user } = useUser();
@@ -34,7 +35,7 @@
     <div class="trakt-genre-header">
       <p class="trakt-genre-title">
         <span class="trakt-genre-dot"></span>
-        LAST 14 DAYS — GENRE BREAKDOWN
+        {m.header_stats_genre_breakdown()}
       </p>
       <p class="trakt-genre-range">{dateRange}</p>
     </div>
@@ -64,7 +65,7 @@
         <div class="trakt-genre-date-labels">
           <span class="trakt-genre-date-label">{startLabel}</span>
           <span class="trakt-genre-date-label">{midDate}</span>
-          <span class="trakt-genre-date-label">Today</span>
+          <span class="trakt-genre-date-label">{m.text_stats_today()}</span>
         </div>
       </div>
 

--- a/projects/client/src/lib/sections/stats/StreakCallout.svelte
+++ b/projects/client/src/lib/sections/stats/StreakCallout.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  import { useUser } from "$lib/features/auth/stores/useUser";
+  import StreakAccumulator from "./_internal/StreakAccumulator.svelte";
+  import { useStreak } from "./_internal/useStreak";
+
+  const { user } = useUser();
+
+  const { streakCount, streakState, isLoading } = $derived(
+    useStreak({ slug: $user.slug }),
+  );
+
+  type Tier = {
+    name: string;
+    emoji: string;
+    message: string;
+  };
+
+  type TierDef = {
+    threshold: number;
+    tier: Tier;
+    exactMessage?: string;
+  };
+
+  const TIERS: TierDef[] = [
+    { threshold: 365, tier: { name: "Eternal", emoji: "👑", message: "Every. Single. Day." }, exactMessage: "A full year. Not a single day missed." },
+    { threshold: 180, tier: { name: "Mythical", emoji: "🌟", message: "Every. Single. Day." }, exactMessage: "Half a year without missing a day." },
+    { threshold: 90, tier: { name: "Legendary", emoji: "⚡", message: "Others only dream of this." }, exactMessage: "90 days. A true legend." },
+    { threshold: 60, tier: { name: "Obsessed", emoji: "💥", message: "At this point it's a lifestyle." }, exactMessage: "60 days. Officially obsessed." },
+    { threshold: 30, tier: { name: "Inferno", emoji: "💥", message: "No days off." }, exactMessage: "A full month. Not a single day missed." },
+    { threshold: 14, tier: { name: "Blazing", emoji: "🔥", message: "You're locked in." }, exactMessage: "Two full weeks. You're locked in." },
+    { threshold: 7, tier: { name: "On Fire", emoji: "🔥", message: "Keep the fire going!" }, exactMessage: "A full week of watching." },
+    { threshold: 3, tier: { name: "Warm Up", emoji: "🔥", message: "A habit is forming." }, exactMessage: "Three days running." },
+    { threshold: 1, tier: { name: "Spark", emoji: "🕯️", message: "Keep it going tomorrow!" }, exactMessage: "It begins." },
+  ];
+
+  const currentTier = $derived.by(() => {
+    const count = $streakCount;
+    for (const { threshold, tier, exactMessage } of TIERS) {
+      if (count >= threshold) {
+        return {
+          ...tier,
+          message: count === threshold && exactMessage ? exactMessage : tier.message,
+        };
+      }
+    }
+    return TIERS[TIERS.length - 1]!.tier;
+  });
+
+  const shouldShow = $derived(!$isLoading && $streakState !== 'none');
+  const isBroken = $derived($streakState === 'broken');
+</script>
+
+{#if shouldShow}
+  <div class="trakt-streak-callout" data-broken={isBroken || undefined}>
+    <div class="trakt-streak-left">
+      <div class="trakt-streak-flame">
+        {currentTier.emoji}
+      </div>
+
+      <div class="trakt-streak-info">
+        <p class="trakt-streak-title">
+          <span class="trakt-streak-count">{$streakCount} day</span> {isBroken ? "streak ended" : "watching streak"}
+        </p>
+        <p class="trakt-streak-subtitle secondary">
+          {#if isBroken}
+            Your {$streakCount} day streak ended yesterday. Start a new one!
+          {:else}
+            {currentTier.message}
+          {/if}
+        </p>
+      </div>
+    </div>
+
+    {#if !isBroken}
+      <StreakAccumulator days={$streakCount} />
+    {/if}
+  </div>
+{/if}
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-streak-callout {
+    margin: 0 var(--layout-distance-side);
+    padding: var(--ni-16) var(--ni-24);
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gap-l);
+
+    background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--purple-900) 30%, var(--shade-930)) 0%,
+      var(--shade-930) 100%
+    );
+    border: 1px solid color-mix(in srgb, var(--purple-800) 25%, var(--shade-910));
+    border-radius: var(--border-radius-l);
+
+    &[data-broken] {
+      opacity: 0.6;
+    }
+  }
+
+  .trakt-streak-left {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-m);
+    min-width: 0;
+  }
+
+  .trakt-streak-flame {
+    width: var(--ni-48);
+    height: var(--ni-48);
+    border-radius: var(--border-radius-m);
+    background: color-mix(in srgb, var(--purple-900) 50%, transparent);
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--ni-28);
+    flex-shrink: 0;
+  }
+
+  .trakt-streak-info {
+    min-width: 0;
+  }
+
+  .trakt-streak-title {
+    font-size: var(--ni-18);
+    font-weight: 600;
+  }
+
+  .trakt-streak-count {
+    font-size: var(--ni-22);
+    color: var(--purple-400);
+  }
+
+  .trakt-streak-subtitle {
+    font-size: var(--font-size-text);
+    margin-top: var(--ni-4);
+  }
+</style>

--- a/projects/client/src/lib/sections/stats/StreakCallout.svelte
+++ b/projects/client/src/lib/sections/stats/StreakCallout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { useUser } from "$lib/features/auth/stores/useUser";
+  import * as m from "$lib/features/i18n/messages.ts";
   import StreakAccumulator from "./_internal/StreakAccumulator.svelte";
   import { useStreak } from "./_internal/useStreak";
 
@@ -22,15 +23,15 @@
   };
 
   const TIERS: TierDef[] = [
-    { threshold: 365, tier: { name: "Eternal", emoji: "👑", message: "Every. Single. Day." }, exactMessage: "A full year. Not a single day missed." },
-    { threshold: 180, tier: { name: "Mythical", emoji: "🌟", message: "Every. Single. Day." }, exactMessage: "Half a year without missing a day." },
-    { threshold: 90, tier: { name: "Legendary", emoji: "⚡", message: "Others only dream of this." }, exactMessage: "90 days. A true legend." },
-    { threshold: 60, tier: { name: "Obsessed", emoji: "💥", message: "At this point it's a lifestyle." }, exactMessage: "60 days. Officially obsessed." },
-    { threshold: 30, tier: { name: "Inferno", emoji: "💥", message: "No days off." }, exactMessage: "A full month. Not a single day missed." },
-    { threshold: 14, tier: { name: "Blazing", emoji: "🔥", message: "You're locked in." }, exactMessage: "Two full weeks. You're locked in." },
-    { threshold: 7, tier: { name: "On Fire", emoji: "🔥", message: "Keep the fire going!" }, exactMessage: "A full week of watching." },
-    { threshold: 3, tier: { name: "Warm Up", emoji: "🔥", message: "A habit is forming." }, exactMessage: "Three days running." },
-    { threshold: 1, tier: { name: "Spark", emoji: "🕯️", message: "Keep it going tomorrow!" }, exactMessage: "It begins." },
+    { threshold: 365, tier: { name: m.text_stats_streak_tier_eternal(), emoji: "👑", message: m.text_stats_streak_every_single_day() }, exactMessage: m.text_stats_streak_exact_year() },
+    { threshold: 180, tier: { name: m.text_stats_streak_tier_mythical(), emoji: "🌟", message: m.text_stats_streak_every_single_day() }, exactMessage: m.text_stats_streak_exact_half_year() },
+    { threshold: 90, tier: { name: m.text_stats_streak_tier_legendary(), emoji: "⚡", message: m.text_stats_streak_others_dream() }, exactMessage: m.text_stats_streak_exact_90() },
+    { threshold: 60, tier: { name: m.text_stats_streak_tier_obsessed(), emoji: "💥", message: m.text_stats_streak_lifestyle() }, exactMessage: m.text_stats_streak_exact_60() },
+    { threshold: 30, tier: { name: m.text_stats_streak_tier_inferno(), emoji: "💥", message: m.text_stats_streak_no_days_off() }, exactMessage: m.text_stats_streak_exact_month() },
+    { threshold: 14, tier: { name: m.text_stats_streak_tier_blazing(), emoji: "🔥", message: m.text_stats_streak_locked_in() }, exactMessage: m.text_stats_streak_exact_two_weeks() },
+    { threshold: 7, tier: { name: m.text_stats_streak_tier_on_fire(), emoji: "🔥", message: m.text_stats_streak_keep_fire() }, exactMessage: m.text_stats_streak_exact_week() },
+    { threshold: 3, tier: { name: m.text_stats_streak_tier_warm_up(), emoji: "🔥", message: m.text_stats_streak_habit_forming() }, exactMessage: m.text_stats_streak_exact_three_days() },
+    { threshold: 1, tier: { name: m.text_stats_streak_tier_spark(), emoji: "🕯️", message: m.text_stats_streak_keep_going() }, exactMessage: m.text_stats_streak_exact_it_begins() },
   ];
 
   const currentTier = $derived.by(() => {
@@ -46,12 +47,18 @@
     return TIERS[TIERS.length - 1]!.tier;
   });
 
+  const streakLabel = $derived(
+    $streakCount === 1
+      ? m.text_stats_day_count({ count: String($streakCount) })
+      : m.text_stats_days_count({ count: String($streakCount) }),
+  );
+
   const shouldShow = $derived(!$isLoading && $streakState !== 'none');
-  const isBroken = $derived($streakState === 'broken');
+  const isAtRisk = $derived($streakState === 'at_risk');
 </script>
 
 {#if shouldShow}
-  <div class="trakt-streak-callout" data-broken={isBroken || undefined}>
+  <div class="trakt-streak-callout" data-at-risk={isAtRisk || undefined}>
     <div class="trakt-streak-left">
       <div class="trakt-streak-flame">
         {currentTier.emoji}
@@ -59,11 +66,11 @@
 
       <div class="trakt-streak-info">
         <p class="trakt-streak-title">
-          <span class="trakt-streak-count">{$streakCount} day</span> {isBroken ? "streak ended" : "watching streak"}
+          <span class="trakt-streak-count">{streakLabel}</span> {m.text_stats_watching_streak()}
         </p>
         <p class="trakt-streak-subtitle secondary">
-          {#if isBroken}
-            Your {$streakCount} day streak ended yesterday. Start a new one!
+          {#if isAtRisk}
+            <span class="trakt-streak-warning">{m.text_stats_watch_today()}</span> {m.text_stats_keep_streak_alive()}
           {:else}
             {currentTier.message}
           {/if}
@@ -71,9 +78,7 @@
       </div>
     </div>
 
-    {#if !isBroken}
-      <StreakAccumulator days={$streakCount} />
-    {/if}
+    <StreakAccumulator days={$streakCount} />
   </div>
 {/if}
 
@@ -97,8 +102,8 @@
     border: 1px solid color-mix(in srgb, var(--purple-800) 25%, var(--shade-910));
     border-radius: var(--border-radius-l);
 
-    &[data-broken] {
-      opacity: 0.6;
+    &[data-at-risk] {
+      opacity: 0.8;
     }
   }
 
@@ -139,5 +144,13 @@
   .trakt-streak-subtitle {
     font-size: var(--font-size-text);
     margin-top: var(--ni-4);
+  }
+
+  .trakt-streak-warning {
+    color: var(--orange-400);
+    background: color-mix(in srgb, var(--orange-900) 35%, transparent);
+    padding: var(--ni-1) var(--ni-6);
+    border-radius: var(--ni-4);
+    font-weight: 600;
   }
 </style>

--- a/projects/client/src/lib/sections/stats/WeeklyPulse.svelte
+++ b/projects/client/src/lib/sections/stats/WeeklyPulse.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import CalendarIcon from "$lib/components/icons/CalendarIcon.svelte";
+  import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
+  import CommentIcon from "$lib/components/icons/CommentIcon.svelte";
+  import DiscoverIcon from "$lib/components/icons/DiscoverIcon.svelte";
+  import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
+  import PlayIcon from "$lib/components/icons/PlayIcon.svelte";
+  import RatingsIcon from "$lib/components/icons/RatingsIcon.svelte";
+  import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
+  import TrendIcon from "$lib/components/icons/TrendIcon.svelte";
+  import ListIcon from "$lib/components/icons/mobile/ListIcon.svelte";
+  import { useUser } from "$lib/features/auth/stores/useUser";
+  import { languageTag } from "$lib/features/i18n";
+  import PulseCell from "./_internal/PulseCell.svelte";
+  import PulseGraph from "./_internal/PulseGraph.svelte";
+  import { useWeeklyPulse } from "./_internal/useWeeklyPulse";
+
+  const { user } = useUser();
+
+  const { stats, graphData, selectedGraph, isLoading } = $derived(
+    useWeeklyPulse({ slug: $user.slug }),
+  );
+
+  const dateRange = $derived.by(() => {
+    const now = new Date();
+    const weekStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6);
+    return `${weekStart.toLocaleString(languageTag(), { month: "short", day: "numeric" })} – ${now.toLocaleString(languageTag(), { month: "short", day: "numeric" })}`;
+  });
+
+  // Graph takes 2 cell slots, so show 4 cells + graph. No graph = 6 cells.
+  const cellCount = $derived($selectedGraph ? 4 : 6);
+  const visibleStats = $derived(($stats ?? []).slice(0, cellCount));
+  const shouldShow = $derived(!$isLoading && visibleStats.length > 0);
+</script>
+
+{#if shouldShow}
+  <div class="trakt-weekly-pulse">
+    <div class="trakt-weekly-pulse-header">
+      <p class="trakt-weekly-pulse-title bold">This Week</p>
+      <p class="trakt-weekly-pulse-range tag secondary">{dateRange}</p>
+    </div>
+
+    <div class="trakt-weekly-pulse-grid">
+      {#each visibleStats as stat (stat.key)}
+        <PulseCell value={stat.value} label={stat.label} delta={stat.delta} note={stat.note}>
+          {#snippet icon()}
+            {#if stat.key === "totalPlays"}
+              <PlayIcon />
+            {:else if stat.key === "episodes"}
+              <ShowIcon />
+            {:else if stat.key === "movies"}
+              <MovieIcon />
+            {:else if stat.key === "shows"}
+              <DiscoverIcon />
+            {:else if stat.key === "activeDays"}
+              <CalendarIcon />
+            {:else if stat.key === "busiestDay"}
+              <TrendIcon direction="up" />
+            {:else if stat.key === "longestBinge"}
+              <PlayIcon />
+            {:else if stat.key === "ratings"}
+              <RatingsIcon />
+            {:else if stat.key === "comments"}
+              <CommentIcon />
+            {:else if stat.key === "lists"}
+              <ListIcon />
+            {:else if stat.key === "hours"}
+              <ClockIcon />
+            {/if}
+          {/snippet}
+        </PulseCell>
+      {/each}
+
+      {#if $selectedGraph && $graphData}
+        <PulseGraph type={$selectedGraph} data={$graphData} />
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style lang="scss">
+  .trakt-weekly-pulse {
+    padding: var(--ni-4) var(--layout-distance-side);
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+
+  .trakt-weekly-pulse-header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--gap-xs);
+  }
+
+  .trakt-weekly-pulse-title {
+    font-size: var(--font-size-text);
+  }
+
+  .trakt-weekly-pulse-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-xs);
+  }
+</style>

--- a/projects/client/src/lib/sections/stats/WeeklyPulse.svelte
+++ b/projects/client/src/lib/sections/stats/WeeklyPulse.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
   import CalendarIcon from "$lib/components/icons/CalendarIcon.svelte";
   import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
-  import CommentIcon from "$lib/components/icons/CommentIcon.svelte";
   import DiscoverIcon from "$lib/components/icons/DiscoverIcon.svelte";
   import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
   import PlayIcon from "$lib/components/icons/PlayIcon.svelte";
-  import RatingsIcon from "$lib/components/icons/RatingsIcon.svelte";
   import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
   import TrendIcon from "$lib/components/icons/TrendIcon.svelte";
-  import ListIcon from "$lib/components/icons/mobile/ListIcon.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import { languageTag } from "$lib/features/i18n";
   import PulseCell from "./_internal/PulseCell.svelte";
@@ -58,12 +55,6 @@
               <TrendIcon direction="up" />
             {:else if stat.key === "longestBinge"}
               <PlayIcon />
-            {:else if stat.key === "ratings"}
-              <RatingsIcon />
-            {:else if stat.key === "comments"}
-              <CommentIcon />
-            {:else if stat.key === "lists"}
-              <ListIcon />
             {:else if stat.key === "hours"}
               <ClockIcon />
             {/if}
@@ -72,7 +63,7 @@
       {/each}
 
       {#if $selectedGraph && $graphData}
-        <PulseGraph type={$selectedGraph} data={$graphData} />
+        <PulseGraph kind={$selectedGraph} data={$graphData} />
       {/if}
     </div>
   </div>

--- a/projects/client/src/lib/sections/stats/WeeklyPulse.svelte
+++ b/projects/client/src/lib/sections/stats/WeeklyPulse.svelte
@@ -8,6 +8,7 @@
   import TrendIcon from "$lib/components/icons/TrendIcon.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import { languageTag } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
   import PulseCell from "./_internal/PulseCell.svelte";
   import PulseGraph from "./_internal/PulseGraph.svelte";
   import { useWeeklyPulse } from "./_internal/useWeeklyPulse";
@@ -33,7 +34,7 @@
 {#if shouldShow}
   <div class="trakt-weekly-pulse">
     <div class="trakt-weekly-pulse-header">
-      <p class="trakt-weekly-pulse-title bold">This Week</p>
+      <p class="trakt-weekly-pulse-title bold">{m.header_stats_this_week()}</p>
       <p class="trakt-weekly-pulse-range tag secondary">{dateRange}</p>
     </div>
 

--- a/projects/client/src/lib/sections/stats/WeeklyPulse.svelte
+++ b/projects/client/src/lib/sections/stats/WeeklyPulse.svelte
@@ -19,14 +19,17 @@
     useWeeklyPulse({ slug: $user.slug }),
   );
 
+  const WEEK_RANGE_OFFSET = 6;
+  const CELLS_WITH_GRAPH = 4;
+  const CELLS_WITHOUT_GRAPH = 6;
+
   const dateRange = $derived.by(() => {
     const now = new Date();
-    const weekStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6);
+    const weekStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - WEEK_RANGE_OFFSET);
     return `${weekStart.toLocaleString(languageTag(), { month: "short", day: "numeric" })} – ${now.toLocaleString(languageTag(), { month: "short", day: "numeric" })}`;
   });
 
-  // Graph takes 2 cell slots, so show 4 cells + graph. No graph = 6 cells.
-  const cellCount = $derived($selectedGraph ? 4 : 6);
+  const cellCount = $derived($selectedGraph ? CELLS_WITH_GRAPH : CELLS_WITHOUT_GRAPH);
   const visibleStats = $derived(($stats ?? []).slice(0, cellCount));
   const shouldShow = $derived(!$isLoading && visibleStats.length > 0);
 </script>

--- a/projects/client/src/lib/sections/stats/_internal/PulseCell.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseCell.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  const {
+    icon,
+    value,
+    label,
+    delta = null,
+    note,
+  }: {
+    icon: Snippet;
+    value: string;
+    label: string;
+    delta?: number | null;
+    note?: string;
+  } = $props();
+
+  const direction = $derived(
+    delta == null ? null : delta > 0 ? "up" : delta < 0 ? "down" : "flat",
+  );
+</script>
+
+<div class="trakt-pulse-cell">
+  <div class="trakt-pulse-cell-icon">
+    {@render icon()}
+  </div>
+
+  <div class="trakt-pulse-cell-body">
+    <p class="trakt-pulse-cell-value">{value}</p>
+    <p class="trakt-pulse-cell-label">{label}</p>
+  </div>
+
+  {#if note}
+    <div class="trakt-pulse-cell-pill" data-direction="neutral">
+      {note}
+    </div>
+  {:else if delta != null && direction}
+    <div class="trakt-pulse-cell-pill" data-direction={direction}>
+      {#if delta > 0}
+        ▲ {delta} vs last week
+      {:else if delta < 0}
+        ▼ {Math.abs(delta)} vs last week
+      {:else}
+        — same
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  .trakt-pulse-cell {
+    flex: 1 0 var(--ni-148);
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-10);
+    padding: var(--ni-16);
+
+    background: var(--shade-930);
+    border: 1px solid var(--shade-910);
+    border-radius: var(--border-radius-m);
+    overflow: hidden;
+  }
+
+  .trakt-pulse-cell-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: var(--ni-28);
+    height: var(--ni-28);
+    border-radius: var(--border-radius-s);
+    background: color-mix(in srgb, var(--purple-900) 50%, transparent);
+
+    :global(svg) {
+      width: var(--ni-16);
+      height: var(--ni-16);
+      color: var(--purple-400);
+    }
+  }
+
+  .trakt-pulse-cell-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-4);
+    flex: 1;
+  }
+
+  .trakt-pulse-cell-value {
+    font-size: var(--ni-32);
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .trakt-pulse-cell-label {
+    font-size: var(--ni-13);
+    color: var(--shade-400);
+  }
+
+  .trakt-pulse-cell-pill {
+    display: inline-flex;
+    align-self: flex-start;
+    padding: var(--ni-4) var(--ni-8);
+    border-radius: var(--border-radius-s);
+    font-size: var(--ni-11);
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+
+    &[data-direction="up"] {
+      color: var(--green-500);
+      background: color-mix(in srgb, var(--green-900) 40%, transparent);
+    }
+
+    &[data-direction="down"] {
+      color: var(--red-500);
+      background: color-mix(in srgb, var(--red-900) 40%, transparent);
+    }
+
+    &[data-direction="flat"],
+    &[data-direction="neutral"] {
+      color: var(--shade-500);
+      background: color-mix(in srgb, var(--shade-900) 50%, transparent);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/stats/_internal/PulseCell.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseCell.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
   import type { Snippet } from "svelte";
 
   const {
@@ -37,11 +38,11 @@
   {:else if delta != null && direction}
     <div class="trakt-pulse-cell-pill" data-direction={direction}>
       {#if delta > 0}
-        ▲ {delta} vs last week
+        {m.text_stats_delta_up({ count: String(delta) })}
       {:else if delta < 0}
-        ▼ {Math.abs(delta)} vs last week
+        {m.text_stats_delta_down({ count: String(Math.abs(delta)) })}
       {:else}
-        — same
+        {m.text_stats_delta_same()}
       {/if}
     </div>
   {/if}

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraph.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraph.svelte
@@ -1,29 +1,21 @@
 <script lang="ts">
-  import type { PulseGraphData } from "./useWeeklyPulse.ts";
+  import type { PulseGraphData } from "./useWeeklyPulse";
 
-  type GraphType =
-    | "dailyBars"
-    | "weekTrend"
-    | "watchClock"
-    | "showsMovies"
-    | "bingeTimeline";
+  type GraphType = "dailyBars" | "weekTrend" | "watchClock" | "showsMovies";
 
-  const { type, data }: { type: GraphType; data: PulseGraphData } = $props();
+  const { kind, data }: { kind: GraphType; data: PulseGraphData } = $props();
 
   const TITLES: Record<GraphType, string> = {
     dailyBars: "Daily Activity",
     weekTrend: "4-Week Trend",
     watchClock: "Peak Hours",
     showsMovies: "Shows vs Movies",
-    bingeTimeline: "Week Timeline",
   };
 
-  const title = $derived(TITLES[type]);
+  const title = $derived(TITLES[kind]);
 
   // Daily bars derived data
-  const dailyMax = $derived(
-    Math.max(...data.dailyBars.thisWeek, 1),
-  );
+  const dailyMax = $derived(Math.max(...data.dailyBars.thisWeek, 1));
 
   // Week trend SVG coordinates
   const trendPoints = $derived.by(() => {
@@ -72,10 +64,11 @@
 <div class="trakt-pulse-graph">
   <p class="trakt-pulse-graph-title">{title}</p>
 
-  {#if type === "dailyBars"}
+  {#if kind ==="dailyBars"}
     <div class="graph-daily-bars">
-      {#each data.dailyBars.dayLabels as dayLabel, i}
-        {@const twHeight = dailyMax > 0 ? (data.dailyBars.thisWeek[i]! / dailyMax) * 48 : 0}
+      {#each data.dailyBars.dayLabels as dayLabel, i (i)}
+        {@const twHeight =
+          dailyMax > 0 ? ((data.dailyBars.thisWeek[i] ?? 0) / dailyMax) * 48 : 0}
         {@const isToday = i === data.dailyBars.todayIndex}
         <div class="daily-bar-col">
           <div class="daily-bar-track">
@@ -89,18 +82,12 @@
         </div>
       {/each}
     </div>
-  {:else if type === "weekTrend"}
+  {:else if kind ==="weekTrend"}
     <div class="graph-week-trend">
       <svg viewBox="0 0 240 96" class="trend-svg">
-        <polygon
-          points={trendPolygon}
-          class="trend-area"
-        />
-        <polyline
-          points={trendPolyline}
-          class="trend-line"
-        />
-        {#each trendPoints as point, i}
+        <polygon points={trendPolygon} class="trend-area" />
+        <polyline points={trendPolyline} class="trend-line" />
+        {#each trendPoints as point, i (i)}
           {@const isLast = i === trendPoints.length - 1}
           <circle
             cx={point.x}
@@ -110,23 +97,21 @@
             class:trend-point-current={isLast}
           />
           {#if isLast}
-            <text
-              x={point.x}
-              y={point.y - 8}
-              class="trend-value"
-            >{point.plays}</text>
+            <text x={point.x} y={point.y - 8} class="trend-value"
+              >{point.plays}</text
+            >
           {/if}
         {/each}
       </svg>
       <div class="trend-labels">
-        {#each trendPoints as point}
+        {#each trendPoints as point (point.label)}
           <span class="trend-label">{point.label}</span>
         {/each}
       </div>
     </div>
-  {:else if type === "watchClock"}
+  {:else if kind ==="watchClock"}
     <div class="graph-watch-clock">
-      {#each data.watchClock.buckets as bucket}
+      {#each data.watchClock.buckets as bucket (bucket.label)}
         <div class="clock-row">
           <span class="clock-label">{bucket.label}</span>
           <div class="clock-bar-track">
@@ -139,7 +124,7 @@
         </div>
       {/each}
     </div>
-  {:else if type === "showsMovies"}
+  {:else if kind ==="showsMovies"}
     <div class="graph-shows-movies">
       <div class="sm-bar-track">
         <div class="sm-bar-shows" style:width="{showsPct}%"></div>
@@ -148,32 +133,14 @@
       <div class="sm-legends">
         <div class="sm-legend">
           <span class="sm-dot sm-dot-shows"></span>
-          <span class="sm-legend-text">{data.showsMovies.episodes} Episodes</span>
+          <span class="sm-legend-text"
+            >{data.showsMovies.episodes} Episodes</span
+          >
         </div>
         <div class="sm-legend">
           <span class="sm-dot sm-dot-movies"></span>
           <span class="sm-legend-text">{data.showsMovies.movies} Movies</span>
         </div>
-      </div>
-    </div>
-  {:else if type === "bingeTimeline"}
-    <div class="graph-binge-timeline">
-      <div class="binge-track">
-        <div class="binge-line"></div>
-        {#each data.bingeTimeline.days as day}
-          {@const size = day.count > 0 ? Math.max(8, (day.count / data.bingeTimeline.maxCount) * 32) : 4}
-          {@const opacity = day.count > 0 ? Math.max(0.4, day.count / data.bingeTimeline.maxCount) : 0.2}
-          <div class="binge-node">
-            <div
-              class="binge-dot"
-              class:binge-dot-empty={day.count === 0}
-              style:width="{size}px"
-              style:height="{size}px"
-              style:opacity={opacity}
-            ></div>
-            <span class="binge-label">{day.label}</span>
-          </div>
-        {/each}
       </div>
     </div>
   {/if}
@@ -220,24 +187,24 @@
   .daily-bar-track {
     position: relative;
     width: 100%;
-    height: 48px;
+    height: var(--ni-48);
     display: flex;
     align-items: flex-end;
     justify-content: center;
   }
 
-
   .daily-bar-fill {
     position: relative;
     width: 70%;
     background: var(--purple-500);
-    border-radius: 2px;
+    border-radius: var(--ni-2);
     min-height: 1px;
     z-index: 1;
 
     &.is-today {
       background: var(--purple-400);
-      box-shadow: 0 0 6px color-mix(in srgb, var(--purple-400) 40%, transparent);
+      box-shadow: 0 0 var(--ni-6)
+        color-mix(in srgb, var(--purple-400) 40%, transparent);
     }
   }
 
@@ -284,7 +251,7 @@
 
   .trend-value {
     fill: var(--shade-400);
-    font-size: 10px;
+    font-size: var(--ni-10);
     text-anchor: middle;
     font-weight: 600;
   }
@@ -318,30 +285,30 @@
   .clock-label {
     font-size: var(--ni-11);
     color: var(--shade-400);
-    width: 72px;
+    width: var(--ni-72);
     flex-shrink: 0;
     text-align: right;
   }
 
   .clock-bar-track {
     flex: 1;
-    height: 6px;
+    height: var(--ni-6);
     background: var(--shade-950);
-    border-radius: 3px;
+    border-radius: var(--ni-4);
     overflow: hidden;
   }
 
   .clock-bar-fill {
     height: 100%;
     background: var(--purple-500);
-    border-radius: 3px;
+    border-radius: var(--ni-4);
     min-width: 2px;
   }
 
   .clock-count {
     font-size: var(--ni-11);
     color: var(--shade-600);
-    width: 28px;
+    width: var(--ni-28);
     text-align: right;
     flex-shrink: 0;
   }
@@ -357,8 +324,8 @@
 
   .sm-bar-track {
     display: flex;
-    height: 8px;
-    border-radius: 4px;
+    height: var(--ni-8);
+    border-radius: var(--ni-4);
     overflow: hidden;
   }
 
@@ -384,8 +351,8 @@
   }
 
   .sm-dot {
-    width: 8px;
-    height: 8px;
+    width: var(--ni-8);
+    height: var(--ni-8);
     border-radius: 50%;
     flex-shrink: 0;
   }
@@ -401,55 +368,5 @@
   .sm-legend-text {
     font-size: var(--ni-11);
     color: var(--shade-400);
-  }
-
-  /* ── Binge Timeline ─────────────────────────────────── */
-  .graph-binge-timeline {
-    display: flex;
-    flex: 1;
-    align-items: center;
-  }
-
-  .binge-track {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    position: relative;
-  }
-
-  .binge-line {
-    position: absolute;
-    top: 50%;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background: var(--shade-900);
-    transform: translateY(calc(-1 * var(--ni-8)));
-  }
-
-  .binge-node {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--ni-4);
-    z-index: 1;
-    flex: 1;
-  }
-
-  .binge-dot {
-    border-radius: 50%;
-    background: var(--purple-500);
-    flex-shrink: 0;
-  }
-
-  .binge-dot-empty {
-    background: var(--shade-900);
-  }
-
-  .binge-label {
-    font-size: var(--ni-10);
-    color: var(--shade-600);
-    line-height: 1;
   }
 </style>

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraph.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraph.svelte
@@ -1,0 +1,455 @@
+<script lang="ts">
+  import type { PulseGraphData } from "./useWeeklyPulse.ts";
+
+  type GraphType =
+    | "dailyBars"
+    | "weekTrend"
+    | "watchClock"
+    | "showsMovies"
+    | "bingeTimeline";
+
+  const { type, data }: { type: GraphType; data: PulseGraphData } = $props();
+
+  const TITLES: Record<GraphType, string> = {
+    dailyBars: "Daily Activity",
+    weekTrend: "4-Week Trend",
+    watchClock: "Peak Hours",
+    showsMovies: "Shows vs Movies",
+    bingeTimeline: "Week Timeline",
+  };
+
+  const title = $derived(TITLES[type]);
+
+  // Daily bars derived data
+  const dailyMax = $derived(
+    Math.max(...data.dailyBars.thisWeek, 1),
+  );
+
+  // Week trend SVG coordinates
+  const trendPoints = $derived.by(() => {
+    const weeks = data.weekTrend.weeks;
+    const maxPlays = Math.max(...weeks.map((w) => w.plays), 1);
+    const VIEWBOX_WIDTH = 240;
+    const GRAPH_AREA_HEIGHT = 80;
+    const padX = 24;
+    const padTop = 24;
+    const padBottom = 4;
+    const width = VIEWBOX_WIDTH - padX * 2;
+    const height = GRAPH_AREA_HEIGHT - padTop - padBottom;
+
+    return weeks.map((w, i) => ({
+      x: padX + (i / Math.max(weeks.length - 1, 1)) * width,
+      y: padTop + height - (w.plays / maxPlays) * height,
+      plays: w.plays,
+      label: w.label,
+    }));
+  });
+
+  const trendPolyline = $derived(
+    trendPoints.map((p) => `${p.x},${p.y}`).join(" "),
+  );
+
+  const trendPolygon = $derived.by(() => {
+    if (trendPoints.length === 0) return "";
+    const first = trendPoints[0]!;
+    const last = trendPoints[trendPoints.length - 1]!;
+    const linePoints = trendPoints.map((p) => `${p.x},${p.y}`).join(" ");
+    return `${linePoints} ${last.x},80 ${first.x},80`;
+  });
+
+  // Watch clock max
+  const clockMax = $derived(
+    Math.max(...data.watchClock.buckets.map((b) => b.count), 1),
+  );
+
+  // Shows vs Movies total
+  const smTotal = $derived(data.showsMovies.episodes + data.showsMovies.movies);
+  const showsPct = $derived(
+    smTotal > 0 ? (data.showsMovies.episodes / smTotal) * 100 : 50,
+  );
+</script>
+
+<div class="trakt-pulse-graph">
+  <p class="trakt-pulse-graph-title">{title}</p>
+
+  {#if type === "dailyBars"}
+    <div class="graph-daily-bars">
+      {#each data.dailyBars.dayLabels as dayLabel, i}
+        {@const twHeight = dailyMax > 0 ? (data.dailyBars.thisWeek[i]! / dailyMax) * 48 : 0}
+        {@const isToday = i === data.dailyBars.todayIndex}
+        <div class="daily-bar-col">
+          <div class="daily-bar-track">
+            <div
+              class="daily-bar-fill"
+              class:is-today={isToday}
+              style:height="{twHeight}px"
+            ></div>
+          </div>
+          <span class="daily-bar-label">{dayLabel}</span>
+        </div>
+      {/each}
+    </div>
+  {:else if type === "weekTrend"}
+    <div class="graph-week-trend">
+      <svg viewBox="0 0 240 96" class="trend-svg">
+        <polygon
+          points={trendPolygon}
+          class="trend-area"
+        />
+        <polyline
+          points={trendPolyline}
+          class="trend-line"
+        />
+        {#each trendPoints as point, i}
+          {@const isLast = i === trendPoints.length - 1}
+          <circle
+            cx={point.x}
+            cy={point.y}
+            r={isLast ? 4 : 2.5}
+            class="trend-point"
+            class:trend-point-current={isLast}
+          />
+          {#if isLast}
+            <text
+              x={point.x}
+              y={point.y - 8}
+              class="trend-value"
+            >{point.plays}</text>
+          {/if}
+        {/each}
+      </svg>
+      <div class="trend-labels">
+        {#each trendPoints as point}
+          <span class="trend-label">{point.label}</span>
+        {/each}
+      </div>
+    </div>
+  {:else if type === "watchClock"}
+    <div class="graph-watch-clock">
+      {#each data.watchClock.buckets as bucket}
+        <div class="clock-row">
+          <span class="clock-label">{bucket.label}</span>
+          <div class="clock-bar-track">
+            <div
+              class="clock-bar-fill"
+              style:width="{(bucket.count / clockMax) * 100}%"
+            ></div>
+          </div>
+          <span class="clock-count">{bucket.count}</span>
+        </div>
+      {/each}
+    </div>
+  {:else if type === "showsMovies"}
+    <div class="graph-shows-movies">
+      <div class="sm-bar-track">
+        <div class="sm-bar-shows" style:width="{showsPct}%"></div>
+        <div class="sm-bar-movies" style:width="{100 - showsPct}%"></div>
+      </div>
+      <div class="sm-legends">
+        <div class="sm-legend">
+          <span class="sm-dot sm-dot-shows"></span>
+          <span class="sm-legend-text">{data.showsMovies.episodes} Episodes</span>
+        </div>
+        <div class="sm-legend">
+          <span class="sm-dot sm-dot-movies"></span>
+          <span class="sm-legend-text">{data.showsMovies.movies} Movies</span>
+        </div>
+      </div>
+    </div>
+  {:else if type === "bingeTimeline"}
+    <div class="graph-binge-timeline">
+      <div class="binge-track">
+        <div class="binge-line"></div>
+        {#each data.bingeTimeline.days as day}
+          {@const size = day.count > 0 ? Math.max(8, (day.count / data.bingeTimeline.maxCount) * 32) : 4}
+          {@const opacity = day.count > 0 ? Math.max(0.4, day.count / data.bingeTimeline.maxCount) : 0.2}
+          <div class="binge-node">
+            <div
+              class="binge-dot"
+              class:binge-dot-empty={day.count === 0}
+              style:width="{size}px"
+              style:height="{size}px"
+              style:opacity={opacity}
+            ></div>
+            <span class="binge-label">{day.label}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  .trakt-pulse-graph {
+    flex: 2 0 calc(var(--ni-148) * 2 + var(--gap-xs));
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-8);
+    padding: var(--ni-16);
+    background: var(--shade-930);
+    border: 1px solid var(--shade-910);
+    border-radius: var(--border-radius-m);
+    overflow: hidden;
+  }
+
+  .trakt-pulse-graph-title {
+    font-size: var(--ni-11);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--shade-400);
+  }
+
+  /* ── Daily Bars ─────────────────────────────────────── */
+  .graph-daily-bars {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--ni-8);
+    flex: 1;
+    padding-top: var(--ni-4);
+  }
+
+  .daily-bar-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--ni-4);
+    flex: 1;
+  }
+
+  .daily-bar-track {
+    position: relative;
+    width: 100%;
+    height: 48px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+  }
+
+
+  .daily-bar-fill {
+    position: relative;
+    width: 70%;
+    background: var(--purple-500);
+    border-radius: 2px;
+    min-height: 1px;
+    z-index: 1;
+
+    &.is-today {
+      background: var(--purple-400);
+      box-shadow: 0 0 6px color-mix(in srgb, var(--purple-400) 40%, transparent);
+    }
+  }
+
+  .daily-bar-label {
+    font-size: var(--ni-10);
+    color: var(--shade-600);
+    line-height: 1;
+  }
+
+  /* ── Week Trend ─────────────────────────────────────── */
+  .graph-week-trend {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-4);
+    flex: 1;
+  }
+
+  .trend-svg {
+    width: 100%;
+    height: auto;
+  }
+
+  .trend-area {
+    fill: color-mix(in srgb, var(--purple-800) 30%, transparent);
+  }
+
+  .trend-line {
+    fill: none;
+    stroke: var(--purple-400);
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .trend-point {
+    fill: var(--purple-400);
+  }
+
+  .trend-point-current {
+    fill: var(--purple-400);
+    stroke: var(--shade-930);
+    stroke-width: 2;
+  }
+
+  .trend-value {
+    fill: var(--shade-400);
+    font-size: 10px;
+    text-anchor: middle;
+    font-weight: 600;
+  }
+
+  .trend-labels {
+    display: flex;
+    justify-content: space-between;
+    padding: 0 var(--ni-24);
+  }
+
+  .trend-label {
+    font-size: var(--ni-10);
+    color: var(--shade-600);
+  }
+
+  /* ── Watch Clock ────────────────────────────────────── */
+  .graph-watch-clock {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-8);
+    flex: 1;
+    justify-content: center;
+  }
+
+  .clock-row {
+    display: flex;
+    align-items: center;
+    gap: var(--ni-8);
+  }
+
+  .clock-label {
+    font-size: var(--ni-11);
+    color: var(--shade-400);
+    width: 72px;
+    flex-shrink: 0;
+    text-align: right;
+  }
+
+  .clock-bar-track {
+    flex: 1;
+    height: 6px;
+    background: var(--shade-950);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .clock-bar-fill {
+    height: 100%;
+    background: var(--purple-500);
+    border-radius: 3px;
+    min-width: 2px;
+  }
+
+  .clock-count {
+    font-size: var(--ni-11);
+    color: var(--shade-600);
+    width: 28px;
+    text-align: right;
+    flex-shrink: 0;
+  }
+
+  /* ── Shows vs Movies ────────────────────────────────── */
+  .graph-shows-movies {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-12);
+    flex: 1;
+    justify-content: center;
+  }
+
+  .sm-bar-track {
+    display: flex;
+    height: 8px;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .sm-bar-shows {
+    background: var(--purple-500);
+    min-width: 2px;
+  }
+
+  .sm-bar-movies {
+    background: var(--orange-500);
+    min-width: 2px;
+  }
+
+  .sm-legends {
+    display: flex;
+    gap: var(--ni-16);
+  }
+
+  .sm-legend {
+    display: flex;
+    align-items: center;
+    gap: var(--ni-4);
+  }
+
+  .sm-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .sm-dot-shows {
+    background: var(--purple-500);
+  }
+
+  .sm-dot-movies {
+    background: var(--orange-500);
+  }
+
+  .sm-legend-text {
+    font-size: var(--ni-11);
+    color: var(--shade-400);
+  }
+
+  /* ── Binge Timeline ─────────────────────────────────── */
+  .graph-binge-timeline {
+    display: flex;
+    flex: 1;
+    align-items: center;
+  }
+
+  .binge-track {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    position: relative;
+  }
+
+  .binge-line {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: var(--shade-900);
+    transform: translateY(calc(-1 * var(--ni-8)));
+  }
+
+  .binge-node {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--ni-4);
+    z-index: 1;
+    flex: 1;
+  }
+
+  .binge-dot {
+    border-radius: 50%;
+    background: var(--purple-500);
+    flex-shrink: 0;
+  }
+
+  .binge-dot-empty {
+    background: var(--shade-900);
+  }
+
+  .binge-label {
+    font-size: var(--ni-10);
+    color: var(--shade-600);
+    line-height: 1;
+  }
+</style>

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraph.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraph.svelte
@@ -1,21 +1,22 @@
 <script lang="ts">
-  import type { PulseGraphData } from "./useWeeklyPulse";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { PulseGraphData } from "./pulseGraphs";
 
   type GraphType = "dailyBars" | "weekTrend" | "watchClock" | "showsMovies";
 
   const { kind, data }: { kind: GraphType; data: PulseGraphData } = $props();
 
   const TITLES: Record<GraphType, string> = {
-    dailyBars: "Daily Activity",
-    weekTrend: "4-Week Trend",
-    watchClock: "Peak Hours",
-    showsMovies: "Shows vs Movies",
+    dailyBars: m.header_stats_graph_daily(),
+    weekTrend: m.header_stats_graph_trend(),
+    watchClock: m.header_stats_graph_peak(),
+    showsMovies: m.header_stats_graph_shows_movies(),
   };
 
   const title = $derived(TITLES[kind]);
 
   // Daily bars derived data
-  const dailyMax = $derived(Math.max(...data.dailyBars.thisWeek, 1));
+  const dailyMax = $derived(Math.max(...data.dailyBars.days, 1));
 
   // Week trend SVG coordinates
   const trendPoints = $derived.by(() => {
@@ -66,19 +67,19 @@
 
   {#if kind ==="dailyBars"}
     <div class="graph-daily-bars">
-      {#each data.dailyBars.dayLabels as dayLabel, i (i)}
-        {@const twHeight =
-          dailyMax > 0 ? ((data.dailyBars.thisWeek[i] ?? 0) / dailyMax) * 48 : 0}
-        {@const isToday = i === data.dailyBars.todayIndex}
+      {#each data.dailyBars.labels as label, i (i)}
+        {@const barHeight =
+          dailyMax > 0 ? ((data.dailyBars.days[i] ?? 0) / dailyMax) * 48 : 0}
+        {@const isToday = label === m.text_stats_today()}
         <div class="daily-bar-col">
           <div class="daily-bar-track">
             <div
               class="daily-bar-fill"
               class:is-today={isToday}
-              style:height="{twHeight}px"
+              style:height="{barHeight}px"
             ></div>
           </div>
-          <span class="daily-bar-label">{dayLabel}</span>
+          <span class="daily-bar-label">{label}</span>
         </div>
       {/each}
     </div>
@@ -134,12 +135,12 @@
         <div class="sm-legend">
           <span class="sm-dot sm-dot-shows"></span>
           <span class="sm-legend-text"
-            >{data.showsMovies.episodes} Episodes</span
+            >{m.text_stats_episodes_count({ count: String(data.showsMovies.episodes) })}</span
           >
         </div>
         <div class="sm-legend">
           <span class="sm-dot sm-dot-movies"></span>
-          <span class="sm-legend-text">{data.showsMovies.movies} Movies</span>
+          <span class="sm-legend-text">{m.text_stats_movies_count({ count: String(data.showsMovies.movies) })}</span>
         </div>
       </div>
     </div>

--- a/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  const { days }: { days: number } = $props();
+
+  const monthCount = $derived(Math.floor(days / 28));
+  const remainingAfterMonths = $derived(days % 28);
+  const weekCount = $derived(Math.floor(remainingAfterMonths / 7));
+  const dayCount = $derived(remainingAfterMonths % 7);
+</script>
+
+<div class="trakt-streak-accumulator">
+  {#if monthCount > 0}
+    <div class="trakt-streak-group">
+      <div class="trakt-streak-tooltip">{monthCount} {monthCount === 1 ? 'month' : 'months'}</div>
+      {#each Array(monthCount) as _, i}
+        <div class="trakt-streak-square month"></div>
+      {/each}
+    </div>
+  {/if}
+
+  {#if weekCount > 0}
+    <div class="trakt-streak-group">
+      <div class="trakt-streak-tooltip">{weekCount} {weekCount === 1 ? 'week' : 'weeks'}</div>
+      {#each Array(weekCount) as _, i}
+        <div class="trakt-streak-square week"></div>
+      {/each}
+    </div>
+  {/if}
+
+  {#if dayCount > 0}
+    <div class="trakt-streak-group">
+      <div class="trakt-streak-tooltip">{dayCount} {dayCount === 1 ? 'day' : 'days'}</div>
+      {#each Array(dayCount) as _, i}
+        <div
+          class="trakt-streak-square day"
+          class:today={i === dayCount - 1}
+        ></div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-streak-accumulator {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--ni-8);
+    flex-shrink: 0;
+    justify-content: flex-end;
+    align-content: center;
+    max-width: var(--ni-320);
+
+    @include for-mobile {
+      display: none;
+    }
+  }
+
+  .trakt-streak-group {
+    display: flex;
+    gap: var(--ni-4);
+    position: relative;
+
+    .trakt-streak-tooltip {
+      position: absolute;
+      bottom: calc(100% + var(--ni-8));
+      left: 50%;
+      transform: translateX(-50%);
+
+      padding: var(--ni-4) var(--ni-10);
+      background: var(--shade-900);
+      border: 1px solid var(--shade-800);
+      border-radius: var(--border-radius-s);
+
+      font-size: var(--ni-11);
+      font-weight: 500;
+      white-space: nowrap;
+      color: var(--color-text-primary);
+
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity var(--transition-increment) ease-in-out;
+    }
+
+    @include for-mouse {
+      &:hover .trakt-streak-tooltip {
+        opacity: 1;
+      }
+
+      &:hover .trakt-streak-square {
+        transform: scale(1.15);
+      }
+    }
+  }
+
+  .trakt-streak-square {
+    width: var(--ni-20);
+    height: var(--ni-20);
+    border-radius: var(--ni-4);
+    cursor: default;
+    transition: transform var(--transition-increment) ease-in-out;
+    position: relative;
+
+    &.day {
+      background: var(--purple-500);
+      box-shadow: 0 0 var(--ni-8) color-mix(in srgb, var(--purple-500) 35%, transparent);
+
+      &.today {
+        &::after {
+          content: '';
+          position: absolute;
+          inset: calc(var(--ni-2) * -1);
+          border: var(--ni-1) solid var(--purple-400);
+          border-radius: var(--ni-6);
+          opacity: 0.6;
+        }
+      }
+    }
+
+    &.week {
+      background: var(--blue-500);
+      box-shadow: 0 0 var(--ni-8) color-mix(in srgb, var(--blue-500) 25%, transparent);
+    }
+
+    &.month {
+      background: var(--orange-500);
+      box-shadow: 0 0 var(--ni-8) color-mix(in srgb, var(--orange-500) 25%, transparent);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
 
+  const DAYS_PER_MONTH = 30;
+  const DAYS_PER_WEEK = 7;
+
   const { days }: { days: number } = $props();
 
-  const monthCount = $derived(Math.floor(days / 30));
-  const remainingAfterMonths = $derived(days % 30);
-  const weekCount = $derived(Math.floor(remainingAfterMonths / 7));
-  const dayCount = $derived(remainingAfterMonths % 7);
+  const monthCount = $derived(Math.floor(days / DAYS_PER_MONTH));
+  const remainingAfterMonths = $derived(days % DAYS_PER_MONTH);
+  const weekCount = $derived(Math.floor(remainingAfterMonths / DAYS_PER_WEEK));
+  const dayCount = $derived(remainingAfterMonths % DAYS_PER_WEEK);
 </script>
 
 <div class="trakt-streak-accumulator">

--- a/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   const { days }: { days: number } = $props();
 
-  const monthCount = $derived(Math.floor(days / 28));
-  const remainingAfterMonths = $derived(days % 28);
+  const monthCount = $derived(Math.floor(days / 30));
+  const remainingAfterMonths = $derived(days % 30);
   const weekCount = $derived(Math.floor(remainingAfterMonths / 7));
   const dayCount = $derived(remainingAfterMonths % 7);
 </script>
@@ -10,8 +10,11 @@
 <div class="trakt-streak-accumulator">
   {#if monthCount > 0}
     <div class="trakt-streak-group">
-      <div class="trakt-streak-tooltip">{monthCount} {monthCount === 1 ? 'month' : 'months'}</div>
-      {#each Array(monthCount) as _, i}
+      <div class="trakt-streak-tooltip">
+        {monthCount}
+        {monthCount === 1 ? "month" : "months"}
+      </div>
+      {#each Array.from({ length: monthCount }) as _, i (i)}
         <div class="trakt-streak-square month"></div>
       {/each}
     </div>
@@ -19,8 +22,11 @@
 
   {#if weekCount > 0}
     <div class="trakt-streak-group">
-      <div class="trakt-streak-tooltip">{weekCount} {weekCount === 1 ? 'week' : 'weeks'}</div>
-      {#each Array(weekCount) as _, i}
+      <div class="trakt-streak-tooltip">
+        {weekCount}
+        {weekCount === 1 ? "week" : "weeks"}
+      </div>
+      {#each Array.from({ length: weekCount }) as _, i (i)}
         <div class="trakt-streak-square week"></div>
       {/each}
     </div>
@@ -28,8 +34,11 @@
 
   {#if dayCount > 0}
     <div class="trakt-streak-group">
-      <div class="trakt-streak-tooltip">{dayCount} {dayCount === 1 ? 'day' : 'days'}</div>
-      {#each Array(dayCount) as _, i}
+      <div class="trakt-streak-tooltip">
+        {dayCount}
+        {dayCount === 1 ? "day" : "days"}
+      </div>
+      {#each Array.from({ length: dayCount }) as _, i (i)}
         <div
           class="trakt-streak-square day"
           class:today={i === dayCount - 1}
@@ -103,11 +112,12 @@
 
     &.day {
       background: var(--purple-500);
-      box-shadow: 0 0 var(--ni-8) color-mix(in srgb, var(--purple-500) 35%, transparent);
+      box-shadow: 0 0 var(--ni-8)
+        color-mix(in srgb, var(--purple-500) 35%, transparent);
 
       &.today {
         &::after {
-          content: '';
+          content: "";
           position: absolute;
           inset: calc(var(--ni-2) * -1);
           border: var(--ni-1) solid var(--purple-400);
@@ -119,12 +129,14 @@
 
     &.week {
       background: var(--blue-500);
-      box-shadow: 0 0 var(--ni-8) color-mix(in srgb, var(--blue-500) 25%, transparent);
+      box-shadow: 0 0 var(--ni-8)
+        color-mix(in srgb, var(--blue-500) 25%, transparent);
     }
 
     &.month {
       background: var(--orange-500);
-      box-shadow: 0 0 var(--ni-8) color-mix(in srgb, var(--orange-500) 25%, transparent);
+      box-shadow: 0 0 var(--ni-8)
+        color-mix(in srgb, var(--orange-500) 25%, transparent);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+
   const { days }: { days: number } = $props();
 
   const monthCount = $derived(Math.floor(days / 30));
@@ -11,8 +13,9 @@
   {#if monthCount > 0}
     <div class="trakt-streak-group">
       <div class="trakt-streak-tooltip">
-        {monthCount}
-        {monthCount === 1 ? "month" : "months"}
+        {monthCount === 1
+          ? m.text_stats_streak_month({ count: String(monthCount) })
+          : m.text_stats_streak_months({ count: String(monthCount) })}
       </div>
       {#each Array.from({ length: monthCount }) as _, i (i)}
         <div class="trakt-streak-square month"></div>
@@ -23,8 +26,9 @@
   {#if weekCount > 0}
     <div class="trakt-streak-group">
       <div class="trakt-streak-tooltip">
-        {weekCount}
-        {weekCount === 1 ? "week" : "weeks"}
+        {weekCount === 1
+          ? m.text_stats_streak_week({ count: String(weekCount) })
+          : m.text_stats_streak_weeks({ count: String(weekCount) })}
       </div>
       {#each Array.from({ length: weekCount }) as _, i (i)}
         <div class="trakt-streak-square week"></div>
@@ -35,8 +39,9 @@
   {#if dayCount > 0}
     <div class="trakt-streak-group">
       <div class="trakt-streak-tooltip">
-        {dayCount}
-        {dayCount === 1 ? "day" : "days"}
+        {dayCount === 1
+          ? m.text_stats_streak_day({ count: String(dayCount) })
+          : m.text_stats_streak_days({ count: String(dayCount) })}
       </div>
       {#each Array.from({ length: dayCount }) as _, i (i)}
         <div

--- a/projects/client/src/lib/sections/stats/_internal/activityHistoryParams.ts
+++ b/projects/client/src/lib/sections/stats/_internal/activityHistoryParams.ts
@@ -1,0 +1,43 @@
+import {
+  movieActivityHistoryQuery,
+} from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import {
+  showActivityHistoryQuery,
+} from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import { usePaginatedListQuery } from '../../lists/stores/usePaginatedListQuery.ts';
+
+const HISTORY_LIMIT = 1000;
+
+export function useActivityHistory(slug: string) {
+  const now = new Date();
+  const startDate = new Date(
+    Date.UTC(
+      now.getUTCFullYear() - 1,
+      now.getUTCMonth(),
+      now.getUTCDate(),
+    ),
+  );
+  const endDate = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() + 1,
+    ),
+  );
+
+  const params = {
+    limit: HISTORY_LIMIT,
+    slug,
+    startDate,
+    endDate,
+  };
+
+  const { list: movies, isLoading: isLoadingMovies } = usePaginatedListQuery(
+    movieActivityHistoryQuery(params),
+  );
+  const { list: shows, isLoading: isLoadingShows } = usePaginatedListQuery(
+    showActivityHistoryQuery(params),
+  );
+
+  return { movies, shows, isLoadingMovies, isLoadingShows };
+}

--- a/projects/client/src/lib/sections/stats/_internal/pulseGraphs.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/pulseGraphs.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/features/i18n/messages.ts', async (importOriginal) => {
+  const original = await importOriginal<Record<string, unknown>>();
+  return {
+    ...original,
+    text_stats_today: () => 'Today',
+    text_stats_time_morning: () => 'Morning',
+    text_stats_time_afternoon: () => 'Afternoon',
+    text_stats_time_evening: () => 'Evening',
+    text_stats_time_late_night: () => 'Late Night',
+    text_stats_weeks_ago: ({ count }: { count: string }) => `${count}w ago`,
+    text_stats_weeks_short: ({ count }: { count: string }) => `${count}w`,
+    text_stats_this_week: () => 'This week',
+  };
+});
+
+import {
+  bucketByTimeOfDay,
+  computeWeekTrend,
+  countByCalendarDay,
+  pickGraph,
+  type PulseGraphData,
+} from './pulseGraphs.ts';
+
+describe('countByCalendarDay', () => {
+  it('returns 7 days of data', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    const result = countByCalendarDay([], now, 'en');
+    expect(result.days).toHaveLength(7);
+    expect(result.labels).toHaveLength(7);
+  });
+
+  it('counts dates into correct day buckets', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    const dates = [
+      new Date('2024-01-15T10:00:00Z'), // today
+      new Date('2024-01-15T14:00:00Z'), // today again
+      new Date('2024-01-14T10:00:00Z'), // yesterday
+    ];
+    const result = countByCalendarDay(dates, now, 'en');
+    expect(result.days[6]).toBe(2); // today = last slot
+    expect(result.days[5]).toBe(1); // yesterday
+  });
+
+  it('ignores dates outside the 7-day window', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    const dates = [
+      new Date('2024-01-07T10:00:00Z'), // 8 days ago, outside window
+    ];
+    const result = countByCalendarDay(dates, now, 'en');
+    expect(result.days.every((d) => d === 0)).toBe(true);
+  });
+});
+
+describe('bucketByTimeOfDay', () => {
+  it('returns 4 time buckets with zero counts for empty input', () => {
+    const result = bucketByTimeOfDay([]);
+    expect(result).toHaveLength(4);
+    result.forEach((bucket) => expect(bucket.count).toBe(0));
+  });
+
+  it('sorts dates into correct time buckets', () => {
+    const dates = [
+      new Date('2024-01-15T06:00:00Z'), // morning (5-12)
+      new Date('2024-01-15T09:00:00Z'), // morning
+      new Date('2024-01-15T14:00:00Z'), // afternoon (12-17)
+      new Date('2024-01-15T19:00:00Z'), // evening (17-22)
+      new Date('2024-01-15T23:00:00Z'), // late night (22+)
+      new Date('2024-01-15T02:00:00Z'), // late night (<5)
+    ];
+    const result = bucketByTimeOfDay(dates);
+    expect(result[0]!.count).toBe(2); // morning
+    expect(result[1]!.count).toBe(1); // afternoon
+    expect(result[2]!.count).toBe(1); // evening
+    expect(result[3]!.count).toBe(2); // late night
+  });
+});
+
+describe('computeWeekTrend', () => {
+  it('returns 4 weeks of data', () => {
+    const now = new Date('2024-01-28T12:00:00Z');
+    const result = computeWeekTrend([], now);
+    expect(result).toHaveLength(4);
+    result.forEach((week) => expect(week.plays).toBe(0));
+  });
+});
+
+describe('pickGraph', () => {
+  const emptyGraphData: PulseGraphData = {
+    dailyBars: { days: [0, 0, 0, 0, 0, 0, 0], labels: [] },
+    weekTrend: {
+      weeks: Array.from({ length: 4 }, () => ({ label: '', plays: 0 })),
+    },
+    watchClock: {
+      buckets: Array.from({ length: 4 }, () => ({ label: '', count: 0 })),
+    },
+    showsMovies: { episodes: 0, movies: 0 },
+  };
+
+  it('returns null when no graph qualifies', () => {
+    expect(pickGraph(emptyGraphData)).toBeNull();
+  });
+
+  it('picks dailyBars when enough active days', () => {
+    const data: PulseGraphData = {
+      ...emptyGraphData,
+      dailyBars: { days: [1, 2, 0, 3, 1, 0, 2], labels: [] },
+    };
+    expect(pickGraph(data)).toBe('dailyBars');
+  });
+
+  it('picks showsMovies when both types are present and balanced', () => {
+    const data: PulseGraphData = {
+      ...emptyGraphData,
+      showsMovies: { episodes: 5, movies: 5 },
+    };
+    expect(pickGraph(data)).toBe('showsMovies');
+  });
+
+  it('picks watchClock when a dominant time slot exists', () => {
+    const data: PulseGraphData = {
+      ...emptyGraphData,
+      watchClock: {
+        buckets: [
+          { label: '', count: 0 },
+          { label: '', count: 0 },
+          { label: '', count: 8 }, // dominant evening
+          { label: '', count: 1 },
+        ],
+      },
+    };
+    expect(pickGraph(data)).toBe('watchClock');
+  });
+});

--- a/projects/client/src/lib/sections/stats/_internal/pulseGraphs.ts
+++ b/projects/client/src/lib/sections/stats/_internal/pulseGraphs.ts
@@ -1,0 +1,153 @@
+import type { AvailableLocale } from '$lib/features/i18n/index.ts';
+import * as m from '$lib/features/i18n/messages.ts';
+import { getDayKey } from '$lib/utils/date/getDayKey.ts';
+import { toHumanDayOfWeek } from '$lib/utils/formatting/date/toHumanDayOfWeek.ts';
+
+export type PulseGraphType =
+  | 'dailyBars'
+  | 'weekTrend'
+  | 'watchClock'
+  | 'showsMovies';
+
+export type PulseGraphData = {
+  readonly dailyBars: {
+    readonly days: readonly number[];
+    readonly labels: readonly string[];
+  };
+  readonly weekTrend: {
+    readonly weeks: ReadonlyArray<{ readonly label: string; readonly plays: number }>;
+  };
+  readonly watchClock: {
+    readonly buckets: ReadonlyArray<{ readonly label: string; readonly count: number }>;
+  };
+  readonly showsMovies: {
+    readonly episodes: number;
+    readonly movies: number;
+  };
+};
+
+export function countByCalendarDay(
+  dates: ReadonlyArray<Date>,
+  now: Date,
+  locale: AvailableLocale,
+): { readonly days: readonly number[]; readonly labels: readonly string[] } {
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const dayRange = Array.from({ length: 7 }, (_, idx) => {
+    const offset = 6 - idx;
+    return new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - offset,
+    );
+  });
+
+  const days = dayRange.map((day) => {
+    const key = getDayKey(day);
+    return dates.filter((d) => getDayKey(d) === key).length;
+  });
+
+  const labels = dayRange.map((day, idx) =>
+    idx === 6 ? m.text_stats_today() : toHumanDayOfWeek(day, locale),
+  );
+
+  return { days, labels };
+}
+
+export function bucketByTimeOfDay(
+  dates: ReadonlyArray<Date>,
+): ReadonlyArray<{ readonly label: string; readonly count: number }> {
+  const counts = dates.reduce(
+    (acc, d) => {
+      const hour = d.getHours();
+      if (hour >= MORNING_START_HOUR && hour < AFTERNOON_START_HOUR) acc[0]++;
+      else if (hour >= AFTERNOON_START_HOUR && hour < EVENING_START_HOUR) acc[1]++;
+      else if (hour >= EVENING_START_HOUR && hour < LATE_NIGHT_START_HOUR) acc[2]++;
+      else acc[3]++;
+      return acc;
+    },
+    [0, 0, 0, 0],
+  );
+
+  return [
+    { label: m.text_stats_time_morning(), count: counts[0] ?? 0 },
+    { label: m.text_stats_time_afternoon(), count: counts[1] ?? 0 },
+    { label: m.text_stats_time_evening(), count: counts[2] ?? 0 },
+    { label: m.text_stats_time_late_night(), count: counts[3] ?? 0 },
+  ];
+}
+
+export function computeWeekTrend(
+  dates: ReadonlyArray<Date>,
+  now: Date,
+): ReadonlyArray<{ readonly label: string; readonly plays: number }> {
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const labels = [
+    m.text_stats_weeks_ago({ count: '4' }),
+    m.text_stats_weeks_short({ count: '3' }),
+    m.text_stats_weeks_short({ count: '2' }),
+    m.text_stats_this_week(),
+  ];
+
+  return Array.from({ length: 4 }, (_, idx) => {
+    const i = 3 - idx;
+    const start = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - (i * 7 + 6),
+    );
+    const end = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - (i * 7) + 1,
+    );
+    const count = dates.filter((d) => d >= start && d < end).length;
+    return { label: labels[idx] ?? '', plays: count };
+  });
+}
+
+export function pickGraph(
+  graphData: PulseGraphData,
+): PulseGraphType | null {
+  type Candidate = { type: PulseGraphType; score: number };
+  const candidates: Candidate[] = [];
+
+  const activeDays = graphData.dailyBars.days.filter((c) => c > 0).length;
+  if (activeDays >= 3) {
+    candidates.push({ type: 'dailyBars', score: activeDays });
+  }
+
+  const weekPlays = graphData.weekTrend.weeks.map((w) => w.plays);
+  const maxWeek = Math.max(...weekPlays);
+  const minWeek = Math.min(...weekPlays);
+  if (maxWeek > 0 && (maxWeek - minWeek) / maxWeek > 0.25) {
+    candidates.push({
+      type: 'weekTrend',
+      score: ((maxWeek - minWeek) / maxWeek) * 10,
+    });
+  }
+
+  const clockTotal = graphData.watchClock.buckets.reduce(
+    (s, b) => s + b.count,
+    0,
+  );
+  const clockPeak = Math.max(
+    ...graphData.watchClock.buckets.map((b) => b.count),
+  );
+  if (clockTotal > 0 && clockPeak / clockTotal > 0.4) {
+    candidates.push({
+      type: 'watchClock',
+      score: (clockPeak / clockTotal) * 10,
+    });
+  }
+
+  const { episodes, movies: movieCount } = graphData.showsMovies;
+  if (episodes > 0 && movieCount > 0) {
+    const balance =
+      Math.min(episodes, movieCount) / Math.max(episodes, movieCount);
+    candidates.push({ type: 'showsMovies', score: balance * 10 });
+  }
+
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => b.score - a.score);
+  return candidates[0]?.type ?? null;
+}

--- a/projects/client/src/lib/sections/stats/_internal/pulseGraphs.ts
+++ b/projects/client/src/lib/sections/stats/_internal/pulseGraphs.ts
@@ -3,6 +3,17 @@ import * as m from '$lib/features/i18n/messages.ts';
 import { getDayKey } from '$lib/utils/date/getDayKey.ts';
 import { toHumanDayOfWeek } from '$lib/utils/formatting/date/toHumanDayOfWeek.ts';
 
+const DAYS_IN_WEEK = 7;
+const TREND_WEEK_COUNT = 4;
+const MORNING_START_HOUR = 5;
+const AFTERNOON_START_HOUR = 12;
+const EVENING_START_HOUR = 17;
+const LATE_NIGHT_START_HOUR = 22;
+
+const MIN_ACTIVE_DAYS_FOR_DAILY = 3;
+const WEEK_TREND_VARIANCE_THRESHOLD = 0.25;
+const CLOCK_PEAK_THRESHOLD = 0.4;
+
 export type PulseGraphType =
   | 'dailyBars'
   | 'weekTrend'
@@ -32,8 +43,8 @@ export function countByCalendarDay(
   locale: AvailableLocale,
 ): { readonly days: readonly number[]; readonly labels: readonly string[] } {
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const dayRange = Array.from({ length: 7 }, (_, idx) => {
-    const offset = 6 - idx;
+  const dayRange = Array.from({ length: DAYS_IN_WEEK }, (_, idx) => {
+    const offset = DAYS_IN_WEEK - 1 - idx;
     return new Date(
       today.getFullYear(),
       today.getMonth(),
@@ -47,7 +58,7 @@ export function countByCalendarDay(
   });
 
   const labels = dayRange.map((day, idx) =>
-    idx === 6 ? m.text_stats_today() : toHumanDayOfWeek(day, locale),
+    idx === DAYS_IN_WEEK - 1 ? m.text_stats_today() : toHumanDayOfWeek(day, locale),
   );
 
   return { days, labels };
@@ -88,17 +99,17 @@ export function computeWeekTrend(
     m.text_stats_this_week(),
   ];
 
-  return Array.from({ length: 4 }, (_, idx) => {
-    const i = 3 - idx;
+  return Array.from({ length: TREND_WEEK_COUNT }, (_, idx) => {
+    const i = TREND_WEEK_COUNT - 1 - idx;
     const start = new Date(
       today.getFullYear(),
       today.getMonth(),
-      today.getDate() - (i * 7 + 6),
+      today.getDate() - (i * DAYS_IN_WEEK + DAYS_IN_WEEK - 1),
     );
     const end = new Date(
       today.getFullYear(),
       today.getMonth(),
-      today.getDate() - (i * 7) + 1,
+      today.getDate() - (i * DAYS_IN_WEEK) + 1,
     );
     const count = dates.filter((d) => d >= start && d < end).length;
     return { label: labels[idx] ?? '', plays: count };
@@ -112,14 +123,14 @@ export function pickGraph(
   const candidates: Candidate[] = [];
 
   const activeDays = graphData.dailyBars.days.filter((c) => c > 0).length;
-  if (activeDays >= 3) {
+  if (activeDays >= MIN_ACTIVE_DAYS_FOR_DAILY) {
     candidates.push({ type: 'dailyBars', score: activeDays });
   }
 
   const weekPlays = graphData.weekTrend.weeks.map((w) => w.plays);
   const maxWeek = Math.max(...weekPlays);
   const minWeek = Math.min(...weekPlays);
-  if (maxWeek > 0 && (maxWeek - minWeek) / maxWeek > 0.25) {
+  if (maxWeek > 0 && (maxWeek - minWeek) / maxWeek > WEEK_TREND_VARIANCE_THRESHOLD) {
     candidates.push({
       type: 'weekTrend',
       score: ((maxWeek - minWeek) / maxWeek) * 10,
@@ -133,7 +144,7 @@ export function pickGraph(
   const clockPeak = Math.max(
     ...graphData.watchClock.buckets.map((b) => b.count),
   );
-  if (clockTotal > 0 && clockPeak / clockTotal > 0.4) {
+  if (clockTotal > 0 && clockPeak / clockTotal > CLOCK_PEAK_THRESHOLD) {
     candidates.push({
       type: 'watchClock',
       score: (clockPeak / clockTotal) * 10,

--- a/projects/client/src/lib/sections/stats/_internal/pulseStats.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/pulseStats.spec.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import type { MovieActivityHistory } from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import type { ShowActivityHistory } from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import {
+  computeDelta,
+  countUniqueDays,
+  dayOfWeekDate,
+  dedup,
+  getBusiestDay,
+  maxPlaysInSingleDay,
+  sumHours,
+  type PulseStat,
+} from './pulseStats.ts';
+
+function movieEntry(runtime: number): MovieActivityHistory {
+  return { movie: { runtime } } as unknown as MovieActivityHistory;
+}
+
+function showEntry(runtime: number): ShowActivityHistory {
+  return { episode: { runtime } } as unknown as ShowActivityHistory;
+}
+
+describe('sumHours', () => {
+  it('returns 0 for empty arrays', () => {
+    expect(sumHours([], [])).toBe(0);
+  });
+
+  it('sums movie runtimes and converts to hours', () => {
+    expect(sumHours([movieEntry(120), movieEntry(60)], [])).toBe(3);
+  });
+
+  it('sums show runtimes and converts to hours', () => {
+    expect(sumHours([], [showEntry(45), showEntry(45)])).toBe(2);
+  });
+
+  it('combines both and rounds', () => {
+    // 150 min → 2.5 → rounds to 3
+    expect(sumHours([movieEntry(100)], [showEntry(50)])).toBe(3);
+  });
+});
+
+describe('countUniqueDays', () => {
+  it('returns 0 for empty array', () => {
+    expect(countUniqueDays([])).toBe(0);
+  });
+
+  it('counts unique days, deduping same-day entries', () => {
+    const dates = [
+      new Date('2024-01-15T10:00:00Z'),
+      new Date('2024-01-15T14:00:00Z'),
+      new Date('2024-01-16T10:00:00Z'),
+    ];
+    expect(countUniqueDays(dates)).toBe(2);
+  });
+});
+
+describe('getBusiestDay', () => {
+  it('returns null for empty array', () => {
+    expect(getBusiestDay([])).toBeNull();
+  });
+
+  it('finds the day of week with most entries', () => {
+    const dates = [
+      new Date('2024-01-15T10:00:00Z'), // Monday (1)
+      new Date('2024-01-15T14:00:00Z'), // Monday (1)
+      new Date('2024-01-17T10:00:00Z'), // Wednesday (3)
+    ];
+    const result = getBusiestDay(dates);
+    expect(result).toEqual({ dayIndex: 1, count: 2 });
+  });
+});
+
+describe('dayOfWeekDate', () => {
+  it('returns a date matching the given day of week', () => {
+    const now = new Date('2024-01-17T12:00:00Z'); // Wednesday
+    const result = dayOfWeekDate(1, now); // Monday
+    expect(result.getDay()).toBe(1);
+  });
+
+  it('returns same day when dayIndex matches now', () => {
+    const now = new Date('2024-01-17T12:00:00Z'); // Wednesday (3)
+    const result = dayOfWeekDate(3, now);
+    expect(result.getDay()).toBe(3);
+  });
+});
+
+describe('maxPlaysInSingleDay', () => {
+  it('returns 0 for empty array', () => {
+    expect(maxPlaysInSingleDay([])).toBe(0);
+  });
+
+  it('finds the max plays on a single day', () => {
+    const dates = [
+      new Date('2024-01-15T10:00:00Z'),
+      new Date('2024-01-15T14:00:00Z'),
+      new Date('2024-01-15T18:00:00Z'),
+      new Date('2024-01-16T10:00:00Z'),
+    ];
+    expect(maxPlaysInSingleDay(dates)).toBe(3);
+  });
+});
+
+describe('computeDelta', () => {
+  it('returns the difference between weeks', () => {
+    expect(computeDelta(10, 7)).toBe(3);
+    expect(computeDelta(5, 8)).toBe(-3);
+    expect(computeDelta(5, 5)).toBe(0);
+  });
+});
+
+describe('dedup', () => {
+  const stat = (key: string, delta: number | null): PulseStat => ({
+    key,
+    value: '0',
+    label: key,
+    delta,
+  });
+
+  it('filters episodes when totalPlays equals episodes', () => {
+    const candidates = [stat('totalPlays', 1), stat('episodes', 1)];
+    const rawCounts = new Map([['totalPlays', 5], ['episodes', 5], ['movies', 0]]);
+    const result = dedup(candidates, rawCounts);
+    expect(result.map((r) => r.key)).toEqual(['totalPlays']);
+  });
+
+  it('filters movies when totalPlays equals movies', () => {
+    const candidates = [stat('totalPlays', 1), stat('movies', 1)];
+    const rawCounts = new Map([['totalPlays', 3], ['episodes', 0], ['movies', 3]]);
+    const result = dedup(candidates, rawCounts);
+    expect(result.map((r) => r.key)).toEqual(['totalPlays']);
+  });
+
+  it('filters zero movies with zero delta', () => {
+    const candidates = [stat('totalPlays', 1), stat('movies', 0)];
+    const rawCounts = new Map([['totalPlays', 5], ['episodes', 3], ['movies', 0]]);
+    const result = dedup(candidates, rawCounts);
+    expect(result.map((r) => r.key)).toEqual(['totalPlays']);
+  });
+
+  it('keeps all items when no dedup rules apply', () => {
+    const candidates = [stat('totalPlays', 1), stat('episodes', 1), stat('movies', 2)];
+    const rawCounts = new Map([['totalPlays', 10], ['episodes', 7], ['movies', 3]]);
+    const result = dedup(candidates, rawCounts);
+    expect(result).toHaveLength(3);
+  });
+});

--- a/projects/client/src/lib/sections/stats/_internal/pulseStats.ts
+++ b/projects/client/src/lib/sections/stats/_internal/pulseStats.ts
@@ -1,0 +1,89 @@
+import type { MovieActivityHistory } from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import type { ShowActivityHistory } from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import { getDayKey } from '$lib/utils/date/getDayKey.ts';
+
+export type PulseStat = {
+  readonly key: string;
+  readonly value: string;
+  readonly label: string;
+  readonly delta: number | null;
+  readonly note?: string;
+};
+
+export function sumHours(
+  movieEntries: ReadonlyArray<MovieActivityHistory>,
+  showEntries: ReadonlyArray<ShowActivityHistory>,
+): number {
+  const movieMinutes = movieEntries.reduce(
+    (sum, m) => sum + m.movie.runtime,
+    0,
+  );
+  const showMinutes = showEntries.reduce(
+    (sum, s) => sum + s.episode.runtime,
+    0,
+  );
+  return Math.round((movieMinutes + showMinutes) / 60);
+}
+
+export function countUniqueDays(dates: ReadonlyArray<Date>): number {
+  return new Set(dates.map(getDayKey)).size;
+}
+
+export function getBusiestDay(
+  dates: ReadonlyArray<Date>,
+): { readonly dayIndex: number; readonly count: number } | null {
+  if (dates.length === 0) return null;
+
+  const counts = dates.reduce((acc, d) => {
+    const dow = d.getDay();
+    acc.set(dow, (acc.get(dow) ?? 0) + 1);
+    return acc;
+  }, new Map<number, number>());
+
+  return [...counts.entries()].reduce(
+    (best, [day, count]) =>
+      count > best.count ? { dayIndex: day, count } : best,
+    { dayIndex: 0, count: 0 },
+  );
+}
+
+export function dayOfWeekDate(dayIndex: number, now: Date): Date {
+  const date = new Date(now);
+  date.setDate(date.getDate() - ((date.getDay() - dayIndex + 7) % 7));
+  return date;
+}
+
+export function maxPlaysInSingleDay(dates: ReadonlyArray<Date>): number {
+  if (dates.length === 0) return 0;
+
+  const counts = dates.reduce((acc, d) => {
+    const key = getDayKey(d);
+    acc.set(key, (acc.get(key) ?? 0) + 1);
+    return acc;
+  }, new Map<string, number>());
+
+  return Math.max(...counts.values());
+}
+
+export function computeDelta(thisWeek: number, lastWeek: number): number {
+  return thisWeek - lastWeek;
+}
+
+export function dedup(
+  candidates: ReadonlyArray<PulseStat>,
+  rawCounts: ReadonlyMap<string, number>,
+): readonly PulseStat[] {
+  const playsRaw = rawCounts.get('totalPlays') ?? 0;
+  const episodesRaw = rawCounts.get('episodes') ?? 0;
+  const moviesRaw = rawCounts.get('movies') ?? 0;
+
+  return candidates.filter((c) => {
+    if (c.key === 'episodes' && playsRaw === episodesRaw && playsRaw > 0) {
+      return false;
+    }
+    if (c.key === 'movies' && playsRaw === moviesRaw && playsRaw > 0) {
+      return false;
+    }
+    return !(c.key === 'movies' && moviesRaw === 0 && c.delta === 0);
+  });
+}

--- a/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/features/i18n/messages.ts', async (importOriginal) => {
+  const original = await importOriginal<Record<string, unknown>>();
+  return {
+    ...original,
+    text_stats_genre_other: () => 'Other',
+  };
+});
+
+import type { MovieActivityHistory } from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import type { ShowActivityHistory } from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import { computeGenreBreakdown, DAY_COUNT } from './useGenreBreakdown.ts';
+
+function movieWith(
+  watchedAt: Date,
+  genres: string[],
+): MovieActivityHistory {
+  return { watchedAt, movie: { genres } } as unknown as MovieActivityHistory;
+}
+
+function showWith(
+  watchedAt: Date,
+  genres: string[],
+): ShowActivityHistory {
+  return { watchedAt, show: { genres } } as unknown as ShowActivityHistory;
+}
+
+describe('computeGenreBreakdown', () => {
+  const now = new Date('2024-01-15T12:00:00Z');
+
+  it('returns 14 days with empty data', () => {
+    const result = computeGenreBreakdown([], [], now);
+    expect(result.days).toHaveLength(DAY_COUNT);
+    expect(result.maxDayTotal).toBe(0);
+    expect(result.legend).toHaveLength(0);
+  });
+
+  it('groups genres by day', () => {
+    const movies = [
+      movieWith(new Date('2024-01-15T10:00:00Z'), ['action']),
+      movieWith(new Date('2024-01-15T14:00:00Z'), ['action']),
+      movieWith(new Date('2024-01-14T10:00:00Z'), ['comedy']),
+    ];
+    const result = computeGenreBreakdown(movies, [], now);
+
+    const today = result.days[DAY_COUNT - 1]!;
+    expect(today.total).toBe(2);
+
+    const yesterday = result.days[DAY_COUNT - 2]!;
+    expect(yesterday.total).toBe(1);
+  });
+
+  it('limits to top 5 genres plus other', () => {
+    const genres = [
+      'action', 'comedy', 'drama', 'horror', 'sci-fi', 'romance', 'thriller',
+    ];
+    const movies = genres.map((g) =>
+      movieWith(new Date('2024-01-15T10:00:00Z'), [g]),
+    );
+    const result = computeGenreBreakdown(movies, [], now);
+    expect(result.legend.length).toBeLessThanOrEqual(6);
+  });
+
+  it('handles entries with no genres as other', () => {
+    const movies = [
+      movieWith(new Date('2024-01-15T10:00:00Z'), []),
+    ];
+    const result = computeGenreBreakdown(movies, [], now);
+    expect(result.legend).toHaveLength(1);
+    expect(result.legend[0]!.genre).toBe('other');
+  });
+
+  it('includes show genres from the show field', () => {
+    const shows = [
+      showWith(new Date('2024-01-15T10:00:00Z'), ['drama']),
+    ];
+    const result = computeGenreBreakdown([], shows, now);
+    expect(result.legend).toHaveLength(1);
+    expect(result.legend[0]!.genre).toBe('drama');
+  });
+
+  it('ignores entries outside the 14-day window', () => {
+    const movies = [
+      movieWith(new Date('2023-12-01T10:00:00Z'), ['action']),
+    ];
+    const result = computeGenreBreakdown(movies, [], now);
+    expect(result.maxDayTotal).toBe(0);
+    expect(result.legend).toHaveLength(0);
+  });
+
+  it('assigns colors to legend entries', () => {
+    const movies = [
+      movieWith(new Date('2024-01-15T10:00:00Z'), ['action']),
+      movieWith(new Date('2024-01-15T11:00:00Z'), ['comedy']),
+    ];
+    const result = computeGenreBreakdown(movies, [], now);
+    result.legend.forEach((entry) => {
+      expect(entry.color).toMatch(/^#[0-9a-f]{6}$/);
+    });
+  });
+
+  it('calculates percentages that reflect genre distribution', () => {
+    const movies = [
+      movieWith(new Date('2024-01-15T10:00:00Z'), ['action']),
+      movieWith(new Date('2024-01-15T11:00:00Z'), ['action']),
+      movieWith(new Date('2024-01-15T12:00:00Z'), ['comedy']),
+    ];
+    const result = computeGenreBreakdown(movies, [], now);
+    const actionEntry = result.legend.find((l) => l.genre === 'action');
+    const comedyEntry = result.legend.find((l) => l.genre === 'comedy');
+    expect(actionEntry!.percentage).toBe(67);
+    expect(comedyEntry!.percentage).toBe(33);
+  });
+});

--- a/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.ts
@@ -1,13 +1,7 @@
 import type { MovieActivityHistory } from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
-import {
-  movieActivityHistoryQuery,
-} from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
 import type { ShowActivityHistory } from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
-import {
-  showActivityHistoryQuery,
-} from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
 import { combineLatest, map, type Observable } from 'rxjs';
-import { usePaginatedListQuery } from '../../lists/stores/usePaginatedListQuery.ts';
+import { useActivityHistory } from './activityHistoryParams.ts';
 
 type UseGenreBreakdownProps = { slug: string };
 
@@ -39,9 +33,9 @@ const GENRE_COLORS = [
   '#555555', // gray - "Other"
 ];
 
-const HISTORY_LIMIT = 1000;
 const TOP_GENRE_COUNT = 5;
 const DAY_COUNT = 14;
+const GENRES_PER_ENTRY = 2;
 
 function genreLabel(slug: string): string {
   return slug
@@ -76,17 +70,18 @@ function computeGenreBreakdown(
     today.getDate() + 1,
   );
 
-  // Collect all entries within the 14-day range, using up to 3 genres each
-  const GENRES_PER_ENTRY = 2;
-  type GenreEntry = { watchedAt: Date; genre: string };
+  // Collect genre entries, weighting each genre as 1/numGenres to avoid
+  // inflating bar heights for multi-genre titles
+  type GenreEntry = { watchedAt: Date; genre: string; weight: number };
   const genreEntries: GenreEntry[] = [];
 
   for (const entry of movies) {
     if (entry.watchedAt >= rangeStart && entry.watchedAt < rangeEnd) {
       const genres = entry.movie.genres.slice(0, GENRES_PER_ENTRY);
       if (genres.length === 0) genres.push('other');
+      const weight = 1 / genres.length;
       for (const genre of genres) {
-        genreEntries.push({ watchedAt: entry.watchedAt, genre });
+        genreEntries.push({ watchedAt: entry.watchedAt, genre, weight });
       }
     }
   }
@@ -95,16 +90,17 @@ function computeGenreBreakdown(
     if (entry.watchedAt >= rangeStart && entry.watchedAt < rangeEnd) {
       const genres = entry.show.genres.slice(0, GENRES_PER_ENTRY);
       if (genres.length === 0) genres.push('other');
+      const weight = 1 / genres.length;
       for (const genre of genres) {
-        genreEntries.push({ watchedAt: entry.watchedAt, genre });
+        genreEntries.push({ watchedAt: entry.watchedAt, genre, weight });
       }
     }
   }
 
-  // Count genres globally to find top 5
+  // Count genres globally (weighted) to find top 5
   const globalCounts = new Map<string, number>();
-  for (const { genre } of genreEntries) {
-    globalCounts.set(genre, (globalCounts.get(genre) ?? 0) + 1);
+  for (const { genre, weight } of genreEntries) {
+    globalCounts.set(genre, (globalCounts.get(genre) ?? 0) + weight);
   }
 
   const sortedGenres = [...globalCounts.entries()]
@@ -124,19 +120,22 @@ function computeGenreBreakdown(
     genreOrder.push('other');
   }
 
-  // Group entries by day
+  // Group entries by day (weighted)
   const dayGenreCounts = new Map<string, Map<string, number>>();
   for (const day of days) {
     dayGenreCounts.set(getDayKey(day), new Map());
   }
 
-  for (const { watchedAt, genre } of genreEntries) {
+  for (const { watchedAt, genre, weight } of genreEntries) {
     const key = getDayKey(watchedAt);
     const dayCounts = dayGenreCounts.get(key);
     if (!dayCounts) continue;
 
     const effectiveGenre = topGenreSet.has(genre) ? genre : 'other';
-    dayCounts.set(effectiveGenre, (dayCounts.get(effectiveGenre) ?? 0) + 1);
+    dayCounts.set(
+      effectiveGenre,
+      (dayCounts.get(effectiveGenre) ?? 0) + weight,
+    );
   }
 
   // Build day data
@@ -153,7 +152,7 @@ function computeGenreBreakdown(
   });
 
   // Build legend
-  const totalEntries = genreEntries.length;
+  const totalWeight = genreEntries.reduce((s, e) => s + e.weight, 0);
   const legend: GenreLegendEntry[] = genreOrder.map((genre, i) => {
     const count = genre === 'other'
       ? sortedGenres
@@ -165,7 +164,7 @@ function computeGenreBreakdown(
     return {
       genre,
       label: genre === 'other' ? 'Other' : genreLabel(genre),
-      percentage: totalEntries > 0 ? Math.round((count / totalEntries) * 100) : 0,
+      percentage: totalWeight > 0 ? Math.round((count / totalWeight) * 100) : 0,
       color: GENRE_COLORS[Math.min(i, GENRE_COLORS.length - 1)] ?? '#555555',
     };
   });
@@ -177,35 +176,8 @@ export function useGenreBreakdown({ slug }: UseGenreBreakdownProps): {
   data: Observable<GenreBreakdownData>;
   isLoading: Observable<boolean>;
 } {
-  // Cache-aligned params — identical to useStreak.ts:88-117
-  const now = new Date();
-  const startDate = new Date(
-    Date.UTC(
-      now.getUTCFullYear() - 1,
-      now.getUTCMonth(),
-      now.getUTCDate(),
-    ),
-  );
-  const endDate = new Date(
-    Date.UTC(
-      now.getUTCFullYear(),
-      now.getUTCMonth(),
-      now.getUTCDate() + 1,
-    ),
-  );
-
-  const params = {
-    limit: HISTORY_LIMIT,
+  const { movies, shows, isLoadingMovies, isLoadingShows } = useActivityHistory(
     slug,
-    startDate,
-    endDate,
-  };
-
-  const { list: movies, isLoading: isLoadingMovies } = usePaginatedListQuery(
-    movieActivityHistoryQuery(params),
-  );
-  const { list: shows, isLoading: isLoadingShows } = usePaginatedListQuery(
-    showActivityHistoryQuery(params),
   );
 
   const data = combineLatest([movies, shows]).pipe(

--- a/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.ts
@@ -1,0 +1,220 @@
+import type { MovieActivityHistory } from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import {
+  movieActivityHistoryQuery,
+} from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import type { ShowActivityHistory } from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import {
+  showActivityHistoryQuery,
+} from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import { combineLatest, map, type Observable } from 'rxjs';
+import { usePaginatedListQuery } from '../../lists/stores/usePaginatedListQuery.ts';
+
+type UseGenreBreakdownProps = { slug: string };
+
+export type GenreDayData = {
+  date: Date;
+  segments: { genre: string; count: number }[];
+  total: number;
+};
+
+export type GenreLegendEntry = {
+  genre: string;
+  label: string;
+  percentage: number;
+  color: string;
+};
+
+export type GenreBreakdownData = {
+  days: GenreDayData[];
+  legend: GenreLegendEntry[];
+  maxDayTotal: number;
+};
+
+const GENRE_COLORS = [
+  '#a87cf0', // purple - slot 1
+  '#6ea1f7', // blue - slot 2
+  '#4ecdc4', // teal - slot 3
+  '#7bc67e', // green - slot 4
+  '#f0a04b', // orange - slot 5
+  '#555555', // gray - "Other"
+];
+
+const HISTORY_LIMIT = 1000;
+const TOP_GENRE_COUNT = 5;
+const DAY_COUNT = 14;
+
+function genreLabel(slug: string): string {
+  return slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function getDayKey(date: Date): string {
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+}
+
+function computeGenreBreakdown(
+  movies: MovieActivityHistory[],
+  shows: ShowActivityHistory[],
+): GenreBreakdownData {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  // Build 14-day range (today through 13 days ago)
+  const days: Date[] = [];
+  for (let i = DAY_COUNT - 1; i >= 0; i--) {
+    days.push(
+      new Date(today.getFullYear(), today.getMonth(), today.getDate() - i),
+    );
+  }
+
+  const rangeStart = days[0] ?? today;
+  const rangeEnd = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate() + 1,
+  );
+
+  // Collect all entries within the 14-day range, using up to 3 genres each
+  const GENRES_PER_ENTRY = 2;
+  type GenreEntry = { watchedAt: Date; genre: string };
+  const genreEntries: GenreEntry[] = [];
+
+  for (const entry of movies) {
+    if (entry.watchedAt >= rangeStart && entry.watchedAt < rangeEnd) {
+      const genres = entry.movie.genres.slice(0, GENRES_PER_ENTRY);
+      if (genres.length === 0) genres.push('other');
+      for (const genre of genres) {
+        genreEntries.push({ watchedAt: entry.watchedAt, genre });
+      }
+    }
+  }
+
+  for (const entry of shows) {
+    if (entry.watchedAt >= rangeStart && entry.watchedAt < rangeEnd) {
+      const genres = entry.show.genres.slice(0, GENRES_PER_ENTRY);
+      if (genres.length === 0) genres.push('other');
+      for (const genre of genres) {
+        genreEntries.push({ watchedAt: entry.watchedAt, genre });
+      }
+    }
+  }
+
+  // Count genres globally to find top 5
+  const globalCounts = new Map<string, number>();
+  for (const { genre } of genreEntries) {
+    globalCounts.set(genre, (globalCounts.get(genre) ?? 0) + 1);
+  }
+
+  const sortedGenres = [...globalCounts.entries()]
+    .sort((a, b) => b[1] - a[1]);
+
+  const topGenres = sortedGenres
+    .slice(0, TOP_GENRE_COUNT)
+    .map(([genre]) => genre);
+
+  const topGenreSet = new Set(topGenres);
+
+  // Determine consistent genre order (top genres + "other")
+  const genreOrder = [...topGenres];
+  const hasOther = sortedGenres.length > TOP_GENRE_COUNT ||
+    topGenreSet.has('other');
+  if (hasOther && !topGenreSet.has('other')) {
+    genreOrder.push('other');
+  }
+
+  // Group entries by day
+  const dayGenreCounts = new Map<string, Map<string, number>>();
+  for (const day of days) {
+    dayGenreCounts.set(getDayKey(day), new Map());
+  }
+
+  for (const { watchedAt, genre } of genreEntries) {
+    const key = getDayKey(watchedAt);
+    const dayCounts = dayGenreCounts.get(key);
+    if (!dayCounts) continue;
+
+    const effectiveGenre = topGenreSet.has(genre) ? genre : 'other';
+    dayCounts.set(effectiveGenre, (dayCounts.get(effectiveGenre) ?? 0) + 1);
+  }
+
+  // Build day data
+  let maxDayTotal = 0;
+  const dayData: GenreDayData[] = days.map((date) => {
+    const dayCounts = dayGenreCounts.get(getDayKey(date)) ?? new Map<string, number>();
+    const segments = genreOrder.map((genre) => ({
+      genre,
+      count: dayCounts.get(genre) ?? 0,
+    }));
+    const total = segments.reduce((sum, s) => sum + s.count, 0);
+    if (total > maxDayTotal) maxDayTotal = total;
+    return { date, segments, total };
+  });
+
+  // Build legend
+  const totalEntries = genreEntries.length;
+  const legend: GenreLegendEntry[] = genreOrder.map((genre, i) => {
+    const count = genre === 'other'
+      ? sortedGenres
+        .filter(([g]) => !topGenreSet.has(g))
+        .reduce((sum, [, c]) => sum + c, 0) +
+        (topGenreSet.has('other') ? (globalCounts.get('other') ?? 0) : 0)
+      : (globalCounts.get(genre) ?? 0);
+
+    return {
+      genre,
+      label: genre === 'other' ? 'Other' : genreLabel(genre),
+      percentage: totalEntries > 0 ? Math.round((count / totalEntries) * 100) : 0,
+      color: GENRE_COLORS[Math.min(i, GENRE_COLORS.length - 1)] ?? '#555555',
+    };
+  });
+
+  return { days: dayData, legend, maxDayTotal };
+}
+
+export function useGenreBreakdown({ slug }: UseGenreBreakdownProps): {
+  data: Observable<GenreBreakdownData>;
+  isLoading: Observable<boolean>;
+} {
+  // Cache-aligned params — identical to useStreak.ts:88-117
+  const now = new Date();
+  const startDate = new Date(
+    Date.UTC(
+      now.getUTCFullYear() - 1,
+      now.getUTCMonth(),
+      now.getUTCDate(),
+    ),
+  );
+  const endDate = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() + 1,
+    ),
+  );
+
+  const params = {
+    limit: HISTORY_LIMIT,
+    slug,
+    startDate,
+    endDate,
+  };
+
+  const { list: movies, isLoading: isLoadingMovies } = usePaginatedListQuery(
+    movieActivityHistoryQuery(params),
+  );
+  const { list: shows, isLoading: isLoadingShows } = usePaginatedListQuery(
+    showActivityHistoryQuery(params),
+  );
+
+  const data = combineLatest([movies, shows]).pipe(
+    map(([$movies, $shows]) => computeGenreBreakdown($movies, $shows)),
+  );
+
+  const isLoading = combineLatest([isLoadingMovies, isLoadingShows]).pipe(
+    map(([$m, $s]) => $m || $s),
+  );
+
+  return { data, isLoading };
+}

--- a/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.ts
@@ -1,27 +1,30 @@
+import * as m from '$lib/features/i18n/messages.ts';
 import type { MovieActivityHistory } from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
 import type { ShowActivityHistory } from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import { getDayKey } from '$lib/utils/date/getDayKey.ts';
+import { toTranslatedGenre } from '$lib/utils/formatting/string/toTranslatedGenre.ts';
 import { combineLatest, map, type Observable } from 'rxjs';
 import { useActivityHistory } from './activityHistoryParams.ts';
 
-type UseGenreBreakdownProps = { slug: string };
+type UseGenreBreakdownProps = { readonly slug: string };
 
 export type GenreDayData = {
-  date: Date;
-  segments: { genre: string; count: number }[];
-  total: number;
+  readonly date: Date;
+  readonly segments: ReadonlyArray<{ readonly genre: string; readonly count: number }>;
+  readonly total: number;
 };
 
 export type GenreLegendEntry = {
-  genre: string;
-  label: string;
-  percentage: number;
-  color: string;
+  readonly genre: string;
+  readonly label: string;
+  readonly percentage: number;
+  readonly color: string;
 };
 
 export type GenreBreakdownData = {
-  days: GenreDayData[];
-  legend: GenreLegendEntry[];
-  maxDayTotal: number;
+  readonly days: ReadonlyArray<GenreDayData>;
+  readonly legend: ReadonlyArray<GenreLegendEntry>;
+  readonly maxDayTotal: number;
 };
 
 const GENRE_COLORS = [
@@ -37,31 +40,20 @@ const TOP_GENRE_COUNT = 5;
 const DAY_COUNT = 14;
 const GENRES_PER_ENTRY = 2;
 
-function genreLabel(slug: string): string {
-  return slug
-    .split('-')
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ');
-}
-
-function getDayKey(date: Date): string {
-  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
-}
-
-function computeGenreBreakdown(
-  movies: MovieActivityHistory[],
-  shows: ShowActivityHistory[],
+export function computeGenreBreakdown(
+  movies: ReadonlyArray<MovieActivityHistory>,
+  shows: ReadonlyArray<ShowActivityHistory>,
+  now: Date,
 ): GenreBreakdownData {
-  const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
-  // Build 14-day range (today through 13 days ago)
-  const days: Date[] = [];
-  for (let i = DAY_COUNT - 1; i >= 0; i--) {
-    days.push(
-      new Date(today.getFullYear(), today.getMonth(), today.getDate() - i),
-    );
-  }
+  const days = Array.from({ length: DAY_COUNT }, (_, i) =>
+    new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - (DAY_COUNT - 1 - i),
+    ),
+  );
 
   const rangeStart = days[0] ?? today;
   const rangeEnd = new Date(
@@ -70,41 +62,54 @@ function computeGenreBreakdown(
     today.getDate() + 1,
   );
 
-  // Collect genre entries, weighting each genre as 1/numGenres to avoid
-  // inflating bar heights for multi-genre titles
-  type GenreEntry = { watchedAt: Date; genre: string; weight: number };
-  const genreEntries: GenreEntry[] = [];
+  type GenreEntry = {
+    readonly watchedAt: Date;
+    readonly genre: string;
+    readonly weight: number;
+  };
 
-  for (const entry of movies) {
-    if (entry.watchedAt >= rangeStart && entry.watchedAt < rangeEnd) {
-      const genres = entry.movie.genres.slice(0, GENRES_PER_ENTRY);
-      if (genres.length === 0) genres.push('other');
-      const weight = 1 / genres.length;
-      for (const genre of genres) {
-        genreEntries.push({ watchedAt: entry.watchedAt, genre, weight });
+  const collectEntries = (
+    entries: ReadonlyArray<{ watchedAt: Date; genres: readonly string[] }>,
+  ): GenreEntry[] =>
+    entries.flatMap((entry) => {
+      if (entry.watchedAt < rangeStart || entry.watchedAt >= rangeEnd) {
+        return [];
       }
-    }
-  }
+      const genres = entry.genres.length > 0
+        ? entry.genres.slice(0, GENRES_PER_ENTRY)
+        : ['other'];
+      const weight = 1 / genres.length;
+      return genres.map((genre) => ({
+        watchedAt: entry.watchedAt,
+        genre,
+        weight,
+      }));
+    });
 
-  for (const entry of shows) {
-    if (entry.watchedAt >= rangeStart && entry.watchedAt < rangeEnd) {
-      const genres = entry.show.genres.slice(0, GENRES_PER_ENTRY);
-      if (genres.length === 0) genres.push('other');
-      const weight = 1 / genres.length;
-      for (const genre of genres) {
-        genreEntries.push({ watchedAt: entry.watchedAt, genre, weight });
-      }
-    }
-  }
+  const genreEntries = [
+    ...collectEntries(
+      movies.map((e) => ({
+        watchedAt: e.watchedAt,
+        genres: e.movie.genres,
+      })),
+    ),
+    ...collectEntries(
+      shows.map((e) => ({
+        watchedAt: e.watchedAt,
+        genres: e.show.genres,
+      })),
+    ),
+  ];
 
   // Count genres globally (weighted) to find top 5
-  const globalCounts = new Map<string, number>();
-  for (const { genre, weight } of genreEntries) {
-    globalCounts.set(genre, (globalCounts.get(genre) ?? 0) + weight);
-  }
+  const globalCounts = genreEntries.reduce((acc, { genre, weight }) => {
+    acc.set(genre, (acc.get(genre) ?? 0) + weight);
+    return acc;
+  }, new Map<string, number>());
 
-  const sortedGenres = [...globalCounts.entries()]
-    .sort((a, b) => b[1] - a[1]);
+  const sortedGenres = [...globalCounts.entries()].sort(
+    (a, b) => b[1] - a[1],
+  );
 
   const topGenres = sortedGenres
     .slice(0, TOP_GENRE_COUNT)
@@ -112,10 +117,9 @@ function computeGenreBreakdown(
 
   const topGenreSet = new Set(topGenres);
 
-  // Determine consistent genre order (top genres + "other")
   const genreOrder = [...topGenres];
-  const hasOther = sortedGenres.length > TOP_GENRE_COUNT ||
-    topGenreSet.has('other');
+  const hasOther =
+    sortedGenres.length > TOP_GENRE_COUNT || topGenreSet.has('other');
   if (hasOther && !topGenreSet.has('other')) {
     genreOrder.push('other');
   }
@@ -139,7 +143,6 @@ function computeGenreBreakdown(
   }
 
   // Build day data
-  let maxDayTotal = 0;
   const dayData: GenreDayData[] = days.map((date) => {
     const dayCounts = dayGenreCounts.get(getDayKey(date)) ?? new Map<string, number>();
     const segments = genreOrder.map((genre) => ({
@@ -147,24 +150,32 @@ function computeGenreBreakdown(
       count: dayCounts.get(genre) ?? 0,
     }));
     const total = segments.reduce((sum, s) => sum + s.count, 0);
-    if (total > maxDayTotal) maxDayTotal = total;
     return { date, segments, total };
   });
+
+  const maxDayTotal = Math.max(...dayData.map((d) => d.total), 0);
 
   // Build legend
   const totalWeight = genreEntries.reduce((s, e) => s + e.weight, 0);
   const legend: GenreLegendEntry[] = genreOrder.map((genre, i) => {
-    const count = genre === 'other'
-      ? sortedGenres
-        .filter(([g]) => !topGenreSet.has(g))
-        .reduce((sum, [, c]) => sum + c, 0) +
-        (topGenreSet.has('other') ? (globalCounts.get('other') ?? 0) : 0)
-      : (globalCounts.get(genre) ?? 0);
+    const count =
+      genre === 'other'
+        ? sortedGenres
+            .filter(([g]) => !topGenreSet.has(g))
+            .reduce((sum, [, c]) => sum + c, 0) +
+          (topGenreSet.has('other')
+            ? (globalCounts.get('other') ?? 0)
+            : 0)
+        : (globalCounts.get(genre) ?? 0);
 
     return {
       genre,
-      label: genre === 'other' ? 'Other' : genreLabel(genre),
-      percentage: totalWeight > 0 ? Math.round((count / totalWeight) * 100) : 0,
+      label:
+        genre === 'other'
+          ? m.text_stats_genre_other()
+          : toTranslatedGenre(genre),
+      percentage:
+        totalWeight > 0 ? Math.round((count / totalWeight) * 100) : 0,
       color: GENRE_COLORS[Math.min(i, GENRE_COLORS.length - 1)] ?? '#555555',
     };
   });
@@ -176,12 +187,13 @@ export function useGenreBreakdown({ slug }: UseGenreBreakdownProps): {
   data: Observable<GenreBreakdownData>;
   isLoading: Observable<boolean>;
 } {
-  const { movies, shows, isLoadingMovies, isLoadingShows } = useActivityHistory(
-    slug,
-  );
+  const { movies, shows, isLoadingMovies, isLoadingShows } =
+    useActivityHistory(slug);
+
+  const now = new Date();
 
   const data = combineLatest([movies, shows]).pipe(
-    map(([$movies, $shows]) => computeGenreBreakdown($movies, $shows)),
+    map(([$movies, $shows]) => computeGenreBreakdown($movies, $shows, now)),
   );
 
   const isLoading = combineLatest([isLoadingMovies, isLoadingShows]).pipe(

--- a/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.ts
@@ -37,7 +37,7 @@ const GENRE_COLORS = [
 ];
 
 const TOP_GENRE_COUNT = 5;
-const DAY_COUNT = 14;
+export const DAY_COUNT = 14;
 const GENRES_PER_ENTRY = 2;
 
 export function computeGenreBreakdown(

--- a/projects/client/src/lib/sections/stats/_internal/useStreak.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useStreak.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { computeStreak } from './useStreak.ts';
+
+describe('computeStreak', () => {
+  it('returns none for empty dates', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    expect(computeStreak([], now)).toEqual({ count: 0, state: 'none' });
+  });
+
+  it('returns active streak when watched today', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    const dates = [
+      new Date('2024-01-15T10:00:00Z'),
+      new Date('2024-01-14T10:00:00Z'),
+      new Date('2024-01-13T10:00:00Z'),
+    ];
+    expect(computeStreak(dates, now)).toEqual({ count: 3, state: 'active' });
+  });
+
+  it('returns at_risk when last watch was yesterday', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    const dates = [
+      new Date('2024-01-14T10:00:00Z'),
+      new Date('2024-01-13T10:00:00Z'),
+    ];
+    expect(computeStreak(dates, now)).toEqual({ count: 2, state: 'at_risk' });
+  });
+
+  it('returns none when gap is more than one day', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    const dates = [
+      new Date('2024-01-12T10:00:00Z'),
+    ];
+    expect(computeStreak(dates, now)).toEqual({ count: 0, state: 'none' });
+  });
+
+  it('breaks streak at gap', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    const dates = [
+      new Date('2024-01-15T10:00:00Z'),
+      new Date('2024-01-14T10:00:00Z'),
+      // gap on Jan 13
+      new Date('2024-01-12T10:00:00Z'),
+    ];
+    expect(computeStreak(dates, now)).toEqual({ count: 2, state: 'active' });
+  });
+
+  it('counts single day as streak of 1', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    const dates = [new Date('2024-01-15T10:00:00Z')];
+    expect(computeStreak(dates, now)).toEqual({ count: 1, state: 'active' });
+  });
+
+  it('handles multiple watches on the same day', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    const dates = [
+      new Date('2024-01-15T08:00:00Z'),
+      new Date('2024-01-15T12:00:00Z'),
+      new Date('2024-01-15T20:00:00Z'),
+      new Date('2024-01-14T10:00:00Z'),
+    ];
+    expect(computeStreak(dates, now)).toEqual({ count: 2, state: 'active' });
+  });
+});

--- a/projects/client/src/lib/sections/stats/_internal/useStreak.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useStreak.ts
@@ -1,15 +1,5 @@
-import {
-  movieActivityHistoryQuery,
-} from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
-import {
-  showActivityHistoryQuery,
-} from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
-import { combineLatest, map } from 'rxjs';
-import { usePaginatedListQuery } from '../../lists/stores/usePaginatedListQuery.ts';
-
-// Uses two separate queries (matching useMonthToDate pattern) rather than the
-// combined activityHistoryQuery, since useMonthToDate already establishes this
-// pattern and the queries may already be cached from other components.
+import { combineLatest, map, shareReplay } from 'rxjs';
+import { useActivityHistory } from './activityHistoryParams.ts';
 
 export type StreakState = 'active' | 'broken' | 'none';
 
@@ -17,8 +7,6 @@ type StreakResult = {
   count: number;
   state: StreakState;
 };
-
-const STREAK_HISTORY_LIMIT = 1000;
 
 type UseStreakProps = {
   slug: string;
@@ -34,8 +22,7 @@ function computeStreak(
   // Collect unique calendar days (local time) with watch activity
   const daysWithActivity = new Set<string>();
   for (const date of watchedDates) {
-    const dayKey =
-      `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+    const dayKey = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
     daysWithActivity.add(dayKey);
   }
 
@@ -86,34 +73,8 @@ function computeStreak(
 }
 
 export function useStreak({ slug }: UseStreakProps) {
-  const now = new Date();
-  const startDate = new Date(
-    Date.UTC(
-      now.getUTCFullYear() - 1,
-      now.getUTCMonth(),
-      now.getUTCDate(),
-    ),
-  );
-  const endDate = new Date(
-    Date.UTC(
-      now.getUTCFullYear(),
-      now.getUTCMonth(),
-      now.getUTCDate() + 1,
-    ),
-  );
-
-  const params = {
-    limit: STREAK_HISTORY_LIMIT,
+  const { movies, shows, isLoadingMovies, isLoadingShows } = useActivityHistory(
     slug,
-    startDate,
-    endDate,
-  };
-
-  const { list: movies, isLoading: isLoadingMovies } = usePaginatedListQuery(
-    movieActivityHistoryQuery(params),
-  );
-  const { list: shows, isLoading: isLoadingShows } = usePaginatedListQuery(
-    showActivityHistoryQuery(params),
   );
 
   const streak = combineLatest([movies, shows]).pipe(
@@ -124,6 +85,7 @@ export function useStreak({ slug }: UseStreakProps) {
       ];
       return computeStreak(allDates);
     }),
+    shareReplay(1),
   );
 
   return {

--- a/projects/client/src/lib/sections/stats/_internal/useStreak.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useStreak.ts
@@ -1,81 +1,76 @@
+import { getDayKey } from '$lib/utils/date/getDayKey.ts';
 import { combineLatest, map, shareReplay } from 'rxjs';
 import { useActivityHistory } from './activityHistoryParams.ts';
 
-export type StreakState = 'active' | 'broken' | 'none';
+export type StreakState = 'active' | 'at_risk' | 'none';
 
 type StreakResult = {
-  count: number;
-  state: StreakState;
+  readonly count: number;
+  readonly state: StreakState;
 };
 
 type UseStreakProps = {
-  slug: string;
+  readonly slug: string;
 };
 
-function computeStreak(
-  watchedDates: Date[],
+export function computeStreak(
+  watchedDates: ReadonlyArray<Date>,
+  now: Date,
 ): StreakResult {
   if (watchedDates.length === 0) {
     return { count: 0, state: 'none' };
   }
 
-  // Collect unique calendar days (local time) with watch activity
-  const daysWithActivity = new Set<string>();
-  for (const date of watchedDates) {
-    const dayKey = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
-    daysWithActivity.add(dayKey);
-  }
+  const daysWithActivity = new Set(watchedDates.map(getDayKey));
 
-  // Walk backwards from today counting consecutive days (local time)
-  const now = new Date();
-  let currentDate = new Date(
+  const today = new Date(
     now.getFullYear(),
     now.getMonth(),
     now.getDate(),
   );
 
-  const todayKey =
-    `${currentDate.getFullYear()}-${currentDate.getMonth()}-${currentDate.getDate()}`;
-  const hasActivityToday = daysWithActivity.has(todayKey);
+  const hasActivityToday = daysWithActivity.has(getDayKey(today));
 
+  let startDate: Date;
   if (!hasActivityToday) {
-    // Check if there was activity yesterday (broken streak)
-    const yesterday = new Date(currentDate);
-    yesterday.setDate(yesterday.getDate() - 1);
-    const yesterdayKey =
-      `${yesterday.getFullYear()}-${yesterday.getMonth()}-${yesterday.getDate()}`;
+    const yesterday = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - 1,
+    );
 
-    if (!daysWithActivity.has(yesterdayKey)) {
+    if (!daysWithActivity.has(getDayKey(yesterday))) {
       return { count: 0, state: 'none' };
     }
 
-    // Walk backwards from yesterday to count the broken streak
-    currentDate = yesterday;
+    startDate = yesterday;
+  } else {
+    startDate = today;
   }
 
   let streakCount = 0;
-  while (true) {
-    const dayKey =
-      `${currentDate.getFullYear()}-${currentDate.getMonth()}-${currentDate.getDate()}`;
-
-    if (!daysWithActivity.has(dayKey)) {
-      break;
-    }
-
+  let checkDate = new Date(startDate);
+  for (let i = 0; i < daysWithActivity.size; i++) {
+    if (!daysWithActivity.has(getDayKey(checkDate))) break;
     streakCount++;
-    currentDate.setDate(currentDate.getDate() - 1);
+    checkDate = new Date(
+      checkDate.getFullYear(),
+      checkDate.getMonth(),
+      checkDate.getDate() - 1,
+    );
   }
 
   return {
     count: streakCount,
-    state: hasActivityToday ? 'active' : 'broken',
+    state: hasActivityToday ? 'active' : 'at_risk',
   };
 }
 
 export function useStreak({ slug }: UseStreakProps) {
-  const { movies, shows, isLoadingMovies, isLoadingShows } = useActivityHistory(
-    slug,
-  );
+  const { movies, shows, isLoadingMovies, isLoadingShows } =
+    useActivityHistory(slug);
+
+  const now = new Date();
 
   const streak = combineLatest([movies, shows]).pipe(
     map(([$movies, $shows]) => {
@@ -83,7 +78,7 @@ export function useStreak({ slug }: UseStreakProps) {
         ...$movies.map((m) => m.watchedAt),
         ...$shows.map((s) => s.watchedAt),
       ];
-      return computeStreak(allDates);
+      return computeStreak(allDates, now);
     }),
     shareReplay(1),
   );

--- a/projects/client/src/lib/sections/stats/_internal/useStreak.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useStreak.ts
@@ -1,0 +1,136 @@
+import {
+  movieActivityHistoryQuery,
+} from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import {
+  showActivityHistoryQuery,
+} from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import { combineLatest, map } from 'rxjs';
+import { usePaginatedListQuery } from '../../lists/stores/usePaginatedListQuery.ts';
+
+// Uses two separate queries (matching useMonthToDate pattern) rather than the
+// combined activityHistoryQuery, since useMonthToDate already establishes this
+// pattern and the queries may already be cached from other components.
+
+export type StreakState = 'active' | 'broken' | 'none';
+
+type StreakResult = {
+  count: number;
+  state: StreakState;
+};
+
+const STREAK_HISTORY_LIMIT = 1000;
+
+type UseStreakProps = {
+  slug: string;
+};
+
+function computeStreak(
+  watchedDates: Date[],
+): StreakResult {
+  if (watchedDates.length === 0) {
+    return { count: 0, state: 'none' };
+  }
+
+  // Collect unique calendar days (local time) with watch activity
+  const daysWithActivity = new Set<string>();
+  for (const date of watchedDates) {
+    const dayKey =
+      `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+    daysWithActivity.add(dayKey);
+  }
+
+  // Walk backwards from today counting consecutive days (local time)
+  const now = new Date();
+  let currentDate = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  );
+
+  const todayKey =
+    `${currentDate.getFullYear()}-${currentDate.getMonth()}-${currentDate.getDate()}`;
+  const hasActivityToday = daysWithActivity.has(todayKey);
+
+  if (!hasActivityToday) {
+    // Check if there was activity yesterday (broken streak)
+    const yesterday = new Date(currentDate);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayKey =
+      `${yesterday.getFullYear()}-${yesterday.getMonth()}-${yesterday.getDate()}`;
+
+    if (!daysWithActivity.has(yesterdayKey)) {
+      return { count: 0, state: 'none' };
+    }
+
+    // Walk backwards from yesterday to count the broken streak
+    currentDate = yesterday;
+  }
+
+  let streakCount = 0;
+  while (true) {
+    const dayKey =
+      `${currentDate.getFullYear()}-${currentDate.getMonth()}-${currentDate.getDate()}`;
+
+    if (!daysWithActivity.has(dayKey)) {
+      break;
+    }
+
+    streakCount++;
+    currentDate.setDate(currentDate.getDate() - 1);
+  }
+
+  return {
+    count: streakCount,
+    state: hasActivityToday ? 'active' : 'broken',
+  };
+}
+
+export function useStreak({ slug }: UseStreakProps) {
+  const now = new Date();
+  const startDate = new Date(
+    Date.UTC(
+      now.getUTCFullYear() - 1,
+      now.getUTCMonth(),
+      now.getUTCDate(),
+    ),
+  );
+  const endDate = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() + 1,
+    ),
+  );
+
+  const params = {
+    limit: STREAK_HISTORY_LIMIT,
+    slug,
+    startDate,
+    endDate,
+  };
+
+  const { list: movies, isLoading: isLoadingMovies } = usePaginatedListQuery(
+    movieActivityHistoryQuery(params),
+  );
+  const { list: shows, isLoading: isLoadingShows } = usePaginatedListQuery(
+    showActivityHistoryQuery(params),
+  );
+
+  const streak = combineLatest([movies, shows]).pipe(
+    map(([$movies, $shows]) => {
+      const allDates = [
+        ...$movies.map((m) => m.watchedAt),
+        ...$shows.map((s) => s.watchedAt),
+      ];
+      return computeStreak(allDates);
+    }),
+  );
+
+  return {
+    streakCount: streak.pipe(map(($s) => $s.count)),
+    streakState: streak.pipe(map(($s) => $s.state)),
+    isLoading: combineLatest([isLoadingMovies, isLoadingShows]).pipe(
+      map(([$m, $s]) => $m || $s),
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
@@ -1,15 +1,9 @@
 import type { MovieActivityHistory } from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
-import {
-  movieActivityHistoryQuery,
-} from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
 import type { ShowActivityHistory } from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
-import {
-  showActivityHistoryQuery,
-} from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
-import { useMonthInReview } from '$lib/sections/banner/month-in-review/_internal/useMonthInReview.ts';
+import { languageTag } from '$lib/features/i18n/index.ts';
 import { toHumanNumber } from '$lib/utils/formatting/number/toHumanNumber.ts';
 import { combineLatest, map, type Observable } from 'rxjs';
-import { usePaginatedListQuery } from '../../lists/stores/usePaginatedListQuery.ts';
+import { useActivityHistory } from './activityHistoryParams.ts';
 
 export type PulseStat = {
   key: string;
@@ -23,13 +17,11 @@ export type PulseGraphType =
   | 'dailyBars'
   | 'weekTrend'
   | 'watchClock'
-  | 'showsMovies'
-  | 'bingeTimeline';
+  | 'showsMovies';
 
 export type PulseGraphData = {
   dailyBars: {
     thisWeek: number[];
-    lastWeek: number[];
     dayLabels: string[];
     todayIndex: number;
   };
@@ -43,10 +35,6 @@ export type PulseGraphData = {
     episodes: number;
     movies: number;
   };
-  bingeTimeline: {
-    days: { label: string; count: number }[];
-    maxCount: number;
-  };
 };
 
 type UseWeeklyPulseProps = {
@@ -54,8 +42,6 @@ type UseWeeklyPulseProps = {
 };
 
 type DateRange = { start: Date; end: Date };
-
-const HISTORY_LIMIT = 1000;
 
 const DAY_NAMES = [
   'Sunday',
@@ -67,11 +53,21 @@ const DAY_NAMES = [
   'Saturday',
 ];
 
+const DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+
 function getDateRange(startDaysAgo: number, endDaysAgo: number): DateRange {
   const now = new Date();
   return {
-    start: new Date(now.getFullYear(), now.getMonth(), now.getDate() - startDaysAgo),
-    end: new Date(now.getFullYear(), now.getMonth(), now.getDate() - endDaysAgo + 1),
+    start: new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() - startDaysAgo,
+    ),
+    end: new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() - endDaysAgo + 1,
+    ),
   };
 }
 
@@ -79,7 +75,9 @@ function filterEntries<T extends { watchedAt: Date }>(
   entries: T[],
   range: DateRange,
 ): T[] {
-  return entries.filter((e) => e.watchedAt >= range.start && e.watchedAt < range.end);
+  return entries.filter((e) =>
+    e.watchedAt >= range.start && e.watchedAt < range.end
+  );
 }
 
 function sumHours(
@@ -142,10 +140,10 @@ function maxPlaysInSingleDay(dates: Date[]): number {
 }
 
 function fmt(n: number): string {
-  return toHumanNumber(n, 'en');
+  return toHumanNumber(n, languageTag());
 }
 
-function delta(thisWeek: number, lastWeek: number): number {
+function computeDelta(thisWeek: number, lastWeek: number): number {
   return thisWeek - lastWeek;
 }
 
@@ -222,12 +220,20 @@ function pickGraph(graphData: PulseGraphData): PulseGraphType | null {
   const maxWeek = Math.max(...weekPlays);
   const minWeek = Math.min(...weekPlays);
   if (maxWeek > 0 && (maxWeek - minWeek) / maxWeek > 0.25) {
-    candidates.push({ type: 'weekTrend', score: (maxWeek - minWeek) / maxWeek * 10 });
+    candidates.push({
+      type: 'weekTrend',
+      score: (maxWeek - minWeek) / maxWeek * 10,
+    });
   }
 
   // watchClock: compelling if a clear peak (one bucket > 40% of total)
-  const clockTotal = graphData.watchClock.buckets.reduce((s, b) => s + b.count, 0);
-  const clockPeak = Math.max(...graphData.watchClock.buckets.map((b) => b.count));
+  const clockTotal = graphData.watchClock.buckets.reduce(
+    (s, b) => s + b.count,
+    0,
+  );
+  const clockPeak = Math.max(
+    ...graphData.watchClock.buckets.map((b) => b.count),
+  );
   if (clockTotal > 0 && clockPeak / clockTotal > 0.4) {
     candidates.push({ type: 'watchClock', score: clockPeak / clockTotal * 10 });
   }
@@ -235,35 +241,39 @@ function pickGraph(graphData: PulseGraphData): PulseGraphType | null {
   // showsMovies: only if both > 0
   const { episodes, movies: movieCount } = graphData.showsMovies;
   if (episodes > 0 && movieCount > 0) {
-    const balance = Math.min(episodes, movieCount) / Math.max(episodes, movieCount);
+    const balance = Math.min(episodes, movieCount) /
+      Math.max(episodes, movieCount);
     candidates.push({ type: 'showsMovies', score: balance * 10 });
   }
-
-  // bingeTimeline: skip (redundant with dailyBars)
 
   if (candidates.length === 0) return null;
   candidates.sort((a, b) => b.score - a.score);
   return candidates[0]!.type;
 }
 
-function dedup(candidates: PulseStat[]): PulseStat[] {
-  const byKey = new Map(candidates.map((c) => [c.key, c]));
-
-  const plays = byKey.get('totalPlays');
-  const episodes = byKey.get('episodes');
-  const moviesItem = byKey.get('movies');
+// Dedup uses raw counts to avoid compact notation collisions (1000 and 1040 both → "1K")
+function dedup(
+  candidates: PulseStat[],
+  rawCounts: Map<string, number>,
+): PulseStat[] {
+  const playsRaw = rawCounts.get('totalPlays') ?? 0;
+  const episodesRaw = rawCounts.get('episodes') ?? 0;
+  const moviesRaw = rawCounts.get('movies') ?? 0;
 
   // If plays == episodes (no movies), drop episodes
-  if (plays && episodes && plays.value === episodes.value) {
+  if (playsRaw === episodesRaw && playsRaw > 0) {
     candidates = candidates.filter((c) => c.key !== 'episodes');
   }
   // If plays == movies (no episodes), drop movies
-  if (plays && moviesItem && plays.value === moviesItem.value) {
+  if (playsRaw === moviesRaw && playsRaw > 0) {
     candidates = candidates.filter((c) => c.key !== 'movies');
   }
-  // If movies == 0 and not already removed, drop
-  if (moviesItem && moviesItem.value === '0' && moviesItem.delta === 0) {
-    candidates = candidates.filter((c) => c.key !== 'movies');
+  // If movies == 0 with no change, not interesting
+  if (moviesRaw === 0) {
+    const moviesItem = candidates.find((c) => c.key === 'movies');
+    if (moviesItem && moviesItem.delta === 0) {
+      candidates = candidates.filter((c) => c.key !== 'movies');
+    }
   }
 
   return candidates;
@@ -275,49 +285,15 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
   selectedGraph: Observable<PulseGraphType | null>;
   isLoading: Observable<boolean>;
 } {
-  // Cache-aligned params — identical to useStreak.ts:88-117
-  const now = new Date();
-  const startDate = new Date(
-    Date.UTC(
-      now.getUTCFullYear() - 1,
-      now.getUTCMonth(),
-      now.getUTCDate(),
-    ),
-  );
-  const endDate = new Date(
-    Date.UTC(
-      now.getUTCFullYear(),
-      now.getUTCMonth(),
-      now.getUTCDate() + 1,
-    ),
-  );
-
-  const params = {
-    limit: HISTORY_LIMIT,
+  const { movies, shows, isLoadingMovies, isLoadingShows } = useActivityHistory(
     slug,
-    startDate,
-    endDate,
-  };
-
-  const { list: movies, isLoading: isLoadingMovies } = usePaginatedListQuery(
-    movieActivityHistoryQuery(params),
   );
-  const { list: shows, isLoading: isLoadingShows } = usePaginatedListQuery(
-    showActivityHistoryQuery(params),
-  );
-
-  // Cache-aligned params — identical to StatChips.svelte:22-28
-  const { review, isLoading: isLoadingReview } = useMonthInReview({
-    slug,
-    month: now.getUTCMonth() + 1,
-    year: now.getUTCFullYear(),
-  });
 
   const thisWeekRange = getDateRange(6, 0);
   const lastWeekRange = getDateRange(13, 7);
 
-  const stats = combineLatest([movies, shows, review]).pipe(
-    map(([$movies, $shows, $review]) => {
+  const stats = combineLatest([movies, shows]).pipe(
+    map(([$movies, $shows]) => {
       const twMovies = filterEntries($movies, thisWeekRange);
       const lwMovies = filterEntries($movies, lastWeekRange);
       const twShows = filterEntries($shows, thisWeekRange);
@@ -346,36 +322,43 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
       const twBingeMax = maxPlaysInSingleDay(twAllDates);
       const lwBingeMax = maxPlaysInSingleDay(lwAllDates);
 
+      // Track raw counts for dedup comparison (avoids compact notation collisions)
+      const rawCounts = new Map<string, number>([
+        ['totalPlays', twAllDates.length],
+        ['episodes', twShows.length],
+        ['movies', twMovies.length],
+      ]);
+
       const candidates: PulseStat[] = [
         {
           key: 'totalPlays',
           value: fmt(twAllDates.length),
           label: 'Plays',
-          delta: delta(twAllDates.length, lwAllDates.length),
+          delta: computeDelta(twAllDates.length, lwAllDates.length),
         },
         {
           key: 'episodes',
           value: fmt(twShows.length),
           label: 'Episodes',
-          delta: delta(twShows.length, lwShows.length),
+          delta: computeDelta(twShows.length, lwShows.length),
         },
         {
           key: 'movies',
           value: fmt(twMovies.length),
           label: 'Movies',
-          delta: delta(twMovies.length, lwMovies.length),
+          delta: computeDelta(twMovies.length, lwMovies.length),
         },
         {
           key: 'shows',
           value: fmt(twShowSlugs.size),
           label: 'Shows',
-          delta: delta(twShowSlugs.size, lwShowSlugs.size),
+          delta: computeDelta(twShowSlugs.size, lwShowSlugs.size),
         },
         {
           key: 'activeDays',
           value: fmt(countUniqueDays(twAllDates)),
           label: 'Active Days',
-          delta: delta(
+          delta: computeDelta(
             countUniqueDays(twAllDates),
             countUniqueDays(lwAllDates),
           ),
@@ -393,42 +376,18 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
           key: 'longestBinge',
           value: fmt(twBingeMax),
           label: 'Best Day',
-          delta: delta(twBingeMax, lwBingeMax),
+          delta: computeDelta(twBingeMax, lwBingeMax),
         },
         {
           key: 'hours',
           value: fmt(twHours),
           label: 'Hours',
-          delta: delta(twHours, lwHours),
+          delta: computeDelta(twHours, lwHours),
         },
       ];
 
-      // Month-in-review stats (no deltas — API lacks date range filtering)
-      if ($review) {
-        candidates.push(
-          {
-            key: 'ratings',
-            value: fmt($review.ratingsCount),
-            label: 'Ratings',
-            delta: null,
-          },
-          {
-            key: 'comments',
-            value: fmt($review.commentsCount),
-            label: 'Comments',
-            delta: null,
-          },
-          {
-            key: 'lists',
-            value: fmt($review.listsCount),
-            label: 'List Items',
-            delta: null,
-          },
-        );
-      }
-
       // Sort: abs(delta) descending, zero-value+zero-delta to back,
-      // null-delta (month-in-review) after history stats
+      // null-delta after history stats
       const sorted = candidates.sort((a, b) => {
         const aIsZero = a.value === '0' && a.delta === 0;
         const bIsZero = b.value === '0' && b.delta === 0;
@@ -441,60 +400,32 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
         return Math.abs(b.delta ?? 0) - Math.abs(a.delta ?? 0);
       });
 
-      return dedup(sorted);
+      return dedup(sorted, rawCounts);
     }),
   );
-
-  const DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
-  const DAY_LABELS_FULL = [
-    'Mon',
-    'Tue',
-    'Wed',
-    'Thu',
-    'Fri',
-    'Sat',
-    'Sun',
-  ];
 
   const graphData = combineLatest([movies, shows]).pipe(
     map(([$movies, $shows]) => {
       const twMovies = filterEntries($movies, thisWeekRange);
-      const lwMovies = filterEntries($movies, lastWeekRange);
       const twShows = filterEntries($shows, thisWeekRange);
-      const lwShows = filterEntries($shows, lastWeekRange);
 
       const twAllDates = [
         ...twMovies.map((m) => m.watchedAt),
         ...twShows.map((s) => s.watchedAt),
       ];
-      const lwAllDates = [
-        ...lwMovies.map((m) => m.watchedAt),
-        ...lwShows.map((s) => s.watchedAt),
-      ];
 
       // All dates for the last 4 weeks
       const fourWeekRange = getDateRange(27, 0);
-      const allRecentMovieDates = filterEntries($movies, fourWeekRange)
-        .map((m) => m.watchedAt);
-      const allRecentShowDates = filterEntries($shows, fourWeekRange)
-        .map((s) => s.watchedAt);
-      const allRecentDates = [...allRecentMovieDates, ...allRecentShowDates];
+      const allRecentDates = [
+        ...filterEntries($movies, fourWeekRange).map((m) => m.watchedAt),
+        ...filterEntries($shows, fourWeekRange).map((s) => s.watchedAt),
+      ];
 
       const todayDow = (new Date().getDay() + 6) % 7;
 
-      const thisWeekByDay = countByWeekday(twAllDates);
-      const lastWeekByDay = countByWeekday(lwAllDates);
-
-      const bingeTimeline = thisWeekByDay.map((count, i) => ({
-        label: DAY_LABELS_FULL[i]!,
-        count,
-      }));
-      const maxCount = Math.max(...thisWeekByDay, 1);
-
       return {
         dailyBars: {
-          thisWeek: thisWeekByDay,
-          lastWeek: lastWeekByDay,
+          thisWeek: countByWeekday(twAllDates),
           dayLabels: DAY_LABELS,
           todayIndex: todayDow,
         },
@@ -508,10 +439,6 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
           episodes: twShows.length,
           movies: twMovies.length,
         },
-        bingeTimeline: {
-          days: bingeTimeline,
-          maxCount,
-        },
       } satisfies PulseGraphData;
     }),
   );
@@ -520,12 +447,8 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
     map(($graphData) => pickGraph($graphData)),
   );
 
-  const isLoading = combineLatest([
-    isLoadingMovies,
-    isLoadingShows,
-    isLoadingReview,
-  ]).pipe(
-    map(([$m, $s, $r]) => $m || $s || $r),
+  const isLoading = combineLatest([isLoadingMovies, isLoadingShows]).pipe(
+    map(([$m, $s]) => $m || $s),
   );
 
   return { stats, graphData, selectedGraph, isLoading };

--- a/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
@@ -1,62 +1,38 @@
-import type { MovieActivityHistory } from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
-import type { ShowActivityHistory } from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
-import { languageTag } from '$lib/features/i18n/index.ts';
+import { getLocale, languageTag } from '$lib/features/i18n/index.ts';
+import * as m from '$lib/features/i18n/messages.ts';
+import { toHumanDayOfWeek } from '$lib/utils/formatting/date/toHumanDayOfWeek.ts';
 import { toHumanNumber } from '$lib/utils/formatting/number/toHumanNumber.ts';
 import { combineLatest, map, type Observable } from 'rxjs';
 import { useActivityHistory } from './activityHistoryParams.ts';
+import {
+  bucketByTimeOfDay,
+  computeWeekTrend,
+  countByCalendarDay,
+  pickGraph,
+  type PulseGraphData,
+  type PulseGraphType,
+} from './pulseGraphs.ts';
+import {
+  computeDelta,
+  countUniqueDays,
+  dayOfWeekDate,
+  dedup,
+  getBusiestDay,
+  maxPlaysInSingleDay,
+  sumHours,
+  type PulseStat,
+} from './pulseStats.ts';
 
-export type PulseStat = {
-  key: string;
-  value: string;
-  label: string;
-  delta: number | null;
-  note?: string;
-};
-
-export type PulseGraphType =
-  | 'dailyBars'
-  | 'weekTrend'
-  | 'watchClock'
-  | 'showsMovies';
-
-export type PulseGraphData = {
-  dailyBars: {
-    thisWeek: number[];
-    dayLabels: string[];
-    todayIndex: number;
-  };
-  weekTrend: {
-    weeks: { label: string; plays: number }[];
-  };
-  watchClock: {
-    buckets: { label: string; count: number }[];
-  };
-  showsMovies: {
-    episodes: number;
-    movies: number;
-  };
-};
+export type { PulseGraphData, PulseGraphType } from './pulseGraphs.ts';
+export type { PulseStat } from './pulseStats.ts';
 
 type UseWeeklyPulseProps = {
-  slug: string;
+  readonly slug: string;
 };
 
-type DateRange = { start: Date; end: Date };
+type DateRange = { readonly start: Date; readonly end: Date };
 
-const DAY_NAMES = [
-  'Sunday',
-  'Monday',
-  'Tuesday',
-  'Wednesday',
-  'Thursday',
-  'Friday',
-  'Saturday',
-];
-
-const DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
-
-function getDateRange(startDaysAgo: number, endDaysAgo: number): DateRange {
-  const now = new Date();
+function getDateRange(startDaysAgo: number, endDaysAgo: number, now: Date): DateRange {
   return {
     start: new Date(
       now.getFullYear(),
@@ -72,7 +48,7 @@ function getDateRange(startDaysAgo: number, endDaysAgo: number): DateRange {
 }
 
 function filterEntries<T extends { watchedAt: Date }>(
-  entries: T[],
+  entries: ReadonlyArray<T>,
   range: DateRange,
 ): T[] {
   return entries.filter((e) =>
@@ -80,217 +56,24 @@ function filterEntries<T extends { watchedAt: Date }>(
   );
 }
 
-function sumHours(
-  movieEntries: MovieActivityHistory[],
-  showEntries: ShowActivityHistory[],
-): number {
-  let totalMinutes = 0;
-  for (const m of movieEntries) {
-    totalMinutes += m.movie.runtime;
-  }
-  for (const s of showEntries) {
-    totalMinutes += s.episode.runtime;
-  }
-  return Math.round(totalMinutes / 60);
-}
-
-function countUniqueDays(dates: Date[]): number {
-  const days = new Set<string>();
-  for (const d of dates) {
-    days.add(`${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`);
-  }
-  return days.size;
-}
-
-function getBusiestDay(dates: Date[]): { day: string; count: number } {
-  if (dates.length === 0) return { day: '—', count: 0 };
-
-  const counts = new Map<number, number>();
-  for (const d of dates) {
-    const dow = d.getDay();
-    counts.set(dow, (counts.get(dow) ?? 0) + 1);
-  }
-
-  let maxDay = 0;
-  let maxCount = 0;
-  for (const [day, count] of counts) {
-    if (count > maxCount) {
-      maxDay = day;
-      maxCount = count;
-    }
-  }
-
-  return { day: DAY_NAMES[maxDay]!, count: maxCount };
-}
-
-function maxPlaysInSingleDay(dates: Date[]): number {
-  if (dates.length === 0) return 0;
-
-  const counts = new Map<string, number>();
-  for (const d of dates) {
-    const key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-
-  let max = 0;
-  for (const count of counts.values()) {
-    if (count > max) max = count;
-  }
-  return max;
-}
-
 function fmt(n: number): string {
   return toHumanNumber(n, languageTag());
 }
 
-function computeDelta(thisWeek: number, lastWeek: number): number {
-  return thisWeek - lastWeek;
-}
-
-function countByWeekday(dates: Date[]): number[] {
-  const counts = Array(7).fill(0) as number[];
-  for (const d of dates) {
-    const dow = (d.getDay() + 6) % 7;
-    counts[dow]++;
-  }
-  return counts;
-}
-
-function bucketByTimeOfDay(dates: Date[]): {
-  label: string;
-  count: number;
-}[] {
-  const buckets = [0, 0, 0, 0];
-  for (const d of dates) {
-    const h = d.getHours();
-    if (h >= 5 && h < 12) buckets[0]++;
-    else if (h >= 12 && h < 17) buckets[1]++;
-    else if (h >= 17 && h < 22) buckets[2]++;
-    else buckets[3]++;
-  }
-  return [
-    { label: 'Morning', count: buckets[0]! },
-    { label: 'Afternoon', count: buckets[1]! },
-    { label: 'Evening', count: buckets[2]! },
-    { label: 'Late Night', count: buckets[3]! },
-  ];
-}
-
-function computeWeekTrend(dates: Date[]): { label: string; plays: number }[] {
-  const now = new Date();
-  const today = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate(),
-  );
-
-  const weeks: { label: string; plays: number }[] = [];
-  const labels = ['4w ago', '3w', '2w', 'This week'];
-
-  for (let i = 3; i >= 0; i--) {
-    const start = new Date(
-      today.getFullYear(),
-      today.getMonth(),
-      today.getDate() - (i * 7 + 6),
-    );
-    const end = new Date(
-      today.getFullYear(),
-      today.getMonth(),
-      today.getDate() - (i * 7) + 1,
-    );
-    const count = dates.filter((d) => d >= start && d < end).length;
-    weeks.push({ label: labels[3 - i]!, plays: count });
-  }
-
-  return weeks;
-}
-
-function pickGraph(graphData: PulseGraphData): PulseGraphType | null {
-  type Candidate = { type: PulseGraphType; score: number };
-  const candidates: Candidate[] = [];
-
-  // dailyBars: compelling if 3+ active days (shows a rhythm)
-  const activeDays = graphData.dailyBars.thisWeek.filter((c) => c > 0).length;
-  if (activeDays >= 3) {
-    candidates.push({ type: 'dailyBars', score: activeDays });
-  }
-
-  // weekTrend: compelling if meaningful variance across 4 weeks
-  const weekPlays = graphData.weekTrend.weeks.map((w) => w.plays);
-  const maxWeek = Math.max(...weekPlays);
-  const minWeek = Math.min(...weekPlays);
-  if (maxWeek > 0 && (maxWeek - minWeek) / maxWeek > 0.25) {
-    candidates.push({
-      type: 'weekTrend',
-      score: (maxWeek - minWeek) / maxWeek * 10,
-    });
-  }
-
-  // watchClock: compelling if a clear peak (one bucket > 40% of total)
-  const clockTotal = graphData.watchClock.buckets.reduce(
-    (s, b) => s + b.count,
-    0,
-  );
-  const clockPeak = Math.max(
-    ...graphData.watchClock.buckets.map((b) => b.count),
-  );
-  if (clockTotal > 0 && clockPeak / clockTotal > 0.4) {
-    candidates.push({ type: 'watchClock', score: clockPeak / clockTotal * 10 });
-  }
-
-  // showsMovies: only if both > 0
-  const { episodes, movies: movieCount } = graphData.showsMovies;
-  if (episodes > 0 && movieCount > 0) {
-    const balance = Math.min(episodes, movieCount) /
-      Math.max(episodes, movieCount);
-    candidates.push({ type: 'showsMovies', score: balance * 10 });
-  }
-
-  if (candidates.length === 0) return null;
-  candidates.sort((a, b) => b.score - a.score);
-  return candidates[0]!.type;
-}
-
-// Dedup uses raw counts to avoid compact notation collisions (1000 and 1040 both → "1K")
-function dedup(
-  candidates: PulseStat[],
-  rawCounts: Map<string, number>,
-): PulseStat[] {
-  const playsRaw = rawCounts.get('totalPlays') ?? 0;
-  const episodesRaw = rawCounts.get('episodes') ?? 0;
-  const moviesRaw = rawCounts.get('movies') ?? 0;
-
-  // If plays == episodes (no movies), drop episodes
-  if (playsRaw === episodesRaw && playsRaw > 0) {
-    candidates = candidates.filter((c) => c.key !== 'episodes');
-  }
-  // If plays == movies (no episodes), drop movies
-  if (playsRaw === moviesRaw && playsRaw > 0) {
-    candidates = candidates.filter((c) => c.key !== 'movies');
-  }
-  // If movies == 0 with no change, not interesting
-  if (moviesRaw === 0) {
-    const moviesItem = candidates.find((c) => c.key === 'movies');
-    if (moviesItem && moviesItem.delta === 0) {
-      candidates = candidates.filter((c) => c.key !== 'movies');
-    }
-  }
-
-  return candidates;
-}
-
 export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
-  stats: Observable<PulseStat[]>;
+  stats: Observable<readonly PulseStat[]>;
   graphData: Observable<PulseGraphData>;
   selectedGraph: Observable<PulseGraphType | null>;
   isLoading: Observable<boolean>;
 } {
-  const { movies, shows, isLoadingMovies, isLoadingShows } = useActivityHistory(
-    slug,
-  );
+  const { movies, shows, isLoadingMovies, isLoadingShows } =
+    useActivityHistory(slug);
 
-  const thisWeekRange = getDateRange(6, 0);
-  const lastWeekRange = getDateRange(13, 7);
+  const now = new Date();
+  const locale = getLocale();
+
+  const thisWeekRange = getDateRange(6, 0, now);
+  const lastWeekRange = getDateRange(13, 7, now);
 
   const stats = combineLatest([movies, shows]).pipe(
     map(([$movies, $shows]) => {
@@ -300,29 +83,39 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
       const lwShows = filterEntries($shows, lastWeekRange);
 
       const twAllDates = [
-        ...twMovies.map((m) => m.watchedAt),
-        ...twShows.map((s) => s.watchedAt),
+        ...twMovies.map((e) => e.watchedAt),
+        ...twShows.map((e) => e.watchedAt),
       ];
       const lwAllDates = [
-        ...lwMovies.map((m) => m.watchedAt),
-        ...lwShows.map((s) => s.watchedAt),
+        ...lwMovies.map((e) => e.watchedAt),
+        ...lwShows.map((e) => e.watchedAt),
       ];
 
-      // Unique show slugs
       const twShowSlugs = new Set(twShows.map((s) => s.show.slug));
       const lwShowSlugs = new Set(lwShows.map((s) => s.show.slug));
 
       const twBusiest = getBusiestDay(twAllDates);
       const lwBusiest = getBusiestDay(lwAllDates);
 
-      // Hours — derived from entry runtimes (with delta)
       const twHours = sumHours(twMovies, twShows);
       const lwHours = sumHours(lwMovies, lwShows);
 
       const twBingeMax = maxPlaysInSingleDay(twAllDates);
       const lwBingeMax = maxPlaysInSingleDay(lwAllDates);
 
-      // Track raw counts for dedup comparison (avoids compact notation collisions)
+      const busiestValue = twBusiest
+        ? toHumanDayOfWeek(dayOfWeekDate(twBusiest.dayIndex, now), locale)
+        : '—';
+
+      const busiestNote = lwBusiest
+        ? m.text_stats_was_last_week({
+            day: toHumanDayOfWeek(
+              dayOfWeekDate(lwBusiest.dayIndex, now),
+              locale,
+            ),
+          })
+        : undefined;
+
       const rawCounts = new Map<string, number>([
         ['totalPlays', twAllDates.length],
         ['episodes', twShows.length],
@@ -333,31 +126,31 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
         {
           key: 'totalPlays',
           value: fmt(twAllDates.length),
-          label: 'Plays',
+          label: m.label_stats_plays(),
           delta: computeDelta(twAllDates.length, lwAllDates.length),
         },
         {
           key: 'episodes',
           value: fmt(twShows.length),
-          label: 'Episodes',
+          label: m.label_stats_episodes(),
           delta: computeDelta(twShows.length, lwShows.length),
         },
         {
           key: 'movies',
           value: fmt(twMovies.length),
-          label: 'Movies',
+          label: m.label_stats_movies(),
           delta: computeDelta(twMovies.length, lwMovies.length),
         },
         {
           key: 'shows',
           value: fmt(twShowSlugs.size),
-          label: 'Shows',
+          label: m.label_stats_shows(),
           delta: computeDelta(twShowSlugs.size, lwShowSlugs.size),
         },
         {
           key: 'activeDays',
           value: fmt(countUniqueDays(twAllDates)),
-          label: 'Active Days',
+          label: m.label_stats_active_days(),
           delta: computeDelta(
             countUniqueDays(twAllDates),
             countUniqueDays(lwAllDates),
@@ -365,29 +158,25 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
         },
         {
           key: 'busiestDay',
-          value: twBusiest.day,
-          label: 'Busiest Day',
+          value: busiestValue,
+          label: m.label_stats_busiest_day(),
           delta: null,
-          note: lwBusiest.day !== '—'
-            ? `was ${lwBusiest.day} last week`
-            : undefined,
+          note: busiestNote,
         },
         {
           key: 'longestBinge',
           value: fmt(twBingeMax),
-          label: 'Best Day',
+          label: m.label_stats_best_day(),
           delta: computeDelta(twBingeMax, lwBingeMax),
         },
         {
           key: 'hours',
           value: fmt(twHours),
-          label: 'Hours',
+          label: m.label_stats_hours(),
           delta: computeDelta(twHours, lwHours),
         },
       ];
 
-      // Sort: abs(delta) descending, zero-value+zero-delta to back,
-      // null-delta after history stats
       const sorted = candidates.sort((a, b) => {
         const aIsZero = a.value === '0' && a.delta === 0;
         const bIsZero = b.value === '0' && b.delta === 0;
@@ -410,27 +199,20 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
       const twShows = filterEntries($shows, thisWeekRange);
 
       const twAllDates = [
-        ...twMovies.map((m) => m.watchedAt),
-        ...twShows.map((s) => s.watchedAt),
+        ...twMovies.map((e) => e.watchedAt),
+        ...twShows.map((e) => e.watchedAt),
       ];
 
-      // All dates for the last 4 weeks
-      const fourWeekRange = getDateRange(27, 0);
+      const fourWeekRange = getDateRange(27, 0, now);
       const allRecentDates = [
-        ...filterEntries($movies, fourWeekRange).map((m) => m.watchedAt),
-        ...filterEntries($shows, fourWeekRange).map((s) => s.watchedAt),
+        ...filterEntries($movies, fourWeekRange).map((e) => e.watchedAt),
+        ...filterEntries($shows, fourWeekRange).map((e) => e.watchedAt),
       ];
-
-      const todayDow = (new Date().getDay() + 6) % 7;
 
       return {
-        dailyBars: {
-          thisWeek: countByWeekday(twAllDates),
-          dayLabels: DAY_LABELS,
-          todayIndex: todayDow,
-        },
+        dailyBars: countByCalendarDay(twAllDates, now, locale),
         weekTrend: {
-          weeks: computeWeekTrend(allRecentDates),
+          weeks: computeWeekTrend(allRecentDates, now),
         },
         watchClock: {
           buckets: bucketByTimeOfDay(twAllDates),

--- a/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
@@ -1,0 +1,532 @@
+import type { MovieActivityHistory } from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import {
+  movieActivityHistoryQuery,
+} from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import type { ShowActivityHistory } from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import {
+  showActivityHistoryQuery,
+} from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import { useMonthInReview } from '$lib/sections/banner/month-in-review/_internal/useMonthInReview.ts';
+import { toHumanNumber } from '$lib/utils/formatting/number/toHumanNumber.ts';
+import { combineLatest, map, type Observable } from 'rxjs';
+import { usePaginatedListQuery } from '../../lists/stores/usePaginatedListQuery.ts';
+
+export type PulseStat = {
+  key: string;
+  value: string;
+  label: string;
+  delta: number | null;
+  note?: string;
+};
+
+export type PulseGraphType =
+  | 'dailyBars'
+  | 'weekTrend'
+  | 'watchClock'
+  | 'showsMovies'
+  | 'bingeTimeline';
+
+export type PulseGraphData = {
+  dailyBars: {
+    thisWeek: number[];
+    lastWeek: number[];
+    dayLabels: string[];
+    todayIndex: number;
+  };
+  weekTrend: {
+    weeks: { label: string; plays: number }[];
+  };
+  watchClock: {
+    buckets: { label: string; count: number }[];
+  };
+  showsMovies: {
+    episodes: number;
+    movies: number;
+  };
+  bingeTimeline: {
+    days: { label: string; count: number }[];
+    maxCount: number;
+  };
+};
+
+type UseWeeklyPulseProps = {
+  slug: string;
+};
+
+type DateRange = { start: Date; end: Date };
+
+const HISTORY_LIMIT = 1000;
+
+const DAY_NAMES = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+function getDateRange(startDaysAgo: number, endDaysAgo: number): DateRange {
+  const now = new Date();
+  return {
+    start: new Date(now.getFullYear(), now.getMonth(), now.getDate() - startDaysAgo),
+    end: new Date(now.getFullYear(), now.getMonth(), now.getDate() - endDaysAgo + 1),
+  };
+}
+
+function filterEntries<T extends { watchedAt: Date }>(
+  entries: T[],
+  range: DateRange,
+): T[] {
+  return entries.filter((e) => e.watchedAt >= range.start && e.watchedAt < range.end);
+}
+
+function sumHours(
+  movieEntries: MovieActivityHistory[],
+  showEntries: ShowActivityHistory[],
+): number {
+  let totalMinutes = 0;
+  for (const m of movieEntries) {
+    totalMinutes += m.movie.runtime;
+  }
+  for (const s of showEntries) {
+    totalMinutes += s.episode.runtime;
+  }
+  return Math.round(totalMinutes / 60);
+}
+
+function countUniqueDays(dates: Date[]): number {
+  const days = new Set<string>();
+  for (const d of dates) {
+    days.add(`${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`);
+  }
+  return days.size;
+}
+
+function getBusiestDay(dates: Date[]): { day: string; count: number } {
+  if (dates.length === 0) return { day: '—', count: 0 };
+
+  const counts = new Map<number, number>();
+  for (const d of dates) {
+    const dow = d.getDay();
+    counts.set(dow, (counts.get(dow) ?? 0) + 1);
+  }
+
+  let maxDay = 0;
+  let maxCount = 0;
+  for (const [day, count] of counts) {
+    if (count > maxCount) {
+      maxDay = day;
+      maxCount = count;
+    }
+  }
+
+  return { day: DAY_NAMES[maxDay]!, count: maxCount };
+}
+
+function maxPlaysInSingleDay(dates: Date[]): number {
+  if (dates.length === 0) return 0;
+
+  const counts = new Map<string, number>();
+  for (const d of dates) {
+    const key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  let max = 0;
+  for (const count of counts.values()) {
+    if (count > max) max = count;
+  }
+  return max;
+}
+
+function fmt(n: number): string {
+  return toHumanNumber(n, 'en');
+}
+
+function delta(thisWeek: number, lastWeek: number): number {
+  return thisWeek - lastWeek;
+}
+
+function countByWeekday(dates: Date[]): number[] {
+  const counts = Array(7).fill(0) as number[];
+  for (const d of dates) {
+    const dow = (d.getDay() + 6) % 7;
+    counts[dow]++;
+  }
+  return counts;
+}
+
+function bucketByTimeOfDay(dates: Date[]): {
+  label: string;
+  count: number;
+}[] {
+  const buckets = [0, 0, 0, 0];
+  for (const d of dates) {
+    const h = d.getHours();
+    if (h >= 5 && h < 12) buckets[0]++;
+    else if (h >= 12 && h < 17) buckets[1]++;
+    else if (h >= 17 && h < 22) buckets[2]++;
+    else buckets[3]++;
+  }
+  return [
+    { label: 'Morning', count: buckets[0]! },
+    { label: 'Afternoon', count: buckets[1]! },
+    { label: 'Evening', count: buckets[2]! },
+    { label: 'Late Night', count: buckets[3]! },
+  ];
+}
+
+function computeWeekTrend(dates: Date[]): { label: string; plays: number }[] {
+  const now = new Date();
+  const today = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  );
+
+  const weeks: { label: string; plays: number }[] = [];
+  const labels = ['4w ago', '3w', '2w', 'This week'];
+
+  for (let i = 3; i >= 0; i--) {
+    const start = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - (i * 7 + 6),
+    );
+    const end = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - (i * 7) + 1,
+    );
+    const count = dates.filter((d) => d >= start && d < end).length;
+    weeks.push({ label: labels[3 - i]!, plays: count });
+  }
+
+  return weeks;
+}
+
+function pickGraph(graphData: PulseGraphData): PulseGraphType | null {
+  type Candidate = { type: PulseGraphType; score: number };
+  const candidates: Candidate[] = [];
+
+  // dailyBars: compelling if 3+ active days (shows a rhythm)
+  const activeDays = graphData.dailyBars.thisWeek.filter((c) => c > 0).length;
+  if (activeDays >= 3) {
+    candidates.push({ type: 'dailyBars', score: activeDays });
+  }
+
+  // weekTrend: compelling if meaningful variance across 4 weeks
+  const weekPlays = graphData.weekTrend.weeks.map((w) => w.plays);
+  const maxWeek = Math.max(...weekPlays);
+  const minWeek = Math.min(...weekPlays);
+  if (maxWeek > 0 && (maxWeek - minWeek) / maxWeek > 0.25) {
+    candidates.push({ type: 'weekTrend', score: (maxWeek - minWeek) / maxWeek * 10 });
+  }
+
+  // watchClock: compelling if a clear peak (one bucket > 40% of total)
+  const clockTotal = graphData.watchClock.buckets.reduce((s, b) => s + b.count, 0);
+  const clockPeak = Math.max(...graphData.watchClock.buckets.map((b) => b.count));
+  if (clockTotal > 0 && clockPeak / clockTotal > 0.4) {
+    candidates.push({ type: 'watchClock', score: clockPeak / clockTotal * 10 });
+  }
+
+  // showsMovies: only if both > 0
+  const { episodes, movies: movieCount } = graphData.showsMovies;
+  if (episodes > 0 && movieCount > 0) {
+    const balance = Math.min(episodes, movieCount) / Math.max(episodes, movieCount);
+    candidates.push({ type: 'showsMovies', score: balance * 10 });
+  }
+
+  // bingeTimeline: skip (redundant with dailyBars)
+
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => b.score - a.score);
+  return candidates[0]!.type;
+}
+
+function dedup(candidates: PulseStat[]): PulseStat[] {
+  const byKey = new Map(candidates.map((c) => [c.key, c]));
+
+  const plays = byKey.get('totalPlays');
+  const episodes = byKey.get('episodes');
+  const moviesItem = byKey.get('movies');
+
+  // If plays == episodes (no movies), drop episodes
+  if (plays && episodes && plays.value === episodes.value) {
+    candidates = candidates.filter((c) => c.key !== 'episodes');
+  }
+  // If plays == movies (no episodes), drop movies
+  if (plays && moviesItem && plays.value === moviesItem.value) {
+    candidates = candidates.filter((c) => c.key !== 'movies');
+  }
+  // If movies == 0 and not already removed, drop
+  if (moviesItem && moviesItem.value === '0' && moviesItem.delta === 0) {
+    candidates = candidates.filter((c) => c.key !== 'movies');
+  }
+
+  return candidates;
+}
+
+export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
+  stats: Observable<PulseStat[]>;
+  graphData: Observable<PulseGraphData>;
+  selectedGraph: Observable<PulseGraphType | null>;
+  isLoading: Observable<boolean>;
+} {
+  // Cache-aligned params — identical to useStreak.ts:88-117
+  const now = new Date();
+  const startDate = new Date(
+    Date.UTC(
+      now.getUTCFullYear() - 1,
+      now.getUTCMonth(),
+      now.getUTCDate(),
+    ),
+  );
+  const endDate = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() + 1,
+    ),
+  );
+
+  const params = {
+    limit: HISTORY_LIMIT,
+    slug,
+    startDate,
+    endDate,
+  };
+
+  const { list: movies, isLoading: isLoadingMovies } = usePaginatedListQuery(
+    movieActivityHistoryQuery(params),
+  );
+  const { list: shows, isLoading: isLoadingShows } = usePaginatedListQuery(
+    showActivityHistoryQuery(params),
+  );
+
+  // Cache-aligned params — identical to StatChips.svelte:22-28
+  const { review, isLoading: isLoadingReview } = useMonthInReview({
+    slug,
+    month: now.getUTCMonth() + 1,
+    year: now.getUTCFullYear(),
+  });
+
+  const thisWeekRange = getDateRange(6, 0);
+  const lastWeekRange = getDateRange(13, 7);
+
+  const stats = combineLatest([movies, shows, review]).pipe(
+    map(([$movies, $shows, $review]) => {
+      const twMovies = filterEntries($movies, thisWeekRange);
+      const lwMovies = filterEntries($movies, lastWeekRange);
+      const twShows = filterEntries($shows, thisWeekRange);
+      const lwShows = filterEntries($shows, lastWeekRange);
+
+      const twAllDates = [
+        ...twMovies.map((m) => m.watchedAt),
+        ...twShows.map((s) => s.watchedAt),
+      ];
+      const lwAllDates = [
+        ...lwMovies.map((m) => m.watchedAt),
+        ...lwShows.map((s) => s.watchedAt),
+      ];
+
+      // Unique show slugs
+      const twShowSlugs = new Set(twShows.map((s) => s.show.slug));
+      const lwShowSlugs = new Set(lwShows.map((s) => s.show.slug));
+
+      const twBusiest = getBusiestDay(twAllDates);
+      const lwBusiest = getBusiestDay(lwAllDates);
+
+      // Hours — derived from entry runtimes (with delta)
+      const twHours = sumHours(twMovies, twShows);
+      const lwHours = sumHours(lwMovies, lwShows);
+
+      const twBingeMax = maxPlaysInSingleDay(twAllDates);
+      const lwBingeMax = maxPlaysInSingleDay(lwAllDates);
+
+      const candidates: PulseStat[] = [
+        {
+          key: 'totalPlays',
+          value: fmt(twAllDates.length),
+          label: 'Plays',
+          delta: delta(twAllDates.length, lwAllDates.length),
+        },
+        {
+          key: 'episodes',
+          value: fmt(twShows.length),
+          label: 'Episodes',
+          delta: delta(twShows.length, lwShows.length),
+        },
+        {
+          key: 'movies',
+          value: fmt(twMovies.length),
+          label: 'Movies',
+          delta: delta(twMovies.length, lwMovies.length),
+        },
+        {
+          key: 'shows',
+          value: fmt(twShowSlugs.size),
+          label: 'Shows',
+          delta: delta(twShowSlugs.size, lwShowSlugs.size),
+        },
+        {
+          key: 'activeDays',
+          value: fmt(countUniqueDays(twAllDates)),
+          label: 'Active Days',
+          delta: delta(
+            countUniqueDays(twAllDates),
+            countUniqueDays(lwAllDates),
+          ),
+        },
+        {
+          key: 'busiestDay',
+          value: twBusiest.day,
+          label: 'Busiest Day',
+          delta: null,
+          note: lwBusiest.day !== '—'
+            ? `was ${lwBusiest.day} last week`
+            : undefined,
+        },
+        {
+          key: 'longestBinge',
+          value: fmt(twBingeMax),
+          label: 'Best Day',
+          delta: delta(twBingeMax, lwBingeMax),
+        },
+        {
+          key: 'hours',
+          value: fmt(twHours),
+          label: 'Hours',
+          delta: delta(twHours, lwHours),
+        },
+      ];
+
+      // Month-in-review stats (no deltas — API lacks date range filtering)
+      if ($review) {
+        candidates.push(
+          {
+            key: 'ratings',
+            value: fmt($review.ratingsCount),
+            label: 'Ratings',
+            delta: null,
+          },
+          {
+            key: 'comments',
+            value: fmt($review.commentsCount),
+            label: 'Comments',
+            delta: null,
+          },
+          {
+            key: 'lists',
+            value: fmt($review.listsCount),
+            label: 'List Items',
+            delta: null,
+          },
+        );
+      }
+
+      // Sort: abs(delta) descending, zero-value+zero-delta to back,
+      // null-delta (month-in-review) after history stats
+      const sorted = candidates.sort((a, b) => {
+        const aIsZero = a.value === '0' && a.delta === 0;
+        const bIsZero = b.value === '0' && b.delta === 0;
+        if (aIsZero !== bIsZero) return aIsZero ? 1 : -1;
+
+        const aIsNull = a.delta === null;
+        const bIsNull = b.delta === null;
+        if (aIsNull !== bIsNull) return aIsNull ? 1 : -1;
+
+        return Math.abs(b.delta ?? 0) - Math.abs(a.delta ?? 0);
+      });
+
+      return dedup(sorted);
+    }),
+  );
+
+  const DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+  const DAY_LABELS_FULL = [
+    'Mon',
+    'Tue',
+    'Wed',
+    'Thu',
+    'Fri',
+    'Sat',
+    'Sun',
+  ];
+
+  const graphData = combineLatest([movies, shows]).pipe(
+    map(([$movies, $shows]) => {
+      const twMovies = filterEntries($movies, thisWeekRange);
+      const lwMovies = filterEntries($movies, lastWeekRange);
+      const twShows = filterEntries($shows, thisWeekRange);
+      const lwShows = filterEntries($shows, lastWeekRange);
+
+      const twAllDates = [
+        ...twMovies.map((m) => m.watchedAt),
+        ...twShows.map((s) => s.watchedAt),
+      ];
+      const lwAllDates = [
+        ...lwMovies.map((m) => m.watchedAt),
+        ...lwShows.map((s) => s.watchedAt),
+      ];
+
+      // All dates for the last 4 weeks
+      const fourWeekRange = getDateRange(27, 0);
+      const allRecentMovieDates = filterEntries($movies, fourWeekRange)
+        .map((m) => m.watchedAt);
+      const allRecentShowDates = filterEntries($shows, fourWeekRange)
+        .map((s) => s.watchedAt);
+      const allRecentDates = [...allRecentMovieDates, ...allRecentShowDates];
+
+      const todayDow = (new Date().getDay() + 6) % 7;
+
+      const thisWeekByDay = countByWeekday(twAllDates);
+      const lastWeekByDay = countByWeekday(lwAllDates);
+
+      const bingeTimeline = thisWeekByDay.map((count, i) => ({
+        label: DAY_LABELS_FULL[i]!,
+        count,
+      }));
+      const maxCount = Math.max(...thisWeekByDay, 1);
+
+      return {
+        dailyBars: {
+          thisWeek: thisWeekByDay,
+          lastWeek: lastWeekByDay,
+          dayLabels: DAY_LABELS,
+          todayIndex: todayDow,
+        },
+        weekTrend: {
+          weeks: computeWeekTrend(allRecentDates),
+        },
+        watchClock: {
+          buckets: bucketByTimeOfDay(twAllDates),
+        },
+        showsMovies: {
+          episodes: twShows.length,
+          movies: twMovies.length,
+        },
+        bingeTimeline: {
+          days: bingeTimeline,
+          maxCount,
+        },
+      } satisfies PulseGraphData;
+    }),
+  );
+
+  const selectedGraph = graphData.pipe(
+    map(($graphData) => pickGraph($graphData)),
+  );
+
+  const isLoading = combineLatest([
+    isLoadingMovies,
+    isLoadingShows,
+    isLoadingReview,
+  ]).pipe(
+    map(([$m, $s, $r]) => $m || $s || $r),
+  );
+
+  return { stats, graphData, selectedGraph, isLoading };
+}

--- a/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
@@ -32,6 +32,12 @@ type UseWeeklyPulseProps = {
 
 type DateRange = { readonly start: Date; readonly end: Date };
 
+const DAYS_IN_WEEK = 7;
+const THIS_WEEK_START = DAYS_IN_WEEK - 1;
+const LAST_WEEK_START = DAYS_IN_WEEK * 2 - 1;
+const LAST_WEEK_END = DAYS_IN_WEEK;
+const FOUR_WEEK_LOOKBACK = DAYS_IN_WEEK * 4 - 1;
+
 function getDateRange(startDaysAgo: number, endDaysAgo: number, now: Date): DateRange {
   return {
     start: new Date(
@@ -72,8 +78,8 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
   const now = new Date();
   const locale = getLocale();
 
-  const thisWeekRange = getDateRange(6, 0, now);
-  const lastWeekRange = getDateRange(13, 7, now);
+  const thisWeekRange = getDateRange(THIS_WEEK_START, 0, now);
+  const lastWeekRange = getDateRange(LAST_WEEK_START, LAST_WEEK_END, now);
 
   const stats = combineLatest([movies, shows]).pipe(
     map(([$movies, $shows]) => {
@@ -203,7 +209,7 @@ export function useWeeklyPulse({ slug }: UseWeeklyPulseProps): {
         ...twShows.map((e) => e.watchedAt),
       ];
 
-      const fourWeekRange = getDateRange(27, 0, now);
+      const fourWeekRange = getDateRange(FOUR_WEEK_LOOKBACK, 0, now);
       const allRecentDates = [
         ...filterEntries($movies, fourWeekRange).map((e) => e.watchedAt),
         ...filterEntries($shows, fourWeekRange).map((e) => e.watchedAt),

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -14,6 +14,8 @@
   import UpNextList from "$lib/sections/lists/progress/UpNextList.svelte";
   import UpcomingList from "$lib/sections/lists/UpcomingList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import StreakCallout from "$lib/sections/stats/StreakCallout.svelte";
+  import WeeklyPulse from "$lib/sections/stats/WeeklyPulse.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   // FIXME: move to PersonalHistoryList when Profile also supports discover mode
@@ -41,7 +43,9 @@
 
     <Banner />
     <UpNextList intent="continue" />
+    <WeeklyPulse />
     <UpNextList intent="start" />
+    <StreakCallout />
     <UpcomingList />
     <PersonalHistoryList mode={$mode} />
     <ActivityList />

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -44,12 +44,16 @@
 
     <Banner />
     <UpNextList intent="continue" />
-    <WeeklyPulse />
+    <RenderFor audience="authenticated" device={["tablet-sm", "tablet-lg", "desktop"]}>
+      <WeeklyPulse />
+    </RenderFor>
     <UpNextList intent="start" />
     <StreakCallout />
     <UpcomingList />
     <PersonalHistoryList mode={$mode} />
-    <GenreBreakdown />
+    <RenderFor audience="authenticated" device={["tablet-sm", "tablet-lg", "desktop"]}>
+      <GenreBreakdown />
+    </RenderFor>
     <ActivityList />
   </RenderFor>
 

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -14,6 +14,7 @@
   import UpNextList from "$lib/sections/lists/progress/UpNextList.svelte";
   import UpcomingList from "$lib/sections/lists/UpcomingList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import GenreBreakdown from "$lib/sections/stats/GenreBreakdown.svelte";
   import StreakCallout from "$lib/sections/stats/StreakCallout.svelte";
   import WeeklyPulse from "$lib/sections/stats/WeeklyPulse.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
@@ -48,6 +49,7 @@
     <StreakCallout />
     <UpcomingList />
     <PersonalHistoryList mode={$mode} />
+    <GenreBreakdown />
     <ActivityList />
   </RenderFor>
 


### PR DESCRIPTION
## Scene Setting

The authenticated home page was missing any kind of activity insights — users had to navigate
to their profile stats to see watching patterns. This PR brings three new stats blocks directly
  to the home page, giving users an immediate visual pulse on their habits the moment they land.

### What's new

- **Weekly Pulse** — a 7×2 heatmap grid showing daily watch activity over the past two weeks,
broken down by media type. Cell intensity reflects relative activity levels.
- **Watching Streak** — a callout tracking consecutive days with watch activity, displayed with
  an accumulator animation.
- **Genre Breakdown** — a stacked bar chart visualizing genre distribution across the last 14
days, styled with a frosted glass treatment.

All components live under `$lib/sections/stats/` with data hooks that derive stats client-side
from existing activity/history endpoints. User-facing strings are fully internationalized.
Readonly types and functional patterns are enforced throughout.

## Show, Don't Tell

<img width="2754" height="1104" alt="CleanShot 2026-03-18 at 17 58 53@2x" src="https://github.com/user-attachments/assets/af54b49a-8baf-488c-97bd-d2c40847a447" />

"Pulse" blocks.  Hidden on mobile.

<img width="2748" height="800" alt="CleanShot 2026-03-18 at 17 59 39@2x" src="https://github.com/user-attachments/assets/cdfd2a1d-46de-465d-8b66-4d1dc4adbc54" />

<img width="968" height="1052" alt="CleanShot 2026-03-18 at 18 03 59@2x" src="https://github.com/user-attachments/assets/88f76be2-c607-4b3c-bf0e-55d131d7e83a" />

Streak counter!!  This one is kept on mobile.

<img width="2854" height="1188" alt="CleanShot 2026-03-18 at 18 04 41@2x" src="https://github.com/user-attachments/assets/19b620b6-d855-41c5-914f-619138c9317b" />

Not 100% down with the style, but we can iterate.  Hidden on mobile.


## Testing: The Dress Rehearsal

Yup.  I got em!

