### PR TITLE
feat: auto resize cards in drilled down view

### DIFF
--- a/projects/client/src/lib/components/lists/grid-list/GridList.svelte
+++ b/projects/client/src/lib/components/lists/grid-list/GridList.svelte
@@ -12,6 +12,7 @@
     promotedItems?: T[];
     dimensionObserver?: (node: HTMLElement) => void;
     listActions?: Snippet;
+    sizing?: "default" | "auto";
   };
 
   const {
@@ -24,6 +25,7 @@
     dimensionObserver,
     metaInfo,
     listActions,
+    sizing = "default",
   }: PageListProps<T> = $props();
 
   const customAction = (node: HTMLElement) => dimensionObserver?.(node);
@@ -42,7 +44,7 @@
   });
 </script>
 
-<section class="trakt-grid-list-container">
+<section class="trakt-grid-list-container" data-sizing={sizing}>
   {#if title}
     <ListHeader {title} {metaInfo} {actions} {listActions} />
   {/if}
@@ -77,12 +79,25 @@
     flex-direction: column;
 
     gap: var(--list-header-gap);
+
+    &[data-sizing="auto"] {
+      .trakt-list-items {
+        grid-template-columns: repeat(
+          auto-fill,
+          minmax(var(--width-item), 1fr)
+        );
+
+        :global(.trakt-card) {
+          --width-override-card: 100%;
+        }
+      }
+    }
   }
 
   .trakt-list-items {
     display: grid;
     grid-template-columns: repeat(auto-fill, var(--width-item));
-    /* TODO: investigate how we can better distribute empty spaces (@anodpixels) */
+
     justify-content: center;
     transition: gap var(--transition-increment) ease-in-out;
     grid-row-gap: var(--gap-l);

--- a/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/DrilledMediaList.svelte
@@ -24,6 +24,7 @@
       {actions}
       {items}
       {listActions}
+      sizing="auto"
       --width-item="var(--width-summary-card)"
     >
       {#snippet empty()}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1914
- Auto resizes summary cards on larger screens.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/4be3efdd-b69a-4049-a3fd-5cadde463846

After:

https://github.com/user-attachments/assets/9473b846-f67a-4a92-bba4-7a431966758e

