### PR TITLE
Add genre breakdown chart to home page

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Библиотека"
+    },
+    "text_stats_today": {
+      "default": "Днес"
+    },
+    "text_stats_genre_other": {
+      "default": "Други"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "По жанрове"
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Bibliotek"
+    },
+    "text_stats_today": {
+      "default": "I dag"
+    },
+    "text_stats_genre_other": {
+      "default": "Andet"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genrefordeling"
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Bibliothek"
+    },
+    "text_stats_today": {
+      "default": "Heute"
+    },
+    "text_stats_genre_other": {
+      "default": "Sonstige"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genre-Verteilung"
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Library"
+    },
+    "text_stats_today": {
+      "default": "Today"
+    },
+    "text_stats_genre_other": {
+      "default": "Other"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genre Breakdown"
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -8124,6 +8124,30 @@
         "web",
         "android"
       ]
+    },
+    "text_stats_today": {
+      "default": "Today",
+      "description": "Label for the current day in stats charts.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "text_stats_genre_other": {
+      "default": "Other",
+      "description": "Label for the 'other' genre bucket in genre breakdown.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genre Breakdown",
+      "description": "Section header for the 14-day genre breakdown chart.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
     }
   }
 }

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Biblioteca"
+    },
+    "text_stats_today": {
+      "default": "Hoy"
+    },
+    "text_stats_genre_other": {
+      "default": "Otros"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Desglose por géneros"
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Colección"
+    },
+    "text_stats_today": {
+      "default": "Hoy"
+    },
+    "text_stats_genre_other": {
+      "default": "Otro"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Desglose de géneros"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Collection"
+    },
+    "text_stats_today": {
+      "default": "Aujourd'hui"
+    },
+    "text_stats_genre_other": {
+      "default": "Autre"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Répartition par genre"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Library"
+    },
+    "text_stats_today": {
+      "default": "Aujourd'hui"
+    },
+    "text_stats_genre_other": {
+      "default": "Autre"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Répartition par genre"
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Cineteca"
+    },
+    "text_stats_today": {
+      "default": "Oggi"
+    },
+    "text_stats_genre_other": {
+      "default": "Altro"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Analisi generi"
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "ライブラリ"
+    },
+    "text_stats_today": {
+      "default": "今日"
+    },
+    "text_stats_genre_other": {
+      "default": "その他"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "ジャンル内訳"
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Bibliotek"
+    },
+    "text_stats_today": {
+      "default": "I dag"
+    },
+    "text_stats_genre_other": {
+      "default": "Annet"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Sjangerfordeling"
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Collectie"
+    },
+    "text_stats_today": {
+      "default": "Vandaag"
+    },
+    "text_stats_genre_other": {
+      "default": "Overig"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genreoverzicht"
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Biblioteka"
+    },
+    "text_stats_today": {
+      "default": "Dzisiaj"
+    },
+    "text_stats_genre_other": {
+      "default": "Inne"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Podział na gatunki"
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Coleção"
+    },
+    "text_stats_today": {
+      "default": "Hoje"
+    },
+    "text_stats_genre_other": {
+      "default": "Outro"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Divisão por Gênero"
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Bibliotecă"
+    },
+    "text_stats_today": {
+      "default": "Astăzi"
+    },
+    "text_stats_genre_other": {
+      "default": "Altele"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Distribuția pe genuri"
     }
   }
 }

--- a/projects/client/i18n/meta/ru-ru.json
+++ b/projects/client/i18n/meta/ru-ru.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Библиотека"
+    },
+    "text_stats_today": {
+      "default": "Сегодня"
+    },
+    "text_stats_genre_other": {
+      "default": "Другое"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Статистика по жанрам"
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Bibliotek"
+    },
+    "text_stats_today": {
+      "default": "Idag"
+    },
+    "text_stats_genre_other": {
+      "default": "Övrigt"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Genrefördelning"
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -3075,6 +3075,15 @@
     },
     "button_label_library": {
       "default": "Бібліотека"
+    },
+    "text_stats_today": {
+      "default": "Сьогодні"
+    },
+    "text_stats_genre_other": {
+      "default": "Інше"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "Жанровий розподіл"
     }
   }
 }

--- a/projects/client/i18n/meta/zh-cn.json
+++ b/projects/client/i18n/meta/zh-cn.json
@@ -3074,6 +3074,15 @@
     },
     "button_label_library": {
       "default": "库"
+    },
+    "text_stats_today": {
+      "default": "今天"
+    },
+    "text_stats_genre_other": {
+      "default": "其他"
+    },
+    "header_stats_genre_breakdown": {
+      "default": "类型分布"
     }
   }
 }

--- a/projects/client/src/lib/sections/stats/GenreBreakdown.svelte
+++ b/projects/client/src/lib/sections/stats/GenreBreakdown.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+  import { useUser } from "$lib/features/auth/stores/useUser.ts";
+  import { languageTag } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { DAY_COUNT, useGenreBreakdown } from "./_internal/useGenreBreakdown.ts";
+
+  const genreMidIndex = Math.floor(DAY_COUNT / 2);
+
+  const { user } = useUser();
+  const { data, isLoading } = $derived(useGenreBreakdown({ slug: $user.slug }));
+
+  const dateRange = $derived.by(() => {
+    const now = new Date();
+    const rangeStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - (DAY_COUNT - 1));
+    return `${rangeStart.toLocaleString(languageTag(), { month: "short", day: "numeric" })} – ${now.toLocaleString(languageTag(), { month: "short", day: "numeric" })}`;
+  });
+
+  const shouldShow = $derived(!$isLoading && $data && $data.days.some(d => d.total > 0));
+
+  const midDate = $derived.by(() => {
+    if (!$data) return "";
+    const mid = $data.days[genreMidIndex];
+    if (!mid) return "";
+    return mid.date.toLocaleString(languageTag(), { month: "short", day: "numeric" });
+  });
+
+  const startLabel = $derived.by(() => {
+    if (!$data) return "";
+    const first = $data.days[0];
+    if (!first) return "";
+    return first.date.toLocaleString(languageTag(), { month: "short", day: "numeric" });
+  });
+</script>
+
+{#if shouldShow}
+  <div class="trakt-genre-breakdown">
+    <div class="trakt-genre-header">
+      <p class="trakt-genre-title">
+        <span class="trakt-genre-dot"></span>
+        {m.header_stats_genre_breakdown()}
+      </p>
+      <p class="trakt-genre-range">{dateRange}</p>
+    </div>
+
+    <div class="trakt-genre-body">
+      <div class="trakt-genre-chart-area">
+        <div class="trakt-genre-bars">
+          {#each $data!.days as day, di (di)}
+            <div class="trakt-genre-bar-col">
+              <div class="trakt-genre-bar" style:height="{$data!.maxDayTotal > 0 ? (day.total / $data!.maxDayTotal) * 100 : 0}%">
+                {#each [...day.segments].reverse() as segment, ri (ri)}
+                  {#if segment.count > 0}
+                    {@const segIndex = day.segments.length - 1 - ri}
+                    {@const legendEntry = $data!.legend[segIndex]}
+                    <div
+                      class="trakt-genre-segment"
+                      style:background-color={legendEntry?.color ?? '#555555'}
+                      style:flex-grow={segment.count}
+                    ></div>
+                  {/if}
+                {/each}
+              </div>
+            </div>
+          {/each}
+        </div>
+
+        <div class="trakt-genre-date-labels">
+          <span class="trakt-genre-date-label">{startLabel}</span>
+          <span class="trakt-genre-date-label">{midDate}</span>
+          <span class="trakt-genre-date-label">{m.text_stats_today()}</span>
+        </div>
+      </div>
+
+      <div class="trakt-genre-legend">
+        {#each $data!.legend as entry (entry.genre)}
+          <div class="trakt-genre-legend-item">
+            <span class="trakt-genre-legend-dot" style:background-color={entry.color}></span>
+            <span class="trakt-genre-legend-label">{entry.label}</span>
+            <span class="trakt-genre-legend-pct">{entry.percentage}%</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style lang="scss">
+  .trakt-genre-breakdown {
+    margin: 0 var(--layout-distance-side);
+    padding: var(--ni-24) var(--ni-28);
+    background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--color-foreground) 4%, transparent) 0%,
+      color-mix(in srgb, var(--color-foreground) 1%, transparent) 100%
+    );
+    backdrop-filter: blur(20px);
+    border: 1px solid color-mix(in srgb, var(--color-foreground) 6%, transparent);
+    border-radius: 20px;
+    box-shadow:
+      0 8px 32px color-mix(in srgb, var(--color-shadow) 30%, transparent),
+      inset 0 1px 0 color-mix(in srgb, var(--color-foreground) 5%, transparent);
+  }
+
+  .trakt-genre-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: var(--ni-20);
+  }
+
+  .trakt-genre-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: color-mix(in srgb, var(--color-foreground) 50%, transparent);
+    font-size: var(--ni-13);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+  }
+
+  .trakt-genre-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--green-500);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--green-500) 50%, transparent);
+    flex-shrink: 0;
+  }
+
+  .trakt-genre-range {
+    color: color-mix(in srgb, var(--color-foreground) 25%, transparent);
+    font-size: var(--ni-12);
+  }
+
+  .trakt-genre-body {
+    display: flex;
+    gap: var(--ni-24);
+  }
+
+  .trakt-genre-chart-area {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .trakt-genre-bars {
+    display: flex;
+    align-items: flex-end;
+    gap: 6px;
+    height: var(--ni-120);
+  }
+
+  .trakt-genre-bar-col {
+    flex: 1;
+    display: flex;
+    align-items: flex-end;
+    height: 100%;
+  }
+
+  .trakt-genre-bar {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    border-radius: 6px 6px 0 0;
+    overflow: hidden;
+    gap: 2px;
+    min-height: 0;
+  }
+
+  .trakt-genre-segment {
+    min-height: var(--ni-2);
+    border-radius: 1px;
+    opacity: 0.85;
+  }
+
+  .trakt-genre-date-labels {
+    display: flex;
+    justify-content: space-between;
+    margin-top: var(--ni-8);
+  }
+
+  .trakt-genre-date-label {
+    color: color-mix(in srgb, var(--color-foreground) 20%, transparent);
+    font-size: var(--ni-11);
+  }
+
+  .trakt-genre-legend {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    justify-content: center;
+    flex-shrink: 0;
+    min-width: 130px;
+  }
+
+  .trakt-genre-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .trakt-genre-legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 4px;
+    opacity: 0.85;
+    flex-shrink: 0;
+  }
+
+  .trakt-genre-legend-label {
+    color: color-mix(in srgb, var(--color-foreground) 45%, transparent);
+    font-size: var(--ni-12);
+    flex: 1;
+  }
+
+  .trakt-genre-legend-pct {
+    color: color-mix(in srgb, var(--color-foreground) 70%, transparent);
+    font-size: var(--ni-12);
+    font-weight: 600;
+  }
+</style>

--- a/projects/client/src/lib/sections/stats/_internal/activityHistoryParams.ts
+++ b/projects/client/src/lib/sections/stats/_internal/activityHistoryParams.ts
@@ -1,0 +1,43 @@
+import {
+  movieActivityHistoryQuery,
+} from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import {
+  showActivityHistoryQuery,
+} from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import { usePaginatedListQuery } from '../../lists/stores/usePaginatedListQuery.ts';
+
+const historyLimit = 1000;
+
+export function useActivityHistory(slug: string) {
+  const now = new Date();
+  const startDate = new Date(
+    Date.UTC(
+      now.getUTCFullYear() - 1,
+      now.getUTCMonth(),
+      now.getUTCDate(),
+    ),
+  );
+  const endDate = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() + 1,
+    ),
+  );
+
+  const params = {
+    limit: historyLimit,
+    slug,
+    startDate,
+    endDate,
+  };
+
+  const { list: movies, isLoading: isLoadingMovies } = usePaginatedListQuery(
+    movieActivityHistoryQuery(params),
+  );
+  const { list: shows, isLoading: isLoadingShows } = usePaginatedListQuery(
+    showActivityHistoryQuery(params),
+  );
+
+  return { movies, shows, isLoadingMovies, isLoadingShows };
+}

--- a/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/features/i18n/messages.ts', async (importOriginal) => {
+  const original = await importOriginal<Record<string, unknown>>();
+  return {
+    ...original,
+    text_stats_genre_other: () => 'Other',
+  };
+});
+
+import type { MovieActivityHistory } from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import type { ShowActivityHistory } from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import { computeGenreBreakdown, DAY_COUNT } from './useGenreBreakdown.ts';
+
+function movieWith(
+  watchedAt: Date,
+  genres: string[],
+): MovieActivityHistory {
+  return { watchedAt, movie: { genres } } as unknown as MovieActivityHistory;
+}
+
+function showWith(
+  watchedAt: Date,
+  genres: string[],
+): ShowActivityHistory {
+  return { watchedAt, show: { genres } } as unknown as ShowActivityHistory;
+}
+
+describe('computeGenreBreakdown', () => {
+  const now = new Date('2024-01-15T12:00:00Z');
+
+  it('returns 14 days with empty data', () => {
+    const result = computeGenreBreakdown([], [], now);
+    expect(result.days).toHaveLength(DAY_COUNT);
+    expect(result.maxDayTotal).toBe(0);
+    expect(result.legend).toHaveLength(0);
+  });
+
+  it('groups genres by day', () => {
+    const movies = [
+      movieWith(new Date('2024-01-15T10:00:00Z'), ['action']),
+      movieWith(new Date('2024-01-15T14:00:00Z'), ['action']),
+      movieWith(new Date('2024-01-14T10:00:00Z'), ['comedy']),
+    ];
+    const result = computeGenreBreakdown(movies, [], now);
+
+    const today = result.days[DAY_COUNT - 1]!;
+    expect(today.total).toBe(2);
+
+    const yesterday = result.days[DAY_COUNT - 2]!;
+    expect(yesterday.total).toBe(1);
+  });
+
+  it('limits to top 5 genres plus other', () => {
+    const genres = [
+      'action', 'comedy', 'drama', 'horror', 'sci-fi', 'romance', 'thriller',
+    ];
+    const movies = genres.map((g) =>
+      movieWith(new Date('2024-01-15T10:00:00Z'), [g]),
+    );
+    const result = computeGenreBreakdown(movies, [], now);
+    expect(result.legend.length).toBeLessThanOrEqual(6);
+  });
+
+  it('handles entries with no genres as other', () => {
+    const movies = [
+      movieWith(new Date('2024-01-15T10:00:00Z'), []),
+    ];
+    const result = computeGenreBreakdown(movies, [], now);
+    expect(result.legend).toHaveLength(1);
+    expect(result.legend[0]!.genre).toBe('other');
+  });
+
+  it('includes show genres from the show field', () => {
+    const shows = [
+      showWith(new Date('2024-01-15T10:00:00Z'), ['drama']),
+    ];
+    const result = computeGenreBreakdown([], shows, now);
+    expect(result.legend).toHaveLength(1);
+    expect(result.legend[0]!.genre).toBe('drama');
+  });
+
+  it('ignores entries outside the 14-day window', () => {
+    const movies = [
+      movieWith(new Date('2023-12-01T10:00:00Z'), ['action']),
+    ];
+    const result = computeGenreBreakdown(movies, [], now);
+    expect(result.maxDayTotal).toBe(0);
+    expect(result.legend).toHaveLength(0);
+  });
+
+  it('assigns colors to legend entries', () => {
+    const movies = [
+      movieWith(new Date('2024-01-15T10:00:00Z'), ['action']),
+      movieWith(new Date('2024-01-15T11:00:00Z'), ['comedy']),
+    ];
+    const result = computeGenreBreakdown(movies, [], now);
+    result.legend.forEach((entry) => {
+      expect(entry.color).toMatch(/^#[0-9a-f]{6}$/);
+    });
+  });
+
+  it('calculates percentages that reflect genre distribution', () => {
+    const movies = [
+      movieWith(new Date('2024-01-15T10:00:00Z'), ['action']),
+      movieWith(new Date('2024-01-15T11:00:00Z'), ['action']),
+      movieWith(new Date('2024-01-15T12:00:00Z'), ['comedy']),
+    ];
+    const result = computeGenreBreakdown(movies, [], now);
+    const actionEntry = result.legend.find((l) => l.genre === 'action');
+    const comedyEntry = result.legend.find((l) => l.genre === 'comedy');
+    expect(actionEntry!.percentage).toBe(67);
+    expect(comedyEntry!.percentage).toBe(33);
+  });
+});

--- a/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useGenreBreakdown.ts
@@ -1,0 +1,204 @@
+import * as m from '$lib/features/i18n/messages.ts';
+import type { MovieActivityHistory } from '$lib/requests/queries/users/movieActivityHistoryQuery.ts';
+import type { ShowActivityHistory } from '$lib/requests/queries/users/showActivityHistoryQuery.ts';
+import { getDayKey } from '$lib/utils/date/getDayKey.ts';
+import { toTranslatedGenre } from '$lib/utils/formatting/string/toTranslatedGenre.ts';
+import { combineLatest, map, type Observable } from 'rxjs';
+import { useActivityHistory } from './activityHistoryParams.ts';
+
+type UseGenreBreakdownProps = { readonly slug: string };
+
+export type GenreDayData = {
+  readonly date: Date;
+  readonly segments: ReadonlyArray<{ readonly genre: string; readonly count: number }>;
+  readonly total: number;
+};
+
+export type GenreLegendEntry = {
+  readonly genre: string;
+  readonly label: string;
+  readonly percentage: number;
+  readonly color: string;
+};
+
+export type GenreBreakdownData = {
+  readonly days: ReadonlyArray<GenreDayData>;
+  readonly legend: ReadonlyArray<GenreLegendEntry>;
+  readonly maxDayTotal: number;
+};
+
+const genreColors = [
+  '#a87cf0', // purple - slot 1
+  '#6ea1f7', // blue - slot 2
+  '#4ecdc4', // teal - slot 3
+  '#7bc67e', // green - slot 4
+  '#f0a04b', // orange - slot 5
+  '#555555', // gray - "Other"
+];
+
+const topGenreCount = 5;
+export const DAY_COUNT = 14;
+const genresPerEntry = 2;
+
+export function computeGenreBreakdown(
+  movies: ReadonlyArray<MovieActivityHistory>,
+  shows: ReadonlyArray<ShowActivityHistory>,
+  now: Date,
+): GenreBreakdownData {
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  const days = Array.from({ length: DAY_COUNT }, (_, i) =>
+    new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - (DAY_COUNT - 1 - i),
+    ),
+  );
+
+  const rangeStart = days[0] ?? today;
+  const rangeEnd = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate() + 1,
+  );
+
+  type GenreEntry = {
+    readonly watchedAt: Date;
+    readonly genre: string;
+    readonly weight: number;
+  };
+
+  const collectEntries = (
+    entries: ReadonlyArray<{ watchedAt: Date; genres: readonly string[] }>,
+  ): GenreEntry[] =>
+    entries.flatMap((entry) => {
+      if (entry.watchedAt < rangeStart || entry.watchedAt >= rangeEnd) {
+        return [];
+      }
+      const genres = entry.genres.length > 0
+        ? entry.genres.slice(0, genresPerEntry)
+        : ['other'];
+      const weight = 1 / genres.length;
+      return genres.map((genre) => ({
+        watchedAt: entry.watchedAt,
+        genre,
+        weight,
+      }));
+    });
+
+  const genreEntries = [
+    ...collectEntries(
+      movies.map((e) => ({
+        watchedAt: e.watchedAt,
+        genres: e.movie.genres,
+      })),
+    ),
+    ...collectEntries(
+      shows.map((e) => ({
+        watchedAt: e.watchedAt,
+        genres: e.show.genres,
+      })),
+    ),
+  ];
+
+  // Count genres globally (weighted) to find top 5
+  const globalCounts = genreEntries.reduce((acc, { genre, weight }) => {
+    acc.set(genre, (acc.get(genre) ?? 0) + weight);
+    return acc;
+  }, new Map<string, number>());
+
+  const sortedGenres = [...globalCounts.entries()].sort(
+    (a, b) => b[1] - a[1],
+  );
+
+  const topGenres = sortedGenres
+    .slice(0, topGenreCount)
+    .map(([genre]) => genre);
+
+  const topGenreSet = new Set(topGenres);
+
+  const genreOrder = [...topGenres];
+  const hasOther =
+    sortedGenres.length > topGenreCount || topGenreSet.has('other');
+  if (hasOther && !topGenreSet.has('other')) {
+    genreOrder.push('other');
+  }
+
+  // Group entries by day (weighted)
+  const dayGenreCounts = new Map<string, Map<string, number>>();
+  for (const day of days) {
+    dayGenreCounts.set(getDayKey(day), new Map());
+  }
+
+  for (const { watchedAt, genre, weight } of genreEntries) {
+    const key = getDayKey(watchedAt);
+    const dayCounts = dayGenreCounts.get(key);
+    if (!dayCounts) continue;
+
+    const effectiveGenre = topGenreSet.has(genre) ? genre : 'other';
+    dayCounts.set(
+      effectiveGenre,
+      (dayCounts.get(effectiveGenre) ?? 0) + weight,
+    );
+  }
+
+  // Build day data
+  const dayData: GenreDayData[] = days.map((date) => {
+    const dayCounts = dayGenreCounts.get(getDayKey(date)) ?? new Map<string, number>();
+    const segments = genreOrder.map((genre) => ({
+      genre,
+      count: dayCounts.get(genre) ?? 0,
+    }));
+    const total = segments.reduce((sum, s) => sum + s.count, 0);
+    return { date, segments, total };
+  });
+
+  const maxDayTotal = Math.max(...dayData.map((d) => d.total), 0);
+
+  // Build legend
+  const totalWeight = genreEntries.reduce((s, e) => s + e.weight, 0);
+  const legend: GenreLegendEntry[] = genreOrder.map((genre, i) => {
+    const count =
+      genre === 'other'
+        ? sortedGenres
+            .filter(([g]) => !topGenreSet.has(g))
+            .reduce((sum, [, c]) => sum + c, 0) +
+          (topGenreSet.has('other')
+            ? (globalCounts.get('other') ?? 0)
+            : 0)
+        : (globalCounts.get(genre) ?? 0);
+
+    return {
+      genre,
+      label:
+        genre === 'other'
+          ? m.text_stats_genre_other()
+          : toTranslatedGenre(genre),
+      percentage:
+        totalWeight > 0 ? Math.round((count / totalWeight) * 100) : 0,
+      color: genreColors[Math.min(i, genreColors.length - 1)] ?? '#555555',
+    };
+  });
+
+  return { days: dayData, legend, maxDayTotal };
+}
+
+export function useGenreBreakdown({ slug }: UseGenreBreakdownProps): {
+  data: Observable<GenreBreakdownData>;
+  isLoading: Observable<boolean>;
+} {
+  const { movies, shows, isLoadingMovies, isLoadingShows } =
+    useActivityHistory(slug);
+
+  const now = new Date();
+
+  const data = combineLatest([movies, shows]).pipe(
+    map(([$movies, $shows]) => computeGenreBreakdown($movies, $shows, now)),
+  );
+
+  const isLoading = combineLatest([isLoadingMovies, isLoadingShows]).pipe(
+    map(([$m, $s]) => $m || $s),
+  );
+
+  return { data, isLoading };
+}

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -14,6 +14,7 @@
   import UpNextList from "$lib/sections/lists/progress/UpNextList.svelte";
   import UpcomingList from "$lib/sections/lists/UpcomingList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import GenreBreakdown from "$lib/sections/stats/GenreBreakdown.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   // FIXME: move to PersonalHistoryList when Profile also supports discover mode
@@ -44,6 +45,9 @@
     <UpNextList intent="start" />
     <UpcomingList />
     <PersonalHistoryList mode={$mode} />
+    <RenderFor audience="authenticated" device={["tablet-sm", "tablet-lg", "desktop"]}>
+      <GenreBreakdown />
+    </RenderFor>
     <ActivityList />
   </RenderFor>
 


### PR DESCRIPTION
## Scene Setting: A Clear Description

Adds a 14-day genre breakdown stacked bar chart to the authenticated home page. The chart visualizes watching habits by genre over the last two weeks, showing the top 5 genres plus an "Other" bucket. Each day is a stacked bar with genre-colored segments, accompanied by a legend with percentage breakdowns.

Not 100% excited by the design, so opening as a draft.  My pref would be to merge and then iterate design after.

What's included:
- GenreBreakdown.svelte — frosted glass card with stacked bar chart and legend
- useGenreBreakdown.ts — pure computeGenreBreakdown function that aggregates movie + show activity history into per-day genre segments with weighted scoring for multi-genre titles
- activityHistoryParams.ts — shared paginated history fetcher (1-year lookback)
- i18n keys for all 20 locales (3 keys: today label, "other" genre label, section header)
- Only renders for authenticated users on tablet/desktop via RenderFor guard
- Hidden when user has no activity in the window (no empty state)

## Show, Don't Tell: Screenshots and Videos

<img width="3314" height="1002" alt="CleanShot 2026-03-21 at 12 32 32@2x" src="https://github.com/user-attachments/assets/fbd0f5f9-17d9-4991-bbed-c55db3ac9903" />

Hidden on mobile.

## Testing: The Dress Rehearsal

The core logic is covered by unit tests in useGenreBreakdown.spec.ts (8 test cases):

- Empty data returns 14 days with zero totals
- Entries group correctly by calendar day
- Top 5 genre limit enforced, overflow bucketed into "other"
- Entries with no genres treated as "other"
- Show genres pulled from the show field (not episode)
- Entries outside the 14-day window are excluded
- Legend colors are valid hex values
- Percentage distribution reflects weighted genre counts (e.g., 67/33 split)