### PR TITLE
feat(summary) / add support for multiple directors

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { TestId } from "$e2e/models/TestId";
+  import Link from "$lib/components/link/Link.svelte";
   import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
   import { toTranslatedStatus } from "$lib/utils/formatting/string/toTranslatedStatus";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
@@ -34,6 +35,13 @@
         href={UrlBuilder.people(mainCredit.key, mainCredit.positions)}
         target="_self"
       />
+      {#each mainCredit.others ?? [] as person}
+        {', '}
+        <Link
+          href={UrlBuilder.people(person.key, mainCredit.positions)}
+          target="_self">{person.name}</Link
+        >
+      {/each}
     </p>
   {/if}
 

--- a/projects/client/src/lib/sections/summary/components/_internal/mapToMainCredit.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/mapToMainCredit.ts
@@ -3,10 +3,16 @@ import type { CrewPositions } from '$lib/requests/models/CrewPosition.ts';
 import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
 import type { MediaCrew } from '$lib/requests/models/MediaCrew.ts';
 
+type AdditionalPerson = {
+  name: string;
+  key: string;
+};
+
 type MainCredit = {
   text: string;
   key: string;
   positions?: CrewPositions;
+  others?: ReadonlyArray<AdditionalPerson>;
 };
 
 function mapToCreator(crew: MediaCrew): MainCredit | null {
@@ -24,19 +30,24 @@ function mapToDirector(
   type: 'movie' | 'episode',
   crew: MediaCrew,
 ): MainCredit | null {
-  const director = crew.directors?.find((person) =>
+  const directors = crew.directors?.filter((person) =>
     person.jobs.some((job) => job.toLowerCase() === 'director')
   );
-  if (!director) return null;
+
+  const [first, ...rest] = directors ?? [];
+  if (!first) return null;
 
   const positions = type === 'movie'
     ? { movies: 'directing' as const }
     : { shows: 'directing' as const };
 
   return {
-    text: m.text_directed_by({ name: director.name }),
-    key: director.key,
+    text: m.text_directed_by({ name: first.name }),
+    key: first.key,
     positions,
+    others: rest.length > 0
+      ? rest.map(({ name, key }) => ({ name, key }))
+      : undefined,
   };
 }
 


### PR DESCRIPTION
## Overview
Enables the display of multiple directors or creators in the summary section. This ensures that all individuals credited in key roles are acknowledged and provides links to their respective profiles.

## Changes
- Updates the `MainCredit` type definition to include an optional `others` field for additional contributors.
- Refactors the director mapping logic to filter and capture all directors instead of only the first one.
- Modifies the summary title component to iterate through and render additional contributors as comma-separated links.

## Testing
- Manual verification of the summary section for media items with multiple directors to ensure names and links render correctly.

Before: 
<img width="967" height="542" alt="image" src="https://github.com/user-attachments/assets/d1d69728-22e9-4fbf-a84d-43d072f73a80" />

After:

<img width="967" height="542" alt="image" src="https://github.com/user-attachments/assets/7a79f217-2c4a-432a-a721-fc00fac362e4" />
