### PR TITLE
feat(watched): shows timestamps on personal history

### DIFF
--- a/projects/client/src/lib/models/ActivityType.ts
+++ b/projects/client/src/lib/models/ActivityType.ts
@@ -1,0 +1,1 @@
+export type ActivityType = 'personal' | 'social';

--- a/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
@@ -64,6 +64,7 @@
     badge={profileBadges}
     source="social-activity"
     action={activityRating}
+    activityType="social"
   />
 {/if}
 
@@ -73,6 +74,7 @@
     activityAt={activity.activityAt}
     badge={summaryBadge}
     source="social-activity"
+    activityType="social"
   />
 {/if}
 

--- a/projects/client/src/lib/sections/lists/components/ActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/ActivityItem.svelte
@@ -1,18 +1,8 @@
 <script lang="ts">
-  import type { SocialActivity } from "$lib/requests/models/SocialActivity";
   import type { Snippet } from "svelte";
-  import type { HistoryEntry } from "../stores/models/HistoryEntry";
   import EpisodeItem from "./EpisodeItem.svelte";
   import MediaItem from "./MediaItem.svelte";
-
-  type SocialActivityCardProps = {
-    activity: SocialActivity | HistoryEntry;
-    activityAt: Date;
-    badge?: Snippet;
-    popupActions?: Snippet;
-    source?: string;
-    action?: Snippet;
-  };
+  import type { ActivityItemProps } from "./_internal/ActivityItemProps";
 
   const {
     activity,
@@ -21,7 +11,10 @@
     popupActions,
     source,
     action,
-  }: SocialActivityCardProps = $props();
+    activityType,
+  }: ActivityItemProps & {
+    action?: Snippet;
+  } = $props();
 </script>
 
 {#if activity.type === "episode"}
@@ -34,6 +27,7 @@
     {popupActions}
     {source}
     {action}
+    {activityType}
   />
 {/if}
 
@@ -47,5 +41,6 @@
     {popupActions}
     {source}
     {action}
+    {activityType}
   />
 {/if}

--- a/projects/client/src/lib/sections/lists/components/ActivitySummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/ActivitySummaryCard.svelte
@@ -1,16 +1,6 @@
 <script lang="ts">
-  import type { SocialActivity } from "$lib/requests/models/SocialActivity";
-  import type { Snippet } from "svelte";
-  import type { HistoryEntry } from "../stores/models/HistoryEntry";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
-
-  type SocialActivityItemProps = {
-    activity: SocialActivity | HistoryEntry;
-    activityAt: Date;
-    badge?: Snippet;
-    popupActions?: Snippet;
-    source?: string;
-  };
+  import type { ActivityItemProps } from "./_internal/ActivityItemProps";
 
   const {
     activity,
@@ -18,7 +8,8 @@
     badge,
     popupActions,
     source,
-  }: SocialActivityItemProps = $props();
+    activityType,
+  }: ActivityItemProps = $props();
 </script>
 
 {#if activity.type === "episode"}
@@ -26,6 +17,7 @@
     {badge}
     {popupActions}
     {source}
+    {activityType}
     date={activityAt}
     episode={activity.episode}
     media={{
@@ -44,6 +36,7 @@
     {popupActions}
     {badge}
     {source}
+    {activityType}
     date={activityAt}
     media={activity.movie}
     type="movie"

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -13,6 +13,7 @@
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { EPISODE_COVER_PLACEHOLDER } from "$lib/utils/assets";
+  import { toHumanDate } from "$lib/utils/formatting/date/toHumanDate";
   import { toRelativeHumanDay } from "$lib/utils/formatting/date/toRelativeHumanDay";
   import { episodeNumberLabel } from "$lib/utils/intl/episodeNumberLabel";
   import { episodeSubtitle } from "$lib/utils/intl/episodeSubtitle";
@@ -178,8 +179,12 @@
             {media.title}
           </p>
         {/if}
-        <p class="trakt-card-subtitle secondary ellipsis">
-          {toRelativeHumanDay(new Date(), rest.date, getLocale())}
+        <p class="trakt-card-subtitle secondary ellipsis capitalize">
+          {#if rest.activityType === "social"}
+            {toRelativeHumanDay(new Date(), rest.date, getLocale())}
+          {:else}
+            {toHumanDate(new Date(), rest.date, getLocale())}
+          {/if}
         </p>
       {:else if rest.type === "episode" || (rest.variant === "start" && "episode" in rest)}
         <p class="trakt-card-title ellipsis">

--- a/projects/client/src/lib/sections/lists/components/_internal/ActivityItemProps.ts
+++ b/projects/client/src/lib/sections/lists/components/_internal/ActivityItemProps.ts
@@ -1,0 +1,13 @@
+import type { ActivityType } from '$lib/models/ActivityType.ts';
+import type { SocialActivity } from '$lib/requests/models/SocialActivity.ts';
+import type { Snippet } from 'svelte';
+import type { HistoryEntry } from '../../stores/models/HistoryEntry.ts';
+
+export type ActivityItemProps = {
+  activity: SocialActivity | HistoryEntry;
+  activityAt: Date;
+  badge?: Snippet;
+  popupActions?: Snippet;
+  source?: string;
+  activityType: ActivityType;
+};

--- a/projects/client/src/lib/sections/lists/components/models/EpisodeCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/EpisodeCardProps.ts
@@ -1,3 +1,4 @@
+import type { ActivityType } from '$lib/models/ActivityType.ts';
 import type { ShowInput } from '$lib/models/MediaInput.ts';
 import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
 import type { EpisodeProgressEntry } from '$lib/requests/models/EpisodeProgressEntry.ts';
@@ -16,7 +17,12 @@ export type EpisodeItemVariant =
     episode: EpisodeEntry;
     context?: EpisodeContext;
   }
-  | { variant: 'activity'; episode: EpisodeEntry; date: Date }
+  | {
+    variant: 'activity';
+    episode: EpisodeEntry;
+    date: Date;
+    activityType: ActivityType;
+  }
   | { variant: 'list-item'; episode: EpisodeEntry };
 
 export type EpisodeCardProps = BaseItemProps & EpisodeItemVariant & {

--- a/projects/client/src/lib/sections/lists/components/models/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/MediaCardProps.ts
@@ -1,3 +1,4 @@
+import type { ActivityType } from '$lib/models/ActivityType.ts';
 import type { MediaInput, MediaInputDefault } from '$lib/models/MediaInput.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { Snippet } from 'svelte';
@@ -5,7 +6,8 @@ import type { BaseItemProps } from './BaseItemProps.ts';
 
 export type MediaItemVariant<T> =
   | { variant?: Nil } & MediaInput<T>
-  | { variant: 'activity'; date: Date } & MediaInput<T>
+  | { variant: 'activity'; date: Date; activityType: ActivityType }
+    & MediaInput<T>
   | { variant: 'next'; progress: number; minutesLeft: number } & MediaInput<T>
   | { variant: 'start' } & MediaInput<T>
   | { variant: 'credit'; role: string } & MediaInput<T>;

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
@@ -30,6 +30,8 @@
 
     return data?.rating;
   });
+
+  const activityType = $derived(isActionable ? "personal" : "social");
 </script>
 
 {#snippet popupActions()}
@@ -69,6 +71,7 @@
     popupActions={isActionable ? popupActions : undefined}
     action={isActionable ? action : undefined}
     source="watch-history"
+    {activityType}
   />
 {/if}
 
@@ -79,5 +82,6 @@
     popupActions={isActionable ? popupActions : undefined}
     badge={isActionable ? action : undefined}
     source="watch-history"
+    {activityType}
   />
 {/if}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1946
- Shows timestamps on personal history when drilled down

## 👀 Examples 👀
<img width="426" height="671" alt="Screenshot 2026-03-23 at 17 44 37" src="https://github.com/user-attachments/assets/c514be24-b082-4504-adec-82ca7fa128d5" />

