### PR TITLE
perf(shows) / consolidate season video requests

### DIFF
--- a/projects/client/src/lib/requests/queries/movies/showVideosQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/showVideosQuery.spec.ts
@@ -12,7 +12,6 @@ describe('showVideosQuery', () => {
         createTestBedQuery(
           showVideosQuery({
             slug: ShowSiloResponseMock.ids.slug,
-            seasons: [1, 2],
           }),
         ),
       mapper: (response) => response?.data,

--- a/projects/client/src/lib/requests/queries/movies/showVideosQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/showVideosQuery.ts
@@ -1,18 +1,17 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { MediaVideoSchema } from '$lib/requests/models/MediaVideo.ts';
-import { castNumberAsString } from '$lib/utils/requests/castNumberAsString.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { VideoResponse } from '@trakt/api';
+import { castNumberAsString } from '../../../utils/requests/castNumberAsString.ts';
 import { mapToMediaVideo } from '../../_internal/mapToMediaVideo.ts';
 
 type ShowVideosParams = {
   slug: string;
-  seasons: number[];
 } & ApiParams;
 
 const showVideoRequest = (
-  { fetch, slug, seasons }: ShowVideosParams,
+  { fetch, slug }: ShowVideosParams,
 ) => {
   const showVideos = api({ fetch })
     .shows
@@ -22,27 +21,20 @@ const showVideoRequest = (
       },
     });
 
-  const seasonVideos = seasons.map((season) =>
-    api({ fetch })
-      .shows
-      .season
-      .videos({
-        params: {
-          id: slug,
-          season: castNumberAsString(season),
-        },
-      })
-  );
+  const allSeasonVideos = api({ fetch })
+    .shows
+    .season
+    .videos({
+      params: {
+        id: slug,
+        season: castNumberAsString('all'),
+      },
+    });
 
-  return Promise.all([showVideos, ...seasonVideos])
-    .then((responses) => {
-      const [showResponse, ...seasonResponses] = responses;
-
+  return Promise.all([showVideos, allSeasonVideos])
+    .then(([showResponse, seasonResponse]) => {
       if (
-        showResponse.status !== 200 ||
-        seasonResponses.some((response) =>
-          response.status !== 200 && response.status !== 404
-        )
+        showResponse.status !== 200 || seasonResponse.status !== 200
       ) {
         return {
           body: [],
@@ -53,7 +45,7 @@ const showVideoRequest = (
       return {
         body: [
           showResponse.body,
-          ...seasonResponses.map((response) => response.body),
+          seasonResponse.body,
         ].flat() as VideoResponse[],
         status: 200,
       };
@@ -63,10 +55,7 @@ const showVideoRequest = (
 export const showVideosQuery = defineQuery({
   key: 'showVideos',
   invalidations: [],
-  dependencies: (params) => [
-    params.slug,
-    ...params.seasons,
-  ],
+  dependencies: (params) => [params.slug],
   request: showVideoRequest,
   mapper: (response) => {
     const seen = new Set<string>();

--- a/projects/client/src/lib/utils/requests/castNumberAsString.ts
+++ b/projects/client/src/lib/utils/requests/castNumberAsString.ts
@@ -3,6 +3,6 @@
  *
  * This function is a workaround for the issue where ts-rest ignores falsy path params.
  */
-export function castNumberAsString(value: number): number {
+export function castNumberAsString(value: number | 'all'): number {
   return `${value}` as unknown as number;
 }

--- a/projects/client/src/mocks/handlers/shows.ts
+++ b/projects/client/src/mocks/handlers/shows.ts
@@ -227,21 +227,12 @@ export const shows = [
     },
   ),
   http.get(
-    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/videos`,
+    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/seasons/all/videos`,
     () => {
-      return HttpResponse.json(ShowSiloVideoResponseMock);
-    },
-  ),
-  http.get(
-    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/seasons/1/videos`,
-    () => {
-      return HttpResponse.json(ShowSiloVideoSeason1ResponseMock);
-    },
-  ),
-  http.get(
-    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/seasons/2/videos`,
-    () => {
-      return HttpResponse.json(ShowSiloVideoSeason2ResponseMock);
+      return HttpResponse.json([
+        ...ShowSiloVideoSeason1ResponseMock,
+        ...ShowSiloVideoSeason2ResponseMock,
+      ]);
     },
   ),
 ];

--- a/projects/client/src/routes/shows/[slug]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/+page.svelte
@@ -18,12 +18,7 @@
   const { show, intl, studios, crew, seasons, streamOn, isLoading, sentiment } =
     $derived(useShow(params.slug));
 
-  const videos = $derived(
-    useShowVideos({
-      slug: params.slug,
-      seasons: ($seasons ?? []).map((season) => season.number),
-    }),
-  );
+  const videos = $derived(useShowVideos({ slug: params.slug }));
 
   const currentSeason = $derived(
     parseInt(page.url.searchParams.get("season") ?? ""),

--- a/projects/client/src/routes/shows/[slug]/useShowVideos.ts
+++ b/projects/client/src/routes/shows/[slug]/useShowVideos.ts
@@ -2,17 +2,8 @@ import { useQuery } from '$lib/features/query/useQuery.ts';
 import { showVideosQuery } from '$lib/requests/queries/movies/showVideosQuery.ts';
 import { map } from 'rxjs';
 
-export function useShowVideos({
-  slug,
-  seasons,
-}: {
-  slug: string;
-  seasons: number[];
-}) {
-  const videos = useQuery(showVideosQuery({
-    slug,
-    seasons,
-  }));
+export function useShowVideos({ slug }: { slug: string }) {
+  const videos = useQuery(showVideosQuery({ slug }));
 
   return videos.pipe(map(($videos) => $videos.data ?? []));
 }


### PR DESCRIPTION
### Overview
Improves the efficiency of loading show-related videos by replacing multiple per-season network requests with a single consolidated API call. This optimization reduces network latency and simplifies the data requirements for show detail pages.

### Changes
- Refactors the show video query to fetch all season videos in one request using the 'all' parameter instead of mapping over individual seasons.
- Updates the utility function to support the 'all' string literal for season-based API calls.
- Simplifies the `useShowVideos` hook and the show page implementation by removing the need to track and pass an array of season numbers.
- Streamlines query dependency tracking to focus solely on the show slug.

### Testing
- Verified that show and season-level videos continue to load and display correctly on the show details page.
- Monitored the network tab to confirm that multiple season video requests are now replaced by a single API call.