### PR TITLE
Fix 'episode' type for 'watch until here' i18n value from 'number' to 'string' 

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2585,7 +2585,7 @@
           "type": "string"
         },
         "episode": {
-          "type": "number"
+          "type": "string"
         },
         "count": {
           "type": "number"


### PR DESCRIPTION
The existing type was a number which lead to being an `Int` in Swift (as expected from a config perspective) however the text needed there needs to be more than just the episode number and therefore requires a `String`.

Eg. if you're marking **season 2 episode 2** as watched, it shouldn't say 
> {...} until episode **2** {...}

and instead should be more like 

> {...} until episode **2x2** {...}

or even (with actual content changes)

> {...} until **S2 E2** {...} 

It appears that the web client already gets around the issue either deliberately or accidentally (see below), however Swift won't let me do that and wants an `Int`:
https://github.com/trakt/trakt-web/blob/dad6a630590983809d9aad2dfbe86fbbb3133a75/projects/client/src/lib/features/confirmation/_internal/getWarningMessage.ts#L34

@seferturan As far as I understand, this won't actually break anything on the web client, but I assume it's probably only the spot above at worst.

Note: The actual removal of `"ios"` from the `exclude` param will be in a separate bulk PR.