### PR TITLE
fix: update list header gap to gap-xs

### DIFF
--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -124,7 +124,7 @@
   --layout-scrollbar-width: var(--ni-8);
   --layout-footer-less-padding: var(--ni-8);
 
-  --list-header-gap: var(--gap-micro);
+  --list-header-gap: var(--gap-xs);
   --list-gap: var(--gap-s);
   @include adaptive-gap(--list-gap);
 


### PR DESCRIPTION
Updates the list header gap CSS custom property from `var(--gap-micro)` to `var(--gap-xs)`.

This change increases the spacing between header elements in lists (titles, subtitles, and actions) for improved visual hierarchy and readability.

## Changes
- Updated `--list-header-gap` variable in `projects/client/src/style/layout/index.scss`

## Affected Components
- SectionList
- GridList
- CollapsableSection