### PR TITLE
feat(lists): add drilldown navigation to personal lists

### DIFF
--- a/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
+++ b/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
@@ -105,6 +105,7 @@
       id={`personal-lists-${type}-list`}
       items={$lists}
       {title}
+      drilldownLink={UrlBuilder.lists.all(slug, type)}
       --height-list="var(--height-lists-list)"
       --height-override-list={$lists.length === 0
         ? "var(--height-poster-list-sm)"

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -54,7 +54,19 @@
   --height-summary-card-cover: var(--ni-208);
   --height-summary-card: var(--height-summary-card-cover);
 
-  --width-list-card: var(--ni-480);
+  --min-list-card-width: var(--ni-340);
+  --max-list-summary-item-count: 5;
+
+  --list-summary-item-count: var(--max-list-summary-item-count);
+  @include dynamic-item-count(--list-summary-item-count,
+    var(--min-list-card-width),
+    var(--max-list-summary-item-count));
+
+  --width-list-card: var(--min-list-card-width);
+  @include dynamic-card-width(--width-list-card,
+    var(--min-list-card-width),
+    var(--list-summary-item-count));
+
   --height-list-card: var(--ni-256);
 
   --width-comment-card: min(var(--ni-480), 85vw);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1964
- Adds proper drill down support to personal lists that show summaries (e..g dynamic sizing and no scrollbars on large screens)



## 👀 Example 👀

https://github.com/user-attachments/assets/77022553-6f04-4593-b078-933ededb47bd


https://github.com/user-attachments/assets/db25b946-58cb-41d6-bbb2-b27e3cc92fdc