### PR TITLE
feat(discover): removes discover toggles on l2 pages

### DIFF
--- a/projects/client/i18n/meta/bg-bg.json
+++ b/projects/client/i18n/meta/bg-bg.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Виж любопитни факти"
+    },
+    "list_title_smart_lists": {
+      "default": "Смарт списъци"
     }
   }
 }

--- a/projects/client/i18n/meta/da-dk.json
+++ b/projects/client/i18n/meta/da-dk.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Se trivia"
+    },
+    "list_title_smart_lists": {
+      "default": "Smarte lister"
     }
   }
 }

--- a/projects/client/i18n/meta/de-de.json
+++ b/projects/client/i18n/meta/de-de.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Trivia anzeigen"
+    },
+    "list_title_smart_lists": {
+      "default": "Smart-Listen"
     }
   }
 }

--- a/projects/client/i18n/meta/en-au.json
+++ b/projects/client/i18n/meta/en-au.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "View trivia"
+    },
+    "list_title_smart_lists": {
+      "default": "Smart Lists"
     }
   }
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -8583,7 +8583,11 @@
     },
     "button_label_view_trivia": {
       "default": "View trivia",
-      "description": "Aria-label for the button that allows users to view trivia for movies or shows.",
+      "description": "Aria-label for the button that allows users to view trivia for movies or shows."
+    },
+    "list_title_smart_lists": {
+      "default": "Smart Lists",
+      "description": "Title for smart lists. This should be as short and concise as possible.",
       "exclude": [
         "android",
         "ios"

--- a/projects/client/i18n/meta/es-es.json
+++ b/projects/client/i18n/meta/es-es.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Ver curiosidades"
+    },
+    "list_title_smart_lists": {
+      "default": "Listas inteligentes"
     }
   }
 }

--- a/projects/client/i18n/meta/es-mx.json
+++ b/projects/client/i18n/meta/es-mx.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Ver datos curiosos"
+    },
+    "list_title_smart_lists": {
+      "default": "Listas inteligentes"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-ca.json
+++ b/projects/client/i18n/meta/fr-ca.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Voir les anecdotes"
+    },
+    "list_title_smart_lists": {
+      "default": "Listes futées"
     }
   }
 }

--- a/projects/client/i18n/meta/fr-fr.json
+++ b/projects/client/i18n/meta/fr-fr.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Voir les anecdotes"
+    },
+    "list_title_smart_lists": {
+      "default": "Listes intelligentes"
     }
   }
 }

--- a/projects/client/i18n/meta/it-it.json
+++ b/projects/client/i18n/meta/it-it.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Scopri le curiosità"
+    },
+    "list_title_smart_lists": {
+      "default": "Liste smart"
     }
   }
 }

--- a/projects/client/i18n/meta/ja-jp.json
+++ b/projects/client/i18n/meta/ja-jp.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "トリビアを見る"
+    },
+    "list_title_smart_lists": {
+      "default": "スマートリスト"
     }
   }
 }

--- a/projects/client/i18n/meta/nb-no.json
+++ b/projects/client/i18n/meta/nb-no.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Se trivia"
+    },
+    "list_title_smart_lists": {
+      "default": "Smarte lister"
     }
   }
 }

--- a/projects/client/i18n/meta/nl-nl.json
+++ b/projects/client/i18n/meta/nl-nl.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Trivia bekijken"
+    },
+    "list_title_smart_lists": {
+      "default": "Slimme lijsten"
     }
   }
 }

--- a/projects/client/i18n/meta/pl-pl.json
+++ b/projects/client/i18n/meta/pl-pl.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Zobacz ciekawostki"
+    },
+    "list_title_smart_lists": {
+      "default": "Smart listy"
     }
   }
 }

--- a/projects/client/i18n/meta/pt-br.json
+++ b/projects/client/i18n/meta/pt-br.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Ver curiosidades"
+    },
+    "list_title_smart_lists": {
+      "default": "Listas Inteligentes"
     }
   }
 }

--- a/projects/client/i18n/meta/ro-ro.json
+++ b/projects/client/i18n/meta/ro-ro.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Vezi curiozități"
+    },
+    "list_title_smart_lists": {
+      "default": "Liste smart"
     }
   }
 }

--- a/projects/client/i18n/meta/ru-ru.json
+++ b/projects/client/i18n/meta/ru-ru.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Посмотреть интересные факты"
+    },
+    "list_title_smart_lists": {
+      "default": "Умные списки"
     }
   }
 }

--- a/projects/client/i18n/meta/sv-se.json
+++ b/projects/client/i18n/meta/sv-se.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Visa kuriosa"
+    },
+    "list_title_smart_lists": {
+      "default": "Smarta listor"
     }
   }
 }

--- a/projects/client/i18n/meta/uk-ua.json
+++ b/projects/client/i18n/meta/uk-ua.json
@@ -3267,6 +3267,9 @@
     },
     "button_label_view_trivia": {
       "default": "Переглянути цікаві факти"
+    },
+    "list_title_smart_lists": {
+      "default": "Розумні списки"
     }
   }
 }

--- a/projects/client/i18n/meta/zh-cn.json
+++ b/projects/client/i18n/meta/zh-cn.json
@@ -3266,6 +3266,9 @@
     },
     "button_label_view_trivia": {
       "default": "查看趣闻"
+    },
+    "list_title_smart_lists": {
+      "default": "智能列表"
     }
   }
 }

--- a/projects/client/src/lib/features/calendar/_internal/CalendarHeader.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarHeader.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import * as m from "$lib/features/i18n/messages.ts";
   import type { CalendarNavigationProps } from "../models/CalendarNavigationProps";
   import CalendarControls from "./CalendarControls.svelte";
 
@@ -7,7 +6,6 @@
 </script>
 
 <div class="calendar-header">
-  <span class="title">{m.header_calendar()}</span>
   <CalendarControls {...navigationProps} />
 </div>
 
@@ -18,10 +16,6 @@
 
     display: flex;
     align-items: center;
-    justify-content: space-between;
-
-    span.title {
-      margin-left: var(--ni-10);
-    }
+    justify-content: flex-end;
   }
 </style>

--- a/projects/client/src/lib/features/discover/useDiscover.ts
+++ b/projects/client/src/lib/features/discover/useDiscover.ts
@@ -10,7 +10,7 @@ import { getDiscoverContext } from './_internal/getDiscoverContext.ts';
 import type { DiscoverMode } from './models/DiscoverMode.ts';
 
 export function useDiscover() {
-  const { options, set } = useToggler('discover');
+  const { options, set, current } = useToggler('discover');
   const { mode, useSeasonalFilters } = getDiscoverContext();
   const { track } = useTrack(AnalyticsEvent.DiscoverMode);
   const { activeTheme } = useSeasonalTheme();
@@ -23,6 +23,7 @@ export function useDiscover() {
 
   return {
     options,
+    current,
     setMode,
     mode,
     useSeasonalFilters: combineLatest(

--- a/projects/client/src/lib/sections/lists/RelatedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/RelatedPaginatedList.svelte
@@ -5,17 +5,15 @@
   import { useRelatedList } from "./stores/useRelatedList";
 
   type RelatedPaginatedListProps = {
-    title: string;
     type: MediaType;
     slug: string;
   };
 
-  const { title, type, slug }: RelatedPaginatedListProps = $props();
+  const { type, slug }: RelatedPaginatedListProps = $props();
 </script>
 
 <DrilledMediaList
   id={`related-list-${type}-${slug}`}
-  {title}
   {type}
   useList={(params) => useRelatedList({ ...params, slug })}
 >

--- a/projects/client/src/lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/anticipated/AnticipatedPaginatedList.svelte
@@ -1,40 +1,21 @@
 <script lang="ts">
-  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
-  import * as m from "$lib/features/i18n/messages.ts";
   import type { Snippet } from "svelte";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import AnticipatedListItem from "./AnticipatedListItem.svelte";
   import { useAnticipatedList } from "./useAnticipatedList";
 
   type AnticipatedListProps = {
-    title: string;
+    title?: string;
     type: DiscoverMode;
     actions?: Snippet;
     search?: Record<string, string>;
   };
 
-  const {
-    title,
-    type,
-    actions: externalActions,
-    search,
-  }: AnticipatedListProps = $props();
+  const { title, type, actions, search }: AnticipatedListProps = $props();
   const { filterMap } = useFilter();
 </script>
-
-{#snippet actions()}
-  {#if externalActions}
-    {@render externalActions()}
-  {:else}
-    <ShareButton
-      {title}
-      textFactory={({ title: name }) => m.text_share_top_list({ name })}
-      source={{ id: "anticipated", type }}
-    />
-  {/if}
-{/snippet}
 
 <DrilledMediaList
   id="view-all-anticipated-${type}"

--- a/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
@@ -5,7 +5,7 @@ import type { PaginatableStore } from './PaginatableStore.ts';
 
 export type MediaListProps<T, M> = {
   id: string;
-  title: string;
+  title?: string;
   type: M;
   item: Snippet<[T]>;
   ctaItem?: Snippet;

--- a/projects/client/src/lib/sections/lists/favorites/FavoritesListPaginated.svelte
+++ b/projects/client/src/lib/sections/lists/favorites/FavoritesListPaginated.svelte
@@ -9,21 +9,19 @@
   import FavoriteMediaItem from "./_internal/FavoriteMediaItem.svelte";
 
   type FavoritesProps = {
-    title: string;
     slug: string;
     mode: DiscoverMode;
     sortBy?: SortBy;
     sortHow?: SortDirection;
   };
 
-  const { title, slug, mode, sortBy, sortHow }: FavoritesProps = $props();
+  const { slug, mode, sortBy, sortHow }: FavoritesProps = $props();
 
   const { isMe } = $derived(useIsMe(slug));
 </script>
 
 <DrilledMediaList
   id="favorites-list-paginated-{mode}-{slug}"
-  {title}
   type={mode}
   useList={(params) =>
     useFavoritesList({

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte
@@ -4,16 +4,11 @@
   import { useRecentlyWatchedList } from "../stores/useRecentlyWatchedList";
   import RecentlyWatchedItem from "./RecentlyWatchedItem.svelte";
 
-  const {
-    title,
-    slug,
-    mode,
-  }: { title: string; slug: string; mode: DiscoverMode } = $props();
+  const { slug, mode }: { slug: string; mode: DiscoverMode } = $props();
 </script>
 
 <DrilledMediaList
   id="recently-watched-list-paginated-{mode}-{slug}"
-  {title}
   type={mode}
   useList={({ limit }: { limit: number }) =>
     useRecentlyWatchedList({

--- a/projects/client/src/lib/sections/lists/library/LibraryListPaginated.svelte
+++ b/projects/client/src/lib/sections/lists/library/LibraryListPaginated.svelte
@@ -14,7 +14,6 @@
 
 <DrilledMediaList
   id="view-all-library"
-  title={m.list_title_library()}
   type={$mode}
   useList={(params) => useLibraryList({ ...params, library })}
 >

--- a/projects/client/src/lib/sections/lists/popular/PopularPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/popular/PopularPaginatedList.svelte
@@ -1,40 +1,21 @@
 <script lang="ts">
-  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
-  import * as m from "$lib/features/i18n/messages.ts";
   import type { Snippet } from "svelte";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import PopularListItem from "./PopularListItem.svelte";
   import { usePopularList } from "./usePopularList";
 
   type PopularListProps = {
-    title: string;
+    title?: string;
     type: DiscoverMode;
     actions?: Snippet;
     search?: Record<string, string>;
   };
 
-  const {
-    title,
-    type,
-    actions: externalActions,
-    search,
-  }: PopularListProps = $props();
+  const { title, type, actions, search }: PopularListProps = $props();
   const { filterMap } = useFilter();
 </script>
-
-{#snippet actions()}
-  {#if externalActions}
-    {@render externalActions()}
-  {:else}
-    <ShareButton
-      {title}
-      textFactory={({ title: name }) => m.text_share_top_list({ name })}
-      source={{ id: "popular", type }}
-    />
-  {/if}
-{/snippet}
 
 <DrilledMediaList
   id="view-all-popular-${type}"

--- a/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { useDiscover } from "$lib/features/discover/useDiscover";
   import { useFilter } from "$lib/features/filters/useFilter";
-  import * as m from "$lib/features/i18n/messages.ts";
   import DrilledMediaList from "$lib/sections/lists/drilldown/DrilledMediaList.svelte";
   import { useUpNextList } from "$lib/sections/lists/progress/useUpNextList";
   import { useStablePaginated } from "$lib/sections/lists/stores/useStablePaginated";
@@ -32,9 +31,6 @@
         return isComparingEpisodes ? l.show.id === r.show.id : l.id === r.id;
       },
     })}
-  title={intent === "start"
-    ? m.list_title_start_watching()
-    : m.list_title_up_next()}
 >
   {#snippet item(progressEntry)}
     {#if progressEntry.intent === "start"}

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
@@ -8,17 +8,15 @@
   import { useRecommendedList } from "./useRecommendedList";
 
   type RecommendedListProps = {
-    title: string;
     type: DiscoverMode;
   };
 
-  const { title, type }: RecommendedListProps = $props();
+  const { type }: RecommendedListProps = $props();
   const { filterMap } = useFilter();
 </script>
 
 <DrilledMediaList
   id="view-all-recommended-${type}"
-  {title}
   {type}
   filter={{
     ...$filterMap,

--- a/projects/client/src/lib/sections/lists/smart/SmartListPaginatedRenderer.svelte
+++ b/projects/client/src/lib/sections/lists/smart/SmartListPaginatedRenderer.svelte
@@ -4,7 +4,6 @@
   import AnticipatedPaginatedList from "../anticipated/AnticipatedPaginatedList.svelte";
   import PopularPaginatedList from "../popular/PopularPaginatedList.svelte";
   import TrendingPaginatedList from "../trending/TrendingPaginatedList.svelte";
-  import SmartListActions from "./_internal/SmartListActions.svelte";
 
   type PaginatedSmartListRendererProps = {
     list: SmartList;
@@ -13,26 +12,21 @@
   const { list }: PaginatedSmartListRendererProps = $props();
 
   const commonProps = $derived({
-    title: list.title,
     type: list.type,
     search: list.params,
   });
 </script>
 
-{#snippet actions()}
-  <SmartListActions {list} />
-{/snippet}
-
 <GlobalParameterEscaper enabled>
   {#if list.target === "trending"}
-    <TrendingPaginatedList {...commonProps} {actions} />
+    <TrendingPaginatedList {...commonProps} />
   {/if}
 
   {#if list.target === "anticipated"}
-    <AnticipatedPaginatedList {...commonProps} {actions} />
+    <AnticipatedPaginatedList {...commonProps} />
   {/if}
 
   {#if list.target === "popular"}
-    <PopularPaginatedList {...commonProps} {actions} />
+    <PopularPaginatedList {...commonProps} />
   {/if}
 </GlobalParameterEscaper>

--- a/projects/client/src/lib/sections/lists/trending/TrendingPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/trending/TrendingPaginatedList.svelte
@@ -1,40 +1,21 @@
 <script lang="ts">
-  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
-  import * as m from "$lib/features/i18n/messages.ts";
   import type { Snippet } from "svelte";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
   import TrendingListItem from "./TrendingListItem.svelte";
   import { useTrendingList } from "./useTrendingList";
 
   type TrendingListProps = {
-    title: string;
+    title?: string;
     type: DiscoverMode;
     actions?: Snippet;
     search?: Record<string, string>;
   };
 
-  const {
-    title,
-    type,
-    actions: externalActions,
-    search,
-  }: TrendingListProps = $props();
+  const { title, type, actions, search }: TrendingListProps = $props();
   const { filterMap } = useFilter();
 </script>
-
-{#snippet actions()}
-  {#if externalActions}
-    {@render externalActions()}
-  {:else}
-    <ShareButton
-      {title}
-      textFactory={({ title: name }) => m.text_share_top_list({ name })}
-      source={{ id: "trending", type }}
-    />
-  {/if}
-{/snippet}
 
 <DrilledMediaList
   id="view-all-trending-${type}"

--- a/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/user/UserListPaginatedList.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
-  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
-  import { useUser } from "$lib/features/auth/stores/useUser";
   import { useFilter } from "$lib/features/filters/useFilter";
-  import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
@@ -24,11 +21,7 @@
 
   const { title, type, list, sortBy, sortHow }: UserListProps = $props();
 
-  const { user } = useUser();
-
   const { filterMap } = useFilter();
-
-  const isListOwner = $derived($user.slug === list.user?.slug);
 
   const listCacheId = $derived.by(() => {
     const sortKey = `${sortBy}-${sortHow}`;
@@ -43,7 +36,6 @@
 
 <DrilledMediaList
   id={`user-paginated-list-${listCacheId}`}
-  {title}
   {type}
   filter={$filterMap}
   useList={(params) =>
@@ -75,18 +67,6 @@
       {list}
       sortTag={sortBy ? sortTag : undefined}
     />
-  {/snippet}
-
-  {#snippet actions()}
-    <ListActions {list} />
-
-    {#if !isListOwner}
-      <ShareButton
-        {title}
-        textFactory={({ title: name }) => m.text_share_list({ name })}
-        source={{ id: "user-list", type }}
-      />
-    {/if}
   {/snippet}
 </DrilledMediaList>
 

--- a/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/WatchlistPaginatedList.svelte
@@ -9,20 +9,18 @@
   import { useWatchList } from "./useWatchList";
 
   type WatchListProps = {
-    title: string;
     type?: DiscoverMode;
     sortBy?: SortBy;
     sortHow?: SortDirection;
   };
 
-  const { title, type, sortBy, sortHow }: WatchListProps = $props();
+  const { type, sortBy, sortHow }: WatchListProps = $props();
 
   const { filterMap } = useFilter();
 </script>
 
 <DrilledMediaList
   id="view-all-watchlist-${type}"
-  {title}
   {type}
   filter={$filterMap}
   useList={(params) =>

--- a/projects/client/src/lib/sections/navbar/NavbarStateSetter.svelte
+++ b/projects/client/src/lib/sections/navbar/NavbarStateSetter.svelte
@@ -10,6 +10,7 @@
     mode,
     hasFilters,
     sortActions,
+    header,
   }: {
     actions?: Snippet;
     seasonalActions?: Snippet;
@@ -18,6 +19,11 @@
     mode?: NavbarMode;
     hasFilters?: boolean;
     sortActions?: Snippet;
+    header?: {
+      title: string;
+      metaInfo?: string | Snippet;
+      actions?: Snippet;
+    };
   } = $props();
 
   const { set, globalSet, reset } = useNavbarState();
@@ -29,6 +35,7 @@
       contextualActions,
       hasFilters,
       sortActions,
+      header,
     });
   });
 

--- a/projects/client/src/lib/sections/navbar/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/SideNavbar.svelte
@@ -12,6 +12,7 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import Toast from "../toast/Toast.svelte";
+  import NavbarHeader from "./_internal/NavbarHeader.svelte";
   import FilterButton from "./components/filter/FilterButton.svelte";
   import GetVIPLink from "./components/GetVIPLink.svelte";
   import JoinTraktButton from "./components/JoinTraktButton.svelte";
@@ -34,6 +35,7 @@
   <div class="trakt-navbar-actions" class:is-hidden={$state.mode === "minimal"}>
     <div class="trakt-navbar-actions-left">
       <RenderFor audience="free"><GetVIPLink source="navbar" /></RenderFor>
+      <NavbarHeader />
     </div>
 
     <div class="trakt-navbar-actions-center">
@@ -226,6 +228,10 @@
       padding-bottom: 0;
       pointer-events: none;
     }
+  }
+
+  .trakt-navbar-actions-left {
+    min-width: 0;
   }
 
   .trakt-navbar-actions-right {

--- a/projects/client/src/lib/sections/navbar/TopNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/TopNavbar.svelte
@@ -2,6 +2,7 @@
   import PlusIcon from "$lib/components/icons/PlusIcon.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { trackWindowScroll } from "$lib/utils/actions/trackWindowScroll";
+  import NavbarHeader from "./_internal/NavbarHeader.svelte";
   import FilterButton from "./components/filter/FilterButton.svelte";
   import GetVIPLink from "./components/GetVIPLink.svelte";
   import JoinTraktButton from "./components/JoinTraktButton.svelte";
@@ -17,7 +18,8 @@
       class:is-hidden={$state.mode === "minimal"}
       use:trackWindowScroll={"trakt-navbar-scroll"}
     >
-      <div class="trakt-navbar-actions">
+      <div class="trakt-navbar-left">
+        <NavbarHeader />
         {@render $state.actions?.()}
       </div>
 
@@ -90,6 +92,10 @@
 
     transition: calc(2 * var(--transition-increment)) ease-in-out;
     transition-property: width, background-color, box-shadow, top, opacity;
+
+    .trakt-navbar-left {
+      min-width: 0;
+    }
 
     .trakt-navbar-links {
       display: flex;

--- a/projects/client/src/lib/sections/navbar/_internal/NavbarHeader.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/NavbarHeader.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { useNavbarState } from "../useNavbarState";
+
+  const { state } = useNavbarState();
+</script>
+
+{#if $state.header?.title}
+  <div class="trakt-navbar-header">
+    <div class="trakt-navbar-header-title">
+      <h1 class="ellipsis">{$state.header.title}</h1>
+      {#if $state.header?.metaInfo}
+        {#if typeof $state.header.metaInfo === "string"}
+          <span class="ellipsis bold meta-info">{$state.header.metaInfo}</span>
+        {:else}
+          {@render $state.header.metaInfo()}
+        {/if}
+      {/if}
+    </div>
+
+    {#if $state.header?.actions}
+      <div class="trakt-navbar-header-actions">
+        {@render $state.header.actions()}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .trakt-navbar-header {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    min-width: 0;
+  }
+
+  .trakt-navbar-header-title {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+
+    .meta-info {
+      color: var(--list-meta-info-color);
+    }
+  }
+
+  .trakt-navbar-header-actions {
+    :global(.trakt-action-button) {
+      :global(svg) {
+        width: var(--ni-24);
+        height: var(--ni-24);
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/navbar/useNavbarState.ts
+++ b/projects/client/src/lib/sections/navbar/useNavbarState.ts
@@ -10,6 +10,11 @@ type NavbarState = {
   contextualActions: Snippet | undefined;
   hasFilters: boolean;
   sortActions?: Snippet;
+  header?: {
+    title: string;
+    metaInfo?: string | Snippet;
+    actions?: Snippet;
+  };
 };
 
 type GlobalNavbarState = {
@@ -28,6 +33,7 @@ const initialNavbarState: NavbarState = {
   contextualActions: undefined,
   hasFilters: false,
   sortActions: undefined,
+  header: undefined,
 };
 
 const navbarStateStore = new BehaviorSubject<NavbarState>(

--- a/projects/client/src/lib/sections/profile/components/ProfileListPaginated.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileListPaginated.svelte
@@ -1,47 +1,35 @@
 <script lang="ts">
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
-  import Toggler from "$lib/components/toggles/Toggler.svelte";
-  import { useToggler } from "$lib/components/toggles/useToggler";
   import * as m from "$lib/features/i18n/messages.ts";
-  import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
   import { useFollowing } from "../stores/useFollowing";
   import ProfileCard from "./ProfileCard.svelte";
 
   const {
     slug,
+    type,
   }: {
     slug: string;
+    type: "following" | "followers";
   } = $props();
 
-  const { current, set, options } = useToggler("social");
-  const { profiles, isLoading } = $derived(useFollowing(slug, $current.value));
+  const { profiles, isLoading } = $derived(useFollowing(slug, type));
 
   const placeholder = $derived(
-    $current.value === "following"
+    type === "following"
       ? m.list_placeholder_following()
       : m.list_placeholder_followers(),
   );
 </script>
 
-{#snippet metaInfo()}
-  <ListMetaInfo text={$current.text()} />
-{/snippet}
-
 <GridList
-  id={`profiles-paginated-list-${slug}-${$current.value}`}
+  id={`profiles-paginated-list-${slug}-${type}`}
   items={$profiles}
-  title={m.list_title_social()}
-  {metaInfo}
   sizing="auto"
   --width-item="var(--ni-148)"
 >
   {#snippet item(profile)}
     <ProfileCard {profile} />
-  {/snippet}
-
-  {#snippet actions()}
-    <Toggler value={$current.value} onChange={set} {options} />
   {/snippet}
 
   {#snippet empty()}

--- a/projects/client/src/routes/calendar/+page.svelte
+++ b/projects/client/src/routes/calendar/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import Calendar from "$lib/features/calendar/Calendar.svelte";
+  import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
 
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
+
+  const { current } = useDiscover();
 </script>
 
 <TraktPage
@@ -16,11 +18,10 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter hasFilters>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-  </NavbarStateSetter>
+  <NavbarStateSetter
+    hasFilters
+    header={{ title: m.header_calendar(), metaInfo: $current.text() }}
+  />
 
   <Calendar />
 </TraktPage>

--- a/projects/client/src/routes/history/+page.svelte
+++ b/projects/client/src/routes/history/+page.svelte
@@ -3,14 +3,13 @@
   import CalendarProvider from "$lib/features/calendar/CalendarProvider.svelte";
   import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import PersonalHistoryPaginatedList from "$lib/sections/lists/history/PersonalHistoryPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
-  const { mode } = useDiscover();
+  const { mode, current } = useDiscover();
   const { history } = useUser();
 </script>
 
@@ -21,11 +20,10 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter hasFilters>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-  </NavbarStateSetter>
+  <NavbarStateSetter
+    hasFilters
+    header={{ title: m.list_title_history(), metaInfo: $current.text() }}
+  />
 
   {#if $history}
     <CalendarProvider initialDate={$history.lastWatchedAt}>

--- a/projects/client/src/routes/lists/official/[list]/+page.svelte
+++ b/projects/client/src/routes/lists/official/[list]/+page.svelte
@@ -3,6 +3,7 @@
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import { useListSorting } from "$lib/sections/lists/user/_internal/useListSorting";
+  import ListActions from "$lib/sections/lists/user/ListActions.svelte";
   import ListSortActions from "$lib/sections/lists/user/ListSortActions.svelte";
   import UserListPaginatedList from "$lib/sections/lists/user/UserListPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
@@ -13,7 +14,7 @@
 
   const { params }: PageProps = $props();
 
-  const type = $derived(mapToMediaType(page.url.searchParams));
+  const { type, text } = $derived(mapToMediaType(page.url.searchParams));
 
   const { list, isLoading } = $derived(
     useListSummary({
@@ -28,6 +29,12 @@
   );
 </script>
 
+{#snippet actions()}
+  {#if $list}
+    <ListActions list={$list} />
+  {/if}
+{/snippet}
+
 <TraktPage
   audience="all"
   image={DEFAULT_SHARE_COVER}
@@ -36,7 +43,14 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter hasFilters>
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: listName,
+      metaInfo: text,
+      actions,
+    }}
+  >
     {#snippet sortActions()}
       <ListSortActions
         {options}

--- a/projects/client/src/routes/lists/smart/view/+page.svelte
+++ b/projects/client/src/routes/lists/smart/view/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages.ts";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import SmartListRenderer from "$lib/sections/lists/smart/SmartListRenderer.svelte";
@@ -18,11 +17,7 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-  </NavbarStateSetter>
+  <NavbarStateSetter header={{ title: m.list_title_smart_lists() }} />
 
   <SmartListRenderer mode={$mode} limit={100} />
 </TraktPage>

--- a/projects/client/src/routes/lists/smart/view/[list]/+page.svelte
+++ b/projects/client/src/routes/lists/smart/view/[list]/+page.svelte
@@ -3,6 +3,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import SmartListActions from "$lib/sections/lists/smart/_internal/SmartListActions.svelte";
   import SmartListPaginatedRenderer from "$lib/sections/lists/smart/SmartListPaginatedRenderer.svelte";
   import { useSmartLists } from "$lib/sections/lists/smart/useSmartLists.ts";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
@@ -22,13 +23,24 @@
   const list = $derived($collection?.find((list) => list.id === listId));
 </script>
 
+{#snippet actions()}
+  {#if list}
+    <SmartListActions {list} />
+  {/if}
+{/snippet}
+
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_COVER}
   title={list?.title || m.page_title_smart_lists()}
   hasDynamicContent={true}
 >
-  <NavbarStateSetter mode="minimal" />
+  <NavbarStateSetter
+    header={{
+      title: list?.title ?? "",
+      actions,
+    }}
+  />
 
   <TraktPageCoverSetter />
 

--- a/projects/client/src/routes/media/anticipated/+page.svelte
+++ b/projects/client/src/routes/media/anticipated/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -8,16 +9,29 @@
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
+{#snippet actions()}
+  <ShareButton
+    title={m.list_title_most_anticipated()}
+    textFactory={({ title: name }) => m.text_share_top_list({ name })}
+    source={{ id: "anticipated", type: "media" }}
+  />
+{/snippet}
+
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_MOVIE_COVER}
   title={m.page_title_anticipated_media()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_most_anticipated(),
+      metaInfo: m.button_text_media(),
+      actions,
+    }}
+  />
+
   <TraktPageCoverSetter />
 
-  <AnticipatedPaginatedList
-    title={m.list_title_most_anticipated()}
-    type="media"
-  />
+  <AnticipatedPaginatedList type="media" />
 </TraktPage>

--- a/projects/client/src/routes/media/popular/+page.svelte
+++ b/projects/client/src/routes/media/popular/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -8,13 +9,29 @@
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
+{#snippet actions()}
+  <ShareButton
+    title={m.list_title_most_popular()}
+    textFactory={({ title: name }) => m.text_share_top_list({ name })}
+    source={{ id: "popular", type: "media" }}
+  />
+{/snippet}
+
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_MOVIE_COVER}
   title={m.page_title_popular_media()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_most_popular(),
+      metaInfo: m.button_text_media(),
+      actions,
+    }}
+  />
+
   <TraktPageCoverSetter />
 
-  <PopularPaginatedList title={m.list_title_most_popular()} type="media" />
+  <PopularPaginatedList type="media" />
 </TraktPage>

--- a/projects/client/src/routes/media/recommended/+page.svelte
+++ b/projects/client/src/routes/media/recommended/+page.svelte
@@ -13,8 +13,14 @@
   image={DEFAULT_SHARE_MOVIE_COVER}
   title={m.page_title_recommended_media()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_recommended(),
+      metaInfo: m.button_text_media(),
+    }}
+  />
   <TraktPageCoverSetter />
 
-  <RecommendedPaginatedList title={m.list_title_recommended()} type="media" />
+  <RecommendedPaginatedList type="media" />
 </TraktPage>

--- a/projects/client/src/routes/media/trending/+page.svelte
+++ b/projects/client/src/routes/media/trending/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -8,13 +9,29 @@
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 </script>
 
+{#snippet actions()}
+  <ShareButton
+    title={m.list_title_trending()}
+    textFactory={({ title: name }) => m.text_share_top_list({ name })}
+    source={{ id: "trending", type: "media" }}
+  />
+{/snippet}
+
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_SHOW_COVER}
   title={m.page_title_trending_media()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_trending(),
+      metaInfo: m.button_text_media(),
+      actions,
+    }}
+  />
+
   <TraktPageCoverSetter />
 
-  <TrendingPaginatedList title={m.list_title_trending()} type="media" />
+  <TrendingPaginatedList type="media" />
 </TraktPage>

--- a/projects/client/src/routes/movies/[slug]/lists/+page.svelte
+++ b/projects/client/src/routes/movies/[slug]/lists/+page.svelte
@@ -14,7 +14,11 @@
   title={m.list_title_popular_lists()}
   image={DEFAULT_SHARE_MOVIE_COVER}
 >
-  <NavbarStateSetter mode="minimal" />
+  <NavbarStateSetter
+    header={{
+      title: m.list_title_popular_lists(),
+    }}
+  />
 
   <ListsPaginated type="movie" slug={params.slug} />
 </TraktPage>

--- a/projects/client/src/routes/movies/[slug]/related/+page.svelte
+++ b/projects/client/src/routes/movies/[slug]/related/+page.svelte
@@ -14,11 +14,11 @@
   title={m.list_title_related_movies()}
   image={DEFAULT_SHARE_MOVIE_COVER}
 >
-  <NavbarStateSetter mode="minimal" />
-
-  <RelatedPaginatedList
-    title={m.list_title_related_movies()}
-    type="movie"
-    slug={params.slug}
+  <NavbarStateSetter
+    header={{
+      title: m.list_title_related_movies(),
+    }}
   />
+
+  <RelatedPaginatedList type="movie" slug={params.slug} />
 </TraktPage>

--- a/projects/client/src/routes/movies/anticipated/+page.svelte
+++ b/projects/client/src/routes/movies/anticipated/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -8,16 +9,29 @@
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
+{#snippet actions()}
+  <ShareButton
+    title={m.list_title_anticipated_movies()}
+    textFactory={({ title: name }) => m.text_share_top_list({ name })}
+    source={{ id: "anticipated", type: "movie" }}
+  />
+{/snippet}
+
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_MOVIE_COVER}
   title={m.page_title_anticipated_movies()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_most_anticipated(),
+      metaInfo: m.button_text_movies(),
+      actions,
+    }}
+  />
+
   <TraktPageCoverSetter />
 
-  <AnticipatedPaginatedList
-    title={m.list_title_anticipated_movies()}
-    type="movie"
-  />
+  <AnticipatedPaginatedList type="movie" />
 </TraktPage>

--- a/projects/client/src/routes/movies/popular/+page.svelte
+++ b/projects/client/src/routes/movies/popular/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -8,13 +9,29 @@
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
+{#snippet actions()}
+  <ShareButton
+    title={m.list_title_popular_movies()}
+    textFactory={({ title: name }) => m.text_share_top_list({ name })}
+    source={{ id: "popular", type: "movie" }}
+  />
+{/snippet}
+
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_MOVIE_COVER}
   title={m.page_title_popular_movies()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_most_popular(),
+      metaInfo: m.button_text_movies(),
+      actions,
+    }}
+  />
+
   <TraktPageCoverSetter />
 
-  <PopularPaginatedList title={m.list_title_popular_movies()} type="movie" />
+  <PopularPaginatedList type="movie" />
 </TraktPage>

--- a/projects/client/src/routes/movies/recommended/+page.svelte
+++ b/projects/client/src/routes/movies/recommended/+page.svelte
@@ -13,11 +13,14 @@
   image={DEFAULT_SHARE_MOVIE_COVER}
   title={m.page_title_recommended_movies()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_recommended(),
+      metaInfo: m.button_text_movies(),
+    }}
+  />
   <TraktPageCoverSetter />
 
-  <RecommendedPaginatedList
-    title={m.list_title_recommended_movies()}
-    type="movie"
-  />
+  <RecommendedPaginatedList type="movie" />
 </TraktPage>

--- a/projects/client/src/routes/movies/trending/+page.svelte
+++ b/projects/client/src/routes/movies/trending/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -8,13 +9,29 @@
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 </script>
 
+{#snippet actions()}
+  <ShareButton
+    title={m.list_title_trending_movies()}
+    textFactory={({ title: name }) => m.text_share_top_list({ name })}
+    source={{ id: "trending", type: "movie" }}
+  />
+{/snippet}
+
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_MOVIE_COVER}
   title={m.page_title_trending_movies()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_trending(),
+      metaInfo: m.button_text_movies(),
+      actions,
+    }}
+  />
+
   <TraktPageCoverSetter />
 
-  <TrendingPaginatedList title={m.list_title_trending_movies()} type="movie" />
+  <TrendingPaginatedList type="movie" />
 </TraktPage>

--- a/projects/client/src/routes/profile/[slug]/favorites/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/favorites/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import FavoritesListPaginated from "$lib/sections/lists/favorites/FavoritesListPaginated.svelte";
@@ -13,7 +12,7 @@
 
   const { params }: PageProps = $props();
 
-  const { mode } = useDiscover();
+  const { mode, current: currentDiscoverMode } = useDiscover();
 
   const { current, update, options, urlBuilder } = $derived(
     useListSorting({ type: "favorites", slug: params.slug }),
@@ -27,11 +26,12 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-
+  <NavbarStateSetter
+    header={{
+      title: m.list_title_favorites(),
+      metaInfo: $currentDiscoverMode.text(),
+    }}
+  >
     {#snippet sortActions()}
       <ListSortActions
         {options}
@@ -42,11 +42,5 @@
     {/snippet}
   </NavbarStateSetter>
 
-  <FavoritesListPaginated
-    slug={params.slug}
-    title={m.list_title_favorites()}
-    mode={$mode}
-    sortBy={$current.sorting.value}
-    sortHow={$current.sortHow}
-  />
+  <FavoritesListPaginated slug={params.slug} mode={$mode} />
 </TraktPage>

--- a/projects/client/src/routes/profile/[slug]/history/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/history/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import RecentlyWatchedPaginatedList from "$lib/sections/lists/history/RecentlyWatchedPaginatedList.svelte";
@@ -11,7 +10,7 @@
 
   const { params }: PageProps = $props();
 
-  const { mode } = useDiscover();
+  const { mode, current } = useDiscover();
 </script>
 
 <TraktPage
@@ -21,15 +20,9 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-  </NavbarStateSetter>
-
-  <RecentlyWatchedPaginatedList
-    title={m.list_title_history()}
-    slug={params.slug}
-    mode={$mode}
+  <NavbarStateSetter
+    header={{ title: m.list_title_history(), metaInfo: $current.text() }}
   />
+
+  <RecentlyWatchedPaginatedList slug={params.slug} mode={$mode} />
 </TraktPage>

--- a/projects/client/src/routes/profile/[slug]/social/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/social/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+  import Toggler from "$lib/components/toggles/Toggler.svelte";
+  import { useToggler } from "$lib/components/toggles/useToggler";
   import { m } from "$lib/features/i18n/messages";
+  import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
@@ -8,7 +11,17 @@
   import type { PageProps } from "./$types";
 
   const { params }: PageProps = $props();
+
+  const { current, set, options } = useToggler("social");
 </script>
+
+{#snippet actions()}
+  <Toggler value={$current.value} onChange={set} {options} />
+{/snippet}
+
+{#snippet metaInfo()}
+  <ListMetaInfo text={$current.text()} />
+{/snippet}
 
 <TraktPage
   audience="all"
@@ -17,7 +30,13 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter mode="minimal" />
+  <NavbarStateSetter
+    header={{
+      title: m.list_title_social(),
+      actions,
+      metaInfo,
+    }}
+  />
 
-  <ProfileListPaginated slug={params.slug} />
+  <ProfileListPaginated slug={params.slug} type={$current.value} />
 </TraktPage>

--- a/projects/client/src/routes/shows/[slug]/lists/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/lists/+page.svelte
@@ -14,7 +14,11 @@
   title={m.list_title_popular_lists()}
   image={DEFAULT_SHARE_SHOW_COVER}
 >
-  <NavbarStateSetter mode="minimal" />
+  <NavbarStateSetter
+    header={{
+      title: m.list_title_popular_lists(),
+    }}
+  />
 
   <ListsPaginated type="show" slug={params.slug} />
 </TraktPage>

--- a/projects/client/src/routes/shows/[slug]/related/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/related/+page.svelte
@@ -14,11 +14,11 @@
   title={m.list_title_related_shows()}
   image={DEFAULT_SHARE_SHOW_COVER}
 >
-  <NavbarStateSetter mode="minimal" />
-
-  <RelatedPaginatedList
-    title={m.list_title_related_shows()}
-    type="show"
-    slug={params.slug}
+  <NavbarStateSetter
+    header={{
+      title: m.list_title_related_shows(),
+    }}
   />
+
+  <RelatedPaginatedList type="show" slug={params.slug} />
 </TraktPage>

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/related/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/related/+page.svelte
@@ -14,11 +14,11 @@
   title={m.list_title_related_shows()}
   image={DEFAULT_SHARE_SHOW_COVER}
 >
-  <NavbarStateSetter mode="minimal" />
-
-  <RelatedPaginatedList
-    title={m.list_title_related_shows()}
-    type="show"
-    slug={params.slug}
+  <NavbarStateSetter
+    header={{
+      title: m.list_title_related_shows(),
+    }}
   />
+
+  <RelatedPaginatedList type="show" slug={params.slug} />
 </TraktPage>

--- a/projects/client/src/routes/shows/anticipated/+page.svelte
+++ b/projects/client/src/routes/shows/anticipated/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -8,16 +9,29 @@
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 </script>
 
+{#snippet actions()}
+  <ShareButton
+    title={m.list_title_anticipated_shows()}
+    textFactory={({ title: name }) => m.text_share_top_list({ name })}
+    source={{ id: "anticipated", type: "show" }}
+  />
+{/snippet}
+
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_SHOW_COVER}
   title={m.page_title_anticipated_shows()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_most_anticipated(),
+      metaInfo: m.button_text_shows(),
+      actions,
+    }}
+  />
+
   <TraktPageCoverSetter />
 
-  <AnticipatedPaginatedList
-    title={m.list_title_anticipated_shows()}
-    type="show"
-  />
+  <AnticipatedPaginatedList type="show" />
 </TraktPage>

--- a/projects/client/src/routes/shows/popular/+page.svelte
+++ b/projects/client/src/routes/shows/popular/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -8,13 +9,29 @@
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 </script>
 
+{#snippet actions()}
+  <ShareButton
+    title={m.list_title_popular_shows()}
+    textFactory={({ title: name }) => m.text_share_top_list({ name })}
+    source={{ id: "popular", type: "show" }}
+  />
+{/snippet}
+
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_SHOW_COVER}
   title={m.page_title_popular_shows()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_most_popular(),
+      metaInfo: m.button_text_shows(),
+      actions,
+    }}
+  />
+
   <TraktPageCoverSetter />
 
-  <PopularPaginatedList title={m.list_title_popular_shows()} type="show" />
+  <PopularPaginatedList type="show" />
 </TraktPage>

--- a/projects/client/src/routes/shows/recommended/+page.svelte
+++ b/projects/client/src/routes/shows/recommended/+page.svelte
@@ -13,11 +13,14 @@
   image={DEFAULT_SHARE_SHOW_COVER}
   title={m.page_title_recommended_shows()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_recommended(),
+      metaInfo: m.button_text_shows(),
+    }}
+  />
   <TraktPageCoverSetter />
 
-  <RecommendedPaginatedList
-    title={m.list_title_recommended_shows()}
-    type="show"
-  />
+  <RecommendedPaginatedList type="show" />
 </TraktPage>

--- a/projects/client/src/routes/shows/trending/+page.svelte
+++ b/projects/client/src/routes/shows/trending/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -8,13 +9,29 @@
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
 </script>
 
+{#snippet actions()}
+  <ShareButton
+    title={m.list_title_trending_shows()}
+    textFactory={({ title: name }) => m.text_share_top_list({ name })}
+    source={{ id: "trending", type: "show" }}
+  />
+{/snippet}
+
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_SHOW_COVER}
   title={m.page_title_trending_shows()}
 >
-  <NavbarStateSetter hasFilters />
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_trending(),
+      metaInfo: m.button_text_shows(),
+      actions,
+    }}
+  />
+
   <TraktPageCoverSetter />
 
-  <TrendingPaginatedList title={m.list_title_trending_shows()} type="show" />
+  <TrendingPaginatedList type="show" />
 </TraktPage>

--- a/projects/client/src/routes/social/activity/+page.svelte
+++ b/projects/client/src/routes/social/activity/+page.svelte
@@ -2,7 +2,6 @@
   import CalendarProvider from "$lib/features/calendar/CalendarProvider.svelte";
   import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import { useActivityList } from "$lib/sections/lists/activity/_internal/useActivityList";
@@ -11,7 +10,7 @@
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
-  const { mode } = useDiscover();
+  const { mode, current } = useDiscover();
 
   const { list, isLoading } = $derived(
     useActivityList({
@@ -28,11 +27,13 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter hasFilters>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-  </NavbarStateSetter>
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_social_activity(),
+      metaInfo: $current.text(),
+    }}
+  />
 
   {#if !$isLoading}
     <CalendarProvider initialDate={$list.at(0)?.activityAt}>

--- a/projects/client/src/routes/users/[user]/library/+page.svelte
+++ b/projects/client/src/routes/users/[user]/library/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Redirect from "$lib/components/router/Redirect.svelte";
+  import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages.ts";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import LibraryListPaginated from "$lib/sections/lists/library/LibraryListPaginated.svelte";
@@ -20,6 +19,8 @@
   );
 
   const isMe = $derived(params.user === "me");
+
+  const { current } = useDiscover();
 </script>
 
 {#if !isMe}
@@ -30,13 +31,9 @@
     image={DEFAULT_SHARE_MOVIE_COVER}
     title={m.page_title_library()}
   >
-    <RenderFor audience="authenticated">
-      <NavbarStateSetter>
-        {#snippet actions()}
-          <DiscoverToggles />
-        {/snippet}
-      </NavbarStateSetter>
-    </RenderFor>
+    <NavbarStateSetter
+      header={{ title: m.list_title_library(), metaInfo: $current.text() }}
+    />
 
     <TraktPageCoverSetter />
 

--- a/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
@@ -3,6 +3,7 @@
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import { useListSorting } from "$lib/sections/lists/user/_internal/useListSorting";
+  import ListActions from "$lib/sections/lists/user/ListActions.svelte";
   import ListSortActions from "$lib/sections/lists/user/ListSortActions.svelte";
   import UserListPaginatedList from "$lib/sections/lists/user/UserListPaginatedList.svelte";
   import { useUserListSummary } from "$lib/sections/lists/user/useUserListSummary.ts";
@@ -20,7 +21,7 @@
     }),
   );
 
-  const type = $derived(mapToMediaType(page.url.searchParams));
+  const { type, text } = $derived(mapToMediaType(page.url.searchParams));
   const listName = $derived($list?.name ?? "");
 
   const { current, update, options, urlBuilder } = $derived(
@@ -28,13 +29,26 @@
   );
 </script>
 
+{#snippet actions()}
+  {#if $list}
+    <ListActions list={$list} />
+  {/if}
+{/snippet}
+
 <TraktPage
   audience="all"
   image={DEFAULT_SHARE_COVER}
   title={listName}
   hasDynamicContent={true}
 >
-  <NavbarStateSetter hasFilters>
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: listName,
+      metaInfo: text,
+      actions,
+    }}
+  >
     {#snippet sortActions()}
       <ListSortActions
         {options}

--- a/projects/client/src/routes/users/[user]/lists/[list]/_internal/mapToMediaType.ts
+++ b/projects/client/src/routes/users/[user]/lists/[list]/_internal/mapToMediaType.ts
@@ -1,11 +1,21 @@
+import { m } from '$lib/features/i18n/messages.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 
-export function mapToMediaType(params: URLSearchParams): MediaType | undefined {
+function toTypeText(type: MediaType) {
+  return type === 'movie' ? m.button_text_movies() : m.button_text_shows();
+}
+
+type ListMediaType = {
+  type?: MediaType;
+  text: string;
+};
+
+export function mapToMediaType(params: URLSearchParams): ListMediaType {
   const type = params.get('type');
 
   if (type !== 'movie' && type !== 'show') {
-    return;
+    return { text: m.button_text_media() };
   }
 
-  return type;
+  return { type, text: toTypeText(type) };
 }

--- a/projects/client/src/routes/users/[user]/lists/view/collaborations/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/view/collaborations/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages.ts";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import PersonalListsPaginated from "$lib/sections/lists/user/PersonalListsPaginated.svelte";
@@ -9,6 +9,8 @@
   import type { PageProps } from "./$types";
 
   const { params }: PageProps = $props();
+
+  const { current } = useDiscover();
 </script>
 
 <TraktPage
@@ -18,11 +20,13 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter hasFilters>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-  </NavbarStateSetter>
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_collaborative_lists(),
+      metaInfo: $current.text(),
+    }}
+  />
 
   <PersonalListsPaginated type="collaboration" slug={params.user} />
 </TraktPage>

--- a/projects/client/src/routes/users/[user]/lists/view/liked/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/view/liked/+page.svelte
@@ -2,8 +2,8 @@
   import Redirect from "$lib/components/router/Redirect.svelte";
   import { useIsMe } from "$lib/features/auth/stores/useIsMe";
   import { useUser } from "$lib/features/auth/stores/useUser";
+  import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages.ts";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import PersonalListsPaginated from "$lib/sections/lists/user/PersonalListsPaginated.svelte";
@@ -15,6 +15,8 @@
   const { params }: PageProps = $props();
   const { user } = useUser();
   const { isMe } = $derived(useIsMe(params.user));
+
+  const { current } = useDiscover();
 </script>
 
 <TraktPage
@@ -28,11 +30,10 @@
 
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter hasFilters>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-  </NavbarStateSetter>
+  <NavbarStateSetter
+    hasFilters
+    header={{ title: m.list_title_liked_lists(), metaInfo: $current.text() }}
+  />
 
   <PersonalListsPaginated type="liked" slug={$user.slug} />
 </TraktPage>

--- a/projects/client/src/routes/users/[user]/lists/view/personal/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/view/personal/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages.ts";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import PersonalListsPaginated from "$lib/sections/lists/user/PersonalListsPaginated.svelte";
@@ -9,6 +9,8 @@
   import type { PageProps } from "./$types";
 
   const { params }: PageProps = $props();
+
+  const { current } = useDiscover();
 </script>
 
 <TraktPage
@@ -18,11 +20,10 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter hasFilters>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-  </NavbarStateSetter>
+  <NavbarStateSetter
+    hasFilters
+    header={{ title: m.list_title_personal_lists(), metaInfo: $current.text() }}
+  />
 
   <PersonalListsPaginated type="personal" slug={params.user} />
 </TraktPage>

--- a/projects/client/src/routes/users/[user]/progress/+page.svelte
+++ b/projects/client/src/routes/users/[user]/progress/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
+  import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages.ts";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
 
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import UpNextPaginatedList from "$lib/sections/lists/progress/UpNextPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
+
+  const { current } = useDiscover();
 </script>
 
 <TraktPage
@@ -16,11 +18,10 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter hasFilters>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-  </NavbarStateSetter>
+  <NavbarStateSetter
+    hasFilters
+    header={{ title: m.list_title_up_next(), metaInfo: $current.text() }}
+  />
 
   <UpNextPaginatedList intent="continue" />
 </TraktPage>

--- a/projects/client/src/routes/users/[user]/start-watching/+page.svelte
+++ b/projects/client/src/routes/users/[user]/start-watching/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
+  import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages.ts";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
 
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import UpNextPaginatedList from "$lib/sections/lists/progress/UpNextPaginatedList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
+
+  const { current } = useDiscover();
 </script>
 
 <TraktPage
@@ -16,11 +18,10 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter hasFilters>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-  </NavbarStateSetter>
+  <NavbarStateSetter
+    hasFilters
+    header={{ title: m.list_title_start_watching(), metaInfo: $current.text() }}
+  />
 
   <UpNextPaginatedList intent="start" />
 </TraktPage>

--- a/projects/client/src/routes/users/[user]/watchlist/+page.svelte
+++ b/projects/client/src/routes/users/[user]/watchlist/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages.ts";
-  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import { useListSorting } from "$lib/sections/lists/user/_internal/useListSorting";
@@ -10,7 +9,7 @@
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 
-  const { mode } = useDiscover();
+  const { mode, current: currentDiscoverMode } = useDiscover();
 
   const { current, update, options, urlBuilder } = $derived(
     useListSorting({ type: "watchlist" }),
@@ -24,11 +23,13 @@
 >
   <TraktPageCoverSetter />
 
-  <NavbarStateSetter hasFilters>
-    {#snippet actions()}
-      <DiscoverToggles />
-    {/snippet}
-
+  <NavbarStateSetter
+    hasFilters
+    header={{
+      title: m.list_title_watchlist(),
+      metaInfo: $currentDiscoverMode.text(),
+    }}
+  >
     {#snippet sortActions()}
       <ListSortActions
         {options}
@@ -40,7 +41,6 @@
   </NavbarStateSetter>
 
   <WatchlistPaginatedList
-    title={m.list_title_watchlist()}
     type={$mode}
     sortBy={$current.sorting.value}
     sortHow={$current.sortHow}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1853
- Discover mode toggles are now only on L1 pages; L2 pages now use that space to place the titles.

## 👀 Example 👀

https://github.com/user-attachments/assets/12659088-a1f5-4f30-8638-75da5a5ccdad

