### PR TITLE
feat(summary): adds drilldowns for section lists

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { appendGlobalParameters } from "$lib/features/parameters/appendGlobalParameters";
   import { useActiveLink } from "$lib/stores/useActiveLink";
+  import { appendClassList } from "$lib/utils/actions/appendClassList";
   import { disableNavigation } from "$lib/utils/actions/disableNavigation";
   import { triggerWithKeyboard } from "$lib/utils/actions/triggerWithKeyboard";
   import { useGuardedHref } from "../../features/auth/stores/useGuardedHref";
@@ -17,6 +18,7 @@
     style = "flat",
     navigationType,
     disabled,
+    classList = "",
     ...props
   }: TraktActionButtonProps | TraktActionButtonAnchorProps = $props();
 
@@ -40,6 +42,7 @@
     use:triggerWithKeyboard
     use:appendGlobalParameters={href}
     use:disableNavigation={rest.disabled}
+    use:appendClassList={classList}
     data-sveltekit-keepfocus
     data-sveltekit-noscroll={noscroll}
     data-sveltekit-replacestate={replacestate}
@@ -58,6 +61,7 @@
   </a>
 {:else}
   <button
+    use:appendClassList={classList}
     class="trakt-action-button trakt-button-link"
     aria-label={label}
     data-color={color}

--- a/projects/client/src/lib/components/buttons/TraktActionButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/TraktActionButtonProps.ts
@@ -6,4 +6,5 @@ export type TraktActionButtonProps = ButtonProps & {
   size?: 'normal' | 'small';
   style?: 'flat' | 'ghost';
   navigationType?: DpadNavigationType;
+  classList?: string;
 };

--- a/projects/client/src/lib/components/lists/ListProps.ts
+++ b/projects/client/src/lib/components/lists/ListProps.ts
@@ -8,4 +8,5 @@ export type ListProps<T> = {
   ctaItem?: Snippet;
   actions?: Snippet;
   drilldownLink?: string;
+  noscroll?: boolean;
 };

--- a/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
@@ -13,6 +13,7 @@
     actions,
     navigationType,
     href,
+    noscroll,
     listActions,
     ...props
   }: {
@@ -24,6 +25,7 @@
     listActions?: Snippet;
     navigationType?: DpadNavigationType;
     href?: string;
+    noscroll?: boolean;
   } & HTMLElementProps = $props();
 </script>
 
@@ -42,9 +44,9 @@
         {@render titleAction({ device: ["desktop", "tablet-lg"] })}
 
         {#if subtitle == null}
-          <ListTitle {title} {href} {metaInfo} style="primary" />
+          <ListTitle {title} {href} {noscroll} {metaInfo} style="primary" />
         {:else}
-          <ListTitle {title} {href} {metaInfo} style="secondary" />
+          <ListTitle {title} {href} {noscroll} {metaInfo} style="secondary" />
           <ListTitle title={`/ ${subtitle}`} style="primary" />
         {/if}
 

--- a/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
@@ -7,10 +7,12 @@
     metaInfo,
     style,
     href,
+    noscroll,
   }: {
     title: string;
     metaInfo?: Snippet;
     href?: string;
+    noscroll?: boolean;
     style: "primary" | "secondary";
   } = $props();
 </script>
@@ -23,7 +25,7 @@
 
 <div class="trakt-list-title">
   {#if href}
-    <Link {href}>{@render content()}</Link>
+    <Link {href} {noscroll}>{@render content()}</Link>
   {:else}
     {@render content()}
   {/if}

--- a/projects/client/src/lib/components/lists/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/SectionList.svelte
@@ -38,6 +38,7 @@
     metaInfo,
     actions,
     drilldownLink,
+    noscroll,
     headerNavigationType,
     subtitle,
     variant = "default",
@@ -90,6 +91,7 @@
   class:section-list-container-mounted={$isMounted}
   class:section-list-container-no-header={!isHeaderVisible}
   class:section-list-has-drilldown={Boolean(drilldownLink)}
+  class:section-list-has-multiple-items={items.length > 1}
   data-dynamic-selector={`[data-dpad-navigation="${DpadNavigationType.Item}"], .${emptyStateClass}:not(:empty)`}
   data-variant={variant}
 >
@@ -100,6 +102,7 @@
         {subtitle}
         {titleAction}
         {metaInfo}
+        {noscroll}
         actions={isCollapsed ? undefined : actions}
         navigationType={headerNavigationType}
         href={drilldownLink}
@@ -253,7 +256,8 @@
     }
   }
 
-  .section-list-container.section-list-has-drilldown {
+  .section-list-has-multiple-items.section-list-has-drilldown,
+  .section-list-has-multiple-items:has(:global(.trakt-view-all-button)) {
     .section-list-horizontal-scroll {
       overflow-x: hidden;
       mask-image: linear-gradient(

--- a/projects/client/src/lib/requests/queries/movies/movieListsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieListsQuery.spec.ts
@@ -1,7 +1,8 @@
 import { OfficialListsMappedMock } from '$mocks/data/lists/mapped/OfficialListsMappedMock.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
-import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { createTestBedInfiniteQuery } from '$test/beds/query/createTestBedInfiniteQuery.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
+import { mapToEntries } from '$test/utils/mapToEntries.ts';
 import { describe, expect, it } from 'vitest';
 import { HereticListsMappedMock } from '../../../../mocks/data/summary/movies/heretic/mapped/HereticListsMappedMock.ts';
 import { movieListsQuery } from './movieListsQuery.ts';
@@ -10,10 +11,10 @@ describe('movieListsQuery', () => {
   it('should query for lists that contain Heretic (2024)', async () => {
     const result = await runQuery({
       factory: () =>
-        createTestBedQuery(
+        createTestBedInfiniteQuery(
           movieListsQuery({ slug: MovieHereticMappedMock.slug, limit: 10 }),
         ),
-      mapper: (response) => response?.data,
+      mapper: mapToEntries,
     });
 
     expect(result).to.deep.equal(HereticListsMappedMock);
@@ -22,14 +23,14 @@ describe('movieListsQuery', () => {
   it('should query for official lists that contain Heretic (2024)', async () => {
     const result = await runQuery({
       factory: () =>
-        createTestBedQuery(
+        createTestBedInfiniteQuery(
           movieListsQuery({
             slug: MovieHereticMappedMock.slug,
             limit: 10,
             type: 'official',
           }),
         ),
-      mapper: (response) => response?.data,
+      mapper: mapToEntries,
     });
 
     expect(result).to.deep.equal(OfficialListsMappedMock);

--- a/projects/client/src/lib/requests/queries/movies/movieListsQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieListsQuery.ts
@@ -1,18 +1,20 @@
-import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { defineInfiniteQuery } from '$lib/features/query/defineQuery.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { mapToMediaListSummary } from '../../_internal/mapToMediaListSummary.ts';
 import { InvalidateAction } from '../../models/InvalidateAction.ts';
 import { MediaListSummarySchema } from '../../models/MediaListSummary.ts';
 
-type MovieListsParams = {
-  slug: string;
-  limit: number;
-  type?: 'official' | 'personal';
-} & ApiParams;
+type MovieListsParams =
+  & { slug: string; type?: 'official' | 'personal' }
+  & PaginationParams
+  & ApiParams;
 
 const movieListsRequest = (
-  { fetch, slug, limit, type }: MovieListsParams,
+  { fetch, slug, limit, page, type }: MovieListsParams,
 ) =>
   api({ fetch })
     .movies
@@ -25,15 +27,21 @@ const movieListsRequest = (
       query: {
         extended: 'images',
         limit,
+        page,
       },
     });
 
-export const movieListsQuery = defineQuery({
+export const movieListsQuery = defineInfiniteQuery({
   key: 'movieLists',
   invalidations: [InvalidateAction.List.Like],
-  dependencies: (params) => [params.slug, params.limit, params.type],
+  dependencies: (
+    params,
+  ) => [params.slug, params.limit, params.page, params.type],
   request: movieListsRequest,
-  mapper: (response) => response.body.map(mapToMediaListSummary),
-  schema: MediaListSummarySchema.array(),
+  mapper: (response) => ({
+    entries: response.body.map(mapToMediaListSummary),
+    page: extractPageMeta(response.headers),
+  }),
+  schema: PaginatableSchemaFactory(MediaListSummarySchema),
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/requests/queries/shows/showListsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/shows/showListsQuery.spec.ts
@@ -1,7 +1,8 @@
 import { OfficialListsMappedMock } from '$mocks/data/lists/mapped/OfficialListsMappedMock.ts';
 import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
-import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { createTestBedInfiniteQuery } from '$test/beds/query/createTestBedInfiniteQuery.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
+import { mapToEntries } from '$test/utils/mapToEntries.ts';
 import { describe, expect, it } from 'vitest';
 import { SiloListsMappedMock } from '../../../../mocks/data/summary/shows/silo/mapped/SiloListsMappedMock.ts';
 import { showListsQuery } from './showListsQuery.ts';
@@ -10,10 +11,10 @@ describe('showListsQuery', () => {
   it('should query for lists that contain Silo (2023)', async () => {
     const result = await runQuery({
       factory: () =>
-        createTestBedQuery(
+        createTestBedInfiniteQuery(
           showListsQuery({ slug: ShowSiloMappedMock.slug, limit: 10 }),
         ),
-      mapper: (response) => response?.data,
+      mapper: mapToEntries,
     });
 
     expect(result).to.deep.equal(SiloListsMappedMock);
@@ -22,14 +23,14 @@ describe('showListsQuery', () => {
   it('should query for official lists that contain Silo (2023)', async () => {
     const result = await runQuery({
       factory: () =>
-        createTestBedQuery(
+        createTestBedInfiniteQuery(
           showListsQuery({
             slug: ShowSiloMappedMock.slug,
             limit: 10,
             type: 'official',
           }),
         ),
-      mapper: (response) => response?.data,
+      mapper: mapToEntries,
     });
 
     expect(result).to.deep.equal(OfficialListsMappedMock);

--- a/projects/client/src/lib/requests/queries/shows/showListsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showListsQuery.ts
@@ -1,18 +1,20 @@
-import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { defineInfiniteQuery } from '$lib/features/query/defineQuery.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
+import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { mapToMediaListSummary } from '../../_internal/mapToMediaListSummary.ts';
 import { InvalidateAction } from '../../models/InvalidateAction.ts';
 import { MediaListSummarySchema } from '../../models/MediaListSummary.ts';
 
-type ShowListsParams = {
-  slug: string;
-  limit: number;
-  type?: 'official' | 'personal';
-} & ApiParams;
+type ShowListsParams =
+  & { slug: string; type?: 'official' | 'personal' }
+  & PaginationParams
+  & ApiParams;
 
 const showListsRequest = (
-  { fetch, slug, limit, type }: ShowListsParams,
+  { fetch, slug, limit, page, type }: ShowListsParams,
 ) =>
   api({ fetch })
     .shows
@@ -25,15 +27,21 @@ const showListsRequest = (
       query: {
         extended: 'images',
         limit,
+        page,
       },
     });
 
-export const showListsQuery = defineQuery({
+export const showListsQuery = defineInfiniteQuery({
   key: 'showLists',
   invalidations: [InvalidateAction.List.Like],
-  dependencies: (params) => [params.slug, params.limit, params.type],
+  dependencies: (
+    params,
+  ) => [params.slug, params.limit, params.page, params.type],
   request: showListsRequest,
-  mapper: (response) => response.body.map(mapToMediaListSummary),
-  schema: MediaListSummarySchema.array(),
+  mapper: (response) => ({
+    entries: response.body.map(mapToMediaListSummary),
+    page: extractPageMeta(response.headers),
+  }),
+  schema: PaginatableSchemaFactory(MediaListSummarySchema),
   ttl: time.minutes(30),
 });

--- a/projects/client/src/lib/sections/lists/CastList.svelte
+++ b/projects/client/src/lib/sections/lists/CastList.svelte
@@ -1,26 +1,46 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
   import type { CastMember } from "$lib/requests/models/MediaCrew";
   import type { MediaType } from "$lib/requests/models/MediaType";
+  import {
+    Drawers,
+    summaryDrawerNavigation,
+  } from "../summary/_internal/summaryDrawerNavigation";
   import CastMemberItem from "./components/CastMemberItem.svelte";
+  import ViewAllButton from "./components/ViewAllButton.svelte";
 
   type CastListProps = {
     title: string;
     cast: CastMember[];
     slug: string;
     type: MediaType;
+    drilldownLink?: string;
   };
 
-  const { title, cast, slug, type }: CastListProps = $props();
+  const { title, cast, slug, type, drilldownLink }: CastListProps = $props();
+  const { buildDrawerLink } = summaryDrawerNavigation();
 </script>
 
 <SectionList
   id={`cast-list-${slug}`}
   items={cast}
   {title}
+  {drilldownLink}
+  noscroll={drilldownLink != null}
   --height-list="var(--height-person-list)"
 >
   {#snippet item(castMember)}
     <CastMemberItem {castMember} {type} />
+  {/snippet}
+
+  {#snippet actions()}
+    <ViewAllButton
+      href={buildDrawerLink(Drawers.Cast)}
+      label={m.button_text_view_all()}
+      noscroll
+      disabled={cast.length === 0}
+      source={{ id: "social" }}
+    />
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/lists/ListsPaginated.svelte
+++ b/projects/client/src/lib/sections/lists/ListsPaginated.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import PaginatedList from "$lib/components/lists/PaginatedList.svelte";
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import { useListSummary } from "$lib/sections/summary/components/lists/useListSummary.ts";
+  import { DEFAULT_LISTS_DRILL_SIZE } from "$lib/utils/constants";
+  import UserList from "./user/UserList.svelte";
+
+  const { slug, type }: { slug: string; type: MediaType } = $props();
+</script>
+
+<div class="trakt-paginated-lists">
+  <PaginatedList
+    {type}
+    useList={(params) =>
+      useListSummary({
+        slug,
+        type: params.type,
+        limit: DEFAULT_LISTS_DRILL_SIZE,
+      })}
+  >
+    {#snippet items(items)}
+      {#each items as list (list.id)}
+        <UserList {list} {type} />
+      {/each}
+    {/snippet}
+  </PaginatedList>
+</div>
+
+<style>
+  .trakt-paginated-lists {
+    display: contents;
+
+    :global(.trakt-paginated-list) {
+      display: flex;
+      flex-direction: column;
+      gap: var(--content-gap);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/RelatedList.svelte
+++ b/projects/client/src/lib/sections/lists/RelatedList.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
-  import MediaList from "$lib/sections/lists/drilldown/MediaList.svelte";
-
+  import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaType } from "$lib/requests/models/MediaType";
+  import MediaList from "$lib/sections/lists/drilldown/MediaList.svelte";
   import DefaultMediaItem from "./components/DefaultMediaItem.svelte";
+  import ViewAllButton from "./components/ViewAllButton.svelte";
   import { useRelatedList } from "./stores/useRelatedList";
 
   type RelatedListProps = {
     title: string;
     type: MediaType;
     slug: string;
+    drilldownLink?: string;
   };
 
-  const { title, type, slug }: RelatedListProps = $props();
+  const { title, type, slug, drilldownLink }: RelatedListProps = $props();
 </script>
 
 <MediaList
@@ -19,10 +21,22 @@
   useList={(params) => useRelatedList({ ...params, slug })}
   {type}
   {title}
+  {drilldownLink}
   --height-override-card="var(--height-portrait-card-sm)"
   --height-override-list="var(--height-poster-list-sm)"
 >
   {#snippet item(media)}
     <DefaultMediaItem {type} {media} source="related" canDeemphasize />
+  {/snippet}
+
+  {#snippet actions(items)}
+    {#if drilldownLink}
+      <ViewAllButton
+        href={drilldownLink}
+        label={m.button_text_view_all()}
+        disabled={items.length === 0}
+        source={{ id: "related" }}
+      />
+    {/if}
   {/snippet}
 </MediaList>

--- a/projects/client/src/lib/sections/lists/RelatedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/RelatedPaginatedList.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import DefaultMediaItem from "./components/DefaultMediaItem.svelte";
+  import DrilledMediaList from "./drilldown/DrilledMediaList.svelte";
+  import { useRelatedList } from "./stores/useRelatedList";
+
+  type RelatedPaginatedListProps = {
+    title: string;
+    type: MediaType;
+    slug: string;
+  };
+
+  const { title, type, slug }: RelatedPaginatedListProps = $props();
+</script>
+
+<DrilledMediaList
+  id={`related-list-${type}-${slug}`}
+  {title}
+  {type}
+  useList={(params) => useRelatedList({ ...params, slug })}
+>
+  {#snippet item(media)}
+    <DefaultMediaItem
+      {type}
+      {media}
+      source="related"
+      canDeemphasize
+      style="summary"
+    />
+  {/snippet}
+</DrilledMediaList>

--- a/projects/client/src/lib/sections/lists/VideoList.svelte
+++ b/projects/client/src/lib/sections/lists/VideoList.svelte
@@ -1,44 +1,23 @@
 <script lang="ts">
-  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
-  import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
-  import * as m from "$lib/features/i18n/messages";
+  import * as m from "$lib/features/i18n/messages.ts";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import type { MediaVideo } from "$lib/requests/models/MediaVideo";
-  import { assertDefined } from "$lib/utils/assert/assertDefined";
-  import { toTranslatedVideoType } from "$lib/utils/formatting/string/toTranslatedVideoType";
-  import { writable } from "$lib/utils/store/WritableSubject.ts";
   import VideoItem from "./components/VideoItem.svelte";
+  import VideoTypeDropdown from "./components/VideoTypeDropdown.svelte";
+  import ViewAllButton from "./components/ViewAllButton.svelte";
   import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
+  import { useVideoTypes } from "./utils/useVideoTypes";
 
   type VideoListProps = {
     slug: string;
     videos: MediaVideo[];
+    drilldownLink?: string;
   };
 
-  const { slug, videos }: VideoListProps = $props();
+  const { slug, videos, drilldownLink }: VideoListProps = $props();
 
-  const { record, types } = $derived.by(() => {
-    if (!videos.length) return { record: {}, types: [] };
-
-    const record = videos.reduce(
-      (acc, video) => {
-        acc[video.type] = acc[video.type] || [];
-        acc[video.type].push(video);
-        return acc;
-      },
-      {} as Record<string, MediaVideo[]>,
-    );
-
-    const types = Object.keys(record) as Array<MediaVideo["type"]>;
-
-    return { record, types };
-  });
-
-  const firstType = $derived(
-    assertDefined(types.at(0), "VideoList: No video types found"),
-  );
-  const active = $derived(writable(firstType));
+  const { record, types, active } = $derived(useVideoTypes(videos));
   const items = $derived(record[$active] ?? []);
 </script>
 
@@ -47,6 +26,8 @@
     id={`video-list-${slug}`}
     {items}
     title={m.list_title_extras()}
+    {drilldownLink}
+    noscroll={drilldownLink != null}
     --height-list={mediaListHeightResolver("landscape")}
     headerNavigationType={DpadNavigationType.List}
   >
@@ -55,25 +36,20 @@
     {/snippet}
 
     {#snippet actions()}
-      {#if types.length > 1}
-        <DropdownList
-          preferNative
-          label={m.dropdown_label_extras()}
-          style="flat"
-          variant="primary"
-          color="blue"
-          size="small"
-          navigationType={DpadNavigationType.Item}
-        >
-          {toTranslatedVideoType($active)}
-          {#snippet items()}
-            {#each types as type}
-              <DropdownItem color="blue" onclick={() => active.set(type)}>
-                {toTranslatedVideoType(type)}
-              </DropdownItem>
-            {/each}
-          {/snippet}
-        </DropdownList>
+      <VideoTypeDropdown
+        {types}
+        active={$active}
+        onchange={(type) => active.set(type)}
+      />
+
+      {#if drilldownLink}
+        <ViewAllButton
+          href={drilldownLink}
+          label={m.button_text_view_all()}
+          noscroll
+          source={{ id: "videos" }}
+          disabled={videos.length === 0}
+        />
       {/if}
     {/snippet}
   </SectionList>

--- a/projects/client/src/lib/sections/lists/components/VideoTypeDropdown.svelte
+++ b/projects/client/src/lib/sections/lists/components/VideoTypeDropdown.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
+  import type { MediaVideo } from "$lib/requests/models/MediaVideo";
+  import { toTranslatedVideoType } from "$lib/utils/formatting/string/toTranslatedVideoType";
+
+  type VideoTypeDropdownProps = {
+    types: Array<MediaVideo["type"]>;
+    active: MediaVideo["type"];
+    onchange: (type: MediaVideo["type"]) => void;
+  };
+
+  const { types, active, onchange }: VideoTypeDropdownProps = $props();
+</script>
+
+{#if types.length > 1}
+  <DropdownList
+    preferNative
+    label={m.dropdown_label_extras()}
+    style="flat"
+    variant="primary"
+    color="blue"
+    size="small"
+    navigationType={DpadNavigationType.Item}
+  >
+    {toTranslatedVideoType(active)}
+    {#snippet items()}
+      {#each types as type}
+        <DropdownItem color="blue" onclick={() => onchange(type)}>
+          {toTranslatedVideoType(type)}
+        </DropdownItem>
+      {/each}
+    {/snippet}
+  </DropdownList>
+{/if}

--- a/projects/client/src/lib/sections/lists/components/ViewAllButton.svelte
+++ b/projects/client/src/lib/sections/lists/components/ViewAllButton.svelte
@@ -30,6 +30,7 @@
   {label}
   {size}
   {...rest}
+  classList="trakt-view-all-button"
   style="ghost"
   onclick={(e) => {
     track({ source: source.id, type: source.type });

--- a/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
@@ -21,6 +21,7 @@
     filterOverride,
     metaInfo,
     drilldownLink,
+    noscroll,
     variant: externalVariant,
     titleAction,
   }: MediaListProps<T, M> = $props();
@@ -54,6 +55,7 @@
   {title}
   {metaInfo}
   {drilldownLink}
+  {noscroll}
   {titleAction}
   actions={externalActions ? actions : undefined}
   --height-list={height}

--- a/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaListProps.ts
@@ -14,6 +14,7 @@ export type MediaListProps<T, M> = {
   empty?: Snippet;
   metaInfo?: Snippet;
   drilldownLink?: string;
+  noscroll?: boolean;
   variant?: 'portrait' | 'landscape';
   titleAction?: Snippet;
 } & FilterParams;

--- a/projects/client/src/lib/sections/lists/utils/useVideoTypes.ts
+++ b/projects/client/src/lib/sections/lists/utils/useVideoTypes.ts
@@ -1,0 +1,23 @@
+import type { MediaVideo } from '$lib/requests/models/MediaVideo';
+import { assertDefined } from '$lib/utils/assert/assertDefined';
+import { writable } from '$lib/utils/store/WritableSubject.ts';
+
+export function useVideoTypes(videos: MediaVideo[]) {
+  const record = videos.reduce(
+    (acc, video) => {
+      acc[video.type] = acc[video.type] || [];
+      acc[video.type].push(video);
+      return acc;
+    },
+    {} as Record<string, MediaVideo[]>,
+  );
+
+  const types = Object.keys(record) as Array<MediaVideo['type']>;
+  const firstType = assertDefined(
+    types.at(0),
+    'useVideoTypes: No video types found',
+  );
+  const active = writable(firstType);
+
+  return { record, types, active };
+}

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -4,9 +4,14 @@
   import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import SeasonList from "$lib/sections/lists/season/SeasonList.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CastList from "../lists/CastList.svelte";
   import RelatedList from "../lists/RelatedList.svelte";
   import WhereToWatchList from "../lists/where-to-watch/WhereToWatchList.svelte";
+  import {
+    Drawers,
+    summaryDrawerNavigation,
+  } from "./_internal/summaryDrawerNavigation";
   import SummaryCover from "./components/_internal/SummaryCover.svelte";
   import Comments from "./components/comments/Comments.svelte";
   import EpisodeSummary from "./components/episode/EpisodeSummary.svelte";
@@ -24,16 +29,25 @@
     crew,
   }: EpisodeSummaryProps = $props();
 
+  const { buildDrawerLink } = summaryDrawerNavigation();
+  const castDrawerLink = $derived(buildDrawerLink(Drawers.Cast));
+  const relatedLink = $derived(
+    UrlBuilder.related.episode(show.slug, episode.season, episode.number),
+  );
+
   const posterSrc = $derived(
     useEpisodeSpoilerImage({ episode, show, variant: "default" }),
   );
 
-  const networks = $derived((() => {
-    const seasonNetwork = seasons
-      .find((s) => s.number === episode.season)?.network;
-    const name = seasonNetwork ?? show.network;
-    return name ? [{ name }] : [];
-  })());
+  const networks = $derived(
+    (() => {
+      const seasonNetwork = seasons.find(
+        (s) => s.number === episode.season,
+      )?.network;
+      const name = seasonNetwork ?? show.network;
+      return name ? [{ name }] : [];
+    })(),
+  );
 </script>
 
 <!-- 
@@ -87,6 +101,7 @@
   cast={crew.cast}
   slug={show.slug}
   type="show"
+  drilldownLink={castDrawerLink}
 />
 
 <Comments
@@ -103,6 +118,7 @@
   title={m.list_title_related_shows()}
   slug={show.slug}
   type="show"
+  drilldownLink={relatedLink}
 />
 
 <SummaryDrawer {crew} {episode} {show} {networks} type="episode" />

--- a/projects/client/src/lib/sections/summary/MovieSummary.svelte
+++ b/projects/client/src/lib/sections/summary/MovieSummary.svelte
@@ -6,10 +6,15 @@
   import type { MediaVideo } from "$lib/requests/models/MediaVideo";
   import type { MovieEntry } from "$lib/requests/models/MovieEntry";
   import type { SentimentAnalysis } from "$lib/requests/models/SentimentAnalysis.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CastList from "../lists/CastList.svelte";
   import RelatedList from "../lists/RelatedList.svelte";
   import VideoList from "../lists/VideoList.svelte";
   import WhereToWatchList from "../lists/where-to-watch/WhereToWatchList.svelte";
+  import {
+    Drawers,
+    summaryDrawerNavigation,
+  } from "./_internal/summaryDrawerNavigation";
   import Comments from "./components/comments/Comments.svelte";
   import Lists from "./components/lists/Lists.svelte";
   import MediaSummary from "./components/media/MediaSummary.svelte";
@@ -18,6 +23,10 @@
   import TriviaList from "./components/trivia/TriviaList.svelte";
   import type { CommonMediaSummaryProps } from "./models/CommonMediaSummaryProps";
   import SummaryDrawer from "./SummaryDrawer.svelte";
+
+  const { buildDrawerLink } = summaryDrawerNavigation();
+  const castDrawerLink = $derived(buildDrawerLink(Drawers.Cast));
+  const videosDrawerLink = $derived(buildDrawerLink(Drawers.Videos));
 
   const {
     media,
@@ -33,9 +42,12 @@
     videos: MediaVideo[];
     sentiment: SentimentAnalysis | Nil;
   } & CommonMediaSummaryProps = $props();
+
+  const relatedLink = $derived(UrlBuilder.related.movie(media.slug));
+  const listsLink = $derived(UrlBuilder.popularLists.movie(media.slug));
 </script>
 
-<SummaryDrawer {sentiment} {studios} {crew} {media} type="movie" />
+<SummaryDrawer {sentiment} {studios} {crew} {media} {videos} type="movie" />
 
 <RenderFor audience="all" device={["mobile", "tablet-sm"]}>
   <MediaSummaryV2 {media} {studios} {crew} {intl} type="movie" />
@@ -62,19 +74,26 @@
   cast={crew.cast}
   slug={media.slug}
   type={media.type}
+  drilldownLink={castDrawerLink}
 />
 
 <Comments {media} type="movie" />
 
-<VideoList slug={media.slug} {videos} />
+<VideoList slug={media.slug} {videos} drilldownLink={videosDrawerLink} />
 
 <RelatedList
   title={m.list_title_related_movies()}
   slug={media.slug}
   type="movie"
+  drilldownLink={relatedLink}
 />
 
 <!-- TODO: move back to designed position when we have faster queries -->
-<Lists slug={media.slug} title={media.title} type="movie" />
+<Lists
+  slug={media.slug}
+  title={media.title}
+  type="movie"
+  drilldownLink={listsLink}
+/>
 
 <TriviaList {media} />

--- a/projects/client/src/lib/sections/summary/ShowSummary.svelte
+++ b/projects/client/src/lib/sections/summary/ShowSummary.svelte
@@ -7,11 +7,16 @@
   import type { Season } from "$lib/requests/models/Season";
   import type { SentimentAnalysis } from "$lib/requests/models/SentimentAnalysis.ts";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CastList from "../lists/CastList.svelte";
   import RelatedList from "../lists/RelatedList.svelte";
   import SeasonList from "../lists/season/SeasonList.svelte";
   import VideoList from "../lists/VideoList.svelte";
   import WhereToWatchList from "../lists/where-to-watch/WhereToWatchList.svelte";
+  import {
+    Drawers,
+    summaryDrawerNavigation,
+  } from "./_internal/summaryDrawerNavigation";
   import Comments from "./components/comments/Comments.svelte";
   import Lists from "./components/lists/Lists.svelte";
   import MediaSummary from "./components/media/MediaSummary.svelte";
@@ -42,15 +47,32 @@
     sentiment,
   }: ShowSummaryProps = $props();
 
+  const { buildDrawerLink } = summaryDrawerNavigation();
+  const castDrawerLink = $derived(buildDrawerLink(Drawers.Cast));
+  const videosDrawerLink = $derived(buildDrawerLink(Drawers.Videos));
+  const relatedLink = $derived(UrlBuilder.related.show(media.slug));
+  const listsLink = $derived(UrlBuilder.popularLists.show(media.slug));
+
   const networks = $derived(
-    [...new Set(
-      [media.network, ...seasons.map((s) => s.network)]
-        .filter((n): n is string => n != null),
-    )].map((name) => ({ name })),
+    [
+      ...new Set(
+        [media.network, ...seasons.map((s) => s.network)].filter(
+          (n): n is string => n != null,
+        ),
+      ),
+    ].map((name) => ({ name })),
   );
 </script>
 
-<SummaryDrawer {sentiment} {studios} {crew} {media} {networks} type="show" />
+<SummaryDrawer
+  {sentiment}
+  {studios}
+  {crew}
+  {media}
+  {networks}
+  {videos}
+  type="show"
+/>
 
 <RenderFor audience="all" device={["mobile", "tablet-sm"]}>
   <MediaSummaryV2 {media} {studios} {intl} {crew} type="show" />
@@ -77,11 +99,12 @@
   cast={crew.cast}
   slug={media.slug}
   type={media.type}
+  drilldownLink={castDrawerLink}
 />
 
 <Comments {media} type="show" />
 
-<VideoList slug={media.slug} {videos} />
+<VideoList slug={media.slug} {videos} drilldownLink={videosDrawerLink} />
 
 <SeasonList show={media} {seasons} {currentSeason} />
 
@@ -89,9 +112,15 @@
   title={m.list_title_related_shows()}
   slug={media.slug}
   type="show"
+  drilldownLink={relatedLink}
 />
 
 <!-- TODO: move back to designed position when we have faster queries -->
-<Lists slug={media.slug} title={media.title} type="show" />
+<Lists
+  slug={media.slug}
+  title={media.title}
+  type="show"
+  drilldownLink={listsLink}
+/>
 
 <TriviaList {media} />

--- a/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
@@ -1,21 +1,36 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import type { MediaVideo } from "$lib/requests/models/MediaVideo";
   import type { SentimentAnalysis } from "$lib/requests/models/SentimentAnalysis";
   import {
     Drawers,
     summaryDrawerNavigation,
   } from "./_internal/summaryDrawerNavigation";
+  import CastDrawer from "./components/cast/CastDrawer.svelte";
   import DetailsDrawer from "./components/details/DetailsDrawer.svelte";
   import type { MediaDetailsProps } from "./components/details/MediaDetailsProps";
   import SentimentDrawer from "./components/sentiment/SentimentDrawer.svelte";
+  import VideoDrawer from "./components/videos/VideoDrawer.svelte";
 
   const {
     sentiment,
+    videos,
     ...details
-  }: { sentiment?: SentimentAnalysis | Nil } & MediaDetailsProps = $props();
+  }: {
+    sentiment?: SentimentAnalysis | Nil;
+    videos?: MediaVideo[];
+  } & MediaDetailsProps = $props();
 
   const { drawer, close } = $derived(
     summaryDrawerNavigation(page.url.searchParams),
+  );
+
+  const mediaSlug = $derived(
+    details.type === "episode" ? details.show.slug : details.media.slug,
+  );
+
+  const relatedType = $derived(
+    details.type === "episode" ? "show" : details.type,
   );
 </script>
 
@@ -25,4 +40,16 @@
 
 {#if drawer === Drawers.Details}
   <DetailsDrawer {...details} onClose={close} />
+{/if}
+
+{#if drawer === Drawers.Cast}
+  <CastDrawer
+    cast={details.crew.cast}
+    type={details.type === "episode" ? "show" : details.type}
+    onClose={close}
+  />
+{/if}
+
+{#if drawer === Drawers.Videos && videos}
+  <VideoDrawer {videos} slug={mediaSlug} onClose={close} />
 {/if}

--- a/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
+++ b/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
@@ -6,6 +6,8 @@ const VIEW_PARAM = 'view';
 export enum Drawers {
   Sentiment = 'sentiment',
   Details = 'details',
+  Cast = 'cast',
+  Videos = 'videos',
 }
 
 function mapToDrawer(value: string | Nil) {
@@ -14,6 +16,10 @@ function mapToDrawer(value: string | Nil) {
       return Drawers.Sentiment;
     case Drawers.Details:
       return Drawers.Details;
+    case Drawers.Cast:
+      return Drawers.Cast;
+    case Drawers.Videos:
+      return Drawers.Videos;
     default:
       return null;
   }

--- a/projects/client/src/lib/sections/summary/components/cast/CastDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/cast/CastDrawer.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import GridList from "$lib/components/lists/grid-list/GridList.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { CastMember } from "$lib/requests/models/MediaCrew";
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import { fade } from "svelte/transition";
+  import CastMemberItem from "../../../lists/components/CastMemberItem.svelte";
+
+  const {
+    onClose,
+    cast,
+    type,
+  }: {
+    cast: CastMember[];
+    type: MediaType;
+    onClose: () => void;
+  } = $props();
+
+  let isOpen = $state(false);
+</script>
+
+<Drawer
+  {onClose}
+  onOpened={() => (isOpen = true)}
+  title={m.list_title_actors()}
+  size="large"
+>
+  {#if isOpen}
+    <div class="cast-drawer-content" transition:fade={{ duration: 150 }}>
+      <GridList
+        id={`cast-list-${type}`}
+        items={cast}
+        --width-item="var(--width-person-card)"
+      >
+        {#snippet item(item)}
+          <CastMemberItem castMember={item} {type} />
+        {/snippet}
+      </GridList>
+    </div>
+  {/if}
+</Drawer>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .cast-drawer-content {
+    display: contents;
+
+    --container-width: calc(var(--drawer-size) - 2 * var(--drawer-padding));
+    --width-override-card: calc(
+      (var(--container-width) - 3 * var(--list-gap)) / 3
+    );
+    --card-aspect-ratio: calc(
+      var(--height-person-card-cover) / var(--min-person-card-width)
+    );
+    --height-override-card-cover: calc(
+      var(--width-override-card) * var(--card-aspect-ratio)
+    );
+    --height-override-card: calc(
+      var(--height-override-card-cover) + var(--height-card-footer)
+    );
+
+    @include for-mobile {
+      --container-width: calc(100dvw - 2 * var(--drawer-padding));
+    }
+
+    :global(.trakt-list-item-container) {
+      padding: 0;
+    }
+
+    :global(.trakt-list-items) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
+++ b/projects/client/src/lib/sections/summary/components/lists/Lists.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import Preview from "$lib/components/badge/Preview.svelte";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import ListSummaryItem from "$lib/sections/lists/components/list-summary/ListSummaryItem.svelte";
+  import ViewAllButton from "$lib/sections/lists/components/ViewAllButton.svelte";
   import UserList from "$lib/sections/lists/user/UserList.svelte";
   import { MAX_LISTS } from "./_internal/constants.ts";
   import { useListSummary } from "./useListSummary.ts";
@@ -13,19 +13,14 @@
     slug,
     type,
     title,
-  }: { slug: string; type: MediaType; title: string } = $props();
+    drilldownLink,
+  }: { slug: string; type: MediaType; title: string; drilldownLink?: string } =
+    $props();
 
   // Due to slow performance, we fetch the lists here instead of useMovie/useShow
-  const { isLoading, personalLists, officialLists } = $derived(
-    useListSummary({
-      slug,
-      type,
-    }),
-  );
+  const { isLoading, list } = $derived(useListSummary({ slug, type }));
 
-  const lists = $derived(
-    [...$officialLists, ...$personalLists].slice(0, MAX_LISTS),
-  );
+  const lists = $derived($list.slice(0, MAX_LISTS));
   const topList = $derived(lists.at(0));
 </script>
 
@@ -40,6 +35,7 @@
     id={`popular-lists-list-${slug}`}
     items={lists}
     title={m.list_title_popular_lists()}
+    {drilldownLink}
     --height-list="var(--height-lists-list)"
   >
     {#snippet item(list)}
@@ -53,7 +49,12 @@
     {/snippet}
 
     {#snippet actions()}
-      <Preview />
+      <ViewAllButton
+        href={drilldownLink}
+        label={m.button_text_view_all()}
+        source={{ id: "popular-lists" }}
+        disabled={lists.length === 0}
+      />
     {/snippet}
   </SectionList>
 </RenderFor>

--- a/projects/client/src/lib/sections/summary/components/lists/useListSummary.ts
+++ b/projects/client/src/lib/sections/summary/components/lists/useListSummary.ts
@@ -1,7 +1,6 @@
-import { useQuery } from '$lib/features/query/useQuery.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { movieListsQuery } from '$lib/requests/queries/movies/movieListsQuery.ts';
-import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
 import { combineLatest, map } from 'rxjs';
 import { showListsQuery } from '../../../../requests/queries/shows/showListsQuery.ts';
 import { MAX_LISTS } from './_internal/constants.ts';
@@ -9,13 +8,15 @@ import { MAX_LISTS } from './_internal/constants.ts';
 type ListSummaryProps = {
   slug: string;
   type: MediaType;
+  limit?: number;
 };
 
 function typeToQuery(
   { slug, type }: ListSummaryProps,
   listType: 'official' | 'personal' = 'personal',
+  limit: number = MAX_LISTS,
 ) {
-  const params = { slug, type: listType, limit: MAX_LISTS };
+  const params = { slug, type: listType, limit };
 
   switch (type) {
     case 'movie':
@@ -25,22 +26,40 @@ function typeToQuery(
   }
 }
 
-export function useListSummary({ slug, type }: ListSummaryProps) {
-  const personalLists = useQuery(typeToQuery({ slug, type }));
-  const officialLists = useQuery(typeToQuery({ slug, type }, 'official'));
-
-  const queries = [personalLists, officialLists];
-  const isLoading = combineLatest(queries).pipe(
-    map(($queries) => $queries.some(toLoadingState)),
+export function useListSummary(
+  { slug, type, limit = MAX_LISTS }: ListSummaryProps,
+) {
+  const personalLists = usePaginatedListQuery(
+    typeToQuery({ slug, type }, 'personal', limit),
+  );
+  const officialLists = usePaginatedListQuery(
+    typeToQuery({ slug, type }, 'official', limit),
   );
 
-  return {
-    isLoading,
-    personalLists: personalLists.pipe(
-      map(($personalLists) => $personalLists.data ?? []),
-    ),
-    officialLists: officialLists.pipe(
-      map(($officialLists) => $officialLists.data ?? []),
-    ),
+  const isLoading = combineLatest([
+    personalLists.isLoading,
+    officialLists.isLoading,
+  ]).pipe(
+    map(($states) => $states.some(Boolean)),
+  );
+
+  const list = combineLatest([personalLists.list, officialLists.list]).pipe(
+    map(([$personal, $official]) => [...$official, ...$personal]),
+  );
+
+  const hasNextPage = combineLatest([
+    personalLists.hasNextPage,
+    officialLists.hasNextPage,
+  ]).pipe(
+    map(($states) => $states.some(Boolean)),
+  );
+
+  const fetchNextPage = async () => {
+    await Promise.all([
+      personalLists.fetchNextPage(),
+      officialLists.fetchNextPage(),
+    ]);
   };
+
+  return { isLoading, list, hasNextPage, fetchNextPage };
 }

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/DetailsButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/DetailsButton.svelte
@@ -29,6 +29,7 @@
 
   const commonProps = $derived({
     href: buildDrawerLink(Drawers.Details),
+    noscroll: true,
     label: m.button_label_details({ title }),
     onclick,
   });

--- a/projects/client/src/lib/sections/summary/components/sentiment/Sentiment.svelte
+++ b/projects/client/src/lib/sections/summary/components/sentiment/Sentiment.svelte
@@ -52,6 +52,7 @@
       <ViewAllButton
         href={buildDrawerLink(Drawers.Sentiment)}
         label={m.button_label_view_sentiment_analysis()}
+        noscroll
         source={{ id: "sentiment" }}
       />
     {/snippet}

--- a/projects/client/src/lib/sections/summary/components/videos/VideoDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/videos/VideoDrawer.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import GridList from "$lib/components/lists/grid-list/GridList.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { MediaVideo } from "$lib/requests/models/MediaVideo";
+  import VideoItem from "$lib/sections/lists/components/VideoItem.svelte";
+  import VideoTypeDropdown from "$lib/sections/lists/components/VideoTypeDropdown.svelte";
+  import { useVideoTypes } from "$lib/sections/lists/utils/useVideoTypes";
+  import { fade } from "svelte/transition";
+
+  const {
+    onClose,
+    videos,
+    slug,
+  }: {
+    videos: MediaVideo[];
+    slug: string;
+    onClose: () => void;
+  } = $props();
+
+  let isOpen = $state(false);
+
+  const { record, types, active } = $derived(useVideoTypes(videos));
+  const items = $derived(record[$active] ?? []);
+</script>
+
+<Drawer
+  {onClose}
+  onOpened={() => (isOpen = true)}
+  title={m.list_title_extras()}
+  size="large"
+>
+  {#snippet badge()}
+    <VideoTypeDropdown
+      {types}
+      active={$active}
+      onchange={(type) => active.set(type)}
+    />
+  {/snippet}
+
+  {#if isOpen}
+    <div class="video-drawer-content" transition:fade={{ duration: 150 }}>
+      <GridList
+        id={`video-drawer-${slug}`}
+        {items}
+        --width-item="var(--width-landscape-card)"
+      >
+        {#snippet item(video)}
+          <VideoItem {video} {slug} />
+        {/snippet}
+      </GridList>
+    </div>
+  {/if}
+</Drawer>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .video-drawer-content {
+    display: contents;
+
+    --container-width: calc(var(--drawer-size) - 2 * var(--drawer-padding));
+    --width-override-card: calc(
+      (var(--container-width) - 2 * var(--list-gap)) / 2
+    );
+    --height-override-card-cover: calc(var(--width-override-card) / 1.786);
+    --height-override-card: calc(
+      var(--height-override-card-cover) + var(--height-card-footer)
+    );
+
+    @include for-mobile {
+      --container-width: calc(100dvw - 2 * var(--drawer-padding));
+    }
+
+    :global(.trakt-list-item-container) {
+      padding: 0;
+    }
+
+    :global(.trakt-list-items) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+</style>

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -176,6 +176,16 @@ export const UrlBuilder = {
     `/people/${id}${buildParamString(positions ?? {})}`,
   episode: (id: string, season: number, episode: number) =>
     `/shows/${id}/seasons/${season}/episodes/${episode}`,
+  related: {
+    movie: (slug: string) => `/movies/${slug}/related`,
+    show: (slug: string) => `/shows/${slug}/related`,
+    episode: (slug: string, season: number, episode: number) =>
+      `/shows/${slug}/seasons/${season}/episodes/${episode}/related`,
+  },
+  popularLists: {
+    movie: (slug: string) => `/movies/${slug}/lists`,
+    show: (slug: string) => `/shows/${slug}/lists`,
+  },
   profile: {
     user: (username: string) => `/profile/${username}`,
     me: () => UrlBuilder.profile.user('me'),

--- a/projects/client/src/routes/movies/[slug]/lists/+page.svelte
+++ b/projects/client/src/routes/movies/[slug]/lists/+page.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import ListsPaginated from "$lib/sections/lists/ListsPaginated.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
+  import type { PageProps } from "./$types";
+
+  const { params }: PageProps = $props();
+</script>
+
+<TraktPage
+  audience="all"
+  title={m.list_title_popular_lists()}
+  image={DEFAULT_SHARE_MOVIE_COVER}
+>
+  <NavbarStateSetter mode="minimal" />
+
+  <ListsPaginated type="movie" slug={params.slug} />
+</TraktPage>

--- a/projects/client/src/routes/movies/[slug]/related/+page.svelte
+++ b/projects/client/src/routes/movies/[slug]/related/+page.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import RelatedPaginatedList from "$lib/sections/lists/RelatedPaginatedList.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
+  import type { PageProps } from "./$types";
+
+  const { params }: PageProps = $props();
+</script>
+
+<TraktPage
+  audience="all"
+  title={m.list_title_related_movies()}
+  image={DEFAULT_SHARE_MOVIE_COVER}
+>
+  <NavbarStateSetter mode="minimal" />
+
+  <RelatedPaginatedList
+    title={m.list_title_related_movies()}
+    type="movie"
+    slug={params.slug}
+  />
+</TraktPage>

--- a/projects/client/src/routes/shows/[slug]/lists/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/lists/+page.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import ListsPaginated from "$lib/sections/lists/ListsPaginated.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
+  import type { PageProps } from "./$types";
+
+  const { params }: PageProps = $props();
+</script>
+
+<TraktPage
+  audience="all"
+  title={m.list_title_popular_lists()}
+  image={DEFAULT_SHARE_SHOW_COVER}
+>
+  <NavbarStateSetter mode="minimal" />
+
+  <ListsPaginated type="show" slug={params.slug} />
+</TraktPage>

--- a/projects/client/src/routes/shows/[slug]/related/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/related/+page.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import RelatedPaginatedList from "$lib/sections/lists/RelatedPaginatedList.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
+  import type { PageProps } from "./$types";
+
+  const { params }: PageProps = $props();
+</script>
+
+<TraktPage
+  audience="all"
+  title={m.list_title_related_shows()}
+  image={DEFAULT_SHARE_SHOW_COVER}
+>
+  <NavbarStateSetter mode="minimal" />
+
+  <RelatedPaginatedList
+    title={m.list_title_related_shows()}
+    type="show"
+    slug={params.slug}
+  />
+</TraktPage>

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/related/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/related/+page.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import RelatedPaginatedList from "$lib/sections/lists/RelatedPaginatedList.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
+  import type { PageProps } from "./$types";
+
+  const { params }: PageProps = $props();
+</script>
+
+<TraktPage
+  audience="all"
+  title={m.list_title_related_shows()}
+  image={DEFAULT_SHARE_SHOW_COVER}
+>
+  <NavbarStateSetter mode="minimal" />
+
+  <RelatedPaginatedList
+    title={m.list_title_related_shows()}
+    type="show"
+    slug={params.slug}
+  />
+</TraktPage>

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -46,8 +46,19 @@
   --height-landscape-card-cover: calc(var(--width-landscape-card) / 1.786);
   --height-landscape-card: calc(var(--height-landscape-card-cover) + var(--height-card-footer));
 
-  --width-person-card: var(--ni-120);
-  --height-person-card-cover: var(--ni-176);
+  --min-person-card-width: var(--ni-120);
+  --max-list-person-item-count: 15;
+
+  --list-person-item-count: var(--max-list-person-item-count);
+  @include dynamic-item-count(--list-person-item-count,
+    var(--min-person-card-width),
+    var(--max-list-person-item-count));
+
+  --width-person-card: var(--min-person-card-width);
+  @include dynamic-card-width(--width-person-card,
+    var(--min-person-card-width),
+    var(--list-person-item-count));
+  --height-person-card-cover: calc(var(--width-person-card) * 176 / 120);
   --height-person-card: calc(var(--height-person-card-cover) + var(--height-card-footer));
 
   --width-summary-card: var(--ni-276);
@@ -69,7 +80,18 @@
 
   --height-list-card: var(--ni-256);
 
-  --width-comment-card: min(var(--ni-480), 85vw);
+  --min-comment-card-width: var(--ni-340);
+  --max-list-comment-item-count: 5;
+
+  --list-comment-item-count: var(--max-list-comment-item-count);
+  @include dynamic-item-count(--list-comment-item-count,
+    var(--min-comment-card-width),
+    var(--max-list-comment-item-count));
+
+  --width-comment-card: var(--min-comment-card-width);
+  @include dynamic-card-width(--width-comment-card,
+    var(--min-comment-card-width),
+    var(--list-comment-item-count));
   --height-comment-card: var(--ni-172);
 
   --width-trivia-card: min(var(--ni-480), 85vw);
@@ -101,20 +123,16 @@
     Profile items use gap: 0, so item count and width are calculated
     without subtracting list-gap (unlike media card lists).
   */
-  --list-profile-item-count: clamp(
-    1,
-    round(down, var(--list-inner-width) / var(--min-profile-item-width), 1),
-    var(--max-list-profile-item-count)
-  );
+  --list-profile-item-count: clamp(1,
+      round(down, var(--list-inner-width) / var(--min-profile-item-width), 1),
+      var(--max-list-profile-item-count));
 
   @supports (-moz-appearance: none) {
     --list-profile-item-count: var(--max-list-profile-item-count);
   }
 
-  --width-profile-item: max(
-    calc(var(--list-inner-width) / var(--list-profile-item-count)),
-    var(--min-profile-item-width)
-  );
+  --width-profile-item: max(calc(var(--list-inner-width) / var(--list-profile-item-count)),
+    var(--min-profile-item-width));
   --height-profile-item: calc(var(--width-profile-item) * 1.2);
 
   @include for-tablet-sm-and-below {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1965
- Adds drilldowns for section lists on summary pages.
  - Except season list, will be a separate item.

## 👀 Example 👀

https://github.com/user-attachments/assets/4f62a52b-7b8d-4ac6-aa56-8040247def57

