### PR TITLE
fix(sentry): reduce sample rate to 10%

### DIFF
--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -49,7 +49,7 @@ export const handleCacheControl: Handle = async ({ event, resolve }) => {
 export const handle: Handle = sequence(
   initCloudflareSentryHandle({
     dsn: SENTRY_DSN,
-    tracesSampleRate: 1,
+    tracesSampleRate: 0.1,
     enableLogs: true,
   }),
   sentryHandle(),


### PR DESCRIPTION
While a favicon error is usually harmless, your specific Sentry configuration can turn this 404 into a "hang" due to how it handles tracing and logging. 
Why it might cause a "hang"
Trace Overhead: You have tracesSampleRate: 1, which means 100% of requests, including the missing favicon, are fully traced. If Sentry struggles to send this trace data (due to network latency or quota limits), it can delay the final response, making the site feel like it's stalling.
Unhandled Exceptions in Middleware: Some Sentry integrations have known bugs where a 404 for /favicon.ico isn't caught correctly by the internal request handler, causing the transaction to stay "open" indefinitely.