### PR TITLE
fix(stats) / sort dates numerically for streaks

### DIFF
--- a/projects/client/src/lib/sections/stats/_internal/useStreak.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useStreak.spec.ts
@@ -74,4 +74,31 @@ describe('computeStreak', () => {
     ];
     expect(computeStreak(dates, now)).toEqual({ count: 2, state: 'active' });
   });
+
+  it('correctly sorts days when single-digit and double-digit values coexist', () => {
+    // getDayKey returns unpadded strings like "2026-3-19".
+    // String sort places "2026-3-19" before "2026-3-3" ("1" < "3" at pos 7),
+    // which breaks streak detection — the sort must be numeric, not lexicographic.
+    const now = new Date('2026-03-30T12:00:00');
+    const dates = [
+      // Continuous streak: March 22–30 (9 days)
+      new Date('2026-03-30'),
+      new Date('2026-03-29'),
+      new Date('2026-03-28'),
+      new Date('2026-03-27'),
+      new Date('2026-03-26'),
+      new Date('2026-03-25'),
+      new Date('2026-03-24'),
+      new Date('2026-03-23'),
+      new Date('2026-03-22'),
+      // Gap on March 21
+      new Date('2026-03-20'),
+      new Date('2026-03-19'),
+      new Date('2026-03-18'),
+      new Date('2026-03-16'),
+      // Older entries that trigger the string-sort bug (single-digit day "3")
+      new Date('2026-03-03'),
+    ];
+    expect(computeStreak(dates, now)).toEqual({ count: 9, state: 'active' });
+  });
 });

--- a/projects/client/src/lib/sections/stats/_internal/useStreak.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useStreak.ts
@@ -22,7 +22,11 @@ export function computeStreak(
     return emptyStreak;
   }
 
-  const daysWithActivity = new Set(watchedDates.map(getDayKey));
+  const daysWithActivity = new Set(
+    watchedDates
+      .toSorted((a, b) => b.getTime() - a.getTime())
+      .map(getDayKey),
+  );
 
   const today = new Date(
     now.getFullYear(),
@@ -45,7 +49,7 @@ export function computeStreak(
 
   const startDate = hasActivityToday ? today : yesterday;
 
-  const sortedDays = [...daysWithActivity].sort().reverse();
+  const sortedDays = [...daysWithActivity];
   const previousDays = sortedDays.slice(
     sortedDays.indexOf(getDayKey(startDate)),
   );


### PR DESCRIPTION
## Overview
Addresses a bug in streak calculations where unpadded date strings were sorted lexicographically rather than chronologically. This caused incorrect streak detection when single-digit and double-digit days coexisted (e.g., "2026-3-19" being placed before "2026-3-3").

## Changes
- Sorts the input dates numerically using timestamps before mapping them to date keys
- Ensures the activity set preserves the correct chronological order to maintain streak continuity
- Removes the previous string-based sorting and reversing logic that caused the ordering errors

## Testing
- Adds a specific unit test case to verify that streaks are correctly calculated when days transition between single and double digits