### PR TITLE
fix(sw) / force immediate service worker activation and reload

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -70,5 +70,28 @@ if (typeof document !== 'undefined') {
   }
 }
 
+/**
+ * When a new Service Worker takes over (skipWaiting + clients.claim), reload
+ * the page so the browser picks up fresh assets instead of serving stale
+ * cached responses from the previous deployment — the primary fix for the
+ * Safari zombie SW hang.
+ *
+ * Guards:
+ * - Only reloads when the page was already controlled (skips the very first
+ *   registration on a new visitor's session to avoid a redundant double load).
+ * - A flag prevents multiple reload attempts if the event fires in quick
+ *   succession.
+ */
+if (typeof navigator !== 'undefined' && navigator.serviceWorker) {
+  const wasControlled = navigator.serviceWorker.controller !== null;
+  const guard = { reloading: false };
+
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (!wasControlled || guard.reloading) return;
+    guard.reloading = true;
+    window.location.reload();
+  });
+}
+
 // If you have a custom error handler, pass it to `handleErrorWithSentry`
 export const handleError = handleErrorWithSentry();

--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -26,6 +26,23 @@ declare let self: ServiceWorkerGlobalScope;
  */
 self.__WB_DISABLE_DEV_LOGS = true;
 
+/**
+ * Activate new SW immediately without waiting for existing tabs to close.
+ * This prevents Safari from getting stuck on a stale/zombied SW that serves
+ * assets incompatible with a fresh Cloudflare deployment.
+ */
+addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+/**
+ * Claim all open clients so the new SW takes control without a page reload
+ * being required on the old tab.
+ */
+addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
 function removeNavigationCache() {
   caches.delete(CacheKey.navigation);
 }


### PR DESCRIPTION
## Overview
Ensures that new service worker deployments take effect immediately across all open tabs. This prevents browsers, specifically Safari, from serving stale cached assets from previous deployments and resolves "zombie" service worker hangs.

## Changes
- Implements `skipWaiting()` in the service worker `install` event to bypass the waiting phase.
- Implements `clients.claim()` in the service worker `activate` event to take control of open clients immediately.
- Adds a `controllerchange` event listener to the client-side hooks to trigger a full page reload when a new service worker takes over.

## Testing
Manual verification of the service worker lifecycle to ensure the `controllerchange` event correctly triggers a page reload and that new assets are served following a deployment.