### PR TITLE
fix(list): enables list likes on own lists

### DIFF
--- a/projects/client/src/lib/sections/lists/user/ListActions.svelte
+++ b/projects/client/src/lib/sections/lists/user/ListActions.svelte
@@ -35,12 +35,21 @@
   const handleLike = $derived(() => {
     $isLiked ? unlikeList() : likeList();
   });
+
+  const isDisabled = $derived($isUpdating || isListOwner);
 </script>
 
 <RenderFor audience="authenticated">
   {#if $isDeleted && isOnListPage}
     <Redirect to={UrlBuilder.lists.user("me")} />
   {/if}
+
+  <LikeListAction
+    onToggle={handleLike}
+    disabled={isDisabled}
+    state={$isLiked ? "liked" : "unliked"}
+    {list}
+  />
 
   {#if isListOwner}
     <PopupMenu
@@ -66,15 +75,6 @@
         />
       {/snippet}
     </PopupMenu>
-  {/if}
-
-  {#if !isListOwner}
-    <LikeListAction
-      onToggle={handleLike}
-      isUpdating={$isUpdating}
-      state={$isLiked ? "liked" : "unliked"}
-      {list}
-    />
   {/if}
 </RenderFor>
 

--- a/projects/client/src/lib/sections/lists/user/_internal/LikeListAction.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/LikeListAction.svelte
@@ -8,12 +8,12 @@
 
   const {
     onToggle,
-    isUpdating,
+    disabled,
     state,
     list,
   }: {
     onToggle: () => void;
-    isUpdating: boolean;
+    disabled: boolean;
     state: "liked" | "unliked";
     list: MediaListSummary;
   } = $props();
@@ -26,7 +26,7 @@
 </script>
 
 <trakt-list-like-action>
-  <Button {label} style="ghost" onclick={onToggle} disabled={isUpdating}>
+  <Button {label} style="ghost" onclick={onToggle} {disabled}>
     {toHumanNumber(list.likeCount, languageTag())}
     {#snippet icon()}
       <LikeIcon style={state === "liked" ? "filled" : "open"} />


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2004
- enables list likes on own lists

## 👀 Examples 👀
Before/after:
<img width="1434" height="323" alt="Screenshot 2026-03-31 at 17 11 47" src="https://github.com/user-attachments/assets/dd8680e5-2dd2-4051-9b69-b5e405a88f7d" />

<img width="1430" height="332" alt="Screenshot 2026-03-31 at 17 13 15" src="https://github.com/user-attachments/assets/fb0fd107-03e8-4ef2-bcd3-813eba94ed21" />

Before/after:
<img width="354" height="363" alt="Screenshot 2026-03-31 at 17 12 49" src="https://github.com/user-attachments/assets/03a259eb-7837-4b92-8379-2a9eb7d7aa1a" />

<img width="354" height="363" alt="Screenshot 2026-03-31 at 17 12 57" src="https://github.com/user-attachments/assets/0e3bbe71-8a4c-417e-ba6e-1fed7dac1155" />

