### PR TITLE
perf(vip): do not preload usage

### DIFF
--- a/projects/client/src/lib/sections/vip/VipManage.svelte
+++ b/projects/client/src/lib/sections/vip/VipManage.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { useUser } from "$lib/features/auth/stores/useUser";
   import AccountDetails from "./_internal/AccountDetails.svelte";
   import UsageLimits from "./_internal/UsageLimits.svelte";
   import { useVip } from "./_internal/useVip";
@@ -7,14 +6,13 @@
   import VipFeatures from "./_internal/VipFeatures.svelte";
 
   const { subscription, isLoading } = useVip();
-  const { limits } = useUser();
 </script>
 
 <VipContent>
-  {#if $limits && !$isLoading}
+  {#if !$isLoading}
     <AccountDetails subscription={$subscription} />
 
-    <UsageLimits limits={$limits} />
+    <UsageLimits />
 
     <VipFeatures />
   {/if}

--- a/projects/client/src/lib/sections/vip/VipSubscribe.svelte
+++ b/projects/client/src/lib/sections/vip/VipSubscribe.svelte
@@ -1,18 +1,12 @@
 <script lang="ts">
-  import { useUser } from "$lib/features/auth/stores/useUser";
   import Subscriptions from "./_internal/Subscriptions.svelte";
   import UpsellFooter from "./_internal/UpsellFooter.svelte";
   import VipContent from "./_internal/VipContent.svelte";
   import VipFeatures from "./_internal/VipFeatures.svelte";
-
-  const { limits } = useUser();
 </script>
 
 <VipContent>
-  {#if $limits}
-    <Subscriptions />
-
-    <VipFeatures />
-    <UpsellFooter />
-  {/if}
+  <Subscriptions />
+  <VipFeatures />
+  <UpsellFooter />
 </VipContent>

--- a/projects/client/src/lib/sections/vip/_internal/UsageBar.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/UsageBar.svelte
@@ -10,11 +10,13 @@
     freeLimit,
     vipLimit,
     variant: externalVariant = "vip",
+    isLoading = false,
   }: {
     current: number;
     freeLimit: number;
     vipLimit: number;
     variant?: "vip" | "free";
+    isLoading?: boolean;
   } = $props();
 
   const isEqualLimit = $derived(freeLimit === vipLimit);
@@ -46,7 +48,7 @@
     class="trakt-progress-bar"
     class:is-over-limit={isOverLimit}
     class:is-low-percentage={isLowPercentage}
-    style:--progress="{progress}%"
+    style:--progress="{isLoading ? 0 : progress}%"
   ></div>
 </div>
 
@@ -121,6 +123,8 @@
     background-color: var(--color-usage-bar);
 
     border-radius: var(--border-radius-xxl);
+
+    transition: width var(--transition-increment) ease-in-out;
 
     &.is-low-percentage {
       width: var(--ni-14);

--- a/projects/client/src/lib/sections/vip/_internal/UsageLimitItem.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/UsageLimitItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import { languageTag } from "$lib/features/i18n";
   import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber";
   import UsageBar from "./UsageBar.svelte";
@@ -7,7 +8,12 @@
   const {
     item,
     variant = "vip",
-  }: { item: UsageCategoryItem; variant?: "vip" | "free" } = $props();
+    isLoading = false,
+  }: {
+    item: UsageCategoryItem;
+    variant?: "vip" | "free";
+    isLoading?: boolean;
+  } = $props();
 
   const limit = $derived(
     variant === "vip" ? item.limits.vip : item.limits.free,
@@ -18,13 +24,17 @@
   <div class="trakt-limit-header">
     <span>{item.title()}</span>
     <div class="trakt-limit-values">
-      <span>
-        {toHumanNumber(item.limits.current, languageTag())}
-      </span>
-      <span class="secondary">/</span>
-      <span class="secondary">
-        {toHumanNumber(limit, languageTag())}
-      </span>
+      {#if isLoading}
+        <LoadingIndicator />
+      {:else}
+        <span>
+          {toHumanNumber(item.limits.current, languageTag())}
+        </span>
+        <span class="secondary">/</span>
+        <span class="secondary">
+          {toHumanNumber(limit, languageTag())}
+        </span>
+      {/if}
     </div>
   </div>
 
@@ -33,6 +43,7 @@
     freeLimit={item.limits.free}
     vipLimit={item.limits.vip}
     {variant}
+    {isLoading}
   />
 </div>
 
@@ -71,5 +82,10 @@
     align-items: center;
     gap: var(--gap-micro);
     justify-content: flex-end;
+
+    :global(.loading-indicator svg) {
+      width: var(--ni-16);
+      height: var(--ni-16);
+    }
   }
 </style>

--- a/projects/client/src/lib/sections/vip/_internal/UsageLimits.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/UsageLimits.svelte
@@ -1,18 +1,22 @@
 <script lang="ts">
-  import type { UserLimits } from "$lib/requests/models/UserLimits";
+  import { useUser } from "$lib/features/auth/stores/useUser";
   import UsageLimitsCard from "./UsageLimitsCard.svelte";
   import { mapToUsageCategories } from "./utils/mapToUsageCategories";
   import VipContentContainer from "./VipContentContainer.svelte";
 
-  const { limits }: { limits: UserLimits } = $props();
+  const { limits } = useUser();
 
-  const categories = $derived(mapToUsageCategories(limits));
+  const categories = $derived(mapToUsageCategories($limits));
 </script>
 
 <VipContentContainer>
   <div class="trakt-vip-usage-limits">
-    {#each categories as category}
-      <UsageLimitsCard items={category.items} title={category.title()} />
+    {#each categories as category, index (index)}
+      <UsageLimitsCard
+        items={category.items}
+        title={category.title()}
+        isLoading={!$limits}
+      />
     {/each}
   </div>
 </VipContentContainer>

--- a/projects/client/src/lib/sections/vip/_internal/UsageLimitsCard.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/UsageLimitsCard.svelte
@@ -9,10 +9,12 @@
     title,
     items,
     variant = "vip",
+    isLoading = false,
   }: {
     title?: string;
     items: UsageCategoryItem[];
     variant?: "free" | "vip";
+    isLoading?: boolean;
   } = $props();
 
   let isExpanded = $state(false);
@@ -28,7 +30,7 @@
 
   <div class="trakt-usage-limits">
     {#each displayableItems as item}
-      <UsageLimitItem {item} {variant} />
+      <UsageLimitItem {item} {variant} {isLoading} />
     {/each}
   </div>
 

--- a/projects/client/src/lib/sections/vip/_internal/utils/mapToUsageCategories.ts
+++ b/projects/client/src/lib/sections/vip/_internal/utils/mapToUsageCategories.ts
@@ -1,6 +1,23 @@
 import * as m from '$lib/features/i18n/messages.ts';
 import type { UserLimits } from '$lib/requests/models/UserLimits.ts';
 
+const emptyLimit = {
+  current: 0,
+  free: 0,
+  vip: 0,
+};
+
+const placeholderLimits: UserLimits = {
+  history: emptyLimit,
+  ratings: emptyLimit,
+  watchlistItems: emptyLimit,
+  totalListItems: emptyLimit,
+  staticLists: emptyLimit,
+  dynamicLists: emptyLimit,
+  digitalLibrary: emptyLimit,
+  totalNotes: emptyLimit,
+};
+
 export type UsageCategoryItem = {
   title: () => string;
   limits: {
@@ -15,7 +32,11 @@ export type UsageCategory = {
   items: UsageCategoryItem[];
 };
 
-export function mapToUsageCategories(limits: UserLimits): UsageCategory[] {
+export function mapToUsageCategories(
+  props: UserLimits | Nil,
+): UsageCategory[] {
+  const limits = props ?? placeholderLimits;
+
   return [
     {
       title: m.usage_title_personal_activity,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2018
- No longer preloads usages in VIP page; they are well defined, we can already render the majority of the component and show placeholders instead.

## 👀 Example 👀

https://github.com/user-attachments/assets/07dabd86-c2a1-49d6-b8e8-2b213dd5607c

