### PR TITLE
fix(navbar): aligns desktop navbar with mobile navbar design

### DIFF
--- a/projects/client/src/lib/sections/navbar/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/SideNavbar.svelte
@@ -34,7 +34,6 @@
 {#if $state.mode !== "hidden"}
   <div class="trakt-navbar-actions" class:is-hidden={$state.mode === "minimal"}>
     <div class="trakt-navbar-actions-left">
-      <RenderFor audience="free"><GetVIPLink source="navbar" /></RenderFor>
       <NavbarHeader />
     </div>
 
@@ -52,6 +51,7 @@
         {/if}
         <FilterButton isDisabled={!$state.hasFilters} />
       </RenderFor>
+      <RenderFor audience="free"><GetVIPLink source="navbar" /></RenderFor>
       <RenderFor audience="public">
         <JoinTraktButton size="small">
           {#snippet icon()}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2035
- Aligns navbar designs between larger and smaller screens; fixes the issue where the vip badge would not fit with the titles.

## 👀 Example 👀
Before/after:
<img width="1134" height="654" alt="Screenshot 2026-04-07 at 15 21 56" src="https://github.com/user-attachments/assets/33d731ff-d5f8-4a76-808b-879186319bb7" />

<img width="1134" height="654" alt="Screenshot 2026-04-07 at 15 21 46" src="https://github.com/user-attachments/assets/47c4a947-e6db-4143-8b23-aceb3af3c7c7" />
