### PR TITLE
feat(summary): adds drilldown for seasons list

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -1628,7 +1628,6 @@
       "default": "Episodes",
       "description": "Title for lists containing episodes of a season. This title should be as short and concise as possible.",
       "exclude": [
-        "web",
         "android"
       ]
     },

--- a/projects/client/src/lib/components/drawer/Drawer.svelte
+++ b/projects/client/src/lib/components/drawer/Drawer.svelte
@@ -269,6 +269,7 @@
     gap: var(--gap-m);
 
     overflow-y: auto;
+    scrollbar-gutter: stable;
     padding-bottom: var(--ni-8);
     overscroll-behavior: contain;
   }

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -28,6 +28,10 @@
   const isHidden = $derived(props.status === "hidden");
   const isListItem = $derived(props.variant === "list-item");
   const style = $derived(props.style ?? "cover");
+  const isCompact = $derived(style === "compact");
+  const resolvedStyle: "cover" | "summary" = $derived(
+    style === "compact" ? "summary" : style,
+  );
 
   const runtime = $derived(
     isNaN(props.episode.runtime) ? props.media.runtime : props.episode.runtime,
@@ -96,7 +100,7 @@
           total={props.episode.total}
           tags={status ? statusTag : progressTags}
           {runtime}
-          {style}
+          style={resolvedStyle}
         />
       {/if}
 
@@ -151,7 +155,7 @@
 {/snippet}
 
 {#snippet card()}
-  {#if style === "summary"}
+  {#if style === "summary" || style === "compact"}
     <MediaSummaryCard
       variant="default"
       episode={props.episode}
@@ -163,11 +167,11 @@
         },
       }}
       popupActions={props.popupActions}
+      layout={isCompact ? "compact" : "default"}
       {tag}
       badge={action}
       {sortTag}
       type="episode"
-      style="summary"
     />
   {/if}
 

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -45,6 +45,7 @@
     contextualTag?: Snippet;
     badge?: Snippet;
     sortTag?: Snippet;
+    layout?: "default" | "compact";
   } & DistributiveOmit<ItemCardProps, "badge" | "action">;
 
   const {
@@ -55,6 +56,7 @@
     source,
     contextualTag,
     sortTag,
+    layout = "default",
     ...rest
   }: SummaryCardProps = $props();
 
@@ -63,7 +65,11 @@
   const isTabletLarge = useMedia(WellKnownMediaQuery.tabletLarge);
   const isDesktop = useMedia(WellKnownMediaQuery.desktop);
 
-  const hasMultiLineTitles = $derived($isTabletLarge || $isDesktop);
+  const isCompact = $derived(layout === "compact");
+
+  const hasMultiLineTitles = $derived(
+    !isCompact && ($isTabletLarge || $isDesktop),
+  );
 
   const coverData = $derived({
     background:
@@ -106,13 +112,29 @@
       ? media.title.toLowerCase() !== media.originalTitle.toLowerCase()
       : false,
   );
+
+  const dimensions = $derived.by(() => {
+    if (layout === "default") {
+      return {
+        width: "var(--width-summary-card)",
+        height: "var(--height-summary-card)",
+        heightCover: "var(--height-summary-card-cover)",
+      };
+    }
+
+    return {
+      width: "var(--width-summary-card-compact)",
+      height: "var(--height-summary-card-compact)",
+      heightCover: "var(--height-summary-card-cover-compact)",
+    };
+  });
 </script>
 
 <Card
-  classList="trakt-summary-card"
-  --height-card="var(--height-summary-card)"
-  --height-card-cover="var(--height-summary-card-cover)"
-  --width-card="var(--width-summary-card)"
+  classList="trakt-summary-card trakt-summary-card-{layout}"
+  --height-card={dimensions.height}
+  --height-card-cover={dimensions.heightCover}
+  --width-card={dimensions.width}
   --poster-aspect-ratio="0.6667"
 >
   {#if popupActions}
@@ -156,6 +178,7 @@
     <SummaryCardDetails
       classList={hasMultiLineTitles ? "multi-line-titles" : ""}
       {tag}
+      {layout}
     >
       {#if rest.type === "season"}
         <p class="trakt-card-title ellipsis">
@@ -226,7 +249,7 @@
     </SummaryCardDetails>
   </Link>
 
-  <SummaryCardBottomBar {contextualTag} {tag}>
+  <SummaryCardBottomBar {contextualTag} {tag} {layout}>
     {#if sortTag}
       {@render sortTag()}
     {:else if badge}
@@ -314,6 +337,20 @@
 
     @include for-tablet-sm-and-below {
       font-size: var(--font-size-title);
+    }
+  }
+
+  :global(.trakt-summary-card-compact) {
+    .trakt-card-title {
+      font-size: var(--font-size-title);
+    }
+
+    .trakt-summary-poster {
+      --poster-width: calc(
+        var(--height-summary-card-cover-compact) * var(--poster-aspect-ratio)
+      );
+
+      height: var(--height-summary-card-cover-compact);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
@@ -10,7 +10,7 @@
 
   type MediaSwipeProps = BaseMediaInput &
     ChildrenProps & {
-      style?: "cover" | "summary";
+      style?: "cover" | "summary" | "compact";
     };
 
   const { type, media, style, children }: MediaSwipeProps = $props();

--- a/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBottomBar.svelte
+++ b/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBottomBar.svelte
@@ -7,25 +7,39 @@
     children,
     tag,
     contextualTag,
-  }: ChildrenProps & { tag?: Snippet; contextualTag?: Snippet } = $props();
+    layout = "default",
+  }: ChildrenProps & {
+    tag?: Snippet;
+    contextualTag?: Snippet;
+    layout?: "default" | "compact";
+  } = $props();
+
+  const isCompact = $derived(layout === "compact");
 </script>
 
 <div
   class="trakt-summary-card-bottom-bar"
   class:has-contextualTag={Boolean(contextualTag)}
+  data-layout={layout}
 >
-  {#if contextualTag}
+  {#if contextualTag && !isCompact}
     <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
       {@render contextualTag()}
     </RenderFor>
   {/if}
 
   {#if tag}
-    <RenderFor audience="all" device={["tablet-sm", "mobile"]}>
+    {#if isCompact}
       <div class="trakt-summary-bottom-bar-tags" in:fade={{ duration: 150 }}>
         {@render tag()}
       </div>
-    </RenderFor>
+    {:else}
+      <RenderFor audience="all" device={["tablet-sm", "mobile"]}>
+        <div class="trakt-summary-bottom-bar-tags" in:fade={{ duration: 150 }}>
+          {@render tag()}
+        </div>
+      </RenderFor>
+    {/if}
   {/if}
 
   {@render children()}
@@ -54,6 +68,12 @@
 
     &.has-contextualTag {
       justify-content: space-between;
+    }
+
+    &[data-layout="compact"] {
+      --poster-width: calc(
+        var(--height-summary-card-cover-compact) * var(--poster-aspect-ratio, 0)
+      );
     }
   }
 

--- a/projects/client/src/lib/sections/lists/components/_internal/SummaryCardDetails.svelte
+++ b/projects/client/src/lib/sections/lists/components/_internal/SummaryCardDetails.svelte
@@ -8,7 +8,14 @@
     children,
     tag,
     classList = "",
-  }: { tag?: Snippet; classList?: string } & ChildrenProps = $props();
+    layout = "default",
+  }: {
+    tag?: Snippet;
+    classList?: string;
+    layout?: "default" | "compact";
+  } & ChildrenProps = $props();
+
+  const isCompact = $derived(layout === "compact");
 </script>
 
 <div class="trakt-summary-card-details" use:appendClassList={classList}>
@@ -16,7 +23,7 @@
     {@render children()}
   </div>
 
-  {#if tag}
+  {#if tag && !isCompact}
     <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
       <div class="trakt-summary-card-tags" in:fade={{ duration: 150 }}>
         {@render tag()}

--- a/projects/client/src/lib/sections/lists/components/models/BaseItemProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/BaseItemProps.ts
@@ -4,7 +4,7 @@ export type BaseItemProps = {
   badge?: Snippet;
   action?: Snippet;
   tag?: Snippet;
-  style?: 'cover' | 'summary';
+  style?: 'cover' | 'summary' | 'compact';
   source?: string;
   popupActions?: Snippet;
 };

--- a/projects/client/src/lib/sections/lists/season/SeasonList.svelte
+++ b/projects/client/src/lib/sections/lists/season/SeasonList.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
 
   import type { Season } from "$lib/requests/models/Season";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import { useSeasonEpisodes } from "$lib/sections/lists/stores/useSeasonEpisodes";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { seasonLabel } from "$lib/utils/intl/seasonLabel";
+  import SeasonDropdown from "./_internal/SeasonDropdown.svelte";
   import SeasonEpisodeList from "./_internal/SeasonEpisodeList.svelte";
   import SeasonPosterList from "./_internal/SeasonPosterList.svelte";
 
@@ -22,29 +25,43 @@
 
   const title = m.list_title_seasons();
   const subtitle = $derived(seasonLabel(currentSeason));
+  const hasSingleSeason = $derived(seasons.length === 1);
 
-  const episodeProps = $derived(
-    seasons.length === 1 ? { title, subtitle } : {},
-  );
+  const isTabletLarge = useMedia(WellKnownMediaQuery.tabletLarge);
+  const isDesktop = useMedia(WellKnownMediaQuery.desktop);
+  const isLargeScreen = $derived($isTabletLarge || $isDesktop);
 
   const previousSeasons = $derived(
     seasons.filter((s) => s.number > 0 && s.number < currentSeason),
   );
+
+  const episodeProps = $derived.by(() => {
+    if (hasSingleSeason) return { title, subtitle };
+    return isLargeScreen ? { title } : {};
+  });
 </script>
 
-{#if seasons.length > 1}
-  <SeasonPosterList
-    {show}
-    {seasons}
-    episodes={$episodes}
-    {title}
-    {subtitle}
-    {currentSeason}
-  />
-{/if}
+<RenderFor audience="all" device={["mobile", "tablet-sm"]}>
+  {#if seasons.length > 1}
+    <SeasonPosterList
+      {show}
+      {seasons}
+      episodes={$episodes}
+      {title}
+      {subtitle}
+      {currentSeason}
+    />
+  {/if}
+</RenderFor>
+
+{#snippet headerActions()}
+  <SeasonDropdown showSlug={show.slug} {seasons} {currentSeason} />
+{/snippet}
+
 <SeasonEpisodeList
   {show}
   {previousSeasons}
   episodes={$episodes}
+  headerActions={isLargeScreen && !hasSingleSeason ? headerActions : undefined}
   {...episodeProps}
 />

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonDropdown.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonDropdown.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import type { Season } from "$lib/requests/models/Season";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+
+  type SeasonDropdownProps = {
+    showSlug: string;
+    seasons: Season[];
+    currentSeason: number;
+  };
+
+  const { showSlug, seasons, currentSeason }: SeasonDropdownProps = $props();
+</script>
+
+<DropdownList
+  preferNative
+  label={m.list_title_seasons()}
+  style="flat"
+  variant="primary"
+  color="blue"
+  size="small"
+  disabled={seasons.length < 2}
+>
+  {currentSeason}
+  {#snippet items()}
+    {#each seasons as season (season.id)}
+      <DropdownItem
+        color="blue"
+        href={UrlBuilder.show(showSlug, { season: season.number })}
+        noscroll
+      >
+        {season.number}
+      </DropdownItem>
+    {/each}
+  {/snippet}
+</DropdownList>

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import type { WatchedEpisode } from "$lib/features/auth/queries/currentUserHistoryQuery.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
+  import type { Season } from "$lib/requests/models/Season";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
+  import EpisodeItem from "$lib/sections/lists/components/EpisodeItem.svelte";
+  import type { BaseItemProps } from "$lib/sections/lists/components/models/BaseItemProps";
+  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
+  import { getEpisodesUntil } from "./getEpisodesUntil";
+  import { WatchedUntilHereIntlProvider } from "./WatchedUntilHereIntlProvider";
+
+  type SeasonEpisodeItemProps = {
+    show: ShowEntry;
+    episode: EpisodeEntry;
+    previousSeasons: Season[];
+    watchedEpisodes?: WatchedEpisode[];
+    hasUnseenEpisodes: boolean;
+    style?: BaseItemProps["style"];
+    source: string;
+  };
+
+  const {
+    show,
+    episode,
+    previousSeasons,
+    watchedEpisodes,
+    hasUnseenEpisodes,
+    style,
+    source,
+  }: SeasonEpisodeItemProps = $props();
+
+  const isFuture = $derived(episode.airDate > new Date());
+  const hasBulkMarkAsWatched = $derived(
+    hasUnseenEpisodes && episode.airDate && !isFuture,
+  );
+</script>
+
+{#snippet popupActions()}
+  <RenderFor audience="authenticated">
+    <MarkAsWatchedAction
+      style="dropdown-item"
+      type="show"
+      size="small"
+      i18n={WatchedUntilHereIntlProvider}
+      title={show.title}
+      media={{
+        id: show.id,
+        airDate: show.airDate,
+        seasons: getEpisodesUntil({
+          previousSeasons,
+          episode,
+          watchedEpisodes,
+        }),
+      }}
+    />
+  </RenderFor>
+{/snippet}
+
+<EpisodeItem
+  {episode}
+  media={show}
+  {style}
+  popupActions={hasBulkMarkAsWatched ? popupActions : undefined}
+  variant={isFuture ? "upcoming" : "default"}
+  context="show"
+  {source}
+/>

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
@@ -1,21 +1,25 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { m } from "$lib/features/i18n/messages.ts";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { Season } from "$lib/requests/models/Season";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
-  import EpisodeItem from "$lib/sections/lists/components/EpisodeItem.svelte";
   import { mediaListHeightResolver } from "$lib/sections/lists/utils/mediaListHeightResolver";
-  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
-  import { getEpisodesUntil } from "./getEpisodesUntil";
-  import { WatchedUntilHereIntlProvider } from "./WatchedUntilHereIntlProvider";
+  import {
+    Drawers,
+    summaryDrawerNavigation,
+  } from "$lib/sections/summary/_internal/summaryDrawerNavigation";
+  import type { Snippet } from "svelte";
+  import ViewAllButton from "../../components/ViewAllButton.svelte";
+  import SeasonEpisodeItem from "./SeasonEpisodeItem.svelte";
 
   type SeasonEpisodeListProps = {
     show: ShowEntry;
     previousSeasons: Season[];
     episodes: EpisodeEntry[];
     title?: string;
+    headerActions?: Snippet;
     subtitle?: string;
   };
 
@@ -25,17 +29,16 @@
     episodes,
     title,
     subtitle,
+    headerActions,
   }: SeasonEpisodeListProps = $props();
 
   const { history } = useUser();
 
   const showProgress = $derived($history?.shows.get(show.id));
   const watchedEpisodes = $derived(showProgress?.episodes);
-
   const hasUnseenEpisodes = $derived(!showProgress?.isWatched);
 
-  const hasBulkMarkAsWatched = (episode: EpisodeEntry) =>
-    hasUnseenEpisodes && episode.airDate && episode.airDate <= new Date();
+  const { buildDrawerLink } = summaryDrawerNavigation();
 </script>
 
 <SectionList
@@ -44,36 +47,30 @@
   {title}
   {subtitle}
   --height-list={mediaListHeightResolver("landscape")}
+  drilldownLink={buildDrawerLink(Drawers.Seasons)}
+  noscroll
 >
   {#snippet item(episode)}
-    {#snippet popupActions()}
-      <RenderFor audience="authenticated">
-        <MarkAsWatchedAction
-          style="dropdown-item"
-          type="show"
-          size="small"
-          i18n={WatchedUntilHereIntlProvider}
-          title={show.title}
-          media={{
-            id: show.id,
-            airDate: show.airDate,
-            seasons: getEpisodesUntil({
-              previousSeasons,
-              episode,
-              watchedEpisodes,
-            }),
-          }}
-        />
-      </RenderFor>
-    {/snippet}
-
-    <EpisodeItem
+    <SeasonEpisodeItem
+      {show}
       {episode}
-      media={show}
-      popupActions={hasBulkMarkAsWatched(episode) ? popupActions : undefined}
-      variant={episode.airDate > new Date() ? "upcoming" : "default"}
-      context="show"
+      {previousSeasons}
+      {watchedEpisodes}
+      {hasUnseenEpisodes}
       source="season-episode-list"
+    />
+  {/snippet}
+
+  {#snippet actions()}
+    {#if headerActions}
+      {@render headerActions()}
+    {/if}
+
+    <ViewAllButton
+      href={buildDrawerLink(Drawers.Seasons)}
+      label={m.button_text_view_all()}
+      noscroll
+      source={{ id: "seasons" }}
     />
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonPopupMenu.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonPopupMenu.svelte
@@ -9,12 +9,17 @@
     title: string;
     episodes: EpisodeEntry[];
     show: ShowEntry;
+    disabled?: boolean;
   };
 
-  const { title, episodes, show }: SeasonPopupMenuProps = $props();
+  const { title, episodes, show, disabled }: SeasonPopupMenuProps = $props();
 </script>
 
-<PopupMenu label={m.button_label_popup_menu({ title })} mode="standalone">
+<PopupMenu
+  label={m.button_label_popup_menu({ title })}
+  mode="standalone"
+  {disabled}
+>
   {#snippet items()}
     <MarkAsWatchedAction
       style="dropdown-item"

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
+  import { m } from "$lib/features/i18n/messages";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { Season } from "$lib/requests/models/Season";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import SeasonItem from "$lib/sections/lists/components/SeasonItem.svelte";
+  import {
+    Drawers,
+    summaryDrawerNavigation,
+  } from "$lib/sections/summary/_internal/summaryDrawerNavigation";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import ViewAllButton from "../../components/ViewAllButton.svelte";
   import SeasonPopupMenu from "./SeasonPopupMenu.svelte";
 
   type SeasonListProps = {
@@ -24,6 +30,8 @@
     subtitle,
     currentSeason,
   }: SeasonListProps = $props();
+
+  const { buildDrawerLink } = summaryDrawerNavigation();
 </script>
 
 <SectionList
@@ -44,5 +52,12 @@
   {/snippet}
   {#snippet actions()}
     <SeasonPopupMenu title={subtitle} {episodes} {show} />
+
+    <ViewAllButton
+      href={buildDrawerLink(Drawers.Seasons)}
+      label={m.button_text_view_all()}
+      noscroll
+      source={{ id: "seasons" }}
+    />
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/summary/ShowSummary.svelte
+++ b/projects/client/src/lib/sections/summary/ShowSummary.svelte
@@ -71,6 +71,9 @@
   {media}
   {networks}
   {videos}
+  {seasons}
+  {currentSeason}
+  showEntry={media}
   type="show"
 />
 

--- a/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { page } from "$app/state";
   import type { MediaVideo } from "$lib/requests/models/MediaVideo";
+  import type { Season } from "$lib/requests/models/Season";
   import type { SentimentAnalysis } from "$lib/requests/models/SentimentAnalysis";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry";
   import WhereToWatchDrawer from "$lib/sections/lists/where-to-watch/_internal/WhereToWatchDrawer.svelte";
   import {
     Drawers,
@@ -11,6 +13,7 @@
   import DetailsDrawer from "./components/details/DetailsDrawer.svelte";
   import type { MediaDetailsProps } from "./components/details/MediaDetailsProps";
   import HistoryDrawer from "./components/history/HistoryDrawer.svelte";
+  import SeasonsDrawer from "./components/seasons/SeasonsDrawer.svelte";
   import SentimentDrawer from "./components/sentiment/SentimentDrawer.svelte";
   import TriviaDrawer from "./components/trivia/TriviaDrawer.svelte";
   import VideoDrawer from "./components/videos/VideoDrawer.svelte";
@@ -18,10 +21,16 @@
   const {
     sentiment,
     videos,
+    seasons,
+    currentSeason,
+    showEntry,
     ...details
   }: {
     sentiment?: SentimentAnalysis | Nil;
     videos?: MediaVideo[];
+    seasons?: Season[];
+    currentSeason?: number;
+    showEntry?: ShowEntry;
   } & MediaDetailsProps = $props();
 
   const { drawer, close } = $derived(
@@ -75,4 +84,8 @@
 
 {#if drawer === Drawers.WhereToWatch}
   <WhereToWatchDrawer {...whereToWatchTarget} onClose={close} />
+{/if}
+
+{#if drawer === Drawers.Seasons && seasons && currentSeason != null && showEntry}
+  <SeasonsDrawer show={showEntry} {seasons} {currentSeason} onClose={close} />
 {/if}

--- a/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
+++ b/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
@@ -11,6 +11,7 @@ export enum Drawers {
   Trivia = 'trivia',
   History = 'history',
   WhereToWatch = 'where-to-watch',
+  Seasons = 'seasons',
 }
 
 function mapToDrawer(value: string | Nil) {
@@ -29,6 +30,8 @@ function mapToDrawer(value: string | Nil) {
       return Drawers.History;
     case Drawers.WhereToWatch:
       return Drawers.WhereToWatch;
+    case Drawers.Seasons:
+      return Drawers.Seasons;
     default:
       return null;
   }

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
+  import GridList from "$lib/components/lists/grid-list/GridList.svelte";
+  import { useUser } from "$lib/features/auth/stores/useUser";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { Season } from "$lib/requests/models/Season";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
+  import SeasonItem from "$lib/sections/lists/components/SeasonItem.svelte";
+  import SeasonEpisodeItem from "$lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte";
+  import SeasonPopupMenu from "$lib/sections/lists/season/_internal/SeasonPopupMenu.svelte";
+  import { useSeasonEpisodes } from "$lib/sections/lists/stores/useSeasonEpisodes";
+  import { seasonLabel } from "$lib/utils/intl/seasonLabel";
+  import { fade } from "svelte/transition";
+
+  const {
+    onClose,
+    show,
+    seasons,
+    currentSeason,
+  }: {
+    show: ShowEntry;
+    seasons: Season[];
+    currentSeason: number;
+    onClose: () => void;
+  } = $props();
+
+  let isOpen = $state(false);
+
+  const { list: episodes, isLoading } = $derived(
+    useSeasonEpisodes(show.slug, currentSeason),
+  );
+
+  const { history } = useUser();
+
+  const showProgress = $derived($history?.shows.get(show.id));
+  const watchedEpisodes = $derived(showProgress?.episodes);
+  const hasUnseenEpisodes = $derived(!showProgress?.isWatched);
+
+  const previousSeasons = $derived(
+    seasons.filter((s) => s.number > 0 && s.number < currentSeason),
+  );
+
+  const buildSeasonLink = (seasonNumber: number) => {
+    const url = new URL(page.url);
+    url.searchParams.set("season", String(seasonNumber));
+    return url.toString();
+  };
+</script>
+
+{#snippet badge()}
+  <SeasonPopupMenu
+    title={seasonLabel(currentSeason)}
+    episodes={$episodes}
+    {show}
+    disabled={$isLoading}
+  />
+{/snippet}
+
+<Drawer
+  {onClose}
+  {badge}
+  onOpened={() => (isOpen = true)}
+  title={m.list_title_seasons()}
+  size="large"
+  metaInfo={seasonLabel(currentSeason)}
+>
+  {#if isOpen}
+    <div class="seasons-drawer-content" transition:fade={{ duration: 150 }}>
+      {#if seasons.length > 1}
+        <div class="seasons-section">
+          <GridList
+            id={`seasons-list-${show.slug}`}
+            items={seasons}
+            --width-item="var(--width-portrait-card)"
+          >
+            {#snippet item(season)}
+              <SeasonItem
+                media={show}
+                {season}
+                isCurrentSeason={season.number === currentSeason}
+                urlBuilder={() => buildSeasonLink(season.number)}
+              />
+            {/snippet}
+          </GridList>
+        </div>
+      {/if}
+
+      <div class="episodes-section">
+        {#snippet metaInfo()}
+          <p class="secondary">
+            {m.tag_text_number_of_episodes({ count: $episodes.length })}
+          </p>
+        {/snippet}
+
+        {#if $isLoading}
+          <LoadingIndicator />
+        {:else}
+          <GridList
+            id={`season-episodes-${show.slug}-${currentSeason}`}
+            title={m.list_title_episodes()}
+            items={$episodes}
+            {metaInfo}
+            --width-item="var(--width-summary-card)"
+          >
+            {#snippet item(episode)}
+              <SeasonEpisodeItem
+                {show}
+                {episode}
+                {previousSeasons}
+                {watchedEpisodes}
+                {hasUnseenEpisodes}
+                style="compact"
+                source="seasons-drawer"
+              />
+            {/snippet}
+          </GridList>
+        {/if}
+      </div>
+    </div>
+  {/if}
+</Drawer>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .seasons-drawer-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xl);
+
+    :global(.trakt-list-item-container) {
+      padding: 0;
+    }
+  }
+
+  .seasons-section {
+    --column-count: 4;
+
+    --container-width: calc(
+      var(--drawer-size) - 2 * var(--drawer-padding) - var(--list-gap) * 2
+    );
+    --width-override-card: calc(
+      (var(--container-width) - (var(--column-count) - 1) * var(--list-gap)) /
+        var(--column-count)
+    );
+    --height-override-card-cover: calc(var(--width-override-card) * 1.5);
+    --height-override-card: calc(
+      var(--height-override-card-cover) + var(--height-card-footer-sm)
+    );
+
+    @include for-mobile {
+      --container-width: calc(100dvw - 2 * var(--drawer-padding));
+    }
+
+    :global(.trakt-list-items) {
+      grid-row-gap: var(--gap-s);
+      grid-template-columns: repeat(var(--column-count), 1fr);
+    }
+  }
+
+  .episodes-section {
+    :global(.trakt-list-items) {
+      grid-template-columns: 1fr;
+      grid-row-gap: var(--gap-s);
+    }
+
+    :global(.trakt-list-inset-title) {
+      margin: 0;
+    }
+  }
+</style>

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -226,9 +226,13 @@
   --font-size-tag: var(--ni-10);
   --font-size-text: var(--ni-14);
 
+  --width-summary-card-compact: 100%;
+  --height-summary-card-cover-compact: var(--ni-112);
+  --height-summary-card-compact: var(--height-summary-card-cover-compact);
+
   @include for-tablet-sm-and-below {
-    --width-summary-card: 100%;
-    --height-summary-card-cover: var(--ni-112);
+    --width-summary-card: var(--width-summary-card-compact);
+    --height-summary-card-cover: var(--height-summary-card-cover-compact);
   }
 
   --font-size-title: var(--ni-18);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1987, fixes #1527
- Adds drilldown for seasons lists; on smaller screens the layout is unchanged with the addition of the drilldown button.

## 👀 Example 👀

https://github.com/user-attachments/assets/d74a6008-5bdc-4a5c-9dae-d4976eabe718

