### PR TITLE
fix(calendar): uses correct ordering when mapping activity

### DIFF
--- a/projects/client/src/lib/sections/lists/stores/_internal/mapToActivityCalendar.spec.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/mapToActivityCalendar.spec.ts
@@ -51,7 +51,7 @@ describe('mapToActivityCalendar', () => {
     const result = mapToActivityCalendar([entry1, entry2], startDate);
 
     const march2 = result.find((day) => day.date.getDate() === 2);
-    expect(march2?.items).toEqual([entry1, entry2]);
+    expect(march2?.items).toEqual([entry2, entry1]);
   });
 
   it('should sort items within the same day by the watched at timestamp', () => {
@@ -59,10 +59,10 @@ describe('mapToActivityCalendar', () => {
     const later = createHistoryEntry(new Date('2024-03-02T20:00:00'));
     const earlier = createHistoryEntry(new Date('2024-03-02T10:00:00'));
 
-    const result = mapToActivityCalendar([later, earlier], startDate);
+    const result = mapToActivityCalendar([earlier, later], startDate);
 
     const day = result.find((day) => day.date.getDate() === 2);
-    expect(day?.items).toEqual([earlier, later]);
+    expect(day?.items).toEqual([later, earlier]);
   });
 
   it('should not include items outside the 7-day range', () => {

--- a/projects/client/src/lib/sections/lists/stores/_internal/mapToActivityCalendar.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/mapToActivityCalendar.ts
@@ -41,7 +41,7 @@ function createHistoryCalendar<T>(
       return {
         date,
         items: items.toSorted((a, b) =>
-          getActivityTime(a).getTime() - getActivityTime(b).getTime()
+          getActivityTime(b).getTime() - getActivityTime(a).getTime()
         ),
       };
     })


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2097
- Fixes an issue when mapping history/activity data, the items were wrongly ordered.

## 👀 Example 👀
In the regular list:
<img width="417" height="217" alt="Screenshot 2026-04-14 at 09 15 18" src="https://github.com/user-attachments/assets/1f84de5f-7d70-435e-a609-b1194131c957" />

Before/after:
<img width="370" height="626" alt="Screenshot 2026-04-14 at 09 17 10" src="https://github.com/user-attachments/assets/bfcba6c0-dee1-4d76-9ec5-d27502ff3fb6" />

<img width="417" height="725" alt="Screenshot 2026-04-14 at 09 14 59" src="https://github.com/user-attachments/assets/ef60d9aa-5eb8-4f5c-8ee0-54b03e1c62d8" />
