### PR TITLE
feat(navbar): adds support for expanding side bar

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -3311,6 +3311,22 @@
         "ios"
       ]
     },
+    "button_label_collapse_navbar": {
+      "default": "Collapse",
+      "description": "Label for the button that collapses the side navigation bar.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "button_label_expand_navbar": {
+      "default": "Expand",
+      "description": "Label for the button that expands the side navigation bar.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "text_show_spoilers": {
       "default": "Show spoilers",
       "description": "Text for the section that allows users to toggle spoilers.",

--- a/projects/client/src/lib/components/icons/MenuIcon.svelte
+++ b/projects/client/src/lib/components/icons/MenuIcon.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  const { state = "closed" }: { state?: "closed" | "open" } = $props();
+</script>
+
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d={state === "open" ? "M3 6H16" : "M3 6H21"}
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+  <path
+    d={state === "open" ? "M3 12H12" : "M3 12H21"}
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+  <path
+    d={state === "open" ? "M3 18H16" : "M3 18H21"}
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+  <path
+    class="caret"
+    class:is-open={state === "open"}
+    d="M21 7L16 12L21 17"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>
+
+<style>
+  path {
+    transition: d var(--transition-increment) ease-in-out;
+  }
+
+  .caret {
+    opacity: 0;
+    transform: translateX(4px);
+    transition:
+      opacity var(--transition-increment) ease-in-out,
+      transform var(--transition-increment) ease-in-out;
+  }
+
+  .caret.is-open {
+    opacity: 1;
+    transform: translateX(0);
+  }
+</style>

--- a/projects/client/src/lib/components/tooltip/Tooltip.svelte
+++ b/projects/client/src/lib/components/tooltip/Tooltip.svelte
@@ -10,6 +10,7 @@
     side = "top",
     delayDuration = 150,
     sideOffset = 8,
+    disabled = false,
   }: TooltipProps & ChildrenProps = $props();
 
   const isMouse = useMedia(WellKnownMediaQuery.mouse);
@@ -26,7 +27,7 @@
 </script>
 
 <Tooltip.Provider>
-  <Tooltip.Root {delayDuration} bind:open>
+  <Tooltip.Root {delayDuration} bind:open disabled={disabled ?? false}>
     <Tooltip.Trigger>
       {#snippet child({ props })}
         <div

--- a/projects/client/src/lib/components/tooltip/TooltipProps.ts
+++ b/projects/client/src/lib/components/tooltip/TooltipProps.ts
@@ -4,4 +4,5 @@ export type TooltipProps = {
   side?: 'top' | 'right' | 'bottom' | 'left';
   delayDuration?: number;
   sideOffset?: number;
+  disabled?: boolean;
 };

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -200,7 +200,7 @@
     --content-gap: var(--gap-m);
 
     transition: var(--transition-increment) ease-in-out;
-    transition-property: gap, margin;
+    transition-property: gap, margin, padding;
 
     display: flex;
     flex-direction: column;

--- a/projects/client/src/lib/sections/navbar/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/SideNavbar.svelte
@@ -1,76 +1,35 @@
 <script lang="ts">
-  import CircularLogo from "$lib/components/icons/CircularLogo.svelte";
-  import DiscoverIcon from "$lib/components/icons/DiscoverIcon.svelte";
-  import HomeIcon from "$lib/components/icons/mobile/HomeIcon.svelte";
-  import ListIcon from "$lib/components/icons/mobile/ListIcon.svelte";
-  import SearchIcon from "$lib/components/icons/SearchIcon.svelte";
+  import MenuIcon from "$lib/components/icons/MenuIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
-  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
-  import type { TooltipProps } from "$lib/components/tooltip/TooltipProps";
+  import Logo from "$lib/components/logo/Logo.svelte";
   import * as m from "$lib/features/i18n/messages";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import RenderFor from "$lib/guards/RenderFor.svelte";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
-  import Toast from "../toast/Toast.svelte";
-  import NavbarHeader from "./_internal/NavbarHeader.svelte";
-  import FilterButton from "./components/filter/FilterButton.svelte";
-  import GetVIPLink from "./components/GetVIPLink.svelte";
-  import JoinTraktButton from "./components/JoinTraktButton.svelte";
+  import { useCollapsedSection } from "$lib/stores/useCollapsedSection";
+  import { slide } from "svelte/transition";
+  import NavbarActions from "./_internal/NavbarActions.svelte";
+  import SideNavbarContent from "./_internal/SideNavbarContent.svelte";
   import ProfileLink from "./components/ProfileLink.svelte";
-  import TraktLogo from "./components/TraktLogo.svelte";
   import UserMenu from "./components/UserMenu.svelte";
   import { useNavbarState } from "./useNavbarState";
 
   const { state } = useNavbarState();
+  const { isCollapsed, toggle } = useCollapsedSection("side-navbar", true);
 
-  const tooltipConfig: Omit<TooltipProps, "content"> = {
-    variant: "compact",
-    side: "right",
-    delayDuration: 0,
-    sideOffset: 16,
-  };
+  $effect(() => {
+    const width = $isCollapsed
+      ? "var(--side-navbar-width-collapsed)"
+      : "var(--side-navbar-width-expanded)";
+    document.documentElement.style.setProperty("--side-navbar-width", width);
+
+    return () => {
+      document.documentElement.style.removeProperty("--side-navbar-width");
+    };
+  });
 </script>
 
 {#if $state.mode !== "hidden"}
-  <div class="trakt-navbar-actions" class:is-hidden={$state.mode === "minimal"}>
-    <div class="trakt-navbar-actions-left">
-      <NavbarHeader />
-    </div>
-
-    <div class="trakt-navbar-actions-center">
-      {#if $state.actions}
-        {@render $state.actions?.()}
-      {/if}
-    </div>
-
-    <div class="trakt-navbar-actions-right">
-      <RenderFor audience="authenticated">
-        {@render $state.sortActions?.()}
-        {#if $state.seasonalActions}
-          {@render $state.seasonalActions?.()}
-        {/if}
-        <FilterButton isDisabled={!$state.hasFilters} />
-      </RenderFor>
-      <RenderFor audience="free"><GetVIPLink source="navbar" /></RenderFor>
-      <RenderFor audience="public">
-        <JoinTraktButton size="small">
-          {#snippet icon()}
-            <CircularLogo />
-          {/snippet}
-        </JoinTraktButton>
-      </RenderFor>
-    </div>
-  </div>
-
-  {#if $state.toastActions || $state.contextualActions}
-    <Toast>
-      {#if $state.contextualActions}
-        {@render $state.contextualActions()}
-      {:else}
-        {@render $state.toastActions?.()}
-      {/if}
-    </Toast>
-  {/if}
+  <NavbarActions />
 
   <header>
     <nav
@@ -78,55 +37,30 @@
       data-dpad-navigation={DpadNavigationType.Navbar}
     >
       <div class="trakt-side-navbar-top">
-        <TraktLogo />
-      </div>
-
-      <div class="trakt-side-navbar-content">
-        <RenderFor audience="authenticated">
-          <Tooltip content={m.page_title_search()} {...tooltipConfig}>
-            <Link href={UrlBuilder.search()} label={m.button_label_search()}>
-              <SearchIcon />
-            </Link>
-          </Tooltip>
-        </RenderFor>
-
-        <Tooltip
-          content={m.page_title_home()}
-          variant="compact"
-          side="right"
-          delayDuration={0}
-          sideOffset={16}
+        <button
+          class="nav-menu-button"
+          onclick={toggle}
+          aria-label={$isCollapsed
+            ? m.button_label_expand_navbar()
+            : m.button_label_collapse_navbar()}
         >
-          <Link href={UrlBuilder.home()} label={m.button_label_home()}>
-            <HomeIcon />
-          </Link>
-        </Tooltip>
-
-        <RenderFor audience="authenticated">
-          <Tooltip content={m.page_title_discover()} {...tooltipConfig}>
-            <Link
-              href={UrlBuilder.discover()}
-              label={m.button_label_discover()}
-            >
-              <DiscoverIcon />
+          <MenuIcon state={$isCollapsed ? "closed" : "open"} />
+        </button>
+        {#if !$isCollapsed}
+          <div class="nav-logo-link" transition:slide={{ duration: 150 }}>
+            <Link href="/" label="Trakt">
+              <Logo />
             </Link>
-          </Tooltip>
-
-          <Tooltip content={m.page_title_lists()} {...tooltipConfig}>
-            <Link
-              href={UrlBuilder.lists.user("me")}
-              label={m.button_label_browse_lists()}
-            >
-              <ListIcon />
-            </Link>
-          </Tooltip>
-        </RenderFor>
+          </div>
+        {/if}
       </div>
 
-      <div class="trakt-side-navbar-bottom">
+      <SideNavbarContent isCollapsed={$isCollapsed} />
+
+      <div class="trakt-side-navbar-bottom" class:is-expanded={!$isCollapsed}>
         <RenderFor audience="authenticated">
-          <UserMenu>
-            <ProfileLink />
+          <UserMenu isExpanded={!$isCollapsed}>
+            <ProfileLink isExpanded={!$isCollapsed} />
           </UserMenu>
         </RenderFor>
       </div>
@@ -134,25 +68,22 @@
   </header>
 {/if}
 
-<style lang="scss">
-  @use "$style/scss/mixins/index" as *;
-
+<style>
   header {
-    --navbar-item-width: var(--ni-24);
-
     --navbar-margin: var(--gap-s);
     --navbar-margin-top: calc(var(--gap-m) + env(safe-area-inset-top));
     --navbar-margin-bottom: calc(var(--gap-m) + env(safe-area-inset-bottom));
+    --nav-icon-size: var(--ni-24);
   }
 
   .trakt-side-navbar {
     contain: layout;
 
     z-index: var(--layer-overlay);
+
     position: fixed;
     top: 0;
     left: 0;
-
     width: var(--side-navbar-width);
     height: calc(
       100dvh - var(--navbar-margin-top) - var(--navbar-margin-bottom)
@@ -170,73 +101,82 @@
     align-items: flex-start;
     justify-content: space-between;
     gap: var(--gap-m);
+
+    &:has(.is-expanded) {
+      width: var(--side-navbar-width-expanded);
+    }
   }
 
   .trakt-side-navbar-top,
-  .trakt-side-navbar-content,
   .trakt-side-navbar-bottom {
     display: flex;
     flex-direction: column;
     align-items: center;
     align-self: center;
-
+    justify-content: center;
     gap: var(--gap-m);
 
     width: var(--side-navbar-width);
-  }
-
-  .trakt-side-navbar-top,
-  .trakt-side-navbar-bottom {
     height: var(--side-navbar-actions-height);
-    justify-content: center;
   }
 
-  .trakt-side-navbar-content {
-    gap: var(--gap-l);
-
-    background-color: var(--color-background-side-navbar);
-
-    border-radius: var(--ni-60);
-    transition: var(--transition-increment) ease-in-out;
-    transition-property: background-color;
-    box-shadow: var(--shadow-navbar);
-
-    padding: var(--ni-10) 0;
+  .trakt-side-navbar-bottom.is-expanded {
+    height: auto;
   }
 
-  .trakt-navbar-actions {
-    height: var(--side-navbar-actions-height);
-    transition: opacity var(--transition-increment) ease-in-out;
+  .trakt-side-navbar-top {
+    flex-direction: row;
+    justify-content: flex-start;
+    gap: var(--gap-xxs);
+    align-self: stretch;
 
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+    :global(.nav-logo-link) {
+      display: flex;
+      align-items: center;
+      overflow: hidden;
+      height: var(--nav-icon-size);
+    }
 
-    gap: var(--gap-m);
+    :global(.nav-logo-link .trakt-link) {
+      display: flex;
 
-    padding: var(--gap-m);
-    margin-top: env(safe-area-inset-top);
+      &:focus-visible :global(svg) {
+        color: var(--color-link-active);
+      }
+    }
 
-    padding-left: calc(
-      var(--layout-distance-side) + var(--layout-sidebar-distance)
-    );
-
-    &.is-hidden {
-      height: 0;
-      opacity: 0;
-      padding-top: 0;
-      padding-bottom: 0;
-      pointer-events: none;
+    :global(.nav-logo-link svg) {
+      height: var(--nav-icon-size);
+      width: auto;
+      color: var(--color-text-primary);
     }
   }
 
-  .trakt-navbar-actions-left {
-    min-width: 0;
-  }
-
-  .trakt-navbar-actions-right {
+  .nav-menu-button {
     display: flex;
     align-items: center;
-    gap: var(--gap-s);
+    justify-content: center;
+    flex-shrink: 0;
+
+    width: var(--side-navbar-width-collapsed);
+    height: var(--side-navbar-width-collapsed);
+
+    padding: 0;
+    background: none;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    color: inherit;
+
+    :global(svg) {
+      width: var(--nav-icon-size);
+      height: var(--nav-icon-size);
+    }
+
+    &:focus-visible {
+      border-radius: var(--border-radius-m);
+      outline: var(--border-thickness-xs) solid var(--color-link-active);
+      outline-offset: var(--ni-neg-8);
+    }
   }
 </style>

--- a/projects/client/src/lib/sections/navbar/_internal/NavGroup.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/NavGroup.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import type { Snippet } from "svelte";
+  import { slide } from "svelte/transition";
+
+  const {
+    href,
+    label,
+    title,
+    icon,
+    isCollapsed,
+    ariaLabel,
+    children,
+  }: {
+    href: string;
+    label: string;
+    title: string;
+    icon: Snippet;
+    isCollapsed: boolean;
+    ariaLabel?: string;
+    children?: Snippet;
+  } = $props();
+</script>
+
+<div class="nav-group">
+  <div class="nav-main-link" class:is-expanded={!isCollapsed}>
+    <Tooltip
+      content={title}
+      disabled={!isCollapsed}
+      variant="compact"
+      side="right"
+      delayDuration={0}
+      sideOffset={16}
+    >
+      <Link {href} {label}>
+        {@render icon()}
+        {#if !isCollapsed}
+          <span class="bold ellipsis nav-label">{title}</span>
+        {/if}
+      </Link>
+    </Tooltip>
+  </div>
+
+  {#if children && !isCollapsed}
+    <div class="nav-sub-items" transition:slide={{ duration: 150 }}>
+      <nav class="nav-sub-items-inner" aria-label={ariaLabel ?? title}>
+        {@render children()}
+      </nav>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .nav-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xxs);
+
+    width: 100%;
+  }
+
+  .nav-main-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &.is-expanded {
+      justify-content: flex-start;
+    }
+
+    :global(.trakt-tooltip-trigger) {
+      min-width: 0;
+    }
+
+    :global(.trakt-link) {
+      display: flex;
+      align-items: center;
+      gap: var(--gap-s);
+      text-decoration: none;
+      min-width: 0;
+    }
+
+    :global(svg) {
+      width: var(--nav-icon-size);
+      height: var(--nav-icon-size);
+      flex-shrink: 0;
+      display: block;
+    }
+  }
+
+  .nav-label {
+    white-space: nowrap;
+  }
+
+  .nav-sub-items-inner {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+    padding-left: calc(var(--nav-icon-size) + var(--gap-s));
+
+    :global(.trakt-link) {
+      text-decoration: none;
+      transition-property: color;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/navbar/_internal/NavbarActions.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/NavbarActions.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import CircularLogo from "$lib/components/icons/CircularLogo.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import Toast from "../../toast/Toast.svelte";
+  import FilterButton from "../components/filter/FilterButton.svelte";
+  import GetVIPLink from "../components/GetVIPLink.svelte";
+  import JoinTraktButton from "../components/JoinTraktButton.svelte";
+  import { useNavbarState } from "../useNavbarState";
+  import NavbarHeader from "./NavbarHeader.svelte";
+
+  const { state } = useNavbarState();
+</script>
+
+<div class="trakt-navbar-actions" class:is-hidden={$state.mode === "minimal"}>
+  <div class="trakt-navbar-actions-left">
+    <NavbarHeader />
+  </div>
+
+  <div class="trakt-navbar-actions-center">
+    {#if $state.actions}
+      {@render $state.actions?.()}
+    {/if}
+  </div>
+
+  <div class="trakt-navbar-actions-right">
+    <RenderFor audience="authenticated">
+      {@render $state.sortActions?.()}
+      {#if $state.seasonalActions}
+        {@render $state.seasonalActions?.()}
+      {/if}
+      <FilterButton isDisabled={!$state.hasFilters} />
+    </RenderFor>
+    <RenderFor audience="free"><GetVIPLink source="navbar" /></RenderFor>
+    <RenderFor audience="public">
+      <JoinTraktButton size="small">
+        {#snippet icon()}
+          <CircularLogo />
+        {/snippet}
+      </JoinTraktButton>
+    </RenderFor>
+  </div>
+</div>
+
+{#if $state.toastActions || $state.contextualActions}
+  <Toast>
+    {#if $state.contextualActions}
+      {@render $state.contextualActions()}
+    {:else}
+      {@render $state.toastActions?.()}
+    {/if}
+  </Toast>
+{/if}
+
+<style>
+  .trakt-navbar-actions {
+    height: var(--side-navbar-actions-height);
+    transition: opacity var(--transition-increment) ease-in-out;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--gap-m);
+    padding: var(--gap-m);
+    margin-top: env(safe-area-inset-top);
+    padding-left: calc(
+      var(--layout-distance-side) + var(--layout-sidebar-distance)
+    );
+
+    &.is-hidden {
+      height: 0;
+      opacity: 0;
+      padding-block: 0;
+      pointer-events: none;
+    }
+  }
+
+  .trakt-navbar-actions-left {
+    min-width: 0;
+  }
+
+  .trakt-navbar-actions-right {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-s);
+  }
+</style>

--- a/projects/client/src/lib/sections/navbar/_internal/SideNavbarContent.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/SideNavbarContent.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import DiscoverIcon from "$lib/components/icons/DiscoverIcon.svelte";
+  import HomeIcon from "$lib/components/icons/mobile/HomeIcon.svelte";
+  import ListIcon from "$lib/components/icons/mobile/ListIcon.svelte";
+  import SearchIcon from "$lib/components/icons/SearchIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import NavGroup from "./NavGroup.svelte";
+
+  const {
+    isCollapsed,
+  }: {
+    isCollapsed: boolean;
+  } = $props();
+</script>
+
+{#snippet iconSearch()}<SearchIcon />{/snippet}
+{#snippet iconHome()}<HomeIcon />{/snippet}
+{#snippet iconDiscover()}<DiscoverIcon />{/snippet}
+{#snippet iconList()}<ListIcon />{/snippet}
+
+{#snippet navSubLink(href: string, title: string)}
+  <Link {href} label={title}>
+    <span>{title}</span>
+  </Link>
+{/snippet}
+
+<div class="trakt-side-navbar-content" class:is-expanded={!isCollapsed}>
+  <RenderFor audience="authenticated">
+    <NavGroup
+      href={UrlBuilder.search()}
+      label={m.button_label_search()}
+      title={m.page_title_search()}
+      icon={iconSearch}
+      {isCollapsed}
+    />
+  </RenderFor>
+
+  <NavGroup
+    href={UrlBuilder.home()}
+    label={m.button_label_home()}
+    title={m.page_title_home()}
+    icon={iconHome}
+    {isCollapsed}
+  >
+    <RenderFor audience="authenticated">
+      {@render navSubLink(UrlBuilder.progress("me"), m.list_title_up_next())}
+      {@render navSubLink(UrlBuilder.calendar(), m.page_title_calendar())}
+    </RenderFor>
+  </NavGroup>
+
+  <RenderFor audience="authenticated">
+    <NavGroup
+      href={UrlBuilder.discover()}
+      label={m.button_label_discover()}
+      title={m.page_title_discover()}
+      icon={iconDiscover}
+      {isCollapsed}
+    >
+      {@render navSubLink(
+        UrlBuilder.trending({ type: "movie" }),
+        m.list_title_trending(),
+      )}
+      {@render navSubLink(
+        UrlBuilder.recommended({ type: "movie" }),
+        m.list_title_recommended(),
+      )}
+      {@render navSubLink(
+        UrlBuilder.anticipated({ type: "movie" }),
+        m.list_title_most_anticipated(),
+      )}
+      {@render navSubLink(
+        UrlBuilder.popular({ type: "movie" }),
+        m.list_title_most_popular(),
+      )}
+    </NavGroup>
+
+    <NavGroup
+      href={UrlBuilder.lists.user("me")}
+      label={m.button_label_browse_lists()}
+      title={m.page_title_lists()}
+      icon={iconList}
+      {isCollapsed}
+    >
+      {@render navSubLink(
+        UrlBuilder.lists.watchlist("me"),
+        m.page_title_watchlist(),
+      )}
+    </NavGroup>
+  </RenderFor>
+</div>
+
+<style>
+  .trakt-side-navbar-content {
+    --nav-icon-size: var(--ni-24);
+    --content-align: center;
+    --content-gap: var(--gap-l);
+    --content-bg: var(--color-background-side-navbar);
+    --content-radius: var(--ni-60);
+    --content-shadow: var(--shadow-navbar);
+    --content-padding: var(--ni-10) 0;
+
+    display: flex;
+    flex-direction: column;
+    align-items: var(--content-align);
+    align-self: center;
+    gap: var(--content-gap);
+
+    width: var(--side-navbar-width);
+
+    background-color: var(--content-bg);
+    box-shadow: var(--content-shadow);
+
+    border-radius: var(--content-radius);
+    padding: var(--content-padding);
+
+    &.is-expanded {
+      --content-align: flex-start;
+      --content-gap: var(--gap-m);
+      --content-bg: transparent;
+      --content-radius: 0;
+      --content-shadow: none;
+      --content-padding: var(--ni-10) var(--ni-12);
+
+      width: var(--side-navbar-width-expanded);
+      align-self: stretch;
+      box-sizing: border-box;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/navbar/components/ProfileLink.svelte
+++ b/projects/client/src/lib/sections/navbar/components/ProfileLink.svelte
@@ -6,6 +6,8 @@
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import ProfileImage from "../../profile-banner/ProfileImage.svelte";
 
+  const { isExpanded = false }: { isExpanded?: boolean } = $props();
+
   const { user } = useUser();
 </script>
 
@@ -22,6 +24,9 @@
       src={$user?.avatar?.url ?? ""}
       isVip={Boolean($user?.isVip)}
     />
+    {#if isExpanded}
+      <span class="trakt-profile-link-username">{$user?.username}</span>
+    {/if}
   </Link>
 </trakt-profile-button>
 
@@ -56,5 +61,12 @@
         --color-border-avatar: var(--color-link-active);
       }
     }
+  }
+
+  .trakt-profile-link-username {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-weight: 500;
   }
 </style>

--- a/projects/client/src/lib/sections/navbar/components/UserMenu.svelte
+++ b/projects/client/src/lib/sections/navbar/components/UserMenu.svelte
@@ -6,83 +6,92 @@
   import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import type { Snippet } from "svelte";
 
-  const { children }: ChildrenProps = $props();
+  const {
+    children,
+    isExpanded = false,
+  }: {
+    children: Snippet;
+    isExpanded?: boolean;
+  } = $props();
 
-  let menuVisible = $state(false);
-  let hideTimeout = $state<ReturnType<typeof setTimeout> | null>(null);
+  let hoverVisible = $state(false);
+  let hideTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const menuVisible = $derived(isExpanded || hoverVisible);
 
   function showMenu() {
+    if (isExpanded) return;
     if (hideTimeout) clearTimeout(hideTimeout);
-    menuVisible = true;
+    hoverVisible = true;
   }
 
   function scheduleHide() {
-    hideTimeout = setTimeout(() => {
-      menuVisible = false;
-    }, 150);
+    if (isExpanded) return;
+    hideTimeout = setTimeout(() => (hoverVisible = false), 150);
   }
 </script>
 
+{#snippet navItem(href: string, label: string, title: string, icon: Snippet)}
+  <div class="item">
+    <Tooltip
+      content={title}
+      disabled={isExpanded}
+      variant="compact"
+      side="right"
+      delayDuration={0}
+      sideOffset={16}
+    >
+      <Link {href} {label}>
+        {@render icon()}
+        {#if isExpanded}
+          <span class="item-label ellipsis bold">{title}</span>
+        {/if}
+      </Link>
+    </Tooltip>
+  </div>
+{/snippet}
+
+{#snippet iconHistory()}<ClockIcon />{/snippet}
+{#snippet iconLibrary()}<LibraryIcon />{/snippet}
+{#snippet iconSettings()}<GearIcon />{/snippet}
+
 <div
   class="trakt-user-menu-zone"
+  class:is-expanded={isExpanded}
   onmouseenter={showMenu}
   onmouseleave={scheduleHide}
   role="presentation"
 >
-  <div class="trakt-user-menu" class:is-visible={menuVisible}>
-    <div class="trakt-user-menu-items">
-      <nav class="trakt-user-menu-items-inner" aria-label="User menu">
-        <div class="trakt-user-menu-item">
-          <Tooltip
-            content={m.page_title_history()}
-            variant="compact"
-            side="right"
-            delayDuration={0}
-            sideOffset={16}
-          >
-            <Link href={UrlBuilder.history.home()} label={m.button_label_history()}>
-              <ClockIcon />
-            </Link>
-          </Tooltip>
-        </div>
-
-        <div class="trakt-user-menu-item">
-          <Tooltip
-            content={m.page_title_library()}
-            variant="compact"
-            side="right"
-            delayDuration={0}
-            sideOffset={16}
-          >
-            <Link href={UrlBuilder.library.home()} label={m.button_label_library()}>
-              <LibraryIcon />
-            </Link>
-          </Tooltip>
-        </div>
-
-        <div class="trakt-user-menu-item">
-          <Tooltip
-            content={m.button_label_settings()}
-            variant="compact"
-            side="right"
-            delayDuration={0}
-            sideOffset={16}
-          >
-            <Link
-              href={UrlBuilder.settings.general()}
-              label={m.button_label_settings()}
-            >
-              <GearIcon />
-            </Link>
-          </Tooltip>
-        </div>
+  <div class="menu" class:is-visible={menuVisible}>
+    <div class="items-grid">
+      <nav class="items" aria-label="User menu">
+        {@render navItem(
+          UrlBuilder.history.home(),
+          m.button_label_history(),
+          m.page_title_history(),
+          iconHistory,
+        )}
+        {@render navItem(
+          UrlBuilder.library.home(),
+          m.button_label_library(),
+          m.page_title_library(),
+          iconLibrary,
+        )}
+        {@render navItem(
+          UrlBuilder.settings.general(),
+          m.button_label_settings(),
+          m.button_label_settings(),
+          iconSettings,
+        )}
       </nav>
     </div>
 
-    <div class="trakt-user-menu-profile">
+    <div class="profile">
       <Tooltip
         content={m.page_title_profile()}
+        disabled={isExpanded}
         variant="compact"
         side="right"
         delayDuration={0}
@@ -95,25 +104,38 @@
 </div>
 
 <style lang="scss">
-  @use "$style/scss/mixins/index" as *;
-
   .trakt-user-menu-zone {
+    --zone-align: center;
+    --zone-gap: var(--gap-l);
+    --zone-icon-size: var(--ni-24);
+    --zone-icon-padding: 0;
+    --zone-items-padding: var(--ni-10) 0;
+
     position: relative;
     height: var(--side-navbar-actions-height);
+
+    &.is-expanded {
+      --zone-align: flex-start;
+      --zone-gap: var(--gap-s);
+      --zone-icon-size: var(--ni-32);
+      --zone-icon-padding: 0 var(--ni-6);
+      --zone-items-padding: 0;
+
+      height: auto;
+      width: 100%;
+    }
   }
 
-  .trakt-user-menu {
+  .menu {
     position: absolute;
     bottom: 0;
     left: 50%;
     transform: translateX(-50%);
-
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: var(--zone-align);
     width: var(--side-navbar-width);
     border-radius: var(--ni-60);
-
     transition:
       background-color var(--transition-increment) ease-in-out,
       box-shadow var(--transition-increment) ease-in-out;
@@ -122,9 +144,20 @@
       background-color: var(--color-background-side-navbar);
       box-shadow: var(--shadow-navbar);
     }
+
+    .is-expanded & {
+      position: static;
+      transform: none;
+      width: 100%;
+      border-radius: 0;
+      padding: 0 calc(var(--ni-16) * 0.5);
+      overflow: hidden;
+      background-color: transparent;
+      box-shadow: none;
+    }
   }
 
-  .trakt-user-menu-items {
+  .items-grid {
     display: grid;
     grid-template-rows: 0fr;
     transition: grid-template-rows var(--transition-increment) ease-in-out;
@@ -132,19 +165,20 @@
     .is-visible & {
       grid-template-rows: 1fr;
     }
+
+    .is-expanded & {
+      width: 100%;
+    }
   }
 
-  .trakt-user-menu-items-inner {
+  .items {
     overflow: hidden;
     min-height: 0;
-
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--gap-l);
-
-    padding: var(--ni-10) 0;
-
+    gap: var(--zone-gap);
+    padding: var(--zone-items-padding);
     opacity: 0;
     pointer-events: none;
     transition: opacity var(--transition-increment) ease-in-out;
@@ -153,19 +187,44 @@
       opacity: 1;
       pointer-events: auto;
     }
+
+    .is-expanded & {
+      align-items: flex-start;
+    }
   }
 
-  .trakt-user-menu-profile {
+  .profile {
     display: flex;
     align-items: center;
     justify-content: center;
     padding: var(--gap-xs) 0;
+
+    .is-expanded & {
+      justify-content: flex-start;
+      width: 100%;
+
+      :global(a.trakt-link) {
+        justify-content: flex-start;
+        gap: var(--gap-s);
+      }
+    }
   }
 
-  .trakt-user-menu-item {
+  .item {
+    .is-expanded & {
+      width: 100%;
+    }
+
+    :global(.trakt-tooltip-trigger) {
+      min-width: 0;
+    }
+
     :global(svg) {
-      width: var(--ni-24);
-      height: var(--ni-24);
+      width: var(--zone-icon-size);
+      height: var(--zone-icon-size);
+      padding: var(--zone-icon-padding);
+      box-sizing: border-box;
+      flex-shrink: 0;
       display: block;
     }
 
@@ -175,6 +234,18 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      min-width: 0;
+
+      .is-expanded & {
+        justify-content: flex-start;
+        gap: var(--gap-s);
+      }
     }
+  }
+
+  .item-label {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 </style>

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -197,6 +197,8 @@
    */
   --navbar-side-padding: var(--ni-16);
   --navbar-height: var(--ni-72);
+  --side-navbar-width-collapsed: var(--ni-48);
+  --side-navbar-width-expanded: var(--ni-180);
   --side-navbar-width: var(--ni-48);
   --side-navbar-actions-height: var(--ni-40);
   --mobile-navbar-height: calc(var(--ni-56) + env(safe-area-inset-bottom, 0));


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2100
- Adds support for expanding the side navbar

## ⚠️ Caveat ⚠️
In the collapsed state, the trakt logo is not visible. I experimented with putting in the actions bar, but that looked crappy:
<img width="370" height="626" alt="Screenshot 2026-04-14 at 10 17 24" src="https://github.com/user-attachments/assets/0e577949-63fd-496c-9b6e-913551d892b4" />

Either we leave it without the logo, or we do a follow-up with a better solution😅

## 👀 Example 👀

https://github.com/user-attachments/assets/ffb13588-aa3a-4189-8319-655ef602103a

