### PR TITLE
fix(summary): displays episodes in season drawer in show context

### DIFF
--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -168,6 +168,8 @@
       }}
       popupActions={props.popupActions}
       layout={isCompact ? "compact" : "default"}
+      context={"context" in props ? props.context : undefined}
+      coverUrl={"coverUrl" in props ? props.coverUrl : undefined}
       {tag}
       badge={action}
       {sortTag}

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -71,13 +71,27 @@
     !isCompact && ($isTabletLarge || $isDesktop),
   );
 
-  const coverData = $derived({
-    background:
-      rest.type === "episode"
-        ? (rest.episode.cover.url ?? EPISODE_COVER_PLACEHOLDER)
-        : media.cover.url.thumb,
-    poster: media.poster.url.thumb,
-    title: rest.type === "episode" ? rest.episode.title : media.title,
+  const isShowContext = $derived(
+    rest.type === "episode" && "context" in rest && rest.context === "show",
+  );
+
+  const coverData = $derived.by(() => {
+    if (rest.type === "episode") {
+      const episodeCover = rest.episode.cover.url ?? EPISODE_COVER_PLACEHOLDER;
+      const posterOverride = "coverUrl" in rest ? rest.coverUrl : undefined;
+
+      return {
+        background: episodeCover,
+        poster: posterOverride ?? media.poster.url.thumb,
+        title: rest.episode.title,
+      };
+    }
+
+    return {
+      background: media.cover.url.thumb,
+      poster: media.poster.url.thumb,
+      title: media.title,
+    };
   });
 
   const indicators = $derived.by(() => {
@@ -128,6 +142,12 @@
       heightCover: "var(--height-summary-card-cover-compact)",
     };
   });
+
+  const href = $derived(
+    isShowContext && rest.type === "episode"
+      ? UrlBuilder.episode(media.slug, rest.episode.season, rest.episode.number)
+      : UrlBuilder.media(media.type, media.slug),
+  );
 </script>
 
 <Card
@@ -158,7 +178,7 @@
   />
 
   <Link
-    href={UrlBuilder.media(media.type, media.slug)}
+    {href}
     onclick={() => source && track({ source, type: rest.type })}
     color="inherit"
   >
@@ -208,6 +228,15 @@
           {:else}
             {toHumanDate(new Date(), rest.date, getLocale())}
           {/if}
+        </p>
+      {:else if isShowContext && rest.type === "episode"}
+        <p class="trakt-card-title ellipsis">
+          <Spoiler media={rest.episode} show={media} type="episode">
+            {rest.episode.title}
+          </Spoiler>
+        </p>
+        <p class="trakt-card-subtitle secondary ellipsis">
+          {episodeSubtitle(rest.episode)}
         </p>
       {:else if rest.type === "episode" || (rest.variant === "start" && "episode" in rest)}
         <p class="trakt-card-title ellipsis">

--- a/projects/client/src/lib/sections/lists/components/models/EpisodeCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/EpisodeCardProps.ts
@@ -11,11 +11,13 @@ export type EpisodeItemVariant =
     variant: 'next';
     episode: EpisodeProgressEntry;
     context?: EpisodeContext;
+    coverUrl?: string;
   }
   | {
     variant: 'default' | 'upcoming' | 'calendar';
     episode: EpisodeEntry;
     context?: EpisodeContext;
+    coverUrl?: string;
   }
   | {
     variant: 'activity';

--- a/projects/client/src/lib/sections/lists/season/SeasonList.svelte
+++ b/projects/client/src/lib/sections/lists/season/SeasonList.svelte
@@ -35,6 +35,10 @@
     seasons.filter((s) => s.number > 0 && s.number < currentSeason),
   );
 
+  const seasonPosterUrl = $derived(
+    seasons.find((s) => s.number === currentSeason)?.poster?.url.thumb,
+  );
+
   const episodeProps = $derived.by(() => {
     if (hasSingleSeason) return { title, subtitle };
     return isLargeScreen ? { title } : {};
@@ -62,6 +66,7 @@
   {show}
   {previousSeasons}
   episodes={$episodes}
+  coverUrl={seasonPosterUrl}
   headerActions={isLargeScreen && !hasSingleSeason ? headerActions : undefined}
   {...episodeProps}
 />

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -18,6 +18,7 @@
     hasUnseenEpisodes: boolean;
     style?: BaseItemProps["style"];
     source: string;
+    coverUrl?: string;
   };
 
   const {
@@ -28,6 +29,7 @@
     hasUnseenEpisodes,
     style,
     source,
+    coverUrl,
   }: SeasonEpisodeItemProps = $props();
 
   const isFuture = $derived(episode.airDate > new Date());
@@ -61,6 +63,7 @@
   {episode}
   media={show}
   {style}
+  {coverUrl}
   popupActions={hasBulkMarkAsWatched ? popupActions : undefined}
   variant={isFuture ? "upcoming" : "default"}
   context="show"

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
@@ -21,6 +21,7 @@
     title?: string;
     headerActions?: Snippet;
     subtitle?: string;
+    coverUrl?: string;
   };
 
   const {
@@ -30,6 +31,7 @@
     title,
     subtitle,
     headerActions,
+    coverUrl,
   }: SeasonEpisodeListProps = $props();
 
   const { history } = useUser();
@@ -57,6 +59,7 @@
       {previousSeasons}
       {watchedEpisodes}
       {hasUnseenEpisodes}
+      {coverUrl}
       source="season-episode-list"
     />
   {/snippet}

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
@@ -42,6 +42,10 @@
     seasons.filter((s) => s.number > 0 && s.number < currentSeason),
   );
 
+  const seasonPosterUrl = $derived(
+    seasons.find((s) => s.number === currentSeason)?.poster?.url.thumb,
+  );
+
   const buildSeasonLink = (seasonNumber: number) => {
     const url = new URL(page.url);
     url.searchParams.set("season", String(seasonNumber));
@@ -111,6 +115,7 @@
                 {previousSeasons}
                 {watchedEpisodes}
                 {hasUnseenEpisodes}
+                coverUrl={seasonPosterUrl}
                 style="compact"
                 source="seasons-drawer"
               />


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2103
- Episodes in the seasons drawer are no shown within the show context:
  - Titles are the episode title.
  - Link is to the episode.
  - Season cover is used as the cover image.

## 👀 Example 👀
Before/after:

https://github.com/user-attachments/assets/3f15babd-74da-4481-a666-723a6324363b


https://github.com/user-attachments/assets/ffda63b4-d637-4d5a-bf32-11f6cf8c519d

