### PR TITLE
fix(media) / unify release date logic

### DIFF
--- a/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.spec.ts
+++ b/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.spec.ts
@@ -26,7 +26,7 @@ describe('getDisplayableRatings', () => {
 
   it('should get the ratings if it has aired items', () => {
     const entry = {
-      airDate: new Date(Date.now() - time.years(1)),
+      effectiveReleaseDate: new Date(Date.now() - time.years(1)),
       type: 'movie',
     } as unknown as MovieEntry;
 
@@ -35,7 +35,7 @@ describe('getDisplayableRatings', () => {
 
   it('should get empty ratings for unaired items', () => {
     const entry = {
-      airDate: new Date(Date.now() + time.years(1)),
+      effectiveReleaseDate: new Date(Date.now() + time.years(1)),
       type: 'movie',
     } as unknown as MovieEntry;
 
@@ -46,7 +46,7 @@ describe('getDisplayableRatings', () => {
 
   it('should get the ratings if a movie is released before the air date', () => {
     const entry = {
-      airDate: new Date(Date.now() + time.days(7)),
+      effectiveReleaseDate: new Date(Date.now() + time.days(7)),
       type: 'movie',
       status: 'released',
     } as unknown as MovieEntry;

--- a/projects/client/src/lib/requests/_internal/mapToEpisodeEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToEpisodeEntry.ts
@@ -19,6 +19,12 @@ export function mapToEpisodeEntry(
 
   const airDate = new Date(episode.first_aired ?? MAX_DATE);
   const releaseDate = new Date(episode.released ?? MAX_DATE);
+  const effectiveReleaseDate = new Date(
+    Math.min(
+      airDate.getTime(),
+      releaseDate.getTime(),
+    ),
+  );
 
   return {
     id: episode.ids.trakt,
@@ -38,10 +44,8 @@ export function mapToEpisodeEntry(
     },
     airDate,
     releaseDate,
-    year: Math.min(
-      airDate.getFullYear(),
-      releaseDate.getFullYear(),
-    ),
+    effectiveReleaseDate,
+    year: effectiveReleaseDate.getFullYear(),
     postCredits: mapToPostCredits(episode),
     rating: mapToTraktRating(episode.rating),
   };

--- a/projects/client/src/lib/requests/_internal/mapToMovieEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMovieEntry.ts
@@ -27,7 +27,7 @@ export function mapToMovieEntry(
   const poster = mapToPoster(movie.images);
   const cover = mapToCover(movie.images);
   const logo = mapToLogo(movie.images);
-  const releaseDate = new Date(movie.released ?? MAX_DATE);
+  const effectiveReleaseDate = new Date(movie.released ?? MAX_DATE);
 
   return {
     id: movie.ids.trakt,
@@ -59,8 +59,9 @@ export function mapToMovieEntry(
     /**
      * Duplicate for compat with other entities.
      */
-    airDate: releaseDate,
-    releaseDate,
+    airDate: effectiveReleaseDate,
+    releaseDate: effectiveReleaseDate,
+    effectiveReleaseDate,
     certification: mapMovieCertificationResponse(movie.certification),
     votes: movie.votes ?? 0,
     plexSlug: movie.ids.plex?.slug,

--- a/projects/client/src/lib/requests/_internal/mapToShowEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToShowEntry.ts
@@ -24,7 +24,7 @@ export function mapToShowEntry(
   const runtime = show.runtime ?? NaN;
   const episodeCount = show.aired_episodes ?? NaN;
   const totalRuntime = show.total_runtime ?? (runtime * episodeCount);
-  const releaseDate = new Date(show.first_aired ?? MAX_DATE);
+  const effectiveReleaseDate = new Date(show.first_aired ?? MAX_DATE);
 
   return {
     id: show.ids.trakt,
@@ -61,8 +61,9 @@ export function mapToShowEntry(
     /**
      * Duplicate for compat with other entities.
      */
-    airDate: releaseDate,
-    releaseDate,
+    airDate: effectiveReleaseDate,
+    releaseDate: effectiveReleaseDate,
+    effectiveReleaseDate,
     certification: show.certification,
     votes: show.votes ?? 0,
     plexSlug: show.ids.plex?.slug,

--- a/projects/client/src/lib/requests/models/EpisodeEntry.ts
+++ b/projects/client/src/lib/requests/models/EpisodeEntry.ts
@@ -17,6 +17,7 @@ const BaseEpisodeEntrySchema = z.object({
   genres: genreOptionSchema.array(),
   airDate: z.date(),
   releaseDate: z.date(),
+  effectiveReleaseDate: z.date(),
   type: EpisodeTypeSchema,
   runtime: z.number(),
   year: z.number(),

--- a/projects/client/src/lib/requests/models/MediaEntry.ts
+++ b/projects/client/src/lib/requests/models/MediaEntry.ts
@@ -43,6 +43,7 @@ export const MediaEntrySchema = z.object({
   trailer: HttpsUrlSchema.nullish(),
   airDate: z.date(),
   releaseDate: z.date(),
+  effectiveReleaseDate: z.date(),
   certification: z.string().nullish(),
   votes: z.number(),
   colors: z.tuple([z.string(), z.string()]).optional(),

--- a/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
@@ -43,6 +43,9 @@ function mapShowProgressResponse(
 
   const airDate = new Date(episode?.first_aired ?? MAX_DATE);
   const releaseDate = new Date(episode?.released ?? MAX_DATE);
+  const effectiveReleaseDate = new Date(
+    Math.min(airDate.getTime(), releaseDate.getTime()),
+  );
 
   const key = `episode-${episode?.ids.trakt ?? crypto.randomUUID()}`;
 
@@ -58,6 +61,7 @@ function mapShowProgressResponse(
     },
     airDate,
     releaseDate,
+    effectiveReleaseDate,
     total: item.aired,
     completed: item.completed,
     remaining: item.aired - item.completed,

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -23,10 +23,7 @@
   const { sortTag, ...props }: EpisodeCardProps & { sortTag?: Snippet } =
     $props();
 
-  const isFuture = $derived(
-    props.episode.airDate > new Date() &&
-      props.episode.releaseDate > new Date(),
-  );
+  const isFuture = $derived(props.episode.effectiveReleaseDate > new Date());
   const isActivity = $derived(props.variant === "activity");
   const isHidden = $derived(props.status === "hidden");
   const isListItem = $derived(props.variant === "list-item");
@@ -110,7 +107,7 @@
       {#if props.variant === "upcoming"}
         <AirDateTag
           i18n={TagIntlProvider}
-          airDate={props.episode.airDate}
+          airDate={props.episode.effectiveReleaseDate}
           type="tag"
         />
         <EpisodeStatusTag

--- a/projects/client/src/lib/sections/lists/progress/_internal/mapToMarkAsWatchedTarget.ts
+++ b/projects/client/src/lib/sections/lists/progress/_internal/mapToMarkAsWatchedTarget.ts
@@ -10,8 +10,7 @@ export function mapToMarkAsWatchedTarget(
       type: 'show' as const,
       media: {
         id: entry.id,
-        airDate: entry.airDate,
-        releaseDate: entry.releaseDate,
+        effectiveReleaseDate: entry.effectiveReleaseDate,
         seasons: [
           {
             number: entry.episode.season,

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -48,8 +48,7 @@
       title={show.title}
       media={{
         id: show.id,
-        airDate: show.airDate,
-        releaseDate: show.releaseDate,
+        effectiveReleaseDate: show.effectiveReleaseDate,
         seasons: getEpisodesUntil({
           previousSeasons,
           episode,

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.spec.ts
@@ -104,7 +104,7 @@ describe('useMarkAsWatched', () => {
   describe('media type: movie', () => {
     const props = {
       type: 'movie' as const,
-      media: { id: 1, airDate: new Date(), releaseDate: new Date() },
+      media: { id: 1, effectiveReleaseDate: new Date() },
     };
 
     runCommonTests(props, InvalidateAction.MarkAsWatched('movie'));
@@ -121,7 +121,7 @@ describe('useMarkAsWatched', () => {
   describe('media type: show', () => {
     const props = {
       type: 'show' as const,
-      media: { id: 1, airDate: new Date(), releaseDate: new Date() },
+      media: { id: 1, effectiveReleaseDate: new Date() },
     };
 
     runCommonTests(props, InvalidateAction.MarkAsWatched('show'));
@@ -150,8 +150,7 @@ describe('useMarkAsWatched', () => {
         id: 1,
         season: 1,
         number: 1,
-        airDate: new Date(),
-        releaseDate: new Date(),
+        effectiveReleaseDate: new Date(),
       },
       show: { id: 3, title: 'show' },
     };
@@ -166,8 +165,7 @@ describe('useMarkAsWatched', () => {
             id: 1,
             season: 1,
             number: 1,
-            airDate: new Date(),
-            releaseDate: new Date(),
+            effectiveReleaseDate: new Date(),
           },
           show: ShowSiloMappedMock,
         })
@@ -185,36 +183,31 @@ describe('useMarkAsWatched', () => {
               id: 1,
               season: 1,
               number: 1,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
             {
               id: 2,
               season: 1,
               number: 2,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
             {
               id: 3,
               season: 1,
               number: 3,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
             {
               id: 4,
               season: 1,
               number: 4,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
             {
               id: 5,
               season: 1,
               number: 5,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
           ],
           show: ShowSiloMappedMock,
@@ -232,8 +225,7 @@ describe('useMarkAsWatched', () => {
             id: 1,
             season: 1,
             number: 2,
-            airDate: new Date(),
-            releaseDate: new Date(),
+            effectiveReleaseDate: new Date(),
           },
           show: ShowSiloMappedMock,
         })
@@ -251,57 +243,49 @@ describe('useMarkAsWatched', () => {
               id: 1,
               season: 1,
               number: 1,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
             {
               id: 2,
               season: 1,
               number: 2,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
             {
               id: 3,
               season: 1,
               number: 3,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
             {
               id: 4,
               season: 1,
               number: 4,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
             {
               id: 5,
               season: 1,
               number: 5,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
             {
               id: 6,
               season: 1,
               number: 6,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
             {
               id: 7,
               season: 1,
               number: 7,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
             {
               id: 8,
               season: 1,
               number: 8,
-              airDate: new Date(),
-              releaseDate: new Date(),
+              effectiveReleaseDate: new Date(),
             },
           ],
           show: ShowDevsMappedMock,

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
@@ -15,7 +15,7 @@ import { toMarkAsWatchedPayload } from './toMarkAsWatchedPayload.ts';
 import { useIsWatched } from './useIsWatched.ts';
 
 export type MarkAsWatchedStoreProps = MediaStoreProps<
-  { id: number; airDate: Date; releaseDate: Date; status?: MediaStatus }
+  { id: number; effectiveReleaseDate: Date; status?: MediaStatus }
 >;
 
 export function useMarkAsWatched(

--- a/projects/client/src/lib/utils/media/hasAired.spec.ts
+++ b/projects/client/src/lib/utils/media/hasAired.spec.ts
@@ -15,8 +15,7 @@ describe('hasAired', () => {
         hasAired({
           status: 'released',
           type: 'movie',
-          airDate: new Date(),
-          releaseDate: new Date(),
+          effectiveReleaseDate: new Date(),
         }),
       ).toBe(true);
     });
@@ -37,8 +36,7 @@ describe('hasAired', () => {
           hasAired({
             status,
             type: 'movie',
-            airDate: futureDate,
-            releaseDate: futureDate,
+            effectiveReleaseDate: futureDate,
           }),
         ).toBe(false);
       });
@@ -49,33 +47,28 @@ describe('hasAired', () => {
         hasAired({
           status: 'post production',
           type: 'movie',
-          airDate: new Date(),
-          releaseDate: new Date(),
+          effectiveReleaseDate: new Date(),
         }),
       ).toBe(true);
     });
 
     it('returns true for movies released on streaming with a future air date', () => {
       const yesterday = addDays(new Date(), -1);
-      const tomorrow = addDays(new Date(), 1);
       expect(
         hasAired({
           type: 'movie',
-          airDate: tomorrow,
-          releaseDate: yesterday,
+          effectiveReleaseDate: yesterday,
         }),
       ).toBe(true);
     });
 
     it('returns true for movies released on streaming with a future air date and non-released status', () => {
       const yesterday = addDays(new Date(), -1);
-      const tomorrow = addDays(new Date(), 1);
       expect(
         hasAired({
           status: 'post production',
           type: 'movie',
-          airDate: tomorrow,
-          releaseDate: yesterday,
+          effectiveReleaseDate: yesterday,
         }),
       ).toBe(true);
     });
@@ -84,42 +77,41 @@ describe('hasAired', () => {
   const runCommonTests = (type: 'show' | 'episode') => {
     it('returns true for items that aired today', () => {
       const today = new Date();
-      expect(hasAired({ airDate: today, releaseDate: today, type })).toBe(true);
+      expect(hasAired({ effectiveReleaseDate: today, type })).toBe(true);
     });
 
     it('returns true for items that aired yesterday', () => {
       const yesterday = addDays(new Date(), -1);
       expect(
-        hasAired({ airDate: yesterday, releaseDate: yesterday, type }),
+        hasAired({ effectiveReleaseDate: yesterday, type }),
       ).toBe(true);
     });
 
     it('returns true for items that aired 1 week ago', () => {
       const oneWeekAgo = addDays(new Date(), -7);
       expect(
-        hasAired({ airDate: oneWeekAgo, releaseDate: oneWeekAgo, type }),
+        hasAired({ effectiveReleaseDate: oneWeekAgo, type }),
       ).toBe(true);
     });
 
     it('returns false for items that will air tomorrow', () => {
       const tomorrow = addDays(new Date(), 1);
       expect(
-        hasAired({ airDate: tomorrow, releaseDate: tomorrow, type }),
+        hasAired({ effectiveReleaseDate: tomorrow, type }),
       ).toBe(false);
     });
 
     it('returns false for items that will air in 7 days', () => {
       const sevenDaysFromNow = addDays(new Date(), 7);
       expect(
-        hasAired({ airDate: sevenDaysFromNow, releaseDate: sevenDaysFromNow, type }),
+        hasAired({ effectiveReleaseDate: sevenDaysFromNow, type }),
       ).toBe(false);
     });
 
     it('returns true for items released on streaming with a future air date', () => {
       const yesterday = addDays(new Date(), -1);
-      const tomorrow = addDays(new Date(), 1);
       expect(
-        hasAired({ airDate: tomorrow, releaseDate: yesterday, type }),
+        hasAired({ effectiveReleaseDate: yesterday, type }),
       ).toBe(true);
     });
   };

--- a/projects/client/src/lib/utils/media/hasAired.ts
+++ b/projects/client/src/lib/utils/media/hasAired.ts
@@ -4,16 +4,12 @@ import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
 
 type HasAiredProps = {
   type: ExtendedMediaType | EpisodeType;
-  airDate: Date;
-  releaseDate: Date;
+  effectiveReleaseDate: Date;
   status?: MediaStatus;
 };
 
 export function hasAired(props: HasAiredProps): boolean {
-  const hasAired = props.airDate <= new Date();
-  const hasReleased = props.releaseDate <= new Date();
-
-  const isAvailable = hasAired || hasReleased;
+  const isAvailable = props.effectiveReleaseDate <= new Date();
 
   if (props.type === 'movie' && Boolean(props.status)) {
     return props.status === 'released' || isAvailable;

--- a/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloMappedMock.ts
@@ -19,6 +19,7 @@ export const EpisodeSiloMappedMock: EpisodeEntry = {
   },
   'airDate': new Date('2023-05-05T01:00:00.000Z'),
   'releaseDate': new Date('2023-05-05T01:00:00.000Z'),
+  'effectiveReleaseDate': new Date('2023-05-05T01:00:00.000Z'),
   'year': 2023,
   'postCredits': [],
 };

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts
@@ -53,6 +53,7 @@ export const MovieHereticMappedMock: MovieEntry = {
   'trailer': 'https://youtube.com/watch?v=jpWUOxRozZg',
   'airDate': new Date('2024-11-08T00:00:00.000Z'),
   'releaseDate': new Date('2024-11-08T00:00:00.000Z'),
+  'effectiveReleaseDate': new Date('2024-11-08T00:00:00.000Z'),
   'certification': 'R',
   'country': 'us',
   'languages': [

--- a/projects/client/src/mocks/data/summary/movies/matrix/MovieMatrixMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/matrix/MovieMatrixMappedMock.ts
@@ -57,6 +57,7 @@ export const MovieMatrixMappedMock: MovieEntry = {
   'trailer': 'https://youtube.com/watch?v=d0XTFAMmhrE',
   'airDate': new Date('1999-03-31T00:00:00.000Z'),
   'releaseDate': new Date('1999-03-31T00:00:00.000Z'),
+  'effectiveReleaseDate': new Date('1999-03-31T00:00:00.000Z'),
   'certification': 'R',
   'votes': 65943,
   'plexSlug': 'the-matrix-1999',

--- a/projects/client/src/mocks/data/summary/shows/devs/ShowDevsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/devs/ShowDevsMappedMock.ts
@@ -60,6 +60,7 @@ export const ShowDevsMappedMock: ShowEntry = {
   'trailer': 'https://youtube.com/watch?v=Fp9LMsI6uJ8',
   'airDate': new Date('2020-03-05T05:00:00.000Z'),
   'releaseDate': new Date('2020-03-05T05:00:00.000Z'),
+  'effectiveReleaseDate': new Date('2020-03-05T05:00:00.000Z'),
   'certification': 'TV-MA',
   'votes': 3522,
   'plexSlug': 'devs',

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts
@@ -50,6 +50,7 @@ export const ShowSiloMappedMock: ShowEntry = {
   'trailer': 'https://youtube.com/watch?v=8ZYhuvIv1pA',
   'airDate': new Date('2023-05-05T01:00:00.000Z'),
   'releaseDate': new Date('2023-05-05T01:00:00.000Z'),
+  'effectiveReleaseDate': new Date('2023-05-05T01:00:00.000Z'),
   'certification': 'TV-MA',
   'network': 'Apple TV+',
   'country': 'us',

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMinimalMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMinimalMappedMock.ts
@@ -4,6 +4,7 @@ import { MAX_DATE } from '$lib/utils/constants.ts';
 export const ShowSiloMinimalMappedMock: ShowEntry = {
   'airDate': MAX_DATE,
   'releaseDate': MAX_DATE,
+  'effectiveReleaseDate': MAX_DATE,
   'certification': undefined,
   'country': undefined,
   'cover': {

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloProgressMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloProgressMappedMock.ts
@@ -17,6 +17,7 @@ export const ShowSiloProgressMappedMock: EpisodeProgressEntry = {
   },
   'airDate': new Date('2024-11-22T02:00:00.000Z'),
   'releaseDate': new Date('2024-11-22T02:00:00.000Z'),
+  'effectiveReleaseDate': new Date('2024-11-22T02:00:00.000Z'),
   'total': 17,
   'completed': 11,
   'remaining': 6,

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonEpisodesMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonEpisodesMappedMock.ts
@@ -4,6 +4,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
   {
     'airDate': new Date('2023-05-05T01:00:00.000Z'),
     'releaseDate': new Date('2023-05-05T01:00:00.000Z'),
+    'effectiveReleaseDate': new Date('2023-05-05T01:00:00.000Z'),
     'cover': {
       'url':
         'https://walter-r2.trakt.tv/images/episodes/005/165/667/screenshots/thumb/e035db5f06.jpg.webp',
@@ -25,6 +26,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
   {
     'airDate': new Date('2023-05-05T01:00:00.000Z'),
     'releaseDate': new Date('2023-05-05T01:00:00.000Z'),
+    'effectiveReleaseDate': new Date('2023-05-05T01:00:00.000Z'),
     'cover': {
       'url':
         'https://walter-r2.trakt.tv/images/episodes/007/374/195/screenshots/thumb/34fd1da36a.jpg.webp',
@@ -46,6 +48,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
   {
     'airDate': new Date('2023-05-12T01:00:00.000Z'),
     'releaseDate': new Date('2023-05-12T01:00:00.000Z'),
+    'effectiveReleaseDate': new Date('2023-05-12T01:00:00.000Z'),
     'cover': {
       'url':
         'https://walter-r2.trakt.tv/images/episodes/007/374/298/screenshots/thumb/ab930b719e.jpg.webp',
@@ -67,6 +70,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
   {
     'airDate': new Date('2023-05-19T01:00:00.000Z'),
     'releaseDate': new Date('2023-05-19T01:00:00.000Z'),
+    'effectiveReleaseDate': new Date('2023-05-19T01:00:00.000Z'),
     'cover': {
       'url':
         'https://walter-r2.trakt.tv/images/episodes/007/374/307/screenshots/thumb/b1d7a96ac8.jpg.webp',
@@ -88,6 +92,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
   {
     'airDate': new Date('2023-05-26T01:00:00.000Z'),
     'releaseDate': new Date('2023-05-26T01:00:00.000Z'),
+    'effectiveReleaseDate': new Date('2023-05-26T01:00:00.000Z'),
     'cover': {
       'url':
         'https://walter-r2.trakt.tv/images/episodes/007/374/308/screenshots/thumb/19c2c320bc.jpg.webp',
@@ -109,6 +114,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
   {
     'airDate': new Date('2023-06-02T01:00:00.000Z'),
     'releaseDate': new Date('2023-06-02T01:00:00.000Z'),
+    'effectiveReleaseDate': new Date('2023-06-02T01:00:00.000Z'),
     'cover': {
       'url':
         'https://walter-r2.trakt.tv/images/episodes/007/374/309/screenshots/thumb/8fd4b52a0a.jpg.webp',
@@ -130,6 +136,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
   {
     'airDate': new Date('2023-06-09T01:00:00.000Z'),
     'releaseDate': new Date('2023-06-09T01:00:00.000Z'),
+    'effectiveReleaseDate': new Date('2023-06-09T01:00:00.000Z'),
     'cover': {
       'url':
         'https://walter-r2.trakt.tv/images/episodes/007/374/310/screenshots/thumb/daaa0c7509.jpg.webp',
@@ -151,6 +158,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
   {
     'airDate': new Date('2023-06-16T01:00:00.000Z'),
     'releaseDate': new Date('2023-06-16T01:00:00.000Z'),
+    'effectiveReleaseDate': new Date('2023-06-16T01:00:00.000Z'),
     'cover': {
       'url':
         'https://walter-r2.trakt.tv/images/episodes/007/374/312/screenshots/thumb/0a23d84196.jpg.webp',
@@ -172,6 +180,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
   {
     'airDate': new Date('2023-06-23T01:00:00.000Z'),
     'releaseDate': new Date('2023-06-23T01:00:00.000Z'),
+    'effectiveReleaseDate': new Date('2023-06-23T01:00:00.000Z'),
     'cover': {
       'url':
         'https://walter-r2.trakt.tv/images/episodes/007/374/313/screenshots/thumb/0671601160.jpg.webp',
@@ -193,6 +202,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
   {
     'airDate': new Date('2023-06-30T01:00:00.000Z'),
     'releaseDate': new Date('2023-06-30T01:00:00.000Z'),
+    'effectiveReleaseDate': new Date('2023-06-30T01:00:00.000Z'),
     'cover': {
       'url':
         'https://walter-r2.trakt.tv/images/episodes/007/374/314/screenshots/thumb/8f3f471d79.jpg.webp',

--- a/projects/client/src/mocks/data/sync/mapped/LibraryMappedMock.ts
+++ b/projects/client/src/mocks/data/sync/mapped/LibraryMappedMock.ts
@@ -7,6 +7,7 @@ export const LibraryMappedMock: LibraryItem[] = [
     'episode': {
       'airDate': new Date('2025-09-04T02:00:00.000Z'),
       'releaseDate': new Date('2025-09-04T02:00:00.000Z'),
+      'effectiveReleaseDate': new Date('2025-09-04T02:00:00.000Z'),
       'cover': {
         'url':
           'https://walter-r2.trakt.tv/images/episodes/013/352/063/screenshots/thumb/60214573bb.jpg.webp',
@@ -29,6 +30,7 @@ export const LibraryMappedMock: LibraryItem[] = [
     'media': {
       'airDate': new Date('1997-08-14T02:00:00.000Z'),
       'releaseDate': new Date('1997-08-14T02:00:00.000Z'),
+      'effectiveReleaseDate': new Date('1997-08-14T02:00:00.000Z'),
       'certification': 'TV-MA',
       'colors': undefined,
       'country': 'us',
@@ -103,6 +105,7 @@ export const LibraryMappedMock: LibraryItem[] = [
     'media': {
       'airDate': new Date('2025-05-02T00:00:00.000Z'),
       'releaseDate': new Date('2025-05-02T00:00:00.000Z'),
+      'effectiveReleaseDate': new Date('2025-05-02T00:00:00.000Z'),
       'certification': undefined,
       'colors': undefined,
       'country': 'us',
@@ -173,6 +176,7 @@ export const LibraryMappedMock: LibraryItem[] = [
     'media': {
       'airDate': new Date('1977-05-25T00:00:00.000Z'),
       'releaseDate': new Date('1977-05-25T00:00:00.000Z'),
+      'effectiveReleaseDate': new Date('1977-05-25T00:00:00.000Z'),
       'certification': 'PG',
       'colors': undefined,
       'country': 'us',
@@ -245,6 +249,7 @@ export const LibraryMappedMock: LibraryItem[] = [
     'episode': {
       'airDate': new Date('1987-04-05T05:00:00.000Z'),
       'releaseDate': new Date('1987-04-05T05:00:00.000Z'),
+      'effectiveReleaseDate': new Date('1987-04-05T05:00:00.000Z'),
       'cover': {
         'url':
           'https://walter-r2.trakt.tv/images/episodes/000/298/461/screenshots/thumb/d5459747f8.jpg.webp',
@@ -267,6 +272,7 @@ export const LibraryMappedMock: LibraryItem[] = [
     'media': {
       'airDate': new Date('1987-04-05T05:00:00.000Z'),
       'releaseDate': new Date('1987-04-05T05:00:00.000Z'),
+      'effectiveReleaseDate': new Date('1987-04-05T05:00:00.000Z'),
       'certification': 'TV-PG',
       'colors': undefined,
       'country': 'us',


### PR DESCRIPTION
### Overview
Standardizes date handling across movies, shows, and episodes by introducing a consolidated `effectiveReleaseDate`. This ensures consistent logic for determining if content has aired and provides more accurate labels in the UI, particularly for the calendar and upcoming episode lists.

### Changes
- Adds `effectiveReleaseDate` to `MediaEntry` and `EpisodeEntry` Zod schemas.
- Updates mappers for episodes to calculate `effectiveReleaseDate` as the earliest of the air date and release date.
- Updates mappers for movies and shows to include `effectiveReleaseDate` for compatibility with shared media interfaces.
- Refactors the `hasAired` utility to simplify its logic by using a single date comparison instead of separate air and release date checks.
- Modifies the `EpisodeItem` component to use `effectiveReleaseDate` for determining future status and displaying air date tags.

### Testing
- Verified that episode status tags and air dates display correctly in the upcoming sections.
- Confirmed that the "isFuture" logic correctly identifies upcoming content based on the new unified date field.