### PR TITLE
Fixes review word counting for international languages

### DIFF
--- a/projects/client/src/lib/sections/summary/components/comments/_internal/drawers/isReviewValid.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/drawers/isReviewValid.spec.ts
@@ -70,4 +70,16 @@ describe('isReviewValid', () => {
   it('should return false for fewer than 5 emoji-free words with surrounding emojis', () => {
     expect(isReviewValid('😀🎉🔥 one two three four 🌟💯')).toBe(false);
   });
+
+  it('should count Japanese words correctly without spaces', () => {
+    expect(isReviewValid('このアニメは本当に素晴らしかった')).toBe(true);
+  });
+
+  it('should return false for too few Japanese characters', () => {
+    expect(isReviewValid('すごい')).toBe(false);
+  });
+
+  it('should count mixed Japanese and English words correctly', () => {
+    expect(isReviewValid('この映画は really amazing')).toBe(true);
+  });
 });

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/drawers/isReviewValid.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/drawers/isReviewValid.ts
@@ -1,9 +1,9 @@
-const WORD_COUNT_THRESHOLD = 5;
+const wordCountThreshold = 5;
+const segmenter = new Intl.Segmenter(undefined, { granularity: 'word' });
 
 export function isReviewValid(review: string): boolean {
-  const words = review
-    .split(/\s+/)
-    .filter((word) => /[\p{L}\p{N}]/u.test(word));
+  const words = [...segmenter.segment(review)]
+    .filter((segment) => segment.isWordLike);
 
-  return words.length >= WORD_COUNT_THRESHOLD;
+  return words.length >= wordCountThreshold;
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2110
- Corrects the word counting logic in review validation to accurately handle international languages.
- Implements `Intl.Segmenter` for robust and language-aware word segmentation.
- Ensures reviews containing languages like Japanese, which may not use spaces between words, or mixed-language reviews, are properly validated against the minimum word count threshold.