### PR TITLE
Year in Review: default template

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -132,6 +132,7 @@ module.exports = {
         'watchlist',
         'worker',
         'ws',
+        'yir',
       ],
     ],
     'type-case': [RuleConfigSeverity.Error, 'always', 'lower-case'],

--- a/deno.lock
+++ b/deno.lock
@@ -4,34 +4,37 @@
     "jsr:@std/cli@^1.0.24": "1.0.24",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/path@^1.1.3": "1.1.3",
+    "npm:@carbon/charts-svelte@^1.24.0": "1.27.3_svelte@5.51.3__acorn@8.15.0",
+    "npm:@carbon/charts@^1.24.0": "1.27.3",
     "npm:@cucumber/cucumber@12.6.0": "12.6.0_@cucumber+gherkin@37.0.1_@cucumber+message-streams@4.0.1__@cucumber+messages@31.2.0_@cucumber+messages@31.2.0",
     "npm:@eslint/js@^10.0.1": "10.0.1_eslint@10.0.0",
-    "npm:@ethercorps/sveltekit-og@4.2.1": "4.2.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3",
+    "npm:@ethercorps/sveltekit-og@4.2.1": "4.2.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
     "npm:@inlang/paraglide-js@2.12.0": "2.12.0",
     "npm:@jsr/libn__fuzzy@0.4": "0.4.0",
     "npm:@jsr/trakt__api@0.4.11": "0.4.11_openapi3-ts@4.5.0",
     "npm:@playwright/test@1.58.2": "1.58.2",
-    "npm:@sentry/sveltekit@10.45.0": "10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3",
-    "npm:@sveltejs/adapter-auto@7.0.1": "7.0.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
-    "npm:@sveltejs/adapter-cloudflare@7.2.7": "7.2.7_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
-    "npm:@sveltejs/kit@^2.55.0": "2.55.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
-    "npm:@sveltejs/vite-plugin-svelte@7.0.0": "7.0.0_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
+    "npm:@sentry/sveltekit@10.45.0": "10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:@sveltejs/adapter-auto@7.0.1": "7.0.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:@sveltejs/adapter-cloudflare@7.2.7": "7.2.7_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:@sveltejs/kit@^2.55.0": "2.55.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:@sveltejs/vite-plugin-svelte@7.0.0": "7.0.0_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0",
     "npm:@tanstack/svelte-query-devtools@5.90.2": "5.90.2_@tanstack+svelte-query@5.90.2__svelte@5.51.3___acorn@8.15.0_svelte@5.51.3__acorn@8.15.0",
     "npm:@tanstack/svelte-query-persist-client@5.90.2": "5.90.2_@tanstack+svelte-query@5.90.2__svelte@5.51.3___acorn@8.15.0_svelte@5.51.3__acorn@8.15.0",
     "npm:@tanstack/svelte-query@5.90.2": "5.90.2_svelte@5.51.3__acorn@8.15.0",
     "npm:@testing-library/jest-dom@6.9.1": "6.9.1",
-    "npm:@testing-library/svelte@5.3.1": "5.3.1_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_vitest@4.1.0__@opentelemetry+api@1.9.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3__msw@2.12.10___typescript@5.8.3_@opentelemetry+api@1.9.0_jsdom@26.1.0_msw@2.12.10__typescript@5.8.3",
+    "npm:@testing-library/svelte@5.3.1": "5.3.1_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_vitest@4.1.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
     "npm:@testing-library/user-event@14.6.1": "14.6.1_@testing-library+dom@10.4.1",
     "npm:@ts-rest/core@3.52.1": "3.52.1_zod@3.25.76",
     "npm:@types/eslint@9.6.1": "9.6.1",
     "npm:@types/papaparse@^5.3.15": "5.5.2",
     "npm:@types/serviceworker@0.0.191": "0.0.191",
     "npm:@use-gesture/vanilla@10.3.1": "10.3.1",
-    "npm:@vite-pwa/sveltekit@1.1.0": "1.1.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
-    "npm:@vitest/coverage-istanbul@4.1.0": "4.1.0_vitest@4.1.0__@opentelemetry+api@1.9.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3__msw@2.12.10___typescript@5.8.3_@opentelemetry+api@1.9.0_jsdom@26.1.0_msw@2.12.10__typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
-    "npm:bits-ui@^2.16.2": "2.16.2_svelte@5.51.3__acorn@8.15.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
+    "npm:@vite-pwa/sveltekit@1.1.0": "1.1.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:@vitest/coverage-istanbul@4.1.0": "4.1.0_vitest@4.1.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:bits-ui@^2.16.2": "2.16.2_svelte@5.51.3__acorn@8.15.0_sass-embedded@1.83.0",
     "npm:concurrently@9.2.1": "9.2.1",
     "npm:cross-env@10.1.0": "10.1.0",
+    "npm:d3@^7.9.0": "7.9.0",
     "npm:date-fns@4.1.0": "4.1.0",
     "npm:esbuild@~0.27.4": "0.27.4",
     "npm:eslint-plugin-svelte@3.15.0": "3.15.0_eslint@10.0.0_svelte@5.51.3__acorn@8.15.0_postcss@8.5.6",
@@ -51,7 +54,7 @@
     "npm:prettier@3.8.1": "3.8.1",
     "npm:resolve-accept-language@3.1.16": "3.1.16",
     "npm:rxjs@^7.8.2": "7.8.2",
-    "npm:sass-embedded@1.97.3": "1.97.3",
+    "npm:sass-embedded@1.83.0": "1.83.0",
     "npm:svelte-check@4.4.0": "4.4.0_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3",
     "npm:svelte-confetti@^2.3.2": "2.3.2_svelte@5.51.3__acorn@8.15.0",
     "npm:svelte@^5.51.3": "5.51.3_acorn@8.15.0",
@@ -59,9 +62,9 @@
     "npm:typescript-eslint@8.56.0": "8.56.0_eslint@10.0.0_typescript@5.8.3_@typescript-eslint+parser@8.56.0__eslint@10.0.0__typescript@5.8.3",
     "npm:typescript@5.8.3": "5.8.3",
     "npm:typesense@^3.0.1": "3.0.1_@babel+runtime@7.28.6",
-    "npm:vite-plugin-pwa@1.2.0": "1.2.0_vite@7.3.1__sass-embedded@1.97.3__picomatch@4.0.3_@babel+core@7.29.0",
-    "npm:vite@8.0.1": "8.0.1_esbuild@0.27.4_sass-embedded@1.97.3",
-    "npm:vitest@4.1.0": "4.1.0_@opentelemetry+api@1.9.0_jsdom@26.1.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_msw@2.12.10__typescript@5.8.3",
+    "npm:vite-plugin-pwa@1.2.0": "1.2.0_vite@7.3.1__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:vite@8.0.1": "8.0.1_esbuild@0.27.4_sass-embedded@1.83.0",
+    "npm:vitest@4.1.0": "4.1.0_jsdom@26.1.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0",
     "npm:workbox-expiration@7.4.0": "7.4.0",
     "npm:workbox-precaching@7.4.0": "7.4.0",
     "npm:workbox-routing@7.4.0": "7.4.0",
@@ -859,6 +862,49 @@
     "@bufbuild/protobuf@2.10.2": {
       "integrity": "sha512-uFsRXwIGyu+r6AMdz+XijIIZJYpoWeYzILt5yZ2d3mCjQrWUTVpVD9WL/jZAbvp+Ed04rOhrsk7FiTcEDseB5A=="
     },
+    "@carbon/charts-svelte@1.27.3_svelte@5.51.3__acorn@8.15.0": {
+      "integrity": "sha512-Ql5HzMQ5kqTdIDHD9FOpshqBQ8X+GsZhaALrnM9W/wPIIqBNbeNPNBFvwMvvi/6Aw/u+kDBzh4s5Kpj85b/GcQ==",
+      "dependencies": [
+        "@carbon/charts",
+        "@ibm/telemetry-js",
+        "svelte"
+      ],
+      "scripts": true
+    },
+    "@carbon/charts@1.27.3": {
+      "integrity": "sha512-Xc8xeujTXoksRKIYzoYXLyMbAr/fxJgLC0/2YiS9ez31xgwr3gPuY4Iijt2KLzMVwmrGSwhZ9VJHCKCrjIKsLQ==",
+      "dependencies": [
+        "@carbon/colors",
+        "@carbon/utils-position",
+        "@ibm/telemetry-js",
+        "@types/d3",
+        "@types/topojson",
+        "d3",
+        "d3-cloud",
+        "d3-sankey",
+        "date-fns",
+        "dompurify",
+        "html-to-image",
+        "lodash-es",
+        "topojson-client",
+        "tslib"
+      ],
+      "scripts": true
+    },
+    "@carbon/colors@11.50.0": {
+      "integrity": "sha512-wJrJvBWiQOoVD0jaKHflC7MFESvzERmL9PCbNK15mCKZRtCZNOP5XhwGRlSrP83DNBmG0kVhCjIt/kmtmXiJHQ==",
+      "dependencies": [
+        "@ibm/telemetry-js"
+      ],
+      "scripts": true
+    },
+    "@carbon/utils-position@1.3.0": {
+      "integrity": "sha512-bfar2dV+fQ15syIrH3n9ujY4PXd1Q+AF2VcTLJIC04IDe2f80zOnJlLNPc/RktHcWTZ7WSQm80cQo3abGcsfTA==",
+      "dependencies": [
+        "@ibm/telemetry-js"
+      ],
+      "scripts": true
+    },
     "@cloudflare/kv-asset-handler@0.4.2": {
       "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="
     },
@@ -1424,7 +1470,7 @@
         "levn"
       ]
     },
-    "@ethercorps/sveltekit-og@4.2.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3": {
+    "@ethercorps/sveltekit-og@4.2.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-mMkoKWMMBXL5iAYrMZqklezZDUU7HpHd+sNsz78e4gElXFyxdOnsIFfPPXpqDcUn6orZHs5MGHvtPi5II5xNAA==",
       "dependencies": [
         "@resvg/resvg-wasm",
@@ -1868,6 +1914,10 @@
     },
     "@humanwhocodes/retry@0.4.3": {
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="
+    },
+    "@ibm/telemetry-js@1.11.0": {
+      "integrity": "sha512-RO/9j+URJnSfseWg9ZkEX9p+a3Ousd33DBU7rOafoZB08RqdzxFVYJ2/iM50dkBuD0o7WX7GYt1sLbNgCoE+pA==",
+      "bin": true
     },
     "@img/colour@1.0.0": {
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="
@@ -2480,96 +2530,6 @@
     "@oxc-project/types@0.120.0": {
       "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="
     },
-    "@parcel/watcher-android-arm64@2.5.4": {
-      "integrity": "sha512-hoh0vx4v+b3BNI7Cjoy2/B0ARqcwVNrzN/n7DLq9ZB4I3lrsvhrkCViJyfTj/Qi5xM9YFiH4AmHGK6pgH1ss7g==",
-      "os": ["android"],
-      "cpu": ["arm64"]
-    },
-    "@parcel/watcher-darwin-arm64@2.5.4": {
-      "integrity": "sha512-kphKy377pZiWpAOyTgQYPE5/XEKVMaj6VUjKT5VkNyUJlr2qZAn8gIc7CPzx+kbhvqHDT9d7EqdOqRXT6vk0zw==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
-    "@parcel/watcher-darwin-x64@2.5.4": {
-      "integrity": "sha512-UKaQFhCtNJW1A9YyVz3Ju7ydf6QgrpNQfRZ35wNKUhTQ3dxJ/3MULXN5JN/0Z80V/KUBDGa3RZaKq1EQT2a2gg==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "@parcel/watcher-freebsd-x64@2.5.4": {
-      "integrity": "sha512-Dib0Wv3Ow/m2/ttvLdeI2DBXloO7t3Z0oCp4bAb2aqyqOjKPPGrg10pMJJAQ7tt8P4V2rwYwywkDhUia/FgS+Q==",
-      "os": ["freebsd"],
-      "cpu": ["x64"]
-    },
-    "@parcel/watcher-linux-arm-glibc@2.5.4": {
-      "integrity": "sha512-I5Vb769pdf7Q7Sf4KNy8Pogl/URRCKu9ImMmnVKYayhynuyGYMzuI4UOWnegQNa2sGpsPSbzDsqbHNMyeyPCgw==",
-      "os": ["linux"],
-      "cpu": ["arm"]
-    },
-    "@parcel/watcher-linux-arm-musl@2.5.4": {
-      "integrity": "sha512-kGO8RPvVrcAotV4QcWh8kZuHr9bXi9a3bSZw7kFarYR0+fGliU7hd/zevhjw8fnvIKG3J9EO5G6sXNGCSNMYPQ==",
-      "os": ["linux"],
-      "cpu": ["arm"]
-    },
-    "@parcel/watcher-linux-arm64-glibc@2.5.4": {
-      "integrity": "sha512-KU75aooXhqGFY2W5/p8DYYHt4hrjHZod8AhcGAmhzPn/etTa+lYCDB2b1sJy3sWJ8ahFVTdy+EbqSBvMx3iFlw==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@parcel/watcher-linux-arm64-musl@2.5.4": {
-      "integrity": "sha512-Qx8uNiIekVutnzbVdrgSanM+cbpDD3boB1f8vMtnuG5Zau4/bdDbXyKwIn0ToqFhIuob73bcxV9NwRm04/hzHQ==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@parcel/watcher-linux-x64-glibc@2.5.4": {
-      "integrity": "sha512-UYBQvhYmgAv61LNUn24qGQdjtycFBKSK3EXr72DbJqX9aaLbtCOO8+1SkKhD/GNiJ97ExgcHBrukcYhVjrnogA==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@parcel/watcher-linux-x64-musl@2.5.4": {
-      "integrity": "sha512-YoRWCVgxv8akZrMhdyVi6/TyoeeMkQ0PGGOf2E4omODrvd1wxniXP+DBynKoHryStks7l+fDAMUBRzqNHrVOpg==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@parcel/watcher-win32-arm64@2.5.4": {
-      "integrity": "sha512-iby+D/YNXWkiQNYcIhg8P5hSjzXEHaQrk2SLrWOUD7VeC4Ohu0WQvmV+HDJokZVJ2UjJ4AGXW3bx7Lls9Ln4TQ==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "@parcel/watcher-win32-ia32@2.5.4": {
-      "integrity": "sha512-vQN+KIReG0a2ZDpVv8cgddlf67J8hk1WfZMMP7sMeZmJRSmEax5xNDNWKdgqSe2brOKTQQAs3aCCUal2qBHAyg==",
-      "os": ["win32"],
-      "cpu": ["ia32"]
-    },
-    "@parcel/watcher-win32-x64@2.5.4": {
-      "integrity": "sha512-3A6efb6BOKwyw7yk9ro2vus2YTt2nvcd56AuzxdMiVOxL9umDyN5PKkKfZ/gZ9row41SjVmTVQNWQhaRRGpOKw==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "@parcel/watcher@2.5.4": {
-      "integrity": "sha512-WYa2tUVV5HiArWPB3ydlOc4R2ivq0IDrlqhMi3l7mVsFEXNcTfxYFPIHXHXIh/ca/y/V5N4E1zecyxdIBjYnkQ==",
-      "dependencies": [
-        "detect-libc",
-        "is-glob",
-        "node-addon-api",
-        "picomatch@4.0.3"
-      ],
-      "optionalDependencies": [
-        "@parcel/watcher-android-arm64",
-        "@parcel/watcher-darwin-arm64",
-        "@parcel/watcher-darwin-x64",
-        "@parcel/watcher-freebsd-x64",
-        "@parcel/watcher-linux-arm-glibc",
-        "@parcel/watcher-linux-arm-musl",
-        "@parcel/watcher-linux-arm64-glibc",
-        "@parcel/watcher-linux-arm64-musl",
-        "@parcel/watcher-linux-x64-glibc",
-        "@parcel/watcher-linux-x64-musl",
-        "@parcel/watcher-win32-arm64",
-        "@parcel/watcher-win32-ia32",
-        "@parcel/watcher-win32-x64"
-      ],
-      "scripts": true
-    },
     "@playwright/test@1.58.2": {
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dependencies": [
@@ -3124,7 +3084,7 @@
         "svelte"
       ]
     },
-    "@sentry/sveltekit@10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3": {
+    "@sentry/sveltekit@10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-owbKr6BlfhODiJzSQrjd+r400PdLjQQkbsNRHBLHjiwrL29Xf8SCM2fzFPh0FZYqgpG/opOi9CAVgNpmq1nWRg==",
       "dependencies": [
         "@babel/parser@7.26.9",
@@ -3137,10 +3097,10 @@
         "magic-string@0.30.21",
         "recast",
         "sorcery",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ],
       "optionalPeers": [
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ]
     },
     "@sentry/vite-plugin@5.1.1_rollup@4.59.0": {
@@ -3189,13 +3149,13 @@
         "acorn"
       ]
     },
-    "@sveltejs/adapter-auto@7.0.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@sveltejs/adapter-auto@7.0.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==",
       "dependencies": [
         "@sveltejs/kit"
       ]
     },
-    "@sveltejs/adapter-cloudflare@7.2.7_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@sveltejs/adapter-cloudflare@7.2.7_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-Kj6GADGhuGZe/A+WnoEdNLdGzAl1Yz/TUpThNNuU9MO/rXrFYsu7/BjxteimyRl4Sx/ypftqKWGtbFl6utJ/0g==",
       "dependencies": [
         "@cloudflare/workers-types",
@@ -3204,7 +3164,7 @@
         "wrangler"
       ]
     },
-    "@sveltejs/kit@2.55.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@sveltejs/kit@2.55.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==",
       "dependencies": [
         "@standard-schema/spec",
@@ -3222,21 +3182,21 @@
         "sirv",
         "svelte",
         "typescript",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ],
       "optionalPeers": [
         "typescript"
       ],
       "bin": true
     },
-    "@sveltejs/vite-plugin-svelte@7.0.0_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@sveltejs/vite-plugin-svelte@7.0.0_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g==",
       "dependencies": [
         "deepmerge",
         "magic-string@0.30.21",
         "obug",
         "svelte",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3",
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0",
         "vitefu"
       ]
     },
@@ -3382,17 +3342,17 @@
         "svelte"
       ]
     },
-    "@testing-library/svelte@5.3.1_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_vitest@4.1.0__@opentelemetry+api@1.9.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3__msw@2.12.10___typescript@5.8.3_@opentelemetry+api@1.9.0_jsdom@26.1.0_msw@2.12.10__typescript@5.8.3": {
+    "@testing-library/svelte@5.3.1_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_vitest@4.1.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
       "dependencies": [
         "@testing-library/dom",
         "@testing-library/svelte-core",
         "svelte",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3",
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0",
         "vitest"
       ],
       "optionalPeers": [
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3",
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0",
         "vitest"
       ]
     },
@@ -3436,6 +3396,166 @@
     "@types/cookie@0.6.0": {
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
+    "@types/d3-array@3.2.2": {
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+    },
+    "@types/d3-axis@3.0.6": {
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dependencies": [
+        "@types/d3-selection"
+      ]
+    },
+    "@types/d3-brush@3.0.6": {
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dependencies": [
+        "@types/d3-selection"
+      ]
+    },
+    "@types/d3-chord@3.0.6": {
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="
+    },
+    "@types/d3-color@3.1.3": {
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "@types/d3-contour@3.0.6": {
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dependencies": [
+        "@types/d3-array",
+        "@types/geojson"
+      ]
+    },
+    "@types/d3-delaunay@6.0.4": {
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="
+    },
+    "@types/d3-dispatch@3.0.7": {
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="
+    },
+    "@types/d3-drag@3.0.7": {
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dependencies": [
+        "@types/d3-selection"
+      ]
+    },
+    "@types/d3-dsv@3.0.7": {
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="
+    },
+    "@types/d3-ease@3.0.2": {
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "@types/d3-fetch@3.0.7": {
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dependencies": [
+        "@types/d3-dsv"
+      ]
+    },
+    "@types/d3-force@3.0.10": {
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="
+    },
+    "@types/d3-format@3.0.4": {
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="
+    },
+    "@types/d3-geo@3.1.0": {
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dependencies": [
+        "@types/geojson"
+      ]
+    },
+    "@types/d3-hierarchy@3.1.7": {
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="
+    },
+    "@types/d3-interpolate@3.0.4": {
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": [
+        "@types/d3-color"
+      ]
+    },
+    "@types/d3-path@3.1.1": {
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "@types/d3-polygon@3.0.2": {
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="
+    },
+    "@types/d3-quadtree@3.0.6": {
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="
+    },
+    "@types/d3-random@3.0.3": {
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="
+    },
+    "@types/d3-scale-chromatic@3.1.0": {
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="
+    },
+    "@types/d3-scale@4.0.9": {
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": [
+        "@types/d3-time"
+      ]
+    },
+    "@types/d3-selection@3.0.11": {
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="
+    },
+    "@types/d3-shape@3.1.8": {
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dependencies": [
+        "@types/d3-path"
+      ]
+    },
+    "@types/d3-time-format@4.0.3": {
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="
+    },
+    "@types/d3-time@3.0.4": {
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "@types/d3-timer@3.0.2": {
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
+    "@types/d3-transition@3.0.9": {
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dependencies": [
+        "@types/d3-selection"
+      ]
+    },
+    "@types/d3-zoom@3.0.8": {
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dependencies": [
+        "@types/d3-interpolate",
+        "@types/d3-selection"
+      ]
+    },
+    "@types/d3@7.4.3": {
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dependencies": [
+        "@types/d3-array",
+        "@types/d3-axis",
+        "@types/d3-brush",
+        "@types/d3-chord",
+        "@types/d3-color",
+        "@types/d3-contour",
+        "@types/d3-delaunay",
+        "@types/d3-dispatch",
+        "@types/d3-drag",
+        "@types/d3-dsv",
+        "@types/d3-ease",
+        "@types/d3-fetch",
+        "@types/d3-force",
+        "@types/d3-format",
+        "@types/d3-geo",
+        "@types/d3-hierarchy",
+        "@types/d3-interpolate",
+        "@types/d3-path",
+        "@types/d3-polygon",
+        "@types/d3-quadtree",
+        "@types/d3-random",
+        "@types/d3-scale",
+        "@types/d3-scale-chromatic",
+        "@types/d3-selection",
+        "@types/d3-shape",
+        "@types/d3-time",
+        "@types/d3-time-format",
+        "@types/d3-timer",
+        "@types/d3-transition",
+        "@types/d3-zoom"
+      ]
+    },
     "@types/deep-eql@4.0.2": {
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="
     },
@@ -3454,6 +3574,9 @@
     },
     "@types/estree@1.0.8": {
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
+    },
+    "@types/geojson@7946.0.16": {
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="
     },
     "@types/json-schema@7.0.15": {
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
@@ -3506,6 +3629,43 @@
       "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
       "dependencies": [
         "@types/node"
+      ]
+    },
+    "@types/topojson-client@3.1.5": {
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "dependencies": [
+        "@types/geojson",
+        "@types/topojson-specification"
+      ]
+    },
+    "@types/topojson-server@3.0.4": {
+      "integrity": "sha512-5+ieK8ePfP+K2VH6Vgs1VCt+fO1U8XZHj0UsF+NktaF0DavAo1q3IvCBXgokk/xmtvoPltSUs6vxuR/zMdOE1g==",
+      "dependencies": [
+        "@types/geojson",
+        "@types/topojson-specification"
+      ]
+    },
+    "@types/topojson-simplify@3.0.3": {
+      "integrity": "sha512-sBO5UZ0O2dB0bNwo0vut2yLHhj3neUGi9uL7/ROdm8Gs6dtt4jcB9OGDKr+M2isZwQM2RuzVmifnMZpxj4IGNw==",
+      "dependencies": [
+        "@types/geojson",
+        "@types/topojson-specification"
+      ]
+    },
+    "@types/topojson-specification@1.0.5": {
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "dependencies": [
+        "@types/geojson"
+      ]
+    },
+    "@types/topojson@3.2.6": {
+      "integrity": "sha512-ppfdlxjxofWJ66XdLgIlER/85RvpGyfOf8jrWf+3kVIjEatFxEZYD/Ea83jO672Xu1HRzd/ghwlbcZIUNHTskw==",
+      "dependencies": [
+        "@types/geojson",
+        "@types/topojson-client",
+        "@types/topojson-server",
+        "@types/topojson-simplify",
+        "@types/topojson-specification"
       ]
     },
     "@types/trusted-types@2.0.7": {
@@ -3621,7 +3781,7 @@
         "@use-gesture/core"
       ]
     },
-    "@vite-pwa/sveltekit@1.1.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@vite-pwa/sveltekit@1.1.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-mMIf2tY+7Hg8jecpu/WY+Ki2ikoXy3hVmt3tOxi0K+lYYnKQrDYthuHireI0S+26Mg9BXzL7qQF1xeB5VYlYlg==",
       "dependencies": [
         "@sveltejs/kit",
@@ -3630,7 +3790,7 @@
         "vite-plugin-pwa"
       ]
     },
-    "@vitest/coverage-istanbul@4.1.0_vitest@4.1.0__@opentelemetry+api@1.9.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3__msw@2.12.10___typescript@5.8.3_@opentelemetry+api@1.9.0_jsdom@26.1.0_msw@2.12.10__typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@vitest/coverage-istanbul@4.1.0_vitest@4.1.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-0+67gA94YToxd+Pc3XgIA/2c8HN2hXNSg3T+1FI4HW7W/2gPitYCtktsY6Ke7vrt5caboMq3TUf0/vwbHRb0og==",
       "dependencies": [
         "@babel/core",
@@ -3657,18 +3817,18 @@
         "tinyrainbow"
       ]
     },
-    "@vitest/mocker@4.1.0_msw@2.12.10__typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@vitest/mocker@4.1.0_msw@2.12.10__typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
       "dependencies": [
         "@vitest/spy",
         "estree-walker@3.0.3",
         "magic-string@0.30.21",
         "msw",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ],
       "optionalPeers": [
         "msw",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ]
     },
     "@vitest/pretty-format@4.1.0": {
@@ -3879,7 +4039,7 @@
       "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
       "bin": true
     },
-    "bits-ui@2.16.2_svelte@5.51.3__acorn@8.15.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "bits-ui@2.16.2_svelte@5.51.3__acorn@8.15.0_sass-embedded@1.83.0": {
       "integrity": "sha512-bgEpRRF7Ck9nRP1pbuKVxpaSMrz+8Pm0y+dmuvlkrSe+uUwIQECef29y6eslFHM6pCAubUh7STrsTLUUp8fzFQ==",
       "dependencies": [
         "@floating-ui/core",
@@ -3917,6 +4077,9 @@
         "update-browserslist-db"
       ],
       "bin": true
+    },
+    "buffer-builder@0.2.0": {
+      "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg=="
     },
     "buffer-from@1.1.2": {
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
@@ -4033,6 +4196,9 @@
     "commander@2.20.3": {
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
+    "commander@7.2.0": {
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+    },
     "comment-json@4.5.1": {
       "integrity": "sha512-taEtr3ozUmOB7it68Jll7s0Pwm+aoiHyXKrEC8SEodL4rNpdfDLqa7PfBlrgFoCNNdR8ImL+muti5IGvktJAAg==",
       "dependencies": [
@@ -4140,6 +4306,240 @@
     "custom-event-polyfill@1.0.7": {
       "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
     },
+    "d3-array@2.12.1": {
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": [
+        "internmap"
+      ]
+    },
+    "d3-array@3.2.4": {
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": [
+        "internmap"
+      ]
+    },
+    "d3-axis@3.0.0": {
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
+    },
+    "d3-brush@3.0.0": {
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dependencies": [
+        "d3-dispatch@3.0.1",
+        "d3-drag",
+        "d3-interpolate",
+        "d3-selection",
+        "d3-transition"
+      ]
+    },
+    "d3-chord@3.0.1": {
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dependencies": [
+        "d3-path@3.1.0"
+      ]
+    },
+    "d3-cloud@1.2.9": {
+      "integrity": "sha512-leL1GLneC9ZQtnV+6TGWrNlGfI1WX7S2arcTv2vae12DaXo5wjm6GBCkskXbrDlyOymd/A75Pyj1H37MW4BZ/Q==",
+      "dependencies": [
+        "d3-dispatch@1.0.6"
+      ]
+    },
+    "d3-color@3.1.0": {
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+    },
+    "d3-contour@4.0.2": {
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dependencies": [
+        "d3-array@3.2.4"
+      ]
+    },
+    "d3-delaunay@6.0.4": {
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dependencies": [
+        "delaunator"
+      ]
+    },
+    "d3-dispatch@1.0.6": {
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
+    },
+    "d3-dispatch@3.0.1": {
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
+    },
+    "d3-drag@3.0.0": {
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dependencies": [
+        "d3-dispatch@3.0.1",
+        "d3-selection"
+      ]
+    },
+    "d3-dsv@3.0.1": {
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dependencies": [
+        "commander@7.2.0",
+        "iconv-lite",
+        "rw"
+      ],
+      "bin": true
+    },
+    "d3-ease@3.0.1": {
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+    },
+    "d3-fetch@3.0.1": {
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dependencies": [
+        "d3-dsv"
+      ]
+    },
+    "d3-force@3.0.0": {
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dependencies": [
+        "d3-dispatch@3.0.1",
+        "d3-quadtree",
+        "d3-timer"
+      ]
+    },
+    "d3-format@3.1.2": {
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="
+    },
+    "d3-geo@3.1.1": {
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dependencies": [
+        "d3-array@3.2.4"
+      ]
+    },
+    "d3-hierarchy@3.1.2": {
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
+    },
+    "d3-interpolate@3.0.1": {
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": [
+        "d3-color"
+      ]
+    },
+    "d3-path@1.0.9": {
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-path@3.1.0": {
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
+    },
+    "d3-polygon@3.0.1": {
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
+    },
+    "d3-quadtree@3.0.1": {
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
+    },
+    "d3-random@3.0.1": {
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
+    },
+    "d3-sankey@0.12.3": {
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dependencies": [
+        "d3-array@2.12.1",
+        "d3-shape@1.3.7"
+      ]
+    },
+    "d3-scale-chromatic@3.1.0": {
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dependencies": [
+        "d3-color",
+        "d3-interpolate"
+      ]
+    },
+    "d3-scale@4.0.2": {
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": [
+        "d3-array@3.2.4",
+        "d3-format",
+        "d3-interpolate",
+        "d3-time",
+        "d3-time-format"
+      ]
+    },
+    "d3-selection@3.0.0": {
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+    },
+    "d3-shape@1.3.7": {
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": [
+        "d3-path@1.0.9"
+      ]
+    },
+    "d3-shape@3.2.0": {
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": [
+        "d3-path@3.1.0"
+      ]
+    },
+    "d3-time-format@4.1.0": {
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": [
+        "d3-time"
+      ]
+    },
+    "d3-time@3.1.0": {
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": [
+        "d3-array@3.2.4"
+      ]
+    },
+    "d3-timer@3.0.1": {
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
+    "d3-transition@3.0.1_d3-selection@3.0.0": {
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": [
+        "d3-color",
+        "d3-dispatch@3.0.1",
+        "d3-ease",
+        "d3-interpolate",
+        "d3-selection",
+        "d3-timer"
+      ]
+    },
+    "d3-zoom@3.0.0": {
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": [
+        "d3-dispatch@3.0.1",
+        "d3-drag",
+        "d3-interpolate",
+        "d3-selection",
+        "d3-transition"
+      ]
+    },
+    "d3@7.9.0": {
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dependencies": [
+        "d3-array@3.2.4",
+        "d3-axis",
+        "d3-brush",
+        "d3-chord",
+        "d3-color",
+        "d3-contour",
+        "d3-delaunay",
+        "d3-dispatch@3.0.1",
+        "d3-drag",
+        "d3-dsv",
+        "d3-ease",
+        "d3-fetch",
+        "d3-force",
+        "d3-format",
+        "d3-geo",
+        "d3-hierarchy",
+        "d3-interpolate",
+        "d3-path@3.1.0",
+        "d3-polygon",
+        "d3-quadtree",
+        "d3-random",
+        "d3-scale",
+        "d3-scale-chromatic",
+        "d3-selection",
+        "d3-shape@3.2.0",
+        "d3-time",
+        "d3-time-format",
+        "d3-timer",
+        "d3-transition",
+        "d3-zoom"
+      ]
+    },
     "data-urls@5.0.0": {
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dependencies": [
@@ -4208,6 +4608,12 @@
         "object-keys"
       ]
     },
+    "delaunator@5.1.0": {
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dependencies": [
+        "robust-predicates"
+      ]
+    },
     "delayed-stream@1.0.0": {
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
@@ -4228,6 +4634,12 @@
     },
     "dom-accessibility-api@0.6.3": {
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="
+    },
+    "dompurify@3.3.3": {
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "optionalDependencies": [
+        "@types/trusted-types"
+      ]
     },
     "dotenv@16.6.1": {
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="
@@ -4912,6 +5324,9 @@
     "html-escaper@2.0.2": {
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
+    "html-to-image@1.11.11": {
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
+    },
     "http-parser-js@0.5.10": {
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA=="
     },
@@ -5001,6 +5416,9 @@
         "hasown",
         "side-channel"
       ]
+    },
+    "internmap@1.0.1": {
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "is-array-buffer@3.0.5": {
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
@@ -5428,6 +5846,9 @@
         "p-locate"
       ]
     },
+    "lodash-es@4.18.1": {
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="
+    },
     "lodash.camelcase@4.3.0": {
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
@@ -5640,9 +6061,6 @@
         "lower-case",
         "tslib"
       ]
-    },
-    "node-addon-api@7.1.1": {
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="
     },
     "node-fetch@2.7.0": {
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
@@ -6114,6 +6532,9 @@
     "rettime@0.10.1": {
       "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw=="
     },
+    "robust-predicates@3.0.3": {
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="
+    },
     "rolldown@1.0.0-rc.10": {
       "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
       "dependencies": [
@@ -6184,7 +6605,7 @@
     "rrweb-cssom@0.8.0": {
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="
     },
-    "runed@0.35.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "runed@0.35.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_svelte@5.51.3__acorn@8.15.0_sass-embedded@1.83.0": {
       "integrity": "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==",
       "dependencies": [
         "@sveltejs/kit",
@@ -6196,6 +6617,9 @@
       "optionalPeers": [
         "@sveltejs/kit"
       ]
+    },
+    "rw@1.3.3": {
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "rxjs@7.8.2": {
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
@@ -6240,104 +6664,111 @@
     "safer-buffer@2.1.2": {
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "sass-embedded-all-unknown@1.97.3": {
-      "integrity": "sha512-t6N46NlPuXiY3rlmG6/+1nwebOBOaLFOOVqNQOC2cJhghOD4hh2kHNQQTorCsbY9S1Kir2la1/XLBwOJfui0xg==",
-      "dependencies": [
-        "sass"
-      ],
-      "cpu": ["!arm", "!arm64", "!riscv64", "!x64"]
-    },
-    "sass-embedded-android-arm64@1.97.3": {
-      "integrity": "sha512-aiZ6iqiHsUsaDx0EFbbmmA0QgxicSxVVN3lnJJ0f1RStY0DthUkquGT5RJ4TPdaZ6ebeJWkboV4bra+CP766eA==",
+    "sass-embedded-android-arm64@1.83.0": {
+      "integrity": "sha512-GBiCvM4a2rkWBLdYDxI6XYnprfk5U5c81g69RC2X6kqPuzxzx8qTArQ9M6keFK4+iDQ5N9QTwFCr0KbZTn+ZNQ==",
       "os": ["android"],
       "cpu": ["arm64"]
     },
-    "sass-embedded-android-arm@1.97.3": {
-      "integrity": "sha512-cRTtf/KV/q0nzGZoUzVkeIVVFv3L/tS1w4WnlHapphsjTXF/duTxI8JOU1c/9GhRPiMdfeXH7vYNcMmtjwX7jg==",
+    "sass-embedded-android-arm@1.83.0": {
+      "integrity": "sha512-uwFSXzJlfbd4Px189xE5l+cxN8+TQpXdQgJec7TIrb4HEY7imabtpYufpVdqUVwT1/uiis5V4+qIEC4Vl5XObQ==",
       "os": ["android"],
       "cpu": ["arm"]
     },
-    "sass-embedded-android-riscv64@1.97.3": {
-      "integrity": "sha512-zVEDgl9JJodofGHobaM/q6pNETG69uuBIGQHRo789jloESxxZe82lI3AWJQuPmYCOG5ElfRthqgv89h3gTeLYA==",
+    "sass-embedded-android-ia32@1.83.0": {
+      "integrity": "sha512-5ATPdGo2SICqAhiJl/Z8KQ23zH4sGgobGgux0TnrNtt83uHZ+r+To/ubVJ7xTkZxed+KJZnIpolGD8dQyQqoTg==",
+      "os": ["android"],
+      "cpu": ["ia32"]
+    },
+    "sass-embedded-android-riscv64@1.83.0": {
+      "integrity": "sha512-aveknUOB8GZewOzVn2Uwk+DKcncTR50Q6vtzslNMGbYnxtgQNHzy8A1qVEviNUruex+pHofppeMK4iMPFAbiEQ==",
       "os": ["android"],
       "cpu": ["riscv64"]
     },
-    "sass-embedded-android-x64@1.97.3": {
-      "integrity": "sha512-3ke0le7ZKepyXn/dKKspYkpBC0zUk/BMciyP5ajQUDy4qJwobd8zXdAq6kOkdiMB+d9UFJOmEkvgFJHl3lqwcw==",
+    "sass-embedded-android-x64@1.83.0": {
+      "integrity": "sha512-WqIay/72ncyf9Ph4vS742J3a73wZihWmzFUwpn1OD6lme1Aj4eWzWIve5IVnlTEJgcZcDHu6ECID9IZgehJKoA==",
       "os": ["android"],
       "cpu": ["x64"]
     },
-    "sass-embedded-darwin-arm64@1.97.3": {
-      "integrity": "sha512-fuqMTqO4gbOmA/kC5b9y9xxNYw6zDEyfOtMgabS7Mz93wimSk2M1quQaTJnL98Mkcsl2j+7shNHxIS/qpcIDDA==",
+    "sass-embedded-darwin-arm64@1.83.0": {
+      "integrity": "sha512-XQl9QqgxFFIPm/CzHhmppse5o9ocxrbaAdC2/DAnlAqvYWBBtgFqPjGoYlej13h9SzfvNoogx+y9r+Ap+e+hYg==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "sass-embedded-darwin-x64@1.97.3": {
-      "integrity": "sha512-b/2RBs/2bZpP8lMkyZ0Px0vkVkT8uBd0YXpOwK7iOwYkAT8SsO4+WdVwErsqC65vI5e1e5p1bb20tuwsoQBMVA==",
+    "sass-embedded-darwin-x64@1.83.0": {
+      "integrity": "sha512-ERQ7Tvp1kFOW3ux4VDFIxb7tkYXHYc+zJpcrbs0hzcIO5ilIRU2tIOK1OrNwrFO6Qxyf7AUuBwYKLAtIU/Nz7g==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "sass-embedded-linux-arm64@1.97.3": {
-      "integrity": "sha512-IP1+2otCT3DuV46ooxPaOKV1oL5rLjteRzf8ldZtfIEcwhSgSsHgA71CbjYgLEwMY9h4jeal8Jfv3QnedPvSjg==",
+    "sass-embedded-linux-arm64@1.83.0": {
+      "integrity": "sha512-syEAVTJt4qhaMLxrSwOWa46zdqHJdnqJkLUK+t9aCr8xqBZLPxSUeIGji76uOehQZ1C+KGFj6n9xstHN6wzOJw==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "sass-embedded-linux-arm@1.97.3": {
-      "integrity": "sha512-2lPQ7HQQg4CKsH18FTsj2hbw5GJa6sBQgDsls+cV7buXlHjqF8iTKhAQViT6nrpLK/e8nFCoaRgSqEC8xMnXuA==",
+    "sass-embedded-linux-arm@1.83.0": {
+      "integrity": "sha512-baG9RYBJxUFmqwDNC9h9ZFElgJoyO3jgHGjzEZ1wHhIS9anpG+zZQvO8bHx3dBpKEImX+DBeLX+CxsFR9n81gQ==",
       "os": ["linux"],
       "cpu": ["arm"]
     },
-    "sass-embedded-linux-musl-arm64@1.97.3": {
-      "integrity": "sha512-Lij0SdZCsr+mNRSyDZ7XtJpXEITrYsaGbOTz5e6uFLJ9bmzUbV7M8BXz2/cA7bhfpRPT7/lwRKPdV4+aR9Ozcw==",
+    "sass-embedded-linux-ia32@1.83.0": {
+      "integrity": "sha512-RRBxQxMpoxu5+XcSSc6QR/o9asEwUzR8AbCS83RaXcdTIHTa/CccQsiAoDDoPlRsMTLqnzs0LKL4CfOsf7zBbA==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "sass-embedded-linux-musl-arm64@1.83.0": {
+      "integrity": "sha512-Y7juhPHClUO2H5O+u+StRy6SEAcwZ+hTEk5WJdEmo1Bb1gDtfHvJaWB/iFZJ2tW0W1e865AZeUrC4OcOFjyAQA==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "sass-embedded-linux-musl-arm@1.97.3": {
-      "integrity": "sha512-cBTMU68X2opBpoYsSZnI321gnoaiMBEtc+60CKCclN6PCL3W3uXm8g4TLoil1hDD6mqU9YYNlVG6sJ+ZNef6Lg==",
+    "sass-embedded-linux-musl-arm@1.83.0": {
+      "integrity": "sha512-Yc7u2TelCfBab+PRob9/MNJFh3EooMiz4urvhejXkihTiKSHGCv5YqDdtWzvyb9tY2Jb7YtYREVuHwfdVn3dTQ==",
       "os": ["linux"],
       "cpu": ["arm"]
     },
-    "sass-embedded-linux-musl-riscv64@1.97.3": {
-      "integrity": "sha512-sBeLFIzMGshR4WmHAD4oIM7WJVkSoCIEwutzptFtGlSlwfNiijULp+J5hA2KteGvI6Gji35apR5aWj66wEn/iA==",
+    "sass-embedded-linux-musl-ia32@1.83.0": {
+      "integrity": "sha512-arQeYwGmwXV8byx5G1PtSzZWW1jbkfR5qrIHMEbTFSAvAxpqjgSvCvrHMOFd73FcMxVaYh4BX9LQNbKinkbEdg==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "sass-embedded-linux-musl-riscv64@1.83.0": {
+      "integrity": "sha512-E6uzlIWz59rut+Z3XR6mLG915zNzv07ISvj3GUNZENdHM7dF8GQ//ANoIpl5PljMQKp89GnYdvo6kj2gnaBf/g==",
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
-    "sass-embedded-linux-musl-x64@1.97.3": {
-      "integrity": "sha512-/oWJ+OVrDg7ADDQxRLC/4g1+Nsz1g4mkYS2t6XmyMJKFTFK50FVI2t5sOdFH+zmMp+nXHKM036W94y9m4jjEcw==",
+    "sass-embedded-linux-musl-x64@1.83.0": {
+      "integrity": "sha512-eAMK6tyGqvqr21r9g8BnR3fQc1rYFj85RGduSQ3xkITZ6jOAnOhuU94N5fwRS852Hpws0lXhET+7JHXgg3U18w==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "sass-embedded-linux-riscv64@1.97.3": {
-      "integrity": "sha512-l3IfySApLVYdNx0Kjm7Zehte1CDPZVcldma3dZt+TfzvlAEerM6YDgsk5XEj3L8eHBCgHgF4A0MJspHEo2WNfA==",
+    "sass-embedded-linux-riscv64@1.83.0": {
+      "integrity": "sha512-Ojpi78pTv02sy2fUYirRGXHLY3fPnV/bvwuC2i5LwPQw2LpCcFyFTtN0c5h4LJDk9P6wr+/ZB/JXU8tHIOlK+Q==",
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
-    "sass-embedded-linux-x64@1.97.3": {
-      "integrity": "sha512-Kwqwc/jSSlcpRjULAOVbndqEy2GBzo6OBmmuBVINWUaJLJ8Kczz3vIsDUWLfWz/kTEw9FHBSiL0WCtYLVAXSLg==",
+    "sass-embedded-linux-x64@1.83.0": {
+      "integrity": "sha512-3iLjlXdoPfgZRtX4odhRvka1BQs5mAXqfCtDIQBgh/o0JnGPzJIWWl9bYLpHxK8qb+uyVBxXYgXpI0sCzArBOw==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "sass-embedded-unknown-all@1.97.3": {
-      "integrity": "sha512-/GHajyYJmvb0IABUQHbVHf1nuHPtIDo/ClMZ81IDr59wT5CNcMe7/dMNujXwWugtQVGI5UGmqXWZQCeoGnct8Q==",
-      "dependencies": [
-        "sass"
-      ],
-      "os": ["!android", "!darwin", "!linux", "!win32"]
-    },
-    "sass-embedded-win32-arm64@1.97.3": {
-      "integrity": "sha512-RDGtRS1GVvQfMGAmVXNxYiUOvPzn9oO1zYB/XUM9fudDRnieYTcUytpNTQZLs6Y1KfJxgt5Y+giRceC92fT8Uw==",
+    "sass-embedded-win32-arm64@1.83.0": {
+      "integrity": "sha512-iOHw/8/t2dlTW3lOFwG5eUbiwhEyGWawivlKWJ8lkXH7fjMpVx2VO9zCFAm8RvY9xOHJ9sf1L7g5bx3EnNP9BQ==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "sass-embedded-win32-x64@1.97.3": {
-      "integrity": "sha512-SFRa2lED9UEwV6vIGeBXeBOLKF+rowF3WmNfb/BzhxmdAsKofCXrJ8ePW7OcDVrvNEbTOGwhsReIsF5sH8fVaw==",
+    "sass-embedded-win32-ia32@1.83.0": {
+      "integrity": "sha512-2PxNXJ8Pad4geVcTXY4rkyTr5AwbF8nfrCTDv0ulbTvPhzX2mMKEGcBZUXWn5BeHZTBc6whNMfS7d5fQXR9dDQ==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "sass-embedded-win32-x64@1.83.0": {
+      "integrity": "sha512-muBXkFngM6eLTNqOV0FQi7Dv9s+YRQ42Yem26mosdan/GmJQc81deto6uDTgrYn+bzFNmiXcOdfm+0MkTWK3OQ==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "sass-embedded@1.97.3": {
-      "integrity": "sha512-eKzFy13Nk+IRHhlAwP3sfuv+PzOrvzUkwJK2hdoCKYcWGSdmwFpeGpWmyewdw8EgBnsKaSBtgf/0b2K635ecSA==",
+    "sass-embedded@1.83.0": {
+      "integrity": "sha512-/8cYZeL39evUqe0o//193na51Q1VWZ61qhxioQvLJwOtWIrX+PgNhCyD8RSuTtmzc4+6+waFZf899bfp/MCUwA==",
       "dependencies": [
         "@bufbuild/protobuf",
+        "buffer-builder",
         "colorjs.io",
         "immutable",
         "rxjs",
@@ -6346,36 +6777,26 @@
         "varint"
       ],
       "optionalDependencies": [
-        "sass-embedded-all-unknown",
         "sass-embedded-android-arm",
         "sass-embedded-android-arm64",
+        "sass-embedded-android-ia32",
         "sass-embedded-android-riscv64",
         "sass-embedded-android-x64",
         "sass-embedded-darwin-arm64",
         "sass-embedded-darwin-x64",
         "sass-embedded-linux-arm",
         "sass-embedded-linux-arm64",
+        "sass-embedded-linux-ia32",
         "sass-embedded-linux-musl-arm",
         "sass-embedded-linux-musl-arm64",
+        "sass-embedded-linux-musl-ia32",
         "sass-embedded-linux-musl-riscv64",
         "sass-embedded-linux-musl-x64",
         "sass-embedded-linux-riscv64",
         "sass-embedded-linux-x64",
-        "sass-embedded-unknown-all",
         "sass-embedded-win32-arm64",
+        "sass-embedded-win32-ia32",
         "sass-embedded-win32-x64"
-      ],
-      "bin": true
-    },
-    "sass@1.97.3": {
-      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
-      "dependencies": [
-        "chokidar",
-        "immutable",
-        "source-map-js"
-      ],
-      "optionalDependencies": [
-        "@parcel/watcher"
       ],
       "bin": true
     },
@@ -6781,7 +7202,7 @@
         "svelte"
       ]
     },
-    "svelte-toolbelt@0.10.6_svelte@5.51.3__acorn@8.15.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "svelte-toolbelt@0.10.6_svelte@5.51.3__acorn@8.15.0_sass-embedded@1.83.0": {
       "integrity": "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==",
       "dependencies": [
         "clsx",
@@ -6911,6 +7332,13 @@
       "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
       "dependencies": [
         "tldts-core@7.0.19"
+      ],
+      "bin": true
+    },
+    "topojson-client@3.1.0": {
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dependencies": [
+        "commander@2.20.3"
       ],
       "bin": true
     },
@@ -7199,18 +7627,18 @@
     "varint@6.0.0": {
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
-    "vite-plugin-pwa@1.2.0_vite@7.3.1__sass-embedded@1.97.3__picomatch@4.0.3_@babel+core@7.29.0": {
+    "vite-plugin-pwa@1.2.0_vite@7.3.1__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==",
       "dependencies": [
         "debug",
         "pretty-bytes@6.1.1",
         "tinyglobby",
-        "vite@7.3.1_sass-embedded@1.97.3_picomatch@4.0.3",
+        "vite@7.3.1_sass-embedded@1.83.0",
         "workbox-build",
         "workbox-window"
       ]
     },
-    "vite@7.3.1_sass-embedded@1.97.3_picomatch@4.0.3": {
+    "vite@7.3.1_sass-embedded@1.83.0": {
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dependencies": [
         "esbuild@0.27.4",
@@ -7228,7 +7656,7 @@
       ],
       "bin": true
     },
-    "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3": {
+    "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0": {
       "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
       "dependencies": [
         "esbuild@0.27.4",
@@ -7248,16 +7676,16 @@
       ],
       "bin": true
     },
-    "vitefu@1.1.2_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "vitefu@1.1.2_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==",
       "dependencies": [
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ],
       "optionalPeers": [
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ]
     },
-    "vitest@4.1.0_@opentelemetry+api@1.9.0_jsdom@26.1.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_msw@2.12.10__typescript@5.8.3": {
+    "vitest@4.1.0_jsdom@26.1.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dependencies": [
         "@opentelemetry/api",
@@ -7280,7 +7708,7 @@
         "tinyexec",
         "tinyglobby",
         "tinyrainbow",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3",
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0",
         "why-is-node-running"
       ],
       "optionalPeers": [
@@ -7715,6 +8143,8 @@
         ],
         "packageJson": {
           "dependencies": [
+            "npm:@carbon/charts-svelte@^1.24.0",
+            "npm:@carbon/charts@^1.24.0",
             "npm:@cucumber/cucumber@12.6.0",
             "npm:@eslint/js@^10.0.1",
             "npm:@ethercorps/sveltekit-og@4.2.1",
@@ -7743,6 +8173,7 @@
             "npm:bits-ui@^2.16.2",
             "npm:concurrently@9.2.1",
             "npm:cross-env@10.1.0",
+            "npm:d3@^7.9.0",
             "npm:date-fns@4.1.0",
             "npm:esbuild@~0.27.4",
             "npm:eslint-plugin-svelte@3.15.0",
@@ -7762,7 +8193,7 @@
             "npm:prettier@3.8.1",
             "npm:resolve-accept-language@3.1.16",
             "npm:rxjs@^7.8.2",
-            "npm:sass-embedded@1.97.3",
+            "npm:sass-embedded@1.83.0",
             "npm:svelte-check@4.4.0",
             "npm:svelte-confetti@^2.3.2",
             "npm:svelte@^5.51.3",

--- a/deno.lock
+++ b/deno.lock
@@ -4,35 +4,39 @@
     "jsr:@std/cli@^1.0.24": "1.0.24",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/path@^1.1.3": "1.1.3",
+    "npm:@carbon/charts-svelte@^1.24.0": "1.27.10_svelte@5.51.3__acorn@8.15.0",
+    "npm:@carbon/charts@^1.24.0": "1.27.10",
     "npm:@cloudflare/workers-types@4.20260504.1": "4.20260504.1",
     "npm:@cucumber/cucumber@12.6.0": "12.6.0_@cucumber+gherkin@37.0.1_@cucumber+message-streams@4.0.1__@cucumber+messages@31.2.0_@cucumber+messages@31.2.0",
     "npm:@eslint/js@^10.0.1": "10.0.1_eslint@10.0.0",
-    "npm:@ethercorps/sveltekit-og@4.2.1": "4.2.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3",
+    "npm:@ethercorps/sveltekit-og@4.2.1": "4.2.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
     "npm:@inlang/paraglide-js@2.12.0": "2.12.0",
     "npm:@jsr/libn__fuzzy@0.4": "0.4.0",
     "npm:@jsr/trakt__api@0.4.11": "0.4.11_openapi3-ts@4.5.0",
     "npm:@playwright/test@1.58.2": "1.58.2",
-    "npm:@sentry/sveltekit@10.45.0": "10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_@cloudflare+workers-types@4.20260504.1",
-    "npm:@sveltejs/adapter-auto@7.0.1": "7.0.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
-    "npm:@sveltejs/adapter-cloudflare@7.2.7": "7.2.7_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
-    "npm:@sveltejs/kit@^2.55.0": "2.55.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
-    "npm:@sveltejs/vite-plugin-svelte@7.0.0": "7.0.0_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
+    "npm:@sentry/sveltekit@10.45.0": "10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:@sveltejs/adapter-auto@7.0.1": "7.0.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:@sveltejs/adapter-cloudflare@7.2.7": "7.2.7_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:@sveltejs/kit@^2.55.0": "2.55.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:@sveltejs/vite-plugin-svelte@7.0.0": "7.0.0_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0",
     "npm:@tanstack/svelte-query-devtools@5.90.2": "5.90.2_@tanstack+svelte-query@5.90.2__svelte@5.51.3___acorn@8.15.0_svelte@5.51.3__acorn@8.15.0",
     "npm:@tanstack/svelte-query-persist-client@5.90.2": "5.90.2_@tanstack+svelte-query@5.90.2__svelte@5.51.3___acorn@8.15.0_svelte@5.51.3__acorn@8.15.0",
     "npm:@tanstack/svelte-query@5.90.2": "5.90.2_svelte@5.51.3__acorn@8.15.0",
     "npm:@testing-library/jest-dom@6.9.1": "6.9.1",
-    "npm:@testing-library/svelte@5.3.1": "5.3.1_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_vitest@4.1.0__@opentelemetry+api@1.9.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3__msw@2.12.10___typescript@5.8.3_@opentelemetry+api@1.9.0_jsdom@26.1.0_msw@2.12.10__typescript@5.8.3",
+    "npm:@testing-library/svelte@5.3.1": "5.3.1_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_vitest@4.1.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
     "npm:@testing-library/user-event@14.6.1": "14.6.1_@testing-library+dom@10.4.1",
     "npm:@ts-rest/core@3.52.1": "3.52.1_zod@3.25.76",
+    "npm:@types/d3@^7.4.3": "7.4.3",
     "npm:@types/eslint@9.6.1": "9.6.1",
     "npm:@types/papaparse@^5.3.15": "5.5.2",
     "npm:@types/serviceworker@0.0.191": "0.0.191",
     "npm:@use-gesture/vanilla@10.3.1": "10.3.1",
-    "npm:@vite-pwa/sveltekit@1.1.0": "1.1.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
-    "npm:@vitest/coverage-istanbul@4.1.0": "4.1.0_vitest@4.1.0__@opentelemetry+api@1.9.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3__msw@2.12.10___typescript@5.8.3_@opentelemetry+api@1.9.0_jsdom@26.1.0_msw@2.12.10__typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
-    "npm:bits-ui@^2.16.2": "2.16.2_svelte@5.51.3__acorn@8.15.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
+    "npm:@vite-pwa/sveltekit@1.1.0": "1.1.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:@vitest/coverage-istanbul@4.1.0": "4.1.0_vitest@4.1.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:bits-ui@^2.16.2": "2.16.2_svelte@5.51.3__acorn@8.15.0_sass-embedded@1.83.0",
     "npm:concurrently@9.2.1": "9.2.1",
     "npm:cross-env@10.1.0": "10.1.0",
+    "npm:d3@^7.9.0": "7.9.0",
     "npm:date-fns@4.1.0": "4.1.0",
     "npm:esbuild@~0.27.4": "0.27.4",
     "npm:eslint-plugin-svelte@3.15.0": "3.15.0_eslint@10.0.0_svelte@5.51.3__acorn@8.15.0_postcss@8.5.6",
@@ -52,7 +56,7 @@
     "npm:prettier@3.8.1": "3.8.1",
     "npm:resolve-accept-language@3.1.16": "3.1.16",
     "npm:rxjs@^7.8.2": "7.8.2",
-    "npm:sass-embedded@1.97.3": "1.97.3",
+    "npm:sass-embedded@1.83.0": "1.83.0",
     "npm:svelte-check@4.4.0": "4.4.0_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3",
     "npm:svelte-confetti@^2.3.2": "2.3.2_svelte@5.51.3__acorn@8.15.0",
     "npm:svelte@^5.51.3": "5.51.3_acorn@8.15.0",
@@ -60,9 +64,9 @@
     "npm:typescript-eslint@8.56.0": "8.56.0_eslint@10.0.0_typescript@5.8.3_@typescript-eslint+parser@8.56.0__eslint@10.0.0__typescript@5.8.3",
     "npm:typescript@5.8.3": "5.8.3",
     "npm:typesense@^3.0.1": "3.0.1_@babel+runtime@7.28.6",
-    "npm:vite-plugin-pwa@1.2.0": "1.2.0_vite@7.3.1__sass-embedded@1.97.3__picomatch@4.0.3_@babel+core@7.29.0",
-    "npm:vite@8.0.1": "8.0.1_esbuild@0.27.4_sass-embedded@1.97.3",
-    "npm:vitest@4.1.0": "4.1.0_@opentelemetry+api@1.9.0_jsdom@26.1.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_msw@2.12.10__typescript@5.8.3",
+    "npm:vite-plugin-pwa@1.2.0": "1.2.0_vite@7.3.1__sass-embedded@1.83.0_sass-embedded@1.83.0",
+    "npm:vite@8.0.1": "8.0.1_esbuild@0.27.4_sass-embedded@1.83.0",
+    "npm:vitest@4.1.0": "4.1.0_jsdom@26.1.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0",
     "npm:workbox-expiration@7.4.0": "7.4.0",
     "npm:workbox-precaching@7.4.0": "7.4.0",
     "npm:workbox-routing@7.4.0": "7.4.0",
@@ -860,6 +864,49 @@
     "@bufbuild/protobuf@2.10.2": {
       "integrity": "sha512-uFsRXwIGyu+r6AMdz+XijIIZJYpoWeYzILt5yZ2d3mCjQrWUTVpVD9WL/jZAbvp+Ed04rOhrsk7FiTcEDseB5A=="
     },
+    "@carbon/charts-svelte@1.27.10_svelte@5.51.3__acorn@8.15.0": {
+      "integrity": "sha512-+/WKuOYTLGkaBjA353x/35H7/0vtiy6kC1WgVxhMI5gWcQeaEAYQFOgW328nG1tgkLp+eWpZOnHbGjsu4D1Uug==",
+      "dependencies": [
+        "@carbon/charts",
+        "@ibm/telemetry-js",
+        "svelte"
+      ],
+      "scripts": true
+    },
+    "@carbon/charts@1.27.10": {
+      "integrity": "sha512-tH6J1ljSVydguK+wtgdbsE0wTxebES2oHKmSKDsBM6NS/TYMi/cvsdbGnj7DOKzudeF5C8PFBogSAxY2gOChHw==",
+      "dependencies": [
+        "@carbon/colors",
+        "@carbon/utils-position",
+        "@ibm/telemetry-js",
+        "@types/d3",
+        "@types/topojson",
+        "d3",
+        "d3-cloud",
+        "d3-sankey",
+        "date-fns",
+        "dompurify",
+        "html-to-image",
+        "lodash-es",
+        "topojson-client",
+        "tslib"
+      ],
+      "scripts": true
+    },
+    "@carbon/colors@11.51.0": {
+      "integrity": "sha512-PgCHKIrZ8t/1oG8ofkv2XDHeuwcmvKsT0nUWVyiCoL6Xf2JWdAyuWyNDDtRuQXJ4ayNAdRk2+pijT23/ooXGlw==",
+      "dependencies": [
+        "@ibm/telemetry-js"
+      ],
+      "scripts": true
+    },
+    "@carbon/utils-position@1.3.0": {
+      "integrity": "sha512-bfar2dV+fQ15syIrH3n9ujY4PXd1Q+AF2VcTLJIC04IDe2f80zOnJlLNPc/RktHcWTZ7WSQm80cQo3abGcsfTA==",
+      "dependencies": [
+        "@ibm/telemetry-js"
+      ],
+      "scripts": true
+    },
     "@cloudflare/kv-asset-handler@0.4.2": {
       "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="
     },
@@ -1425,7 +1472,7 @@
         "levn"
       ]
     },
-    "@ethercorps/sveltekit-og@4.2.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3": {
+    "@ethercorps/sveltekit-og@4.2.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-mMkoKWMMBXL5iAYrMZqklezZDUU7HpHd+sNsz78e4gElXFyxdOnsIFfPPXpqDcUn6orZHs5MGHvtPi5II5xNAA==",
       "dependencies": [
         "@resvg/resvg-wasm",
@@ -1869,6 +1916,10 @@
     },
     "@humanwhocodes/retry@0.4.3": {
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="
+    },
+    "@ibm/telemetry-js@1.11.0": {
+      "integrity": "sha512-RO/9j+URJnSfseWg9ZkEX9p+a3Ousd33DBU7rOafoZB08RqdzxFVYJ2/iM50dkBuD0o7WX7GYt1sLbNgCoE+pA==",
+      "bin": true
     },
     "@img/colour@1.0.0": {
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="
@@ -2481,96 +2532,6 @@
     "@oxc-project/types@0.120.0": {
       "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="
     },
-    "@parcel/watcher-android-arm64@2.5.4": {
-      "integrity": "sha512-hoh0vx4v+b3BNI7Cjoy2/B0ARqcwVNrzN/n7DLq9ZB4I3lrsvhrkCViJyfTj/Qi5xM9YFiH4AmHGK6pgH1ss7g==",
-      "os": ["android"],
-      "cpu": ["arm64"]
-    },
-    "@parcel/watcher-darwin-arm64@2.5.4": {
-      "integrity": "sha512-kphKy377pZiWpAOyTgQYPE5/XEKVMaj6VUjKT5VkNyUJlr2qZAn8gIc7CPzx+kbhvqHDT9d7EqdOqRXT6vk0zw==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
-    "@parcel/watcher-darwin-x64@2.5.4": {
-      "integrity": "sha512-UKaQFhCtNJW1A9YyVz3Ju7ydf6QgrpNQfRZ35wNKUhTQ3dxJ/3MULXN5JN/0Z80V/KUBDGa3RZaKq1EQT2a2gg==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "@parcel/watcher-freebsd-x64@2.5.4": {
-      "integrity": "sha512-Dib0Wv3Ow/m2/ttvLdeI2DBXloO7t3Z0oCp4bAb2aqyqOjKPPGrg10pMJJAQ7tt8P4V2rwYwywkDhUia/FgS+Q==",
-      "os": ["freebsd"],
-      "cpu": ["x64"]
-    },
-    "@parcel/watcher-linux-arm-glibc@2.5.4": {
-      "integrity": "sha512-I5Vb769pdf7Q7Sf4KNy8Pogl/URRCKu9ImMmnVKYayhynuyGYMzuI4UOWnegQNa2sGpsPSbzDsqbHNMyeyPCgw==",
-      "os": ["linux"],
-      "cpu": ["arm"]
-    },
-    "@parcel/watcher-linux-arm-musl@2.5.4": {
-      "integrity": "sha512-kGO8RPvVrcAotV4QcWh8kZuHr9bXi9a3bSZw7kFarYR0+fGliU7hd/zevhjw8fnvIKG3J9EO5G6sXNGCSNMYPQ==",
-      "os": ["linux"],
-      "cpu": ["arm"]
-    },
-    "@parcel/watcher-linux-arm64-glibc@2.5.4": {
-      "integrity": "sha512-KU75aooXhqGFY2W5/p8DYYHt4hrjHZod8AhcGAmhzPn/etTa+lYCDB2b1sJy3sWJ8ahFVTdy+EbqSBvMx3iFlw==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@parcel/watcher-linux-arm64-musl@2.5.4": {
-      "integrity": "sha512-Qx8uNiIekVutnzbVdrgSanM+cbpDD3boB1f8vMtnuG5Zau4/bdDbXyKwIn0ToqFhIuob73bcxV9NwRm04/hzHQ==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@parcel/watcher-linux-x64-glibc@2.5.4": {
-      "integrity": "sha512-UYBQvhYmgAv61LNUn24qGQdjtycFBKSK3EXr72DbJqX9aaLbtCOO8+1SkKhD/GNiJ97ExgcHBrukcYhVjrnogA==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@parcel/watcher-linux-x64-musl@2.5.4": {
-      "integrity": "sha512-YoRWCVgxv8akZrMhdyVi6/TyoeeMkQ0PGGOf2E4omODrvd1wxniXP+DBynKoHryStks7l+fDAMUBRzqNHrVOpg==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@parcel/watcher-win32-arm64@2.5.4": {
-      "integrity": "sha512-iby+D/YNXWkiQNYcIhg8P5hSjzXEHaQrk2SLrWOUD7VeC4Ohu0WQvmV+HDJokZVJ2UjJ4AGXW3bx7Lls9Ln4TQ==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "@parcel/watcher-win32-ia32@2.5.4": {
-      "integrity": "sha512-vQN+KIReG0a2ZDpVv8cgddlf67J8hk1WfZMMP7sMeZmJRSmEax5xNDNWKdgqSe2brOKTQQAs3aCCUal2qBHAyg==",
-      "os": ["win32"],
-      "cpu": ["ia32"]
-    },
-    "@parcel/watcher-win32-x64@2.5.4": {
-      "integrity": "sha512-3A6efb6BOKwyw7yk9ro2vus2YTt2nvcd56AuzxdMiVOxL9umDyN5PKkKfZ/gZ9row41SjVmTVQNWQhaRRGpOKw==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "@parcel/watcher@2.5.4": {
-      "integrity": "sha512-WYa2tUVV5HiArWPB3ydlOc4R2ivq0IDrlqhMi3l7mVsFEXNcTfxYFPIHXHXIh/ca/y/V5N4E1zecyxdIBjYnkQ==",
-      "dependencies": [
-        "detect-libc",
-        "is-glob",
-        "node-addon-api",
-        "picomatch@4.0.3"
-      ],
-      "optionalDependencies": [
-        "@parcel/watcher-android-arm64",
-        "@parcel/watcher-darwin-arm64",
-        "@parcel/watcher-darwin-x64",
-        "@parcel/watcher-freebsd-x64",
-        "@parcel/watcher-linux-arm-glibc",
-        "@parcel/watcher-linux-arm-musl",
-        "@parcel/watcher-linux-arm64-glibc",
-        "@parcel/watcher-linux-arm64-musl",
-        "@parcel/watcher-linux-x64-glibc",
-        "@parcel/watcher-linux-x64-musl",
-        "@parcel/watcher-win32-arm64",
-        "@parcel/watcher-win32-ia32",
-        "@parcel/watcher-win32-x64"
-      ],
-      "scripts": true
-    },
     "@playwright/test@1.58.2": {
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dependencies": [
@@ -3129,7 +3090,7 @@
         "svelte"
       ]
     },
-    "@sentry/sveltekit@10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_@cloudflare+workers-types@4.20260504.1": {
+    "@sentry/sveltekit@10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-owbKr6BlfhODiJzSQrjd+r400PdLjQQkbsNRHBLHjiwrL29Xf8SCM2fzFPh0FZYqgpG/opOi9CAVgNpmq1nWRg==",
       "dependencies": [
         "@babel/parser@7.26.9",
@@ -3142,10 +3103,10 @@
         "magic-string@0.30.21",
         "recast",
         "sorcery",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ],
       "optionalPeers": [
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ]
     },
     "@sentry/vite-plugin@5.1.1_rollup@4.59.0": {
@@ -3194,13 +3155,13 @@
         "acorn"
       ]
     },
-    "@sveltejs/adapter-auto@7.0.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@sveltejs/adapter-auto@7.0.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==",
       "dependencies": [
         "@sveltejs/kit"
       ]
     },
-    "@sveltejs/adapter-cloudflare@7.2.7_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@sveltejs/adapter-cloudflare@7.2.7_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-Kj6GADGhuGZe/A+WnoEdNLdGzAl1Yz/TUpThNNuU9MO/rXrFYsu7/BjxteimyRl4Sx/ypftqKWGtbFl6utJ/0g==",
       "dependencies": [
         "@cloudflare/workers-types",
@@ -3209,7 +3170,7 @@
         "wrangler"
       ]
     },
-    "@sveltejs/kit@2.55.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@sveltejs/kit@2.55.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==",
       "dependencies": [
         "@standard-schema/spec",
@@ -3227,21 +3188,21 @@
         "sirv",
         "svelte",
         "typescript",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ],
       "optionalPeers": [
         "typescript"
       ],
       "bin": true
     },
-    "@sveltejs/vite-plugin-svelte@7.0.0_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@sveltejs/vite-plugin-svelte@7.0.0_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g==",
       "dependencies": [
         "deepmerge",
         "magic-string@0.30.21",
         "obug",
         "svelte",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3",
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0",
         "vitefu"
       ]
     },
@@ -3387,17 +3348,17 @@
         "svelte"
       ]
     },
-    "@testing-library/svelte@5.3.1_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_vitest@4.1.0__@opentelemetry+api@1.9.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3__msw@2.12.10___typescript@5.8.3_@opentelemetry+api@1.9.0_jsdom@26.1.0_msw@2.12.10__typescript@5.8.3": {
+    "@testing-library/svelte@5.3.1_svelte@5.51.3__acorn@8.15.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_vitest@4.1.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
       "dependencies": [
         "@testing-library/dom",
         "@testing-library/svelte-core",
         "svelte",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3",
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0",
         "vitest"
       ],
       "optionalPeers": [
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3",
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0",
         "vitest"
       ]
     },
@@ -3441,6 +3402,166 @@
     "@types/cookie@0.6.0": {
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
+    "@types/d3-array@3.2.2": {
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+    },
+    "@types/d3-axis@3.0.6": {
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dependencies": [
+        "@types/d3-selection"
+      ]
+    },
+    "@types/d3-brush@3.0.6": {
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dependencies": [
+        "@types/d3-selection"
+      ]
+    },
+    "@types/d3-chord@3.0.6": {
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="
+    },
+    "@types/d3-color@3.1.3": {
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "@types/d3-contour@3.0.6": {
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dependencies": [
+        "@types/d3-array",
+        "@types/geojson"
+      ]
+    },
+    "@types/d3-delaunay@6.0.4": {
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="
+    },
+    "@types/d3-dispatch@3.0.7": {
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="
+    },
+    "@types/d3-drag@3.0.7": {
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dependencies": [
+        "@types/d3-selection"
+      ]
+    },
+    "@types/d3-dsv@3.0.7": {
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="
+    },
+    "@types/d3-ease@3.0.2": {
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "@types/d3-fetch@3.0.7": {
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dependencies": [
+        "@types/d3-dsv"
+      ]
+    },
+    "@types/d3-force@3.0.10": {
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="
+    },
+    "@types/d3-format@3.0.4": {
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="
+    },
+    "@types/d3-geo@3.1.0": {
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dependencies": [
+        "@types/geojson"
+      ]
+    },
+    "@types/d3-hierarchy@3.1.7": {
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="
+    },
+    "@types/d3-interpolate@3.0.4": {
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": [
+        "@types/d3-color"
+      ]
+    },
+    "@types/d3-path@3.1.1": {
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "@types/d3-polygon@3.0.2": {
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="
+    },
+    "@types/d3-quadtree@3.0.6": {
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="
+    },
+    "@types/d3-random@3.0.3": {
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="
+    },
+    "@types/d3-scale-chromatic@3.1.0": {
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="
+    },
+    "@types/d3-scale@4.0.9": {
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": [
+        "@types/d3-time"
+      ]
+    },
+    "@types/d3-selection@3.0.11": {
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="
+    },
+    "@types/d3-shape@3.1.8": {
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dependencies": [
+        "@types/d3-path"
+      ]
+    },
+    "@types/d3-time-format@4.0.3": {
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="
+    },
+    "@types/d3-time@3.0.4": {
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "@types/d3-timer@3.0.2": {
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
+    "@types/d3-transition@3.0.9": {
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dependencies": [
+        "@types/d3-selection"
+      ]
+    },
+    "@types/d3-zoom@3.0.8": {
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dependencies": [
+        "@types/d3-interpolate",
+        "@types/d3-selection"
+      ]
+    },
+    "@types/d3@7.4.3": {
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dependencies": [
+        "@types/d3-array",
+        "@types/d3-axis",
+        "@types/d3-brush",
+        "@types/d3-chord",
+        "@types/d3-color",
+        "@types/d3-contour",
+        "@types/d3-delaunay",
+        "@types/d3-dispatch",
+        "@types/d3-drag",
+        "@types/d3-dsv",
+        "@types/d3-ease",
+        "@types/d3-fetch",
+        "@types/d3-force",
+        "@types/d3-format",
+        "@types/d3-geo",
+        "@types/d3-hierarchy",
+        "@types/d3-interpolate",
+        "@types/d3-path",
+        "@types/d3-polygon",
+        "@types/d3-quadtree",
+        "@types/d3-random",
+        "@types/d3-scale",
+        "@types/d3-scale-chromatic",
+        "@types/d3-selection",
+        "@types/d3-shape",
+        "@types/d3-time",
+        "@types/d3-time-format",
+        "@types/d3-timer",
+        "@types/d3-transition",
+        "@types/d3-zoom"
+      ]
+    },
     "@types/deep-eql@4.0.2": {
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="
     },
@@ -3459,6 +3580,9 @@
     },
     "@types/estree@1.0.8": {
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
+    },
+    "@types/geojson@7946.0.16": {
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="
     },
     "@types/json-schema@7.0.15": {
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
@@ -3511,6 +3635,43 @@
       "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
       "dependencies": [
         "@types/node"
+      ]
+    },
+    "@types/topojson-client@3.1.5": {
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "dependencies": [
+        "@types/geojson",
+        "@types/topojson-specification"
+      ]
+    },
+    "@types/topojson-server@3.0.4": {
+      "integrity": "sha512-5+ieK8ePfP+K2VH6Vgs1VCt+fO1U8XZHj0UsF+NktaF0DavAo1q3IvCBXgokk/xmtvoPltSUs6vxuR/zMdOE1g==",
+      "dependencies": [
+        "@types/geojson",
+        "@types/topojson-specification"
+      ]
+    },
+    "@types/topojson-simplify@3.0.3": {
+      "integrity": "sha512-sBO5UZ0O2dB0bNwo0vut2yLHhj3neUGi9uL7/ROdm8Gs6dtt4jcB9OGDKr+M2isZwQM2RuzVmifnMZpxj4IGNw==",
+      "dependencies": [
+        "@types/geojson",
+        "@types/topojson-specification"
+      ]
+    },
+    "@types/topojson-specification@1.0.5": {
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "dependencies": [
+        "@types/geojson"
+      ]
+    },
+    "@types/topojson@3.2.6": {
+      "integrity": "sha512-ppfdlxjxofWJ66XdLgIlER/85RvpGyfOf8jrWf+3kVIjEatFxEZYD/Ea83jO672Xu1HRzd/ghwlbcZIUNHTskw==",
+      "dependencies": [
+        "@types/geojson",
+        "@types/topojson-client",
+        "@types/topojson-server",
+        "@types/topojson-simplify",
+        "@types/topojson-specification"
       ]
     },
     "@types/trusted-types@2.0.7": {
@@ -3626,7 +3787,7 @@
         "@use-gesture/core"
       ]
     },
-    "@vite-pwa/sveltekit@1.1.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@vite-pwa/sveltekit@1.1.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-mMIf2tY+7Hg8jecpu/WY+Ki2ikoXy3hVmt3tOxi0K+lYYnKQrDYthuHireI0S+26Mg9BXzL7qQF1xeB5VYlYlg==",
       "dependencies": [
         "@sveltejs/kit",
@@ -3635,7 +3796,7 @@
         "vite-plugin-pwa"
       ]
     },
-    "@vitest/coverage-istanbul@4.1.0_vitest@4.1.0__@opentelemetry+api@1.9.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3__msw@2.12.10___typescript@5.8.3_@opentelemetry+api@1.9.0_jsdom@26.1.0_msw@2.12.10__typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@vitest/coverage-istanbul@4.1.0_vitest@4.1.0__jsdom@26.1.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-0+67gA94YToxd+Pc3XgIA/2c8HN2hXNSg3T+1FI4HW7W/2gPitYCtktsY6Ke7vrt5caboMq3TUf0/vwbHRb0og==",
       "dependencies": [
         "@babel/core",
@@ -3662,18 +3823,18 @@
         "tinyrainbow"
       ]
     },
-    "@vitest/mocker@4.1.0_msw@2.12.10__typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "@vitest/mocker@4.1.0_msw@2.12.10__typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
       "dependencies": [
         "@vitest/spy",
         "estree-walker@3.0.3",
         "magic-string@0.30.21",
         "msw",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ],
       "optionalPeers": [
         "msw",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ]
     },
     "@vitest/pretty-format@4.1.0": {
@@ -3884,7 +4045,7 @@
       "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
       "bin": true
     },
-    "bits-ui@2.16.2_svelte@5.51.3__acorn@8.15.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "bits-ui@2.16.2_svelte@5.51.3__acorn@8.15.0_sass-embedded@1.83.0": {
       "integrity": "sha512-bgEpRRF7Ck9nRP1pbuKVxpaSMrz+8Pm0y+dmuvlkrSe+uUwIQECef29y6eslFHM6pCAubUh7STrsTLUUp8fzFQ==",
       "dependencies": [
         "@floating-ui/core",
@@ -3922,6 +4083,9 @@
         "update-browserslist-db"
       ],
       "bin": true
+    },
+    "buffer-builder@0.2.0": {
+      "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg=="
     },
     "buffer-from@1.1.2": {
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
@@ -4038,6 +4202,9 @@
     "commander@2.20.3": {
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
+    "commander@7.2.0": {
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+    },
     "comment-json@4.5.1": {
       "integrity": "sha512-taEtr3ozUmOB7it68Jll7s0Pwm+aoiHyXKrEC8SEodL4rNpdfDLqa7PfBlrgFoCNNdR8ImL+muti5IGvktJAAg==",
       "dependencies": [
@@ -4145,6 +4312,240 @@
     "custom-event-polyfill@1.0.7": {
       "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
     },
+    "d3-array@2.12.1": {
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": [
+        "internmap"
+      ]
+    },
+    "d3-array@3.2.4": {
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": [
+        "internmap"
+      ]
+    },
+    "d3-axis@3.0.0": {
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
+    },
+    "d3-brush@3.0.0": {
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dependencies": [
+        "d3-dispatch@3.0.1",
+        "d3-drag",
+        "d3-interpolate",
+        "d3-selection",
+        "d3-transition"
+      ]
+    },
+    "d3-chord@3.0.1": {
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dependencies": [
+        "d3-path@3.1.0"
+      ]
+    },
+    "d3-cloud@1.2.9": {
+      "integrity": "sha512-leL1GLneC9ZQtnV+6TGWrNlGfI1WX7S2arcTv2vae12DaXo5wjm6GBCkskXbrDlyOymd/A75Pyj1H37MW4BZ/Q==",
+      "dependencies": [
+        "d3-dispatch@1.0.6"
+      ]
+    },
+    "d3-color@3.1.0": {
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+    },
+    "d3-contour@4.0.2": {
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dependencies": [
+        "d3-array@3.2.4"
+      ]
+    },
+    "d3-delaunay@6.0.4": {
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dependencies": [
+        "delaunator"
+      ]
+    },
+    "d3-dispatch@1.0.6": {
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
+    },
+    "d3-dispatch@3.0.1": {
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
+    },
+    "d3-drag@3.0.0": {
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dependencies": [
+        "d3-dispatch@3.0.1",
+        "d3-selection"
+      ]
+    },
+    "d3-dsv@3.0.1": {
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dependencies": [
+        "commander@7.2.0",
+        "iconv-lite",
+        "rw"
+      ],
+      "bin": true
+    },
+    "d3-ease@3.0.1": {
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+    },
+    "d3-fetch@3.0.1": {
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dependencies": [
+        "d3-dsv"
+      ]
+    },
+    "d3-force@3.0.0": {
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dependencies": [
+        "d3-dispatch@3.0.1",
+        "d3-quadtree",
+        "d3-timer"
+      ]
+    },
+    "d3-format@3.1.2": {
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="
+    },
+    "d3-geo@3.1.1": {
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dependencies": [
+        "d3-array@3.2.4"
+      ]
+    },
+    "d3-hierarchy@3.1.2": {
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
+    },
+    "d3-interpolate@3.0.1": {
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": [
+        "d3-color"
+      ]
+    },
+    "d3-path@1.0.9": {
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-path@3.1.0": {
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
+    },
+    "d3-polygon@3.0.1": {
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
+    },
+    "d3-quadtree@3.0.1": {
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
+    },
+    "d3-random@3.0.1": {
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
+    },
+    "d3-sankey@0.12.3": {
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dependencies": [
+        "d3-array@2.12.1",
+        "d3-shape@1.3.7"
+      ]
+    },
+    "d3-scale-chromatic@3.1.0": {
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dependencies": [
+        "d3-color",
+        "d3-interpolate"
+      ]
+    },
+    "d3-scale@4.0.2": {
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": [
+        "d3-array@3.2.4",
+        "d3-format",
+        "d3-interpolate",
+        "d3-time",
+        "d3-time-format"
+      ]
+    },
+    "d3-selection@3.0.0": {
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+    },
+    "d3-shape@1.3.7": {
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": [
+        "d3-path@1.0.9"
+      ]
+    },
+    "d3-shape@3.2.0": {
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": [
+        "d3-path@3.1.0"
+      ]
+    },
+    "d3-time-format@4.1.0": {
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": [
+        "d3-time"
+      ]
+    },
+    "d3-time@3.1.0": {
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": [
+        "d3-array@3.2.4"
+      ]
+    },
+    "d3-timer@3.0.1": {
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
+    "d3-transition@3.0.1_d3-selection@3.0.0": {
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": [
+        "d3-color",
+        "d3-dispatch@3.0.1",
+        "d3-ease",
+        "d3-interpolate",
+        "d3-selection",
+        "d3-timer"
+      ]
+    },
+    "d3-zoom@3.0.0": {
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": [
+        "d3-dispatch@3.0.1",
+        "d3-drag",
+        "d3-interpolate",
+        "d3-selection",
+        "d3-transition"
+      ]
+    },
+    "d3@7.9.0": {
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dependencies": [
+        "d3-array@3.2.4",
+        "d3-axis",
+        "d3-brush",
+        "d3-chord",
+        "d3-color",
+        "d3-contour",
+        "d3-delaunay",
+        "d3-dispatch@3.0.1",
+        "d3-drag",
+        "d3-dsv",
+        "d3-ease",
+        "d3-fetch",
+        "d3-force",
+        "d3-format",
+        "d3-geo",
+        "d3-hierarchy",
+        "d3-interpolate",
+        "d3-path@3.1.0",
+        "d3-polygon",
+        "d3-quadtree",
+        "d3-random",
+        "d3-scale",
+        "d3-scale-chromatic",
+        "d3-selection",
+        "d3-shape@3.2.0",
+        "d3-time",
+        "d3-time-format",
+        "d3-timer",
+        "d3-transition",
+        "d3-zoom"
+      ]
+    },
     "data-urls@5.0.0": {
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dependencies": [
@@ -4213,6 +4614,12 @@
         "object-keys"
       ]
     },
+    "delaunator@5.1.0": {
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dependencies": [
+        "robust-predicates"
+      ]
+    },
     "delayed-stream@1.0.0": {
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
@@ -4233,6 +4640,12 @@
     },
     "dom-accessibility-api@0.6.3": {
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="
+    },
+    "dompurify@3.4.2": {
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "optionalDependencies": [
+        "@types/trusted-types"
+      ]
     },
     "dotenv@16.6.1": {
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="
@@ -4917,6 +5330,9 @@
     "html-escaper@2.0.2": {
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
+    "html-to-image@1.11.11": {
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
+    },
     "http-parser-js@0.5.10": {
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA=="
     },
@@ -5006,6 +5422,9 @@
         "hasown",
         "side-channel"
       ]
+    },
+    "internmap@1.0.1": {
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "is-array-buffer@3.0.5": {
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
@@ -5433,6 +5852,9 @@
         "p-locate"
       ]
     },
+    "lodash-es@4.18.1": {
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="
+    },
     "lodash.camelcase@4.3.0": {
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
@@ -5645,9 +6067,6 @@
         "lower-case",
         "tslib"
       ]
-    },
-    "node-addon-api@7.1.1": {
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="
     },
     "node-fetch@2.7.0": {
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
@@ -6119,6 +6538,9 @@
     "rettime@0.10.1": {
       "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw=="
     },
+    "robust-predicates@3.0.3": {
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="
+    },
     "rolldown@1.0.0-rc.10": {
       "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
       "dependencies": [
@@ -6189,7 +6611,7 @@
     "rrweb-cssom@0.8.0": {
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="
     },
-    "runed@0.35.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "runed@0.35.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.83.0___sass-embedded@1.83.0__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.83.0__sass-embedded@1.83.0_svelte@5.51.3__acorn@8.15.0_sass-embedded@1.83.0": {
       "integrity": "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==",
       "dependencies": [
         "@sveltejs/kit",
@@ -6201,6 +6623,9 @@
       "optionalPeers": [
         "@sveltejs/kit"
       ]
+    },
+    "rw@1.3.3": {
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "rxjs@7.8.2": {
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
@@ -6245,104 +6670,111 @@
     "safer-buffer@2.1.2": {
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "sass-embedded-all-unknown@1.97.3": {
-      "integrity": "sha512-t6N46NlPuXiY3rlmG6/+1nwebOBOaLFOOVqNQOC2cJhghOD4hh2kHNQQTorCsbY9S1Kir2la1/XLBwOJfui0xg==",
-      "dependencies": [
-        "sass"
-      ],
-      "cpu": ["!arm", "!arm64", "!riscv64", "!x64"]
-    },
-    "sass-embedded-android-arm64@1.97.3": {
-      "integrity": "sha512-aiZ6iqiHsUsaDx0EFbbmmA0QgxicSxVVN3lnJJ0f1RStY0DthUkquGT5RJ4TPdaZ6ebeJWkboV4bra+CP766eA==",
+    "sass-embedded-android-arm64@1.83.0": {
+      "integrity": "sha512-GBiCvM4a2rkWBLdYDxI6XYnprfk5U5c81g69RC2X6kqPuzxzx8qTArQ9M6keFK4+iDQ5N9QTwFCr0KbZTn+ZNQ==",
       "os": ["android"],
       "cpu": ["arm64"]
     },
-    "sass-embedded-android-arm@1.97.3": {
-      "integrity": "sha512-cRTtf/KV/q0nzGZoUzVkeIVVFv3L/tS1w4WnlHapphsjTXF/duTxI8JOU1c/9GhRPiMdfeXH7vYNcMmtjwX7jg==",
+    "sass-embedded-android-arm@1.83.0": {
+      "integrity": "sha512-uwFSXzJlfbd4Px189xE5l+cxN8+TQpXdQgJec7TIrb4HEY7imabtpYufpVdqUVwT1/uiis5V4+qIEC4Vl5XObQ==",
       "os": ["android"],
       "cpu": ["arm"]
     },
-    "sass-embedded-android-riscv64@1.97.3": {
-      "integrity": "sha512-zVEDgl9JJodofGHobaM/q6pNETG69uuBIGQHRo789jloESxxZe82lI3AWJQuPmYCOG5ElfRthqgv89h3gTeLYA==",
+    "sass-embedded-android-ia32@1.83.0": {
+      "integrity": "sha512-5ATPdGo2SICqAhiJl/Z8KQ23zH4sGgobGgux0TnrNtt83uHZ+r+To/ubVJ7xTkZxed+KJZnIpolGD8dQyQqoTg==",
+      "os": ["android"],
+      "cpu": ["ia32"]
+    },
+    "sass-embedded-android-riscv64@1.83.0": {
+      "integrity": "sha512-aveknUOB8GZewOzVn2Uwk+DKcncTR50Q6vtzslNMGbYnxtgQNHzy8A1qVEviNUruex+pHofppeMK4iMPFAbiEQ==",
       "os": ["android"],
       "cpu": ["riscv64"]
     },
-    "sass-embedded-android-x64@1.97.3": {
-      "integrity": "sha512-3ke0le7ZKepyXn/dKKspYkpBC0zUk/BMciyP5ajQUDy4qJwobd8zXdAq6kOkdiMB+d9UFJOmEkvgFJHl3lqwcw==",
+    "sass-embedded-android-x64@1.83.0": {
+      "integrity": "sha512-WqIay/72ncyf9Ph4vS742J3a73wZihWmzFUwpn1OD6lme1Aj4eWzWIve5IVnlTEJgcZcDHu6ECID9IZgehJKoA==",
       "os": ["android"],
       "cpu": ["x64"]
     },
-    "sass-embedded-darwin-arm64@1.97.3": {
-      "integrity": "sha512-fuqMTqO4gbOmA/kC5b9y9xxNYw6zDEyfOtMgabS7Mz93wimSk2M1quQaTJnL98Mkcsl2j+7shNHxIS/qpcIDDA==",
+    "sass-embedded-darwin-arm64@1.83.0": {
+      "integrity": "sha512-XQl9QqgxFFIPm/CzHhmppse5o9ocxrbaAdC2/DAnlAqvYWBBtgFqPjGoYlej13h9SzfvNoogx+y9r+Ap+e+hYg==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "sass-embedded-darwin-x64@1.97.3": {
-      "integrity": "sha512-b/2RBs/2bZpP8lMkyZ0Px0vkVkT8uBd0YXpOwK7iOwYkAT8SsO4+WdVwErsqC65vI5e1e5p1bb20tuwsoQBMVA==",
+    "sass-embedded-darwin-x64@1.83.0": {
+      "integrity": "sha512-ERQ7Tvp1kFOW3ux4VDFIxb7tkYXHYc+zJpcrbs0hzcIO5ilIRU2tIOK1OrNwrFO6Qxyf7AUuBwYKLAtIU/Nz7g==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "sass-embedded-linux-arm64@1.97.3": {
-      "integrity": "sha512-IP1+2otCT3DuV46ooxPaOKV1oL5rLjteRzf8ldZtfIEcwhSgSsHgA71CbjYgLEwMY9h4jeal8Jfv3QnedPvSjg==",
+    "sass-embedded-linux-arm64@1.83.0": {
+      "integrity": "sha512-syEAVTJt4qhaMLxrSwOWa46zdqHJdnqJkLUK+t9aCr8xqBZLPxSUeIGji76uOehQZ1C+KGFj6n9xstHN6wzOJw==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "sass-embedded-linux-arm@1.97.3": {
-      "integrity": "sha512-2lPQ7HQQg4CKsH18FTsj2hbw5GJa6sBQgDsls+cV7buXlHjqF8iTKhAQViT6nrpLK/e8nFCoaRgSqEC8xMnXuA==",
+    "sass-embedded-linux-arm@1.83.0": {
+      "integrity": "sha512-baG9RYBJxUFmqwDNC9h9ZFElgJoyO3jgHGjzEZ1wHhIS9anpG+zZQvO8bHx3dBpKEImX+DBeLX+CxsFR9n81gQ==",
       "os": ["linux"],
       "cpu": ["arm"]
     },
-    "sass-embedded-linux-musl-arm64@1.97.3": {
-      "integrity": "sha512-Lij0SdZCsr+mNRSyDZ7XtJpXEITrYsaGbOTz5e6uFLJ9bmzUbV7M8BXz2/cA7bhfpRPT7/lwRKPdV4+aR9Ozcw==",
+    "sass-embedded-linux-ia32@1.83.0": {
+      "integrity": "sha512-RRBxQxMpoxu5+XcSSc6QR/o9asEwUzR8AbCS83RaXcdTIHTa/CccQsiAoDDoPlRsMTLqnzs0LKL4CfOsf7zBbA==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "sass-embedded-linux-musl-arm64@1.83.0": {
+      "integrity": "sha512-Y7juhPHClUO2H5O+u+StRy6SEAcwZ+hTEk5WJdEmo1Bb1gDtfHvJaWB/iFZJ2tW0W1e865AZeUrC4OcOFjyAQA==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "sass-embedded-linux-musl-arm@1.97.3": {
-      "integrity": "sha512-cBTMU68X2opBpoYsSZnI321gnoaiMBEtc+60CKCclN6PCL3W3uXm8g4TLoil1hDD6mqU9YYNlVG6sJ+ZNef6Lg==",
+    "sass-embedded-linux-musl-arm@1.83.0": {
+      "integrity": "sha512-Yc7u2TelCfBab+PRob9/MNJFh3EooMiz4urvhejXkihTiKSHGCv5YqDdtWzvyb9tY2Jb7YtYREVuHwfdVn3dTQ==",
       "os": ["linux"],
       "cpu": ["arm"]
     },
-    "sass-embedded-linux-musl-riscv64@1.97.3": {
-      "integrity": "sha512-sBeLFIzMGshR4WmHAD4oIM7WJVkSoCIEwutzptFtGlSlwfNiijULp+J5hA2KteGvI6Gji35apR5aWj66wEn/iA==",
+    "sass-embedded-linux-musl-ia32@1.83.0": {
+      "integrity": "sha512-arQeYwGmwXV8byx5G1PtSzZWW1jbkfR5qrIHMEbTFSAvAxpqjgSvCvrHMOFd73FcMxVaYh4BX9LQNbKinkbEdg==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "sass-embedded-linux-musl-riscv64@1.83.0": {
+      "integrity": "sha512-E6uzlIWz59rut+Z3XR6mLG915zNzv07ISvj3GUNZENdHM7dF8GQ//ANoIpl5PljMQKp89GnYdvo6kj2gnaBf/g==",
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
-    "sass-embedded-linux-musl-x64@1.97.3": {
-      "integrity": "sha512-/oWJ+OVrDg7ADDQxRLC/4g1+Nsz1g4mkYS2t6XmyMJKFTFK50FVI2t5sOdFH+zmMp+nXHKM036W94y9m4jjEcw==",
+    "sass-embedded-linux-musl-x64@1.83.0": {
+      "integrity": "sha512-eAMK6tyGqvqr21r9g8BnR3fQc1rYFj85RGduSQ3xkITZ6jOAnOhuU94N5fwRS852Hpws0lXhET+7JHXgg3U18w==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "sass-embedded-linux-riscv64@1.97.3": {
-      "integrity": "sha512-l3IfySApLVYdNx0Kjm7Zehte1CDPZVcldma3dZt+TfzvlAEerM6YDgsk5XEj3L8eHBCgHgF4A0MJspHEo2WNfA==",
+    "sass-embedded-linux-riscv64@1.83.0": {
+      "integrity": "sha512-Ojpi78pTv02sy2fUYirRGXHLY3fPnV/bvwuC2i5LwPQw2LpCcFyFTtN0c5h4LJDk9P6wr+/ZB/JXU8tHIOlK+Q==",
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
-    "sass-embedded-linux-x64@1.97.3": {
-      "integrity": "sha512-Kwqwc/jSSlcpRjULAOVbndqEy2GBzo6OBmmuBVINWUaJLJ8Kczz3vIsDUWLfWz/kTEw9FHBSiL0WCtYLVAXSLg==",
+    "sass-embedded-linux-x64@1.83.0": {
+      "integrity": "sha512-3iLjlXdoPfgZRtX4odhRvka1BQs5mAXqfCtDIQBgh/o0JnGPzJIWWl9bYLpHxK8qb+uyVBxXYgXpI0sCzArBOw==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "sass-embedded-unknown-all@1.97.3": {
-      "integrity": "sha512-/GHajyYJmvb0IABUQHbVHf1nuHPtIDo/ClMZ81IDr59wT5CNcMe7/dMNujXwWugtQVGI5UGmqXWZQCeoGnct8Q==",
-      "dependencies": [
-        "sass"
-      ],
-      "os": ["!android", "!darwin", "!linux", "!win32"]
-    },
-    "sass-embedded-win32-arm64@1.97.3": {
-      "integrity": "sha512-RDGtRS1GVvQfMGAmVXNxYiUOvPzn9oO1zYB/XUM9fudDRnieYTcUytpNTQZLs6Y1KfJxgt5Y+giRceC92fT8Uw==",
+    "sass-embedded-win32-arm64@1.83.0": {
+      "integrity": "sha512-iOHw/8/t2dlTW3lOFwG5eUbiwhEyGWawivlKWJ8lkXH7fjMpVx2VO9zCFAm8RvY9xOHJ9sf1L7g5bx3EnNP9BQ==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "sass-embedded-win32-x64@1.97.3": {
-      "integrity": "sha512-SFRa2lED9UEwV6vIGeBXeBOLKF+rowF3WmNfb/BzhxmdAsKofCXrJ8ePW7OcDVrvNEbTOGwhsReIsF5sH8fVaw==",
+    "sass-embedded-win32-ia32@1.83.0": {
+      "integrity": "sha512-2PxNXJ8Pad4geVcTXY4rkyTr5AwbF8nfrCTDv0ulbTvPhzX2mMKEGcBZUXWn5BeHZTBc6whNMfS7d5fQXR9dDQ==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "sass-embedded-win32-x64@1.83.0": {
+      "integrity": "sha512-muBXkFngM6eLTNqOV0FQi7Dv9s+YRQ42Yem26mosdan/GmJQc81deto6uDTgrYn+bzFNmiXcOdfm+0MkTWK3OQ==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "sass-embedded@1.97.3": {
-      "integrity": "sha512-eKzFy13Nk+IRHhlAwP3sfuv+PzOrvzUkwJK2hdoCKYcWGSdmwFpeGpWmyewdw8EgBnsKaSBtgf/0b2K635ecSA==",
+    "sass-embedded@1.83.0": {
+      "integrity": "sha512-/8cYZeL39evUqe0o//193na51Q1VWZ61qhxioQvLJwOtWIrX+PgNhCyD8RSuTtmzc4+6+waFZf899bfp/MCUwA==",
       "dependencies": [
         "@bufbuild/protobuf",
+        "buffer-builder",
         "colorjs.io",
         "immutable",
         "rxjs",
@@ -6351,36 +6783,26 @@
         "varint"
       ],
       "optionalDependencies": [
-        "sass-embedded-all-unknown",
         "sass-embedded-android-arm",
         "sass-embedded-android-arm64",
+        "sass-embedded-android-ia32",
         "sass-embedded-android-riscv64",
         "sass-embedded-android-x64",
         "sass-embedded-darwin-arm64",
         "sass-embedded-darwin-x64",
         "sass-embedded-linux-arm",
         "sass-embedded-linux-arm64",
+        "sass-embedded-linux-ia32",
         "sass-embedded-linux-musl-arm",
         "sass-embedded-linux-musl-arm64",
+        "sass-embedded-linux-musl-ia32",
         "sass-embedded-linux-musl-riscv64",
         "sass-embedded-linux-musl-x64",
         "sass-embedded-linux-riscv64",
         "sass-embedded-linux-x64",
-        "sass-embedded-unknown-all",
         "sass-embedded-win32-arm64",
+        "sass-embedded-win32-ia32",
         "sass-embedded-win32-x64"
-      ],
-      "bin": true
-    },
-    "sass@1.97.3": {
-      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
-      "dependencies": [
-        "chokidar",
-        "immutable",
-        "source-map-js"
-      ],
-      "optionalDependencies": [
-        "@parcel/watcher"
       ],
       "bin": true
     },
@@ -6786,7 +7208,7 @@
         "svelte"
       ]
     },
-    "svelte-toolbelt@0.10.6_svelte@5.51.3__acorn@8.15.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "svelte-toolbelt@0.10.6_svelte@5.51.3__acorn@8.15.0_sass-embedded@1.83.0": {
       "integrity": "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==",
       "dependencies": [
         "clsx",
@@ -6916,6 +7338,13 @@
       "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
       "dependencies": [
         "tldts-core@7.0.19"
+      ],
+      "bin": true
+    },
+    "topojson-client@3.1.0": {
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dependencies": [
+        "commander@2.20.3"
       ],
       "bin": true
     },
@@ -7204,18 +7633,18 @@
     "varint@6.0.0": {
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
-    "vite-plugin-pwa@1.2.0_vite@7.3.1__sass-embedded@1.97.3__picomatch@4.0.3_@babel+core@7.29.0": {
+    "vite-plugin-pwa@1.2.0_vite@7.3.1__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==",
       "dependencies": [
         "debug",
         "pretty-bytes@6.1.1",
         "tinyglobby",
-        "vite@7.3.1_sass-embedded@1.97.3_picomatch@4.0.3",
+        "vite@7.3.1_sass-embedded@1.83.0",
         "workbox-build",
         "workbox-window"
       ]
     },
-    "vite@7.3.1_sass-embedded@1.97.3_picomatch@4.0.3": {
+    "vite@7.3.1_sass-embedded@1.83.0": {
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dependencies": [
         "esbuild@0.27.4",
@@ -7233,7 +7662,7 @@
       ],
       "bin": true
     },
-    "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3": {
+    "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0": {
       "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
       "dependencies": [
         "esbuild@0.27.4",
@@ -7253,16 +7682,16 @@
       ],
       "bin": true
     },
-    "vitefu@1.1.2_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3": {
+    "vitefu@1.1.2_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==",
       "dependencies": [
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ],
       "optionalPeers": [
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3"
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0"
       ]
     },
-    "vitest@4.1.0_@opentelemetry+api@1.9.0_jsdom@26.1.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_msw@2.12.10__typescript@5.8.3": {
+    "vitest@4.1.0_jsdom@26.1.0_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.83.0_sass-embedded@1.83.0": {
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dependencies": [
         "@opentelemetry/api",
@@ -7285,7 +7714,7 @@
         "tinyexec",
         "tinyglobby",
         "tinyrainbow",
-        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.97.3",
+        "vite@8.0.1_esbuild@0.27.4_sass-embedded@1.83.0",
         "why-is-node-running"
       ],
       "optionalPeers": [
@@ -7583,11 +8012,12 @@
         "regexparam"
       ]
     },
-    "wrangler@4.66.0_@cloudflare+workers-types@4.20260218.0_unenv@2.0.0-rc.24_workerd@1.20260217.0": {
+    "wrangler@4.66.0_@cloudflare+workers-types@4.20260504.1": {
       "integrity": "sha512-b9RVIdKai0BXDuYg0iN0zwVnVbULkvdKGP7Bf1uFY2GhJ/nzDGqgwQbCwgDIOhmaBC8ynhk/p22M2jc8tJy+dQ==",
       "dependencies": [
         "@cloudflare/kv-asset-handler",
         "@cloudflare/unenv-preset",
+        "@cloudflare/workers-types",
         "blake3-wasm",
         "esbuild@0.27.3",
         "miniflare",
@@ -7597,6 +8027,9 @@
       ],
       "optionalDependencies": [
         "fsevents@2.3.3"
+      ],
+      "optionalPeers": [
+        "@cloudflare/workers-types"
       ],
       "bin": true
     },
@@ -7716,6 +8149,8 @@
         ],
         "packageJson": {
           "dependencies": [
+            "npm:@carbon/charts-svelte@^1.24.0",
+            "npm:@carbon/charts@^1.24.0",
             "npm:@cloudflare/workers-types@4.20260504.1",
             "npm:@cucumber/cucumber@12.6.0",
             "npm:@eslint/js@^10.0.1",
@@ -7736,6 +8171,7 @@
             "npm:@testing-library/svelte@5.3.1",
             "npm:@testing-library/user-event@14.6.1",
             "npm:@ts-rest/core@3.52.1",
+            "npm:@types/d3@^7.4.3",
             "npm:@types/eslint@9.6.1",
             "npm:@types/papaparse@^5.3.15",
             "npm:@types/serviceworker@0.0.191",
@@ -7745,6 +8181,7 @@
             "npm:bits-ui@^2.16.2",
             "npm:concurrently@9.2.1",
             "npm:cross-env@10.1.0",
+            "npm:d3@^7.9.0",
             "npm:date-fns@4.1.0",
             "npm:esbuild@~0.27.4",
             "npm:eslint-plugin-svelte@3.15.0",
@@ -7764,7 +8201,7 @@
             "npm:prettier@3.8.1",
             "npm:resolve-accept-language@3.1.16",
             "npm:rxjs@^7.8.2",
-            "npm:sass-embedded@1.97.3",
+            "npm:sass-embedded@1.83.0",
             "npm:svelte-check@4.4.0",
             "npm:svelte-confetti@^2.3.2",
             "npm:svelte@^5.51.3",

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7220,6 +7220,432 @@
         "ios"
       ]
     },
+    "yir_title_year_to_date": {
+      "default": "Year to date",
+      "description": "Title shown for the current year's Year in Review.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_title_year_in_review": {
+      "default": "Year in Review",
+      "description": "Main title for the Year in Review page.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_totals": {
+      "default": "{year} Totals",
+      "description": "Section title for the yearly totals overview.",
+      "variables": {
+        "year": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_tv_shows": {
+      "default": "TV Shows",
+      "description": "Section title for TV shows statistics.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_movies": {
+      "default": "Movies",
+      "description": "Section title for movies statistics.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_highest_rated_shows": {
+      "default": "Highest Rated TV Shows",
+      "description": "Section title for highest rated TV shows.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_highest_rated_movies": {
+      "default": "Highest Rated Movies",
+      "description": "Section title for highest rated movies.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_show_genres": {
+      "default": "TV Show Genres",
+      "description": "Section title for TV show genres.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_movie_genres": {
+      "default": "Movie Genres",
+      "description": "Section title for movie genres.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_networks": {
+      "default": "TV Show Networks",
+      "description": "Section title for TV show networks.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_studios": {
+      "default": "Movie Studios",
+      "description": "Section title for movie studios.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_top_actors": {
+      "default": "Top Actors",
+      "description": "Section title for top actors.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_top_actresses": {
+      "default": "Top Actresses",
+      "description": "Section title for top actresses.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_top_directors": {
+      "default": "Top Directors",
+      "description": "Section title for top directors.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_top_writers": {
+      "default": "Top Writers",
+      "description": "Section title for top writers.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_calendar_first_play": {
+      "default": "first play of {year}",
+      "description": "Label for the first play of the year in the calendar section.",
+      "variables": {
+        "year": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_calendar_last_play": {
+      "default": "last play of {year}",
+      "description": "Label for the last play of the year in the calendar section.",
+      "variables": {
+        "year": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_most_watched": {
+      "default": "most watched {type}",
+      "description": "Label for most watched items.",
+      "variables": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_hours_watched": {
+      "default": "hours watched",
+      "description": "Label for hours watched statistic.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_per_month": {
+      "default": "per month",
+      "description": "Label for per month statistics.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_per_week": {
+      "default": "per week",
+      "description": "Label for per week statistics.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_per_day": {
+      "default": "per day",
+      "description": "Label for per day statistics.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_collected": {
+      "default": "collected",
+      "description": "Label for collected items statistic.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_plays_by_week": {
+      "default": "{type} plays by week",
+      "description": "Label for plays by week chart.",
+      "variables": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_plays_by_month": {
+      "default": "{type} plays by month",
+      "description": "Label for plays by month chart.",
+      "variables": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_plays_by_day": {
+      "default": "{type} plays by day of the week",
+      "description": "Label for plays by day of week chart.",
+      "variables": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_plays_by_hour": {
+      "default": "{type} plays by time of day",
+      "description": "Label for plays by time of day chart.",
+      "variables": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_week_number": {
+      "default": "Week {weekNumber}",
+      "description": "Label for week number in charts.",
+      "variables": {
+        "weekNumber": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_play": {
+      "default": "{count, plural, one {play} other {plays}}",
+      "description": "Unit for plays (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_hour": {
+      "default": "{count, plural, one {hour} other {hours}}",
+      "description": "Unit for hours (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_rating": {
+      "default": "{count, plural, one {rating} other {ratings}}",
+      "description": "Unit for ratings (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_comment": {
+      "default": "{count, plural, one {comment} other {comments}}",
+      "description": "Unit for comments (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_list": {
+      "default": "{count, plural, one {list} other {lists}}",
+      "description": "Unit for lists (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_movie": {
+      "default": "{count, plural, one {movie} other {movies}}",
+      "description": "Unit for movies (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_show": {
+      "default": "{count, plural, one {show} other {shows}}",
+      "description": "Unit for shows (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_episode": {
+      "default": "{count, plural, one {episode} other {episodes}}",
+      "description": "Unit for episodes (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_button_previous": {
+      "default": "Previous",
+      "description": "Button text for previous page.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_button_next": {
+      "default": "Next",
+      "description": "Button text for next page.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_share_text": {
+      "default": "Check out my {year} Year in Review on Trakt",
+      "description": "Share text used when sharing a Year in Review page.",
+      "variables": {
+        "year": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_button_see_more": {
+      "default": "See More",
+      "description": "Button text for see more.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_state_loading": {
+      "default": "Loading...",
+      "description": "Loading state text.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_upgrade_message": {
+      "default": "Upgrade to VIP and get your own all time and yearly Year in Review pages, plus a lot more great features!",
+      "description": "Message encouraging users to upgrade to VIP for Year in Review.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "vip_feature_title_mir": {
       "default": "Month in Review",
       "description": "Title for the Month in Review VIP feature.",

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7232,6 +7232,432 @@
         "ios"
       ]
     },
+    "yir_title_year_to_date": {
+      "default": "Year to date",
+      "description": "Title shown for the current year's Year in Review.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_title_year_in_review": {
+      "default": "Year in Review",
+      "description": "Main title for the Year in Review page.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_totals": {
+      "default": "{year} Totals",
+      "description": "Section title for the yearly totals overview.",
+      "variables": {
+        "year": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_tv_shows": {
+      "default": "TV Shows",
+      "description": "Section title for TV shows statistics.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_movies": {
+      "default": "Movies",
+      "description": "Section title for movies statistics.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_highest_rated_shows": {
+      "default": "Highest Rated TV Shows",
+      "description": "Section title for highest rated TV shows.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_highest_rated_movies": {
+      "default": "Highest Rated Movies",
+      "description": "Section title for highest rated movies.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_show_genres": {
+      "default": "TV Show Genres",
+      "description": "Section title for TV show genres.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_movie_genres": {
+      "default": "Movie Genres",
+      "description": "Section title for movie genres.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_networks": {
+      "default": "TV Show Networks",
+      "description": "Section title for TV show networks.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_studios": {
+      "default": "Movie Studios",
+      "description": "Section title for movie studios.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_top_actors": {
+      "default": "Top Actors",
+      "description": "Section title for top actors.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_top_actresses": {
+      "default": "Top Actresses",
+      "description": "Section title for top actresses.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_top_directors": {
+      "default": "Top Directors",
+      "description": "Section title for top directors.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_section_title_top_writers": {
+      "default": "Top Writers",
+      "description": "Section title for top writers.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_calendar_first_play": {
+      "default": "first play of {year}",
+      "description": "Label for the first play of the year in the calendar section.",
+      "variables": {
+        "year": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_calendar_last_play": {
+      "default": "last play of {year}",
+      "description": "Label for the last play of the year in the calendar section.",
+      "variables": {
+        "year": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_most_watched": {
+      "default": "most watched {type}",
+      "description": "Label for most watched items.",
+      "variables": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_hours_watched": {
+      "default": "hours watched",
+      "description": "Label for hours watched statistic.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_per_month": {
+      "default": "per month",
+      "description": "Label for per month statistics.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_per_week": {
+      "default": "per week",
+      "description": "Label for per week statistics.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_per_day": {
+      "default": "per day",
+      "description": "Label for per day statistics.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_collected": {
+      "default": "collected",
+      "description": "Label for collected items statistic.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_plays_by_week": {
+      "default": "{type} plays by week",
+      "description": "Label for plays by week chart.",
+      "variables": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_plays_by_month": {
+      "default": "{type} plays by month",
+      "description": "Label for plays by month chart.",
+      "variables": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_plays_by_day": {
+      "default": "{type} plays by day of the week",
+      "description": "Label for plays by day of week chart.",
+      "variables": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_plays_by_hour": {
+      "default": "{type} plays by time of day",
+      "description": "Label for plays by time of day chart.",
+      "variables": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_label_week_number": {
+      "default": "Week {weekNumber}",
+      "description": "Label for week number in charts.",
+      "variables": {
+        "weekNumber": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_play": {
+      "default": "{count, plural, one {play} other {plays}}",
+      "description": "Unit for plays (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_hour": {
+      "default": "{count, plural, one {hour} other {hours}}",
+      "description": "Unit for hours (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_rating": {
+      "default": "{count, plural, one {rating} other {ratings}}",
+      "description": "Unit for ratings (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_comment": {
+      "default": "{count, plural, one {comment} other {comments}}",
+      "description": "Unit for comments (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_list": {
+      "default": "{count, plural, one {list} other {lists}}",
+      "description": "Unit for lists (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_movie": {
+      "default": "{count, plural, one {movie} other {movies}}",
+      "description": "Unit for movies (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_show": {
+      "default": "{count, plural, one {show} other {shows}}",
+      "description": "Unit for shows (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_unit_episode": {
+      "default": "{count, plural, one {episode} other {episodes}}",
+      "description": "Unit for episodes (singular/plural).",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_button_previous": {
+      "default": "Previous",
+      "description": "Button text for previous page.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_button_next": {
+      "default": "Next",
+      "description": "Button text for next page.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_share_text": {
+      "default": "Check out my {year} Year in Review on Trakt",
+      "description": "Share text used when sharing a Year in Review page.",
+      "variables": {
+        "year": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_button_see_more": {
+      "default": "See More",
+      "description": "Button text for see more.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_state_loading": {
+      "default": "Loading...",
+      "description": "Loading state text.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_upgrade_message": {
+      "default": "Upgrade to VIP and get your own all time and yearly Year in Review pages, plus a lot more great features!",
+      "description": "Message encouraging users to upgrade to VIP for Year in Review.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "vip_feature_title_mir": {
       "default": "Month in Review",
       "description": "Title for the Month in Review VIP feature.",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -54,7 +54,7 @@
     "playwright": "1.58.2",
     "prettier": "3.8.1",
     "prettier-plugin-svelte": "3.4.1",
-    "sass-embedded": "1.97.3",
+    "sass-embedded": "1.83.0",
     "svelte-check": "4.4.0",
     "typescript": "5.8.3",
     "typescript-eslint": "8.56.0",
@@ -94,6 +94,9 @@
     "workbox-strategies": "7.4.0",
     "zod": "3.25.76",
     "zod-to-json-schema": "3.25.1",
-    "papaparse": "^5.4.1"
+    "papaparse": "^5.4.1",
+    "@carbon/charts": "^1.24.0",
+    "@carbon/charts-svelte": "^1.24.0",
+    "d3": "^7.9.0"
   }
 }

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -39,6 +39,7 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/svelte": "5.3.1",
     "@testing-library/user-event": "14.6.1",
+    "@types/d3": "^7.4.3",
     "@types/eslint": "9.6.1",
     "@types/serviceworker": "0.0.191",
     "@vite-pwa/sveltekit": "1.1.0",
@@ -55,7 +56,7 @@
     "playwright": "1.58.2",
     "prettier": "3.8.1",
     "prettier-plugin-svelte": "3.4.1",
-    "sass-embedded": "1.97.3",
+    "sass-embedded": "1.83.0",
     "svelte-check": "4.4.0",
     "typescript": "5.8.3",
     "typescript-eslint": "8.56.0",
@@ -95,6 +96,9 @@
     "workbox-strategies": "7.4.0",
     "zod": "3.25.76",
     "zod-to-json-schema": "3.25.1",
-    "papaparse": "^5.4.1"
+    "papaparse": "^5.4.1",
+    "@carbon/charts": "^1.24.0",
+    "@carbon/charts-svelte": "^1.24.0",
+    "d3": "^7.9.0"
   }
 }

--- a/projects/client/src/lib/components/charts/BarChart.svelte
+++ b/projects/client/src/lib/components/charts/BarChart.svelte
@@ -4,30 +4,17 @@
   import { ScaleTypes } from "@carbon/charts";
   import { BarChartSimple, type BarChartOptions } from "@carbon/charts-svelte";
   import "@carbon/charts-svelte/styles.css";
-  import { onMount } from "svelte";
+  import type { BarChartProps } from "./models/BarChartProps";
 
   const barSpacing = 2;
 
-  type TooltipArgs = { value: number; label: string; index: number };
+  const { data, tooltipHTML }: BarChartProps = $props();
 
-  const {
-    data,
-    labels,
-    tooltipHTML,
-  }: {
-    data: number[];
-    labels: string[];
-    tooltipHTML?: (args: TooltipArgs) => string;
-  } = $props();
+  const values = $derived(data.map((d) => d.value));
+  const labels = $derived(data.map((d) => d.label));
 
-  const chartData = $derived(
-    data
-      .map((value, i) => ({ label: labels[i], value }))
-      .filter((entry) => entry.label !== undefined),
-  );
+  const maxValue = $derived(Math.max(...values, 0));
 
-  const maxValue = $derived(Math.max(...data, 0));
-  // TODO: resizing seems to blink some of the bars
   const { observedDimension, observeDimension } = useDimensionObserver(
     "width",
     time.fps(30),
@@ -77,18 +64,10 @@
       return `var(--color-bar-hover, ${barColor})`;
     },
   });
-
-  let isMounted = $state(false);
-
-  onMount(() => {
-    isMounted = true;
-  });
 </script>
 
 <div class="trakt-bar-chart" use:observeDimension>
-  {#if isMounted && $observedDimension > 0 && chartData.length > 0}
-    <BarChartSimple data={chartData} {options} />
-  {/if}
+  <BarChartSimple {data} {options} />
 </div>
 
 <style lang="scss">

--- a/projects/client/src/lib/components/charts/BarChart.svelte
+++ b/projects/client/src/lib/components/charts/BarChart.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+  import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver.ts";
+  import { time } from "$lib/utils/timing/time.ts";
+  import { ScaleTypes } from "@carbon/charts";
+  import { BarChartSimple, type BarChartOptions } from "@carbon/charts-svelte";
+  import "@carbon/charts-svelte/styles.css";
+  import { onMount } from "svelte";
+
+  const barSpacing = 2;
+
+  type TooltipArgs = { value: number; label: string; index: number };
+
+  const {
+    data,
+    labels,
+    tooltipHTML,
+  }: {
+    data: number[];
+    labels: string[];
+    tooltipHTML?: (args: TooltipArgs) => string;
+  } = $props();
+
+  const chartData = $derived(
+    data
+      .map((value, i) => ({ label: labels[i], value }))
+      .filter((entry) => entry.label !== undefined),
+  );
+
+  const maxValue = $derived(Math.max(...data, 0));
+  // TODO: resizing seems to blink some of the bars
+  const { observedDimension, observeDimension } = useDimensionObserver(
+    "width",
+    time.fps(30),
+  );
+
+  const barWidth = $derived(
+    data.length > 0
+      ? Math.floor($observedDimension / data.length) - barSpacing
+      : 0,
+  );
+
+  const options: BarChartOptions = $derived({
+    axes: {
+      left: { mapsTo: "value", visible: false },
+      bottom: { mapsTo: "label", scaleType: ScaleTypes.LABELS },
+    },
+    grid: {
+      x: { enabled: false },
+      y: { enabled: false },
+    },
+    bars: { width: barWidth },
+    legend: { enabled: false },
+    toolbar: { enabled: false },
+    tooltip: {
+      enabled: tooltipHTML != null,
+      customHTML: (points: Array<{ value: number; label: string }>) => {
+        if (!tooltipHTML) return "";
+        if (!points || points.length === 0) return "";
+        const point = points[0];
+        const index = labels.indexOf(point.label);
+        return tooltipHTML({
+          value: point.value,
+          label: point.label,
+          index,
+        });
+      },
+    },
+    resizable: false,
+    width: `${$observedDimension}px`,
+    height: "180px",
+    getFillColor: (_, __, data) => {
+      const barColor =
+        data?.value === maxValue
+          ? "var(--color-bar-custom-highlight, var(--color-bar-chart-bar-highlight))"
+          : "var(--color-bar-custom-default, var(--color-bar-chart-bar-default))";
+
+      return `var(--color-bar-hover, ${barColor})`;
+    },
+  });
+
+  let isMounted = $state(false);
+
+  onMount(() => {
+    isMounted = true;
+  });
+</script>
+
+<div class="trakt-bar-chart" use:observeDimension>
+  {#if isMounted && $observedDimension > 0 && chartData.length > 0}
+    <BarChartSimple data={chartData} {options} />
+  {/if}
+</div>
+
+<style lang="scss">
+  .trakt-bar-chart {
+    width: 100%;
+    height: 100%;
+
+    :global(.cds--chart-holder) {
+      --cds-grid-bg: transparent;
+      --cds-text-primary: var(
+        --color-text-primary-override,
+        var(--color-text-primary)
+      );
+      --cds-text-secondary: var(
+        --color-text-secondary-override,
+        var(--color-text-secondary)
+      );
+      --cds-charts-font-family: "Roboto", Arial, sans-serif;
+      --cds-charts-font-family-condensed: "Roboto", Arial, sans-serif;
+    }
+
+    :global(.bar) {
+      transition: fill var(--transition-increment) ease-in-out;
+    }
+
+    :global(.bar:hover) {
+      --color-bar-hover: var(
+        --color-bar-custom-hover,
+        var(--color-bar-chart-bar-hover)
+      );
+    }
+  }
+
+  // Carbon renders its tooltip wrapper outside the chart-holder DOM, so its
+  // `--cds-layer-02` background and hardcoded box-shadow can't be reached
+  // through CSS-variable cascade. These overrides flatten the wrapper so the
+  // YirTooltip styling shows through cleanly.
+  :global(.cds--cc--tooltip) {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+  }
+</style>

--- a/projects/client/src/lib/components/charts/BarChart.svelte
+++ b/projects/client/src/lib/components/charts/BarChart.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
+  import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
+  import { time } from "$lib/utils/timing/time";
+  import { ScaleTypes } from "@carbon/charts";
+  import { BarChartSimple, type BarChartOptions } from "@carbon/charts-svelte";
+  import "@carbon/charts-svelte/styles.css";
+  import { flushSync } from "svelte";
+  import type { BarChartProps, TooltipArgs } from "./models/BarChartProps";
+
+  const barSpacing = 2;
+  const chartPaddingVar = "var(--ni-12)";
+
+  const { data, tooltip, tickLabels }: BarChartProps = $props();
+
+  // Carbon Charts keys bars by `group`; remap label → group so D3 join is stable on resize.
+  const carbonData = $derived(
+    data.map((d) => ({ group: d.label, value: d.value })),
+  );
+
+  const values = $derived(data.map((d) => d.value));
+  const labels = $derived(data.map((d) => d.label));
+
+  const maxValue = $derived(Math.max(...values, 0));
+
+  const chartPadding = useVarToPixels(chartPaddingVar);
+  const { observedDimension: observedContainerDimension, observeDimension } =
+    useDimensionObserver("width", time.fps(30));
+
+  const observedDimension = $derived(
+    $observedContainerDimension - $chartPadding * 2,
+  );
+
+  const barWidth = $derived(
+    data.length > 0
+      ? Math.floor(observedDimension / data.length) - barSpacing
+      : 0,
+  );
+
+  const getFillColor = $derived(
+    (_: unknown, __: unknown, data: { value: number } | undefined) => {
+      const barColor =
+        data?.value === maxValue
+          ? "var(--color-bar-custom-highlight, var(--color-bar-chart-bar-highlight))"
+          : "var(--color-bar-custom-default, var(--color-bar-chart-bar-default))";
+
+      return `var(--color-bar-hover, ${barColor})`;
+    },
+  );
+
+  let tooltipContainer: HTMLDivElement | undefined = $state();
+  let tooltipArgs: TooltipArgs | null = $state(null);
+
+  const customHTML = $derived(
+    (points: Array<{ value: number; group: string }>) => {
+      if (!tooltip || !tooltipContainer) return "";
+      if (!points?.length) return "";
+      const point = points[0];
+      const index = labels.indexOf(point.group);
+      tooltipArgs = { value: point.value, label: point.group, index };
+      flushSync();
+      return tooltipContainer.innerHTML;
+    },
+  );
+
+  const options: BarChartOptions = $derived({
+    axes: {
+      left: { mapsTo: "value", visible: false },
+      bottom: {
+        mapsTo: "group",
+        scaleType: ScaleTypes.LABELS,
+        ticks: tickLabels ? { values: tickLabels } : undefined,
+      },
+    },
+    grid: {
+      x: { enabled: false },
+      y: { enabled: false },
+    },
+    bars: { width: barWidth },
+    legend: { enabled: false },
+    toolbar: { enabled: false },
+    tooltip: {
+      enabled: tooltip != null,
+      customHTML,
+    },
+    resizable: false,
+    width: `${observedDimension}px`,
+    height: "var(--height-bar-chart)",
+    getFillColor,
+  });
+</script>
+
+<div
+  class="trakt-bar-chart"
+  use:observeDimension
+  style="--chart-padding: {$chartPadding}px"
+>
+  <BarChartSimple data={carbonData} {options} />
+
+  <!--
+    CarbonCharts does not support snippets as tooltips. So we render them to a
+    hidden container and pull the HTML into Carbon's custom tooltip renderer.
+    This way, at least from a consumer pov, a snippet can be passed in.
+  -->
+  <div bind:this={tooltipContainer} style="display:none" aria-hidden="true">
+    {#if tooltip && tooltipArgs}
+      {@render tooltip(tooltipArgs)}
+    {/if}
+  </div>
+</div>
+
+<style lang="scss">
+  .trakt-bar-chart {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+
+    padding: var(--chart-padding);
+    box-sizing: border-box;
+
+    :global(.cds--chart-holder) {
+      --cds-grid-bg: transparent;
+      --cds-text-primary: var(
+        --color-bar-chart-text-primary,
+        var(--color-text-primary)
+      );
+      --cds-text-secondary: var(
+        --color-bar-chart-text-secondary,
+        var(--color-text-secondary)
+      );
+      --cds-charts-font-family: "Roboto", Arial, sans-serif;
+      --cds-charts-font-family-condensed: "Roboto", Arial, sans-serif;
+    }
+
+    :global(.bar) {
+      transition: fill var(--transition-increment) ease-in-out;
+    }
+
+    :global(.bar:hover) {
+      --color-bar-hover: var(
+        --color-bar-custom-hover,
+        var(--color-bar-chart-bar-hover)
+      );
+    }
+  }
+
+  // Carbon renders its tooltip wrapper outside the chart-holder DOM, so its
+  // `--cds-layer-02` background and hardcoded box-shadow can't be reached
+  // through CSS-variable cascade. These overrides flatten the wrapper so the
+  // YirTooltip styling shows through cleanly.
+  :global(.cds--cc--tooltip) {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+  }
+</style>

--- a/projects/client/src/lib/components/charts/BubbleChart.svelte
+++ b/projects/client/src/lib/components/charts/BubbleChart.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
+  import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
+  import { hierarchy, pack } from "d3";
+  import type {
+    BubbleChartItem,
+    BubbleChartProps,
+    BubbleChartTooltipArgs,
+  } from "./models/BubbleChartProps";
+
+  const { items, tooltip }: BubbleChartProps = $props();
+
+  type HierarchyDatum = {
+    item?: BubbleChartItem;
+    value?: number;
+    children?: HierarchyDatum[];
+  };
+
+  type PackedNode = {
+    item: BubbleChartItem;
+    x: number;
+    y: number;
+    r: number;
+    fill: string;
+  };
+
+  const padding = 3;
+  const filterId = `bubble-chart-whiteimage-${crypto.randomUUID()}`;
+
+  const minContentRadius = useVarToPixels("var(--min-radius-bubble-chart)");
+  const observedHeight = useVarToPixels("var(--height-bubble-chart)");
+
+  const { observedDimension: observedWidth, observeDimension } =
+    useDimensionObserver("width");
+
+  let hovered = $state<PackedNode | null>(null);
+  let pointer = $state({ x: 0, y: 0 });
+  let failedImages = $state<Set<number>>(new Set());
+
+  const nodes = $derived.by<PackedNode[]>(() => {
+    const width = $observedWidth;
+    const height = $observedHeight;
+    if (width === 0 || height === 0 || items.length === 0) return [];
+
+    const root = hierarchy<HierarchyDatum>(
+      {
+        children: items.map((item) => ({ item, value: item.value })),
+      },
+      (d) => d.children ?? null,
+    )
+      .sum((d) => d.value ?? 0)
+      .sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
+
+    const layout = pack<HierarchyDatum>()
+      .size([width, height])
+      .padding(padding);
+
+    return layout(root)
+      .leaves()
+      .map((leaf) => {
+        const item = leaf.data.item!;
+        return { item, x: leaf.x, y: leaf.y, r: leaf.r, fill: item.color };
+      });
+  });
+
+  function imageSizeFor(r: number): number {
+    return Math.min(r * 1.2, 80);
+  }
+
+  function fontSizeFor(r: number): number {
+    return Math.max(12, r / 4);
+  }
+
+  function truncatedLabel(label: string, r: number): string {
+    const maxChars = Math.floor(r / 5);
+    return label.length > maxChars ? label.substring(0, maxChars) + "…" : label;
+  }
+
+  function handlePointerEnter(node: PackedNode, event: PointerEvent) {
+    hovered = node;
+    pointer = { x: event.clientX, y: event.clientY };
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (!hovered) return;
+    pointer = { x: event.clientX, y: event.clientY };
+  }
+
+  function handlePointerLeave() {
+    hovered = null;
+  }
+
+  function handleImageError(id: number) {
+    failedImages.add(id);
+  }
+
+  const tooltipArgs = $derived<BubbleChartTooltipArgs | null>(
+    hovered ? { item: hovered.item } : null,
+  );
+</script>
+
+<div
+  class="bubble-chart"
+  use:observeDimension
+  onpointermove={handlePointerMove}
+  onpointerleave={handlePointerLeave}
+  role="presentation"
+>
+  <svg
+    width={$observedWidth}
+    height={$observedHeight}
+    role="img"
+    aria-label="Bubble chart"
+  >
+    <defs>
+      <filter id={filterId}>
+        <feColorMatrix
+          in="SourceGraphic"
+          type="matrix"
+          values="0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 1 0"
+        />
+      </filter>
+    </defs>
+
+    {#each nodes as node (node.item.id)}
+      {@const showImage = node.item.imageUrl && !failedImages.has(node.item.id)}
+      {@const hasRoomForContent = node.r >= $minContentRadius}
+      {@const imageSize = imageSizeFor(node.r)}
+
+      <g
+        class="node"
+        onpointerenter={(event) => handlePointerEnter(node, event)}
+        role="img"
+        aria-label={node.item.label}
+      >
+        <circle cx={node.x} cy={node.y} r={node.r} fill={node.fill} />
+
+        {#if hasRoomForContent}
+          {#if showImage}
+            <image
+              href={node.item.imageUrl}
+              x={node.x - imageSize / 2}
+              y={node.y - imageSize / 2}
+              width={imageSize}
+              height={imageSize}
+              preserveAspectRatio="xMidYMid meet"
+              filter="url(#{filterId})"
+              pointer-events="none"
+              onerror={() => handleImageError(node.item.id)}
+            />
+          {:else}
+            <text
+              x={node.x}
+              y={node.y}
+              text-anchor="middle"
+              dominant-baseline="middle"
+              font-size={fontSizeFor(node.r)}
+              font-weight="600"
+              fill="#fff"
+              pointer-events="none"
+            >
+              {truncatedLabel(node.item.label, node.r)}
+            </text>
+          {/if}
+        {/if}
+      </g>
+    {/each}
+  </svg>
+
+  <!-- TODO: see if we can leverage Tooltip.svelte here -->
+  {#if tooltip && tooltipArgs && hovered}
+    <div
+      class="bubble-chart-tooltip"
+      style:left="{pointer.x}px"
+      style:top="{pointer.y}px"
+    >
+      {@render tooltip(tooltipArgs)}
+    </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  .bubble-chart {
+    position: relative;
+    width: 100%;
+    height: 100%;
+
+    svg {
+      display: block;
+    }
+
+    .node {
+      cursor: pointer;
+      transform-box: fill-box;
+      transform-origin: center;
+      transition: transform var(--transition-increment) ease;
+
+      &:hover {
+        transform: scale(1.05);
+      }
+    }
+  }
+
+  .bubble-chart-tooltip {
+    position: fixed;
+    pointer-events: none;
+    transform: translate(-50%, calc(-100% - var(--ni-12)));
+    z-index: var(--layer-top);
+  }
+</style>

--- a/projects/client/src/lib/components/charts/models/BarChartProps.ts
+++ b/projects/client/src/lib/components/charts/models/BarChartProps.ts
@@ -1,0 +1,11 @@
+type BarChartData = {
+  value: number;
+  label: string;
+};
+
+type TooltipArgs = { value: number; label: string; index: number };
+
+export type BarChartProps = {
+  data: BarChartData[];
+  tooltipHTML?: (args: TooltipArgs) => string;
+};

--- a/projects/client/src/lib/components/charts/models/BarChartProps.ts
+++ b/projects/client/src/lib/components/charts/models/BarChartProps.ts
@@ -1,0 +1,14 @@
+import type { Snippet } from 'svelte';
+
+type BarChartData = {
+  value: number;
+  label: string;
+};
+
+export type TooltipArgs = { value: number; label: string; index: number };
+
+export type BarChartProps = {
+  data: BarChartData[];
+  tickLabels?: string[];
+  tooltip?: Snippet<[TooltipArgs]>;
+};

--- a/projects/client/src/lib/components/charts/models/BubbleChartProps.ts
+++ b/projects/client/src/lib/components/charts/models/BubbleChartProps.ts
@@ -1,0 +1,18 @@
+import type { Snippet } from 'svelte';
+
+export type BubbleChartItem = {
+  id: number;
+  label: string;
+  value: number;
+  imageUrl?: string | null;
+  color: string;
+};
+
+export type BubbleChartTooltipArgs = {
+  item: BubbleChartItem;
+};
+
+export type BubbleChartProps = {
+  items: BubbleChartItem[];
+  tooltip?: Snippet<[BubbleChartTooltipArgs]>;
+};

--- a/projects/client/src/lib/components/tooltip/Tooltip.svelte
+++ b/projects/client/src/lib/components/tooltip/Tooltip.svelte
@@ -44,7 +44,9 @@
         {#if arrowClass}
           <Tooltip.Arrow class={arrowClass} />
         {/if}
-        {#if variant === "default"}
+        {#if typeof content === "function"}
+          {@render content()}
+        {:else if variant === "default"}
           <p>{content}</p>
         {:else}
           {content}

--- a/projects/client/src/lib/components/tooltip/TooltipProps.ts
+++ b/projects/client/src/lib/components/tooltip/TooltipProps.ts
@@ -1,5 +1,7 @@
+import type { Snippet } from 'svelte';
+
 export type TooltipProps = {
-  content: string;
+  content: string | Snippet;
   variant?: 'default' | 'compact';
   side?: 'top' | 'right' | 'bottom' | 'left';
   delayDuration?: number;

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -1,3 +1,4 @@
 export enum FeatureFlag {
   ThisWeek = 'this-week',
+  YearInReview = 'year-in-review',
 }

--- a/projects/client/src/lib/requests/_internal/mapToMovieEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMovieEntry.ts
@@ -1,4 +1,5 @@
 import { MAX_DATE } from '$lib/utils/constants.ts';
+import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import type { MovieCertificationResponse, MovieResponse } from '@trakt/api';
 import type { MovieEntry } from '../models/MovieEntry.ts';
@@ -27,6 +28,11 @@ export function mapToMovieEntry(
   const poster = mapToPoster(movie.images);
   const cover = mapToCover(movie.images);
   const logo = mapToLogo(movie.images);
+
+  const thumbCandidate = findDefined(
+    ...(movie.images?.thumb ?? []),
+  );
+
   const effectiveReleaseDate = new Date(movie.released ?? MAX_DATE);
 
   return {
@@ -48,7 +54,12 @@ export function mapToMovieEntry(
     cover,
     logo,
     thumb: {
-      url: cover.url.thumb,
+      url: prependHttps(
+        findDefined(
+          thumbCandidate,
+        ),
+        cover.url.thumb,
+      ),
     },
     genres: movie.genres ?? [],
     status: movie.status ?? 'unknown',

--- a/projects/client/src/lib/requests/_internal/mapToYirDetail.ts
+++ b/projects/client/src/lib/requests/_internal/mapToYirDetail.ts
@@ -1,0 +1,234 @@
+import type { MovieResponse, ShowResponse } from '@trakt/api';
+import type {
+  YirCompany,
+  YirDetail,
+  YirGenresGroup,
+  YirMostWatchedItem,
+  YirStatsCategory,
+  YirTopRatedItem,
+  YirWatchedItem,
+} from '../models/YirDetail.ts';
+import { mapToMovieEntry } from './mapToMovieEntry.ts';
+import { mapToShowEntry } from './mapToShowEntry.ts';
+import { appendWebp } from '$lib/utils/url/appendWebp.ts';
+import { prependHttps } from '$lib/utils/url/prependHttps.ts';
+
+type RawStats = {
+  total: number;
+  yearly: number;
+  monthly: number;
+  weekly: number;
+  daily: number;
+};
+
+type RawDistributions = {
+  weekly: number[];
+  monthly: number[];
+  days: number[];
+  hourly?: number[];
+};
+
+type RawStatsCategory = {
+  minutes: RawStats;
+  play_counts: RawStats;
+  collected_counts: RawStats;
+  ratings_counts: RawStats;
+  comments_counts: RawStats;
+  distributions?: RawDistributions;
+  items_count?: number;
+};
+
+type RawWatchedItem = {
+  type: 'episode' | 'movie';
+  watched_at: string;
+  show?: ShowResponse;
+  movie?: MovieResponse;
+  episode?: { title: string; season: number; number: number };
+};
+
+type RawMostWatchedShow = {
+  plays: number;
+  minutes: number;
+  show: ShowResponse;
+};
+
+type RawMostWatchedMovie = {
+  plays: number;
+  minutes: number;
+  movie: MovieResponse;
+};
+
+type RawGenresGroup = {
+  item_count: number;
+  genres: Array<{ slug: string; name: string; count: number }>;
+};
+
+type RawCompany = {
+  id: number;
+  name: string;
+  count: number;
+  image_url?: string | null;
+  color?: string | null;
+};
+
+type RawTopRatedShow = {
+  rating: number;
+  show: ShowResponse;
+};
+
+type RawTopRatedMovie = {
+  rating: number;
+  movie: MovieResponse;
+};
+
+type RawYirResponse = {
+  stats: {
+    all: RawStatsCategory & { lists_counts: RawStats };
+    shows: RawStatsCategory;
+    movies: RawStatsCategory;
+  };
+  images: {
+    cover: string;
+    story: string;
+  };
+  first_watched: RawWatchedItem | null;
+  last_watched: RawWatchedItem | null;
+  most_watched: {
+    shows: RawMostWatchedShow[];
+    movies: RawMostWatchedMovie[];
+  };
+  genres: {
+    shows: RawGenresGroup;
+    movies: RawGenresGroup;
+  };
+  networks: RawCompany[];
+  production_companies: RawCompany[];
+  top_rated: {
+    shows: RawTopRatedShow[];
+    movies: RawTopRatedMovie[];
+  };
+};
+
+function mapStatsCategory(raw: RawStatsCategory): YirStatsCategory {
+  return {
+    minutes: raw.minutes,
+    playCounts: raw.play_counts,
+    collectedCounts: raw.collected_counts,
+    ratingsCounts: raw.ratings_counts,
+    commentsCounts: raw.comments_counts,
+    distributions: raw.distributions,
+    itemsCount: raw.items_count,
+  };
+}
+
+function mapWatchedItemEntry(raw: RawWatchedItem) {
+  if (raw.type === 'episode' && raw.show) return mapToShowEntry(raw.show);
+  if (raw.movie) return mapToMovieEntry(raw.movie);
+  return null;
+}
+
+function mapWatchedItem(raw: RawWatchedItem | null): YirWatchedItem | null {
+  if (!raw) return null;
+
+  const entry = mapWatchedItemEntry(raw);
+  if (!entry) return null;
+
+  return {
+    type: raw.type,
+    watchedAt: new Date(raw.watched_at),
+    entry,
+    episodeTitle: raw.episode?.title,
+  };
+}
+
+function mapMostWatchedShows(
+  raw: RawMostWatchedShow[],
+): YirMostWatchedItem[] {
+  return raw.map((item) => ({
+    plays: item.plays,
+    minutes: item.minutes,
+    entry: mapToShowEntry(item.show),
+  }));
+}
+
+function mapMostWatchedMovies(
+  raw: RawMostWatchedMovie[],
+): YirMostWatchedItem[] {
+  return raw.map((item) => ({
+    plays: item.plays,
+    minutes: item.minutes,
+    entry: mapToMovieEntry(item.movie),
+  }));
+}
+
+function mapGenresGroup(raw: RawGenresGroup): YirGenresGroup {
+  return {
+    itemCount: raw.item_count,
+    genres: raw.genres,
+  };
+}
+
+function mapCompanies(raw: RawCompany[]): YirCompany[] {
+  return raw.map((item) => ({
+    id: item.id,
+    name: item.name,
+    count: item.count,
+    imageUrl: item.image_url
+      ? appendWebp(prependHttps(item.image_url))
+      : null,
+    color: item.color,
+  }));
+}
+
+function mapTopRatedShows(raw: RawTopRatedShow[]): YirTopRatedItem[] {
+  return raw.map((item) => ({
+    rating: item.rating,
+    entry: mapToShowEntry(item.show),
+  }));
+}
+
+function mapTopRatedMovies(raw: RawTopRatedMovie[]): YirTopRatedItem[] {
+  return raw.map((item) => ({
+    rating: item.rating,
+    entry: mapToMovieEntry(item.movie),
+  }));
+}
+
+export function mapToYirDetail(response: RawYirResponse): YirDetail {
+  const { stats, images } = response;
+
+  return {
+    stats: {
+      all: {
+        ...mapStatsCategory(stats.all),
+        listsCounts: stats.all.lists_counts,
+      },
+      shows: mapStatsCategory(stats.shows),
+      movies: mapStatsCategory(stats.movies),
+    },
+    images: {
+      cover: appendWebp(prependHttps(images.cover)) ?? images.cover,
+      story: appendWebp(prependHttps(images.story)) ?? images.story,
+    },
+    firstWatched: mapWatchedItem(response.first_watched),
+    lastWatched: mapWatchedItem(response.last_watched),
+    mostWatched: {
+      shows: mapMostWatchedShows(response.most_watched?.shows ?? []),
+      movies: mapMostWatchedMovies(response.most_watched?.movies ?? []),
+    },
+    genres: {
+      shows: mapGenresGroup(
+        response.genres?.shows ?? { item_count: 0, genres: [] },
+      ),
+      movies: mapGenresGroup(
+        response.genres?.movies ?? { item_count: 0, genres: [] },
+      ),
+    },
+    networks: mapCompanies(response.networks ?? []),
+    productionCompanies: mapCompanies(response.production_companies ?? []),
+    topRated: {
+      shows: mapTopRatedShows(response.top_rated?.shows ?? []),
+      movies: mapTopRatedMovies(response.top_rated?.movies ?? []),
+    },
+  };
+}

--- a/projects/client/src/lib/requests/_internal/mapToYirPerson.ts
+++ b/projects/client/src/lib/requests/_internal/mapToYirPerson.ts
@@ -1,0 +1,41 @@
+import type { PersonResponse } from '@trakt/api';
+import type { YirPerson } from '../models/YirPerson.ts';
+import { mapToHeadshot } from './mapToHeadshot.ts';
+
+type RawYirPersonTitle = {
+  title: string;
+  type: 'show' | 'movie';
+  trakt_id: number;
+  episode_count?: number;
+};
+
+type RawYirPerson = {
+  person: PersonResponse;
+  count: {
+    movies: number;
+    shows: number;
+  };
+  titles: RawYirPersonTitle[];
+};
+
+function mapPerson(raw: RawYirPerson): YirPerson {
+  return {
+    id: raw.person.ids.trakt,
+    name: raw.person.name,
+    slug: raw.person.ids.slug,
+    headshot: mapToHeadshot(raw.person.images),
+    count: raw.count,
+    titles: raw.titles.map((t) => ({
+      title: t.title,
+      type: t.type,
+      traktId: t.trakt_id,
+      episodeCount: t.episode_count,
+    })),
+  };
+}
+
+export function mapToYirPeople(
+  response: RawYirPerson[],
+): YirPerson[] {
+  return response.map(mapPerson);
+}

--- a/projects/client/src/lib/requests/models/YirDetail.ts
+++ b/projects/client/src/lib/requests/models/YirDetail.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+import { MediaEntrySchema } from './MediaEntry.ts';
+
+const YirStatsSchema = z.object({
+  total: z.number(),
+  yearly: z.number(),
+  monthly: z.number(),
+  weekly: z.number(),
+  daily: z.number(),
+});
+
+const YirDistributionsSchema = z.object({
+  weekly: z.number().array(),
+  monthly: z.number().array(),
+  days: z.number().array(),
+  hourly: z.number().array().optional(),
+});
+
+const YirStatsCategorySchema = z.object({
+  minutes: YirStatsSchema,
+  playCounts: YirStatsSchema,
+  collectedCounts: YirStatsSchema,
+  ratingsCounts: YirStatsSchema,
+  commentsCounts: YirStatsSchema,
+  distributions: YirDistributionsSchema.optional(),
+  itemsCount: z.number().optional(),
+});
+
+const YirGenreSchema = z.object({
+  slug: z.string(),
+  name: z.string(),
+  count: z.number(),
+});
+
+const YirGenresGroupSchema = z.object({
+  itemCount: z.number(),
+  genres: YirGenreSchema.array(),
+});
+
+const YirCompanySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  count: z.number(),
+  imageUrl: z.string().nullish(),
+  color: z.string().nullish(),
+});
+
+const YirMostWatchedItemSchema = z.object({
+  plays: z.number(),
+  minutes: z.number(),
+  entry: MediaEntrySchema,
+});
+
+const YirTopRatedItemSchema = z.object({
+  rating: z.number(),
+  entry: MediaEntrySchema,
+});
+
+const YirWatchedItemSchema = z.object({
+  type: z.enum(['episode', 'movie']),
+  watchedAt: z.date(),
+  entry: MediaEntrySchema,
+  episodeTitle: z.string().nullish(),
+});
+
+export const YirDetailSchema = z.object({
+  stats: z.object({
+    all: YirStatsCategorySchema.merge(z.object({
+      listsCounts: YirStatsSchema,
+    })),
+    shows: YirStatsCategorySchema,
+    movies: YirStatsCategorySchema,
+  }),
+  images: z.object({
+    cover: z.string(),
+    story: z.string(),
+  }),
+  firstWatched: YirWatchedItemSchema.nullish(),
+  lastWatched: YirWatchedItemSchema.nullish(),
+  mostWatched: z.object({
+    shows: YirMostWatchedItemSchema.array(),
+    movies: YirMostWatchedItemSchema.array(),
+  }),
+  genres: z.object({
+    shows: YirGenresGroupSchema,
+    movies: YirGenresGroupSchema,
+  }),
+  networks: YirCompanySchema.array(),
+  productionCompanies: YirCompanySchema.array(),
+  topRated: z.object({
+    shows: YirTopRatedItemSchema.array(),
+    movies: YirTopRatedItemSchema.array(),
+  }),
+});
+
+export type YirDetail = z.infer<typeof YirDetailSchema>;
+export type YirStats = z.infer<typeof YirStatsSchema>;
+export type YirStatsCategory = z.infer<typeof YirStatsCategorySchema>;
+export type YirDistributions = z.infer<typeof YirDistributionsSchema>;
+export type YirGenre = z.infer<typeof YirGenreSchema>;
+export type YirGenresGroup = z.infer<typeof YirGenresGroupSchema>;
+export type YirCompany = z.infer<typeof YirCompanySchema>;
+export type YirMostWatchedItem = z.infer<typeof YirMostWatchedItemSchema>;
+export type YirTopRatedItem = z.infer<typeof YirTopRatedItemSchema>;
+export type YirWatchedItem = z.infer<typeof YirWatchedItemSchema>;

--- a/projects/client/src/lib/requests/models/YirPerson.ts
+++ b/projects/client/src/lib/requests/models/YirPerson.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { ImageUrlsSchema } from './ImageUrlsSchema.ts';
+
+const YirPersonTitleSchema = z.object({
+  title: z.string(),
+  type: z.enum(['show', 'movie']),
+  traktId: z.number(),
+  episodeCount: z.number().optional(),
+});
+
+export const YirPersonSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  slug: z.string(),
+  headshot: z.object({
+    url: ImageUrlsSchema,
+  }),
+  count: z.object({
+    movies: z.number(),
+    shows: z.number(),
+  }),
+  titles: YirPersonTitleSchema.array(),
+});
+
+export type YirPerson = z.infer<typeof YirPersonSchema>;
+export type YirPersonTitle = z.infer<typeof YirPersonTitleSchema>;
+
+export type YirPeopleType =
+  | 'actors'
+  | 'actresses'
+  | 'directors'
+  | 'writers';

--- a/projects/client/src/lib/requests/queries/users/userProfileQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userProfileQuery.ts
@@ -16,7 +16,7 @@ const userProfileRequest = (
         id: slug,
       },
       query: {
-        extended: 'full,vip',
+        extended: 'full,vip,images' as 'full,vip',
       },
     });
 

--- a/projects/client/src/lib/requests/queries/users/yirDetailQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/yirDetailQuery.ts
@@ -1,0 +1,33 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { mapToYirDetail } from '../../_internal/mapToYirDetail.ts';
+import { YirDetailSchema } from '../../models/YirDetail.ts';
+
+export type YirDetailParams = {
+  slug: string;
+  year: number;
+} & ApiParams;
+
+const yirDetailRequest = async (
+  { fetch, slug, year }: YirDetailParams,
+) => {
+  const response = await rawApiFetch({
+    fetch,
+    path: `/users/${slug}/yir/${year}?extended=images`,
+  });
+
+  return response.ok
+    ? { body: await response.json(), status: 200 }
+    : { body: null, status: response.status };
+};
+
+export const yirDetailQuery = defineQuery({
+  key: 'yirDetail',
+  invalidations: [],
+  dependencies: (params) => [params.slug, params.year],
+  request: yirDetailRequest,
+  mapper: (response) => response.body ? mapToYirDetail(response.body) : null,
+  schema: YirDetailSchema.nullable(),
+  ttl: time.hours(1),
+});

--- a/projects/client/src/lib/requests/queries/users/yirPeopleQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/yirPeopleQuery.ts
@@ -1,0 +1,34 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { mapToYirPeople } from '../../_internal/mapToYirPerson.ts';
+import { type YirPeopleType, YirPersonSchema } from '../../models/YirPerson.ts';
+
+export type YirPeopleParams = {
+  slug: string;
+  year: number;
+  type: YirPeopleType;
+} & ApiParams;
+
+const yirPeopleRequest = async (
+  { fetch, slug, year, type }: YirPeopleParams,
+) => {
+  const response = await rawApiFetch({
+    fetch,
+    path: `/users/${slug}/yir/${year}/people/${type}?extended=images`,
+  });
+
+  return response.ok
+    ? { body: await response.json(), status: 200 }
+    : { body: [], status: response.status };
+};
+
+export const yirPeopleQuery = defineQuery({
+  key: 'yirPeople',
+  invalidations: [],
+  dependencies: (params) => [params.slug, params.year, params.type],
+  request: yirPeopleRequest,
+  mapper: (response) => mapToYirPeople(response.body),
+  schema: YirPersonSchema.array(),
+  ttl: time.hours(3),
+});

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -178,7 +178,7 @@
     <NavbarStateSetter mode="full" />
   {/if}
 
-  <div class="trakt-content" {...dynamicContentProps}>
+  <div class="trakt-content" data-mode={mode} {...dynamicContentProps}>
     {@render children()}
   </div>
 
@@ -222,6 +222,12 @@
     @include for-mobile {
       margin-top: var(--gap-xxs);
       --content-gap: var(--gap-s);
+    }
+
+    &[data-mode="content-only"] {
+      padding-left: 0;
+      margin-top: 0;
+      gap: 0;
     }
   }
 </style>

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -193,7 +193,7 @@
     <NavbarStateSetter mode="full" />
   {/if}
 
-  <div class="trakt-content" {...dynamicContentProps}>
+  <div class="trakt-content" data-mode={mode} {...dynamicContentProps}>
     {@render children()}
   </div>
 
@@ -237,6 +237,12 @@
     @include for-mobile {
       margin-top: var(--gap-xxs);
       --content-gap: var(--gap-s);
+    }
+
+    &[data-mode="content-only"] {
+      padding-left: 0;
+      margin-top: 0;
+      gap: 0;
     }
   }
 </style>

--- a/projects/client/src/lib/sections/navbar/NavbarStateSetter.svelte
+++ b/projects/client/src/lib/sections/navbar/NavbarStateSetter.svelte
@@ -11,6 +11,7 @@
     showFilters,
     headerActions,
     header,
+    sidebar,
   }: {
     actions?: Snippet;
     contextualActions?: Snippet;
@@ -24,6 +25,9 @@
       metaInfo?: string | Snippet;
       actions?: Snippet;
     };
+    sidebar?: {
+      mode: "default" | "fixed";
+    };
   } = $props();
 
   const { set, globalSet, reset } = useNavbarState();
@@ -36,6 +40,7 @@
       showFilters,
       headerActions,
       header,
+      sidebar,
     });
   });
 

--- a/projects/client/src/lib/sections/navbar/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/SideNavbar.svelte
@@ -6,6 +6,7 @@
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { useCollapsedSection } from "$lib/stores/useCollapsedSection";
+  import { combineLatest, map } from "rxjs";
   import { slide } from "svelte/transition";
   import NavbarActions from "./_internal/NavbarActions.svelte";
   import SideNavbarContent from "./_internal/SideNavbarContent.svelte";
@@ -14,7 +15,16 @@
   import { useNavbarState } from "./useNavbarState";
 
   const { state } = useNavbarState();
-  const { isCollapsed, toggle } = useCollapsedSection("side-navbar", true);
+  const { isCollapsed: storedCollapsed, toggle } = useCollapsedSection(
+    "side-navbar",
+    true,
+  );
+
+  // Pages can opt into a forced-collapsed sidebar (e.g. YIR), which always
+  // wins over the user's stored preference for the duration of that page.
+  const isCollapsed = combineLatest([storedCollapsed, state]).pipe(
+    map(([stored, $state]) => $state.forceCollapsed || stored),
+  );
 
   $effect(() => {
     const width = $isCollapsed

--- a/projects/client/src/lib/sections/navbar/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/SideNavbar.svelte
@@ -10,14 +10,22 @@
   import NavbarActions from "./_internal/NavbarActions.svelte";
   import SideNavbarContent from "./_internal/SideNavbarContent.svelte";
   import ProfileLink from "./components/ProfileLink.svelte";
+  import TraktLogo from "./components/TraktLogo.svelte";
   import UserMenu from "./components/UserMenu.svelte";
   import { useNavbarState } from "./useNavbarState";
 
   const { state } = useNavbarState();
-  const { isCollapsed, toggle } = useCollapsedSection("side-navbar", true);
+  const { isCollapsed: storedIsCollapsed, toggle } = useCollapsedSection(
+    "side-navbar",
+    true,
+  );
+
+  const isCollapsed = $derived(
+    $state.sidebar?.mode === "fixed" ? true : $storedIsCollapsed,
+  );
 
   $effect(() => {
-    const width = $isCollapsed
+    const width = isCollapsed
       ? "var(--side-navbar-width-collapsed)"
       : "var(--side-navbar-width-expanded)";
     document.documentElement.style.setProperty("--side-navbar-width", width);
@@ -36,17 +44,21 @@
       class="trakt-side-navbar"
       data-dpad-navigation={DpadNavigationType.Navbar}
     >
-      <div class="trakt-side-navbar-top">
-        <button
-          class="nav-menu-button"
-          onclick={toggle}
-          aria-label={$isCollapsed
-            ? m.button_label_expand_navbar()
-            : m.button_label_collapse_navbar()}
-        >
-          <MenuIcon state={$isCollapsed ? "closed" : "open"} />
-        </button>
-        {#if !$isCollapsed}
+      <div class="trakt-side-navbar-top" class:is-expanded={!isCollapsed}>
+        {#if $state.sidebar?.mode === "fixed"}
+          <TraktLogo />
+        {:else}
+          <button
+            class="nav-menu-button"
+            onclick={toggle}
+            aria-label={isCollapsed
+              ? m.button_label_expand_navbar()
+              : m.button_label_collapse_navbar()}
+          >
+            <MenuIcon state={isCollapsed ? "closed" : "open"} />
+          </button>
+        {/if}
+        {#if !isCollapsed}
           <div class="nav-logo-link" transition:slide={{ duration: 150 }}>
             <Link href="/" label="Trakt">
               <Logo />
@@ -55,12 +67,12 @@
         {/if}
       </div>
 
-      <SideNavbarContent isCollapsed={$isCollapsed} />
+      <SideNavbarContent {isCollapsed} />
 
-      <div class="trakt-side-navbar-bottom" class:is-expanded={!$isCollapsed}>
+      <div class="trakt-side-navbar-bottom" class:is-expanded={!isCollapsed}>
         <RenderFor audience="authenticated">
-          <UserMenu isExpanded={!$isCollapsed}>
-            <ProfileLink isExpanded={!$isCollapsed} />
+          <UserMenu isExpanded={!isCollapsed}>
+            <ProfileLink isExpanded={!isCollapsed} />
           </UserMenu>
         </RenderFor>
       </div>
@@ -124,9 +136,12 @@
     height: auto;
   }
 
+  .trakt-side-navbar-top.is-expanded {
+    justify-content: flex-start;
+  }
+
   .trakt-side-navbar-top {
     flex-direction: row;
-    justify-content: flex-start;
     gap: var(--gap-xxs);
     align-self: stretch;
 

--- a/projects/client/src/lib/sections/navbar/useNavbarState.ts
+++ b/projects/client/src/lib/sections/navbar/useNavbarState.ts
@@ -20,11 +20,13 @@ type NavbarState = {
 type GlobalNavbarState = {
   toastActions: Snippet | Nil;
   mode: NavbarMode;
+  forceCollapsed: boolean;
 };
 
 const globalNavbarStateStore = new BehaviorSubject<GlobalNavbarState>({
   toastActions: null,
   mode: 'hidden',
+  forceCollapsed: false,
 });
 
 const initialNavbarState: NavbarState = {

--- a/projects/client/src/lib/sections/navbar/useNavbarState.ts
+++ b/projects/client/src/lib/sections/navbar/useNavbarState.ts
@@ -15,6 +15,9 @@ type NavbarState = {
     metaInfo?: string | Snippet;
     actions?: Snippet;
   };
+  sidebar: {
+    mode: 'default' | 'fixed';
+  };
 };
 
 type GlobalNavbarState = {
@@ -34,6 +37,9 @@ const initialNavbarState: NavbarState = {
   showFilters: true,
   headerActions: undefined,
   header: undefined,
+  sidebar: {
+    mode: 'default',
+  },
 };
 
 const navbarStateStore = new BehaviorSubject<NavbarState>(

--- a/projects/client/src/lib/sections/yir/YirPage.svelte
+++ b/projects/client/src/lib/sections/yir/YirPage.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
-  import YirDefault from "./default/YirDefault.svelte";
-  import YirTitleSection from "./default/_internal/YirTitleSection.svelte";
-  import YirHeader from "./_internal/YirHeader.svelte";
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import { useNavbarState } from "$lib/sections/navbar/useNavbarState";
+  import YirHeader from "./_internal/YirHeader.svelte";
   import { useYirDetail } from "./_internal/useYirDetail";
+  import YirDefault from "./default/YirDefault.svelte";
+  import YirTitleSection from "./default/_internal/YirTitleSection.svelte";
 
   const { slug, year }: { slug: string; year: number } = $props();
 
-  const { detail, isLoading } = $derived(
-    useYirDetail({ slug, year }),
-  );
+  const { detail, isLoading } = $derived(useYirDetail({ slug, year }));
 
   // The expanded sidebar overlaps and crowds the YIR layout — force the
   // collapsed/default-width sidebar for the duration of this page.
@@ -19,6 +17,21 @@
     globalSet({ forceCollapsed: true });
     return () => globalSet({ forceCollapsed: false });
   });
+
+  /*
+    TODO:
+    - 'deno task check' issues
+    - css var for bar chart height
+    - bar chart flickering on resize
+    - use UrlBuilder where applicable, e.g. people section
+    - sidebar collapse state via NavbarStateSetter in +page.svelte, instead of effect here
+      -- collapse also can keep profile section open
+    - placeholders need to be different; e.g. first play placeholder is purple
+    - bar chart readability on mobile size (especially the weekly ones)
+    - people section -> as you go down, it starts showing bits of the next row
+    - extract bubble chart
+    - extract genres chart
+  */
 </script>
 
 <div class="yir-page" id="year-in-review">

--- a/projects/client/src/lib/sections/yir/YirPage.svelte
+++ b/projects/client/src/lib/sections/yir/YirPage.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import YirDefault from "./default/YirDefault.svelte";
+  import YirTitleSection from "./default/_internal/YirTitleSection.svelte";
+  import YirHeader from "./_internal/YirHeader.svelte";
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
+  import { useNavbarState } from "$lib/sections/navbar/useNavbarState";
+  import { useYirDetail } from "./_internal/useYirDetail";
+
+  const { slug, year }: { slug: string; year: number } = $props();
+
+  const { detail, isLoading } = $derived(
+    useYirDetail({ slug, year }),
+  );
+
+  // The expanded sidebar overlaps and crowds the YIR layout — force the
+  // collapsed/default-width sidebar for the duration of this page.
+  const { globalSet } = useNavbarState();
+  $effect(() => {
+    globalSet({ forceCollapsed: true });
+    return () => globalSet({ forceCollapsed: false });
+  });
+</script>
+
+<div class="yir-page" id="year-in-review">
+  <YirHeader {slug} {year} />
+
+  <YirTitleSection {slug} {year} coverImage={$detail?.images.cover} />
+
+  {#if $isLoading}
+    <div class="yir-loading">
+      <LoadingIndicator />
+    </div>
+  {:else if $detail}
+    <YirDefault detail={$detail} {slug} {year} />
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-page {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--shade-950);
+    color: var(--shade-10);
+    overflow-x: hidden;
+
+    // YIR is rendered with a dark backdrop regardless of user theme.
+    // These overrides force chart colors to stay legible.
+    --color-bar-custom-default: var(--shade-300);
+    --color-bar-custom-highlight: var(--shade-10);
+    --color-bar-custom-hover: var(--red-700);
+    --color-text-primary-override: var(--shade-10);
+    --color-text-secondary-override: var(--shade-500);
+
+    // YIR-only: account for the side navbar's outer margin (gap-s on each
+    // side, see SideNavbar.svelte) so the visible gap on the right of the
+    // navbar matches the gap on the left, instead of the global +ni-16.
+    --layout-sidebar-distance: calc(
+      var(--side-navbar-width) + 2 * var(--gap-s)
+    );
+
+    @include for-tablet-sm-and-below {
+      --layout-sidebar-distance: 0;
+    }
+  }
+
+  .yir-loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: var(--ni-96) 0;
+    color: var(--shade-10);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/YirPage.svelte
+++ b/projects/client/src/lib/sections/yir/YirPage.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
+  import YirHeader from "./_internal/YirHeader.svelte";
+  import { useYirDetail } from "./_internal/useYirDetail";
+  import YirDefault from "./default/YirDefault.svelte";
+  import YirTitleSection from "./default/_internal/YirTitleSection.svelte";
+
+  const { slug, year }: { slug: string; year: number } = $props();
+
+  const { detail, isLoading } = $derived(useYirDetail({ slug, year }));
+</script>
+
+<div class="yir-page" id="year-in-review">
+  <YirHeader {slug} {year} />
+
+  <YirTitleSection {slug} {year} coverImage={$detail?.images.cover} />
+
+  {#if $isLoading}
+    <div class="yir-loading">
+      <LoadingIndicator />
+    </div>
+  {:else if $detail}
+    <YirDefault detail={$detail} {slug} {year} />
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-page {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--shade-950);
+    color: var(--shade-10);
+    overflow-x: hidden;
+
+    // YIR is rendered with a dark backdrop regardless of user theme.
+    // These overrides force chart colors to stay legible.
+    --color-bar-custom-default: var(--shade-300);
+    --color-bar-custom-highlight: var(--shade-10);
+    --color-bar-custom-hover: var(--red-700);
+    --color-bar-chart-text-primary: var(--shade-10);
+    --color-bar-chart-text-secondary: var(--shade-500);
+
+    // YIR-only: account for the side navbar's outer margin (gap-s on each
+    // side, see SideNavbar.svelte) so the visible gap on the right of the
+    // navbar matches the gap on the left, instead of the global +ni-16.
+    --layout-sidebar-distance: calc(
+      var(--side-navbar-width) + 2 * var(--gap-s)
+    );
+
+    @include for-tablet-sm-and-below {
+      --layout-sidebar-distance: 0;
+    }
+  }
+
+  .yir-loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: var(--ni-96) 0;
+    color: var(--shade-10);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
@@ -1,0 +1,278 @@
+<script lang="ts">
+  import { browser } from "$app/environment";
+  import { page } from "$app/state";
+  import { map } from "rxjs";
+
+  import { useShare } from "$lib/components/buttons/share/useShare";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import { useQuery } from "$lib/features/query/useQuery";
+  import { m } from "$lib/paraglide/messages";
+  import { userProfileQuery } from "$lib/requests/queries/users/userProfileQuery";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+
+  import VipBadge from "$lib/components/badge/VipBadge.svelte";
+  import CaretLeftIcon from "$lib/components/icons/CaretLeftIcon.svelte";
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
+  import ShareIcon from "$lib/components/icons/ShareIcon.svelte";
+
+  const {
+    slug,
+    year,
+  }: {
+    slug: string;
+    year: number;
+  } = $props();
+
+  const profileQuery = $derived(useQuery(userProfileQuery({ slug })));
+  const profile = $derived(profileQuery.pipe(map(($q) => $q.data)));
+
+  const currentYear = new Date().getFullYear();
+  const isCurrentYear = $derived(year === currentYear);
+  const canGoNext = $derived(year < currentYear);
+
+  const periodLabel = $derived(
+    isCurrentYear ? m.yir_title_year_to_date() : m.yir_title_year_in_review(),
+  );
+
+  const prevYearUrl = $derived(UrlBuilder.users(slug).yearToDate(year - 1));
+  const nextYearUrl = $derived(UrlBuilder.users(slug).yearToDate(year + 1));
+
+  const { share } = $derived(useShare({ id: "yir" }));
+
+  const shareData = $derived({
+    title: m.yir_share_text({ year }),
+    text: m.yir_share_text({ year }),
+    url: browser ? page.url.toString() : "",
+  });
+
+  const canShare = $derived(
+    browser && !!navigator.canShare && navigator.canShare(shareData),
+  );
+
+  let isScrolled = $state(false);
+
+  $effect(() => {
+    if (!browser) return;
+    const onScroll = () => {
+      isScrolled = window.scrollY > 0;
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  });
+</script>
+
+<header class="yir-header" class:scrolled={isScrolled}>
+  <nav class="yir-header-section yir-header-center">
+    <a
+      href={prevYearUrl}
+      class="yir-header-nav-btn"
+      aria-label={m.yir_button_previous()}
+    >
+      <CaretLeftIcon />
+    </a>
+    <span class="yir-header-year-label">
+      <strong>{year}</strong>
+      <span class="yir-header-period">{periodLabel}</span>
+    </span>
+    {#if canGoNext}
+      <a
+        href={nextYearUrl}
+        class="yir-header-nav-btn"
+        aria-label={m.yir_button_next()}
+      >
+        <CaretRightIcon />
+      </a>
+    {:else}
+      <span class="yir-header-nav-btn disabled" aria-hidden="true">
+        <CaretRightIcon />
+      </span>
+    {/if}
+  </nav>
+
+  {#if $profile && ($profile.isVip || $profile.isDirector)}
+    <div class="yir-header-vip">
+      <VipBadge isDirector={$profile.isDirector} />
+    </div>
+  {/if}
+  {#if $profile}
+    <a href="/users/{slug}" class="yir-header-user">
+      <div class="yir-header-avatar">
+        <CrossOriginImage src={$profile.avatar.url} alt="" />
+      </div>
+      <span class="yir-header-username">{$profile.username}</span>
+    </a>
+  {/if}
+  {#if canShare}
+    <button
+      class="yir-header-share"
+      onclick={() => share(shareData)}
+      aria-label={m.button_label_share({ title: m.yir_share_text({ year }) })}
+    >
+      <ShareIcon />
+    </button>
+  {/if}
+</header>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
+
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--gap-m);
+
+    padding: var(--ni-20) var(--ni-10);
+
+    background: transparent;
+    color: var(--shade-10);
+
+    transition:
+      background-color 0.2s,
+      backdrop-filter 0.2s;
+
+    &.scrolled {
+      background: var(--color-background-mobile-navbar);
+      box-shadow: var(--shadow-navbar);
+      backdrop-filter: blur(var(--ni-8));
+    }
+  }
+
+  .yir-header-section {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-s);
+    min-width: 0;
+  }
+
+  .yir-header-center {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    gap: var(--gap-s);
+  }
+
+  .yir-header-nav-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--ni-8);
+    background: none;
+    border: none;
+    color: var(--shade-10);
+    cursor: pointer;
+    text-decoration: none;
+    transition: color 0.2s;
+
+    &:hover:not(.disabled) {
+      color: var(--purple-300);
+    }
+
+    &.disabled {
+      opacity: 0.3;
+      cursor: default;
+    }
+
+    :global(svg) {
+      width: var(--ni-14);
+      height: var(--ni-14);
+    }
+  }
+
+  .yir-header-year-label {
+    font-size: 14px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    white-space: nowrap;
+
+    strong {
+      font-weight: 700;
+    }
+  }
+
+  .yir-header-user {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    color: var(--shade-10);
+    text-decoration: none;
+    min-width: 0;
+  }
+
+  .yir-header-avatar {
+    width: var(--ni-28);
+    height: var(--ni-28);
+    border-radius: 50%;
+    overflow: hidden;
+    background: var(--shade-800);
+    flex-shrink: 0;
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+
+  .yir-header-username {
+    font-size: 14px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .yir-header-share {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--ni-8);
+    background: none;
+    border: none;
+    color: var(--shade-10);
+    cursor: pointer;
+    transition: color 0.2s;
+
+    &:hover {
+      color: var(--purple-300);
+    }
+
+    :global(svg) {
+      width: var(--ni-20);
+      height: var(--ni-20);
+    }
+  }
+
+  @include for-tablet-sm-and-below {
+    .yir-header-period {
+      display: none;
+    }
+
+    .yir-header-username {
+      display: none;
+    }
+  }
+
+  @include for-mobile {
+    .yir-header {
+      padding: var(--ni-8) var(--ni-12);
+      gap: var(--gap-xs);
+    }
+
+    .yir-header-vip {
+      display: none;
+    }
+
+    .yir-header-user {
+      margin-right: auto;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
@@ -14,6 +14,7 @@
   import CaretLeftIcon from "$lib/components/icons/CaretLeftIcon.svelte";
   import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
   import ShareIcon from "$lib/components/icons/ShareIcon.svelte";
+  import { trackWindowScroll } from "$lib/utils/actions/trackWindowScroll";
 
   const {
     slug,
@@ -48,21 +49,9 @@
   const canShare = $derived(
     browser && !!navigator.canShare && navigator.canShare(shareData),
   );
-
-  let isScrolled = $state(false);
-
-  $effect(() => {
-    if (!browser) return;
-    const onScroll = () => {
-      isScrolled = window.scrollY > 0;
-    };
-    onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  });
 </script>
 
-<header class="yir-header" class:scrolled={isScrolled}>
+<header class="yir-header" use:trackWindowScroll={"scrolled"}>
   <nav class="yir-header-section yir-header-center">
     <a
       href={prevYearUrl}
@@ -138,10 +127,18 @@
       background-color 0.2s,
       backdrop-filter 0.2s;
 
-    &.scrolled {
+    &:global(.scrolled) {
       background: var(--color-background-mobile-navbar);
       box-shadow: var(--shadow-navbar);
       backdrop-filter: blur(var(--ni-8));
+
+      color: var(--color-text-primary);
+
+      :global(.yir-header-nav-btn),
+      :global(.yir-header-user),
+      :global(.yir-header-share) {
+        color: var(--color-text-primary);
+      }
     }
   }
 

--- a/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+  import { browser } from "$app/environment";
+  import { page } from "$app/state";
+  import { map } from "rxjs";
+
+  import { useShare } from "$lib/components/buttons/share/useShare";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import { useQuery } from "$lib/features/query/useQuery";
+  import { m } from "$lib/paraglide/messages";
+  import { userProfileQuery } from "$lib/requests/queries/users/userProfileQuery";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+
+  import VipBadge from "$lib/components/badge/VipBadge.svelte";
+  import CaretLeftIcon from "$lib/components/icons/CaretLeftIcon.svelte";
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
+  import ShareIcon from "$lib/components/icons/ShareIcon.svelte";
+  import { trackWindowScroll } from "$lib/utils/actions/trackWindowScroll";
+
+  const {
+    slug,
+    year,
+  }: {
+    slug: string;
+    year: number;
+  } = $props();
+
+  const profileQuery = $derived(useQuery(userProfileQuery({ slug })));
+  const profile = $derived(profileQuery.pipe(map(($q) => $q.data)));
+
+  const currentYear = new Date().getFullYear();
+  const isCurrentYear = $derived(year === currentYear);
+  const canGoNext = $derived(year < currentYear);
+
+  const periodLabel = $derived(
+    isCurrentYear ? m.yir_title_year_to_date() : m.yir_title_year_in_review(),
+  );
+
+  const prevYearUrl = $derived(UrlBuilder.users(slug).yearToDate(year - 1));
+  const nextYearUrl = $derived(UrlBuilder.users(slug).yearToDate(year + 1));
+
+  const { share } = $derived(useShare({ id: "yir" }));
+
+  const shareData = $derived({
+    title: m.yir_share_text({ year }),
+    text: m.yir_share_text({ year }),
+    url: browser ? page.url.toString() : "",
+  });
+
+  const canShare = $derived(
+    browser && !!navigator.canShare && navigator.canShare(shareData),
+  );
+</script>
+
+<header class="yir-header" use:trackWindowScroll={"scrolled"}>
+  <nav class="yir-header-section yir-header-center">
+    <a
+      href={prevYearUrl}
+      class="yir-header-nav-btn"
+      aria-label={m.yir_button_previous()}
+    >
+      <CaretLeftIcon />
+    </a>
+    <span class="yir-header-year-label">
+      <strong>{year}</strong>
+      <span class="yir-header-period">{periodLabel}</span>
+    </span>
+    {#if canGoNext}
+      <a
+        href={nextYearUrl}
+        class="yir-header-nav-btn"
+        aria-label={m.yir_button_next()}
+      >
+        <CaretRightIcon />
+      </a>
+    {:else}
+      <span class="yir-header-nav-btn disabled" aria-hidden="true">
+        <CaretRightIcon />
+      </span>
+    {/if}
+  </nav>
+
+  {#if $profile && ($profile.isVip || $profile.isDirector)}
+    <div class="yir-header-vip">
+      <VipBadge isDirector={$profile.isDirector} />
+    </div>
+  {/if}
+  {#if $profile}
+    <a href={UrlBuilder.profile.user(slug)} class="yir-header-user">
+      <div class="yir-header-avatar">
+        <CrossOriginImage src={$profile.avatar.url} alt="" />
+      </div>
+      <span class="yir-header-username">{$profile.username}</span>
+    </a>
+  {/if}
+  {#if canShare}
+    <button
+      class="yir-header-share"
+      onclick={() => share(shareData)}
+      aria-label={m.button_label_share({ title: m.yir_share_text({ year }) })}
+    >
+      <ShareIcon />
+    </button>
+  {/if}
+</header>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
+
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--gap-m);
+
+    padding: var(--ni-20) var(--ni-10);
+
+    background: transparent;
+    color: var(--shade-10);
+
+    transition:
+      background-color 0.2s,
+      backdrop-filter 0.2s;
+
+    &:global(.scrolled) {
+      background: var(--color-background-mobile-navbar);
+      box-shadow: var(--shadow-navbar);
+      backdrop-filter: blur(var(--ni-8));
+
+      color: var(--color-text-primary);
+
+      :global(.yir-header-nav-btn),
+      :global(.yir-header-user),
+      :global(.yir-header-share) {
+        color: var(--color-text-primary);
+      }
+    }
+  }
+
+  .yir-header-section {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-s);
+    min-width: 0;
+  }
+
+  .yir-header-center {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    gap: var(--gap-s);
+  }
+
+  .yir-header-nav-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--ni-8);
+    background: none;
+    border: none;
+    color: var(--shade-10);
+    cursor: pointer;
+    text-decoration: none;
+    transition: color 0.2s;
+
+    &:hover:not(.disabled) {
+      color: var(--purple-300);
+    }
+
+    &.disabled {
+      opacity: 0.3;
+      cursor: default;
+    }
+
+    :global(svg) {
+      width: var(--ni-14);
+      height: var(--ni-14);
+    }
+  }
+
+  .yir-header-year-label {
+    font-size: var(--font-size-text);
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    white-space: nowrap;
+
+    strong {
+      font-weight: 700;
+    }
+  }
+
+  .yir-header-user {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    color: var(--shade-10);
+    text-decoration: none;
+    min-width: 0;
+  }
+
+  .yir-header-avatar {
+    width: var(--ni-28);
+    height: var(--ni-28);
+    border-radius: 50%;
+    overflow: hidden;
+    background: var(--shade-800);
+    flex-shrink: 0;
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+
+  .yir-header-username {
+    font-size: var(--font-size-text);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .yir-header-share {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--ni-8);
+    background: none;
+    border: none;
+    color: var(--shade-10);
+    cursor: pointer;
+    transition: color 0.2s;
+
+    &:hover {
+      color: var(--purple-300);
+    }
+
+    :global(svg) {
+      width: var(--ni-20);
+      height: var(--ni-20);
+    }
+  }
+
+  @include for-tablet-sm-and-below {
+    .yir-header-period {
+      display: none;
+    }
+
+    .yir-header-username {
+      display: none;
+    }
+  }
+
+  @include for-mobile {
+    .yir-header {
+      padding: var(--ni-8) var(--ni-12);
+      gap: var(--gap-xs);
+    }
+
+    .yir-header-vip {
+      display: none;
+    }
+
+    .yir-header-user {
+      margin-right: auto;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/_internal/YirTooltip.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirTooltip.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  const {
+    main,
+    sub,
+    extra,
+  }: {
+    main: string;
+    sub?: string;
+    extra?: string;
+  } = $props();
+</script>
+
+<div class="yir-tooltip">
+  <div class="yir-tooltip-main">{main}</div>
+  {#if sub}
+    <div class="yir-tooltip-sub">{sub}</div>
+  {/if}
+  {#if extra}
+    <div class="yir-tooltip-extra">{extra}</div>
+  {/if}
+</div>
+
+<style lang="scss">
+  // Styles are :global so the same classes can be reused by Carbon's
+  // tooltip customHTML callback (see yirTooltipHTML.ts), which renders
+  // outside this component's DOM.
+  :global(.yir-tooltip) {
+    background: color-mix(in srgb, var(--shade-1000) 92%, transparent);
+    border: var(--border-thickness-xxs) solid var(--shade-800);
+    border-radius: var(--border-radius-xs);
+    padding: var(--ni-8) var(--ni-12);
+    color: var(--shade-10);
+    font-family: inherit;
+    box-shadow: 0 var(--ni-2) var(--ni-8)
+      color-mix(in srgb, var(--shade-1000) 60%, transparent);
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  :global(.yir-tooltip-main) {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--shade-10);
+
+    &:not(:last-child) {
+      margin-bottom: var(--ni-4);
+    }
+  }
+
+  :global(.yir-tooltip-sub),
+  :global(.yir-tooltip-extra) {
+    font-size: 11px;
+    color: var(--shade-500);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/_internal/YirTooltip.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirTooltip.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  const {
+    main,
+    sub,
+    extra,
+  }: {
+    main: string;
+    sub?: string;
+    extra?: string;
+  } = $props();
+</script>
+
+<div class="yir-tooltip">
+  <div class="yir-tooltip-main">{main}</div>
+  {#if sub}
+    <div class="yir-tooltip-sub">{sub}</div>
+  {/if}
+  {#if extra}
+    <div class="yir-tooltip-extra">{extra}</div>
+  {/if}
+</div>
+
+<style lang="scss">
+  // Styles are :global so the same classes can be reused by Carbon's
+  // tooltip customHTML callback (see yirTooltipHTML.ts), which renders
+  // outside this component's DOM.
+  :global(.yir-tooltip) {
+    background: color-mix(in srgb, var(--shade-1000) 92%, transparent);
+    border: var(--border-thickness-xxs) solid var(--shade-800);
+    border-radius: var(--border-radius-xs);
+    padding: var(--ni-8) var(--ni-12);
+    color: var(--shade-10);
+    font-family: inherit;
+    box-shadow: 0 var(--ni-2) var(--ni-8)
+      color-mix(in srgb, var(--shade-1000) 60%, transparent);
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  :global(.yir-tooltip-main) {
+    font-size: var(--font-size-text);
+    font-weight: 600;
+    color: var(--shade-10);
+
+    &:not(:last-child) {
+      margin-bottom: var(--ni-4);
+    }
+  }
+
+  :global(.yir-tooltip-sub),
+  :global(.yir-tooltip-extra) {
+    font-size: var(--ni-12);
+    color: var(--shade-500);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/_internal/useYirDetail.ts
+++ b/projects/client/src/lib/sections/yir/_internal/useYirDetail.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import { yirDetailQuery } from '$lib/requests/queries/users/yirDetailQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { map } from 'rxjs';
+
+type UseYirDetailProps = {
+  slug: string;
+  year: number;
+};
+
+export function useYirDetail(props: UseYirDetailProps) {
+  const query = useQuery(yirDetailQuery(props));
+
+  return {
+    detail: query.pipe(map(($query) => $query.data)),
+    isLoading: query.pipe(map(toLoadingState)),
+  };
+}

--- a/projects/client/src/lib/sections/yir/_internal/useYirPeople.ts
+++ b/projects/client/src/lib/sections/yir/_internal/useYirPeople.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import { yirPeopleQuery } from '$lib/requests/queries/users/yirPeopleQuery.ts';
+import type { YirPeopleType } from '$lib/requests/models/YirPerson.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { map } from 'rxjs';
+
+type UseYirPeopleProps = {
+  slug: string;
+  year: number;
+  type: YirPeopleType;
+};
+
+export function useYirPeople(props: UseYirPeopleProps) {
+  const query = useQuery(yirPeopleQuery(props));
+
+  return {
+    people: query.pipe(map(($query) => $query.data)),
+    isLoading: query.pipe(map(toLoadingState)),
+  };
+}

--- a/projects/client/src/lib/sections/yir/_internal/yirTooltipHTML.ts
+++ b/projects/client/src/lib/sections/yir/_internal/yirTooltipHTML.ts
@@ -1,0 +1,30 @@
+// Imported for the CSS side effect — YirTooltip's :global styles are reused
+// here when rendering the tooltip via Carbon's customHTML callback.
+import "./YirTooltip.svelte";
+
+export type YirTooltipContent = {
+  main: string;
+  sub?: string;
+  extra?: string;
+};
+
+const escapeHtml = (text: string): string =>
+  text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const line = (className: string, text: string | undefined): string =>
+  text ? `<div class="${className}">${escapeHtml(text)}</div>` : "";
+
+export const yirTooltipHTML = (
+  { main, sub, extra }: YirTooltipContent,
+): string => `
+  <div class="yir-tooltip">
+    ${line("yir-tooltip-main", main)}
+    ${line("yir-tooltip-sub", sub)}
+    ${line("yir-tooltip-extra", extra)}
+  </div>
+`;

--- a/projects/client/src/lib/sections/yir/default/YirDefault.svelte
+++ b/projects/client/src/lib/sections/yir/default/YirDefault.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import type { YirDetail } from "$lib/requests/models/YirDetail";
+  import YirTotalsSection from "./_internal/YirTotalsSection.svelte";
+  import YirCalendarSection from "./_internal/YirCalendarSection.svelte";
+  import YirStatsSection from "./_internal/YirStatsSection.svelte";
+  import YirMostWatchedSection from "./_internal/YirMostWatchedSection.svelte";
+  import YirGenresSection from "./_internal/YirGenresSection.svelte";
+  import YirNetworksSection from "./_internal/YirNetworksSection.svelte";
+  import YirStudiosSection from "./_internal/YirStudiosSection.svelte";
+  import YirRatedSection from "./_internal/YirRatedSection.svelte";
+  import YirPeopleSection from "./_internal/YirPeopleSection.svelte";
+  import YirUpgradeSection from "./_internal/YirUpgradeSection.svelte";
+
+  const {
+    detail,
+    slug,
+    year,
+  }: {
+    detail: YirDetail;
+    slug: string;
+    year: number;
+  } = $props();
+</script>
+
+<YirTotalsSection stats={detail.stats.all} {year} />
+
+{#if detail.firstWatched}
+  <YirCalendarSection how="first" item={detail.firstWatched} {year} />
+{/if}
+
+<!-- TV Shows -->
+{#if detail.stats.shows.playCounts.total > 0}
+  <YirStatsSection type="shows" stats={detail.stats.shows} {year} />
+{/if}
+
+{#if detail.mostWatched.shows.length > 0}
+  <YirMostWatchedSection type="shows" items={detail.mostWatched.shows} />
+{/if}
+
+{#if detail.genres.shows.itemCount > 0}
+  <YirGenresSection type="shows" genres={detail.genres.shows} />
+{/if}
+
+{#if detail.networks.length > 0}
+  <YirNetworksSection networks={detail.networks} />
+{/if}
+
+{#if detail.topRated.shows.length > 0}
+  <YirRatedSection type="shows" items={detail.topRated.shows} />
+{/if}
+
+<!-- Movies -->
+{#if detail.stats.movies.playCounts.total > 0}
+  <YirStatsSection type="movies" stats={detail.stats.movies} {year} />
+{/if}
+
+{#if detail.mostWatched.movies.length > 0}
+  <YirMostWatchedSection type="movies" items={detail.mostWatched.movies} />
+{/if}
+
+{#if detail.genres.movies.itemCount > 0}
+  <YirGenresSection type="movies" genres={detail.genres.movies} />
+{/if}
+
+{#if detail.productionCompanies.length > 0}
+  <YirStudiosSection studios={detail.productionCompanies} />
+{/if}
+
+{#if detail.topRated.movies.length > 0}
+  <YirRatedSection type="movies" items={detail.topRated.movies} />
+{/if}
+
+<!-- People -->
+<YirPeopleSection {slug} {year} />
+
+{#if detail.lastWatched}
+  <YirCalendarSection how="last" item={detail.lastWatched} {year} />
+{/if}
+
+<YirUpgradeSection />

--- a/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import type { YirWatchedItem } from "$lib/requests/models/YirDetail";
+  import CalendarIcon from "$lib/components/icons/CalendarIcon.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { m } from "$lib/paraglide/messages";
+  import { toHumanLongDate } from "$lib/utils/formatting/date/toHumanLongDate";
+  import { toHumanClockTime } from "$lib/utils/formatting/date/toHumanClockTime";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+
+  const {
+    how,
+    item,
+    year,
+  }: {
+    how: "first" | "last";
+    item: YirWatchedItem;
+    year: number;
+  } = $props();
+
+  const formattedDate = $derived(toHumanLongDate(item.watchedAt, languageTag()));
+  const formattedTime = $derived(toHumanClockTime(item.watchedAt, languageTag()));
+
+  const slug = $derived(item.entry.slug);
+  const mediaType = $derived(item.entry.type === "show" ? "shows" : "movies");
+  const itemUrl = $derived(`/${mediaType}/${slug}`);
+
+  const headerText = $derived(
+    how === "first"
+      ? m.yir_calendar_first_play({ year })
+      : m.yir_calendar_last_play({ year })
+  );
+</script>
+
+<section
+  class="yir-calendar-section"
+  id="section-{how}-play"
+>
+  <div
+    class="yir-calendar-bg"
+    style:background-image="url({item.entry.cover.url.medium})"
+  ></div>
+  <div class="yir-calendar-shade"></div>
+
+  <div class="yir-calendar-inner">
+    <YirSectionHeader>
+      {headerText}
+    </YirSectionHeader>
+
+    <a href={itemUrl} class="yir-calendar-media">
+      {#if item.entry.logo.url.medium}
+        <div class="yir-logo-wrapper">
+          <img
+            class="yir-calendar-logo"
+            src={item.entry.logo.url.medium}
+            alt={item.entry.title}
+          />
+        </div>
+      {:else}
+        <h3 class="yir-calendar-title">{item.entry.title}</h3>
+      {/if}
+
+      {#if item.episodeTitle}
+        <h4 class="yir-calendar-episode">{item.episodeTitle}</h4>
+      {/if}
+    </a>
+
+    <div class="yir-calendar-date">
+      <span class="yir-calendar-icon"><CalendarIcon /></span>
+      <span class="yir-calendar-month">{formattedDate}</span>
+      <span class="yir-calendar-time">{formattedTime}</span>
+    </div>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-calendar-section {
+    position: relative;
+    text-align: center;
+    background-color: var(--shade-950);
+  }
+
+  .yir-calendar-bg {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    opacity: 1;
+    transition: opacity 1s;
+  }
+
+  .yir-calendar-shade {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      color-mix(in srgb, var(--shade-1000) 80%, transparent),
+      transparent
+    );
+  }
+
+  .yir-calendar-inner {
+    position: relative;
+    z-index: 1;
+    padding: var(--ni-20) 0 var(--ni-88) 0;
+  }
+
+  .yir-calendar-media {
+    display: block;
+    text-decoration: none;
+    color: var(--shade-10);
+  }
+
+  .yir-logo-wrapper {
+    .yir-calendar-logo {
+      max-width: 70%;
+      width: var(--ni-300);
+    }
+  }
+
+  .yir-calendar-title {
+    font-size: 40px;
+    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2)
+      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+    margin: 0;
+
+    @include for-mobile {
+      font-size: 32px;
+      padding: 0 var(--ni-16);
+    }
+  }
+
+  .yir-calendar-episode {
+    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2)
+      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+    margin: var(--ni-10) 0 0 0;
+    font-size: 22px;
+
+    @include for-mobile {
+      font-size: 16px;
+      padding: 0 var(--ni-16);
+    }
+  }
+
+  .yir-calendar-date {
+    display: inline-grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    align-items: center;
+    gap: 0 var(--gap-xs);
+    margin-top: var(--ni-60);
+    line-height: 1.2;
+  }
+
+  .yir-calendar-icon {
+    grid-row: 1 / 3;
+    display: flex;
+    align-items: center;
+    color: var(--shade-10);
+    opacity: 0.7;
+
+    :global(svg) {
+      width: var(--ni-36);
+      height: var(--ni-36);
+    }
+  }
+
+  .yir-calendar-month {
+    text-transform: uppercase;
+    font-size: 17px;
+    font-weight: bold;
+    text-align: left;
+  }
+
+  .yir-calendar-time {
+    font-size: 17px;
+    text-align: left;
+    padding-top: 2px;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  import CalendarIcon from "$lib/components/icons/CalendarIcon.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { m } from "$lib/paraglide/messages";
+  import type { YirWatchedItem } from "$lib/requests/models/YirDetail";
+  import { PLACEHOLDERS } from "$lib/utils/assets";
+  import { toHumanClockTime } from "$lib/utils/formatting/date/toHumanClockTime";
+  import { toHumanLongDate } from "$lib/utils/formatting/date/toHumanLongDate";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+
+  const {
+    how,
+    item,
+    year,
+  }: {
+    how: "first" | "last";
+    item: YirWatchedItem;
+    year: number;
+  } = $props();
+
+  const formattedDate = $derived(
+    toHumanLongDate(item.watchedAt, languageTag()),
+  );
+  const formattedTime = $derived(
+    toHumanClockTime(item.watchedAt, languageTag()),
+  );
+
+  const itemUrl = $derived(UrlBuilder.media(item.entry.type, item.entry.slug));
+
+  const headerText = $derived(
+    how === "first"
+      ? m.yir_calendar_first_play({ year })
+      : m.yir_calendar_last_play({ year }),
+  );
+</script>
+
+<section class="yir-calendar-section" id="section-{how}-play">
+  <div
+    class="yir-calendar-bg"
+    style:background-image="url({item.entry.cover.url.medium})"
+  ></div>
+  <div class="yir-calendar-shade"></div>
+
+  <div class="yir-calendar-inner">
+    <YirSectionHeader>
+      {headerText}
+    </YirSectionHeader>
+
+    <a href={itemUrl} class="yir-calendar-media">
+      {#if !PLACEHOLDERS.includes(item.entry.logo.url.medium)}
+        <div class="yir-logo-wrapper">
+          <img
+            class="yir-calendar-logo"
+            src={item.entry.logo.url.medium}
+            alt={item.entry.title}
+          />
+        </div>
+      {:else}
+        <h3 class="yir-calendar-title">{item.entry.title}</h3>
+      {/if}
+
+      {#if item.episodeTitle}
+        <h4 class="yir-calendar-episode">{item.episodeTitle}</h4>
+      {/if}
+    </a>
+
+    <div class="yir-calendar-date">
+      <span class="yir-calendar-icon"><CalendarIcon /></span>
+      <span class="yir-calendar-month">{formattedDate}</span>
+      <span class="yir-calendar-time">{formattedTime}</span>
+    </div>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-calendar-section {
+    position: relative;
+    text-align: center;
+    background-color: var(--shade-950);
+  }
+
+  .yir-calendar-bg {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    opacity: 1;
+    transition: opacity 1s;
+  }
+
+  .yir-calendar-shade {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      color-mix(in srgb, var(--shade-1000) 80%, transparent),
+      transparent
+    );
+  }
+
+  .yir-calendar-inner {
+    position: relative;
+    z-index: 1;
+    padding: var(--ni-20) 0 var(--ni-88) 0;
+  }
+
+  .yir-calendar-media {
+    display: block;
+    text-decoration: none;
+    color: var(--shade-10);
+  }
+
+  .yir-logo-wrapper {
+    .yir-calendar-logo {
+      max-width: 70%;
+      width: var(--ni-300);
+    }
+  }
+
+  .yir-calendar-title {
+    font-size: var(--ni-40);
+    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2)
+      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+    margin: 0;
+
+    @include for-mobile {
+      font-size: var(--ni-32);
+      padding: 0 var(--ni-16);
+    }
+  }
+
+  .yir-calendar-episode {
+    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2)
+      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+    margin: var(--ni-10) 0 0 0;
+    font-size: var(--ni-22);
+
+    @include for-mobile {
+      font-size: var(--ni-16);
+      padding: 0 var(--ni-16);
+    }
+  }
+
+  .yir-calendar-date {
+    display: inline-grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    align-items: center;
+    gap: 0 var(--gap-xs);
+    margin-top: var(--ni-60);
+    line-height: 1.2;
+  }
+
+  .yir-calendar-icon {
+    grid-row: 1 / 3;
+    display: flex;
+    align-items: center;
+    color: var(--shade-10);
+    opacity: 0.7;
+
+    :global(svg) {
+      width: var(--ni-36);
+      height: var(--ni-36);
+    }
+  }
+
+  .yir-calendar-month {
+    text-transform: uppercase;
+    font-size: var(--ni-18);
+    font-weight: bold;
+    text-align: left;
+  }
+
+  .yir-calendar-time {
+    font-size: var(--ni-18);
+    text-align: left;
+    padding-top: 2px;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirDailyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirDailyPlaysChart.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import { getLocale } from "$lib/features/i18n";
+  import { toHumanDayOfWeek } from "$lib/utils/formatting/date/toHumanDayOfWeek";
+  import { yirTooltipHTML } from "../../_internal/yirTooltipHTML.ts";
+
+  const { data }: { data: number[] } = $props();
+
+  const labels = $derived.by(() => {
+    const locale = getLocale();
+    // January 3, 2021 was a Sunday, so we use it as a base.
+    return Array.from({ length: 7 }, (_, i) =>
+      toHumanDayOfWeek(new Date(2021, 0, 3 + i), locale),
+    );
+  });
+
+  function tooltipHTML({ value, label }: { value: number; label: string }) {
+    return yirTooltipHTML({
+      main: `${value} ${value === 1 ? "play" : "plays"}`,
+      sub: label,
+    });
+  }
+</script>
+
+<BarChart {data} {labels} {tooltipHTML} />

--- a/projects/client/src/lib/sections/yir/default/_internal/YirDailyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirDailyPlaysChart.svelte
@@ -2,17 +2,10 @@
   import BarChart from "$lib/components/charts/BarChart.svelte";
   import { getLocale } from "$lib/features/i18n";
   import { toHumanDayOfWeek } from "$lib/utils/formatting/date/toHumanDayOfWeek";
+  import { setDay } from "date-fns/setDay";
   import { yirTooltipHTML } from "../../_internal/yirTooltipHTML.ts";
 
   const { data }: { data: number[] } = $props();
-
-  const labels = $derived.by(() => {
-    const locale = getLocale();
-    // January 3, 2021 was a Sunday, so we use it as a base.
-    return Array.from({ length: 7 }, (_, i) =>
-      toHumanDayOfWeek(new Date(2021, 0, 3 + i), locale),
-    );
-  });
 
   function tooltipHTML({ value, label }: { value: number; label: string }) {
     return yirTooltipHTML({
@@ -20,6 +13,14 @@
       sub: label,
     });
   }
+
+  const chartData = $derived.by(() => {
+    const locale = getLocale();
+    return data.map((value, index) => ({
+      value,
+      label: toHumanDayOfWeek(setDay(new Date(0), index), locale),
+    }));
+  });
 </script>
 
-<BarChart {data} {labels} {tooltipHTML} />
+<BarChart data={chartData} {tooltipHTML} />

--- a/projects/client/src/lib/sections/yir/default/_internal/YirDailyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirDailyPlaysChart.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import { getLocale } from "$lib/features/i18n";
+  import { toHumanDayOfWeek } from "$lib/utils/formatting/date/toHumanDayOfWeek";
+  import { setDay } from "date-fns/setDay";
+  import YirTooltip from "../../_internal/YirTooltip.svelte";
+
+  const { data }: { data: number[] } = $props();
+
+  const chartData = $derived.by(() => {
+    const locale = getLocale();
+    return data.map((value, index) => ({
+      value,
+      label: toHumanDayOfWeek(setDay(new Date(0), index), locale),
+    }));
+  });
+</script>
+
+<BarChart data={chartData}>
+  {#snippet tooltip({ value, label })}
+    <YirTooltip main="{value} {value === 1 ? 'play' : 'plays'}" sub={label} />
+  {/snippet}
+</BarChart>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirGenresSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirGenresSection.svelte
@@ -1,0 +1,221 @@
+<script lang="ts">
+  import type { YirGenresGroup } from "$lib/requests/models/YirDetail";
+  import { m } from "$lib/paraglide/messages";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+  import YirPageInner from "./YirPageInner.svelte";
+
+  const {
+    type,
+    genres,
+  }: {
+    type: "shows" | "movies";
+    genres: YirGenresGroup;
+  } = $props();
+
+  const sectionTitle = $derived(
+    type === "shows" ? m.yir_section_title_show_genres() : m.yir_section_title_movie_genres(),
+  );
+
+  const typeLabel = $derived(
+    type === "shows" ? "show" : "movie",
+  );
+
+  const chartColors = [
+    "#CC333F",
+    "#00A0B0",
+    "#EB6841",
+    "#6A4A3C",
+    "#EDC951",
+    "#AB3E5B",
+    "#B3CC57",
+    "#EF746F",
+    "#3E4147",
+    "#FFBE40",
+    "#7B3B3B",
+  ];
+
+  function getBarColor(index: number): string {
+    return chartColors[index % chartColors.length] ?? "#222";
+  }
+</script>
+
+<section class="yir-genres-section" id="section-{type}-genres">
+  <YirPageInner>
+    <YirSectionHeader>
+      {sectionTitle}
+    </YirSectionHeader>
+
+    <div class="yir-genre-bars">
+      {#each genres.genres as genre, index}
+        {@const percentage = (genre.count / genres.itemCount) * 100}
+        {@const maxCount = genres.genres[0]?.count ?? 1}
+        {@const relativePercentage = (genre.count / maxCount) * 100}
+        <div class="yir-genre-row" data-index={index}>
+          <div class="yir-genre-info" style:border-left-color={getBarColor(index)}>
+            <span class="yir-genre-name">{genre.name}</span>
+            <span class="yir-genre-count">
+              {genre.count.toLocaleString()} {genre.count === 1 ? typeLabel : `${typeLabel}s`}
+            </span>
+          </div>
+          <div
+            class="yir-genre-bar"
+            style:--bar-width="{Math.max(percentage, 5)}%"
+            style:--mobile-bar-width="{relativePercentage}%"
+            style:background-color={getBarColor(index)}
+          >
+            <span class="yir-genre-percentage">{Math.round(percentage)}%</span>
+            <span class="yir-genre-label" style:border-color={getBarColor(index)}>
+              {genre.name}
+              <span class="yir-genre-count-desktop">
+                {genre.count.toLocaleString()} {genre.count === 1 ? typeLabel : `${typeLabel}s`}
+              </span>
+            </span>
+          </div>
+        </div>
+      {/each}
+    </div>
+  </YirPageInner>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-genres-section {
+    background-color: var(--shade-1000);
+    padding-bottom: var(--ni-72);
+
+    @include for-mobile {
+      padding-bottom: var(--ni-40);
+    }
+  }
+
+  .yir-genre-bars {
+    display: flex;
+    padding: var(--ni-40) var(--ni-16) var(--ni-60) var(--ni-16);
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    &:hover .yir-genre-bar:not(:hover) {
+      opacity: 0.5;
+    }
+
+    &:hover .yir-genre-bar .yir-genre-percentage {
+      opacity: 1;
+    }
+
+    @include for-mobile {
+      flex-direction: column;
+      padding: 0 var(--ni-16);
+      overflow: visible;
+    }
+  }
+
+  .yir-genre-row {
+    display: contents;
+
+    @include for-mobile {
+      display: flex;
+      flex-direction: column;
+      margin-bottom: var(--ni-16);
+    }
+  }
+
+  .yir-genre-info {
+    display: none;
+
+    @include for-mobile {
+      display: flex;
+      flex-direction: column;
+      margin-bottom: var(--ni-2);
+      padding-left: var(--ni-6);
+      border-left: var(--border-thickness-xxs) solid;
+    }
+  }
+
+  .yir-genre-name {
+    font-size: 14px;
+    text-transform: uppercase;
+    color: var(--shade-10);
+    font-weight: 500;
+    line-height: 1.2;
+  }
+
+  .yir-genre-bar {
+    height: var(--ni-30);
+    margin-left: var(--ni-2);
+    position: relative;
+    min-width: var(--ni-44);
+    width: var(--bar-width);
+    transition: all 0.5s;
+    cursor: pointer;
+
+    @include for-mobile {
+      height: var(--ni-30);
+      min-height: var(--ni-30);
+      width: var(--mobile-bar-width);
+      margin-left: 0;
+      margin-bottom: 0;
+      display: block;
+    }
+  }
+
+  .yir-genre-row:first-child .yir-genre-bar {
+    margin-left: 0;
+  }
+
+  .yir-genre-percentage {
+    color: var(--shade-1000);
+    position: absolute;
+    width: 100%;
+    text-align: center;
+    left: 0;
+    top: var(--ni-8);
+    font-size: 12px;
+    opacity: 0;
+    transition: opacity 0.5s;
+
+    @include for-mobile {
+      display: none;
+    }
+  }
+
+  .yir-genre-label {
+    position: absolute;
+    left: 0;
+    bottom: var(--ni-30);
+    font-size: 12px;
+    text-transform: uppercase;
+    white-space: nowrap;
+    padding: var(--ni-4) var(--ni-6);
+    color: var(--shade-10);
+    border-left: var(--border-thickness-xs) solid;
+    pointer-events: none;
+
+    @include for-mobile {
+      display: none;
+    }
+  }
+
+  .yir-genre-row[data-index]:nth-child(even) .yir-genre-label {
+    top: var(--ni-30);
+    bottom: auto;
+  }
+
+  .yir-genre-count {
+    font-size: 12px;
+    color: var(--shade-400);
+    text-transform: uppercase;
+  }
+
+  .yir-genre-count-desktop {
+    display: block;
+    font-size: 10px;
+    color: var(--shade-400);
+    text-transform: uppercase;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirGenresSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirGenresSection.svelte
@@ -1,0 +1,240 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { YirGenresGroup } from "$lib/requests/models/YirDetail";
+  import YirPageInner from "./YirPageInner.svelte";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+
+  const {
+    type,
+    genres,
+  }: {
+    type: "shows" | "movies";
+    genres: YirGenresGroup;
+  } = $props();
+
+  const sectionTitle = $derived(
+    type === "shows"
+      ? m.yir_section_title_show_genres()
+      : m.yir_section_title_movie_genres(),
+  );
+
+  const typeLabel = $derived(type === "shows" ? "show" : "movie");
+
+  const chartColors = [
+    "#CC333F",
+    "#00A0B0",
+    "#EB6841",
+    "#6A4A3C",
+    "#EDC951",
+    "#AB3E5B",
+    "#B3CC57",
+    "#EF746F",
+    "#3E4147",
+    "#FFBE40",
+    "#7B3B3B",
+  ];
+
+  function getBarColor(index: number): string {
+    return chartColors[index % chartColors.length] ?? "#222";
+  }
+</script>
+
+<section class="yir-genres-section" id="section-{type}-genres">
+  <YirPageInner>
+    <YirSectionHeader>
+      {sectionTitle}
+    </YirSectionHeader>
+
+    <div class="yir-genre-bars">
+      {#each genres.genres as genre, index (genre.name)}
+        {@const percentage = (genre.count / genres.itemCount) * 100}
+        {@const maxCount = genres.genres[0]?.count ?? 1}
+        {@const relativePercentage = (genre.count / maxCount) * 100}
+        <div class="yir-genre-row" data-index={index}>
+          <div
+            class="yir-genre-info"
+            style:border-left-color={getBarColor(index)}
+          >
+            <span class="yir-genre-name">{genre.name}</span>
+            <span class="yir-genre-count">
+              {genre.count.toLocaleString()}
+              {genre.count === 1 ? typeLabel : `${typeLabel}s`}
+            </span>
+          </div>
+          <div
+            class="yir-genre-bar"
+            style:--bar-width="{Math.max(percentage, 5)}%"
+            style:--mobile-bar-width="{relativePercentage}%"
+            style:background-color={getBarColor(index)}
+          >
+            <span class="yir-genre-percentage">{Math.round(percentage)}%</span>
+            <span
+              class="yir-genre-label"
+              style:border-color={getBarColor(index)}
+            >
+              <span class="yir-genre-name-desktop">{genre.name}</span>
+              <span class="yir-genre-count-desktop">
+                {genre.count.toLocaleString()}
+                {genre.count === 1 ? typeLabel : `${typeLabel}s`}
+              </span>
+            </span>
+          </div>
+        </div>
+      {/each}
+    </div>
+  </YirPageInner>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-genres-section {
+    background-color: var(--shade-1000);
+    padding-bottom: var(--ni-72);
+
+    @include for-mobile {
+      padding-bottom: var(--ni-40);
+    }
+  }
+
+  .yir-genre-bars {
+    display: flex;
+    padding: var(--ni-40) var(--ni-16) var(--ni-60) var(--ni-16);
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    &:hover .yir-genre-bar:not(:hover) {
+      opacity: 0.5;
+    }
+
+    &:hover .yir-genre-bar .yir-genre-percentage {
+      opacity: 1;
+    }
+
+    @include for-tablet-sm-and-below {
+      flex-direction: column;
+      padding: 0 var(--ni-16);
+      overflow: visible;
+    }
+  }
+
+  .yir-genre-row {
+    display: contents;
+
+    @include for-tablet-sm-and-below {
+      display: flex;
+      flex-direction: column;
+      margin-bottom: var(--ni-16);
+    }
+  }
+
+  .yir-genre-info {
+    display: none;
+
+    @include for-tablet-sm-and-below {
+      display: flex;
+      flex-direction: column;
+      margin-bottom: var(--ni-2);
+      padding-left: var(--ni-6);
+      border-left: var(--border-thickness-xxs) solid;
+    }
+  }
+
+  .yir-genre-name {
+    font-size: var(--ni-14);
+    text-transform: capitalize;
+    color: var(--shade-10);
+    font-weight: 500;
+    line-height: 1.2;
+  }
+
+  .yir-genre-name-desktop {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-transform: capitalize;
+    font-size: var(--ni-14);
+  }
+
+  .yir-genre-bar {
+    height: var(--ni-30);
+    margin-left: var(--ni-2);
+    position: relative;
+    min-width: var(--ni-44);
+    width: var(--bar-width);
+    transition: all 0.5s;
+    cursor: pointer;
+
+    @include for-tablet-lg {
+      min-width: var(--ni-32);
+    }
+
+    @include for-tablet-sm-and-below {
+      height: var(--ni-30);
+      min-height: var(--ni-30);
+      width: var(--mobile-bar-width);
+      margin-left: 0;
+      margin-bottom: 0;
+      display: block;
+    }
+  }
+
+  .yir-genre-row:first-child .yir-genre-bar {
+    margin-left: 0;
+  }
+
+  .yir-genre-percentage {
+    color: var(--shade-1000);
+    position: absolute;
+    width: 100%;
+    text-align: center;
+    left: 0;
+    top: var(--ni-8);
+    font-size: 12px;
+    opacity: 0;
+    transition: opacity 0.5s;
+
+    @include for-tablet-sm-and-below {
+      display: none;
+    }
+  }
+
+  .yir-genre-label {
+    position: absolute;
+    left: 0;
+    bottom: var(--ni-30);
+    width: 200%;
+    box-sizing: border-box;
+    font-size: 12px;
+    white-space: nowrap;
+    padding: var(--ni-4) var(--ni-6);
+    color: var(--shade-10);
+    border-left: var(--border-thickness-xs) solid;
+    pointer-events: none;
+
+    @include for-tablet-sm-and-below {
+      display: none;
+    }
+  }
+
+  .yir-genre-row[data-index]:nth-child(even) .yir-genre-label {
+    top: var(--ni-30);
+    bottom: auto;
+  }
+
+  .yir-genre-count {
+    font-size: 12px;
+    color: var(--shade-400);
+  }
+
+  .yir-genre-count-desktop {
+    display: block;
+    font-size: 10px;
+    color: var(--shade-400);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirHourlyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirHourlyPlaysChart.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { toHumanClockTime } from "$lib/utils/formatting/date/toHumanClockTime";
+  import { toHumanHour } from "$lib/utils/formatting/date/toHumanHour";
+  import { yirTooltipHTML } from "../../_internal/yirTooltipHTML.ts";
+
+  const { data }: { data: number[] } = $props();
+
+  const labels = $derived.by(() => {
+    const locale = languageTag();
+    return Array.from({ length: 24 }, (_, hour) =>
+      toHumanHour(new Date(2021, 0, 1, hour, 0), locale),
+    );
+  });
+
+  function tooltipHTML({ index, value }: { index: number; value: number }) {
+    const locale = languageTag();
+    const start = toHumanClockTime(new Date(2021, 0, 1, index, 0), locale);
+    const end = toHumanClockTime(new Date(2021, 0, 1, index, 59), locale);
+    return yirTooltipHTML({
+      main: `${value} ${value === 1 ? "play" : "plays"}`,
+      sub: `${start} - ${end}`,
+    });
+  }
+</script>
+
+<BarChart {data} {labels} {tooltipHTML} />

--- a/projects/client/src/lib/sections/yir/default/_internal/YirHourlyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirHourlyPlaysChart.svelte
@@ -3,26 +3,32 @@
   import { languageTag } from "$lib/features/i18n";
   import { toHumanClockTime } from "$lib/utils/formatting/date/toHumanClockTime";
   import { toHumanHour } from "$lib/utils/formatting/date/toHumanHour";
+  import { setHours } from "date-fns/setHours";
+  import { setMinutes } from "date-fns/setMinutes";
   import { yirTooltipHTML } from "../../_internal/yirTooltipHTML.ts";
 
   const { data }: { data: number[] } = $props();
 
-  const labels = $derived.by(() => {
-    const locale = languageTag();
-    return Array.from({ length: 24 }, (_, hour) =>
-      toHumanHour(new Date(2021, 0, 1, hour, 0), locale),
-    );
-  });
-
   function tooltipHTML({ index, value }: { index: number; value: number }) {
     const locale = languageTag();
-    const start = toHumanClockTime(new Date(2021, 0, 1, index, 0), locale);
-    const end = toHumanClockTime(new Date(2021, 0, 1, index, 59), locale);
+    const start = toHumanClockTime(setHours(new Date(0), index), locale);
+    const end = toHumanClockTime(
+      setMinutes(setHours(new Date(0), index), 59),
+      locale,
+    );
     return yirTooltipHTML({
       main: `${value} ${value === 1 ? "play" : "plays"}`,
       sub: `${start} - ${end}`,
     });
   }
+
+  const chartData = $derived.by(() => {
+    const locale = languageTag();
+    return data.map((value, index) => ({
+      value,
+      label: toHumanHour(setHours(new Date(0), index), locale),
+    }));
+  });
 </script>
 
-<BarChart {data} {labels} {tooltipHTML} />
+<BarChart data={chartData} {tooltipHTML} />

--- a/projects/client/src/lib/sections/yir/default/_internal/YirHourlyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirHourlyPlaysChart.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import { toHumanClockTime } from "$lib/utils/formatting/date/toHumanClockTime";
+  import { toHumanHour } from "$lib/utils/formatting/date/toHumanHour";
+  import { setHours } from "date-fns/setHours";
+  import { setMinutes } from "date-fns/setMinutes";
+  import YirTooltip from "../../_internal/YirTooltip.svelte";
+
+  const { data }: { data: number[] } = $props();
+
+  const chartData = $derived.by(() => {
+    const locale = languageTag();
+    return data.map((value, index) => ({
+      value,
+      label: toHumanHour(setHours(new Date(0), index), locale),
+    }));
+  });
+
+  const isMobile = useMedia(WellKnownMediaQuery.mobile);
+
+  const tickLabels = $derived.by(() => {
+    if (!$isMobile) return chartData.map((d) => d.label);
+    return chartData.map((d, i) => (i % 6 === 0 ? d.label : ""));
+  });
+</script>
+
+<BarChart data={chartData} {tickLabels}>
+  {#snippet tooltip({ value, index })}
+    {@const locale = languageTag()}
+    {@const start = toHumanClockTime(setHours(new Date(0), index), locale)}
+    {@const end = toHumanClockTime(
+      setMinutes(setHours(new Date(0), index), 59),
+      locale,
+    )}
+    <YirTooltip
+      main="{value} {value === 1 ? 'play' : 'plays'}"
+      sub="{start} - {end}"
+    />
+  {/snippet}
+</BarChart>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirMonthlyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirMonthlyPlaysChart.svelte
@@ -2,16 +2,10 @@
   import BarChart from "$lib/components/charts/BarChart.svelte";
   import { languageTag } from "$lib/features/i18n";
   import { toHumanMonth } from "$lib/utils/formatting/date/toHumanMonth";
+  import { setMonth } from "date-fns/setMonth";
   import { yirTooltipHTML } from "../../_internal/yirTooltipHTML.ts";
 
   const { data }: { data: number[] } = $props();
-
-  const labels = $derived.by(() => {
-    const locale = languageTag();
-    return Array.from({ length: 12 }, (_, i) =>
-      toHumanMonth(new Date(2021, i, 1), locale, "short"),
-    );
-  });
 
   function tooltipHTML({ value, label }: { value: number; label: string }) {
     return yirTooltipHTML({
@@ -19,6 +13,14 @@
       sub: label,
     });
   }
+
+  const chartData = $derived.by(() => {
+    const locale = languageTag();
+    return data.map((value, index) => ({
+      value,
+      label: toHumanMonth(setMonth(new Date(0), index), locale, "short"),
+    }));
+  });
 </script>
 
-<BarChart {data} {labels} {tooltipHTML} />
+<BarChart data={chartData} {tooltipHTML} />

--- a/projects/client/src/lib/sections/yir/default/_internal/YirMonthlyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirMonthlyPlaysChart.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { toHumanMonth } from "$lib/utils/formatting/date/toHumanMonth";
+  import { yirTooltipHTML } from "../../_internal/yirTooltipHTML.ts";
+
+  const { data }: { data: number[] } = $props();
+
+  const labels = $derived.by(() => {
+    const locale = languageTag();
+    return Array.from({ length: 12 }, (_, i) =>
+      toHumanMonth(new Date(2021, i, 1), locale, "short"),
+    );
+  });
+
+  function tooltipHTML({ value, label }: { value: number; label: string }) {
+    return yirTooltipHTML({
+      main: `${value} ${value === 1 ? "play" : "plays"}`,
+      sub: label,
+    });
+  }
+</script>
+
+<BarChart {data} {labels} {tooltipHTML} />

--- a/projects/client/src/lib/sections/yir/default/_internal/YirMonthlyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirMonthlyPlaysChart.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { toHumanMonth } from "$lib/utils/formatting/date/toHumanMonth";
+  import { setMonth } from "date-fns/setMonth";
+  import YirTooltip from "../../_internal/YirTooltip.svelte";
+
+  const { data }: { data: number[] } = $props();
+
+  const chartData = $derived.by(() => {
+    const locale = languageTag();
+    return data.map((value, index) => ({
+      value,
+      label: toHumanMonth(setMonth(new Date(0), index), locale, "short"),
+    }));
+  });
+</script>
+
+<BarChart data={chartData}>
+  {#snippet tooltip({ value, label })}
+    <YirTooltip main="{value} {value === 1 ? 'play' : 'plays'}" sub={label} />
+  {/snippet}
+</BarChart>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
@@ -1,0 +1,303 @@
+<script lang="ts">
+  import { languageTag } from "$lib/features/i18n";
+  import { m } from "$lib/paraglide/messages";
+  import type { YirMostWatchedItem } from "$lib/requests/models/YirDetail";
+  import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+
+  const {
+    type,
+    items,
+  }: {
+    type: "shows" | "movies";
+    items: YirMostWatchedItem[];
+  } = $props();
+
+  const typeLabel = $derived(type === "shows" ? "show" : "movie");
+
+  let activeIndex = $state(0);
+
+  function itemUrl(item: YirMostWatchedItem): string {
+    return UrlBuilder.media(
+      type === "shows" ? "show" : "movie",
+      item.entry.slug,
+    );
+  }
+
+  function formatMinutes(minutes: number): string {
+    return toHumanDuration({ minutes }, languageTag());
+  }
+</script>
+
+<section class="yir-most-watched-section" id="section-{type}-most-watched">
+  <!-- Featured card area with fanart backgrounds -->
+  <div class="yir-most-watched-page">
+    {#each items as item, index}
+      <div
+        class="yir-fanart-bg"
+        class:current={index === activeIndex}
+        style:background-image="url({item.entry.cover.url.medium})"
+      >
+        <div class="yir-shade"></div>
+        <div class="yir-featured-card">
+          <YirSectionHeader flat rank={index + 1}>
+            {m.yir_label_most_watched({ type: typeLabel })}
+          </YirSectionHeader>
+
+          <a href={itemUrl(item)} class="yir-card-media">
+            <div class="yir-logo-wrapper">
+              {#if item.entry.logo.url.medium}
+                <img
+                  class="yir-card-logo"
+                  src={item.entry.logo.url.medium}
+                  alt={item.entry.title}
+                />
+              {:else}
+                <h3 class="yir-card-title">{item.entry.title}</h3>
+              {/if}
+            </div>
+          </a>
+
+          <div class="yir-card-stats">
+            <div class="yir-stat-line">
+              {formatMinutes(item.minutes)}
+            </div>
+            <div class="yir-stat-line">
+              {item.plays.toLocaleString()}
+              {item.plays === 1 ? "play" : "plays"}
+            </div>
+          </div>
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  <!-- Thumbnail grid -->
+  <div class="yir-most-watched-grid">
+    {#each items as item, index}
+      <a
+        href={itemUrl(item)}
+        class="yir-grid-item"
+        onmouseenter={() => {
+          activeIndex = index;
+        }}
+      >
+        <div class="yir-rank-wrapper">
+          <span class="yir-rank">{index + 1}</span>
+        </div>
+        <img
+          class="yir-grid-thumb"
+          src={item.entry.thumb.url}
+          alt={item.entry.title}
+        />
+      </a>
+    {/each}
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-most-watched-section {
+    background-color: var(--shade-950);
+    text-align: center;
+    position: relative;
+  }
+
+  .yir-most-watched-page {
+    position: relative;
+    height: 530px;
+
+    @include for-mobile {
+      height: 430px;
+    }
+  }
+
+  .yir-fanart-bg {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    z-index: 1;
+    opacity: 0;
+    transition: all 0.5s;
+
+    &.current {
+      opacity: 1;
+      z-index: 2;
+    }
+  }
+
+  .yir-shade {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      color-mix(in srgb, var(--shade-1000) 80%, transparent),
+      transparent
+    );
+  }
+
+  .yir-featured-card {
+    position: relative;
+    z-index: 1;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .yir-card-media {
+    text-decoration: none;
+    color: var(--shade-10);
+    margin-top: var(--ni-20);
+  }
+
+  .yir-logo-wrapper {
+    .yir-card-logo {
+      max-width: 70%;
+      width: var(--ni-300);
+    }
+  }
+
+  .yir-card-title {
+    font-size: 40px;
+    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2)
+      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+    margin: 0;
+
+    @include for-mobile {
+      font-size: 32px;
+    }
+  }
+
+  .yir-card-stats {
+    margin-top: var(--ni-72);
+  }
+
+  .yir-stat-line {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--gap-xxs);
+    margin-top: var(--ni-6);
+    font-size: 18px;
+  }
+
+  .yir-most-watched-grid {
+    display: flex;
+    position: relative;
+    z-index: 3;
+    // Side margin (not padding) so the rounded outer corners and drop-
+    // shadow trace the actual thumbnail strip. The negative top margin
+    // lifts the strip so roughly half of it overlays the fanart hero —
+    // 16:9 thumbs across 10 items make the strip ~5.6% of its width tall,
+    // so -3% lifts ~half.
+    margin: -2.5% var(--layout-sidebar-distance) 0;
+    // Solid backdrop so hover-faded thumbs reveal this dark color instead
+    // of bleeding the fanart through.
+    background-color: var(--shade-1000);
+    border-radius: var(--border-radius-s);
+    // Drop-shadow follows the alpha outline (incl. the first/last thumbs'
+    // rounded corners), so the strip reads as floating above the fanart.
+    filter: drop-shadow(
+      0 var(--ni-4) var(--ni-12)
+        color-mix(in srgb, var(--shade-1000) 70%, transparent)
+    );
+
+    &:hover {
+      .yir-grid-item {
+        opacity: 0.3;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
+    }
+
+    @include for-tablet-sm-and-below {
+      // Full-bleed strip on smaller screens — no rounded corners,
+      // no lift. Horizontal scroll lets all 10 thumbs be reached.
+      // overflow-x:auto forces overflow-y to clip per CSS spec, which
+      // would cut off the rank circles (positioned top:-12 on each
+      // item, ~26px tall with their border). padding-top creates the
+      // vertical room they need; matching negative margin-top puts
+      // the thumb row back at its natural "below the fanart" position
+      // and background-clip keeps the dark backdrop behind the thumbs
+      // only — the padding area above is transparent so ranks read
+      // against the section bg, like on desktop.
+      border-radius: 0;
+      overflow-x: auto;
+      padding-top: var(--ni-16);
+      margin-top: calc(-1 * var(--ni-16));
+      background-clip: content-box;
+      scrollbar-width: none;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+  }
+
+  .yir-grid-item:first-child .yir-grid-thumb {
+    border-top-left-radius: var(--border-radius-s);
+    border-bottom-left-radius: var(--border-radius-s);
+  }
+
+  .yir-grid-item:last-child .yir-grid-thumb {
+    border-top-right-radius: var(--border-radius-s);
+    border-bottom-right-radius: var(--border-radius-s);
+  }
+
+  @include for-tablet-sm-and-below {
+    .yir-grid-item:first-child .yir-grid-thumb,
+    .yir-grid-item:last-child .yir-grid-thumb {
+      border-radius: 0;
+    }
+  }
+
+  .yir-grid-item {
+    flex: 1;
+    position: relative;
+    transition: all 0.5s;
+    cursor: pointer;
+
+    @include for-tablet-sm-and-below {
+      flex: 0 0 20%;
+    }
+
+    @include for-mobile {
+      flex: 0 0 50%;
+    }
+  }
+
+  .yir-rank-wrapper {
+    position: absolute;
+    z-index: 1;
+    left: 0;
+    top: var(--ni-neg-12);
+    text-align: center;
+    width: 100%;
+  }
+
+  .yir-rank {
+    background-color: var(--shade-800);
+    color: var(--shade-10);
+    display: inline-block;
+    font-size: 11px;
+    font-weight: bold;
+    border: var(--border-thickness-xs) solid var(--shade-10);
+    border-radius: 50%;
+    height: var(--ni-22);
+    width: var(--ni-22);
+    line-height: 2.2;
+  }
+
+  .yir-grid-thumb {
+    width: 100%;
+    display: block;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
@@ -1,0 +1,304 @@
+<script lang="ts">
+  import { languageTag } from "$lib/features/i18n";
+  import { m } from "$lib/paraglide/messages";
+  import type { YirMostWatchedItem } from "$lib/requests/models/YirDetail";
+  import { PLACEHOLDERS } from "$lib/utils/assets";
+  import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+
+  const {
+    type,
+    items,
+  }: {
+    type: "shows" | "movies";
+    items: YirMostWatchedItem[];
+  } = $props();
+
+  const typeLabel = $derived(type === "shows" ? "show" : "movie");
+
+  let activeIndex = $state(0);
+
+  function itemUrl(item: YirMostWatchedItem): string {
+    return UrlBuilder.media(
+      type === "shows" ? "show" : "movie",
+      item.entry.slug,
+    );
+  }
+
+  function formatMinutes(minutes: number): string {
+    return toHumanDuration({ minutes }, languageTag());
+  }
+</script>
+
+<section class="yir-most-watched-section" id="section-{type}-most-watched">
+  <!-- Featured card area with fanart backgrounds -->
+  <div class="yir-most-watched-page">
+    {#each items as item, index (item.entry.id)}
+      <div
+        class="yir-fanart-bg"
+        class:current={index === activeIndex}
+        style:background-image="url({item.entry.cover.url.medium})"
+      >
+        <div class="yir-shade"></div>
+        <div class="yir-featured-card">
+          <YirSectionHeader flat rank={index + 1}>
+            {m.yir_label_most_watched({ type: typeLabel })}
+          </YirSectionHeader>
+
+          <a href={itemUrl(item)} class="yir-card-media">
+            <div class="yir-logo-wrapper">
+              {#if !PLACEHOLDERS.includes(item.entry.logo.url.medium)}
+                <img
+                  class="yir-card-logo"
+                  src={item.entry.logo.url.medium}
+                  alt={item.entry.title}
+                />
+              {:else}
+                <h3 class="yir-card-title">{item.entry.title}</h3>
+              {/if}
+            </div>
+          </a>
+
+          <div class="yir-card-stats">
+            <div class="yir-stat-line">
+              {formatMinutes(item.minutes)}
+            </div>
+            <div class="yir-stat-line">
+              {item.plays.toLocaleString()}
+              {item.plays === 1 ? "play" : "plays"}
+            </div>
+          </div>
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  <!-- Thumbnail grid -->
+  <div class="yir-most-watched-grid">
+    {#each items as item, index (item.entry.id)}
+      <a
+        href={itemUrl(item)}
+        class="yir-grid-item"
+        onmouseenter={() => {
+          activeIndex = index;
+        }}
+      >
+        <div class="yir-rank-wrapper">
+          <span class="yir-rank">{index + 1}</span>
+        </div>
+        <img
+          class="yir-grid-thumb"
+          src={item.entry.thumb.url}
+          alt={item.entry.title}
+        />
+      </a>
+    {/each}
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-most-watched-section {
+    background-color: var(--shade-950);
+    text-align: center;
+    position: relative;
+  }
+
+  .yir-most-watched-page {
+    position: relative;
+    height: 530px;
+
+    @include for-mobile {
+      height: 430px;
+    }
+  }
+
+  .yir-fanart-bg {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    z-index: 1;
+    opacity: 0;
+    transition: all 0.5s;
+
+    &.current {
+      opacity: 1;
+      z-index: 2;
+    }
+  }
+
+  .yir-shade {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      color-mix(in srgb, var(--shade-1000) 80%, transparent),
+      transparent
+    );
+  }
+
+  .yir-featured-card {
+    position: relative;
+    z-index: 1;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .yir-card-media {
+    text-decoration: none;
+    color: var(--shade-10);
+    margin-top: var(--ni-20);
+  }
+
+  .yir-logo-wrapper {
+    .yir-card-logo {
+      max-width: 70%;
+      width: var(--ni-300);
+    }
+  }
+
+  .yir-card-title {
+    font-size: var(--ni-32);
+    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2)
+      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+    margin: 0;
+
+    @include for-mobile {
+      font-size: var(--ni-24);
+    }
+  }
+
+  .yir-card-stats {
+    margin-top: var(--ni-72);
+  }
+
+  .yir-stat-line {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--gap-xxs);
+    margin-top: var(--ni-6);
+    font-size: var(--ni-18);
+  }
+
+  .yir-most-watched-grid {
+    display: flex;
+    position: relative;
+    z-index: 3;
+    // Side margin (not padding) so the rounded outer corners and drop-
+    // shadow trace the actual thumbnail strip. The negative top margin
+    // lifts the strip so roughly half of it overlays the fanart hero —
+    // 16:9 thumbs across 10 items make the strip ~5.6% of its width tall,
+    // so -3% lifts ~half.
+    margin: -2.5% var(--layout-sidebar-distance) 0;
+    // Solid backdrop so hover-faded thumbs reveal this dark color instead
+    // of bleeding the fanart through.
+    background-color: var(--shade-1000);
+    border-radius: var(--border-radius-s);
+    // Drop-shadow follows the alpha outline (incl. the first/last thumbs'
+    // rounded corners), so the strip reads as floating above the fanart.
+    filter: drop-shadow(
+      0 var(--ni-4) var(--ni-12)
+        color-mix(in srgb, var(--shade-1000) 70%, transparent)
+    );
+
+    &:hover {
+      .yir-grid-item {
+        opacity: 0.3;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
+    }
+
+    @include for-tablet-sm-and-below {
+      // Full-bleed strip on smaller screens — no rounded corners,
+      // no lift. Horizontal scroll lets all 10 thumbs be reached.
+      // overflow-x:auto forces overflow-y to clip per CSS spec, which
+      // would cut off the rank circles (positioned top:-12 on each
+      // item, ~26px tall with their border). padding-top creates the
+      // vertical room they need; matching negative margin-top puts
+      // the thumb row back at its natural "below the fanart" position
+      // and background-clip keeps the dark backdrop behind the thumbs
+      // only — the padding area above is transparent so ranks read
+      // against the section bg, like on desktop.
+      border-radius: 0;
+      overflow-x: auto;
+      padding-top: var(--ni-16);
+      margin-top: calc(-1 * var(--ni-16));
+      background-clip: content-box;
+      scrollbar-width: none;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+  }
+
+  .yir-grid-item:first-child .yir-grid-thumb {
+    border-top-left-radius: var(--border-radius-s);
+    border-bottom-left-radius: var(--border-radius-s);
+  }
+
+  .yir-grid-item:last-child .yir-grid-thumb {
+    border-top-right-radius: var(--border-radius-s);
+    border-bottom-right-radius: var(--border-radius-s);
+  }
+
+  @include for-tablet-sm-and-below {
+    .yir-grid-item:first-child .yir-grid-thumb,
+    .yir-grid-item:last-child .yir-grid-thumb {
+      border-radius: 0;
+    }
+  }
+
+  .yir-grid-item {
+    flex: 1;
+    position: relative;
+    transition: all 0.5s;
+    cursor: pointer;
+
+    @include for-tablet-sm-and-below {
+      flex: 0 0 20%;
+    }
+
+    @include for-mobile {
+      flex: 0 0 50%;
+    }
+  }
+
+  .yir-rank-wrapper {
+    position: absolute;
+    z-index: 1;
+    left: 0;
+    top: var(--ni-neg-12);
+    text-align: center;
+    width: 100%;
+  }
+
+  .yir-rank {
+    background-color: var(--shade-800);
+    color: var(--shade-10);
+    display: inline-block;
+    font-size: var(--ni-12);
+    font-weight: bold;
+    border: var(--border-thickness-xs) solid var(--shade-10);
+    border-radius: 50%;
+    height: var(--ni-22);
+    width: var(--ni-22);
+    line-height: 2.2;
+  }
+
+  .yir-grid-thumb {
+    width: 100%;
+    display: block;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirNetworksChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirNetworksChart.svelte
@@ -1,0 +1,221 @@
+<script lang="ts">
+  import type { YirCompany } from "$lib/requests/models/YirDetail";
+  import { hierarchy, pack } from "d3";
+  import YirTooltip from "../../_internal/YirTooltip.svelte";
+
+  const {
+    companies,
+    type = "shows",
+  }: {
+    companies: YirCompany[];
+    type?: "shows" | "movies";
+  } = $props();
+
+  type PackedNode = {
+    company: YirCompany;
+    x: number;
+    y: number;
+    r: number;
+    fill: string;
+  };
+
+  const fallbackFill = "#333";
+  const padding = 3;
+  const minContentRadius = 20;
+  const blackPattern = /^#0{3}(?:0{3})?$/i;
+
+  let container = $state<HTMLDivElement | undefined>();
+  let width = $state(0);
+  let height = $state(0);
+  let hovered = $state<PackedNode | null>(null);
+  let pointer = $state({ x: 0, y: 0 });
+  let failedImages = $state<Set<number>>(new Set());
+
+  $effect(() => {
+    if (!container) return;
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0].contentRect;
+      width = rect.width;
+      height = rect.height;
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  });
+
+  function fillFor(company: YirCompany): string {
+    const raw = (company.color ?? "").toLowerCase();
+    if (!raw || blackPattern.test(raw)) return fallbackFill;
+    return company.color ?? fallbackFill;
+  }
+
+  const nodes = $derived.by<PackedNode[]>(() => {
+    if (width === 0 || height === 0 || companies.length === 0) return [];
+
+    const root = hierarchy<{ company?: YirCompany; value?: number }>({
+      children: companies.map((company) => ({
+        company,
+        value: company.count,
+      })),
+    }, (d) => d.children as never)
+      .sum((d) => d.value ?? 0)
+      .sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
+
+    const layout = pack<{ company?: YirCompany; value?: number }>()
+      .size([width, height])
+      .padding(padding);
+
+    return layout(root).leaves().map((leaf) => {
+      const company = leaf.data.company!;
+      return {
+        company,
+        x: leaf.x,
+        y: leaf.y,
+        r: leaf.r,
+        fill: fillFor(company),
+      };
+    });
+  });
+
+  function imageSizeFor(r: number): number {
+    return Math.min(r * 1.2, 80);
+  }
+
+  function fontSizeFor(r: number): number {
+    return Math.max(12, r / 4);
+  }
+
+  function truncatedName(name: string, r: number): string {
+    const maxChars = Math.floor(r / 5);
+    return name.length > maxChars
+      ? name.substring(0, maxChars) + "..."
+      : name;
+  }
+
+  function itemLabelFor(count: number): string {
+    if (type === "movies") return count === 1 ? "movie" : "movies";
+    return count === 1 ? "show" : "shows";
+  }
+
+  function handlePointerEnter(node: PackedNode, event: PointerEvent) {
+    hovered = node;
+    pointer = { x: event.clientX, y: event.clientY };
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (!hovered) return;
+    pointer = { x: event.clientX, y: event.clientY };
+  }
+
+  function handlePointerLeave() {
+    hovered = null;
+  }
+
+  function handleImageError(companyId: number) {
+    failedImages = new Set(failedImages).add(companyId);
+  }
+</script>
+
+<div
+  class="yir-networks-chart"
+  bind:this={container}
+  onpointermove={handlePointerMove}
+  onpointerleave={handlePointerLeave}
+>
+  <svg {width} {height} role="img" aria-label="Top networks">
+    <defs>
+      <filter id="yir-networks-whiteimage">
+        <feColorMatrix
+          in="SourceGraphic"
+          type="matrix"
+          values="0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 1 0"
+        />
+      </filter>
+    </defs>
+
+    {#each nodes as node (node.company.id)}
+      {@const showImage =
+        node.company.imageUrl && !failedImages.has(node.company.id)}
+      {@const hasRoomForContent = node.r >= minContentRadius}
+      {@const imageSize = imageSizeFor(node.r)}
+
+      <g
+        class="node"
+        onpointerenter={(event) => handlePointerEnter(node, event)}
+      >
+        <circle cx={node.x} cy={node.y} r={node.r} fill={node.fill} />
+
+        {#if hasRoomForContent}
+          {#if showImage}
+            <image
+              href={node.company.imageUrl}
+              x={node.x - imageSize / 2}
+              y={node.y - imageSize / 2}
+              width={imageSize}
+              height={imageSize}
+              preserveAspectRatio="xMidYMid meet"
+              filter="url(#yir-networks-whiteimage)"
+              pointer-events="none"
+              onerror={() => handleImageError(node.company.id)}
+            />
+          {:else}
+            <text
+              x={node.x}
+              y={node.y}
+              text-anchor="middle"
+              dominant-baseline="middle"
+              font-size={fontSizeFor(node.r)}
+              font-weight="600"
+              fill="#fff"
+              pointer-events="none"
+            >
+              {truncatedName(node.company.name, node.r)}
+            </text>
+          {/if}
+        {/if}
+      </g>
+    {/each}
+  </svg>
+
+  {#if hovered}
+    <div
+      class="yir-networks-chart-tooltip"
+      style:left="{pointer.x}px"
+      style:top="{pointer.y}px"
+    >
+      <YirTooltip
+        main={hovered.company.name}
+        sub="{hovered.company.count} {itemLabelFor(hovered.company.count)}"
+      />
+    </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  .yir-networks-chart {
+    position: relative;
+    width: 100%;
+    height: var(--ni-640);
+
+    svg {
+      display: block;
+    }
+
+    .node {
+      cursor: pointer;
+      transform-box: fill-box;
+      transform-origin: center;
+      transition: transform 0.2s ease;
+
+      &:hover {
+        transform: scale(1.05);
+      }
+    }
+  }
+
+  .yir-networks-chart-tooltip {
+    position: fixed;
+    pointer-events: none;
+    transform: translate(-50%, calc(-100% - var(--ni-12)));
+    z-index: var(--layer-top);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirNetworksChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirNetworksChart.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import BubbleChart from "$lib/components/charts/BubbleChart.svelte";
+  import type { YirCompany } from "$lib/requests/models/YirDetail";
+  import YirTooltip from "../../_internal/YirTooltip.svelte";
+
+  const {
+    companies,
+    type = "shows",
+  }: {
+    companies: YirCompany[];
+    type?: "shows" | "movies";
+  } = $props();
+
+  const fallbackColor = "#333";
+  const blackPattern = /^#0{3}(?:0{3})?$/i;
+
+  function colorFor(company: YirCompany): string {
+    const raw = (company.color ?? "").toLowerCase();
+    if (!raw || blackPattern.test(raw)) return fallbackColor;
+    return company.color ?? fallbackColor;
+  }
+
+  const items = $derived(
+    companies.map((c) => ({
+      id: c.id,
+      label: c.name,
+      value: c.count,
+      imageUrl: c.imageUrl,
+      color: colorFor(c),
+    })),
+  );
+
+  function itemLabelFor(count: number): string {
+    if (type === "movies") return count === 1 ? "movie" : "movies";
+    return count === 1 ? "show" : "shows";
+  }
+</script>
+
+<div class="yir-networks-chart">
+  <BubbleChart {items}>
+    {#snippet tooltip({ item })}
+      <YirTooltip
+        main={item.label}
+        sub="{item.value} {itemLabelFor(item.value)}"
+      />
+    {/snippet}
+  </BubbleChart>
+</div>
+
+<style lang="scss">
+  .yir-networks-chart {
+    width: 100%;
+    height: var(--height-bubble-chart);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirNetworksSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirNetworksSection.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import type { YirCompany } from "$lib/requests/models/YirDetail";
+  import { m } from "$lib/paraglide/messages";
+  import YirNetworksChart from "./YirNetworksChart.svelte";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+  import YirPageInner from "./YirPageInner.svelte";
+
+  const {
+    networks,
+  }: {
+    networks: YirCompany[];
+  } = $props();
+</script>
+
+<section class="yir-networks-section" id="section-shows-networks">
+  <YirPageInner>
+    <YirSectionHeader>
+      {m.yir_section_title_networks()}
+    </YirSectionHeader>
+
+    <div class="yir-network-bubbles">
+      <YirNetworksChart companies={networks} type="shows" />
+    </div>
+  </YirPageInner>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-networks-section {
+    background-color: var(--shade-950);
+  }
+
+  .yir-network-bubbles {
+    width: 100%;
+    height: var(--ni-640);
+    margin-top: var(--ni-neg-40);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    @include for-mobile {
+      height: var(--ni-480);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPageInner.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPageInner.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  const {
+    children,
+  }: {
+    children: Snippet;
+  } = $props();
+</script>
+
+<div class="yir-page-inner">
+  {@render children()}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-page-inner {
+    position: relative;
+    width: 100%;
+    max-width: var(--ni-1280);
+    margin: 0 auto;
+    // On desktop, --layout-sidebar-distance accounts for the fixed side
+    // navbar (width + gap); on tablet-sm-and-below it's 0 since there's no
+    // side nav. Keeping it symmetric so the page reads centered.
+    padding: 0
+      max(var(--layout-distance-side), var(--layout-sidebar-distance));
+    box-sizing: border-box;
+
+    @include for-tablet-sm-and-below {
+      max-width: var(--ni-920);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
-  import type { YirPeopleType, YirPerson } from "$lib/requests/models/YirPerson";
-  import { useYirPeople } from "../../_internal/useYirPeople";
   import { m } from "$lib/paraglide/messages";
+  import type {
+    YirPeopleType,
+    YirPerson,
+  } from "$lib/requests/models/YirPerson";
+  import { useYirPeople } from "../../_internal/useYirPeople";
   import YirSectionHeader from "./YirSectionHeader.svelte";
 
   const {
@@ -16,14 +19,12 @@
     label: string;
   } = $props();
 
-  const { people, isLoading } = $derived(
-    useYirPeople({ slug, year, type }),
-  );
+  const { people, isLoading } = $derived(useYirPeople({ slug, year, type }));
 
   const ITEMS_PER_ROW = 5;
 
   let currentPage = $state(0);
-  let viewportEl = $state<HTMLDivElement | undefined>(undefined);
+  let viewportEl: HTMLDivElement | undefined;
   let rowHeight = $state(0);
   let hoveredPerson = $state<number | null>(null);
   let tooltipPosition = $state<{ x: number; y: number } | null>(null);
@@ -55,9 +56,8 @@
     });
   }
 
-  $effect(() => {
-    if (!viewportEl) return;
-
+  function observeResize(node: HTMLDivElement) {
+    viewportEl = node;
     measureRowHeight();
 
     // Row height depends on the width of each `.yir-person-link` (the
@@ -65,12 +65,12 @@
     // the viewport resizes and keep the scroll aligned with the current page.
     const resizeObserver = new ResizeObserver(() => {
       measureRowHeight();
-      viewportEl?.scrollTo({ top: currentPage * rowHeight, behavior: "instant" });
+      node.scrollTo({ top: currentPage * rowHeight, behavior: "instant" });
     });
-    resizeObserver.observe(viewportEl);
+    resizeObserver.observe(node);
 
-    return () => resizeObserver.disconnect();
-  });
+    return { destroy: () => resizeObserver.disconnect() };
+  }
 
   function personUrl(person: YirPerson): string {
     return `/people/${person.slug}`;
@@ -119,7 +119,7 @@
 
     <div
       class="yir-people-viewport"
-      bind:this={viewportEl}
+      use:observeResize
       style:height={rowHeight > 0 ? `${rowHeight}px` : "auto"}
     >
       <div class="yir-people-wrapper">
@@ -142,12 +142,14 @@
               <h2 class="yir-person-name">{person.name}</h2>
               {#if person.count.movies > 0}
                 <h3 class="yir-person-count">
-                  {person.count.movies} {person.count.movies === 1 ? "movie" : "movies"}
+                  {person.count.movies}
+                  {person.count.movies === 1 ? "movie" : "movies"}
                 </h3>
               {/if}
               {#if person.count.shows > 0}
                 <h3 class="yir-person-count">
-                  {person.count.shows} {person.count.shows === 1 ? "show" : "shows"}
+                  {person.count.shows}
+                  {person.count.shows === 1 ? "show" : "shows"}
                 </h3>
               {/if}
             </div>
@@ -167,7 +169,11 @@
           {#each person.titles as title}
             <div class="yir-tooltip-title">
               {#if title.type === "show" && title.episodeCount}
-                {title.title} — <span class="yir-episode-count">{title.episodeCount} {title.episodeCount === 1 ? "episode" : "episodes"}</span>
+                {title.title} —
+                <span class="yir-episode-count">
+                  {title.episodeCount}
+                  {title.episodeCount === 1 ? "episode" : "episodes"}
+                </span>
               {:else}
                 {title.title}
               {/if}

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
@@ -1,0 +1,393 @@
+<script lang="ts">
+  import type { YirPeopleType, YirPerson } from "$lib/requests/models/YirPerson";
+  import { useYirPeople } from "../../_internal/useYirPeople";
+  import { m } from "$lib/paraglide/messages";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+
+  const {
+    slug,
+    year,
+    type,
+    label,
+  }: {
+    slug: string;
+    year: number;
+    type: YirPeopleType;
+    label: string;
+  } = $props();
+
+  const { people, isLoading } = $derived(
+    useYirPeople({ slug, year, type }),
+  );
+
+  const ITEMS_PER_ROW = 5;
+
+  let currentPage = $state(0);
+  let viewportEl = $state<HTMLDivElement | undefined>(undefined);
+  let rowHeight = $state(0);
+  let hoveredPerson = $state<number | null>(null);
+  let tooltipPosition = $state<{ x: number; y: number } | null>(null);
+
+  const totalPages = $derived(
+    Math.ceil(($people?.length ?? 0) / ITEMS_PER_ROW),
+  );
+
+  const hasPrevious = $derived(currentPage > 0);
+  const hasNext = $derived(currentPage < totalPages - 1);
+  const multiPage = $derived(totalPages > 1);
+
+  function measureRowHeight() {
+    if (!viewportEl) return;
+    const firstLink = viewportEl.querySelector(
+      ".yir-person-link",
+    ) as HTMLElement | null;
+    if (firstLink) {
+      rowHeight = firstLink.offsetHeight;
+    }
+  }
+
+  function goToPage(page: number) {
+    measureRowHeight();
+    currentPage = page;
+    viewportEl?.scrollTo({
+      top: page * rowHeight,
+      behavior: "smooth",
+    });
+  }
+
+  $effect(() => {
+    if (!viewportEl) return;
+
+    measureRowHeight();
+
+    // Row height depends on the width of each `.yir-person-link` (the
+    // circular headshot scales with its container), so re-measure whenever
+    // the viewport resizes and keep the scroll aligned with the current page.
+    const resizeObserver = new ResizeObserver(() => {
+      measureRowHeight();
+      viewportEl?.scrollTo({ top: currentPage * rowHeight, behavior: "instant" });
+    });
+    resizeObserver.observe(viewportEl);
+
+    return () => resizeObserver.disconnect();
+  });
+
+  function personUrl(person: YirPerson): string {
+    return `/people/${person.slug}`;
+  }
+
+  function handlePersonMouseEnter(event: MouseEvent, index: number) {
+    const target = event.currentTarget as HTMLElement;
+    const rect = target.getBoundingClientRect();
+    hoveredPerson = index;
+    tooltipPosition = {
+      x: rect.left + rect.width / 2,
+      y: rect.top - 10,
+    };
+  }
+
+  function handlePersonMouseLeave() {
+    hoveredPerson = null;
+    tooltipPosition = null;
+  }
+</script>
+
+{#if $isLoading}
+  <div class="yir-people-group">
+    <YirSectionHeader compact>
+      {label}
+    </YirSectionHeader>
+    <p class="yir-people-loading">{m.yir_state_loading()}</p>
+  </div>
+{:else if $people && $people.length > 0}
+  <div class="yir-people-group">
+    <YirSectionHeader compact noTopPadding={type === "actresses"}>
+      {label}
+    </YirSectionHeader>
+
+    {#if multiPage}
+      <button
+        class="yir-pager"
+        class:invisible={!hasPrevious}
+        onclick={() => goToPage(currentPage - 1)}
+      >
+        <span class="yir-pager-chevron">&and;</span>
+        <span class="yir-pager-text">{m.yir_button_previous()}</span>
+        <span class="yir-pager-chevron">&and;</span>
+      </button>
+    {/if}
+
+    <div
+      class="yir-people-viewport"
+      bind:this={viewportEl}
+      style:height={rowHeight > 0 ? `${rowHeight}px` : "auto"}
+    >
+      <div class="yir-people-wrapper">
+        {#each $people as person, index}
+          <a
+            href={personUrl(person)}
+            class="yir-person-link"
+            onmouseenter={(e) => handlePersonMouseEnter(e, index)}
+            onmouseleave={handlePersonMouseLeave}
+          >
+            <div class="yir-person">
+              <span class="yir-rank">{index + 1}</span>
+              <div class="yir-headshot">
+                <img
+                  src={person.headshot.url.thumb}
+                  alt={person.name}
+                  class="yir-headshot-img"
+                />
+              </div>
+              <h2 class="yir-person-name">{person.name}</h2>
+              {#if person.count.movies > 0}
+                <h3 class="yir-person-count">
+                  {person.count.movies} {person.count.movies === 1 ? "movie" : "movies"}
+                </h3>
+              {/if}
+              {#if person.count.shows > 0}
+                <h3 class="yir-person-count">
+                  {person.count.shows} {person.count.shows === 1 ? "show" : "shows"}
+                </h3>
+              {/if}
+            </div>
+          </a>
+        {/each}
+      </div>
+    </div>
+
+    {#if hoveredPerson !== null && tooltipPosition && $people}
+      {@const person = $people[hoveredPerson]}
+      {#if person?.titles.length > 0}
+        <div
+          class="yir-person-tooltip"
+          style:left="{tooltipPosition.x}px"
+          style:top="{tooltipPosition.y}px"
+        >
+          {#each person.titles as title}
+            <div class="yir-tooltip-title">
+              {#if title.type === "show" && title.episodeCount}
+                {title.title} — <span class="yir-episode-count">{title.episodeCount} {title.episodeCount === 1 ? "episode" : "episodes"}</span>
+              {:else}
+                {title.title}
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    {/if}
+
+    {#if multiPage}
+      <button
+        class="yir-pager"
+        class:invisible={!hasNext}
+        onclick={() => goToPage(currentPage + 1)}
+      >
+        <span class="yir-pager-chevron">&or;</span>
+        <span class="yir-pager-text">{m.yir_button_see_more()}</span>
+        <span class="yir-pager-chevron">&or;</span>
+      </button>
+    {/if}
+  </div>
+{/if}
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-people-group {
+    overflow: hidden;
+    padding-bottom: var(--ni-30);
+  }
+
+  .yir-people-loading {
+    text-align: center;
+    opacity: 0.5;
+    color: var(--shade-10);
+  }
+
+  .yir-pager {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    gap: var(--gap-xs);
+    padding: var(--ni-10) 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--shade-500);
+    transition: color 0.3s;
+
+    &:hover {
+      color: var(--shade-300);
+    }
+
+    &.invisible {
+      visibility: hidden;
+    }
+  }
+
+  .yir-pager-chevron {
+    font-size: 10px;
+    line-height: 1;
+  }
+
+  .yir-pager-text {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+  }
+
+  .yir-people-viewport {
+    overflow: hidden;
+  }
+
+  .yir-people-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+
+    &:hover .yir-person-link:not(:hover) .yir-person {
+      opacity: 0.5;
+    }
+  }
+
+  .yir-person-link {
+    text-decoration: none;
+    color: var(--shade-10);
+    width: 20%;
+
+    &:hover {
+      .yir-headshot {
+        box-shadow: 0 0 var(--ni-20) var(--purple-500);
+
+        &::after {
+          border-color: var(--purple-500);
+        }
+      }
+
+      .yir-person-name {
+        color: var(--purple-500);
+      }
+
+      .yir-person-count {
+        color: var(--shade-100);
+      }
+    }
+
+    @include for-mobile {
+      width: 50%;
+    }
+  }
+
+  .yir-person {
+    margin: var(--ni-20) 0 var(--ni-10) 0;
+    padding: 0 var(--ni-14);
+    transition: all 0.5s;
+    text-align: center;
+    position: relative;
+  }
+
+  .yir-rank {
+    position: absolute;
+    top: 0;
+    left: var(--ni-14);
+    color: var(--shade-10);
+    font-weight: bold;
+    font-size: 13px;
+    z-index: 2;
+    text-shadow: 0 var(--ni-1) var(--ni-2)
+      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+  }
+
+  .yir-headshot {
+    background-color: var(--shade-1000);
+    position: relative;
+    overflow: hidden;
+    border-radius: 50%;
+    transition: box-shadow 0.5s;
+
+    &::before {
+      content: "";
+      padding-top: 100%;
+      float: left;
+    }
+
+    &::after {
+      content: "";
+      position: absolute;
+      border-radius: 100%;
+      width: 100%;
+      height: 100%;
+      box-shadow: 0 0 0 var(--ni-104) var(--shade-1000);
+      left: 0;
+      top: 0;
+      border: var(--border-thickness-xxs) solid var(--shade-600);
+      transition: border-color 0.5s;
+    }
+  }
+
+  .yir-headshot-img {
+    width: 100%;
+    position: absolute;
+    top: -10%;
+    left: 0;
+  }
+
+  .yir-person-name {
+    font-size: 15px;
+    margin-top: var(--ni-12);
+    margin-bottom: var(--ni-8);
+    color: var(--shade-10);
+    transition: all 0.5s;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @include for-mobile {
+      font-size: 13px;
+    }
+  }
+
+  .yir-person-count {
+    font-size: 11px;
+    text-transform: uppercase;
+    color: var(--shade-300);
+    margin: var(--ni-2) 0 0 0;
+    transition: all 0.5s;
+
+    @include for-mobile {
+      font-size: 10px;
+    }
+  }
+
+  .yir-person-tooltip {
+    position: fixed;
+    transform: translate(-50%, -100%);
+    background: color-mix(in srgb, var(--shade-1000) 92%, transparent);
+    border: var(--border-thickness-xxs) solid var(--shade-800);
+    border-radius: var(--border-radius-xs);
+    padding: var(--ni-8) var(--ni-12);
+    white-space: nowrap;
+    z-index: 10;
+    font-size: 12px;
+    line-height: 1.6;
+    pointer-events: none;
+    box-shadow: 0 var(--ni-2) var(--ni-8)
+      color-mix(in srgb, var(--shade-1000) 60%, transparent);
+    font-family: inherit;
+
+    @include for-mobile {
+      display: none;
+    }
+  }
+
+  .yir-tooltip-title {
+    color: var(--shade-10);
+    text-align: center;
+  }
+
+  .yir-episode-count {
+    font-style: italic;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
@@ -1,0 +1,373 @@
+<script lang="ts">
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import { m } from "$lib/paraglide/messages";
+  import type {
+    YirPeopleType,
+    YirPerson,
+  } from "$lib/requests/models/YirPerson";
+  import { PLACEHOLDERS } from "$lib/utils/assets";
+  import { DEFAULT_AVATAR } from "$lib/utils/constants";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { useYirPeople } from "../../_internal/useYirPeople";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+
+  const {
+    slug,
+    year,
+    type,
+    label,
+  }: {
+    slug: string;
+    year: number;
+    type: YirPeopleType;
+    label: string;
+  } = $props();
+
+  const { people, isLoading } = $derived(useYirPeople({ slug, year, type }));
+
+  const ITEMS_PER_ROW = 5;
+
+  let currentPage = $state(0);
+  let viewportEl: HTMLDivElement | undefined;
+  let rowHeight = $state(0);
+
+  const totalPages = $derived(
+    Math.ceil(($people?.length ?? 0) / ITEMS_PER_ROW),
+  );
+
+  const hasPrevious = $derived(currentPage > 0);
+  const hasNext = $derived(currentPage < totalPages - 1);
+  const multiPage = $derived(totalPages > 1);
+
+  function measureRowHeight() {
+    if (!viewportEl) return;
+    const firstLink = viewportEl.querySelector(
+      ".yir-person-link",
+    ) as HTMLElement | null;
+    if (firstLink) {
+      rowHeight = firstLink.offsetHeight;
+    }
+  }
+
+  function goToPage(page: number) {
+    measureRowHeight();
+    currentPage = page;
+    viewportEl?.scrollTo({
+      top: page * rowHeight,
+      behavior: "smooth",
+    });
+  }
+
+  function observeResize(node: HTMLDivElement) {
+    viewportEl = node;
+    measureRowHeight();
+
+    // Row height depends on the width of each `.yir-person-link` (the
+    // circular headshot scales with its container), so re-measure whenever
+    // the viewport resizes and keep the scroll aligned with the current page.
+    const resizeObserver = new ResizeObserver(() => {
+      measureRowHeight();
+      node.scrollTo({ top: currentPage * rowHeight, behavior: "instant" });
+    });
+    resizeObserver.observe(node);
+
+    return { destroy: () => resizeObserver.disconnect() };
+  }
+
+  function personUrl(person: YirPerson): string {
+    return UrlBuilder.people(person.slug);
+  }
+</script>
+
+{#if $isLoading}
+  <div class="yir-people-group">
+    <YirSectionHeader compact>
+      {label}
+    </YirSectionHeader>
+    <p class="yir-people-loading">{m.yir_state_loading()}</p>
+  </div>
+{:else if $people && $people.length > 0}
+  <div class="yir-people-group">
+    <YirSectionHeader compact noTopPadding={type === "actresses"}>
+      {label}
+    </YirSectionHeader>
+
+    {#if multiPage}
+      <button
+        class="yir-pager"
+        class:invisible={!hasPrevious}
+        onclick={() => goToPage(currentPage - 1)}
+      >
+        <span class="yir-pager-chevron">&and;</span>
+        <span class="yir-pager-text">{m.yir_button_previous()}</span>
+        <span class="yir-pager-chevron">&and;</span>
+      </button>
+    {/if}
+
+    <div
+      class="yir-people-viewport"
+      use:observeResize
+      style:height={rowHeight > 0 ? `${rowHeight}px` : "auto"}
+    >
+      <div class="yir-people-wrapper">
+        {#each $people as person, index (person.slug)}
+          {@const isDefault = PLACEHOLDERS.includes(person.headshot.url.thumb)}
+          <Tooltip
+            variant="default"
+            disabled={person.titles.length === 0}
+            side="top"
+          >
+            {#snippet content()}
+              {#each person.titles as title (title.traktId)}
+                <div class="yir-tooltip-title">
+                  {#if title.type === "show" && title.episodeCount}
+                    <span>{title.title} —</span>
+                    <span class="yir-episode-count">
+                      {title.episodeCount}
+                      {title.episodeCount === 1 ? "episode" : "episodes"}
+                    </span>
+                  {:else}
+                    <span>{title.title}</span>
+                  {/if}
+                </div>
+              {/each}
+            {/snippet}
+            <a href={personUrl(person)} class="yir-person-link">
+              <div class="yir-person">
+                <span class="yir-rank">{index + 1}</span>
+                <div class="yir-headshot">
+                  <img
+                    src={isDefault ? DEFAULT_AVATAR : person.headshot.url.thumb}
+                    alt={person.name}
+                    class="yir-headshot-img"
+                    class:is-default={isDefault}
+                  />
+                </div>
+                <h2 class="yir-person-name">{person.name}</h2>
+                <h3 class="yir-person-count">
+                  {#if person.count.movies > 0}
+                    {person.count.movies}
+                    {person.count.movies === 1 ? "movie" : "movies"}
+                  {:else}
+                    &nbsp;
+                  {/if}
+                </h3>
+                <h3 class="yir-person-count">
+                  {#if person.count.shows > 0}
+                    {person.count.shows}
+                    {person.count.shows === 1 ? "show" : "shows"}
+                  {:else}
+                    &nbsp;
+                  {/if}
+                </h3>
+              </div>
+            </a>
+          </Tooltip>
+        {/each}
+      </div>
+    </div>
+
+    {#if multiPage}
+      <button
+        class="yir-pager"
+        class:invisible={!hasNext}
+        onclick={() => goToPage(currentPage + 1)}
+      >
+        <span class="yir-pager-chevron">&or;</span>
+        <span class="yir-pager-text">{m.yir_button_see_more()}</span>
+        <span class="yir-pager-chevron">&or;</span>
+      </button>
+    {/if}
+  </div>
+{/if}
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-people-group {
+    overflow: hidden;
+    padding-bottom: var(--ni-30);
+  }
+
+  .yir-people-loading {
+    text-align: center;
+    opacity: 0.5;
+    color: var(--shade-10);
+  }
+
+  .yir-pager {
+    -webkit-tap-highlight-color: transparent;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    gap: var(--gap-xs);
+    padding: var(--ni-10) 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--shade-500);
+    transition: color 0.3s;
+
+    &:hover {
+      color: var(--shade-300);
+    }
+
+    &.invisible {
+      visibility: hidden;
+    }
+  }
+
+  .yir-pager-chevron {
+    font-size: var(--font-size-tag);
+    line-height: 1;
+  }
+
+  .yir-pager-text {
+    font-size: var(--ni-12);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+  }
+
+  .yir-people-viewport {
+    overflow: hidden;
+  }
+
+  .yir-people-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+
+    &:hover :global(.trakt-tooltip-trigger:not(:hover) .yir-person) {
+      opacity: 0.5;
+    }
+
+    :global(.trakt-tooltip-trigger) {
+      width: 20%;
+
+      @include for-mobile {
+        width: 50%;
+      }
+    }
+  }
+
+  .yir-person-link {
+    text-decoration: none;
+    color: var(--shade-10);
+    width: 100%;
+
+    @include for-mouse {
+      &:hover {
+        .yir-headshot {
+          box-shadow: 0 0 var(--ni-20) var(--purple-500);
+
+          &::after {
+            border-color: var(--purple-500);
+          }
+        }
+
+        .yir-person-name {
+          color: var(--purple-500);
+        }
+
+        .yir-person-count {
+          color: var(--shade-100);
+        }
+      }
+    }
+  }
+
+  .yir-person {
+    margin: var(--ni-20) 0 var(--ni-10) 0;
+    padding: 0 var(--ni-14);
+    transition: all 0.5s;
+    text-align: center;
+    position: relative;
+  }
+
+  .yir-rank {
+    position: absolute;
+    top: 0;
+    left: var(--ni-14);
+    color: var(--shade-10);
+    font-weight: bold;
+    font-size: var(--ni-12);
+    z-index: 2;
+    text-shadow: 0 var(--ni-1) var(--ni-2)
+      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+  }
+
+  .yir-headshot {
+    background-color: var(--shade-1000);
+    position: relative;
+    overflow: hidden;
+    border-radius: 50%;
+    transition: box-shadow 0.5s;
+
+    &::before {
+      content: "";
+      padding-top: 100%;
+      float: left;
+    }
+
+    &::after {
+      content: "";
+      position: absolute;
+      border-radius: 100%;
+      width: 100%;
+      height: 100%;
+      box-shadow: 0 0 0 var(--ni-104) var(--shade-1000);
+      left: 0;
+      top: 0;
+      border: var(--border-thickness-xxs) solid var(--shade-600);
+      transition: border-color 0.5s;
+    }
+  }
+
+  .yir-headshot-img {
+    width: 100%;
+    position: absolute;
+    top: -10%;
+    left: 0;
+
+    &.is-default {
+      top: 0;
+    }
+  }
+
+  .yir-person-name {
+    font-size: var(--ni-16);
+    margin-top: var(--ni-12);
+    margin-bottom: var(--ni-8);
+    color: var(--shade-10);
+    transition: all 0.5s;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @include for-mobile {
+      font-size: var(--ni-12);
+    }
+  }
+
+  .yir-person-count {
+    font-size: var(--ni-12);
+    text-transform: uppercase;
+    color: var(--shade-300);
+    margin: var(--ni-2) 0 0 0;
+    transition: all 0.5s;
+
+    @include for-mobile {
+      font-size: var(--font-size-tag);
+    }
+  }
+
+  .yir-tooltip-title {
+    text-align: center;
+  }
+
+  .yir-episode-count {
+    font-style: italic;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPeopleSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPeopleSection.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import YirPeopleGroup from "./YirPeopleGroup.svelte";
+  import YirPageInner from "./YirPageInner.svelte";
+  import { m } from "$lib/paraglide/messages";
+
+  const {
+    slug,
+    year,
+  }: {
+    slug: string;
+    year: number;
+  } = $props();
+</script>
+
+<section class="yir-people-section" id="section-people">
+  <YirPageInner>
+    <YirPeopleGroup {slug} {year} type="actors" label={m.yir_section_title_top_actors()} />
+    <YirPeopleGroup {slug} {year} type="actresses" label={m.yir_section_title_top_actresses()} />
+    <YirPeopleGroup {slug} {year} type="directors" label={m.yir_section_title_top_directors()} />
+    <YirPeopleGroup {slug} {year} type="writers" label={m.yir_section_title_top_writers()} />
+  </YirPageInner>
+</section>
+
+<style lang="scss">
+  .yir-people-section {
+    background-color: var(--shade-1000);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { YirTopRatedItem } from "$lib/requests/models/YirDetail";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import YirPageInner from "./YirPageInner.svelte";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+
+  const {
+    type,
+    items,
+  }: {
+    type: "shows" | "movies";
+    items: YirTopRatedItem[];
+  } = $props();
+
+  const sectionTitle = $derived(
+    type === "shows"
+      ? m.yir_section_title_highest_rated_shows()
+      : m.yir_section_title_highest_rated_movies(),
+  );
+
+  let activeIndex = $state(0);
+
+  function itemUrl(item: YirTopRatedItem): string {
+    return UrlBuilder.media(
+      type === "shows" ? "show" : "movie",
+      item.entry.slug,
+    );
+  }
+</script>
+
+<section class="yir-rated-section" id="section-{type}-ratings">
+  {#each items as item, index}
+    <div
+      class="yir-fanart-bg"
+      class:current={index === activeIndex}
+      style:background-image="url({item.entry.cover?.url?.medium ?? ''})"
+    ></div>
+  {/each}
+
+  <div class="yir-rated-inner">
+    <YirSectionHeader>
+      {sectionTitle}
+    </YirSectionHeader>
+
+    <YirPageInner>
+      <div class="yir-posters">
+        {#each items as item, index}
+          <a
+            href={itemUrl(item)}
+            class="yir-grid-item"
+            title={item.entry.title}
+            onmouseenter={() => {
+              activeIndex = index;
+            }}
+          >
+            <div class="yir-poster">
+              <div class="yir-corner-rating">
+                <span>{item.rating}</span>
+              </div>
+              <img
+                class="yir-poster-img"
+                src={item.entry.poster.url.thumb}
+                alt={item.entry.title}
+              />
+            </div>
+          </a>
+        {/each}
+      </div>
+    </YirPageInner>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-rated-section {
+    text-align: center;
+    position: relative;
+    background-color: var(--shade-950);
+  }
+
+  .yir-fanart-bg {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    opacity: 0;
+    transition: all 0.5s;
+
+    &.current {
+      opacity: 1;
+    }
+  }
+
+  .yir-rated-inner {
+    position: relative;
+    z-index: 1;
+    background-color: color-mix(in srgb, var(--shade-1000) 30%, transparent);
+    padding-bottom: var(--ni-72);
+
+    @include for-mobile {
+      padding-bottom: var(--ni-40);
+    }
+  }
+
+  .yir-posters {
+    text-align: center;
+
+    &:hover .yir-grid-item:not(:hover) {
+      .yir-poster-img,
+      .yir-corner-rating {
+        opacity: 0.3;
+      }
+    }
+  }
+
+  .yir-grid-item {
+    width: 10%;
+    display: inline-block;
+    padding: 0;
+    margin: 0;
+    text-decoration: none;
+
+    @include for-mobile {
+      width: 20%;
+    }
+  }
+
+  .yir-poster {
+    border: none;
+    background-color: var(--shade-1000);
+    box-shadow: 0 0 var(--ni-20) var(--shade-1000);
+    position: relative;
+
+    .yir-poster-img,
+    .yir-corner-rating {
+      transition: all 0.5s;
+    }
+  }
+
+  .yir-corner-rating {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 1;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 0 var(--ni-32) var(--ni-32) 0;
+    border-color: transparent var(--red-500) transparent transparent;
+    font-weight: bold;
+    color: var(--shade-10);
+
+    span {
+      position: absolute;
+      top: var(--ni-4);
+      right: var(--ni-neg-32);
+      width: var(--ni-18);
+      text-align: center;
+      font-size: var(--ni-11);
+    }
+  }
+
+  .yir-poster-img {
+    width: 100%;
+    display: block;
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { YirTopRatedItem } from "$lib/requests/models/YirDetail";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import YirPageInner from "./YirPageInner.svelte";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+
+  const {
+    type,
+    items,
+  }: {
+    type: "shows" | "movies";
+    items: YirTopRatedItem[];
+  } = $props();
+
+  const sectionTitle = $derived(
+    type === "shows"
+      ? m.yir_section_title_highest_rated_shows()
+      : m.yir_section_title_highest_rated_movies(),
+  );
+
+  let activeIndex = $state(0);
+
+  function itemUrl(item: YirTopRatedItem): string {
+    return UrlBuilder.media(
+      type === "shows" ? "show" : "movie",
+      item.entry.slug,
+    );
+  }
+</script>
+
+<section class="yir-rated-section" id="section-{type}-ratings">
+  {#each items as item, index (item.entry.id)}
+    <div
+      class="yir-fanart-bg"
+      class:current={index === activeIndex}
+      style:background-image="url({item.entry.cover?.url?.medium ?? ''})"
+    ></div>
+  {/each}
+
+  <div class="yir-rated-inner">
+    <YirSectionHeader>
+      {sectionTitle}
+    </YirSectionHeader>
+
+    <YirPageInner>
+      <div class="yir-posters">
+        {#each items as item, index (item.entry.id)}
+          <a
+            href={itemUrl(item)}
+            class="yir-grid-item"
+            title={item.entry.title}
+            onmouseenter={() => {
+              activeIndex = index;
+            }}
+          >
+            <div class="yir-poster">
+              <div class="yir-corner-rating">
+                <span>{item.rating}</span>
+              </div>
+              <img
+                class="yir-poster-img"
+                src={item.entry.poster.url.thumb}
+                alt={item.entry.title}
+              />
+            </div>
+          </a>
+        {/each}
+      </div>
+    </YirPageInner>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-rated-section {
+    text-align: center;
+    position: relative;
+    background-color: var(--shade-950);
+  }
+
+  .yir-fanart-bg {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    opacity: 0;
+    transition: all 0.5s;
+
+    &.current {
+      opacity: 1;
+    }
+  }
+
+  .yir-rated-inner {
+    position: relative;
+    z-index: 1;
+    background-color: color-mix(in srgb, var(--shade-1000) 30%, transparent);
+    padding-bottom: var(--ni-72);
+
+    @include for-mobile {
+      padding-bottom: var(--ni-40);
+    }
+  }
+
+  .yir-posters {
+    text-align: center;
+
+    &:hover .yir-grid-item:not(:hover) {
+      .yir-poster-img,
+      .yir-corner-rating {
+        opacity: 0.3;
+      }
+    }
+  }
+
+  .yir-grid-item {
+    width: 10%;
+    display: inline-block;
+    padding: 0;
+    margin: 0;
+    text-decoration: none;
+
+    @include for-mobile {
+      width: 20%;
+    }
+  }
+
+  .yir-poster {
+    border: none;
+    background-color: var(--shade-1000);
+    box-shadow: 0 0 var(--ni-20) var(--shade-1000);
+    position: relative;
+
+    .yir-poster-img,
+    .yir-corner-rating {
+      transition: all 0.5s;
+    }
+  }
+
+  .yir-corner-rating {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 1;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 0 var(--ni-32) var(--ni-32) 0;
+    border-color: transparent var(--red-500) transparent transparent;
+    font-weight: bold;
+    color: var(--shade-10);
+
+    span {
+      position: absolute;
+      top: var(--ni-4);
+      right: var(--ni-neg-32);
+      width: var(--ni-18);
+      text-align: center;
+      font-size: var(--ni-11);
+    }
+  }
+
+  .yir-poster-img {
+    width: 100%;
+    display: block;
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirSectionHeader.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirSectionHeader.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  const {
+    children,
+    rank,
+    compact = false,
+    noTopPadding = false,
+    flat = false,
+  }: {
+    children: Snippet;
+    rank?: number;
+    compact?: boolean;
+    noTopPadding?: boolean;
+    flat?: boolean;
+  } = $props();
+</script>
+
+<div
+  class="yir-section-header"
+  class:compact
+  class:no-top-padding={noTopPadding}
+  class:flat
+>
+  <h2>
+    {#if rank !== undefined}
+      <span class="yir-header-number">
+        <span class="yir-hash">#</span>{rank}
+      </span>
+    {/if}
+    <span class="yir-header-text">
+      {@render children()}
+    </span>
+  </h2>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-section-header {
+    text-align: center;
+    padding: var(--ni-72) 0;
+
+    &.compact {
+      padding-bottom: var(--ni-20);
+    }
+
+    &.no-top-padding {
+      padding-top: 0;
+    }
+
+    &.flat {
+      padding: 0;
+    }
+
+    h2 {
+      text-transform: uppercase;
+      display: inline-block;
+      letter-spacing: 1px;
+      border: var(--border-thickness-xxs) solid var(--shade-10);
+      background-color: color-mix(in srgb, var(--shade-1000) 50%, transparent);
+      font-size: 16px;
+      line-height: 1;
+      text-align: center;
+      margin: 0;
+    }
+
+    .yir-header-number {
+      display: inline-block;
+      background-color: var(--shade-10);
+      color: var(--shade-1000);
+      padding: var(--ni-6) var(--ni-8);
+      margin-right: var(--ni-neg-4);
+    }
+
+    .yir-hash {
+      font-size: 14px;
+    }
+
+    .yir-header-text {
+      display: inline-block;
+      padding: var(--ni-6) var(--ni-8);
+    }
+
+    @include for-mobile {
+      padding: var(--ni-40) 0;
+
+      &.compact {
+        padding-bottom: var(--ni-16);
+      }
+
+      &.no-top-padding {
+        padding-top: 0;
+      }
+
+      &.flat {
+        padding: 0;
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirSectionHeader.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirSectionHeader.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  const {
+    children,
+    rank,
+    compact = false,
+    noTopPadding = false,
+    flat = false,
+  }: {
+    children: Snippet;
+    rank?: number;
+    compact?: boolean;
+    noTopPadding?: boolean;
+    flat?: boolean;
+  } = $props();
+</script>
+
+<div
+  class="yir-section-header"
+  class:compact
+  class:no-top-padding={noTopPadding}
+  class:flat
+>
+  <h2>
+    {#if rank !== undefined}
+      <span class="yir-header-number">
+        <span class="yir-hash">#</span>{rank}
+      </span>
+    {/if}
+    <span class="yir-header-text">
+      {@render children()}
+    </span>
+  </h2>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-section-header {
+    text-align: center;
+    padding: var(--ni-72) 0;
+
+    &.compact {
+      padding-bottom: var(--ni-20);
+    }
+
+    &.no-top-padding {
+      padding-top: 0;
+    }
+
+    &.flat {
+      padding: 0;
+    }
+
+    h2 {
+      text-transform: uppercase;
+      display: inline-block;
+      letter-spacing: 1px;
+      border: var(--border-thickness-xxs) solid var(--shade-10);
+      background-color: color-mix(in srgb, var(--shade-1000) 50%, transparent);
+      font-size: var(--ni-16);
+      line-height: 1;
+      text-align: center;
+      margin: 0;
+    }
+
+    .yir-header-number {
+      display: inline-block;
+      background-color: var(--shade-10);
+      color: var(--shade-1000);
+      padding: var(--ni-6) var(--ni-8);
+      margin-right: var(--ni-neg-4);
+    }
+
+    .yir-hash {
+      font-size: var(--font-size-text);
+    }
+
+    .yir-header-text {
+      display: inline-block;
+      padding: var(--ni-6) var(--ni-8);
+    }
+
+    @include for-mobile {
+      padding: var(--ni-40) 0;
+
+      &.compact {
+        padding-bottom: var(--ni-16);
+      }
+
+      &.no-top-padding {
+        padding-top: 0;
+      }
+
+      &.flat {
+        padding: 0;
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+  import type { YirStatsCategory } from "$lib/requests/models/YirDetail";
+  import ArrowRightIcon from "$lib/components/icons/ArrowRightIcon.svelte";
+  import YirWeeklyPlaysChart from "./YirWeeklyPlaysChart.svelte";
+  import YirMonthlyPlaysChart from "./YirMonthlyPlaysChart.svelte";
+  import YirDailyPlaysChart from "./YirDailyPlaysChart.svelte";
+  import YirHourlyPlaysChart from "./YirHourlyPlaysChart.svelte";
+  import { m } from "$lib/paraglide/messages";
+  import { formatNumber } from "$lib/utils/format/formatNumber";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+  import YirPageInner from "./YirPageInner.svelte";
+
+  const {
+    type,
+    stats,
+    year,
+  }: {
+    type: "shows" | "movies";
+    stats: YirStatsCategory;
+    year: number;
+  } = $props();
+
+  const sectionTitle = $derived(type === "shows" ? m.yir_section_title_tv_shows() : m.yir_section_title_movies());
+  const specificType = $derived(type === "shows" ? "episode" : "movie");
+
+  function formatDecimal(value: number): string {
+    return value.toFixed(1);
+  }
+
+  const hoursTotal = $derived(Math.round(stats.minutes.total / 60));
+  const hoursMonthly = $derived(stats.minutes.monthly / 60);
+  const hoursWeekly = $derived(stats.minutes.weekly / 60);
+  const hoursDaily = $derived(stats.minutes.daily / 60);
+</script>
+
+<section class="yir-stats-section" id="section-{type}-stats">
+  <YirPageInner>
+    <YirSectionHeader>
+      <strong>{formatNumber(stats.itemsCount ?? 0)}</strong> {sectionTitle}
+    </YirSectionHeader>
+
+    <div class="yir-watched-stats">
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatNumber(hoursTotal)}</span>
+        <span class="yir-stat-unit">{m.yir_label_hours_watched()}</span>
+      </div>
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatDecimal(hoursMonthly)}</span>
+        <span class="yir-stat-unit">{m.yir_label_per_month()}</span>
+      </div>
+      <span class="yir-stat-arrow"><ArrowRightIcon /></span>
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatDecimal(hoursWeekly)}</span>
+        <span class="yir-stat-unit">{m.yir_label_per_week()}</span>
+      </div>
+      <span class="yir-stat-arrow"><ArrowRightIcon /></span>
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatDecimal(hoursDaily)}</span>
+        <span class="yir-stat-unit">{m.yir_label_per_day()}</span>
+      </div>
+    </div>
+
+    <div class="yir-separator"></div>
+
+    <div class="yir-watched-stats">
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatNumber(stats.playCounts.total)}</span>
+        <span class="yir-stat-unit">
+          {specificType} {stats.playCounts.total === 1 ? "play" : "plays"}
+        </span>
+      </div>
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatDecimal(stats.playCounts.monthly)}</span>
+        <span class="yir-stat-unit">{m.yir_label_per_month()}</span>
+      </div>
+      <span class="yir-stat-arrow"><ArrowRightIcon /></span>
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatDecimal(stats.playCounts.weekly)}</span>
+        <span class="yir-stat-unit">{m.yir_label_per_week()}</span>
+      </div>
+      <span class="yir-stat-arrow"><ArrowRightIcon /></span>
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatDecimal(stats.playCounts.daily)}</span>
+        <span class="yir-stat-unit">{m.yir_label_per_day()}</span>
+      </div>
+    </div>
+
+    <div class="yir-separator"></div>
+
+    {#if stats.distributions}
+      <div class="yir-chart-container">
+        <YirWeeklyPlaysChart data={stats.distributions.weekly} {year} />
+      </div>
+      <h2 class="yir-under-chart">{m.yir_label_plays_by_week({ type: specificType })}</h2>
+
+      <div class="yir-charts-row">
+        <div>
+          <YirMonthlyPlaysChart data={stats.distributions.monthly} />
+          <h2 class="yir-under-chart">{m.yir_label_plays_by_month({ type: specificType })}</h2>
+        </div>
+        <div>
+          <YirDailyPlaysChart data={stats.distributions.days} />
+          <h2 class="yir-under-chart">{m.yir_label_plays_by_day({ type: specificType })}</h2>
+        </div>
+      </div>
+
+      {#if stats.distributions.hourly}
+        <div class="yir-chart-container yir-chart-container-hourly">
+          <YirHourlyPlaysChart data={stats.distributions.hourly} />
+        </div>
+        <h2 class="yir-under-chart">{m.yir_label_plays_by_hour({ type: specificType })}</h2>
+      {/if}
+    {/if}
+  </YirPageInner>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-stats-section {
+    background-color: var(--shade-950);
+    padding-bottom: var(--ni-72);
+
+    @include for-mobile {
+      padding-bottom: var(--ni-40);
+    }
+  }
+
+  .yir-watched-stats {
+    display: flex;
+    align-items: center;
+    padding: 0 10% var(--ni-40) 10%;
+
+    &:last-of-type {
+      padding-bottom: var(--ni-20);
+    }
+
+    @include for-tablet-sm-and-below {
+      padding-left: 5%;
+      padding-right: 5%;
+    }
+
+    @include for-mobile {
+      padding-left: 3%;
+      padding-right: 3%;
+      flex-wrap: wrap;
+
+      .yir-stat {
+        width: 50%;
+        flex: none;
+        margin-bottom: var(--ni-16);
+      }
+    }
+  }
+
+  .yir-stat {
+    flex: 1;
+    text-align: center;
+  }
+
+  .yir-stat-arrow {
+    display: flex;
+    align-items: center;
+    color: var(--shade-700);
+    flex-shrink: 0;
+    padding: 0 var(--ni-8);
+
+    :global(svg) {
+      width: var(--ni-32);
+      height: var(--ni-32);
+    }
+
+    @include for-mobile {
+      display: none;
+    }
+  }
+
+  .yir-stat-number {
+    display: block;
+    font-size: 60px;
+    font-weight: bold;
+    line-height: 1;
+    color: var(--shade-10);
+
+    @include for-tablet-sm-and-below {
+      font-size: 45px;
+    }
+
+    @include for-mobile {
+      font-size: 30px;
+    }
+  }
+
+  .yir-stat-unit {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--gap-xxs);
+    font-size: 14px;
+    text-transform: uppercase;
+    color: var(--shade-300);
+    margin-top: 0;
+
+    @include for-mobile {
+      font-size: 13px;
+    }
+  }
+
+  .yir-separator {
+    border-bottom: var(--border-thickness-xxs) dashed var(--shade-800);
+    margin: var(--ni-40) 0;
+  }
+
+  .yir-under-chart {
+    font-size: 14px;
+    text-transform: uppercase;
+    color: var(--shade-300);
+    margin: var(--ni-16) 0 0 0;
+    text-align: center;
+  }
+
+  .yir-charts-row {
+    display: grid;
+    // minmax(0, 1fr) lets the columns shrink below their content's
+    // min-size. Carbon's BarChart uses an explicit pixel width (set
+    // from the observed container width), and a plain `1fr` defaults to
+    // `minmax(auto, 1fr)`, which won't shrink past that pixel value
+    // when the viewport narrows.
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: var(--gap-xl);
+    margin-top: var(--ni-72);
+
+    // Extra horizontal breathing room around the charts on smaller
+    // screens so the bars don't hug the viewport edges.
+    @include for-tablet-sm-and-below {
+      padding: 0 var(--ni-20);
+    }
+
+    @include for-mobile {
+      grid-template-columns: 1fr;
+      margin-top: var(--ni-52);
+    }
+  }
+
+  .yir-chart-container {
+    margin-top: var(--ni-72);
+    overflow-x: auto;
+    overflow-y: hidden;
+    /* Hide scrollbar but keep functionality */
+    scrollbar-width: thin;
+    scrollbar-color: var(--shade-800) transparent;
+
+    // Extra horizontal breathing room around the charts on smaller
+    // screens so the bars don't hug the viewport edges.
+    @include for-tablet-sm-and-below {
+      padding-left: var(--ni-20);
+      padding-right: var(--ni-20);
+    }
+
+    @include for-mobile {
+      margin-top: var(--ni-52);
+    }
+
+    &::-webkit-scrollbar {
+      height: var(--ni-6);
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: var(--shade-800);
+      border-radius: var(--border-radius-xs);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
@@ -1,0 +1,318 @@
+<script lang="ts">
+  import ArrowRightIcon from "$lib/components/icons/ArrowRightIcon.svelte";
+  import { m } from "$lib/paraglide/messages";
+  import type { YirStatsCategory } from "$lib/requests/models/YirDetail";
+  import { formatNumber } from "$lib/utils/format/formatNumber";
+  import YirDailyPlaysChart from "./YirDailyPlaysChart.svelte";
+  import YirHourlyPlaysChart from "./YirHourlyPlaysChart.svelte";
+  import YirMonthlyPlaysChart from "./YirMonthlyPlaysChart.svelte";
+  import YirPageInner from "./YirPageInner.svelte";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+  import YirWeeklyPlaysChart from "./YirWeeklyPlaysChart.svelte";
+
+  const {
+    type,
+    stats,
+    year,
+  }: {
+    type: "shows" | "movies";
+    stats: YirStatsCategory;
+    year: number;
+  } = $props();
+
+  const sectionTitle = $derived(
+    type === "shows"
+      ? m.yir_section_title_tv_shows()
+      : m.yir_section_title_movies(),
+  );
+  const specificType = $derived(type === "shows" ? "episode" : "movie");
+
+  function formatDecimal(value: number): string {
+    return value.toFixed(1);
+  }
+
+  const hoursTotal = $derived(Math.round(stats.minutes.total / 60));
+  const hoursMonthly = $derived(stats.minutes.monthly / 60);
+  const hoursWeekly = $derived(stats.minutes.weekly / 60);
+  const hoursDaily = $derived(stats.minutes.daily / 60);
+</script>
+
+<section class="yir-stats-section" id="section-{type}-stats">
+  <YirPageInner>
+    <YirSectionHeader>
+      <strong>{formatNumber(stats.itemsCount ?? 0)}</strong>
+      {sectionTitle}
+    </YirSectionHeader>
+
+    <div class="yir-watched-stats">
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatNumber(hoursTotal)}</span>
+        <span class="yir-stat-unit">{m.yir_label_hours_watched()}</span>
+      </div>
+      <span class="yir-stat-arrow"><ArrowRightIcon /></span>
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatDecimal(hoursMonthly)}</span>
+        <span class="yir-stat-unit">{m.yir_label_per_month()}</span>
+      </div>
+      <span class="yir-stat-arrow"><ArrowRightIcon /></span>
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatDecimal(hoursWeekly)}</span>
+        <span class="yir-stat-unit">{m.yir_label_per_week()}</span>
+      </div>
+      <span class="yir-stat-arrow"><ArrowRightIcon /></span>
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatDecimal(hoursDaily)}</span>
+        <span class="yir-stat-unit">{m.yir_label_per_day()}</span>
+      </div>
+    </div>
+
+    <div class="yir-separator"></div>
+
+    <div class="yir-watched-stats">
+      <div class="yir-stat">
+        <span class="yir-stat-number">
+          {formatNumber(stats.playCounts.total)}
+        </span>
+        <span class="yir-stat-unit">
+          {specificType}
+          {stats.playCounts.total === 1 ? "play" : "plays"}
+        </span>
+      </div>
+      <span class="yir-stat-arrow"><ArrowRightIcon /></span>
+      <div class="yir-stat">
+        <span class="yir-stat-number">
+          {formatDecimal(stats.playCounts.monthly)}
+        </span>
+        <span class="yir-stat-unit">{m.yir_label_per_month()}</span>
+      </div>
+      <span class="yir-stat-arrow"><ArrowRightIcon /></span>
+      <div class="yir-stat">
+        <span class="yir-stat-number">
+          {formatDecimal(stats.playCounts.weekly)}
+        </span>
+        <span class="yir-stat-unit">{m.yir_label_per_week()}</span>
+      </div>
+      <span class="yir-stat-arrow"><ArrowRightIcon /></span>
+      <div class="yir-stat">
+        <span class="yir-stat-number">
+          {formatDecimal(stats.playCounts.daily)}
+        </span>
+        <span class="yir-stat-unit">{m.yir_label_per_day()}</span>
+      </div>
+    </div>
+
+    <div class="yir-separator"></div>
+
+    {#if stats.distributions}
+      <div class="yir-chart-container">
+        <YirWeeklyPlaysChart data={stats.distributions.weekly} {year} />
+      </div>
+      <h2 class="yir-under-chart">
+        {m.yir_label_plays_by_week({ type: specificType })}
+      </h2>
+
+      <div class="yir-charts-row">
+        <div>
+          <YirMonthlyPlaysChart data={stats.distributions.monthly} />
+          <h2 class="yir-under-chart">
+            {m.yir_label_plays_by_month({ type: specificType })}
+          </h2>
+        </div>
+        <div>
+          <YirDailyPlaysChart data={stats.distributions.days} />
+          <h2 class="yir-under-chart">
+            {m.yir_label_plays_by_day({ type: specificType })}
+          </h2>
+        </div>
+      </div>
+
+      {#if stats.distributions.hourly}
+        <div class="yir-chart-container yir-chart-container-hourly">
+          <YirHourlyPlaysChart data={stats.distributions.hourly} />
+        </div>
+        <h2 class="yir-under-chart">
+          {m.yir_label_plays_by_hour({ type: specificType })}
+        </h2>
+      {/if}
+    {/if}
+  </YirPageInner>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-stats-section {
+    background-color: var(--shade-950);
+    padding-bottom: var(--ni-72);
+
+    @include for-mobile {
+      padding-bottom: var(--ni-40);
+    }
+  }
+
+  .yir-watched-stats {
+    display: flex;
+    align-items: flex-start;
+    padding: 0 10% 0 10%;
+
+    &:last-of-type {
+      padding-bottom: var(--ni-20);
+    }
+
+    @include for-tablet-sm-and-below {
+      padding-left: 5%;
+      padding-right: 5%;
+    }
+
+    @include for-mobile {
+      padding-left: 3%;
+      padding-right: 3%;
+      flex-wrap: wrap;
+
+      .yir-stat {
+        width: 50%;
+        flex: none;
+        margin-bottom: var(--ni-16);
+      }
+    }
+  }
+
+  .yir-stat {
+    flex: 1;
+    text-align: center;
+  }
+
+  .yir-stat-arrow {
+    display: flex;
+    align-items: center;
+    color: var(--shade-700);
+    flex-shrink: 0;
+    // Vertical offset = (number font-size − svg size) / 2, so the arrow
+    // centers on the big number rather than on the row's flex-start baseline.
+    padding: var(--ni-14) var(--ni-8) 0;
+
+    // First arrow is hidden but still takes space so the columns align
+    // identically across both stat rows.
+    .yir-watched-stats > &:first-of-type {
+      visibility: hidden;
+    }
+
+    :global(svg) {
+      width: var(--ni-32);
+      height: var(--ni-32);
+    }
+
+    @include for-tablet-sm-and-below {
+      padding-top: var(--ni-6);
+    }
+
+    @include for-mobile {
+      display: none;
+    }
+  }
+
+  .yir-stat-number {
+    display: block;
+    font-size: var(--ni-48);
+    font-weight: bold;
+    line-height: 1;
+    color: var(--shade-10);
+
+    @include for-tablet-sm-and-below {
+      font-size: var(--ni-40);
+    }
+
+    @include for-mobile {
+      font-size: var(--ni-30);
+    }
+  }
+
+  .yir-stat-unit {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--gap-xxs);
+    font-size: var(--font-size-text);
+    text-transform: uppercase;
+    color: var(--shade-300);
+    margin-top: 0;
+
+    @include for-mobile {
+      font-size: var(--ni-12);
+    }
+  }
+
+  .yir-separator {
+    border-bottom: var(--border-thickness-xxs) dashed var(--shade-800);
+    margin: var(--ni-40) 0;
+  }
+
+  .yir-under-chart {
+    font-size: var(--font-size-text);
+    text-transform: uppercase;
+    color: var(--shade-300);
+    margin: var(--ni-16) 0 0 0;
+    text-align: center;
+  }
+
+  .yir-charts-row {
+    display: grid;
+    // minmax(0, 1fr) lets the columns shrink below their content's
+    // min-size. Carbon's BarChart uses an explicit pixel width (set
+    // from the observed container width), and a plain `1fr` defaults to
+    // `minmax(auto, 1fr)`, which won't shrink past that pixel value
+    // when the viewport narrows.
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: var(--gap-xl);
+    margin-top: var(--ni-72);
+
+    > div {
+      min-width: 0;
+      width: 100%;
+    }
+
+    // Extra horizontal breathing room around the charts on smaller
+    // screens so the bars don't hug the viewport edges.
+    @include for-tablet-sm-and-below {
+      padding: 0 var(--ni-20);
+    }
+
+    @include for-mobile {
+      grid-template-columns: 1fr;
+      margin-top: var(--ni-52);
+    }
+  }
+
+  .yir-chart-container {
+    margin-top: var(--ni-72);
+    overflow-x: auto;
+    overflow-y: hidden;
+    /* Hide scrollbar but keep functionality */
+    scrollbar-width: thin;
+    scrollbar-color: var(--shade-800) transparent;
+
+    // Extra horizontal breathing room around the charts on smaller
+    // screens so the bars don't hug the viewport edges.
+    @include for-tablet-sm-and-below {
+      padding-left: var(--ni-20);
+      padding-right: var(--ni-20);
+    }
+
+    @include for-mobile {
+      margin-top: var(--ni-52);
+    }
+
+    &::-webkit-scrollbar {
+      height: var(--ni-6);
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: var(--shade-800);
+      border-radius: var(--border-radius-xs);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirStudiosSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirStudiosSection.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import type { YirCompany } from "$lib/requests/models/YirDetail";
+  import { m } from "$lib/paraglide/messages";
+  import YirNetworksChart from "./YirNetworksChart.svelte";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+  import YirPageInner from "./YirPageInner.svelte";
+
+  const {
+    studios,
+  }: {
+    studios: YirCompany[];
+  } = $props();
+</script>
+
+<section class="yir-studios-section" id="section-movies-networks">
+  <YirPageInner>
+    <YirSectionHeader>
+      {m.yir_section_title_studios()}
+    </YirSectionHeader>
+
+    <div class="yir-studio-bubbles">
+      <YirNetworksChart companies={studios} type="movies" />
+    </div>
+  </YirPageInner>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-studios-section {
+    background-color: var(--shade-950);
+  }
+
+  .yir-studio-bubbles {
+    width: 100%;
+    height: var(--ni-640);
+    margin-top: var(--ni-neg-40);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    @include for-mobile {
+      height: var(--ni-480);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirTitleSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirTitleSection.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+  import { useQuery } from "$lib/features/query/useQuery";
+  import { userProfileQuery } from "$lib/requests/queries/users/userProfileQuery";
+  import { map } from "rxjs";
+  import { m } from "$lib/paraglide/messages";
+  import { DEFAULT_COVER } from "$lib/utils/constants";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+
+  const {
+    slug,
+    year,
+    coverImage,
+  }: {
+    slug: string;
+    year: number;
+    coverImage: string | Nil;
+  } = $props();
+
+  const profileQuery = $derived(
+    useQuery(userProfileQuery({ slug })),
+  );
+  const profile = $derived(
+    profileQuery.pipe(map(($q) => $q.data)),
+  );
+
+  const now = new Date();
+  const isCurrentYear = $derived(year === now.getFullYear());
+  const subtitle = $derived(isCurrentYear ? m.yir_title_year_to_date() : m.yir_title_year_in_review());
+
+  const coverSrc = $derived(
+    $profile?.cover?.url || coverImage || DEFAULT_COVER,
+  );
+</script>
+
+<section class="yir-title-page">
+  <div class="yir-cover-bg">
+    <CrossOriginImage src={coverSrc} alt="" />
+  </div>
+  <div class="yir-titles-wrapper">
+    <div class="yir-titles">
+      {#if $profile}
+        <div class="yir-user">
+          <a href="/users/{slug}" class="yir-avatar-link">
+            <div class="yir-avatar">
+              <CrossOriginImage
+                src={$profile.avatar.url}
+                alt={$profile.name.full ?? slug}
+              />
+            </div>
+          </a>
+          <span class="yir-display-name">
+            <a href="/users/{slug}">{$profile.name.full || $profile.username}</a>
+          </span>
+        </div>
+        <div class="yir-under-user"></div>
+      {/if}
+
+      <h1 class="yir-year">{year}</h1>
+      <h2 class="yir-subtitle">{subtitle}</h2>
+    </div>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-title-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    min-height: 100dvh;
+    background-color: var(--shade-950);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .yir-cover-bg {
+    position: absolute;
+    inset: 0;
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center;
+    }
+  }
+
+  .yir-titles-wrapper {
+    width: 100%;
+    text-align: center;
+    position: relative;
+    z-index: 1;
+  }
+
+  .yir-titles {
+    display: inline-block;
+    background: radial-gradient(circle, var(--shade-900) 20%, var(--shade-950) 80%);
+    padding: var(--ni-20);
+    box-shadow: 0 0 var(--ni-52) var(--shade-1000);
+
+    @include for-mobile {
+      max-width: 80%;
+    }
+  }
+
+  .yir-user {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ni-10);
+  }
+
+  .yir-avatar-link {
+    display: flex;
+    flex-shrink: 0;
+  }
+
+  .yir-avatar {
+    width: var(--ni-40);
+    height: var(--ni-40);
+    border-radius: 50%;
+    border: var(--border-thickness-xs) solid var(--shade-10);
+    background-color: var(--shade-10);
+    overflow: hidden;
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    @include for-mobile {
+      width: var(--ni-30);
+      height: var(--ni-30);
+    }
+  }
+
+  .yir-display-name {
+    display: inline-block;
+    font-size: 26px;
+
+    a {
+      color: var(--shade-10);
+      text-decoration: none;
+    }
+
+    @include for-mobile {
+      font-size: 20px;
+    }
+  }
+
+  .yir-under-user {
+    width: var(--ni-380);
+    max-width: 100%;
+    border-bottom: var(--border-thickness-xxs) dashed var(--shade-500);
+    margin: var(--ni-24) auto var(--ni-6) auto;
+
+    @include for-mobile {
+      width: var(--ni-256);
+    }
+  }
+
+  .yir-year {
+    font-size: 180px;
+    font-weight: normal;
+    margin: 0;
+    line-height: 1;
+    color: var(--shade-10);
+
+    @include for-mobile {
+      font-size: 100px;
+    }
+  }
+
+  .yir-subtitle {
+    background-color: var(--shade-10);
+    color: var(--shade-950);
+    display: block;
+    text-transform: uppercase;
+    padding: var(--ni-8) var(--ni-16);
+    letter-spacing: 3px;
+    word-spacing: 5px;
+    margin: 0;
+    text-align: center;
+    font-size: 18px;
+    font-weight: normal;
+    line-height: 1;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirTitleSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirTitleSection.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import { useQuery } from "$lib/features/query/useQuery";
+  import { m } from "$lib/paraglide/messages";
+  import { userProfileQuery } from "$lib/requests/queries/users/userProfileQuery";
+  import { DEFAULT_COVER } from "$lib/utils/constants";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { map } from "rxjs";
+
+  const {
+    slug,
+    year,
+    coverImage,
+  }: {
+    slug: string;
+    year: number;
+    coverImage: string | Nil;
+  } = $props();
+
+  const profileQuery = $derived(useQuery(userProfileQuery({ slug })));
+  const profile = $derived(profileQuery.pipe(map(($q) => $q.data)));
+
+  const now = new Date();
+  const isCurrentYear = $derived(year === now.getFullYear());
+  const subtitle = $derived(
+    isCurrentYear ? m.yir_title_year_to_date() : m.yir_title_year_in_review(),
+  );
+
+  const coverSrc = $derived(
+    $profile?.cover?.url || coverImage || DEFAULT_COVER,
+  );
+</script>
+
+<section class="yir-title-page">
+  <div class="yir-cover-bg">
+    <CrossOriginImage src={coverSrc} alt="" />
+  </div>
+  <div class="yir-titles-wrapper">
+    <div class="yir-titles">
+      {#if $profile}
+        <div class="yir-user">
+          <a href={UrlBuilder.profile.user(slug)} class="yir-avatar-link">
+            <div class="yir-avatar">
+              <CrossOriginImage
+                src={$profile.avatar.url}
+                alt={$profile.name.full ?? slug}
+              />
+            </div>
+          </a>
+          <span class="yir-display-name">
+            <a href={UrlBuilder.profile.user(slug)}>
+              {$profile.name.full || $profile.username}
+            </a>
+          </span>
+        </div>
+        <div class="yir-under-user"></div>
+      {/if}
+
+      <h1 class="yir-year">{year}</h1>
+      <h2 class="yir-subtitle">{subtitle}</h2>
+    </div>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-title-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    min-height: 100dvh;
+    background-color: var(--shade-950);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .yir-cover-bg {
+    position: absolute;
+    inset: 0;
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center;
+    }
+  }
+
+  .yir-titles-wrapper {
+    width: 100%;
+    text-align: center;
+    position: relative;
+    z-index: 1;
+  }
+
+  .yir-titles {
+    display: inline-block;
+    background: radial-gradient(
+      circle,
+      var(--shade-900) 20%,
+      var(--shade-950) 80%
+    );
+    padding: var(--ni-20);
+    box-shadow: 0 0 var(--ni-52) var(--shade-1000);
+
+    @include for-mobile {
+      max-width: 80%;
+    }
+  }
+
+  .yir-user {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ni-10);
+  }
+
+  .yir-avatar-link {
+    display: flex;
+    flex-shrink: 0;
+  }
+
+  .yir-avatar {
+    width: var(--ni-40);
+    height: var(--ni-40);
+    border-radius: 50%;
+    border: var(--border-thickness-xs) solid var(--shade-10);
+    background-color: var(--shade-10);
+    overflow: hidden;
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    @include for-mobile {
+      width: var(--ni-30);
+      height: var(--ni-30);
+    }
+  }
+
+  .yir-display-name {
+    display: inline-block;
+    font-size: var(--ni-24);
+
+    a {
+      color: var(--shade-10);
+      text-decoration: none;
+    }
+
+    @include for-mobile {
+      font-size: var(--ni-20);
+    }
+  }
+
+  .yir-under-user {
+    width: var(--ni-380);
+    max-width: 100%;
+    border-bottom: var(--border-thickness-xxs) dashed var(--shade-500);
+    margin: var(--ni-24) auto var(--ni-6) auto;
+
+    @include for-mobile {
+      width: var(--ni-256);
+    }
+  }
+
+  .yir-year {
+    font-size: var(--ni-180);
+    font-weight: normal;
+    margin: 0;
+    line-height: 1;
+    color: var(--shade-10);
+
+    @include for-mobile {
+      font-size: var(--ni-104);
+    }
+  }
+
+  .yir-subtitle {
+    background-color: var(--shade-10);
+    color: var(--shade-950);
+    display: block;
+    text-transform: uppercase;
+    padding: var(--ni-8) var(--ni-16);
+    letter-spacing: 3px;
+    word-spacing: 5px;
+    margin: 0;
+    text-align: center;
+    font-size: var(--ni-18);
+    font-weight: normal;
+    line-height: 1;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+  import type { YirStatsCategory } from "$lib/requests/models/YirDetail";
+  import BookmarkIcon from "$lib/components/icons/BookmarkIcon.svelte";
+  import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
+  import CommentIcon from "$lib/components/icons/CommentIcon.svelte";
+  import FavoriteIcon from "$lib/components/icons/FavoriteIcon.svelte";
+  import ListIcon from "$lib/components/icons/mobile/ListIcon.svelte";
+  import MarkAsWatchedIcon from "$lib/components/icons/MarkAsWatchedIcon.svelte";
+  import { m } from "$lib/paraglide/messages";
+  import { formatNumber } from "$lib/utils/format/formatNumber";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+  import YirPageInner from "./YirPageInner.svelte";
+
+  type AllStats = YirStatsCategory & {
+    listsCounts: { total: number };
+  };
+
+  const {
+    stats,
+    year,
+  }: {
+    stats: AllStats;
+    year: number;
+  } = $props();
+
+  const hoursWatched = $derived(
+    Math.round(stats.minutes.total / 60),
+  );
+</script>
+
+<section class="yir-totals-section" id="section-totals">
+  <YirPageInner>
+    <YirSectionHeader>
+      {m.yir_section_title_totals({ year })}
+    </YirSectionHeader>
+
+    <div class="yir-stats-row">
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatNumber(stats.playCounts.total)}</span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon"><MarkAsWatchedIcon state="unwatched" /></span>
+          {stats.playCounts.total === 1 ? "play" : "plays"}
+        </span>
+      </div>
+
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatNumber(hoursWatched)}</span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon"><ClockIcon /></span>
+          {hoursWatched === 1 ? "hour" : "hours"}
+        </span>
+      </div>
+
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatNumber(stats.collectedCounts.total)}</span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon"><BookmarkIcon state="added" /></span>
+          collected
+        </span>
+      </div>
+    </div>
+
+    <div class="yir-stats-row">
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatNumber(stats.ratingsCounts.total)}</span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon"><FavoriteIcon state="filled" /></span>
+          {stats.ratingsCounts.total === 1 ? "rating" : "ratings"}
+        </span>
+      </div>
+
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatNumber(stats.commentsCounts.total)}</span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon"><CommentIcon style="filled" /></span>
+          {stats.commentsCounts.total === 1 ? "comment" : "comments"}
+        </span>
+      </div>
+
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatNumber(stats.listsCounts.total)}</span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon"><ListIcon /></span>
+          {stats.listsCounts.total === 1 ? "list" : "lists"}
+        </span>
+      </div>
+    </div>
+  </YirPageInner>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-totals-section {
+    background-color: var(--shade-1000);
+    padding-bottom: var(--ni-72);
+  }
+
+  .yir-stats-row {
+    display: flex;
+    justify-content: center;
+    padding: 0 20% var(--ni-40) 20%;
+
+    &:last-child {
+      padding-bottom: var(--ni-20);
+    }
+
+    @include for-tablet-sm-and-below {
+      padding-left: 10%;
+      padding-right: 10%;
+    }
+
+    @include for-mobile {
+      padding-left: 3%;
+      padding-right: 3%;
+    }
+  }
+
+  .yir-stat {
+    flex: 1;
+    text-align: center;
+  }
+
+  .yir-stat-number {
+    display: block;
+    font-size: 60px;
+    font-weight: bold;
+    line-height: 1;
+    color: var(--shade-10);
+
+    @include for-tablet-sm-and-below {
+      font-size: 45px;
+    }
+
+    @include for-mobile {
+      font-size: 30px;
+    }
+  }
+
+  .yir-stat-unit {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--gap-xxs);
+    font-size: 14px;
+    text-transform: uppercase;
+    color: var(--shade-300);
+    margin-top: 0;
+  }
+
+  .yir-stat-icon {
+    display: inline-flex;
+    align-items: center;
+
+    :global(svg) {
+      width: var(--ni-14);
+      height: var(--ni-14);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+  import BookmarkIcon from "$lib/components/icons/BookmarkIcon.svelte";
+  import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
+  import CommentIcon from "$lib/components/icons/CommentIcon.svelte";
+  import FavoriteIcon from "$lib/components/icons/FavoriteIcon.svelte";
+  import MarkAsWatchedIcon from "$lib/components/icons/MarkAsWatchedIcon.svelte";
+  import ListIcon from "$lib/components/icons/mobile/ListIcon.svelte";
+  import { m } from "$lib/paraglide/messages";
+  import type { YirStatsCategory } from "$lib/requests/models/YirDetail";
+  import { formatNumber } from "$lib/utils/format/formatNumber";
+  import YirPageInner from "./YirPageInner.svelte";
+  import YirSectionHeader from "./YirSectionHeader.svelte";
+
+  type AllStats = YirStatsCategory & {
+    listsCounts: { total: number };
+  };
+
+  const {
+    stats,
+    year,
+  }: {
+    stats: AllStats;
+    year: number;
+  } = $props();
+
+  const hoursWatched = $derived(Math.round(stats.minutes.total / 60));
+</script>
+
+<section class="yir-totals-section" id="section-totals">
+  <YirPageInner>
+    <YirSectionHeader>
+      {m.yir_section_title_totals({ year })}
+    </YirSectionHeader>
+
+    <div class="yir-stats-row">
+      <div class="yir-stat">
+        <span class="yir-stat-number">
+          {formatNumber(stats.playCounts.total)}
+        </span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon">
+            <MarkAsWatchedIcon state="unwatched" />
+          </span>
+          {stats.playCounts.total === 1 ? "play" : "plays"}
+        </span>
+      </div>
+
+      <div class="yir-stat">
+        <span class="yir-stat-number">{formatNumber(hoursWatched)}</span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon"><ClockIcon /></span>
+          {hoursWatched === 1 ? "hour" : "hours"}
+        </span>
+      </div>
+
+      <div class="yir-stat">
+        <span class="yir-stat-number">
+          {formatNumber(stats.collectedCounts.total)}
+        </span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon"><BookmarkIcon state="added" /></span>
+          collected
+        </span>
+      </div>
+    </div>
+
+    <div class="yir-stats-row">
+      <div class="yir-stat">
+        <span class="yir-stat-number">
+          {formatNumber(stats.ratingsCounts.total)}
+        </span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon"><FavoriteIcon state="filled" /></span>
+          {stats.ratingsCounts.total === 1 ? "rating" : "ratings"}
+        </span>
+      </div>
+
+      <div class="yir-stat">
+        <span class="yir-stat-number">
+          {formatNumber(stats.commentsCounts.total)}
+        </span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon"><CommentIcon style="filled" /></span>
+          {stats.commentsCounts.total === 1 ? "comment" : "comments"}
+        </span>
+      </div>
+
+      <div class="yir-stat">
+        <span class="yir-stat-number">
+          {formatNumber(stats.listsCounts.total)}
+        </span>
+        <span class="yir-stat-unit">
+          <span class="yir-stat-icon"><ListIcon /></span>
+          {stats.listsCounts.total === 1 ? "list" : "lists"}
+        </span>
+      </div>
+    </div>
+  </YirPageInner>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-totals-section {
+    background-color: var(--shade-1000);
+    padding-bottom: var(--ni-72);
+  }
+
+  .yir-stats-row {
+    display: flex;
+    justify-content: center;
+    padding: 0 20% var(--ni-40) 20%;
+
+    &:last-child {
+      padding-bottom: var(--ni-20);
+    }
+
+    @include for-tablet-sm-and-below {
+      padding-left: 10%;
+      padding-right: 10%;
+    }
+
+    @include for-mobile {
+      padding-left: 3%;
+      padding-right: 3%;
+    }
+  }
+
+  .yir-stat {
+    flex: 1;
+    text-align: center;
+  }
+
+  .yir-stat-number {
+    display: block;
+    font-size: var(--ni-60);
+    font-weight: bold;
+    line-height: 1;
+    color: var(--shade-10);
+
+    @include for-tablet-sm-and-below {
+      font-size: var(--ni-44);
+    }
+
+    @include for-mobile {
+      font-size: var(--ni-30);
+    }
+  }
+
+  .yir-stat-unit {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--gap-xxs);
+    font-size: var(--font-size-text);
+    text-transform: uppercase;
+    color: var(--shade-300);
+    margin-top: 0;
+  }
+
+  .yir-stat-icon {
+    display: inline-flex;
+    align-items: center;
+
+    :global(svg) {
+      width: var(--ni-14);
+      height: var(--ni-14);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirUpgradeSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirUpgradeSection.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import GetVIPLink from "$lib/sections/navbar/components/GetVIPLink.svelte";
+  import { m } from "$lib/paraglide/messages";
+  import YirPageInner from "./YirPageInner.svelte";
+</script>
+
+<RenderFor audience="free">
+  <section class="yir-vip-page">
+    <YirPageInner>
+      <div class="yir-upgrade-content">
+        <div class="yir-go-vip">
+          <p class="yir-upgrade-text">
+            {m.yir_upgrade_message()}
+          </p>
+          <GetVIPLink source="yir" />
+        </div>
+      </div>
+    </YirPageInner>
+  </section>
+</RenderFor>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-vip-page {
+    position: relative;
+    background-color: var(--shade-950);
+  }
+
+  .yir-upgrade-content {
+    text-align: center;
+    padding: var(--ni-72) 0;
+  }
+
+  .yir-go-vip {
+    margin: 0 auto;
+    background: var(--shade-950);
+    width: var(--ni-380);
+    max-width: 75%;
+    font-size: 16px;
+    box-shadow: 0 0 var(--ni-52) var(--red-800);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: var(--ni-20);
+    transition: all 0.5s;
+    gap: var(--gap-m);
+
+    &:hover {
+      background: var(--shade-930);
+    }
+
+    @include for-mobile {
+      max-width: 90%;
+      font-size: 14px;
+    }
+  }
+
+  .yir-upgrade-text {
+    color: var(--shade-10);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirUpgradeSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirUpgradeSection.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { m } from "$lib/paraglide/messages";
+  import GetVIPLink from "$lib/sections/navbar/components/GetVIPLink.svelte";
+  import YirPageInner from "./YirPageInner.svelte";
+</script>
+
+<RenderFor audience="free">
+  <section class="yir-vip-page">
+    <YirPageInner>
+      <div class="yir-upgrade-content">
+        <div class="yir-go-vip">
+          <p class="yir-upgrade-text">
+            {m.yir_upgrade_message()}
+          </p>
+          <GetVIPLink source="yir" />
+        </div>
+      </div>
+    </YirPageInner>
+  </section>
+</RenderFor>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-vip-page {
+    position: relative;
+    background-color: var(--shade-950);
+  }
+
+  .yir-upgrade-content {
+    text-align: center;
+    padding: var(--ni-72) 0;
+  }
+
+  .yir-go-vip {
+    margin: 0 auto;
+    background: var(--shade-950);
+    width: var(--ni-380);
+    max-width: 75%;
+    font-size: var(--ni-16);
+    box-shadow: 0 0 var(--ni-52) var(--red-800);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: var(--ni-20);
+    transition: all 0.5s;
+    gap: var(--gap-m);
+
+    &:hover {
+      background: var(--shade-930);
+    }
+
+    @include for-mobile {
+      max-width: 90%;
+      font-size: var(--font-size-text);
+    }
+  }
+
+  .yir-upgrade-text {
+    color: var(--shade-10);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirWeeklyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirWeeklyPlaysChart.svelte
@@ -2,6 +2,8 @@
   import BarChart from "$lib/components/charts/BarChart.svelte";
   import { languageTag } from "$lib/features/i18n";
   import { toHumanShortDate } from "$lib/utils/formatting/date/toHumanShortDate";
+  import { addDays } from "date-fns/addDays";
+  import { startOfYear } from "date-fns/startOfYear";
   import { yirTooltipHTML } from "../../_internal/yirTooltipHTML.ts";
 
   const {
@@ -12,18 +14,13 @@
     year: number;
   } = $props();
 
-  const labels = $derived(Array.from({ length: 52 }, (_, i) => `${i + 1}`));
-
   function getWeekDateRange(weekNumber: number): string {
     const locale = languageTag();
-    const firstDay = new Date(year, 0, 1);
-    const daysOffset = (weekNumber - 1) * 7;
-
-    const weekStart = new Date(firstDay);
-    weekStart.setDate(firstDay.getDate() + daysOffset);
-
-    const weekEnd = new Date(weekStart);
-    weekEnd.setDate(weekStart.getDate() + 6);
+    const weekStart = addDays(
+      startOfYear(new Date(year, 0, 1)),
+      (weekNumber - 1) * 7,
+    );
+    const weekEnd = addDays(weekStart, 6);
 
     return `${toHumanShortDate(weekStart, locale)} - ${toHumanShortDate(weekEnd, locale)}`;
   }
@@ -36,6 +33,13 @@
       extra: getWeekDateRange(weekNumber),
     });
   }
+
+  const chartData = $derived(
+    data.map((value, index) => ({
+      value,
+      label: `${index + 1}`,
+    })),
+  );
 </script>
 
-<BarChart {data} {labels} {tooltipHTML} />
+<BarChart data={chartData} {tooltipHTML} />

--- a/projects/client/src/lib/sections/yir/default/_internal/YirWeeklyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirWeeklyPlaysChart.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { toHumanShortDate } from "$lib/utils/formatting/date/toHumanShortDate";
+  import { yirTooltipHTML } from "../../_internal/yirTooltipHTML.ts";
+
+  const {
+    data,
+    year,
+  }: {
+    data: number[];
+    year: number;
+  } = $props();
+
+  const labels = $derived(Array.from({ length: 52 }, (_, i) => `${i + 1}`));
+
+  function getWeekDateRange(weekNumber: number): string {
+    const locale = languageTag();
+    const firstDay = new Date(year, 0, 1);
+    const daysOffset = (weekNumber - 1) * 7;
+
+    const weekStart = new Date(firstDay);
+    weekStart.setDate(firstDay.getDate() + daysOffset);
+
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekStart.getDate() + 6);
+
+    return `${toHumanShortDate(weekStart, locale)} - ${toHumanShortDate(weekEnd, locale)}`;
+  }
+
+  function tooltipHTML({ value, label }: { value: number; label: string }) {
+    const weekNumber = parseInt(label, 10);
+    return yirTooltipHTML({
+      main: `${value} ${value === 1 ? "play" : "plays"}`,
+      sub: `Week ${weekNumber}`,
+      extra: getWeekDateRange(weekNumber),
+    });
+  }
+</script>
+
+<BarChart {data} {labels} {tooltipHTML} />

--- a/projects/client/src/lib/sections/yir/default/_internal/YirWeeklyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirWeeklyPlaysChart.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import { toHumanShortDate } from "$lib/utils/formatting/date/toHumanShortDate";
+  import { addDays } from "date-fns/addDays";
+  import { startOfYear } from "date-fns/startOfYear";
+  import YirTooltip from "../../_internal/YirTooltip.svelte";
+
+  const {
+    data,
+    year,
+  }: {
+    data: number[];
+    year: number;
+  } = $props();
+
+  function getWeekDateRange(weekNumber: number): string {
+    const locale = languageTag();
+    const weekStart = addDays(
+      startOfYear(new Date(year, 0, 1)),
+      (weekNumber - 1) * 7,
+    );
+    const weekEnd = addDays(weekStart, 6);
+
+    return `${toHumanShortDate(weekStart, locale)} - ${toHumanShortDate(weekEnd, locale)}`;
+  }
+
+  const chartData = $derived(
+    data.map((value, index) => ({
+      value,
+      label: `${index + 1}`,
+    })),
+  );
+
+  const isDesktop = useMedia(WellKnownMediaQuery.desktop);
+
+  const tickLabels = $derived.by(() => {
+    if ($isDesktop) return chartData.map((d) => d.label);
+    return chartData.map((d, i) => (i % 4 === 0 ? d.label : ""));
+  });
+</script>
+
+<BarChart data={chartData} {tickLabels}>
+  {#snippet tooltip({ value, label })}
+    {@const weekNumber = parseInt(label, 10)}
+    <YirTooltip
+      main="{value} {value === 1 ? 'play' : 'plays'}"
+      sub="Week {weekNumber}"
+      extra={getWeekDateRange(weekNumber)}
+    />
+  {/snippet}
+</BarChart>

--- a/projects/client/src/lib/stores/css/useDimensionObserver.ts
+++ b/projects/client/src/lib/stores/css/useDimensionObserver.ts
@@ -1,4 +1,5 @@
 import { BehaviorSubject } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 export type Dimension = 'width' | 'height' | 'bottom';
 
 // Extract dimension getter function
@@ -19,7 +20,10 @@ const setObservedDimension = (
   }
 };
 
-export const useDimensionObserver = (dimension: Dimension) => {
+export const useDimensionObserver = (
+  dimension: Dimension,
+  debounce?: number,
+) => {
   const observedDimension = new BehaviorSubject(0);
 
   const observeDimension = (node: HTMLElement) => {
@@ -57,7 +61,9 @@ export const useDimensionObserver = (dimension: Dimension) => {
   };
 
   return {
-    observedDimension,
+    observedDimension: debounce != null
+      ? observedDimension.pipe(debounceTime(debounce))
+      : observedDimension,
     observeDimension,
   };
 };

--- a/projects/client/src/lib/stores/css/useDimensionObserver.ts
+++ b/projects/client/src/lib/stores/css/useDimensionObserver.ts
@@ -1,3 +1,4 @@
+import { debounce } from '$lib/utils/timing/debounce.ts';
 import { BehaviorSubject } from 'rxjs';
 export type Dimension = 'width' | 'height' | 'bottom';
 
@@ -19,23 +20,30 @@ const setObservedDimension = (
   }
 };
 
-export const useDimensionObserver = (dimension: Dimension) => {
+export const useDimensionObserver = (
+  dimension: Dimension,
+  debounceMs?: number,
+) => {
   const observedDimension = new BehaviorSubject(0);
 
   const observeDimension = (node: HTMLElement) => {
+    const update = () =>
+      setObservedDimension(node, dimension, observedDimension);
+    const debouncedUpdate = debounceMs != null
+      ? debounce(update, debounceMs)
+      : update;
+
     // Initial size
-    setObservedDimension(node, dimension, observedDimension);
+    update();
 
     // Mutation observer for DOM changes
-    const mutationObserver = new MutationObserver(() => {
-      setObservedDimension(node, dimension, observedDimension);
-    });
+    const mutationObserver = new MutationObserver(() => debouncedUpdate());
 
     // Resize observer for explicit size changes
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         if (entry.target === node) {
-          setObservedDimension(node, dimension, observedDimension);
+          debouncedUpdate();
         }
       }
     });

--- a/projects/client/src/lib/utils/array/findMaxIndex.spec.ts
+++ b/projects/client/src/lib/utils/array/findMaxIndex.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { findMaxIndex } from "./findMaxIndex";
+
+describe("findMaxIndex", () => {
+  it("returns index of maximum value", () => {
+    const values = [1, 5, 3, 9, 2];
+    expect(findMaxIndex(values)).toBe(3);
+  });
+
+  it("returns first index when multiple max values exist", () => {
+    const values = [1, 9, 3, 9, 2];
+    expect(findMaxIndex(values)).toBe(1);
+  });
+
+  it("handles single element array", () => {
+    expect(findMaxIndex([42])).toBe(0);
+  });
+
+  it("handles negative numbers", () => {
+    const values = [-5, -2, -10, -1];
+    expect(findMaxIndex(values)).toBe(3);
+  });
+
+  it("handles all same values", () => {
+    const values = [5, 5, 5, 5];
+    expect(findMaxIndex(values)).toBe(0);
+  });
+
+  it("handles max at beginning", () => {
+    const values = [100, 50, 25, 10];
+    expect(findMaxIndex(values)).toBe(0);
+  });
+
+  it("handles max at end", () => {
+    const values = [10, 25, 50, 100];
+    expect(findMaxIndex(values)).toBe(3);
+  });
+
+  it("handles decimal values", () => {
+    const values = [1.1, 2.5, 1.9, 2.4];
+    expect(findMaxIndex(values)).toBe(1);
+  });
+
+  it("handles zero and positive numbers", () => {
+    const values = [0, 1, 2, 3];
+    expect(findMaxIndex(values)).toBe(3);
+  });
+
+  it("returns -1 for empty array", () => {
+    expect(findMaxIndex([])).toBe(-1);
+  });
+});

--- a/projects/client/src/lib/utils/array/findMaxIndex.ts
+++ b/projects/client/src/lib/utils/array/findMaxIndex.ts
@@ -1,0 +1,6 @@
+export function findMaxIndex(values: number[]): number {
+  if (values.length === 0) return -1;
+
+  const maxValue = Math.max(...values);
+  return values.indexOf(maxValue);
+}

--- a/projects/client/src/lib/utils/format/formatNumber.spec.ts
+++ b/projects/client/src/lib/utils/format/formatNumber.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { formatNumber } from "./formatNumber";
+
+describe("formatNumber", () => {
+  it("formats whole numbers with thousand separators", () => {
+    expect(formatNumber(1234)).toMatch(/1[,\s]234/);
+  });
+
+  it("rounds decimals to nearest integer", () => {
+    const result = formatNumber(1234.5);
+    expect(result).toMatch(/1[,\s]235/);
+  });
+
+  it("rounds down when decimal is less than 0.5", () => {
+    const result = formatNumber(1234.4);
+    expect(result).toMatch(/1[,\s]234/);
+  });
+
+  it("handles zero", () => {
+    expect(formatNumber(0)).toBe("0");
+  });
+
+  it("handles single digits", () => {
+    expect(formatNumber(5)).toBe("5");
+  });
+
+  it("handles numbers under 1000", () => {
+    expect(formatNumber(999)).toBe("999");
+  });
+
+  it("formats large numbers", () => {
+    const result = formatNumber(1234567);
+    // Different locales use different separators (comma or space)
+    expect(result).toMatch(/1[,\s]234[,\s]567/);
+  });
+
+  it("handles negative numbers", () => {
+    const result = formatNumber(-1234);
+    expect(result).toMatch(/-1[,\s]234/);
+  });
+});

--- a/projects/client/src/lib/utils/format/formatNumber.ts
+++ b/projects/client/src/lib/utils/format/formatNumber.ts
@@ -1,0 +1,3 @@
+export function formatNumber(value: number): string {
+  return Math.round(value).toLocaleString();
+}

--- a/projects/client/src/lib/utils/formatting/date/toHumanClockTime.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanClockTime.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { toHumanClockTime } from './toHumanClockTime.ts';
+
+describe('toHumanClockTime', () => {
+  it('should format a time with hour and minute in English by default', () => {
+    const date = new Date(2026, 3, 20, 14, 30);
+    expect(toHumanClockTime(date)).toBe('2:30 PM');
+  });
+
+  it('should pad single-digit minutes with a leading zero', () => {
+    const date = new Date(2026, 3, 20, 9, 5);
+    expect(toHumanClockTime(date)).toBe('9:05 AM');
+  });
+});

--- a/projects/client/src/lib/utils/formatting/date/toHumanClockTime.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanClockTime.ts
@@ -1,0 +1,11 @@
+import type { AvailableLanguage } from '$lib/features/i18n/index.ts';
+
+export function toHumanClockTime(
+  date: Date,
+  locale: AvailableLanguage = 'en',
+): string {
+  return date.toLocaleTimeString(locale, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}

--- a/projects/client/src/lib/utils/formatting/date/toHumanHour.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanHour.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { toHumanHour } from './toHumanHour.ts';
+
+describe('toHumanHour', () => {
+  it('should format an hour in English by default', () => {
+    const date = new Date(2026, 3, 20, 15, 0);
+    expect(toHumanHour(date)).toBe('3 PM');
+  });
+
+  it('should format midnight correctly', () => {
+    const date = new Date(2026, 3, 20, 0, 0);
+    expect(toHumanHour(date)).toBe('12 AM');
+  });
+});

--- a/projects/client/src/lib/utils/formatting/date/toHumanHour.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanHour.ts
@@ -1,0 +1,10 @@
+import type { AvailableLanguage } from '$lib/features/i18n/index.ts';
+
+export function toHumanHour(
+  date: Date,
+  locale: AvailableLanguage = 'en',
+): string {
+  return date.toLocaleTimeString(locale, {
+    hour: 'numeric',
+  });
+}

--- a/projects/client/src/lib/utils/formatting/date/toHumanLongDate.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanLongDate.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { toHumanLongDate } from './toHumanLongDate.ts';
+
+describe('toHumanLongDate', () => {
+  it('should format a date as long date in English by default', () => {
+    const date = new Date('2026-04-20T12:00:00Z');
+    expect(toHumanLongDate(date)).toBe('April 20, 2026');
+  });
+
+  it('should format a date in the provided locale', () => {
+    const date = new Date('2026-04-20T12:00:00Z');
+    expect(toHumanLongDate(date, 'es')).toBe('20 de abril de 2026');
+  });
+});

--- a/projects/client/src/lib/utils/formatting/date/toHumanLongDate.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanLongDate.ts
@@ -1,0 +1,12 @@
+import type { AvailableLanguage } from '$lib/features/i18n/index.ts';
+
+export function toHumanLongDate(
+  date: Date,
+  locale: AvailableLanguage = 'en',
+): string {
+  return date.toLocaleDateString(locale, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}

--- a/projects/client/src/lib/utils/formatting/date/toHumanShortDate.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanShortDate.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { toHumanShortDate } from './toHumanShortDate.ts';
+
+describe('toHumanShortDate', () => {
+  it('should format a date as short date in English by default', () => {
+    const date = new Date('2026-04-20T12:00:00Z');
+    expect(toHumanShortDate(date)).toBe('Apr 20');
+  });
+
+  it('should format a date in the provided locale', () => {
+    const date = new Date('2026-04-20T12:00:00Z');
+    expect(toHumanShortDate(date, 'es')).toBe('20 abr');
+  });
+});

--- a/projects/client/src/lib/utils/formatting/date/toHumanShortDate.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanShortDate.ts
@@ -1,0 +1,11 @@
+import type { AvailableLanguage } from '$lib/features/i18n/index.ts';
+
+export function toHumanShortDate(
+  date: Date,
+  locale: AvailableLanguage = 'en',
+): string {
+  return date.toLocaleDateString(locale, {
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/projects/client/src/lib/utils/url/appendWebp.ts
+++ b/projects/client/src/lib/utils/url/appendWebp.ts
@@ -1,0 +1,6 @@
+export function appendWebp(url: HttpsUrl): HttpsUrl;
+export function appendWebp(url: HttpsUrl | Nil): HttpsUrl | Nil;
+export function appendWebp(url: HttpsUrl | Nil): HttpsUrl | Nil {
+  if (!url || url.endsWith('.webp')) return url;
+  return `${url}.webp` as HttpsUrl;
+}

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -94,6 +94,7 @@
   <link rel="stylesheet" href="https://cdn.plyr.io/3.8.3/plyr.css" />
   <!-- Plyr JS -->
   <script src="https://cdn.plyr.io/3.8.3/plyr.js"></script>
+  <!-- Carbon Charts CSS (note: loaded in script for proper module resolution) -->
   <style>
     html,
     body {

--- a/projects/client/src/routes/users/[user]/year/[year]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/year/[year]/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import Frame from "$lib/components/frame/Frame.svelte";
   import { useIsMe } from "$lib/features/auth/stores/useIsMe";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import * as m from "$lib/features/i18n/messages.ts";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import YirPage from "$lib/sections/yir/YirPage.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { PageProps } from "./$types";
 
@@ -37,13 +40,19 @@
 
   <TraktPageCoverSetter />
 
-  <Frame
-    slug={params.user}
-    urlBuilder={(slug: string, token: string | Nil) => {
-      return UrlBuilder.og.frame.yearToDate(slug, params.year, token);
-    }}
-    title={pageTitle}
-    mode="cover"
-    source="yir"
-  />
+  <RenderForFeature flag={FeatureFlag.YearInReview}>
+    {#snippet enabled()}
+      <YirPage slug={params.user} {year} />
+    {/snippet}
+
+    <Frame
+      slug={params.user}
+      urlBuilder={(slug: string, token: string | Nil) => {
+        return UrlBuilder.og.frame.yearToDate(slug, params.year, token);
+      }}
+      title={pageTitle}
+      mode="cover"
+      source="yir"
+    />
+  </RenderForFeature>
 </TraktPage>

--- a/projects/client/src/routes/users/[user]/year/[year]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/year/[year]/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import Frame from "$lib/components/frame/Frame.svelte";
   import { useIsMe } from "$lib/features/auth/stores/useIsMe";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import * as m from "$lib/features/i18n/messages.ts";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import YirPage from "$lib/sections/yir/YirPage.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { PageProps } from "./$types";
 
@@ -33,17 +36,23 @@
 </script>
 
 <TraktPage {audience} image={pageImage} title={pageTitle} mode="content-only">
-  <NavbarStateSetter mode="minimal" />
+  <NavbarStateSetter mode="minimal" sidebar={{ mode: "fixed" }} />
 
   <TraktPageCoverSetter />
 
-  <Frame
-    slug={params.user}
-    urlBuilder={(slug: string, token: string | Nil) => {
-      return UrlBuilder.og.frame.yearToDate(slug, params.year, token);
-    }}
-    title={pageTitle}
-    mode="cover"
-    source="yir"
-  />
+  <RenderForFeature flag={FeatureFlag.YearInReview}>
+    {#snippet enabled()}
+      <YirPage slug={params.user} {year} />
+    {/snippet}
+
+    <Frame
+      slug={params.user}
+      urlBuilder={(slug: string, token: string | Nil) => {
+        return UrlBuilder.og.frame.yearToDate(slug, params.year, token);
+      }}
+      title={pageTitle}
+      mode="cover"
+      source="yir"
+    />
+  </RenderForFeature>
 </TraktPage>

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -4,9 +4,7 @@
   /**
    * Dynamic card size config
    */
-  --list-inner-width: calc(
-    100dvw - 2 * var(--layout-distance-side) - var(--layout-sidebar-distance)
-  );
+  --list-inner-width: calc(100dvw - 2 * var(--layout-distance-side) - var(--layout-sidebar-distance));
   --max-list-item-count: 10;
   --max-list-landscape-item-count: 7;
 
@@ -16,13 +14,11 @@
   --min-portrait-card-width: var(--ni-132);
   --min-landscape-card-width: var(--ni-200);
 
-  @include dynamic-item-count(
-    --list-item-count,
+  @include dynamic-item-count(--list-item-count,
     var(--min-portrait-card-width),
     var(--max-list-item-count),
   );
-  @include dynamic-item-count(
-    --list-landscape-item-count,
+  @include dynamic-item-count(--list-landscape-item-count,
     var(--min-landscape-card-width),
     var(--max-list-landscape-item-count),
   );
@@ -34,50 +30,38 @@
   --height-card-footer-sm: var(--ni-28);
 
   --width-portrait-card: var(--min-portrait-card-width);
-  @include dynamic-card-width(
-    --width-portrait-card,
+  @include dynamic-card-width(--width-portrait-card,
     var(--min-portrait-card-width),
     var(--list-item-count),
   );
   --height-portrait-card-cover: calc(var(--width-portrait-card) * 1.5);
-  --height-portrait-card: calc(
-    var(--height-portrait-card-cover) + var(--height-card-footer)
-  );
-  --height-portrait-card-sm: calc(
-    var(--height-portrait-card-cover) + var(--height-card-footer-sm)
-  );
+  --height-portrait-card: calc(var(--height-portrait-card-cover) + var(--height-card-footer));
+  --height-portrait-card-sm: calc(var(--height-portrait-card-cover) + var(--height-card-footer-sm));
 
   --width-landscape-card: var(--min-landscape-card-width);
-  @include dynamic-card-width(
-    --width-landscape-card,
+  @include dynamic-card-width(--width-landscape-card,
     var(--min-landscape-card-width),
     var(--list-landscape-item-count),
   );
   --height-landscape-card-cover: calc(var(--width-landscape-card) / 1.786);
-  --height-landscape-card: calc(
-    var(--height-landscape-card-cover) + var(--height-card-footer)
-  );
+  --height-landscape-card: calc(var(--height-landscape-card-cover) + var(--height-card-footer));
 
   --min-person-card-width: var(--ni-120);
   --max-list-person-item-count: 15;
 
   --list-person-item-count: var(--max-list-person-item-count);
-  @include dynamic-item-count(
-    --list-person-item-count,
+  @include dynamic-item-count(--list-person-item-count,
     var(--min-person-card-width),
     var(--max-list-person-item-count),
   );
 
   --width-person-card: var(--min-person-card-width);
-  @include dynamic-card-width(
-    --width-person-card,
+  @include dynamic-card-width(--width-person-card,
     var(--min-person-card-width),
     var(--list-person-item-count),
   );
   --height-person-card-cover: calc(var(--width-person-card) * 176 / 120);
-  --height-person-card: calc(
-    var(--height-person-card-cover) + var(--height-card-footer)
-  );
+  --height-person-card: calc(var(--height-person-card-cover) + var(--height-card-footer));
 
   --width-summary-card: var(--ni-276);
   --height-summary-card-cover: var(--ni-208);
@@ -87,15 +71,13 @@
   --max-list-summary-item-count: 5;
 
   --list-summary-item-count: var(--max-list-summary-item-count);
-  @include dynamic-item-count(
-    --list-summary-item-count,
+  @include dynamic-item-count(--list-summary-item-count,
     var(--min-list-card-width),
     var(--max-list-summary-item-count),
   );
 
   --width-list-card: var(--min-list-card-width);
-  @include dynamic-card-width(
-    --width-list-card,
+  @include dynamic-card-width(--width-list-card,
     var(--min-list-card-width),
     var(--list-summary-item-count),
   );
@@ -106,15 +88,13 @@
   --max-list-comment-item-count: 5;
 
   --list-comment-item-count: var(--max-list-comment-item-count);
-  @include dynamic-item-count(
-    --list-comment-item-count,
+  @include dynamic-item-count(--list-comment-item-count,
     var(--min-comment-card-width),
     var(--max-list-comment-item-count),
   );
 
   --width-comment-card: var(--min-comment-card-width);
-  @include dynamic-card-width(
-    --width-comment-card,
+  @include dynamic-card-width(--width-comment-card,
     var(--min-comment-card-width),
     var(--list-comment-item-count),
   );
@@ -140,9 +120,7 @@
   --width-cta-activity-card: var(--ni-340);
   --height-cta-activity-card: var(--height-landscape-card-cover);
 
-  --width-cta-list-placeholder-card: calc(
-    100dvw - 2 * var(--layout-distance-side) - var(--layout-sidebar-distance)
-  );
+  --width-cta-list-placeholder-card: calc(100dvw - 2 * var(--layout-distance-side) - var(--layout-sidebar-distance));
 
   --min-profile-item-width: var(--ni-80);
   --max-list-profile-item-count: 20;
@@ -151,20 +129,16 @@
     Profile items use gap: 0, so item count and width are calculated
     without subtracting list-gap (unlike media card lists).
   */
-  --list-profile-item-count: clamp(
-    1,
-    round(down, var(--list-inner-width) / var(--min-profile-item-width), 1),
-    var(--max-list-profile-item-count)
-  );
+  --list-profile-item-count: clamp(1,
+      round(down, var(--list-inner-width) / var(--min-profile-item-width), 1),
+      var(--max-list-profile-item-count));
 
   @supports (-moz-appearance: none) {
     --list-profile-item-count: var(--max-list-profile-item-count);
   }
 
-  --width-profile-item: max(
-    calc(var(--list-inner-width) / var(--list-profile-item-count)),
-    var(--min-profile-item-width)
-  );
+  --width-profile-item: max(calc(var(--list-inner-width) / var(--list-profile-item-count)),
+    var(--min-profile-item-width));
   --height-profile-item: calc(var(--width-profile-item) * 1.2);
 
   @include for-tablet-sm-and-below {
@@ -175,9 +149,7 @@
   --width-where-to-watch-item: var(--ni-96);
   --height-where-to-watch-item: var(--ni-96);
 
-  --preferred-sentiment-card-width: calc(
-    3 * var(--width-where-to-watch-item) + 2 * var(--list-gap)
-  );
+  --preferred-sentiment-card-width: calc(3 * var(--width-where-to-watch-item) + 2 * var(--list-gap));
   --width-sentiment-card: min(var(--preferred-sentiment-card-width), 85vw);
   --height-sentiment-card: var(--ni-188);
 
@@ -195,78 +167,45 @@
     Pulse graphs occupy 2 slots, so we round down to the nearest
     even number to prevent a graph from half-overflowing at the edge.
   */
-  --pulse-item-count: clamp(
-    2,
-    calc(
-      2
-        * round(
-        down,
-        var(--list-inner-width)
-          / (
-          2 * (var(--min-pulse-card-width) + var(--list-gap))
-        ),
-        1
-      )
-    ),
-    var(--max-pulse-item-count)
-  );
+  --pulse-item-count: clamp(2,
+    calc(2 * round(down,
+        var(--list-inner-width) / (2 * (var(--min-pulse-card-width) + var(--list-gap))),
+        1)),
+    var(--max-pulse-item-count));
 
   @supports (-moz-appearance: none) {
     --pulse-item-count: var(--max-pulse-item-count);
   }
 
-  @include dynamic-card-width(
-    --width-pulse-card,
+  @include dynamic-card-width(--width-pulse-card,
     var(--min-pulse-card-width),
     var(--pulse-item-count),
   );
 
   --height-pulse-card: var(--ni-156);
-  --height-pulse-list: calc(
-    var(--height-pulse-card) + var(--layout-scrollbar-width)
-  );
+  --height-pulse-list: calc(var(--height-pulse-card) + var(--layout-scrollbar-width));
 
   /**
    * List dimensions
    */
-  --height-landscape-list: calc(
-    var(--height-landscape-card) + var(--layout-scrollbar-width)
-  );
-  --height-person-list: calc(
-    var(--height-person-card) + var(--layout-scrollbar-width)
-  );
-  --height-poster-list: calc(
-    var(--height-portrait-card) + var(--layout-scrollbar-width)
-  );
-  --height-poster-list-sm: calc(
-    var(--height-portrait-card-sm) + var(--layout-scrollbar-width)
-  );
-  --height-lists-list: calc(
-    var(--height-list-card) + var(--layout-scrollbar-width)
-      + var(--layout-footer-less-padding)
-  );
-  --height-comments-list: calc(
-    var(--height-comment-card) + var(--layout-scrollbar-width)
-      + var(--layout-footer-less-padding)
-  );
-  --height-trivia-list: calc(
-    var(--height-trivia-card) + var(--layout-scrollbar-width)
-      + var(--layout-footer-less-padding)
-  );
-  --height-sentiment-list: calc(
-    var(--height-sentiment-card) + var(--layout-footer-less-padding)
-  );
-  --height-comment-thread-list: calc(
-    var(--height-comment-thread-card) + var(--layout-scrollbar-width)
-      + var(--layout-footer-less-padding)
-  );
-  --height-profile-list: calc(
-    var(--height-profile-item) + var(--layout-scrollbar-width)
-  );
-  --height-where-to-watch-list: calc(
-    var(--height-where-to-watch-item) + var(--layout-scrollbar-width)
-      + var(--layout-footer-less-padding)
-  );
+  --height-landscape-list: calc(var(--height-landscape-card) + var(--layout-scrollbar-width));
+  --height-person-list: calc(var(--height-person-card) + var(--layout-scrollbar-width));
+  --height-poster-list: calc(var(--height-portrait-card) + var(--layout-scrollbar-width));
+  --height-poster-list-sm: calc(var(--height-portrait-card-sm) + var(--layout-scrollbar-width));
+  --height-lists-list: calc(var(--height-list-card) + var(--layout-scrollbar-width) + var(--layout-footer-less-padding));
+  --height-comments-list: calc(var(--height-comment-card) + var(--layout-scrollbar-width) + var(--layout-footer-less-padding));
+  --height-trivia-list: calc(var(--height-trivia-card) + var(--layout-scrollbar-width) + var(--layout-footer-less-padding));
+  --height-sentiment-list: calc(var(--height-sentiment-card) + var(--layout-footer-less-padding));
+  --height-comment-thread-list: calc(var(--height-comment-thread-card) + var(--layout-scrollbar-width) + var(--layout-footer-less-padding));
+  --height-profile-list: calc(var(--height-profile-item) + var(--layout-scrollbar-width));
+  --height-where-to-watch-list: calc(var(--height-where-to-watch-item) + var(--layout-scrollbar-width) + var(--layout-footer-less-padding));
+
+  /**
+   * Chart dimensions
+   */
+  --height-bar-chart: var(--ni-180);
+  --height-bubble-chart: var(--ni-640);
+  --min-radius-bubble-chart: var(--ni-20);
 
   /**
    * Structural variables
@@ -289,17 +228,8 @@
 
   --summary-side-action-bar-width: var(--ni-40);
   --summary-poster-gap: var(--gap-s);
-  --summary-poster-width: min(
-    calc(
-      100dvw
-        - 2
-        * (
-        var(--layout-distance-side) + var(--summary-side-action-bar-width)
-          + var(--summary-poster-gap)
-      )
-    ),
-    var(--ni-320)
-  );
+  --summary-poster-width: min(calc(100dvw - 2 * (var(--layout-distance-side) + var(--summary-side-action-bar-width) + var(--summary-poster-gap))),
+    var(--ni-320));
 
   --toggle-large-width: var(--ni-88);
 

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -18,21 +18,17 @@
   --color-input-background: var(--shade-10);
 
   --color-drawer-border: var(--shade-400);
-  --background-vip-drawer: radial-gradient(
-    ellipse 80% 86% at 7.82% 100%,
-    var(--red-50) 0%,
-    var(--color-card-background) 100%
-  );
+  --background-vip-drawer: radial-gradient(ellipse 80% 86% at 7.82% 100%,
+      var(--red-50) 0%,
+      var(--color-card-background) 100%);
 
   /**
    * Navbar
    */
   --color-background-navbar-base: var(--color-floating-background);
-  --color-background-navbar: color-mix(
-    in srgb,
-    var(--color-background-navbar-base) 90%,
-    transparent
-  );
+  --color-background-navbar: color-mix(in srgb,
+      var(--color-background-navbar-base) 90%,
+      transparent);
   --color-foreground-navbar: var(--color-foreground);
   --color-border: var(--shade-200);
   --color-background-side-navbar: var(--color-background-navbar-base);
@@ -51,25 +47,21 @@
   /*
    * Cta
    */
-  --color-cta-background-gradient: linear-gradient(
-    260deg,
-    color-mix(in srgb, var(--shade-10) 60%, transparent) 0%,
-    var(--shade-10) 65%
-  );
+  --color-cta-background-gradient: linear-gradient(260deg,
+      color-mix(in srgb, var(--shade-10) 60%, transparent) 0%,
+      var(--shade-10) 65%);
 
   /*
    * List
    */
-  --list-shadow: radial-gradient(
-    50% 50% at 50% 50%,
-    color-mix(in srgb, var(--color-shadow) 86%, transparent) 0%,
-    color-mix(in srgb, var(--color-shadow) 62%, transparent) 24%,
-    color-mix(in srgb, var(--color-shadow) 43%, transparent) 34%,
-    color-mix(in srgb, var(--color-shadow) 29%, transparent) 46%,
-    color-mix(in srgb, var(--color-shadow) 18%, transparent) 63%,
-    color-mix(in srgb, var(--color-shadow) 7%, transparent) 86%,
-    transparent 100%
-  );
+  --list-shadow: radial-gradient(50% 50% at 50% 50%,
+      color-mix(in srgb, var(--color-shadow) 86%, transparent) 0%,
+      color-mix(in srgb, var(--color-shadow) 62%, transparent) 24%,
+      color-mix(in srgb, var(--color-shadow) 43%, transparent) 34%,
+      color-mix(in srgb, var(--color-shadow) 29%, transparent) 46%,
+      color-mix(in srgb, var(--color-shadow) 18%, transparent) 63%,
+      color-mix(in srgb, var(--color-shadow) 7%, transparent) 86%,
+      transparent 100%);
   --list-meta-info-color: var(--purple-700);
 
   /*
@@ -86,11 +78,9 @@
   /*
    * Navbar
    */
-  --color-background-mobile-navbar: color-mix(
-    in srgb,
-    var(--color-background-navbar-base) 90%,
-    transparent
-  );
+  --color-background-mobile-navbar: color-mix(in srgb,
+      var(--color-background-navbar-base) 90%,
+      transparent);
 
   /*
    * Tooltip
@@ -109,11 +99,9 @@
   /**
    * Toasts
    */
-  --color-toast-background: color-mix(
-    in srgb,
+  --color-toast-background: color-mix(in srgb,
     var(--shade-100) 70%,
-    transparent 30%
-  );
+    transparent 30%);
   --color-toast-border: var(--shade-200);
   --color-toast-progress-bar-background: var(--shade-300);
   --color-toast-progress-bar-progress: var(--shade-500);
@@ -137,11 +125,9 @@
   /**
    * Calendar
    */
-  --color-calendar-background: color-mix(
-    in srgb,
+  --color-calendar-background: color-mix(in srgb,
     var(--color-background-navbar-base) 90%,
-    transparent
-  );
+    transparent);
   --color-calendar-inactive-background: var(--color-background-navbar-base);
   --color-calendar-active-background: var(--shade-200);
   --color-calendar-background-hover: var(--shade-100);
@@ -170,11 +156,9 @@
   /*
    * Dialogs & drawers
    */
-  --color-drawer-background: color-mix(
-    in srgb,
+  --color-drawer-background: color-mix(in srgb,
     var(--shade-70) 94%,
-    transparent
-  );
+    transparent);
   --color-dialog-background: var(--color-drawer-background);
   --color-modal-background: var(--color-card-background);
 
@@ -183,84 +167,58 @@
    */
   --color-sentiment-good: var(--purple-700);
   --color-sentiment-bad: var(--red-800);
-  --color-sentiment-highlight-border: color-mix(
-    in srgb,
+  --color-sentiment-highlight-border: color-mix(in srgb,
     var(--shade-800) 10%,
-    transparent
-  );
-  --background-sentiment-highlight: linear-gradient(
-    135deg,
+    transparent);
+  --background-sentiment-highlight: linear-gradient(135deg,
     color-mix(in srgb, var(--shade-800) 5%, transparent) 0%,
-    color-mix(in srgb, var(--shade-800) 2.5%, transparent) 100%
-  );
+    color-mix(in srgb, var(--shade-800) 2.5%, transparent) 100%);
 
   /*
    * VIP page
    */
-  --background-vip-content: linear-gradient(
-    180deg,
+  --background-vip-content: linear-gradient(180deg,
     var(--red-50) 0%,
-    var(--shade-50) 100%
-  );
-  --background-usage-limits-card: linear-gradient(
-    180deg,
+    var(--shade-50) 100%);
+  --background-usage-limits-card: linear-gradient(180deg,
     color-mix(in srgb, var(--shade-50) 80%, transparent) 0%,
-    color-mix(in srgb, var(--shade-100) 80%, transparent) 100%
-  );
+    color-mix(in srgb, var(--shade-100) 80%, transparent) 100%);
   --color-usage-bar-background: var(--shade-300);
   --color-usage-bar: var(--color-text-primary);
-  --background-vip-glass-card: radial-gradient(
-    circle at top left,
+  --background-vip-glass-card: radial-gradient(circle at top left,
     color-mix(in srgb, var(--shade-10) 30%, transparent) 0%,
-    color-mix(in srgb, var(--shade-10) 60%, transparent) 60%
-  );
-  --background-vip-plain-glass-card: color-mix(
-    in srgb,
+    color-mix(in srgb, var(--shade-10) 60%, transparent) 60%);
+  --background-vip-plain-glass-card: color-mix(in srgb,
     var(--shade-10) 60%,
-    transparent
-  );
-  --color-vip-upgrade-button: color-mix(
-    in srgb,
+    transparent);
+  --color-vip-upgrade-button: color-mix(in srgb,
     var(--red-50) 25%,
-    transparent
-  );
-  --background-subscription-card: radial-gradient(
-    ellipse 110% 125% at 8% 100%,
+    transparent);
+  --background-subscription-card: radial-gradient(ellipse 110% 125% at 8% 100%,
     var(--shade-20) 0%,
-    var(--shade-100) 100%
-  );
-  --background-popular-subscription-card: radial-gradient(
-    ellipse 110% 125% at 8% 100%,
+    var(--shade-100) 100%);
+  --background-popular-subscription-card: radial-gradient(ellipse 110% 125% at 8% 100%,
     var(--shade-20) 0%,
-    color-mix(in srgb, var(--red-950) 10%, var(--shade-10)) 100%
-  );
+    color-mix(in srgb, var(--red-950) 10%, var(--shade-10)) 100%);
   --color-vip-popular-tag: #fdc700;
   --color-vip-border-accent: var(--red-600);
   --color-vip-surface-muted: var(--red-50);
-  --background-vip-elevated-card: radial-gradient(
-    167.08% 143.09% at 7.82% 100%,
+  --background-vip-elevated-card: radial-gradient(167.08% 143.09% at 7.82% 100%,
     var(--color-vip-surface-muted) 0%,
-    var(--shade-100) 100%
-  );
+    var(--shade-100) 100%);
   --color-vip-discount-pill: var(--red-700);
-  --color-vip-discount-pill-background: color-mix(
-    in srgb,
+  --color-vip-discount-pill-background: color-mix(in srgb,
     var(--red-700) 10%,
-    transparent
-  );
+    transparent);
   /*
    * Profile page
    */
-  --background-profile-details: radial-gradient(
-    50% 40% at 50% 0%,
+  --background-profile-details: radial-gradient(50% 40% at 50% 0%,
     var(--purple-50) 0%,
-    var(--shade-50) 100%
-  );
-  --background-vip-profile-details: radial-gradient(
-    50% 40% at 50% 0%,
+    var(--shade-50) 100%);
+  --background-vip-profile-details: radial-gradient(50% 40% at 50% 0%,
     var(--red-20) 0%,
-    var(--shade-50) 100%
-  );
+    var(--shade-50) 100%);
 
   /*
    * Tab view
@@ -273,11 +231,9 @@
    * Streak
    */
   --color-streak-border: var(--shade-70);
-  --color-streak-surface: linear-gradient(
-    90deg,
+  --color-streak-surface: linear-gradient(90deg,
     var(--shade-20) 0%,
-    var(--shade-40) 100%
-  );
+    var(--shade-40) 100%);
   --color-streak-day: var(--purple-600);
 
   /*
@@ -288,6 +244,13 @@
   --color-heatmap-l2: var(--purple-300);
   --color-heatmap-l3: var(--purple-500);
   --color-heatmap-l4: var(--purple-700);
+
+  /*
+   * Charts
+   */
+  --color-bar-chart-bar-default: var(--shade-200);
+  --color-bar-chart-bar-highlight: var(--shade-800);
+  --color-bar-chart-bar-hover: var(--purple-500);
 }
 
 // Define theme variables for dark mode
@@ -296,38 +259,30 @@
   --color-shadow: var(--shade-940);
 
   --color-foreground: var(--shade-10);
-  --color-background: color-mix(
-    in srgb,
-    var(--shade-920) 97%,
-    var(--purple-900)
-  );
+  --color-background: color-mix(in srgb,
+      var(--shade-920) 97%,
+      var(--purple-900));
 
   --color-text-primary: var(--shade-10);
   --color-text-secondary: var(--shade-300);
   --color-text-emphasis: var(--purple-300);
 
-  --color-input-background: color-mix(
-    in srgb,
-    var(--shade-800) 25%,
-    transparent
-  );
+  --color-input-background: color-mix(in srgb,
+      var(--shade-800) 25%,
+      transparent);
 
   --color-drawer-border: var(--shade-700);
-  --background-vip-drawer: radial-gradient(
-    ellipse 80% 86% at 7.82% 100%,
-    var(--red-950) 0%,
-    var(--color-card-background) 100%
-  );
+  --background-vip-drawer: radial-gradient(ellipse 80% 86% at 7.82% 100%,
+      var(--red-950) 0%,
+      var(--color-card-background) 100%);
 
   /**
    * Navbar
    */
   --color-background-navbar-base: var(--color-floating-background);
-  --color-background-navbar: color-mix(
-    in srgb,
-    var(--color-background-navbar-base) 90%,
-    transparent
-  );
+  --color-background-navbar: color-mix(in srgb,
+      var(--color-background-navbar-base) 90%,
+      transparent);
   --color-foreground-navbar: var(--shade-10);
   --color-border: var(--shade-700);
   --color-background-side-navbar: var(--color-background-navbar-base);
@@ -346,23 +301,19 @@
   /*
    * Cta
    */
-  --color-cta-background-gradient: linear-gradient(
-    260deg,
-    color-mix(in srgb, var(--shade-900) 60%, transparent) 0%,
-    var(--shade-900) 65%
-  );
+  --color-cta-background-gradient: linear-gradient(260deg,
+      color-mix(in srgb, var(--shade-900) 60%, transparent) 0%,
+      var(--shade-900) 65%);
 
   /*
    * List
    */
-  --list-shadow: radial-gradient(
-    50% 50% at 50% 50%,
-    color-mix(in srgb, var(--color-shadow) 90%, transparent) 0%,
-    color-mix(in srgb, var(--color-shadow) 45%, transparent) 32%,
-    color-mix(in srgb, var(--color-shadow) 30%, transparent) 61%,
-    color-mix(in srgb, var(--color-shadow) 25%, transparent) 80%,
-    transparent 100%
-  );
+  --list-shadow: radial-gradient(50% 50% at 50% 50%,
+      color-mix(in srgb, var(--color-shadow) 90%, transparent) 0%,
+      color-mix(in srgb, var(--color-shadow) 45%, transparent) 32%,
+      color-mix(in srgb, var(--color-shadow) 30%, transparent) 61%,
+      color-mix(in srgb, var(--color-shadow) 25%, transparent) 80%,
+      transparent 100%);
   --list-meta-info-color: var(--purple-400);
 
   /*
@@ -379,11 +330,9 @@
   /*
    * Navbar
    */
-  --color-background-mobile-navbar: color-mix(
-    in srgb,
-    var(--color-background-navbar-base) 80%,
-    transparent
-  );
+  --color-background-mobile-navbar: color-mix(in srgb,
+      var(--color-background-navbar-base) 80%,
+      transparent);
 
   /*
    * Tooltip
@@ -403,11 +352,9 @@
   /**
    * Toasts
    */
-  --color-toast-background: color-mix(
-    in srgb,
-    var(--shade-900) 70%,
-    transparent 30%
-  );
+  --color-toast-background: color-mix(in srgb,
+      var(--shade-900) 70%,
+      transparent 30%);
   --color-toast-border: var(--shade-700);
   --color-toast-progress-bar-background: var(--shade-500);
   --color-toast-progress-bar-progress: var(--shade-200);
@@ -431,11 +378,9 @@
   /**
    * Calendar
    */
-  --color-calendar-background: color-mix(
-    in srgb,
-    var(--color-background-navbar-base) 90%,
-    transparent
-  );
+  --color-calendar-background: color-mix(in srgb,
+      var(--color-background-navbar-base) 90%,
+      transparent);
   --color-calendar-inactive-background: var(--color-background-navbar-base);
   --color-calendar-active-background: var(--shade-800);
   --color-calendar-background-hover: var(--shade-700);
@@ -464,11 +409,9 @@
   /*
    * Dialogs & drawers
    */
-  --color-drawer-background: color-mix(
-    in srgb,
-    var(--shade-920) 94%,
-    transparent
-  );
+  --color-drawer-background: color-mix(in srgb,
+      var(--shade-920) 94%,
+      transparent);
   --color-dialog-background: var(--color-drawer-background);
   --color-modal-background: var(--color-card-background);
 
@@ -477,84 +420,58 @@
    */
   --color-sentiment-good: var(--purple-200);
   --color-sentiment-bad: var(--red-100);
-  --color-sentiment-highlight-border: color-mix(
-    in srgb,
-    var(--shade-10) 10%,
-    transparent
-  );
-  --background-sentiment-highlight: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--shade-10) 5%, transparent) 0%,
-    color-mix(in srgb, var(--shade-10) 2.5%, transparent) 100%
-  );
+  --color-sentiment-highlight-border: color-mix(in srgb,
+      var(--shade-10) 10%,
+      transparent);
+  --background-sentiment-highlight: linear-gradient(135deg,
+      color-mix(in srgb, var(--shade-10) 5%, transparent) 0%,
+      color-mix(in srgb, var(--shade-10) 2.5%, transparent) 100%);
 
   /*
    * VIP page
    */
-  --background-vip-content: linear-gradient(
-    180deg,
-    var(--red-975) 0%,
-    var(--shade-1000) 100%
-  );
-  --background-usage-limits-card: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--shade-930) 80%, transparent) 0%,
-    color-mix(in srgb, var(--shade-1000) 80%, transparent) 100%
-  );
+  --background-vip-content: linear-gradient(180deg,
+      var(--red-975) 0%,
+      var(--shade-1000) 100%);
+  --background-usage-limits-card: linear-gradient(180deg,
+      color-mix(in srgb, var(--shade-930) 80%, transparent) 0%,
+      color-mix(in srgb, var(--shade-1000) 80%, transparent) 100%);
   --color-usage-bar-background: var(--shade-800);
   --color-usage-bar: var(--shade-100);
-  --background-vip-glass-card: radial-gradient(
-    circle at top left,
-    color-mix(in srgb, var(--red-900) 20%, transparent) 0%,
-    transparent 60%
-  );
-  --background-vip-plain-glass-card: color-mix(
-    in srgb,
-    var(--shade-10) 10%,
-    transparent
-  );
-  --color-vip-upgrade-button: color-mix(
-    in srgb,
-    var(--red-950) 25%,
-    transparent
-  );
-  --background-subscription-card: radial-gradient(
-    ellipse 110% 125% at 8% 100%,
-    var(--shade-920) 0%,
-    var(--shade-1000) 100%
-  );
-  --background-popular-subscription-card: radial-gradient(
-    ellipse 110% 125% at 8% 100%,
-    var(--red-950) 0%,
-    var(--shade-1000) 100%
-  );
+  --background-vip-glass-card: radial-gradient(circle at top left,
+      color-mix(in srgb, var(--red-900) 20%, transparent) 0%,
+      transparent 60%);
+  --background-vip-plain-glass-card: color-mix(in srgb,
+      var(--shade-10) 10%,
+      transparent);
+  --color-vip-upgrade-button: color-mix(in srgb,
+      var(--red-950) 25%,
+      transparent);
+  --background-subscription-card: radial-gradient(ellipse 110% 125% at 8% 100%,
+      var(--shade-920) 0%,
+      var(--shade-1000) 100%);
+  --background-popular-subscription-card: radial-gradient(ellipse 110% 125% at 8% 100%,
+      var(--red-950) 0%,
+      var(--shade-1000) 100%);
   --color-vip-popular-tag: #fdc700;
   --color-vip-border-accent: #b31818;
   --color-vip-surface-muted: #490105;
-  --background-vip-elevated-card: radial-gradient(
-    167.08% 143.09% at 7.82% 100%,
-    var(--color-vip-surface-muted) 0%,
-    var(--shade-1000) 100%
-  );
+  --background-vip-elevated-card: radial-gradient(167.08% 143.09% at 7.82% 100%,
+      var(--color-vip-surface-muted) 0%,
+      var(--shade-1000) 100%);
   --color-vip-discount-pill: var(--red-100);
-  --color-vip-discount-pill-background: color-mix(
-    in srgb,
-    var(--red-100) 10%,
-    transparent
-  );
+  --color-vip-discount-pill-background: color-mix(in srgb,
+      var(--red-100) 10%,
+      transparent);
   /*
    * Profile page
    */
-  --background-profile-details: radial-gradient(
-    50% 40% at 50% 0%,
-    var(--purple-950) 0%,
-    var(--purple-1000) 100%
-  );
-  --background-vip-profile-details: radial-gradient(
-    50% 40% at 50% 0%,
-    var(--red-950) 0%,
-    var(--red-1000) 100%
-  );
+  --background-profile-details: radial-gradient(50% 40% at 50% 0%,
+      var(--purple-950) 0%,
+      var(--purple-1000) 100%);
+  --background-vip-profile-details: radial-gradient(50% 40% at 50% 0%,
+      var(--red-950) 0%,
+      var(--red-1000) 100%);
 
   /*
    * Tab view
@@ -567,11 +484,9 @@
    * Streak
    */
   --color-streak-border: var(--shade-900);
-  --color-streak-surface: linear-gradient(
-    90deg,
-    var(--shade-940) 0%,
-    var(--shade-920) 100%
-  );
+  --color-streak-surface: linear-gradient(90deg,
+      var(--shade-940) 0%,
+      var(--shade-920) 100%);
   --color-streak-day: var(--purple-400);
 
   /*
@@ -582,6 +497,13 @@
   --color-heatmap-l2: var(--purple-700);
   --color-heatmap-l3: var(--purple-500);
   --color-heatmap-l4: var(--purple-300);
+
+  /*
+   * Charts
+   */
+  --color-bar-chart-bar-default: var(--shade-300);
+  --color-bar-chart-bar-highlight: var(--shade-10);
+  --color-bar-chart-bar-hover: var(--purple-500);
 }
 
 // Apply themes to selectors


### PR DESCRIPTION
## Description

Introduces the **Year in Review (YIR) default template** — a full-page, visually rich summary of a user's watching activity for a given year. The feature is gated behind the `YearInReview` feature flag and renders at `/users/[user]/year/[year]`.

## Screenshots

<img width="1510" height="1399" alt="image" src="https://github.com/user-attachments/assets/1833ae89-282c-44ba-aced-d6b676e3c701" />

<img width="1656" height="690" alt="image" src="https://github.com/user-attachments/assets/2206c387-7a0c-4b09-a4b1-f04c4c3e9f05" />

<img width="1503" height="1074" alt="image" src="https://github.com/user-attachments/assets/9fdb7314-e7ae-4c3d-a6ff-1d01320cc256" />

## What's included

**Page composition & layout**
- `YirPage` entry point with loading state, delegating to `YirDefault` — a composition shell that conditionally renders each section based on available data
- `TraktPage` updated with a `content-only` mode to allow full-bleed rendering without standard content wrapper spacing

**Sections** (each under `lib/sections/yir/default/_internal/`):
- **Title** — Full-viewport hero with user avatar, display name, year, and cover image background
- **Totals** — Aggregate stats: total plays, hours watched, collected, ratings, comments, lists
- **Calendar** — First/last watched item of the year with fanart background and formatted date
- **Stats** — Detailed hours/plays breakdown (total, per-month, per-week, per-day) with four chart visualizations (weekly, monthly, daily, hourly)
- **Most Watched** — Ranked carousel with fanart crossfade on hover and thumbnail grid
- **Genres** — Horizontal stacked bars (desktop) / vertical list (mobile) with color-coded genre breakdown
- **Networks / Studios** — Circle-pack bubble charts via Carbon Charts with injected company logos and brand colors
- **Rated** — Grid of top-rated posters with rating badges and fanart backgrounds
- **People** — Paginated grid of actors, actresses, directors, writers with circular headshots and hover tooltips
- **Upgrade CTA** — VIP upsell shown only to free users via `RenderFor`

**Charts** (Carbon Charts):
- `YirWeeklyPlaysChart` (52 bars), `YirMonthlyPlaysChart` (12 bars), `YirDailyPlaysChart` (7 bars), `YirHourlyPlaysChart` (24 bars) — all with locale-aware labels and peak-bar highlighting
- `YirNetworksChart` — Circle-pack with `MutationObserver`-driven logo injection

**API layer:**
- `yirDetailQuery` + `mapToYirDetail` — fetches and maps the full YIR response with Zod-validated domain models
- `yirPeopleQuery` + `mapToYirPerson` — fetches people data by type (actors, actresses, directors, writers)
- Reactive hooks: `useYirDetail`, `useYirPeople`

**Utilities:**
- `findMaxIndex` — returns index of max value in an array (used by charts)
- `formatNumber` — locale-aware number formatting with rounding
- `appendWebp` — appends `.webp` to image URLs for optimized delivery

**Other changes:**
- Added `YearInReview` to `FeatureFlag` enum
- `prependHttps` now normalizes legacy CDN hostnames (`walter-r2.trakt.tv`, `walter.trakt.tv`) to `media.trakt.tv`
- `userProfileQuery` extended to request image data for cover images
- `mapToUserProfile` applies WebP optimization to VIP cover images
- 289 new i18n keys for all YIR labels, section titles, and UI states

## Tests

- `findMaxIndex.spec.ts` — 9 test cases covering edge cases (ties, negatives, single element, decimals)
- `formatNumber.spec.ts` — 8 locale-agnostic test cases covering rounding, separators, and negative numbers