### PR TITLE
fix(auth): ensures full trakt.tv logout

### DIFF
--- a/projects/client/src/lib/features/auth/stores/useAuth.ts
+++ b/projects/client/src/lib/features/auth/stores/useAuth.ts
@@ -21,6 +21,8 @@ export function useAuth() {
 
     await invalidate(InvalidateAction.Auth);
     await workerRequest(WorkerMessage.CacheBust);
+
+    globalThis.window.location.href = 'https://trakt.tv/logout';
   };
 
   const login = async () => {


### PR DESCRIPTION
## 🎶 Notes 🎶

- On logout, redirects to `https://trakt.tv/logout`; after which it will auto redirect back.
- ⚠️ Caveat: it will redirect back to `app.trakt.tv`, so a bit annoying on dev setups. Future improvement; add support for a `return_to` param or something