### PR TITLE
feat(summary): displays episode counts for cast

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToMediaCredits.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaCredits.ts
@@ -11,6 +11,7 @@ import type {
   PeopleShowCreditsResponse,
   ShowResponse,
 } from '@trakt/api';
+import type { MediaEntry } from '../models/MediaEntry.ts';
 
 type MediaCreditsResponse =
   | PeopleMovieCreditsResponse
@@ -49,6 +50,19 @@ function mapToMediaEntry(entryResponse: EntryResponse) {
 type CrewResponse = NonNullable<MediaCreditsResponse['crew']>;
 type CrewEntry = CrewResponse[string][number];
 
+type CastResponse = NonNullable<MediaCreditsResponse['cast']>;
+type CastEntry = CastResponse[number];
+
+function toCredit(media: MediaEntry, entry: CrewEntry | CastEntry) {
+  return {
+    media,
+    key: media.key,
+    ...('episode_count' in entry && entry.episode_count != null
+      ? { episodeCount: entry.episode_count }
+      : {}),
+  };
+}
+
 export function mapToMediaCredits(
   response: MediaCreditsResponse,
 ): MediaCredits {
@@ -66,10 +80,9 @@ export function mapToMediaCredits(
     const media = mapToMediaEntry(entry);
 
     entries?.push({
-      media,
+      ...toCredit(media, entry),
       type: 'cast',
       character: entry.character,
-      key: media.key,
     });
   });
 
@@ -78,10 +91,9 @@ export function mapToMediaCredits(
     const mediaEntries = entries.map((entry: CrewEntry) => {
       const media = mapToMediaEntry(entry);
       return {
-        media,
+        ...toCredit(media, entry),
         type: 'crew',
         job: entry.job,
-        key: media.key,
       };
     });
 

--- a/projects/client/src/lib/requests/_internal/mapToMediaCrew.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaCrew.ts
@@ -13,13 +13,20 @@ export const EMPTY_CREW: Readonly<MediaCrew> = {
   cast: [],
 };
 
+function toMember(response: CrewResponse | CastResponse) {
+  return ({
+    name: response.person.name,
+    key: response.person.ids.slug,
+    ...(response.episode_count != null ? { episodeCount: response.episode_count } : {}),
+  });
+}
+
 function toCrewMember(
   crewResponse: CrewResponse,
 ): CrewMember {
   return ({
+    ...toMember(crewResponse),
     jobs: crewResponse.jobs,
-    name: crewResponse.person.name,
-    key: crewResponse.person.ids.slug,
   });
 }
 
@@ -27,9 +34,8 @@ function toCastMember(
   castResponse: CastResponse,
 ): CastMember {
   return ({
-    name: castResponse.person.name,
+    ...toMember(castResponse),
     characterName: castResponse.characters.at(0) ?? '',
-    key: castResponse.person.ids.slug,
     headshot: mapToHeadshot(castResponse.person.images),
   });
 }

--- a/projects/client/src/lib/requests/models/MediaCredits.ts
+++ b/projects/client/src/lib/requests/models/MediaCredits.ts
@@ -5,6 +5,7 @@ import { crewPositionSchema } from './CrewPosition.ts';
 const BaseCreditSchema = z.object({
   media: MediaEntrySchema,
   key: z.string(),
+  episodeCount: z.number().optional(),
 });
 
 const CharacterSchema = BaseCreditSchema.extend({

--- a/projects/client/src/lib/requests/models/MediaCrew.ts
+++ b/projects/client/src/lib/requests/models/MediaCrew.ts
@@ -3,17 +3,19 @@ import { ImageUrlsSchema } from './ImageUrlsSchema.ts';
 
 export type Job = string;
 
-export const CrewMemberSchema = z.object({
-  jobs: z.array(z.string()),
+const baseSchema = z.object({
   name: z.string(),
   key: z.string(),
+  episodeCount: z.number().optional(),
+});
+
+export const CrewMemberSchema = baseSchema.extend({
+  jobs: z.array(z.string()),
 });
 export type CrewMember = z.infer<typeof CrewMemberSchema>;
 
-export const CastMemberSchema = z.object({
-  name: z.string(),
+export const CastMemberSchema = baseSchema.extend({
   characterName: z.string(),
-  key: z.string(),
   headshot: z.object({
     url: ImageUrlsSchema,
   }),

--- a/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
@@ -2,6 +2,8 @@
   import CardCover from "$lib/components/card/CardCover.svelte";
   import CardFooter from "$lib/components/card/CardFooter.svelte";
   import Link from "$lib/components/link/Link.svelte";
+  import EpisodeCountTag from "$lib/components/media/tags/EpisodeCountTag.svelte";
+  import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import PersonCard from "$lib/components/people/card/PersonCard.svelte";
   import * as m from "$lib/features/i18n/messages";
   import type { CastMember } from "$lib/requests/models/MediaCrew";
@@ -20,12 +22,23 @@
   });
 </script>
 
+{#snippet tag()}
+  {#if type === "show" && castMember.episodeCount}
+    <EpisodeCountTag
+      count={castMember.episodeCount}
+      i18n={TagIntlProvider}
+      type="tag"
+    />
+  {/if}
+{/snippet}
+
 <PersonCard>
   <Link focusable={false} href={UrlBuilder.people(castMember.key, params)}>
     <CardCover
       title={castMember.name}
       src={castMember.headshot.url.thumb}
       alt={`${m.image_alt_person_headshot({ person: castMember.name })}`}
+      {tag}
     />
   </Link>
   <CardFooter>

--- a/projects/client/src/lib/sections/lists/components/CreditMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditMediaItem.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+  import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
+  import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
+  import EpisodeCountTag from "$lib/components/media/tags/EpisodeCountTag.svelte";
+  import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import * as m from "$lib/features/i18n/messages";
   import type { MediaCredit } from "$lib/requests/models/MediaCredits";
   import { toTranslatedJob } from "$lib/utils/formatting/string/toTranslatedJob";
@@ -23,14 +27,31 @@
 
     return toTranslatedJob(job);
   };
+
+  const media = $derived(mediaCredit.media);
 </script>
 
+{#snippet tag()}
+  <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} />
+
+  {#if media.type === "show" && mediaCredit.episodeCount}
+    <EpisodeCountTag i18n={TagIntlProvider} count={mediaCredit.episodeCount} />
+  {/if}
+
+  {#if media.type === "movie"}
+    {#if media.airDate < new Date()}
+      <DurationTag i18n={TagIntlProvider} runtime={media.runtime} />
+    {/if}
+  {/if}
+{/snippet}
+
 <DefaultMediaItem
-  type={mediaCredit.media.type}
-  media={mediaCredit.media}
+  type={media.type}
+  {media}
   {source}
   variant="credit"
   {mode}
+  {tag}
   role={mediaCredit.type === "cast"
     ? toCharacter(mediaCredit.character)
     : toJob(mediaCredit.job)}

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloPeopleMappedMock.ts
@@ -4,6 +4,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
   'cast': [
     {
       'characterName': 'Juliette Nichols',
+      'episodeCount': 19,
       'headshot': {
         'url': {
           'thumb':
@@ -17,6 +18,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Robert Sims',
+      'episodeCount': 19,
       'headshot': {
         'url': {
           'thumb':
@@ -30,6 +32,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Martha Walker',
+      'episodeCount': 19,
       'headshot': {
         'url': {
           'thumb':
@@ -43,6 +46,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Paul Billings',
+      'episodeCount': 19,
       'headshot': {
         'url': {
           'thumb':
@@ -56,6 +60,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Lukas Kyle',
+      'episodeCount': 19,
       'headshot': {
         'url': {
           'thumb':
@@ -69,6 +74,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Patrick Kennedy',
+      'episodeCount': 19,
       'headshot': {
         'url': {
           'thumb':
@@ -82,6 +88,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Bernard Holland',
+      'episodeCount': 19,
       'headshot': {
         'url': {
           'thumb':
@@ -95,6 +102,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Knox',
+      'episodeCount': 9,
       'headshot': {
         'url': {
           'thumb':
@@ -108,6 +116,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Hank',
+      'episodeCount': 9,
       'headshot': {
         'url': {
           'thumb':
@@ -121,6 +130,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Shirley',
+      'episodeCount': 9,
       'headshot': {
         'url': {
           'thumb':
@@ -134,6 +144,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Camille Sims',
+      'episodeCount': 9,
       'headshot': {
         'url': {
           'thumb':
@@ -147,6 +158,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Carla McLain',
+      'episodeCount': 9,
       'headshot': {
         'url': {
           'thumb':
@@ -160,6 +172,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'characterName': 'Solo',
+      'episodeCount': 9,
       'headshot': {
         'url': {
           'thumb':
@@ -175,6 +188,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
   'directors': [
     {
       'key': 'rhiannon-preece-towey',
+      'episodeCount': 10,
       'jobs': [
         'Script Supervisor',
       ],
@@ -182,6 +196,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'bert',
+      'episodeCount': 5,
       'jobs': [
         'Director',
       ],
@@ -189,6 +204,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'michael-dinner',
+      'episodeCount': 4,
       'jobs': [
         'Director',
       ],
@@ -196,6 +212,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'morten-tyldum',
+      'episodeCount': 3,
       'jobs': [
         'Director',
       ],
@@ -203,6 +220,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'adam-bernstein-5c662b3b-7930-4ca7-82a4-b0342f518e01',
+      'episodeCount': 3,
       'jobs': [
         'Director',
       ],
@@ -210,6 +228,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'david-semel',
+      'episodeCount': 2,
       'jobs': [
         'Director',
       ],
@@ -217,6 +236,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'bertie',
+      'episodeCount': 2,
       'jobs': [
         'Director',
       ],
@@ -224,6 +244,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'aric-avelino',
+      'episodeCount': 2,
       'jobs': [
         'Director',
       ],
@@ -233,6 +254,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
   'writers': [
     {
       'key': 'hugh-howey',
+      'episodeCount': 17,
       'jobs': [
         'Book',
       ],
@@ -240,6 +262,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'graham-yost',
+      'episodeCount': 3,
       'jobs': [
         'Writer',
       ],
@@ -247,6 +270,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'cassie-pappas',
+      'episodeCount': 2,
       'jobs': [
         'Writer',
       ],
@@ -254,6 +278,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'jessica-blaire-c7557156-391c-48b4-b128-8f7ef2d2a94b',
+      'episodeCount': 2,
       'jobs': [
         'Writer',
       ],
@@ -261,6 +286,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'ingrid-escajeda',
+      'episodeCount': 2,
       'jobs': [
         'Writer',
       ],
@@ -268,6 +294,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'jeffery-wang',
+      'episodeCount': 2,
       'jobs': [
         'Writer',
       ],
@@ -275,6 +302,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'fred-golan',
+      'episodeCount': 2,
       'jobs': [
         'Writer',
       ],
@@ -282,6 +310,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'remi-aubuchon',
+      'episodeCount': 1,
       'jobs': [
         'Writer',
       ],
@@ -289,6 +318,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'aric-avelino',
+      'episodeCount': 1,
       'jobs': [
         'Writer',
       ],
@@ -296,6 +326,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'lekethia-dalcoe',
+      'episodeCount': 1,
       'jobs': [
         'Writer',
       ],
@@ -303,6 +334,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'sal-calleros',
+      'episodeCount': 1,
       'jobs': [
         'Writer',
       ],
@@ -310,6 +342,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'jenny-dearmitt',
+      'episodeCount': 1,
       'jobs': [
         'Writer',
       ],
@@ -317,6 +350,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
     },
     {
       'key': 'katherine-disavino',
+      'episodeCount': 1,
       'jobs': [
         'Writer',
       ],
@@ -326,6 +360,7 @@ export const ShowSiloPeopleMappedMock: MediaCrew = {
   'creators': [
     {
       'key': 'graham-yost',
+      'episodeCount': 17,
       'jobs': [
         'Creator',
       ],


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2125
- In cast and credits lists, for shows, the number of episodes a person has been in is shown.
  - On the show summary page: shown as a tag on the poster
  - On the person summary page: updated the count in the footer

## 👀 Examples 👀
Before/after:
<img width="1015" height="821" alt="Screenshot 2026-04-16 at 10 38 49" src="https://github.com/user-attachments/assets/62bd5c58-70d9-4eec-9d06-dab34be05c3b" />

<img width="1015" height="821" alt="Screenshot 2026-04-16 at 10 39 05" src="https://github.com/user-attachments/assets/3fa9acd3-dd9e-442f-ac93-1d80a7017364" />

Before/after:
<img width="1121" height="327" alt="Screenshot 2026-04-16 at 10 39 51" src="https://github.com/user-attachments/assets/dc6a9607-cd7b-420f-a8eb-59589d6f775c" />

<img width="1121" height="327" alt="Screenshot 2026-04-16 at 10 40 00" src="https://github.com/user-attachments/assets/c5d74948-5b8b-4f93-9fb7-2cf8de8feb7b" />
