### PR TITLE
Displays localized air time for shows and episodes

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2441,6 +2441,21 @@
         "android"
       ]
     },
+    "text_airs_day_time": {
+      "default": "{day}s at {time}",
+      "description": "Formatted text showing the recurring day and time a show airs.",
+      "exclude": [
+        "android"
+      ],
+      "variables": {
+        "day": {
+          "type": "string"
+        },
+        "time": {
+          "type": "string"
+        }
+      }
+    },
     "header_aired": {
       "default": "Aired",
       "description": "Header for the section that shows when a show has aired.",

--- a/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
@@ -26,7 +26,7 @@ export const TagIntlProvider: TagIntl = {
     delta ? toHumanNumber(Math.abs(delta), languageTag()) : '—',
   postCredits: (count) =>
     `${m.header_post_credits()} · ${toHumanNumber(count, languageTag())}`,
-  toDay: (date) => toHumanDay(date, getLocale()),
+  toDay: (date) => toHumanDay({ date, locale: getLocale() }),
   watchedLabel: () => m.tag_text_watched(),
   toRemainingDuration: (duration) =>
     m.tag_text_remaining_duration({

--- a/projects/client/src/lib/features/calendar/_internal/CalendarItems.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarItems.svelte
@@ -33,7 +33,7 @@
       {#if day.items.length > 0}
         <div id={dateKey(day.date)} class="calendar-day-anchor">
           <GridList
-            title={toHumanDay(day.date, getLocale())}
+            title={toHumanDay({ date: day.date, locale: getLocale() })}
             items={day.items}
             id={dateKey(day.date)}
             {item}

--- a/projects/client/src/lib/features/calendar/_internal/Day.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/Day.svelte
@@ -29,7 +29,7 @@
 <button
   class="trakt-calendar-day-button"
   aria-label={m.button_label_go_to_calendar_day({
-    day: toHumanDay(day.date, getLocale()),
+    day: toHumanDay({ date: day.date, locale: getLocale() }),
   })}
   class:has-items={itemCount > 0}
   class:is-active={isActiveDate}

--- a/projects/client/src/lib/requests/_internal/mapToShowEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToShowEntry.ts
@@ -74,6 +74,13 @@ export function mapToShowEntry(
     totalRuntime,
     rating: mapToTraktRating(show.rating),
     network: show.network,
+    airs: show.airs?.day && show.airs.time && show.airs.timezone
+      ? {
+        day: show.airs.day,
+        time: show.airs.time,
+        timezone: show.airs.timezone,
+      }
+      : undefined,
     homepage: prependHttps(show.homepage),
     socialMedia: mapToSocialMedia(show),
   };

--- a/projects/client/src/lib/requests/models/ShowEntry.ts
+++ b/projects/client/src/lib/requests/models/ShowEntry.ts
@@ -2,9 +2,17 @@ import { z } from 'zod';
 import { EpisodeCountSchema } from './EpisodeCount.ts';
 import { MediaEntrySchema } from './MediaEntry.ts';
 
+export const ShowAirsSchema = z.object({
+  day: z.string(),
+  time: z.string(),
+  timezone: z.string(),
+});
+export type ShowAirs = z.infer<typeof ShowAirsSchema>;
+
 export const ShowEntrySchema = MediaEntrySchema.merge(EpisodeCountSchema)
   .extend({
     network: z.string().nullish(),
     totalRuntime: z.number(),
+    airs: ShowAirsSchema.nullish(),
   });
 export type ShowEntry = z.infer<typeof ShowEntrySchema>;

--- a/projects/client/src/lib/sections/components/DateWithAnniversary.svelte
+++ b/projects/client/src/lib/sections/components/DateWithAnniversary.svelte
@@ -7,6 +7,6 @@
 </script>
 
 <p class="no-wrap ellipsis">
-  {toHumanDay(date, getLocale(), "short")}
+  {toHumanDay({ date, locale: getLocale(), format: "short" })}
   ({getYearsDifference(date, referenceDate)})
 </p>

--- a/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
@@ -81,7 +81,11 @@ export function formatSortValue(item: SortInput, sortBy?: SortBy) {
 
   switch (sortBy) {
     case 'added':
-      return toHumanDay(getAddedAt(item), getLocale(), 'short');
+      return toHumanDay({
+        date: getAddedAt(item),
+        locale: getLocale(),
+        format: 'short',
+      });
     case 'runtime': {
       const runtime = getRuntimeMinutes(item);
       return toHumanDuration({ minutes: runtime }, languageTag());
@@ -90,7 +94,7 @@ export function formatSortValue(item: SortInput, sortBy?: SortBy) {
       const airDate = getAirDate(item);
       return isMaxDate(airDate)
         ? m.tag_text_tba()
-        : toHumanDay(airDate, getLocale(), 'short');
+        : toHumanDay({ date: airDate, locale: getLocale(), format: 'short' });
     }
     case 'percentage': {
       const rating = getRating(item);

--- a/projects/client/src/lib/sections/stats/_internal/utils/getDateRangeLabel.ts
+++ b/projects/client/src/lib/sections/stats/_internal/utils/getDateRangeLabel.ts
@@ -4,7 +4,7 @@ import type { DateRange } from '../models/DateRange.ts';
 
 export function getDateRangeLabel(range: DateRange) {
   const locale = getLocale();
-  return `${toHumanDay(range.start, locale, 'short')} - ${
-    toHumanDay(range.end, locale, 'short')
+  return `${toHumanDay({ date: range.start, locale, format: 'short' })} - ${
+    toHumanDay({ date: range.end, locale, format: 'short' })
   }`;
 }

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentHeader.svelte
@@ -30,7 +30,7 @@
 </script>
 
 <div class="trakt-comment-header">
-  <TextCardHeader subTitle={toHumanDay(comment.createdAt, getLocale())}>
+  <TextCardHeader subTitle={toHumanDay({ date: comment.createdAt, locale: getLocale() })}>
     {#snippet icon()}
       <UserAvatar user={comment.user} size="small" />
     {/snippet}

--- a/projects/client/src/lib/sections/summary/components/details/MediaDetailsProps.ts
+++ b/projects/client/src/lib/sections/summary/components/details/MediaDetailsProps.ts
@@ -3,7 +3,6 @@ import type { MediaCrew } from '$lib/requests/models/MediaCrew.ts';
 import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
 import type { MediaNetwork } from '$lib/requests/models/MediaNetwork.ts';
 import type { MediaStudio } from '$lib/requests/models/MediaStudio.ts';
-import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import type { ShowEntry } from '$lib/requests/models/ShowEntry.ts';
 
 type EpisodeProps = {
@@ -12,8 +11,14 @@ type EpisodeProps = {
   show: ShowEntry;
 };
 
-type MediaProps = {
-  type: MediaType;
+type ShowProps = {
+  type: 'show';
+  media: ShowEntry;
+  studios: MediaStudio[];
+};
+
+type MovieProps = {
+  type: 'movie';
   media: MediaEntry;
   studios: MediaStudio[];
 };
@@ -21,4 +26,4 @@ type MediaProps = {
 export type MediaDetailsProps = {
   crew: MediaCrew;
   networks?: MediaNetwork[];
-} & (EpisodeProps | MediaProps);
+} & (EpisodeProps | ShowProps | MovieProps);

--- a/projects/client/src/lib/sections/summary/components/details/_internal/MediaDetails.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/MediaDetails.spec.ts
@@ -11,7 +11,7 @@ import { ShowSiloPeopleMappedMock } from '$mocks/data/summary/shows/silo/mapped/
 import { ShowSiloStudiosMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloStudiosMappedMock.ts';
 import { renderComponent } from '$test/beds/component/renderComponent.ts';
 import { screen, waitFor } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MediaDetailsProps } from '../MediaDetailsProps.ts';
 import MediaDetails from './MediaDetails.svelte';
 
@@ -251,6 +251,95 @@ describe('MediaDetails', () => {
 
         expect(directorLabel).not.toBeInTheDocument();
         expect(creatorLabel).toBeInTheDocument();
+      });
+    });
+
+    describe('airs', () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2025-01-15T00:00:00Z'));
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('should display the airs day and time for a currently airing show', async () => {
+        renderComponent(
+          MediaDetails,
+          { props: defaultProps },
+        );
+
+        await waitFor(() => {
+          const airsLabel = screen.getByText('Airs');
+          const airsValue = screen.getByText('Fridays at 2:00 AM');
+
+          expect(airsLabel).toBeInTheDocument();
+          expect(airsValue).toBeInTheDocument();
+        });
+      });
+
+      it('should hide airs for an ended show', async () => {
+        renderComponent(
+          MediaDetails,
+          {
+            props: {
+              ...defaultProps,
+              media: {
+                ...defaultProps.media,
+                status: 'ended',
+              },
+            },
+          },
+        );
+
+        await waitFor(() => {
+          const airsLabel = screen.queryByText('Airs');
+          expect(airsLabel).not.toBeInTheDocument();
+        });
+      });
+
+      it('should hide airs for an upcoming show', async () => {
+        const nextYear = new Date();
+        nextYear.setFullYear(nextYear.getFullYear() + 1);
+
+        renderComponent(
+          MediaDetails,
+          {
+            props: {
+              ...defaultProps,
+              media: {
+                ...defaultProps.media,
+                airDate: nextYear,
+              },
+            },
+          },
+        );
+
+        await waitFor(() => {
+          const airsLabel = screen.queryByText('Airs');
+          expect(airsLabel).not.toBeInTheDocument();
+        });
+      });
+
+      it('should hide airs when airs data is missing', async () => {
+        renderComponent(
+          MediaDetails,
+          {
+            props: {
+              ...defaultProps,
+              media: {
+                ...defaultProps.media,
+                airs: undefined,
+              },
+            },
+          },
+        );
+
+        await waitFor(() => {
+          const airsLabel = screen.queryByText('Airs');
+          expect(airsLabel).not.toBeInTheDocument();
+        });
       });
     });
   });

--- a/projects/client/src/lib/sections/summary/components/details/_internal/MediaDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/MediaDetails.svelte
@@ -21,7 +21,7 @@
               <p class="capitalize ellipsis">{value.label}</p>
             </Link>
           {:else}
-            <p class="capitalize ellipsis">{value}</p>
+            <p class="capitalize">{value}</p>
           {/if}
         {/snippet}
       </CollapsableValues>

--- a/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
@@ -60,7 +60,9 @@ function episodeAirDate(episode: EpisodeEntry) {
   return {
     title: isUpcomingItem ? m.header_airs() : m.header_aired(),
     values: [
-      isTba ? m.tag_text_tba() : toHumanDay(episode.airDate, getLocale()),
+      isTba
+        ? m.tag_text_tba()
+        : toHumanDay(episode.airDate, getLocale(), 'long-with-time'),
     ],
   };
 }

--- a/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
@@ -14,12 +14,21 @@ import type { MediaStudio } from '$lib/requests/models/MediaStudio.ts';
 import type { ShowEntry } from '$lib/requests/models/ShowEntry.ts';
 import { isMaxDate } from '$lib/utils/date/isMaxDate.ts';
 import { toHumanDay } from '$lib/utils/formatting/date/toHumanDay.ts';
+import { toHumanDayTime } from '$lib/utils/formatting/date/toHumanDayTime.ts';
 import { toHumanDuration } from '$lib/utils/formatting/date/toHumanDuration.ts';
 import { toCountryName } from '$lib/utils/formatting/intl/toCountryName.ts';
 import { toLanguageName } from '$lib/utils/formatting/intl/toLanguageName.ts';
 import { toTranslatedStatus } from '$lib/utils/formatting/string/toTranslatedStatus.ts';
 import type { MediaDetailsProps } from '../MediaDetailsProps.ts';
 import { toCrewMemberWithJob } from './toCrewMemberWithJob.ts';
+
+const ENDED_STATUSES = new Set(['ended', 'canceled']);
+
+function isCurrentlyAiring(show: ShowEntry, now: Date): boolean {
+  return !isMaxDate(show.airDate) &&
+    show.airDate <= now &&
+    !ENDED_STATUSES.has(show.status);
+}
 
 function originalTitle(media: MediaEntry) {
   if (!media.originalTitle || media.originalTitle === media.title) {
@@ -40,7 +49,7 @@ function mediaAirDate(media: MediaEntry) {
   const isUpcomingItem = media.airDate > new Date();
   return {
     title: isUpcomingItem ? m.header_expected_premiere() : m.header_premiered(),
-    values: [toHumanDay(media.airDate, getLocale())],
+    values: [toHumanDay({ date: media.airDate, locale: getLocale() })],
   };
 }
 
@@ -60,9 +69,11 @@ function episodeAirDate(episode: EpisodeEntry) {
   return {
     title: isUpcomingItem ? m.header_airs() : m.header_aired(),
     values: [
-      isTba
-        ? m.tag_text_tba()
-        : toHumanDay(episode.airDate, getLocale(), 'long-with-time'),
+      isTba ? m.tag_text_tba() : toHumanDay({
+        date: episode.airDate,
+        locale: getLocale(),
+        format: 'long-with-time',
+      }),
     ],
   };
 }
@@ -78,6 +89,22 @@ function networks(entries: MediaNetwork[] | undefined) {
   return {
     title: m.header_network(),
     values: entries?.map((network) => network.name),
+  };
+}
+
+function showAirs(show: ShowEntry, now: Date): MediaDetail {
+  if (!show.airs || !isCurrentlyAiring(show, now)) {
+    return { title: m.header_airs() };
+  }
+
+  const local = toHumanDayTime({ ...show.airs, locale: languageTag() });
+  if (!local) {
+    return { title: m.header_airs() };
+  }
+
+  return {
+    title: m.header_airs(),
+    values: [m.text_airs_day_time(local)],
   };
 }
 
@@ -209,11 +236,16 @@ export function useMediaDetails(props: MediaDetailsProps): MediaDetail[] {
     ];
   }
 
+  const now = new Date();
+  const showAirsDetails = props.type === 'show'
+    ? [showAirs(props.media, now)]
+    : [];
   const totalRuntimeDetails = props.type === 'show'
-    ? [totalRuntime(props.media as ShowEntry)]
+    ? [totalRuntime(props.media)]
     : [];
 
   return [
+    ...showAirsDetails,
     mediaAirDate(props.media),
     mediaStatus(props.media),
     runtime(props.media),

--- a/projects/client/src/lib/sections/summary/components/notes/_internal/NoteHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/notes/_internal/NoteHeader.svelte
@@ -9,7 +9,7 @@
   const { note }: { note: UserNote } = $props();
 </script>
 
-<TextCardHeader subTitle={toHumanDay(note.updatedAt, getLocale())}>
+<TextCardHeader subTitle={toHumanDay({ date: note.updatedAt, locale: getLocale() })}>
   {#snippet icon()}
     <NoteIcon {note} />
   {/snippet}

--- a/projects/client/src/lib/sections/summary/components/people/v2/_internal/PersonDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/_internal/PersonDetails.svelte
@@ -44,7 +44,7 @@
         <Celebration />
       {/if}
       <span class="bold secondary">{m.header_birthday()}</span>
-      <p>{toHumanDay(birthday, getLocale(), "short")}</p>
+      <p>{toHumanDay({ date: birthday, locale: getLocale(), format: "short" })}</p>
     </div>
     <div class="trakt-detail-separator"></div>
     <div class="trakt-person-detail">

--- a/projects/client/src/lib/sections/vip/_internal/AccountDetails.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/AccountDetails.svelte
@@ -37,7 +37,7 @@
           {#if subscription?.memberSince}
             <p>
               {m.text_member_since({
-                date: toHumanDay(subscription.memberSince, getLocale()),
+                date: toHumanDay({ date: subscription.memberSince, locale: getLocale() }),
               })}
             </p>
           {/if}

--- a/projects/client/src/lib/sections/vip/_internal/SubscriptionStatus.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/SubscriptionStatus.svelte
@@ -27,7 +27,7 @@
       {#snippet icon()}
         <CalendarIcon />
       {/snippet}
-      {toHumanDay(subscription.renewsAt, getLocale())}
+      {toHumanDay({ date: subscription.renewsAt, locale: getLocale() })}
     </SubscriptionDetail>
   {/if}
 
@@ -36,7 +36,7 @@
       {#snippet icon()}
         <CalendarIcon />
       {/snippet}
-      {toHumanDay(subscription.expiresAt, getLocale())}
+      {toHumanDay({ date: subscription.expiresAt, locale: getLocale() })}
     </SubscriptionDetail>
   {/if}
 

--- a/projects/client/src/lib/utils/formatting/date/toHumanDay.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanDay.spec.ts
@@ -5,31 +5,41 @@ describe('toHumanDay', () => {
   it('will display September 19th, 2023', () => {
     const day = new Date('2023-09-19');
 
-    expect(toHumanDay(day, 'en')).toBe('September 19th, 2023');
+    expect(toHumanDay({ date: day, locale: 'en' })).toBe(
+      'September 19th, 2023',
+    );
   });
 
   it('will display 19 september 2023', () => {
     const day = new Date('2023-09-19');
 
-    expect(toHumanDay(day, 'nl-nl')).toBe('19 september 2023');
+    expect(toHumanDay({ date: day, locale: 'nl-nl' })).toBe(
+      '19 september 2023',
+    );
   });
 
   it('will display the day only', () => {
     const day = new Date('December 17, 1995 03:24:00');
 
-    expect(toHumanDay(day, 'en')).toBe('December 17th, 1995');
+    expect(toHumanDay({ date: day, locale: 'en' })).toBe(
+      'December 17th, 1995',
+    );
   });
 
   it('will display September 19th, 2023', () => {
     const day = new Date('2023-09-19');
 
-    expect(toHumanDay(day, 'en', 'short')).toBe('Sep 19, 2023');
+    expect(toHumanDay({ date: day, locale: 'en', format: 'short' })).toBe(
+      'Sep 19, 2023',
+    );
   });
 
   it('will display September 19th, 2023 9:00 PM (long-with-time)', () => {
     const day = new Date('September 19, 2023 21:00:00');
 
-    expect(toHumanDay(day, 'en', 'long-with-time')).toBe(
+    expect(
+      toHumanDay({ date: day, locale: 'en', format: 'long-with-time' }),
+    ).toBe(
       'September 19th, 2023 9:00 PM',
     );
   });

--- a/projects/client/src/lib/utils/formatting/date/toHumanDay.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanDay.spec.ts
@@ -25,4 +25,12 @@ describe('toHumanDay', () => {
 
     expect(toHumanDay(day, 'en', 'short')).toBe('Sep 19, 2023');
   });
+
+  it('will display September 19th, 2023 9:00 PM (long-with-time)', () => {
+    const day = new Date('September 19, 2023 21:00:00');
+
+    expect(toHumanDay(day, 'en', 'long-with-time')).toBe(
+      'September 19th, 2023 9:00 PM',
+    );
+  });
 });

--- a/projects/client/src/lib/utils/formatting/date/toHumanDay.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanDay.ts
@@ -8,10 +8,14 @@ const FORMAT_STRINGS = {
   'long-with-time': 'PPP p',
 } as const;
 
+type ToHumanDayProps = {
+  date: Date;
+  locale: AvailableLocale;
+  format?: keyof typeof FORMAT_STRINGS;
+};
+
 export function toHumanDay(
-  date: Date,
-  localeKey: AvailableLocale,
-  formatOption: keyof typeof FORMAT_STRINGS = 'long',
+  { date, locale: localeKey, format: formatOption = 'long' }: ToHumanDayProps,
 ): string {
   const locale = LOCALE_MAP[localeKey] ?? LOCALE_MAP['en'];
   const formatString = FORMAT_STRINGS[formatOption];

--- a/projects/client/src/lib/utils/formatting/date/toHumanDay.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanDay.ts
@@ -2,13 +2,19 @@ import type { AvailableLocale } from '$lib/features/i18n/index.ts';
 import { LOCALE_MAP } from '$lib/utils/formatting/date/LOCALE_MAP.ts';
 import { format } from 'date-fns/format';
 
+const FORMAT_STRINGS = {
+  short: 'PP',
+  long: 'PPP',
+  'long-with-time': 'PPP p',
+} as const;
+
 export function toHumanDay(
   date: Date,
   localeKey: AvailableLocale,
-  formatOption: 'short' | 'long' = 'long',
+  formatOption: keyof typeof FORMAT_STRINGS = 'long',
 ): string {
   const locale = LOCALE_MAP[localeKey] ?? LOCALE_MAP['en'];
-  const formatString = formatOption === 'short' ? 'PP' : 'PPP';
+  const formatString = FORMAT_STRINGS[formatOption];
 
   return format(date, formatString, {
     locale,

--- a/projects/client/src/lib/utils/formatting/date/toHumanDayTime.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanDayTime.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { toHumanDayTime } from './toHumanDayTime.ts';
+
+describe('toHumanDayTime', () => {
+  // Fixed date in January (standard time) for deterministic tests.
+  const now = new Date('2025-01-06T00:00:00Z');
+
+  it('keeps the same day and time when source and user timezones match', () => {
+    const result = toHumanDayTime(
+      { day: 'Monday', time: '10:00', timezone: 'UTC', locale: 'en', now },
+    );
+
+    expect(result).toEqual({ day: 'Monday', time: '10:00 AM' });
+  });
+
+  it('converts across timezones within the same day', () => {
+    const result = toHumanDayTime(
+      {
+        day: 'Monday',
+        time: '10:00',
+        timezone: 'America/New_York',
+        locale: 'en',
+        now,
+      },
+    );
+
+    expect(result).toEqual({ day: 'Monday', time: '3:00 PM' });
+  });
+
+  it('wraps the day when the source time crosses midnight UTC', () => {
+    const result = toHumanDayTime(
+      {
+        day: 'Monday',
+        time: '22:00',
+        timezone: 'America/New_York',
+        locale: 'en',
+        now,
+      },
+    );
+
+    expect(result).toEqual({ day: 'Tuesday', time: '3:00 AM' });
+  });
+
+  it('uses DST offset when reference date is in summer', () => {
+    const summer = new Date('2025-07-07T00:00:00Z');
+    const result = toHumanDayTime(
+      {
+        day: 'Monday',
+        time: '10:00',
+        timezone: 'America/New_York',
+        locale: 'en',
+        now: summer,
+      },
+    );
+
+    expect(result).toEqual({ day: 'Monday', time: '2:00 PM' });
+  });
+
+  it('returns undefined for an invalid day', () => {
+    const result = toHumanDayTime(
+      { day: 'Funday', time: '10:00', timezone: 'UTC', locale: 'en', now },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for an invalid time', () => {
+    const result = toHumanDayTime(
+      { day: 'Monday', time: 'not-a-time', timezone: 'UTC', locale: 'en', now },
+    );
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/projects/client/src/lib/utils/formatting/date/toHumanDayTime.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanDayTime.ts
@@ -1,0 +1,92 @@
+const DAYS_INDEX: Record<string, number> = {
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+};
+
+type ToHumanDayTimeProps = {
+  day: string;
+  time: string;
+  timezone: string;
+  locale: string;
+  now?: Date;
+};
+
+/**
+ * Returns the most recent Sunday (midnight UTC) relative to the given date.
+ * This ensures timezone offset calculations reflect the current DST state.
+ */
+function recentSunday(now: Date): number {
+  const date = new Date(
+    Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()),
+  );
+  date.setUTCDate(date.getUTCDate() - date.getUTCDay());
+  return date.getTime();
+}
+
+/**
+ * Converts a broadcast day/time/timezone to the user's local day and time.
+ *
+ * Takes a day name (e.g. "Thursday"), time (e.g. "21:00"), and IANA timezone
+ * (e.g. "America/New_York") and returns the equivalent day and formatted time
+ * in the user's browser timezone, localized to the provided locale.
+ */
+export function toHumanDayTime(
+  { day, time, timezone, locale, now = new Date() }: ToHumanDayTimeProps,
+): { day: string; time: string } | undefined {
+  const dayIndex = DAYS_INDEX[day];
+  if (dayIndex == null) return;
+
+  const [hourStr, minuteStr] = time.split(':');
+  const hour = Number(hourStr);
+  const minute = Number(minuteStr);
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return;
+
+  // Use the most recent Sunday to build a candidate UTC moment for
+  // hour:minute on the target day. Using the current week ensures the
+  // timezone offset calculation reflects the active DST state.
+  const sundayMs = recentSunday(now);
+  const refDayMs = sundayMs + dayIndex * 86_400_000;
+  const refUtcMs = refDayMs + hour * 3_600_000 + minute * 60_000;
+
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour: 'numeric',
+    minute: 'numeric',
+    day: 'numeric',
+    hour12: false,
+  }).formatToParts(new Date(refUtcMs));
+
+  const sourceHour = Number(parts.find((p) => p.type === 'hour')?.value);
+  const sourceMinute = Number(parts.find((p) => p.type === 'minute')?.value);
+  const sourceDay = Number(parts.find((p) => p.type === 'day')?.value);
+
+  if (
+    !Number.isFinite(sourceHour) ||
+    !Number.isFinite(sourceMinute) ||
+    !Number.isFinite(sourceDay)
+  ) {
+    return;
+  }
+
+  const refDay = new Date(refUtcMs).getUTCDate();
+  const dayDiffMinutes = (refDay - sourceDay) * 24 * 60;
+  const timeDiffMinutes = (hour * 60 + minute) -
+    (sourceHour * 60 + sourceMinute);
+  const offsetMs = (dayDiffMinutes + timeDiffMinutes) * 60 * 1000;
+
+  const utcDate = new Date(refUtcMs + offsetMs);
+
+  const dayStr = new Intl.DateTimeFormat(locale, { weekday: 'long' })
+    .format(utcDate);
+  const timeStr = new Intl.DateTimeFormat(locale, {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(utcDate);
+
+  return { day: dayStr, time: timeStr };
+}

--- a/projects/client/src/mocks/data/summary/shows/devs/ShowDevsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/devs/ShowDevsMappedMock.ts
@@ -69,6 +69,11 @@ export const ShowDevsMappedMock: ShowEntry = {
     'count': 8,
   },
   'totalRuntime': 416,
+  'airs': {
+    'day': 'Thursday',
+    'time': '00:00',
+    'timezone': 'America/New_York',
+  },
   'imdbId': 'tt8134186',
   'tmdbId': 81349,
   'homepage': 'https://www.fxnetworks.com/shows/devs',

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts
@@ -64,6 +64,11 @@ export const ShowSiloMappedMock: ShowEntry = {
     'count': 15,
   },
   'totalRuntime': 900,
+  'airs': {
+    'day': 'Thursday',
+    'time': '21:00',
+    'timezone': 'America/New_York',
+  },
   'imdbId': 'tt14688458',
   'tmdbId': 125988,
   'homepage': 'https://tv.apple.com/show/umc.cmc.3yksgc857px0k0rqe5zd4jice',

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMinimalMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloMinimalMappedMock.ts
@@ -56,4 +56,5 @@ export const ShowSiloMinimalMappedMock: ShowEntry = {
   'tmdbId': 125988,
   'homepage': undefined,
   'socialMedia': undefined,
+  'airs': undefined,
 };

--- a/projects/client/src/mocks/data/sync/mapped/LibraryMappedMock.ts
+++ b/projects/client/src/mocks/data/sync/mapped/LibraryMappedMock.ts
@@ -29,6 +29,11 @@ export const LibraryMappedMock: LibraryItem[] = [
     'key': 'episode-13352063',
     'media': {
       'airDate': new Date('1997-08-14T02:00:00.000Z'),
+      'airs': {
+        'day': 'Wednesday',
+        'time': '22:00',
+        'timezone': 'America/New_York',
+      },
       'releaseDate': new Date('1997-08-14T02:00:00.000Z'),
       'effectiveReleaseDate': new Date('1997-08-14T02:00:00.000Z'),
       'certification': 'TV-MA',
@@ -271,6 +276,11 @@ export const LibraryMappedMock: LibraryItem[] = [
     'key': 'episode-298461',
     'media': {
       'airDate': new Date('1987-04-05T05:00:00.000Z'),
+      'airs': {
+        'day': 'Sunday',
+        'time': '00:00',
+        'timezone': 'America/New_York',
+      },
       'releaseDate': new Date('1987-04-05T05:00:00.000Z'),
       'effectiveReleaseDate': new Date('1987-04-05T05:00:00.000Z'),
       'certification': 'TV-PG',

--- a/projects/client/src/routes/_design_system/formatting/dates/+page.svelte
+++ b/projects/client/src/routes/_design_system/formatting/dates/+page.svelte
@@ -208,7 +208,7 @@
           <TableRow highlight={isToday(date)}>
             <TableCell>{getDateLabel(date)}</TableCell>
             <TableCell>{toHumanDate(today, date, getLocale())}</TableCell>
-            <TableCell>{toHumanDay(date, getLocale())}</TableCell>
+            <TableCell>{toHumanDay({ date, locale: getLocale() })}</TableCell>
             <TableCell>{toHumanMonth(date, languageTag())}</TableCell>
             <TableCell>{toHumanETA(today, date, getLocale())}</TableCell>
           </TableRow>


### PR DESCRIPTION
## Description

This pull request introduces the display of a TV show's recurring air day and time on its details panel. The air time is converted from the show's broadcast timezone to the user's local timezone, including handling day rollovers. This provides users with accurate, localized information about when a show typically airs.

Additionally, the formatting for episode air dates has been enhanced to include the time, offering a more complete picture of when individual episodes aired or will air. This ensures a consistent and comprehensive presentation of air time information across the application.

## Screenshots

#### Show
<img width="1593" height="607" alt="image" src="https://github.com/user-attachments/assets/3fd190bf-077c-430c-927e-e65040216ca3" />

#### Episode
<img width="1589" height="435" alt="image" src="https://github.com/user-attachments/assets/3e011b46-c4ac-48fe-a62e-0057db726b6d" />

## Testing

Comprehensive unit tests have been added for the `MediaDetails` component to ensure the "Airs" information is displayed correctly for currently airing shows and hidden for ended, upcoming, or shows with missing data.

A new utility function, `toHumanDayTime`, includes its own set of tests to verify accurate timezone conversion and day rollover logic. The `toHumanDay` utility also received an additional test for its new 'long-with-time' format, ensuring proper date and time formatting.