### PR TITLE
fix(episodes) / use effective release date for display and sorting

### DIFF
--- a/projects/client/src/lib/requests/_internal/coalesceEpisodes.spec.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceEpisodes.spec.ts
@@ -22,6 +22,7 @@ describe('coalesceEpisodes', () => {
           episode: 1,
           type: premiereType,
           airDate: new Date('2024-01-01'),
+          effectiveReleaseDate: new Date('2024-01-01'),
         } as unknown as UpcomingEpisodeEntry,
         {
           show,
@@ -29,6 +30,7 @@ describe('coalesceEpisodes', () => {
           episode: 10,
           type: finaleType,
           airDate: new Date('2024-01-01'),
+          effectiveReleaseDate: new Date('2024-01-01'),
         } as unknown as UpcomingEpisodeEntry,
       ];
 
@@ -52,6 +54,7 @@ describe('coalesceEpisodes', () => {
           episode: 1,
           type: premiereType,
           airDate: new Date('2024-01-01'),
+          effectiveReleaseDate: new Date('2024-01-01'),
         } as unknown as UpcomingEpisodeEntry,
         {
           show,
@@ -59,6 +62,7 @@ describe('coalesceEpisodes', () => {
           episode: 2,
           type: 'regular',
           airDate: new Date('2024-03-01'),
+          effectiveReleaseDate: new Date('2024-03-01'),
         } as unknown as UpcomingEpisodeEntry,
       ];
 
@@ -77,6 +81,7 @@ describe('coalesceEpisodes', () => {
           episode: 1,
           type: premiereType,
           airDate: new Date('2024-01-01'),
+          effectiveReleaseDate: new Date('2024-01-01'),
         } as unknown as UpcomingEpisodeEntry,
         {
           show: show2,
@@ -84,6 +89,7 @@ describe('coalesceEpisodes', () => {
           episode: 10,
           type: finaleType,
           airDate: new Date('2024-03-01'),
+          effectiveReleaseDate: new Date('2024-03-01'),
         } as unknown as UpcomingEpisodeEntry,
       ];
 
@@ -102,6 +108,7 @@ describe('coalesceEpisodes', () => {
           episode: 1,
           type: premiereType,
           airDate: new Date('2024-01-01'),
+          effectiveReleaseDate: new Date('2024-01-01'),
         } as unknown as UpcomingEpisodeEntry,
         {
           show: show2,
@@ -109,6 +116,7 @@ describe('coalesceEpisodes', () => {
           episode: 1,
           type: premiereType,
           airDate: new Date('2024-01-01'),
+          effectiveReleaseDate: new Date('2024-01-01'),
         } as unknown as UpcomingEpisodeEntry,
         {
           show: show1,
@@ -116,6 +124,7 @@ describe('coalesceEpisodes', () => {
           episode: 10,
           type: finaleType,
           airDate: new Date('2024-01-01'),
+          effectiveReleaseDate: new Date('2024-01-01'),
         } as unknown as UpcomingEpisodeEntry,
         {
           show: show2,
@@ -123,6 +132,7 @@ describe('coalesceEpisodes', () => {
           episode: 10,
           type: finaleType,
           airDate: new Date('2024-01-01'),
+          effectiveReleaseDate: new Date('2024-01-01'),
         } as unknown as UpcomingEpisodeEntry,
       ];
 
@@ -153,6 +163,7 @@ describe('coalesceEpisodes', () => {
         episode: 1,
         type: 'regular',
         airDate: new Date('2024-01-01'),
+        effectiveReleaseDate: new Date('2024-01-01'),
       } as unknown as UpcomingEpisodeEntry,
 
       {
@@ -161,6 +172,7 @@ describe('coalesceEpisodes', () => {
         episode: 2,
         type: 'regular',
         airDate: new Date('2024-01-08'),
+        effectiveReleaseDate: new Date('2024-01-08'),
       } as unknown as UpcomingEpisodeEntry,
     ];
 
@@ -169,7 +181,7 @@ describe('coalesceEpisodes', () => {
     expect(result).toEqual(episodes);
   });
 
-  it('should sort episodes by air date', () => {
+  it('should sort episodes by effective release date', () => {
     const show = { id: 1, title: 'Test Show' };
     const episodes = [
       {
@@ -178,6 +190,7 @@ describe('coalesceEpisodes', () => {
         episode: 2,
         type: 'regular',
         airDate: new Date('2024-01-08'),
+        effectiveReleaseDate: new Date('2024-01-08'),
       } as unknown as UpcomingEpisodeEntry,
       {
         show,
@@ -185,13 +198,18 @@ describe('coalesceEpisodes', () => {
         episode: 1,
         type: 'regular',
         airDate: new Date('2024-01-01'),
+        effectiveReleaseDate: new Date('2024-01-01'),
       } as unknown as UpcomingEpisodeEntry,
     ];
 
     const result = coalesceEpisodes(episodes);
 
-    expect(assertDefined(result[0]).airDate).toEqual(new Date('2024-01-01'));
-    expect(assertDefined(result[1]).airDate).toEqual(new Date('2024-01-08'));
+    expect(assertDefined(result[0]).effectiveReleaseDate).toEqual(
+      new Date('2024-01-01'),
+    );
+    expect(assertDefined(result[1]).effectiveReleaseDate).toEqual(
+      new Date('2024-01-08'),
+    );
   });
 
   describe('coalesce: season premiere and season finale', () => {
@@ -219,6 +237,7 @@ describe('coalesceEpisodes', () => {
         episode: 1,
         type: 'season_premiere',
         airDate: new Date('2024-01-01'),
+        effectiveReleaseDate: new Date('2024-01-01'),
       } as unknown as UpcomingEpisodeEntry,
       {
         show,
@@ -226,6 +245,7 @@ describe('coalesceEpisodes', () => {
         episode: 2,
         type: 'standard',
         airDate: new Date('2024-01-01'),
+        effectiveReleaseDate: new Date('2024-01-01'),
       } as unknown as UpcomingEpisodeEntry,
     ];
 

--- a/projects/client/src/lib/requests/_internal/coalesceEpisodes.ts
+++ b/projects/client/src/lib/requests/_internal/coalesceEpisodes.ts
@@ -12,7 +12,7 @@ export function coalesceEpisodes(
     (acc, episode) => {
       const dateKey = dateKeyFn
         ? dateKeyFn(episode)
-        : getDayKey(episode.airDate);
+        : getDayKey(episode.effectiveReleaseDate);
       const key = `${episode.show.id}-${episode.season}-${dateKey}`;
       acc[key] ??= {
         episodes: [],
@@ -66,6 +66,6 @@ export function coalesceEpisodes(
   });
 
   return coalesced.toSorted((a, b) =>
-    a.airDate.getTime() - b.airDate.getTime()
+    a.effectiveReleaseDate.getTime() - b.effectiveReleaseDate.getTime()
   );
 }

--- a/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.spec.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.spec.ts
@@ -38,11 +38,11 @@ const createContinueEpisode = (
 
 const createStartEpisode = (
   key: string,
-  airDate: Date,
+  effectiveReleaseDate: Date,
 ): UpNextEntry => ({
   key,
   intent: 'start',
-  airDate,
+  effectiveReleaseDate,
 } as UpNextEntry);
 
 describe('interleaveMediaProgress', () => {

--- a/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.ts
@@ -7,7 +7,9 @@ type SortMediaProgressProps = {
 };
 
 function getEpisodeDate(episode: UpNextEntry) {
-  return episode.intent === 'start' ? episode.airDate : episode.lastWatchedAt;
+  return episode.intent === 'start'
+    ? episode.effectiveReleaseDate
+    : episode.lastWatchedAt;
 }
 
 function getMovieDate(movie: MovieProgressEntry) {

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -137,7 +137,7 @@
         <TagBar>
           <AirDateTag
             i18n={TagIntlProvider}
-            airDate={props.episode.airDate}
+            airDate={props.episode.effectiveReleaseDate}
             type="text"
           />
           <TextTag>

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -32,9 +32,9 @@
     coverUrl,
   }: SeasonEpisodeItemProps = $props();
 
-  const isFuture = $derived(episode.airDate > new Date());
+  const isFuture = $derived(episode.effectiveReleaseDate > new Date());
   const hasBulkMarkAsWatched = $derived(
-    hasUnseenEpisodes && episode.airDate && !isFuture,
+    hasUnseenEpisodes && episode.effectiveReleaseDate && !isFuture,
   );
 </script>
 

--- a/projects/client/src/lib/sections/summary/components/details/_internal/MediaDetails.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/MediaDetails.spec.ts
@@ -401,6 +401,7 @@ describe('MediaDetails', () => {
             episode: {
               ...defaultProps.episode,
               airDate: nextYear,
+              effectiveReleaseDate: nextYear,
             },
           } as MediaDetailsProps,
         },

--- a/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
@@ -63,14 +63,14 @@ function mediaStatus(media: MediaEntry) {
 }
 
 function episodeAirDate(episode: EpisodeEntry) {
-  const isUpcomingItem = episode.airDate > new Date();
-  const isTba = isMaxDate(episode.airDate);
+  const isUpcomingItem = episode.effectiveReleaseDate > new Date();
+  const isTba = isMaxDate(episode.effectiveReleaseDate);
 
   return {
     title: isUpcomingItem ? m.header_airs() : m.header_aired(),
     values: [
       isTba ? m.tag_text_tba() : toHumanDay({
-        date: episode.airDate,
+        date: episode.effectiveReleaseDate,
         locale: getLocale(),
         format: 'long-with-time',
       }),


### PR DESCRIPTION
### Overview
This PR ensures that episode display, sorting, and status logic consistently utilize the `effectiveReleaseDate` instead of the standard `airDate`. This addresses issues where missing or inaccurate air dates caused episodes to be incorrectly categorized or ordered in the UI.

### Changes
- Updates episode coalescence logic to group episodes using the effective release date.
- Modifies media progress interleaving to prioritize the effective release date when determining the date for unstarted episodes.
- Switches UI components, including the episode item and season list, to use the effective release date for tags and availability calculations.
- Refactors media detail headers to determine "upcoming" or "TBA" status based on the effective release date.

### Testing
- Verified that episode lists and detail views correctly display release information and maintain proper chronological order.
- Confirmed that "upcoming" and "aired" statuses accurately reflect the effective release date across the application.

Before:
<img width="853" height="251" alt="image" src="https://github.com/user-attachments/assets/ac0032ed-218c-466f-9866-b102f5f73139" />

After:
<img width="853" height="251" alt="image" src="https://github.com/user-attachments/assets/7f58ae29-0f40-4708-8625-a521563c7b1f" />
