### PR TITLE
feat: crowdin workflow upgrades

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -57,7 +57,7 @@ jobs:
     needs: files-changed
     if: ${{
       github.ref == 'refs/heads/main' &&
-      github.head_ref != 'i18n_crowdin_main' &&
+      github.head_ref != 'i18n_crowdin_updates' &&
       needs.files-changed.outputs.i18n_source == 'true'
       }}
     name: Release the Translation Fiends (Localize)
@@ -189,7 +189,7 @@ jobs:
   e2e:
     needs: files-changed
     if: ${{
-      github.ref != 'refs/heads/main' && github.head_ref != 'i18n_crowdin_main' &&
+      github.ref != 'refs/heads/main' && github.head_ref != 'i18n_crowdin_updates' &&
       (
       needs.files-changed.outputs.client_source == 'true' ||
       needs.files-changed.outputs.workflows == 'true'

--- a/.github/workflows/i18n_sync.yml
+++ b/.github/workflows/i18n_sync.yml
@@ -1,0 +1,55 @@
+name: The CrowdIn Sync
+
+# Schedule the workflow to run every day at 14:00 UTC.
+# The workflow can also be triggered manually if needed too.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 14 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  sync-crowdin:
+    name: CrowdIn Sync
+    runs-on: ubuntu-latest
+    concurrency:
+      group: sync-crowdin
+      cancel-in-progress: true
+
+    steps:
+      - name: Summoning the GitHub App Token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Sync and PR with updates if needed
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: false
+          # Bundle ID 6 refers to our 'Web' export bundle in CrowdIn
+          download_bundle: 6
+          skip_untranslated_strings: true
+          export_only_approved: true
+          localization_branch_name: i18n_crowdin_updates
+          commit_message: 'feat(i18n): updates from CrowdIn'
+          create_pull_request: true
+          pull_request_base_branch_name: 'main'
+          pull_request_title: 'feat(i18n): updates from CrowdIn'
+          pull_request_reviewers: 'seferturan,vladjerca'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/i18n_translate.yml
+++ b/.github/workflows/i18n_translate.yml
@@ -87,6 +87,7 @@ jobs:
           # Bundle ID 6 refers to our 'Web' export bundle in CrowdIn
           download_bundle: 6
           skip_untranslated_strings: true
+          export_only_approved: true
           create_pull_request: false
           localization_branch_name: main
           commit_message: 'feat(i18n): update translations'

--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -27,7 +27,7 @@ jobs:
           skip-checkout: true
 
   merge:
-    if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main' && github.head_ref != 'i18n_crowdin_main'
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main' && github.head_ref != 'i18n_crowdin_updates'
     name: The Convergence of Realms (Enable Auto Merge)
     runs-on: ubuntu-latest
     steps:

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,7 +4,7 @@ files:
   - source: /projects/client/i18n/meta/en.json
     translation: /projects/client/i18n/messages/%locale%.json
 pull_request_title: 'feat(i18n): localization updates'
-pull_request_assignees:
+pull_request_reviewers:
   - vladjerca
   - seferturan
 commit_message: 'feat(i18n): update %original_file_name%'


### PR DESCRIPTION
- this little PR adds new sync workflow that will run every day and PR any new translations changes that might occur. This basically allows to completely get rid of CrowdIn platform Github Integration and now have everything based on GH Actions
- Android/iOS will have workflows in their own repos
- also fixed `pull_request_assignees` to be `pull_request_reviewers`