### PR TITLE
feat(button): introduces distinct secondary action button style

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -187,6 +187,28 @@
       margin: var(--ni-4);
     }
 
+    &[data-variant="secondary"]:not([data-style="ghost"]):not([disabled]) {
+      background-color: color-mix(
+        in srgb,
+        var(--color-foreground-action-button) 5%,
+        transparent
+      );
+      border: var(--border-thickness-xxs) solid
+        color-mix(
+          in srgb,
+          var(--color-foreground-action-button) 50%,
+          transparent
+        );
+      color: var(--color-text-primary);
+
+      @include for-mouse {
+        &:hover {
+          background-color: var(--color-background-action-button);
+          color: var(--color-foreground-action-button);
+        }
+      }
+    }
+
     &[data-style="ghost"] {
       background-color: transparent;
 

--- a/projects/client/src/lib/sections/media-actions/drop/DropButton.svelte
+++ b/projects/client/src/lib/sections/media-actions/drop/DropButton.svelte
@@ -57,7 +57,7 @@
 {/if}
 
 {#if style === "action"}
-  <ActionButton {...commonProps} {...props}>
+  <ActionButton {...commonProps} {...props} style="ghost">
     <DropIcon />
   </ActionButton>
 {/if}

--- a/projects/client/src/lib/sections/media-actions/restore/RestoreButton.svelte
+++ b/projects/client/src/lib/sections/media-actions/restore/RestoreButton.svelte
@@ -48,7 +48,7 @@
 {/if}
 
 {#if style === "action"}
-  <ActionButton {...commonProps} {...props}>
+  <ActionButton {...commonProps} {...props} style="ghost">
     <RestoreIcon />
   </ActionButton>
 {/if}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2157
- Introduces a more distinct secondary style to action buttons.

## 👀 Example 👀
Before/after:
<img width="953" height="511" alt="Screenshot 2026-04-20 at 12 57 08" src="https://github.com/user-attachments/assets/d04b4c67-b4f8-447d-bf3c-1ee578f89ac1" />

<img width="959" height="514" alt="Screenshot 2026-04-20 at 13 14 42" src="https://github.com/user-attachments/assets/ab9355b2-699e-4540-9216-a24c676a3450" />

Before/after:
<img width="953" height="511" alt="Screenshot 2026-04-20 at 12 57 18" src="https://github.com/user-attachments/assets/77bac646-3a18-430f-95ba-0187590da273" />

<img width="959" height="514" alt="Screenshot 2026-04-20 at 13 14 53" src="https://github.com/user-attachments/assets/516428b4-7dc9-4a11-9eb0-0dcd809e2b5c" />
