### PR TITLE
Feat/consistent indicator tags

### DIFF
--- a/projects/client/src/lib/features/auth/queries/currentUserHistoryQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserHistoryQuery.ts
@@ -58,6 +58,7 @@ export const WatchedShowSchema = WatchedMediaSchema.extend({
   isWatched: z.boolean(),
   isPartiallyWatched: z.boolean(),
   watchedDates: z.array(z.date()),
+  playsPerSeason: z.map(z.number(), z.number()),
 });
 export type WatchedShow = z.infer<typeof WatchedShowSchema>;
 
@@ -87,6 +88,11 @@ function mapWatchedShowResponse(entry: WatchedShowsResponse[0]): WatchedShow {
     ? Math.min(...regularEpisodes.map((episode) => episode.plays))
     : 0;
 
+  const playsPerSeason = episodes.reduce(
+    (acc, { season }) => acc.set(season, (acc.get(season) ?? 0) + 1),
+    new Map<number, number>(),
+  );
+
   return {
     id: show.ids.trakt,
     watchedAt: new Date(last_watched_at),
@@ -95,6 +101,7 @@ function mapWatchedShowResponse(entry: WatchedShowsResponse[0]): WatchedShow {
     plays,
     episodes,
     watchedDates: episodes.map((e) => e.watchedAt),
+    playsPerSeason,
   };
 }
 

--- a/projects/client/src/lib/features/calendar/CalendarItem.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarItem.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import EpisodeItem from "$lib/sections/lists/components/EpisodeItem.svelte";
+  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
+  import { hasAired } from "$lib/utils/media/hasAired";
   import type { CalendarItem } from "./_internal/useCalendar";
   import CalendarMediaCard from "./CalendarMediaCard.svelte";
 
@@ -11,11 +14,25 @@
 
 <trakt-calendar-item data-variant={variant}>
   {#if "show" in item}
+    {#snippet popupActions()}
+      <RenderFor audience="authenticated">
+        <MarkAsWatchedAction
+          style="dropdown-item"
+          type="episode"
+          title={item.title}
+          show={item.show}
+          media={item}
+          mode="hybrid"
+        />
+      </RenderFor>
+    {/snippet}
+
     <EpisodeItem
       episode={item}
       media={item.show}
       variant={variant === "default" ? "upcoming" : "calendar"}
       source="calendar"
+      popupActions={hasAired(item) ? popupActions : undefined}
     />
   {/if}
 

--- a/projects/client/src/lib/features/spoilers/_internal/useSpoilerAction.ts
+++ b/projects/client/src/lib/features/spoilers/_internal/useSpoilerAction.ts
@@ -1,8 +1,8 @@
 import { SPOILER_CLASS_NAME } from '$lib/features/spoilers/constants.ts';
-import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import type { ExtendedMediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { useMediaSpoiler } from '../useMediaSpoiler.ts';
 
-type SpoilerActionProps = MediaStoreProps;
+type SpoilerActionProps = ExtendedMediaStoreProps;
 
 export function useSpoilerAction(rest: SpoilerActionProps) {
   const { isSpoilerHidden } = useMediaSpoiler(rest);

--- a/projects/client/src/lib/features/spoilers/useMediaSpoiler.ts
+++ b/projects/client/src/lib/features/spoilers/useMediaSpoiler.ts
@@ -1,11 +1,11 @@
-import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import type { ExtendedMediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import {
   useIsWatched,
 } from '$lib/sections/media-actions/mark-as-watched/useIsWatched.ts';
 import { combineLatest, map } from 'rxjs';
 import { useSpoiler } from './_internal/useSpoiler.ts';
 
-export type MediaSpoilerProps = MediaStoreProps;
+export type MediaSpoilerProps = ExtendedMediaStoreProps;
 
 export function useMediaSpoiler(props: MediaSpoilerProps) {
   const { isWatched } = useIsWatched(props);

--- a/projects/client/src/lib/models/MediaStoreProps.ts
+++ b/projects/client/src/lib/models/MediaStoreProps.ts
@@ -16,7 +16,8 @@ type EpisodeCount = {
 
 type SeasonProps<T> = {
   type: 'season';
-  media: ArrayOrSingle<T & { number: number }>;
+  media: ArrayOrSingle<T & { number: number; episodes: { count: number } }>;
+  show: { id: number };
 };
 
 type EpisodeProps<T> = {

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
-  import BookmarkIcon from "$lib/components/icons/BookmarkIcon.svelte";
   import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
   import CertificationTag from "$lib/components/media/tags/CertificationTag.svelte";
   import DurationTag from "$lib/components/media/tags/DurationTag.svelte";
   import EpisodeCountTag from "$lib/components/media/tags/EpisodeCountTag.svelte";
-  import IndicatorTag from "$lib/components/media/tags/IndicatorTag.svelte";
   import MediaIconTag from "$lib/components/media/tags/MediaIconTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import TagBar from "$lib/components/tags/TagBar.svelte";
-  import TrackIcon from "$lib/components/TrackIcon.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaInputDefault } from "$lib/models/MediaInput";
   import ListAction from "$lib/sections/components/lists-drawer/ListAction.svelte";
@@ -21,6 +18,7 @@
   import type { MediaCardProps } from "../components/models/MediaCardProps";
   import MediaItem from "./MediaItem.svelte";
   import MediaSwipe from "./MediaSwipe.svelte";
+  import StatusIndicators from "./StatusIndicators.svelte";
 
   const {
     type,
@@ -68,15 +66,7 @@
 {/snippet}
 
 {#snippet indicatorTags()}
-  {#if $isWatched}
-    <IndicatorTag>
-      <TrackIcon />
-    </IndicatorTag>
-  {:else if $isWatchlisted}
-    <IndicatorTag>
-      <BookmarkIcon state="added" />
-    </IndicatorTag>
-  {/if}
+  <StatusIndicators isWatched={$isWatched} isWatchlisted={$isWatchlisted} />
 {/snippet}
 
 {#snippet tag()}

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -6,6 +6,7 @@
   import Link from "$lib/components/link/Link.svelte";
   import LandscapeCard from "$lib/components/media/card/LandscapeCard.svelte";
   import PortraitCard from "$lib/components/media/card/PortraitCard.svelte";
+  import IndicatorTags from "$lib/components/tags/IndicatorTags.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -28,6 +29,7 @@
     episode,
     media: show,
     source,
+    indicators,
     ...rest
   }: EpisodeCardProps = $props();
 
@@ -69,6 +71,12 @@
         alt={`${show.title} - ${episode.title}`}
         {badge}
       />
+
+      {#if indicators}
+        <IndicatorTags>
+          {@render indicators()}
+        </IndicatorTags>
+      {/if}
     </Link>
 
     <CardFooter {tag} />
@@ -89,6 +97,12 @@
         {badge}
         {tag}
       />
+
+      {#if indicators}
+        <IndicatorTags>
+          {@render indicators()}
+        </IndicatorTags>
+      {/if}
     </Link>
 
     <CardFooter {action}>

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -13,12 +13,14 @@
   import TextTag from "$lib/components/tags/TextTag.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
+  import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
   import { episodeNumberLabel } from "$lib/utils/intl/episodeNumberLabel";
   import type { Snippet } from "svelte";
   import SummaryCardRating from "./_internal/SummaryCardRating.svelte";
   import EpisodeCard from "./EpisodeCard.svelte";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
   import type { EpisodeCardProps } from "./models/EpisodeCardProps";
+  import StatusIndicators from "./StatusIndicators.svelte";
 
   const { sortTag, ...props }: EpisodeCardProps & { sortTag?: Snippet } =
     $props();
@@ -38,13 +40,39 @@
   );
 
   const status = $derived(getEpisodeStatus(props.episode.type));
+
+  const { isWatched } = $derived(
+    useIsWatched({ type: "episode", media: props.episode, show: props.media }),
+  );
+
+  const hasMarkAsWatched = $derived.by(() => {
+    if (isListItem || isFuture || isHidden || isActivity) {
+      return false;
+    }
+
+    return !$isWatched;
+  });
+
+  const hasIndicators = $derived.by(() => {
+    const standAloneVariants: ReadonlyArray<string> = [
+      "list-item",
+      "default",
+      "calendar",
+    ];
+
+    return standAloneVariants.includes(props.variant) ? $isWatched : false;
+  });
 </script>
+
+{#snippet indicatorTags()}
+  <StatusIndicators isWatched={$isWatched} isWatchlisted={false} />
+{/snippet}
 
 {#snippet action()}
   {#if props.action}
     {@render props.action()}
   {:else}
-    {#if !isFuture && !isActivity && !isHidden && !isListItem}
+    {#if hasMarkAsWatched}
       <RenderFor audience="authenticated">
         <MarkAsWatchedAction
           mode={props.variant === "next" && props.context !== "show"
@@ -174,11 +202,17 @@
       badge={action}
       {sortTag}
       type="episode"
+      indicators={hasIndicators ? indicatorTags : undefined}
     />
   {/if}
 
   {#if style === "cover"}
-    <EpisodeCard {...props} {tag} {action} />
+    <EpisodeCard
+      {...props}
+      {tag}
+      {action}
+      indicators={hasIndicators ? indicatorTags : undefined}
+    />
   {/if}
 {/snippet}
 

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -57,6 +57,7 @@
     contextualTag,
     sortTag,
     layout = "default",
+    indicators,
     ...rest
   }: SummaryCardProps = $props();
 
@@ -94,13 +95,6 @@
     };
   });
 
-  const indicators = $derived.by(() => {
-    if (rest.type !== "movie" && rest.type !== "show") {
-      return;
-    }
-
-    return rest.indicators;
-  });
   const ratedItem = $derived.by(() => {
     switch (rest.type) {
       case "movie":

--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -6,15 +6,18 @@
   import Link from "$lib/components/link/Link.svelte";
   import PortraitCard from "$lib/components/media/card/PortraitCard.svelte";
   import SeasonLabelTag from "$lib/components/media/tags/SeasonLabelTag.svelte";
+  import IndicatorTags from "$lib/components/tags/IndicatorTags.svelte";
   import TagBar from "$lib/components/tags/TagBar.svelte";
   import { lineClamp } from "$lib/components/text/lineClamp";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
   import { seasonLabel } from "$lib/utils/intl/seasonLabel";
   import type { Snippet } from "svelte";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
   import type { SeasonCardProps } from "./models/SeasonCardProps";
+  import StatusIndicators from "./StatusIndicators.svelte";
 
   const scrollOffset = 8;
 
@@ -35,6 +38,10 @@
   } & SeasonCardProps = $props();
 
   const { track } = useTrack(AnalyticsEvent.SummaryDrilldown);
+
+  const { isWatched } = $derived(
+    useIsWatched({ type: "season", media: season, show: media }),
+  );
 
   const scrollToItem = (element: HTMLElement) => {
     if (!isCurrentSeason || variant === "list-item") return;
@@ -61,6 +68,10 @@
     });
   };
 </script>
+
+{#snippet indicatorTags()}
+  <StatusIndicators isWatched={$isWatched} isWatchlisted={false} />
+{/snippet}
 
 <div
   class="trakt-season-item"
@@ -103,6 +114,10 @@
           src={season.poster?.url.medium ?? media.poster.url.medium}
           alt={seasonLabel(season.number)}
         />
+
+        <IndicatorTags>
+          {@render indicatorTags()}
+        </IndicatorTags>
       </Link>
       <CardFooter tag={variant === "list-item" ? tag : undefined}>
         {#if variant === "default"}
@@ -128,6 +143,7 @@
       {style}
       {popupActions}
       {sortTag}
+      indicators={indicatorTags}
     />
   {/if}
 </div>

--- a/projects/client/src/lib/sections/lists/components/StatusIndicators.svelte
+++ b/projects/client/src/lib/sections/lists/components/StatusIndicators.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import BookmarkIcon from "$lib/components/icons/BookmarkIcon.svelte";
+  import IndicatorTag from "$lib/components/media/tags/IndicatorTag.svelte";
+  import TrackIcon from "$lib/components/TrackIcon.svelte";
+
+  type StatusIndicatorsProps = {
+    isWatched: boolean;
+    isWatchlisted: boolean;
+  };
+
+  const { isWatched, isWatchlisted }: StatusIndicatorsProps = $props();
+</script>
+
+{#if isWatched}
+  <IndicatorTag>
+    <TrackIcon />
+  </IndicatorTag>
+{:else if isWatchlisted}
+  <IndicatorTag>
+    <BookmarkIcon state="added" />
+  </IndicatorTag>
+{/if}

--- a/projects/client/src/lib/sections/lists/components/models/BaseItemProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/BaseItemProps.ts
@@ -7,4 +7,5 @@ export type BaseItemProps = {
   style?: 'cover' | 'summary' | 'compact';
   source?: string;
   popupActions?: Snippet;
+  indicators?: Snippet;
 };

--- a/projects/client/src/lib/sections/lists/components/models/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/MediaCardProps.ts
@@ -15,7 +15,6 @@ export type MediaItemVariant<T> =
 
 type BaseMediaProps<T> = BaseItemProps & MediaItemVariant<T> & {
   coverTag?: Snippet;
-  indicators?: Snippet;
   mode?: 'standalone' | 'mixed';
   onclick?: (item: T) => void;
 };

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -7,6 +7,7 @@
   import EpisodeItem from "$lib/sections/lists/components/EpisodeItem.svelte";
   import type { BaseItemProps } from "$lib/sections/lists/components/models/BaseItemProps";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
+  import { useMarkAsWatched } from "$lib/sections/media-actions/mark-as-watched/useMarkAsWatched";
   import { getEpisodesUntil } from "./getEpisodesUntil";
   import { WatchedUntilHereIntlProvider } from "./WatchedUntilHereIntlProvider";
 
@@ -36,26 +37,42 @@
   const hasBulkMarkAsWatched = $derived(
     hasUnseenEpisodes && episode.effectiveReleaseDate && !isFuture,
   );
+
+  const { isWatchable } = $derived(
+    useMarkAsWatched({ type: "episode", media: episode, show }),
+  );
+
+  const isActionable = $derived(isWatchable || hasBulkMarkAsWatched);
 </script>
 
 {#snippet popupActions()}
   <RenderFor audience="authenticated">
     <MarkAsWatchedAction
       style="dropdown-item"
-      type="show"
-      size="small"
-      i18n={WatchedUntilHereIntlProvider}
-      title={show.title}
-      media={{
-        id: show.id,
-        effectiveReleaseDate: show.effectiveReleaseDate,
-        seasons: getEpisodesUntil({
-          previousSeasons,
-          episode,
-          watchedEpisodes,
-        }),
-      }}
+      type="episode"
+      title={episode.title}
+      {show}
+      media={episode}
+      mode="hybrid"
     />
+    {#if hasBulkMarkAsWatched}
+      <MarkAsWatchedAction
+        style="dropdown-item"
+        type="show"
+        size="small"
+        i18n={WatchedUntilHereIntlProvider}
+        title={show.title}
+        media={{
+          id: show.id,
+          effectiveReleaseDate: show.effectiveReleaseDate,
+          seasons: getEpisodesUntil({
+            previousSeasons,
+            episode,
+            watchedEpisodes,
+          }),
+        }}
+      />
+    {/if}
   </RenderFor>
 {/snippet}
 
@@ -64,7 +81,7 @@
   media={show}
   {style}
   {coverUrl}
-  popupActions={hasBulkMarkAsWatched ? popupActions : undefined}
+  popupActions={isActionable ? popupActions : undefined}
   variant={isFuture ? "upcoming" : "default"}
   context="show"
   {source}

--- a/projects/client/src/lib/sections/lists/user/_internal/PopupActions.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/PopupActions.svelte
@@ -30,6 +30,7 @@
       return {
         type: listedItem.type,
         media: season,
+        show: listedItem.entry.show,
         title: `${listedItem.entry.show.title} ${seasonLabel(season.number)}`,
       };
     }

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
@@ -1,8 +1,8 @@
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { map } from 'rxjs';
-import type { MediaStoreProps } from '../../../models/MediaStoreProps.ts';
+import type { ExtendedMediaStoreProps } from '../../../models/MediaStoreProps.ts';
 
-export type IsWatchedProps = MediaStoreProps;
+export type IsWatchedProps = ExtendedMediaStoreProps;
 
 export function useIsWatched(props: IsWatchedProps) {
   const { type } = props;
@@ -12,7 +12,10 @@ export function useIsWatched(props: IsWatchedProps) {
   const episodes = props.type === 'episode'
     ? Array.isArray(props.media) ? props.media : [props.media]
     : [];
-  const showId = props.type === 'episode' ? props.show.id : -1;
+  const showId = 'show' in props ? props.show.id : -1;
+  const seasons = props.type === 'season'
+    ? Array.isArray(props.media) ? props.media : [props.media]
+    : [];
 
   const isWatched = history.pipe(
     map(($history) => {
@@ -31,6 +34,14 @@ export function useIsWatched(props: IsWatchedProps) {
             watchedEpisodes.some((e) =>
               e.season === episode.season && e.episode === episode.number
             )
+          );
+        }
+        case 'season': {
+          const countBySeason = $history.shows.get(showId)?.playsPerSeason ??
+            new Map<number, number>();
+
+          return seasons.every((season) =>
+            (countBySeason.get(season.number) ?? 0) >= season.episodes.count
           );
         }
         case 'show': {

--- a/projects/client/src/mocks/data/users/mapped/UserHistoryMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/UserHistoryMappedMock.ts
@@ -74,6 +74,7 @@ export const UserHistoryMappedMock: UserHistory = {
       'isWatched': true,
       'isPartiallyWatched': false,
       'plays': 1,
+      'playsPerSeason': new Map([[0, 1], [1, 8]]),
       'watchedAt': new Date('2024-12-27T16:28:32.000Z'),
       'watchedDates': [
         new Date('2024-12-27T16:28:32.000Z'),
@@ -100,6 +101,7 @@ export const UserHistoryMappedMock: UserHistory = {
       'isWatched': false,
       'isPartiallyWatched': true,
       'plays': 0,
+      'playsPerSeason': new Map([[1, 1]]),
       'watchedAt': new Date('2024-12-27T16:13:42.000Z'),
       'watchedDates': [new Date('2024-12-27T16:13:42.000Z')],
     }],


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2161
- Also uses the the `watched` tags for seasons and episodes.

## 👀 Examples 👀
<img width="473" height="998" alt="Screenshot 2026-04-20 at 15 02 37" src="https://github.com/user-attachments/assets/d8dfa2c4-12e1-49f2-a51d-cbd0e7bd0200" />

<img width="424" height="460" alt="Screenshot 2026-04-20 at 15 03 02" src="https://github.com/user-attachments/assets/50bc23d8-854b-4a15-b81f-33e313ee5639" />
