### PR TITLE
fix(landing): use static card sizes on landing page

### DIFF
--- a/projects/client/src/lib/sections/landing/components/TrendingItems.svelte
+++ b/projects/client/src/lib/sections/landing/components/TrendingItems.svelte
@@ -71,6 +71,14 @@
   }
 
   .trakt-landing-trending-items {
+    --width-card: var(--min-portrait-card-width);
+    --height-card-cover: calc(var(--width-card) * 1.5);
+    --width-portrait-card: var(--width-card);
+    --height-portrait-card-cover: var(--height-card-cover);
+    --height-portrait-card: calc(
+      var(--height-card-cover) + var(--height-card-footer-sm)
+    );
+
     display: grid;
     grid-template-rows: repeat(2, 1fr);
     grid-auto-flow: column;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2159
- Uses fixed card sized on landing screen

## 👀 Example 👀

Before/after:
<img width="1434" height="724" alt="Screenshot 2026-04-21 at 13 15 17" src="https://github.com/user-attachments/assets/449d8ae5-de0d-42e3-8c25-769bb8b50c80" />

<img width="1434" height="724" alt="Screenshot 2026-04-21 at 13 15 24" src="https://github.com/user-attachments/assets/18f2805f-8874-4185-a44e-9b4e39487c49" />
