### PR TITLE
Feat/use auto close button for ratings prompt

### DIFF
--- a/projects/client/src/lib/components/buttons/AutoCloseButton.svelte
+++ b/projects/client/src/lib/components/buttons/AutoCloseButton.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import { autoDismiss } from "$lib/utils/actions/autoDismiss";
+  import CloseIcon from "../icons/CloseIcon.svelte";
+  import ActionButton from "./ActionButton.svelte";
+  import type { TraktActionButtonProps } from "./TraktActionButtonProps";
+
+  type AutoCloseButtonProps = {
+    onclick: () => void;
+    label: string;
+  } & Pick<TraktActionButtonProps, "style" | "color">;
+
+  const {
+    onclick,
+    label,
+    style = "ghost",
+    color,
+  }: AutoCloseButtonProps = $props();
+</script>
+
+<div
+  class="trakt-auto-close-button"
+  use:autoDismiss={{
+    onDismiss: onclick,
+  }}
+>
+  <ActionButton {onclick} {label} {style} {color} size="small">
+    <CloseIcon />
+  </ActionButton>
+</div>
+
+<style>
+  .trakt-auto-close-button {
+    position: relative;
+    flex-shrink: 0;
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: var(--ni-36);
+      height: var(--ni-36);
+      border-radius: 50%;
+      background: conic-gradient(
+        var(--color-progress-ring, var(--purple-500))
+          calc(var(--progress, 0) * 360deg),
+        transparent 0deg 360deg
+      );
+      mask: radial-gradient(
+        circle closest-side,
+        transparent calc(100% - 2px),
+        black calc(100% - 2px)
+      );
+      pointer-events: none;
+      z-index: var(--layer-background);
+    }
+
+    :global(.trakt-action-button) {
+      border-radius: 50%;
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/popover/Popover.svelte
+++ b/projects/client/src/lib/components/popover/Popover.svelte
@@ -29,7 +29,11 @@
     {@render children()}
   </Popover.Trigger>
   <Popover.Portal>
-    <Popover.Content sideOffset={8} side="top">
+    <Popover.Content
+      sideOffset={8}
+      side="top"
+      style="z-index: var(--layer-top)"
+    >
       {@render content()}
     </Popover.Content>
   </Popover.Portal>

--- a/projects/client/src/lib/components/snackbar/Snackbar.svelte
+++ b/projects/client/src/lib/components/snackbar/Snackbar.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import AutoCloseButton from "$lib/components/buttons/AutoCloseButton.svelte";
   import Button from "$lib/components/buttons/Button.svelte";
-  import CloseIcon from "$lib/components/icons/CloseIcon.svelte";
   import Popover from "$lib/components/popover/Popover.svelte";
   import { m } from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
-  import { autoDismiss } from "$lib/utils/actions/autoDismiss.ts";
   import type { Snippet } from "svelte";
   import { onMount } from "svelte";
   import { fly } from "svelte/transition";
@@ -65,14 +63,6 @@
   </Button>
 {/snippet}
 
-{#snippet closeButton(dismissAction: typeof autoDismiss)}
-  <div class="snackbar-close" use:dismissAction={{ onDismiss }}>
-    <ActionButton onclick={onDismiss} label="close" size="small" style="ghost">
-      <CloseIcon />
-    </ActionButton>
-  </div>
-{/snippet}
-
 <RenderFor audience="all" device={["mobile", "tablet-sm"]}>
   {@render children?.()}
 
@@ -87,7 +77,7 @@
     >
       <p class="snackbar-message">{message}</p>
       {@render actionButton()}
-      {@render closeButton(autoDismiss)}
+      <AutoCloseButton onclick={onDismiss} label={m.button_label_close()} />
     </div>
   {/if}
 </RenderFor>
@@ -99,14 +89,14 @@
       <div class="snackbar-popover" role="status" aria-live="polite">
         <div class="snackbar-popover-header">
           <span class="bold title">{title}</span>
-          {@render closeButton(autoDismiss)}
+          <AutoCloseButton onclick={onDismiss} label={m.button_label_close()} />
         </div>
         <p>{message}</p>
         <div class="snackbar-popover-actions">
           <Button
             size="small"
             color="default"
-            label="cancel"
+            label={m.button_label_cancel()}
             onclick={onDismiss}
           >
             {m.button_text_cancel()}
@@ -169,36 +159,5 @@
     display: flex;
     justify-content: flex-end;
     gap: var(--ni-8);
-  }
-
-  .snackbar-close {
-    position: relative;
-    flex-shrink: 0;
-
-    &::before {
-      content: "";
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      width: var(--ni-36);
-      height: var(--ni-36);
-      border-radius: 50%;
-      background: conic-gradient(
-        var(--purple-500) calc(var(--progress, 0) * 360deg),
-        transparent 0deg 360deg
-      );
-      mask: radial-gradient(
-        circle closest-side,
-        transparent calc(100% - 2px),
-        black calc(100% - 2px)
-      );
-      pointer-events: none;
-      z-index: var(--layer-background);
-    }
-
-    :global(.trakt-action-button) {
-      border-radius: 50%;
-    }
   }
 </style>

--- a/projects/client/src/lib/components/snackbar/Snackbar.svelte
+++ b/projects/client/src/lib/components/snackbar/Snackbar.svelte
@@ -113,7 +113,7 @@
     position: fixed;
     left: 50%;
     transform: translateX(-50%);
-    z-index: var(--layer-overlay);
+    z-index: var(--layer-top);
 
     width: min(var(--ni-480), calc(100dvw - var(--ni-32)));
     padding: var(--ni-12) var(--ni-16);

--- a/projects/client/src/lib/features/theme/components/_internal/BaseSplashscreen.svelte
+++ b/projects/client/src/lib/features/theme/components/_internal/BaseSplashscreen.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
-  import CloseIcon from "$lib/components/icons/CloseIcon.svelte";
-  import { autoDismiss } from "$lib/utils/actions/autoDismiss.ts";
+  import AutoCloseButton from "$lib/components/buttons/AutoCloseButton.svelte";
+  import { m } from "$lib/features/i18n/messages";
   import { fade } from "svelte/transition";
 
   const {
@@ -13,22 +12,15 @@
 </script>
 
 {#if hasSplashScreen}
-  <div
-    class="trakt-seasonal-splash-screen"
-    transition:fade={{ duration: 150 }}
-    use:autoDismiss={{ onDismiss }}
-  >
+  <div class="trakt-seasonal-splash-screen" transition:fade={{ duration: 150 }}>
     {@render children()}
-    <div class="trakt-splash-close-button">
-      <ActionButton
-        color="purple"
-        onclick={onDismiss}
-        label="close"
-        size="small"
-      >
-        <CloseIcon />
-      </ActionButton>
-    </div>
+    <AutoCloseButton
+      onclick={onDismiss}
+      label={m.button_label_close()}
+      style="flat"
+      color="purple"
+      --color-progress-ring="var(--shade-10)"
+    />
   </div>
 {/if}
 
@@ -61,33 +53,11 @@
       object-fit: contain;
     }
 
-    .trakt-splash-close-button {
+    :global(.trakt-auto-close-button) {
       position: absolute;
       left: 50%;
       transform: translateX(-50%);
       bottom: calc(env(safe-area-inset-bottom, 0) + var(--ni-48));
-
-      &::before {
-        content: "";
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        width: var(--ni-36);
-        height: var(--ni-36);
-        border-radius: 50%;
-        background: conic-gradient(
-          var(--shade-10) calc(var(--progress, 0) * 360deg),
-          transparent 0deg 360deg
-        );
-
-        pointer-events: none;
-        z-index: -1;
-      }
-
-      :global(.trakt-action-button) {
-        border-radius: 50%;
-      }
     }
   }
 </style>

--- a/projects/client/src/lib/features/toast/constants/index.ts
+++ b/projects/client/src/lib/features/toast/constants/index.ts
@@ -3,4 +3,3 @@ import { time } from '$lib/utils/timing/time.ts';
 export const RECENTLY_WATCHED_WINDOW = time.days(1);
 export const DISMISSAL_STORAGE_KEY = 'rate_now_toast_dismissed';
 export const DISMISSAL_LIMIT = 10;
-export const RATING_LINGER_DURATION = time.seconds(3);

--- a/projects/client/src/lib/sections/media-actions/favorite/FavoriteAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/favorite/FavoriteAction.svelte
@@ -16,6 +16,7 @@
     id: number;
     onAction?: (state: boolean) => void;
     navigationType?: DpadNavigationType;
+    onclick?: () => void;
   };
 
   const {
@@ -26,6 +27,7 @@
     id,
     onAction,
     navigationType,
+    onclick,
   }: FavoriteActionProps = $props();
 
   let showNotePrompt = $state(false);
@@ -55,6 +57,17 @@
     }),
   );
 
+  const handler = (action: "add" | "remove") => {
+    onclick?.();
+
+    if (action === "add") {
+      addToFavorites();
+      return;
+    }
+
+    confirmRemove();
+  };
+
   onMount(() => {
     return isUpdatingFavorite.subscribe((value) => onAction?.(value));
   });
@@ -78,7 +91,7 @@
     {size}
     isFavorited={$isFavorited}
     isFavoriteUpdating={$isUpdatingFavorite}
-    onAdd={addToFavorites}
-    onRemove={confirmRemove}
+    onAdd={() => handler("add")}
+    onRemove={() => handler("remove")}
   />
 </NotePrompt>

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -13,6 +13,7 @@
 
   const {
     variant = "guard",
+    onclick,
     ...props
   }: RateNowProps & { variant?: "allow" | "guard" } = $props();
 
@@ -63,12 +64,16 @@
       <RatingStars
         rating={$pendingRating ?? $current?.rating}
         isRating={$pendingRating !== null}
-        onRemoveRating={removeRating}
+        onRemoveRating={() => {
+          onclick?.();
+          removeRating();
+        }}
         onAddRating={(rating: number, ev: MouseEvent) => {
           if (rating === $current?.rating) {
             return;
           }
 
+          onclick?.();
           setConfettiPosition(rating, ev);
           addRating(rating);
         }}
@@ -86,6 +91,7 @@
             type={props.type}
             id={props.media.id}
             navigationType={DpadNavigationType.Item}
+            {onclick}
           />
         </div>
       {/if}

--- a/projects/client/src/lib/sections/summary/components/rating/models/RateNowProps.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/models/RateNowProps.ts
@@ -14,4 +14,6 @@ type RateableMedia = {
   media: MediaEntry;
 };
 
-export type RateNowProps = RateableEpisode | RateableMedia;
+export type RateNowProps = (RateableEpisode | RateableMedia) & {
+  onclick?: () => void;
+};

--- a/projects/client/src/lib/sections/toast/NavbarToastContent.svelte
+++ b/projects/client/src/lib/sections/toast/NavbarToastContent.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { RATING_LINGER_DURATION } from "$lib/features/toast/constants/index.ts";
   import { useLastWatched } from "$lib/features/toast/useLastWatched";
   import { useNowPlaying } from "$lib/features/toast/useNowPlaying";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
@@ -7,7 +6,7 @@
   import RateNowContent from "$lib/sections/toast/_internal/RateNowContent.svelte";
   import { useCurrentUserLastWatched } from "$lib/sections/toast/_internal/useCurrentUserLastWatched";
   import { useCurrentUserNowWatching } from "$lib/sections/toast/_internal/useCurrentUserNowWatching";
-  import { map, of, switchMap, timer } from "rxjs";
+  import { filter } from "rxjs";
   import { onMount } from "svelte";
 
   const { nowWatching } = useCurrentUserNowWatching();
@@ -20,14 +19,9 @@
     const unsubscribeNowWatching = nowWatching.subscribe((val) =>
       nowPlaying.next(val),
     );
+
     const unsubscribeLastWatched = lastWatchedItem
-      .pipe(
-        switchMap((val) =>
-          val !== null
-            ? of(val)
-            : timer(RATING_LINGER_DURATION).pipe(map(() => null)),
-        ),
-      )
+      .pipe(filter((val) => val !== null))
       .subscribe((val) => lastWatched.next(val));
 
     return () => {

--- a/projects/client/src/lib/sections/toast/_internal/RateNowContent.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/RateNowContent.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import AutoCloseButton from "$lib/components/buttons/AutoCloseButton.svelte";
   import CloseIcon from "$lib/components/icons/CloseIcon.svelte";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
-  import * as m from "$lib/features/i18n/messages";
+  import { m } from "$lib/features/i18n/messages";
   import type { LastWatchedItem } from "$lib/features/toast/models/LastWatchedItem";
   import { useLastWatched } from "$lib/features/toast/useLastWatched";
   import RateNow from "$lib/sections/summary/components/rating/RateNow.svelte";
@@ -11,6 +12,8 @@
   import ToastItemCard from "./ToastItemCard.svelte";
 
   const { lastWatched }: { lastWatched: LastWatchedItem } = $props();
+
+  let interactionCounter = $state(0);
 
   const { dismiss, suppress, isAtLimit } = useLastWatched();
 
@@ -21,6 +24,10 @@
   });
 
   const title = $derived(getToastTitle(lastWatched));
+
+  const handleDismiss = () => {
+    dismiss(lastWatched.media.id, lastWatched.type, "manual");
+  };
 </script>
 
 <div class="trakt-now-playing-container">
@@ -29,24 +36,37 @@
   <div class="trakt-now-playing-content">
     <div class="trakt-rate-now-header">
       <p class="ellipsis">{title}</p>
-      <ActionButton
-        onclick={() => {
-          dismiss(lastWatched.media.id, lastWatched.type, "manual");
-          if (!$isAtLimit) {
-            return;
-          }
+      {#if interactionCounter > 0}
+        {#key interactionCounter}
+          <AutoCloseButton
+            onclick={handleDismiss}
+            label={m.button_label_dismiss()}
+          />
+        {/key}
+      {:else}
+        <ActionButton
+          onclick={() => {
+            handleDismiss();
+            if (!$isAtLimit) {
+              return;
+            }
 
-          confirmSuppression();
-        }}
-        label={m.button_label_dismiss()}
-        style="ghost"
-        size="small"
-      >
-        <CloseIcon />
-      </ActionButton>
+            confirmSuppression();
+          }}
+          label={m.button_label_dismiss()}
+          style="ghost"
+          size="small"
+        >
+          <CloseIcon />
+        </ActionButton>
+      {/if}
     </div>
     <div class="trakt-rate-now-container">
-      <RateNow {...lastWatched} variant="allow" />
+      <RateNow
+        {...lastWatched}
+        variant="allow"
+        onclick={() => (interactionCounter += 1)}
+      />
     </div>
   </div>
 </div>
@@ -74,11 +94,7 @@
   .trakt-rate-now-header {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
-
-    :global(.trakt-action-button) {
-      margin-top: var(--ni-neg-14);
-    }
+    align-items: center;
   }
 
   .trakt-rate-now-container {

--- a/projects/client/src/lib/utils/actions/autoDismiss.ts
+++ b/projects/client/src/lib/utils/actions/autoDismiss.ts
@@ -1,34 +1,42 @@
 import { time } from '$lib/utils/timing/time.ts';
 import { interval } from 'rxjs';
 
-const FPS = 30;
+const defaultDuration = time.seconds(10);
+const fps = 30;
 
 export type AutoDismissProps = {
   onDismiss: () => void;
-  durationSeconds?: number;
+  durationMs?: number;
   now?: () => number;
 };
 
 export function autoDismiss(
   node: HTMLElement,
-  { onDismiss, durationSeconds = 10, now = Date.now }: AutoDismissProps,
+  { onDismiss, durationMs = defaultDuration, now = Date.now }: AutoDismissProps,
 ) {
+  let params = { onDismiss, durationMs, now };
   const startTime = now();
-  const durationMs = durationSeconds * 1000;
 
-  const subscription = interval(time.fps(FPS)).subscribe(() => {
-    const elapsedMs = now() - startTime;
-    const progress = Math.min(elapsedMs / durationMs, 1);
+  const subscription = interval(time.fps(fps)).subscribe(() => {
+    const elapsedMs = params.now() - startTime;
+    const progress = Math.min(elapsedMs / params.durationMs, 1);
 
     node.style.setProperty('--progress', String(progress));
 
     if (progress >= 1) {
       subscription.unsubscribe();
-      onDismiss();
+      params.onDismiss();
     }
   });
 
   return {
+    update(newParams: AutoDismissProps) {
+      params = {
+        onDismiss: newParams.onDismiss,
+        durationMs: newParams.durationMs ?? params.durationMs,
+        now: newParams.now ?? params.now,
+      };
+    },
     destroy() {
       subscription.unsubscribe();
     },


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2164
- Small refactor to extract a common `AutoCloseButton`.
- The ratings prompt now uses the `AutoCloseButton`.
  - Initial situation: no timer, no auto close; i.e. a persistent prompt.
  - After the initial interaction, the timer starts running and the `AutoCloseButton` will animate the progress around the icon.
  - Interacting again will reset it.
  - Timer is reset on interaction level now, not after the query invalidations are done.
- Also contains a small fix for the snackbar and popover z-index.

## 👀 Example 👀

https://github.com/user-attachments/assets/78da598b-9cd4-4d84-96a1-0c108da6301d

