### PR TITLE
feat(calendar): show episode air time on calendar cards

### DIFF
--- a/projects/client/src/lib/components/media/tags/AirTimeTag.svelte
+++ b/projects/client/src/lib/components/media/tags/AirTimeTag.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import StemTag from "$lib/components/tags/StemTag.svelte";
+  import { getLocale } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { isMaxDate } from "$lib/utils/date/isMaxDate";
+  import { toHumanTime } from "$lib/utils/formatting/date/toHumanTime.ts";
+
+  const { airDate }: { airDate: Date } = $props();
+
+  const time = $derived(
+    isMaxDate(airDate)
+      ? m.tag_text_tba()
+      : toHumanTime({ date: airDate, locale: getLocale() }),
+  );
+</script>
+
+<StemTag>
+  <p class="bold no-wrap">
+    {time}
+  </p>
+</StemTag>

--- a/projects/client/src/lib/features/calendar/CalendarItem.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarItem.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { EpisodeIntlProvider } from "$lib/components/episode/EpisodeIntlProvider";
+  import EpisodeStatusTag from "$lib/components/episode/tags/EpisodeStatusTag.svelte";
+  import AirTimeTag from "$lib/components/media/tags/AirTimeTag.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import EpisodeItem from "$lib/sections/lists/components/EpisodeItem.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
@@ -33,7 +36,16 @@
       variant={variant === "default" ? "upcoming" : "calendar"}
       source="calendar"
       popupActions={hasAired(item) ? popupActions : undefined}
-    />
+    >
+      {#snippet tag()}
+        <AirTimeTag airDate={item.airDate} />
+        <EpisodeStatusTag
+          i18n={EpisodeIntlProvider}
+          episodeType={item.type}
+          type="tag"
+        />
+      {/snippet}
+    </EpisodeItem>
   {/if}
 
   {#if item.type === "movie"}

--- a/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
@@ -30,7 +30,9 @@
 </script>
 
 {#snippet tag()}
-  <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} type="tag" />
+  <div class="trakt-media-tag">
+    <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} type="tag" />
+  </div>
 {/snippet}
 
 <LandscapeCard>
@@ -82,3 +84,18 @@
     </p>
   </CardFooter>
 </LandscapeCard>
+
+<style>
+  .trakt-media-tag {
+    width: 100%;
+
+    display: flex;
+    align-items: center;
+
+    gap: var(--gap-micro);
+
+    :global(.trakt-tag) {
+      background: var(--color-background-cover-tag);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -95,10 +95,10 @@
 {/snippet}
 
 {#snippet tag()}
-  {#if props.tag}
-    {@render props.tag()}
-  {:else}
-    <div class="trakt-episode-tag">
+  <div class="trakt-episode-tag">
+    {#if props.tag}
+      {@render props.tag()}
+    {:else}
       {#if ["default"].includes(props.variant)}
         <DurationTag i18n={TagIntlProvider} {runtime} type="tag" />
       {/if}
@@ -178,8 +178,8 @@
           </TextTag>
         </TagBar>
       {/if}
-    </div>
-  {/if}
+    {/if}
+  </div>
 {/snippet}
 
 {#snippet card()}

--- a/projects/client/src/lib/utils/formatting/date/toHumanTime.spec.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanTime.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { toHumanTime } from './toHumanTime.ts';
+
+describe('toHumanTime', () => {
+  const date = new Date('2025-01-06T09:00:00Z');
+
+  it('formats time in 24h for nl-nl', () => {
+    const result = toHumanTime({ date, locale: 'nl-nl' });
+
+    expect(result).toBe('09:00');
+  });
+
+  it('formats time with AM/PM for en', () => {
+    const result = toHumanTime({ date, locale: 'en' });
+
+    expect(result).toBe('9:00 AM');
+  });
+
+  it('formats time with AM/PM for en-au', () => {
+    const result = toHumanTime({ date, locale: 'en-au' });
+
+    expect(result).toBe('9:00 AM');
+  });
+
+  it('zero-pads hours for 24h locales', () => {
+    const midnight = new Date('2025-01-06T00:00:00Z');
+    const result = toHumanTime({ date: midnight, locale: 'de-de' });
+
+    expect(result).toBe('00:00');
+  });
+});

--- a/projects/client/src/lib/utils/formatting/date/toHumanTime.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanTime.ts
@@ -1,0 +1,14 @@
+import type { AvailableLocale } from '$lib/features/i18n/index.ts';
+import { LOCALE_MAP } from '$lib/utils/formatting/date/LOCALE_MAP.ts';
+import { format } from 'date-fns/format';
+
+type ToHumanTimeProps = {
+  date: Date;
+  locale: AvailableLocale;
+};
+
+export function toHumanTime(
+  { date, locale }: ToHumanTimeProps,
+): string {
+  return format(date, 'p', { locale: LOCALE_MAP[locale] });
+}


### PR DESCRIPTION
- Adds an air time tag for episode artwork in the Calendar view
- Hides the time tag for movies because movie calendar data does not include an exact time
- Aligns cover tag styling with existing translucent artwork tags

Related to https://roadmap.trakt.tv/p/display-episode-airtime and https://github.com/trakt/trakt-web/issues/2032

<img width="1170" height="888" alt="Screenshot 2026-04-27 at 10 42 24" src="https://github.com/user-attachments/assets/ff178a98-6c97-4622-853a-e2159868684d" />
