### PR TITLE
fix(navbar): keep desktop actions sticky while scrolling

### DIFF
--- a/projects/client/src/lib/features/calendar/CalendarLayout.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarLayout.svelte
@@ -150,7 +150,9 @@
   }
 
   .calendar-navigation {
-    --sticky-top: calc(env(safe-area-inset-top, 0) + var(--gap-m));
+    --sticky-top: calc(
+      var(--navbar-actions-bottom, env(safe-area-inset-top, 0))
+    );
 
     box-shadow: var(--shadow-raised);
 

--- a/projects/client/src/lib/sections/navbar/_internal/NavbarActions.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/NavbarActions.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import CircularLogo from "$lib/components/icons/CircularLogo.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { trackElementBottom } from "$lib/utils/actions/trackElementBottom";
+  import { trackWindowScroll } from "$lib/utils/actions/trackWindowScroll";
   import Toast from "../../toast/Toast.svelte";
   import FilterButton from "../components/filter/FilterButton.svelte";
   import GetVIPLink from "../components/GetVIPLink.svelte";
@@ -11,7 +13,12 @@
   const { state } = useNavbarState();
 </script>
 
-<div class="trakt-navbar-actions" class:is-hidden={$state.mode === "minimal"}>
+<div
+  class="trakt-navbar-actions"
+  class:is-hidden={$state.mode === "minimal"}
+  use:trackElementBottom={"--navbar-actions-bottom"}
+  use:trackWindowScroll={"trakt-navbar-actions-scroll"}
+>
   <div class="trakt-navbar-actions-left">
     <NavbarHeader />
   </div>
@@ -40,6 +47,11 @@
   </div>
 </div>
 
+<div
+  class="trakt-navbar-actions-spacer"
+  class:is-hidden={$state.mode === "minimal"}
+></div>
+
 {#if $state.toastActions || $state.contextualActions}
   <Toast>
     {#if $state.contextualActions}
@@ -51,9 +63,25 @@
 {/if}
 
 <style>
+  .trakt-navbar-actions,
+  .trakt-navbar-actions-spacer {
+    --navbar-actions-height: calc(
+      var(--side-navbar-actions-height) + var(--gap-m) + var(--gap-m) +
+        env(safe-area-inset-top, 0)
+    );
+
+    height: var(--navbar-actions-height);
+    box-sizing: border-box;
+  }
+
   .trakt-navbar-actions {
-    height: var(--side-navbar-actions-height);
-    transition: opacity var(--transition-increment) ease-in-out;
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: opacity;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: var(--layer-overlay);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -64,6 +92,43 @@
       var(--layout-distance-side) + var(--layout-sidebar-distance)
     );
 
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity var(--transition-increment) ease-in-out;
+    }
+
+    &::before {
+      backdrop-filter: blur(var(--ni-10));
+      background: color-mix(
+        in srgb,
+        var(--color-background-navbar) 75%,
+        transparent
+      );
+      mask-image: linear-gradient(
+        to bottom,
+        black 0%,
+        color-mix(in srgb, black 99%, transparent) 10%,
+        color-mix(in srgb, black 95%, transparent) 20%,
+        color-mix(in srgb, black 89%, transparent) 30%,
+        color-mix(in srgb, black 81%, transparent) 40%,
+        color-mix(in srgb, black 71%, transparent) 50%,
+        color-mix(in srgb, black 59%, transparent) 60%,
+        color-mix(in srgb, black 45%, transparent) 70%,
+        color-mix(in srgb, black 31%, transparent) 80%,
+        color-mix(in srgb, black 16%, transparent) 90%,
+        transparent 100%
+      );
+    }
+
+    &:global(.trakt-navbar-actions-scroll)::before {
+      opacity: 1;
+    }
+
     &.is-hidden {
       height: 0;
       opacity: 0;
@@ -72,8 +137,19 @@
     }
   }
 
+  .trakt-navbar-actions-spacer.is-hidden {
+    height: 0;
+  }
+
   .trakt-navbar-actions-left {
     min-width: 0;
+  }
+
+  .trakt-navbar-actions-left,
+  .trakt-navbar-actions-center,
+  .trakt-navbar-actions-right {
+    position: relative;
+    z-index: 1;
   }
 
   .trakt-navbar-actions-right {

--- a/projects/client/src/lib/utils/actions/trackElementBottom.ts
+++ b/projects/client/src/lib/utils/actions/trackElementBottom.ts
@@ -15,10 +15,13 @@ export function trackElementBottom(
     'scroll',
     update,
   );
+  const resizeObserver = new ResizeObserver(update);
+  resizeObserver.observe(node);
 
   return {
     destroy() {
       unregisterScroll();
+      resizeObserver.disconnect();
       document.documentElement.style.removeProperty(cssVarName);
     },
   };


### PR DESCRIPTION
## 🎶 Notes 🎶

- Keeps the desktop navbar action/header row fixed while scrolling, including on paginated pages
- Adds a spacer so content layout does not jump under the fixed actions row
- Offsets calendar sticky navigation below the desktop actions row to avoid overlap
- Updates the desktop scroll treatment to use a progressive blur with a subtle gradient
- Keeps the sidebar logo above the navbar visual effect
- Lightens shared meta/subtitle text for better readability

## 👀 Example 👀

Before:

<img width="1114" height="928" alt="Screenshot 2026-04-27 at 14 24 34" src="https://github.com/user-attachments/assets/199c26a7-4712-47e6-99cf-3b40158452a6" />
<img width="1158" height="972" alt="Screenshot 2026-04-27 at 14 24 47" src="https://github.com/user-attachments/assets/1d41b783-42fc-43ae-a27a-de2bc1539034" />
<img width="1114" height="928" alt="Screenshot 2026-04-27 at 14 25 25" src="https://github.com/user-attachments/assets/40aab46b-637a-4328-b571-e81711c02f2c" />


After:

<img width="1158" height="972" alt="Screenshot 2026-04-27 at 14 24 32" src="https://github.com/user-attachments/assets/f2ae83be-f11d-43c6-b02c-bcc13b7ece2d" />
<img width="1158" height="972" alt="Screenshot 2026-04-27 at 14 25 19" src="https://github.com/user-attachments/assets/93ebe675-9683-4891-936a-b57b9d17e817" />
<img width="1158" height="972" alt="Screenshot 2026-04-27 at 14 26 21" src="https://github.com/user-attachments/assets/16df6b86-d982-4472-a4a6-243e23adf821" />

Video:

Uploading Screen Recording 2026-04-27 at 14.29.42.mov…

