### PR TITLE
Feat/adds sorting options to continue watching

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6316,6 +6316,19 @@
         "ios"
       ]
     },
+    "button_text_sort_remaining": {
+      "default": "Remaining",
+      "description": "Text for the button that allows users to sort shows by the number of remaining episodes or movies to watch.",
+      "exclude": []
+    },
+    "button_label_sort_remaining": {
+      "default": "Sort by remaining episodes or movies",
+      "description": "Aria-label for the button that allows users to sort shows by the number of remaining episodes or movies to watch.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "text_about_user": {
       "default": "About {username}",
       "description": "Text for the section that shows a specific users 'about me' description.",

--- a/projects/client/src/lib/components/icons/RemainingIcon.svelte
+++ b/projects/client/src/lib/components/icons/RemainingIcon.svelte
@@ -1,0 +1,11 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 -960 960 960"
+  fill="currentColor"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M160-240v-80h320v80H160Zm0-160v-80h320v80H160Zm0-160v-80h320v80H160ZM600-120v-480l320 240-320 240Z"
+  />
+</svg>

--- a/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.spec.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.spec.ts
@@ -5,25 +5,31 @@ import { interleaveMediaProgress } from './interleaveMediaProgress.ts';
 
 const createContinueMovie = (
   key: string,
-  airDate: Date,
+  airDate: Date = new Date('2020-01-01'),
   lastWatchedAt: Date | null = null,
-): MovieProgressEntry => ({
-  key,
-  airDate,
-  lastWatchedAt,
-} as MovieProgressEntry);
+  effectiveReleaseDate: Date = airDate,
+): MovieProgressEntry =>
+  ({
+    key,
+    airDate,
+    lastWatchedAt,
+    effectiveReleaseDate,
+  }) as MovieProgressEntry;
 
 const createContinueEpisode = (
   key: string,
-  showAirDate: Date,
+  showAirDate: Date = new Date('2020-01-01'),
   lastWatchedAt: Date | null = null,
-): UpNextEntry => ({
-  key,
-  show: {
-    airDate: showAirDate,
-  },
-  lastWatchedAt,
-} as UpNextEntry);
+  effectiveReleaseDate: Date = showAirDate,
+  remaining = 1,
+): UpNextEntry =>
+  ({
+    key,
+    show: { airDate: showAirDate },
+    lastWatchedAt,
+    effectiveReleaseDate,
+    remaining,
+  }) as UpNextEntry;
 
 describe('interleaveMediaProgress', () => {
   describe('with empty arrays', () => {
@@ -102,6 +108,135 @@ describe('interleaveMediaProgress', () => {
       expect(result[1]!.key).toBe('episode-2');
       expect(result[2]!.key).toBe('movie-1');
       expect(result[3]!.key).toBe('episode-1');
+    });
+  });
+
+  describe('sorting by released', () => {
+    it('should interleave by effectiveReleaseDate descending', () => {
+      const episodes = [
+        createContinueEpisode(
+          'episode-2',
+          new Date('2020-01-01'),
+          null,
+          new Date('2024-03-01'),
+        ),
+        createContinueEpisode(
+          'episode-1',
+          new Date('2020-01-01'),
+          null,
+          new Date('2024-01-01'),
+        ),
+      ];
+      const movies = [
+        createContinueMovie(
+          'movie-a',
+          new Date('2020-01-01'),
+          null,
+          new Date('2024-04-01'),
+        ),
+        createContinueMovie(
+          'movie-b',
+          new Date('2020-01-01'),
+          null,
+          new Date('2024-02-01'),
+        ),
+      ];
+
+      const result = interleaveMediaProgress({
+        episodes,
+        movies,
+        sortBy: 'released',
+        sortHow: 'desc',
+      });
+
+      expect(result.map((e) => e.key)).toEqual([
+        'movie-a',
+        'episode-2',
+        'movie-b',
+        'episode-1',
+      ]);
+    });
+
+    it('should interleave by effectiveReleaseDate ascending', () => {
+      const episodes = [
+        createContinueEpisode(
+          'episode-1',
+          new Date('2020-01-01'),
+          null,
+          new Date('2024-01-01'),
+        ),
+        createContinueEpisode(
+          'episode-2',
+          new Date('2020-01-01'),
+          null,
+          new Date('2024-03-01'),
+        ),
+      ];
+      const movies = [
+        createContinueMovie(
+          'movie-a',
+          new Date('2020-01-01'),
+          null,
+          new Date('2023-12-01'),
+        ),
+        createContinueMovie(
+          'movie-b',
+          new Date('2020-01-01'),
+          null,
+          new Date('2024-02-01'),
+        ),
+      ];
+
+      const result = interleaveMediaProgress({
+        episodes,
+        movies,
+        sortBy: 'released',
+        sortHow: 'asc',
+      });
+
+      expect(result.map((e) => e.key)).toEqual([
+        'movie-a',
+        'episode-1',
+        'movie-b',
+        'episode-2',
+      ]);
+    });
+  });
+
+  describe('sorting by remaining', () => {
+    it('should place all movies before episodes since movies have no remaining', () => {
+      const episodes = [
+        createContinueEpisode(
+          'episode-1',
+          new Date('2020-01-01'),
+          null,
+          undefined,
+          5,
+        ),
+        createContinueEpisode(
+          'episode-2',
+          new Date('2020-01-01'),
+          null,
+          undefined,
+          2,
+        ),
+      ];
+      const movies = [
+        createContinueMovie('movie-1'),
+        createContinueMovie('movie-2'),
+      ];
+
+      const result = interleaveMediaProgress({
+        episodes,
+        movies,
+        sortBy: 'remaining',
+        sortHow: 'asc',
+      });
+
+      expect(result[0]!.key).toBe('movie-1');
+      expect(result[1]!.key).toBe('movie-2');
+      expect(result[2]!.key).toBe('episode-1');
+      expect(result[3]!.key).toBe('episode-2');
     });
   });
 });

--- a/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.ts
@@ -1,30 +1,74 @@
+import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts';
+import type { SortDirection } from '$lib/sections/lists/user/models/SortDirection.ts';
 import type { MovieProgressEntry } from '../../../models/MovieProgressEntry.ts';
 import type { UpNextEntry } from '../../../models/UpNextEntry.ts';
+import { sortMovieProgress } from './sortMovieProgress.ts';
 
 type SortMediaProgressProps = {
   episodes: UpNextEntry[];
   movies: MovieProgressEntry[];
+  sortBy?: UpNextSortBy;
+  sortHow?: SortDirection;
 };
 
-export function interleaveMediaProgress(props: SortMediaProgressProps) {
-  const { episodes, movies } = props;
+function getComparableValues(
+  movie: MovieProgressEntry,
+  episode: UpNextEntry,
+  sortBy: UpNextSortBy,
+): [number, number] {
+  switch (sortBy) {
+    case 'released':
+      return [
+        movie.effectiveReleaseDate.getTime(),
+        episode.effectiveReleaseDate.getTime(),
+      ];
+    case 'remaining':
+      return [0, episode.remaining];
+  }
+}
+
+function shouldInsertBefore(
+  movie: MovieProgressEntry,
+  episode: UpNextEntry,
+  sortBy: UpNextSortBy | undefined,
+  direction: number,
+): boolean {
+  if (!sortBy) {
+    const date = movie.lastWatchedAt;
+    if (!date) return false;
+    const episodeDate = episode.lastWatchedAt;
+    return direction === 1
+      ? !episodeDate || date < episodeDate
+      : !episodeDate || date > episodeDate;
+  }
+
+  const [movieValue, episodeValue] = getComparableValues(
+    movie,
+    episode,
+    sortBy,
+  );
+  return (movieValue - episodeValue) * direction < 0;
+}
+
+export function interleaveMediaProgress(
+  { episodes, movies, sortBy, sortHow = 'desc' }: SortMediaProgressProps,
+) {
+  const sortedMovies = sortBy
+    ? sortMovieProgress({ entries: movies, sortBy, sortHow })
+    : movies;
+
+  const direction = sortHow === 'asc' ? 1 : -1;
 
   const { result, insertedKeys } = episodes.reduce(
     (acc, episode) => {
-      const episodeDate = episode.lastWatchedAt;
+      const moviesToInsert = sortedMovies.filter((movie) => {
+        if (acc.insertedKeys.has(movie.key)) return false;
 
-      const moviesToInsert = movies
-        .filter((movie) => {
-          const date = movie.lastWatchedAt;
-          if (acc.insertedKeys.has(movie.key) || !date) {
-            return false;
-          }
+        const insert = shouldInsertBefore(movie, episode, sortBy, direction);
 
-          const isMoreRecent = !episodeDate || date > episodeDate;
-          isMoreRecent && acc.insertedKeys.add(movie.key);
-
-          return isMoreRecent;
-        });
+        if (insert) acc.insertedKeys.add(movie.key);
+        return insert;
+      });
 
       return {
         result: [...acc.result, ...moviesToInsert, episode],
@@ -37,9 +81,9 @@ export function interleaveMediaProgress(props: SortMediaProgressProps) {
     },
   );
 
-  const remainingMovies = movies.filter((movie) => {
-    return !insertedKeys.has(movie.key);
-  });
+  const remainingMovies = sortedMovies.filter((movie) =>
+    !insertedKeys.has(movie.key)
+  );
 
   return [...result, ...remainingMovies];
 }

--- a/projects/client/src/lib/requests/queries/sync/_internal/sortMovieProgress.spec.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/sortMovieProgress.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import type { MovieProgressEntry } from '../../../models/MovieProgressEntry.ts';
+import { sortMovieProgress } from './sortMovieProgress.ts';
+
+const createMovie = (
+  key: string,
+  {
+    lastWatchedAt = null,
+    effectiveReleaseDate = new Date('2020-01-01'),
+  }: {
+    lastWatchedAt?: Date | null;
+    effectiveReleaseDate?: Date;
+  } = {},
+): MovieProgressEntry =>
+  ({
+    key,
+    lastWatchedAt,
+    effectiveReleaseDate,
+  }) as MovieProgressEntry;
+
+describe('sortMovieProgress', () => {
+  describe('default sort (no sortBy)', () => {
+    it('should sort by lastWatchedAt descending by default', () => {
+      const entries = [
+        createMovie('a', { lastWatchedAt: new Date('2024-01-01') }),
+        createMovie('b', { lastWatchedAt: new Date('2024-01-03') }),
+        createMovie('c', { lastWatchedAt: new Date('2024-01-02') }),
+      ];
+
+      const result = sortMovieProgress({ entries });
+
+      expect(result.map((e) => e.key)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('should sort by lastWatchedAt ascending when sortHow is asc', () => {
+      const entries = [
+        createMovie('a', { lastWatchedAt: new Date('2024-01-03') }),
+        createMovie('b', { lastWatchedAt: new Date('2024-01-01') }),
+        createMovie('c', { lastWatchedAt: new Date('2024-01-02') }),
+      ];
+
+      const result = sortMovieProgress({ entries, sortHow: 'asc' });
+
+      expect(result.map((e) => e.key)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('should place entries with no lastWatchedAt last when descending', () => {
+      const entries = [
+        createMovie('a', { lastWatchedAt: null }),
+        createMovie('b', { lastWatchedAt: new Date('2024-01-01') }),
+      ];
+
+      const result = sortMovieProgress({ entries });
+
+      expect(result.map((e) => e.key)).toEqual(['b', 'a']);
+    });
+  });
+
+  describe('sortBy released', () => {
+    it('should sort by effectiveReleaseDate descending by default', () => {
+      const entries = [
+        createMovie('a', { effectiveReleaseDate: new Date('2023-01-01') }),
+        createMovie('b', { effectiveReleaseDate: new Date('2023-03-01') }),
+        createMovie('c', { effectiveReleaseDate: new Date('2023-02-01') }),
+      ];
+
+      const result = sortMovieProgress({ entries, sortBy: 'released' });
+
+      expect(result.map((e) => e.key)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('should sort by effectiveReleaseDate ascending when sortHow is asc', () => {
+      const entries = [
+        createMovie('a', { effectiveReleaseDate: new Date('2023-03-01') }),
+        createMovie('b', { effectiveReleaseDate: new Date('2023-01-01') }),
+        createMovie('c', { effectiveReleaseDate: new Date('2023-02-01') }),
+      ];
+
+      const result = sortMovieProgress({
+        entries,
+        sortBy: 'released',
+        sortHow: 'asc',
+      });
+
+      expect(result.map((e) => e.key)).toEqual(['b', 'c', 'a']);
+    });
+  });
+
+  describe('sortBy remaining', () => {
+    it('should return entries in stable order since movies have no remaining', () => {
+      const entries = [
+        createMovie('a', { lastWatchedAt: new Date('2024-01-01') }),
+        createMovie('b', { lastWatchedAt: new Date('2024-01-02') }),
+      ];
+
+      const result = sortMovieProgress({ entries, sortBy: 'remaining' });
+
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/projects/client/src/lib/requests/queries/sync/_internal/sortMovieProgress.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/sortMovieProgress.ts
@@ -1,0 +1,33 @@
+import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts';
+import type { SortDirection } from '$lib/sections/lists/user/models/SortDirection.ts';
+import type { MovieProgressEntry } from '../../../models/MovieProgressEntry.ts';
+
+type SortMovieProgressProps = {
+  entries: ReadonlyArray<MovieProgressEntry>;
+  sortBy?: UpNextSortBy;
+  sortHow?: SortDirection;
+};
+
+function getSortValue(
+  entry: MovieProgressEntry,
+  sortBy: UpNextSortBy | undefined,
+): number {
+  switch (sortBy) {
+    case 'released':
+      return entry.effectiveReleaseDate.getTime();
+    case 'remaining':
+      return 0;
+    default:
+      return entry.lastWatchedAt?.getTime() ?? 0;
+  }
+}
+
+export function sortMovieProgress(
+  { entries, sortBy, sortHow = 'desc' }: SortMovieProgressProps,
+): MovieProgressEntry[] {
+  const direction = sortHow === 'asc' ? 1 : -1;
+
+  return entries.toSorted(
+    (a, b) => (getSortValue(a, sortBy) - getSortValue(b, sortBy)) * direction,
+  );
+}

--- a/projects/client/src/lib/requests/queries/sync/mediaProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/mediaProgressQuery.ts
@@ -4,6 +4,8 @@ import { type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts';
+import type { SortDirection } from '$lib/sections/lists/user/models/SortDirection.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import z from 'zod';
 import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
@@ -18,7 +20,14 @@ import {
 } from './movieProgressQuery.ts';
 import { mapUpNextResponse, upNextNitroRequest } from './upNextNitroQuery.ts';
 
-type MediaProgressParams = PaginationParams & ApiParams & FilterParams;
+type MediaProgressParams =
+  & PaginationParams
+  & ApiParams
+  & FilterParams
+  & {
+    sortBy?: UpNextSortBy;
+    sortHow?: SortDirection;
+  };
 
 const MediaProgressSchema = z.union([
   UpNextEntrySchema,
@@ -42,6 +51,8 @@ export const mediaProgressQuery = defineInfiniteQuery({
   ) => [
     params.page,
     params.limit,
+    params.sortBy,
+    params.sortHow,
     ...getGlobalFilterDependencies(params.filter),
   ],
   request: (params) =>
@@ -49,7 +60,7 @@ export const mediaProgressQuery = defineInfiniteQuery({
       upNextNitroRequest(params),
       movieProgressRequest(params),
     ]),
-  mapper: ([upNextResponse, movieProgressResponse]) => {
+  mapper: ([upNextResponse, movieProgressResponse], { sortBy, sortHow }) => {
     const episodes = upNextResponse.body.map(mapUpNextResponse);
 
     const movies = movieProgressResponse.body
@@ -60,6 +71,8 @@ export const mediaProgressQuery = defineInfiniteQuery({
       entries: interleaveMediaProgress({
         episodes,
         movies,
+        sortBy,
+        sortHow,
       }),
       page: extractPageMeta(upNextResponse.headers),
     };

--- a/projects/client/src/lib/requests/queries/sync/movieProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/movieProgressQuery.ts
@@ -4,6 +4,8 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts';
+import type { SortDirection } from '$lib/sections/lists/user/models/SortDirection.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { MovieProgressResponse } from '@trakt/api';
 import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
@@ -14,11 +16,16 @@ import {
   MovieProgressSchema,
 } from '../../models/MovieProgressEntry.ts';
 import { isValidProgressMovie } from './_internal/isValidProgressMovie.ts';
+import { sortMovieProgress } from './_internal/sortMovieProgress.ts';
 
 type MovieProgressParams =
   & PaginationParams
   & ApiParams
-  & FilterParams;
+  & FilterParams
+  & {
+    sortBy?: UpNextSortBy;
+    sortHow?: SortDirection;
+  };
 
 export const mapToMovieProgressEntry = (
   response: MovieProgressResponse,
@@ -65,14 +72,18 @@ export const movieProgressQuery = defineInfiniteQuery({
   ) => [
     params.page,
     params.limit,
+    params.sortBy,
+    params.sortHow,
     ...getGlobalFilterDependencies(params.filter),
   ],
   request: movieProgressRequest,
-  mapper: (response) => {
+  mapper: (response, { sortBy, sortHow }) => {
+    const entries = response.body
+      .map(mapToMovieProgressEntry)
+      .filter(isValidProgressMovie);
+
     return {
-      entries: response.body
-        .map(mapToMovieProgressEntry)
-        .filter(isValidProgressMovie),
+      entries: sortMovieProgress({ entries, sortBy, sortHow }),
       page: extractPageMeta(response.headers),
     };
   },

--- a/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
@@ -4,6 +4,8 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts';
+import type { SortDirection } from '$lib/sections/lists/user/models/SortDirection.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { type UpNextResponse } from '@trakt/api';
 import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
@@ -19,7 +21,11 @@ import {
 type UpNextParams =
   & PaginationParams
   & ApiParams
-  & FilterParams;
+  & FilterParams
+  & {
+    sortBy?: UpNextSortBy;
+    sortHow?: SortDirection;
+  };
 
 export function mapUpNextResponse(item: UpNextResponse): UpNextEntry {
   const show = mapToShowEntry(item.show);
@@ -38,7 +44,7 @@ export function mapUpNextResponse(item: UpNextResponse): UpNextEntry {
 export const upNextNitroRequest = (
   params: UpNextParams,
 ) => {
-  const { fetch, limit, page, filter } = params;
+  const { fetch, limit, page, filter, sortBy, sortHow } = params;
 
   return api({ fetch })
     .sync
@@ -50,6 +56,8 @@ export const upNextNitroRequest = (
         limit,
         intent: 'continue',
         ...filter,
+        ...(sortBy ? { sort_by: sortBy } : {}),
+        ...(sortHow ? { sort_how: sortHow } : {}),
       },
     });
 };
@@ -68,6 +76,8 @@ export const upNextNitroQuery = defineInfiniteQuery({
   ) => [
     params.page,
     params.limit,
+    params.sortBy,
+    params.sortHow,
     ...getGlobalFilterDependencies(params.filter),
   ],
   request: upNextNitroRequest,

--- a/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/progress/UpNextPaginatedList.svelte
@@ -2,10 +2,13 @@
   import { useDiscover } from "$lib/features/discover/useDiscover";
   import { useFilter } from "$lib/features/filters/useFilter";
   import DrilledMediaList from "$lib/sections/lists/drilldown/DrilledMediaList.svelte";
+  import type { UpNextSortProps } from "$lib/sections/lists/progress/UpNextSortProps";
   import { useUpNextList } from "$lib/sections/lists/progress/useUpNextList";
   import { useStablePaginated } from "$lib/sections/lists/stores/useStablePaginated";
   import DropNotePromptProvider from "$lib/sections/media-actions/drop/DropNotePromptProvider.svelte";
   import ContinueWatchingItem from "./_internal/ContinueWatchingItem.svelte";
+
+  const { sortBy, sortHow }: UpNextSortProps = $props();
 
   const { mode } = useDiscover();
   const { filterMap } = useFilter();
@@ -20,7 +23,7 @@
     useList={(listParams) =>
       useStablePaginated({
         ...listParams,
-        useList: useUpNextList,
+        useList: (params) => useUpNextList({ ...params, sortBy, sortHow }),
         compareFn: (l, r) => {
           const isComparingEpisodes = "show" in l && "show" in r;
           return isComparingEpisodes ? l.show.id === r.show.id : l.id === r.id;

--- a/projects/client/src/lib/sections/lists/progress/UpNextSortBy.ts
+++ b/projects/client/src/lib/sections/lists/progress/UpNextSortBy.ts
@@ -1,0 +1,1 @@
+export type UpNextSortBy = 'released' | 'remaining';

--- a/projects/client/src/lib/sections/lists/progress/UpNextSortProps.ts
+++ b/projects/client/src/lib/sections/lists/progress/UpNextSortProps.ts
@@ -1,0 +1,7 @@
+import type { SortDirection } from '$lib/sections/lists/user/models/SortDirection.ts';
+import type { UpNextSortBy } from './UpNextSortBy.ts';
+
+export type UpNextSortProps = {
+  sortBy?: UpNextSortBy;
+  sortHow?: SortDirection;
+};

--- a/projects/client/src/lib/sections/lists/progress/useUpNextList.ts
+++ b/projects/client/src/lib/sections/lists/progress/useUpNextList.ts
@@ -13,13 +13,17 @@ import {
 import {
   upNextNitroQuery,
 } from '$lib/requests/queries/sync/upNextNitroQuery.ts';
+import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts';
 import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
+import type { SortDirection } from '$lib/sections/lists/user/models/SortDirection.ts';
 
 export type UpNextStoreProps =
   & PaginationParams
   & FilterParams
   & {
     type: DiscoverMode;
+    sortBy?: UpNextSortBy;
+    sortHow?: SortDirection;
   };
 
 type ProgressEntry = UpNextEntry | MovieProgressEntry;

--- a/projects/client/src/lib/sections/lists/progress/useUpNextSorting.ts
+++ b/projects/client/src/lib/sections/lists/progress/useUpNextSorting.ts
@@ -1,0 +1,84 @@
+import * as m from '$lib/features/i18n/messages.ts';
+import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts';
+import type { ListUrlBuilder } from '$lib/sections/lists/user/models/ListUrlBuilder.ts';
+import type { SortDirection } from '$lib/sections/lists/user/models/SortDirection.ts';
+import type { Sorting } from '$lib/sections/lists/user/models/Sorting.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
+import { BehaviorSubject, map, type Observable } from 'rxjs';
+
+const upNextSortOptions: Sorting<UpNextSortBy>[] = [
+  {
+    value: undefined,
+    text: m.button_text_sort_default,
+    label: m.button_label_sort_default,
+  },
+  {
+    value: 'released',
+    text: m.button_text_sort_release_date,
+    label: m.button_label_sort_release_date,
+  },
+  {
+    value: 'remaining',
+    text: m.button_text_sort_remaining,
+    label: m.button_label_sort_remaining,
+  },
+];
+
+type UpNextSorting = {
+  current: Observable<{
+    sorting: Sorting<UpNextSortBy>;
+    sortHow: SortDirection;
+  }>;
+  options: Sorting<UpNextSortBy>[];
+  update: (params: Record<string, string>) => void;
+  urlBuilder: ListUrlBuilder<UpNextSortBy>;
+};
+
+function mapToDirection(value: string | Nil): SortDirection | undefined {
+  return value === 'asc' || value === 'desc' ? value : undefined;
+}
+
+function mapToSortBy(value: string | Nil): UpNextSortBy | undefined {
+  return upNextSortOptions.find((option) => option.value === value)?.value;
+}
+
+export function useUpNextSorting(user: string): UpNextSorting {
+  const params = new BehaviorSubject<Record<string, string | null>>({
+    sort_by: null,
+    sort_how: null,
+  });
+
+  function update(newParams: Record<string, string>) {
+    params.next({ ...newParams });
+  }
+
+  return {
+    update,
+    options: upNextSortOptions,
+    current: params.pipe(
+      map(($params) => {
+        const sortBy = mapToSortBy($params.sort_by);
+        const sortHow = mapToDirection($params.sort_how);
+
+        const sorting = upNextSortOptions.find(
+          (option) => option.value === sortBy,
+        );
+
+        return {
+          sorting: assertDefined(
+            sorting,
+            'Expected valid up-next sorting option',
+          ),
+          sortHow: sortHow ?? 'desc',
+        };
+      }),
+    ),
+    urlBuilder: ({ sortBy, sortHow }) => {
+      return UrlBuilder.progress(user, {
+        ...(sortBy ? { sort_by: sortBy } : {}),
+        ...(sortHow ? { sort_how: sortHow } : {}),
+      });
+    },
+  };
+}

--- a/projects/client/src/lib/sections/lists/user/ListSortActions.svelte
+++ b/projects/client/src/lib/sections/lists/user/ListSortActions.svelte
@@ -1,11 +1,13 @@
-<script lang="ts">
+<script lang="ts" generics="T extends SortBy | UpNextSortBy">
   import { page } from "$app/state";
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
   import SortIcon from "$lib/components/icons/SortIcon.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import type { UpNextSortBy } from "$lib/sections/lists/progress/UpNextSortBy";
   import { writable } from "$lib/utils/store/WritableSubject.ts";
   import SortOptionsDrawer from "./_internal/SortOptionsDrawer.svelte";
   import type { ListUrlBuilder } from "./models/ListUrlBuilder";
+  import type { SortBy } from "./models/SortBy";
   import type { SortDirection } from "./models/SortDirection";
   import type { Sorting } from "./models/Sorting";
 
@@ -16,9 +18,9 @@
     onUpdate,
     disabled,
   }: {
-    options: Sorting[];
-    current: { sortHow: SortDirection; sorting: Sorting };
-    urlBuilder: ListUrlBuilder;
+    options: Sorting<T>[];
+    current: { sortHow: SortDirection; sorting: Sorting<T> };
+    urlBuilder: ListUrlBuilder<T>;
     onUpdate: (params: Record<string, string>) => void;
     disabled?: boolean;
   } = $props();

--- a/projects/client/src/lib/sections/lists/user/_internal/SortIcon.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SortIcon.svelte
@@ -2,14 +2,17 @@
   import CalendarIcon from "$lib/components/icons/CalendarIcon.svelte";
   import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
   import RatingIcon from "$lib/components/icons/RatingIcon.svelte";
+  import RemainingIcon from "$lib/components/icons/RemainingIcon.svelte";
   import SortAlphaIcon from "$lib/components/icons/SortAlphaIcon.svelte";
   import StarIcon from "$lib/components/icons/StarIcon.svelte";
+  import type { UpNextSortBy } from "$lib/sections/lists/progress/UpNextSortBy";
   import type { SortBy } from "../models/SortBy";
 
   const {
     sortBy,
     variant = "default",
-  }: { sortBy: SortBy; variant?: "default" | "value" } = $props();
+  }: { sortBy: SortBy | UpNextSortBy; variant?: "default" | "value" } =
+    $props();
 </script>
 
 {#if sortBy === "percentage" && variant === "default"}
@@ -28,4 +31,8 @@
 
 {#if sortBy === "title"}
   <SortAlphaIcon />
+{/if}
+
+{#if sortBy === "remaining"}
+  <RemainingIcon />
 {/if}

--- a/projects/client/src/lib/sections/lists/user/_internal/SortOptionsDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SortOptionsDrawer.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang="ts" generics="T extends SortBy | UpNextSortBy">
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
   import Drawer from "$lib/components/drawer/Drawer.svelte";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
@@ -7,7 +7,9 @@
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
   import { m } from "$lib/features/i18n/messages";
+  import type { UpNextSortBy } from "$lib/sections/lists/progress/UpNextSortBy";
   import type { ListUrlBuilder } from "../models/ListUrlBuilder";
+  import type { SortBy } from "../models/SortBy";
   import type { SortDirection } from "../models/SortDirection";
   import type { Sorting } from "../models/Sorting";
   import SortIcon from "./SortIcon.svelte";
@@ -18,10 +20,10 @@
     current,
     urlBuilder,
   }: {
-    options: Sorting[];
+    options: Sorting<T>[];
     onClose: () => void;
-    current: { sortHow: SortDirection; sorting: Sorting };
-    urlBuilder: ListUrlBuilder;
+    current: { sortHow: SortDirection; sorting: Sorting<T> };
+    urlBuilder: ListUrlBuilder<T>;
   } = $props();
 
   const { track } = useTrack(AnalyticsEvent.ListSort);

--- a/projects/client/src/lib/sections/lists/user/models/ListUrlBuilder.ts
+++ b/projects/client/src/lib/sections/lists/user/models/ListUrlBuilder.ts
@@ -1,9 +1,11 @@
 import type { SortBy } from './SortBy.ts';
 import type { SortDirection } from './SortDirection.ts';
 
-export type ListUrlBuilderParams = {
-  sortBy?: SortBy;
+export type ListUrlBuilderParams<T = SortBy> = {
+  sortBy?: T;
   sortHow?: SortDirection;
 };
 
-export type ListUrlBuilder = (params: ListUrlBuilderParams) => string;
+export type ListUrlBuilder<T = SortBy> = (
+  params: ListUrlBuilderParams<T>,
+) => string;

--- a/projects/client/src/lib/sections/lists/user/models/Sorting.ts
+++ b/projects/client/src/lib/sections/lists/user/models/Sorting.ts
@@ -1,7 +1,7 @@
 import type { SortBy } from './SortBy.ts';
 
-export type Sorting = {
+export type Sorting<T = SortBy> = {
   text: () => string;
   label: () => string;
-  value: SortBy | undefined;
+  value: T | undefined;
 };

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -166,7 +166,8 @@ export const UrlBuilder = {
       return '/social/activity';
     },
   },
-  progress: (user: string) => `/users/${user}/progress`,
+  progress: (user: string, params: Record<string, string | number> = {}) =>
+    `/users/${user}/progress${buildParamString(sanitizeParams(params))}`,
   startWatching: (user: string, params: Record<string, string | number> = {}) =>
     `/users/${user}/start-watching${buildParamString(sanitizeParams(params))}`,
 

--- a/projects/client/src/routes/users/[user]/progress/+page.svelte
+++ b/projects/client/src/routes/users/[user]/progress/+page.svelte
@@ -1,14 +1,24 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages.ts";
 
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import UpNextPaginatedList from "$lib/sections/lists/progress/UpNextPaginatedList.svelte";
+  import { useUpNextSorting } from "$lib/sections/lists/progress/useUpNextSorting";
+  import ListSortActions from "$lib/sections/lists/user/ListSortActions.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   const { current } = useDiscover();
+
+  const {
+    current: currentSort,
+    update,
+    options,
+    urlBuilder,
+  } = useUpNextSorting(page.params.user ?? "me");
 </script>
 
 <TraktPage
@@ -21,7 +31,19 @@
   <NavbarStateSetter
     hasFilters
     header={{ title: m.list_title_up_next(), metaInfo: $current.text() }}
-  />
+  >
+    {#snippet sortActions()}
+      <ListSortActions
+        {options}
+        {urlBuilder}
+        current={$currentSort}
+        onUpdate={update}
+      />
+    {/snippet}
+  </NavbarStateSetter>
 
-  <UpNextPaginatedList />
+  <UpNextPaginatedList
+    sortBy={$currentSort.sorting?.value}
+    sortHow={$currentSort.sortHow}
+  />
 </TraktPage>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2203
- Adds support for sorting in the `continue watching` list.
  - To be followed up by sorting in the progress list (#2204)
- Icon to be followed up on also.
- For movie progress, this is a half-solution (until we move that also to the same endpoint).
  - Under the assumption that users will have more shows than paused movies.
  - Movie sorting is handled client side and interleaved (similar to how it was already interleaving, but now also respects the sort params).

## 👀 Example 👀

https://github.com/user-attachments/assets/0ceba72f-6a00-4c54-9fab-61c20425de56

