### PR TITLE
fix: only one popup menu can be opened at a time

### DIFF
--- a/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
+++ b/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
@@ -20,6 +20,7 @@
   use:disableTransitionOn={"touch"}
   use:portalTrigger
   aria-haspopup="true"
+  aria-expanded={$isOpened}
   class="trakt-popup-menu-button"
   data-mode={mode}
   data-size={size}

--- a/projects/client/src/lib/features/portal/usePortal.spec.ts
+++ b/projects/client/src/lib/features/portal/usePortal.spec.ts
@@ -29,7 +29,7 @@ describe('action: usePortal', () => {
     component.destroy();
   });
 
-  it('should add a single underlay', async () => {
+  it('should add a single underlay, even after multiple clicks', async () => {
     const targetNode = document.createElement('div');
     const popupNode = document.createElement('div');
 
@@ -38,6 +38,9 @@ describe('action: usePortal', () => {
     const { portalTrigger } = usePortal();
 
     const component = await renderStore(() => portalTrigger(targetNode));
+    // Click three times to open/close/open
+    targetNode.dispatchEvent(new Event('click'));
+    targetNode.dispatchEvent(new Event('click'));
     targetNode.dispatchEvent(new Event('click'));
 
     const underlays = document.querySelectorAll(`#${PORTAL_UNDERLAY_ID}`);
@@ -45,6 +48,10 @@ describe('action: usePortal', () => {
     const underlay = assertDefined(underlays[0]);
     expect(document.body.contains(underlay)).toBe(true);
 
+    // Clicking again destroys the underlay
+    targetNode.dispatchEvent(new Event('click'));
+    const underlays2 = document.querySelectorAll(`#${PORTAL_UNDERLAY_ID}`);
+    expect(underlays2).toHaveLength(0);
     component.destroy();
   });
 

--- a/projects/client/src/lib/features/portal/usePortal.ts
+++ b/projects/client/src/lib/features/portal/usePortal.ts
@@ -55,6 +55,14 @@ export function usePortal(props?: PortalProps) {
     isPopupOpen.next(true);
   };
 
+  const toggleHandler = (target: HTMLElement) => {
+    if (isPopupOpen.value) {
+      closeHandler();
+    } else {
+      openHandler(target);
+    }
+  };
+
   const portalTrigger = (targetNode: HTMLElement) => {
     const closeAroundTarget = (event: Event) => {
       const isPersistent = props?.type === 'persistent';
@@ -64,7 +72,7 @@ export function usePortal(props?: PortalProps) {
 
       closeHandler();
     };
-    const openAroundTarget = () => openHandler(targetNode);
+    const openAroundTarget = () => toggleHandler(targetNode);
 
     onMount(() => {
       clickOutside(targetNode);

--- a/projects/client/src/lib/features/portal/usePortal.ts
+++ b/projects/client/src/lib/features/portal/usePortal.ts
@@ -73,18 +73,18 @@ export function usePortal(props?: PortalProps) {
 
       closeHandler();
     };
-    const openAroundTarget = () => toggleHandler(targetNode);
+    const toggleAroundTarget = () => toggleHandler(targetNode);
 
     onMount(() => {
       clickOutside(targetNode);
       targetNode.addEventListener('clickoutside', closeAroundTarget);
-      targetNode.addEventListener('click', openAroundTarget);
+      targetNode.addEventListener('click', toggleAroundTarget);
     });
 
     return {
       destroy() {
         targetNode.removeEventListener('clickoutside', closeAroundTarget);
-        targetNode.removeEventListener('click', openAroundTarget);
+        targetNode.removeEventListener('click', toggleAroundTarget);
         removeHelpers(null);
         popupContainer.value?.remove();
       },

--- a/projects/client/src/lib/features/portal/usePortal.ts
+++ b/projects/client/src/lib/features/portal/usePortal.ts
@@ -58,9 +58,10 @@ export function usePortal(props?: PortalProps) {
   const toggleHandler = (target: HTMLElement) => {
     if (isPopupOpen.value) {
       closeHandler();
-    } else {
-      openHandler(target);
+      return;
     }
+
+    openHandler(target);
   };
 
   const portalTrigger = (targetNode: HTMLElement) => {


### PR DESCRIPTION
Fixes https://github.com/trakt/trakt-web/issues/2206

Changes popup behavior so that clicking the button while opened will close the button rather than recreating a clone/underlay.

Also adds `aria-expanded` prop to the button. This will help people using screen readers to know the state of the button.

Lastly, changes the test to check this state.

<img width="571" height="372" alt="image" src="https://github.com/user-attachments/assets/44b79b28-2c2e-44fd-ada0-d9aeaf5bcc11" />
<!--
## Scene Setting: A Clear Description
## Show, Don't Tell: Screenshots and Videos

A picture is worth a thousand lines of code, they say. Include screenshots or
videos that showcase your changes in action. Capture the essence of your
contribution, the visual flair of your code, and the impact it has on the user
experience. Think of it as a film trailer, offering a glimpse into the cinematic
world you've created.

## Testing: The Dress Rehearsal

Before the grand premiere, ensure your code has undergone rigorous testing.
Write unit tests that validate the functionality of your changes, ensuring they
perform flawlessly under the spotlight. Think of it as a dress rehearsal, where
every line of code is scrutinized and perfected before the final performance.

## Code Review: The Critic's Eye

Be prepared to address feedback from the project maintainers and other
contributors. Embrace their insights, for they are the seasoned critics of the
trakt-web theater. Engage in constructive dialogue, refine your code based on
their suggestions, and together we'll ensure your contribution is a cinematic
masterpiece.

## Other Considerations:

- **Coding Standards:** Adhere to the project's coding standards, ensuring your
  code is as elegant as a film score and as readable as a well-written
  screenplay.
- **Commit Messages:** Craft clear and concise commit messages that explain the
  purpose of each change, like a director's notes guiding the audience through
  the film's narrative. We use [Conventional Commits](https://www.conventionalcommits.org/), so please follow this specification.
- **Documentation:** If your changes affect the documentation, update it
  accordingly, ensuring it remains as informative as a film encyclopedia.

## Conventional Commit Cheat-sheet:

- **feat:** A new feature
- **fix:** A bug fix
- **docs:** Documentation only changes
- **style:** Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- **refactor:** A code change that neither fixes a bug nor adds a feature
- **perf:** A code change that improves performance
- **test:** Adding missing tests or correcting existing tests
- **chore:** Changes to the build process or auxiliary tools and libraries such as documentation generation

By following these guidelines, you'll ensure your pull request is a cinematic
triumph, a contribution worthy of a place in the trakt-web hall of fame. Now,
let the show begin!
-->

## Pull Request Checklist

Before you dim the lights and raise the curtain on your cinematic masterpiece,
make sure your pull request has passed these critical checks:

- [x] **Clear and Concise Title:** Does your title shine a spotlight on the
      essence of your changes?
- [x] **Detailed Description:** Have you set the stage with a compelling
      narrative that explains the "why" and "how" of your changes?
- [x] **Screenshots/Videos:** Have you captured the magic with visual evidence
      that showcases your changes in action?
- [x] **Tests:** Has your code undergone a rigorous dress rehearsal with unit
      tests to ensure it performs flawlessly under pressure?
- [x] **Coding Standards:** Does your code adhere to the project's style guide,
      ensuring it's as elegant as a film score?
- [x] **Commit Messages:** Are your commit messages clear and concise, guiding
      the audience through the evolution of your code?
- [x] **Documentation:** If your changes impact the script, have you updated the
      documentation accordingly?
- [x] **Code Review:** Are you prepared to embrace feedback from the discerning
      eyes of the project maintainers and fellow contributors?
