### PR TITLE
fix(settings): improve settings navigation with header, logout button…

### DIFF
--- a/projects/client/src/lib/components/buttons/logout/LogoutButton.svelte
+++ b/projects/client/src/lib/components/buttons/logout/LogoutButton.svelte
@@ -43,9 +43,11 @@
 {/if}
 
 {#if style === "action"}
-  <ActionButton {...commonProps} style="ghost">
-    <LogoutIcon />
-  </ActionButton>
+  <div class="trakt-logout-action-button">
+    <ActionButton {...commonProps} style="ghost" color="red">
+      <LogoutIcon />
+    </ActionButton>
+  </div>
 {/if}
 
 {#if style === "dropdown-item"}
@@ -56,3 +58,27 @@
     {/snippet}
   </DropdownItem>
 {/if}
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-logout-action-button {
+    --color-logout-button: var(--color-background-red);
+
+    :global(
+      .trakt-action-button[data-style="ghost"][data-variant="primary"][data-color="red"]
+    ) {
+      --color-foreground-action-button: var(--color-logout-button);
+
+      @include for-mouse {
+        &:hover {
+          background-color: color-mix(
+            in srgb,
+            var(--color-logout-button) 10%,
+            transparent
+          );
+        }
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/navbar/NavbarStateSetter.svelte
+++ b/projects/client/src/lib/sections/navbar/NavbarStateSetter.svelte
@@ -4,21 +4,21 @@
 
   const {
     actions,
-    seasonalActions,
     contextualActions,
     toastActions,
     mode,
     hasFilters,
-    sortActions,
+    showFilters,
+    headerActions,
     header,
   }: {
     actions?: Snippet;
-    seasonalActions?: Snippet;
     contextualActions?: Snippet;
     toastActions?: Snippet | Nil;
     mode?: NavbarMode;
     hasFilters?: boolean;
-    sortActions?: Snippet;
+    showFilters?: boolean;
+    headerActions?: Snippet;
     header?: {
       title: string;
       metaInfo?: string | Snippet;
@@ -31,10 +31,10 @@
   $effect(() => {
     set({
       actions,
-      seasonalActions,
       contextualActions,
       hasFilters,
-      sortActions,
+      showFilters,
+      headerActions,
       header,
     });
   });

--- a/projects/client/src/lib/sections/navbar/TopNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/TopNavbar.svelte
@@ -32,9 +32,10 @@
           </JoinTraktButton>
         </RenderFor>
         <RenderFor audience="authenticated">
-          {@render $state.sortActions?.()}
-          {@render $state.seasonalActions?.()}
-          <FilterButton isDisabled={!$state.hasFilters} />
+          {@render $state.headerActions?.()}
+          {#if $state.showFilters}
+            <FilterButton isDisabled={!$state.hasFilters} />
+          {/if}
         </RenderFor>
         <RenderFor audience="free"><GetVIPLink source="navbar" /></RenderFor>
       </div>

--- a/projects/client/src/lib/sections/navbar/_internal/NavbarActions.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/NavbarActions.svelte
@@ -24,11 +24,10 @@
 
   <div class="trakt-navbar-actions-right">
     <RenderFor audience="authenticated">
-      {@render $state.sortActions?.()}
-      {#if $state.seasonalActions}
-        {@render $state.seasonalActions?.()}
+      {@render $state.headerActions?.()}
+      {#if $state.showFilters}
+        <FilterButton isDisabled={!$state.hasFilters} />
       {/if}
-      <FilterButton isDisabled={!$state.hasFilters} />
     </RenderFor>
     <RenderFor audience="free"><GetVIPLink source="navbar" /></RenderFor>
     <RenderFor audience="public">

--- a/projects/client/src/lib/sections/navbar/useNavbarState.ts
+++ b/projects/client/src/lib/sections/navbar/useNavbarState.ts
@@ -6,10 +6,10 @@ export type NavbarMode = 'full' | 'minimal' | 'hidden';
 
 type NavbarState = {
   actions: Snippet | undefined;
-  seasonalActions: Snippet | undefined;
   contextualActions: Snippet | undefined;
   hasFilters: boolean;
-  sortActions?: Snippet;
+  showFilters: boolean;
+  headerActions?: Snippet;
   header?: {
     title: string;
     metaInfo?: string | Snippet;
@@ -29,10 +29,10 @@ const globalNavbarStateStore = new BehaviorSubject<GlobalNavbarState>({
 
 const initialNavbarState: NavbarState = {
   actions: undefined,
-  seasonalActions: undefined,
   contextualActions: undefined,
   hasFilters: false,
-  sortActions: undefined,
+  showFilters: true,
+  headerActions: undefined,
   header: undefined,
 };
 

--- a/projects/client/src/lib/sections/settings/_internal/SettingsNavbar.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsNavbar.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import LogoutButton from "$lib/components/buttons/logout/LogoutButton.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
@@ -25,10 +24,7 @@
 
 <RenderFor audience="authenticated" device={["tablet-lg", "desktop"]}>
   <div class="trakt-settings-navbar">
-    <div class="trakt-settings-sidebar-content">
-      {@render settingsLinks()}
-    </div>
-    <LogoutButton />
+    {@render settingsLinks()}
   </div>
 </RenderFor>
 
@@ -42,29 +38,21 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-settings-navbar {
+    position: sticky;
+    top: calc(env(safe-area-inset-top, 0) + var(--content-gap));
+    align-self: start;
+
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
 
     gap: var(--gap-s);
 
-    min-height: var(--ni-480);
-    max-height: calc(100dvh - var(--content-gap));
-
-    :global(.trakt-button) {
-      width: fit-content;
-    }
-
     @include for-tablet-sm-and-below {
+      position: static;
+
       min-height: 0;
       height: fit-content;
     }
-  }
-
-  .trakt-settings-sidebar-content {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-l);
   }
 
   .trakt-settings-links {
@@ -79,18 +67,38 @@
     }
 
     :global(.trakt-link) {
+      display: block;
+      padding: var(--ni-10) var(--ni-12);
+
+      border-radius: var(--border-radius-m);
+
       text-decoration: none;
+
+      transition: background-color var(--transition-increment) ease-in-out;
     }
 
     :global(.trakt-link.trakt-link-active) {
+      background-color: color-mix(
+        in srgb,
+        var(--color-link-active) 14%,
+        transparent
+      );
+
       :global(span.title) {
-        color: var(--color-text-primary);
+        color: var(--color-link-active);
       }
     }
 
     @include for-tablet-sm-and-below {
       flex-direction: row;
+      flex-wrap: wrap;
       align-items: center;
+
+      gap: var(--gap-xs);
+
+      :global(.trakt-link) {
+        padding: var(--ni-8) var(--ni-10);
+      }
     }
   }
 </style>

--- a/projects/client/src/routes/discover/+page.svelte
+++ b/projects/client/src/routes/discover/+page.svelte
@@ -38,7 +38,7 @@
       <DiscoverToggles />
     {/snippet}
 
-    {#snippet seasonalActions()}
+    {#snippet headerActions()}
       <SeasonalToggle />
     {/snippet}
   </NavbarStateSetter>

--- a/projects/client/src/routes/lists/official/[list]/+page.svelte
+++ b/projects/client/src/routes/lists/official/[list]/+page.svelte
@@ -51,7 +51,7 @@
       actions,
     }}
   >
-    {#snippet sortActions()}
+    {#snippet headerActions()}
       <ListSortActions
         {options}
         {urlBuilder}

--- a/projects/client/src/routes/profile/[slug]/favorites/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/favorites/+page.svelte
@@ -32,7 +32,7 @@
       metaInfo: $currentDiscoverMode.text(),
     }}
   >
-    {#snippet sortActions()}
+    {#snippet headerActions()}
       <ListSortActions
         {options}
         {urlBuilder}

--- a/projects/client/src/routes/settings/+layout.svelte
+++ b/projects/client/src/routes/settings/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LogoutButton from "$lib/components/buttons/logout/LogoutButton.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -9,12 +10,20 @@
   const { children } = $props();
 </script>
 
+{#snippet headerActions()}
+  <LogoutButton style="action" />
+{/snippet}
+
 <TraktPage
   audience="authenticated"
   image={DEFAULT_SHARE_COVER}
   title={m.page_title_settings()}
 >
-  <NavbarStateSetter mode="minimal" />
+  <NavbarStateSetter
+    showFilters={false}
+    {headerActions}
+    header={{ title: m.page_title_settings() }}
+  />
   <TraktPageCoverSetter />
 
   <Settings>

--- a/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
@@ -49,7 +49,7 @@
       actions,
     }}
   >
-    {#snippet sortActions()}
+    {#snippet headerActions()}
       <ListSortActions
         {options}
         {urlBuilder}

--- a/projects/client/src/routes/users/[user]/start-watching/+page.svelte
+++ b/projects/client/src/routes/users/[user]/start-watching/+page.svelte
@@ -31,7 +31,7 @@
       metaInfo: $currentDiscoverMode.text(),
     }}
   >
-    {#snippet sortActions()}
+    {#snippet headerActions()}
       <ListSortActions
         {options}
         {urlBuilder}

--- a/projects/client/src/routes/users/[user]/watchlist/+page.svelte
+++ b/projects/client/src/routes/users/[user]/watchlist/+page.svelte
@@ -31,7 +31,7 @@
       metaInfo: $currentDiscoverMode.text(),
     }}
   >
-    {#snippet sortActions()}
+    {#snippet headerActions()}
       <ListSortActions
         {options}
         {urlBuilder}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds the standard page header to the settings
- Moves the Log out action from the settings sidebar into the header action area
- Styles the Log out action as an icon-only destructive action matching the "nav action" button sizing and hover behavior
- Keeps the selected settings sidebar item highlighted with the app tint color
- Makes the settings sidebar navigation sticky while the settings content scrolls

(This one will even be better when the navigation bar will be sticky too ☺️)

## 👀 Example 👀

Before
<img width="1200" height="972" alt="Screenshot 2026-04-28 at 11 29 49" src="https://github.com/user-attachments/assets/b35f2a2a-dd74-4642-877e-77df759d62d5" />
<img width="753" height="972" alt="Screenshot 2026-04-28 at 11 29 56" src="https://github.com/user-attachments/assets/b7f09117-f95f-4ef4-bf6b-5743ff3979bf" />
<img width="1233" height="972" alt="Screenshot 2026-04-28 at 11 30 12" src="https://github.com/user-attachments/assets/ee84ee4f-334f-47ef-bfec-aed5e738c152" />

After
<img width="1200" height="972" alt="Screenshot 2026-04-28 at 11 30 18" src="https://github.com/user-attachments/assets/22db46f2-0b8b-45e2-8fb0-b22536244e1b" />
<img width="721" height="972" alt="Screenshot 2026-04-28 at 11 30 26" src="https://github.com/user-attachments/assets/03d0023b-864c-40a0-b86e-d2c629c0674b" />
<img width="1260" height="972" alt="Screenshot 2026-04-28 at 11 30 34" src="https://github.com/user-attachments/assets/0ec2fceb-d9a0-4815-ae79-b791d7c4962b" />


