### PR TITLE
fix(frame): Derives postmessage target origin

### DIFF
--- a/projects/client/src/lib/components/frame/_internal/frameListener.ts
+++ b/projects/client/src/lib/components/frame/_internal/frameListener.ts
@@ -4,11 +4,6 @@ import { onMount } from 'svelte';
 import { UrlBuilder } from '../../../utils/url/UrlBuilder.ts';
 import { useShare } from '../../buttons/share/useShare.ts';
 
-const VALID_ORIGINS: string[] = [
-  'https://trakt.tv',
-  'http://localhost:3000',
-] as const;
-
 type FrameMessage = {
   type: 'embeddedHeight';
   height: number;
@@ -38,8 +33,15 @@ export function frameListener(
 ) {
   const { share } = useShare({ id: source });
 
+  let iframeOrigin: string;
+  try {
+    iframeOrigin = new URL(element.src).origin;
+  } catch {
+    return;
+  }
+
   const handleMessage = (event: MessageEvent<FrameMessage>) => {
-    if (!VALID_ORIGINS.includes(event.origin)) {
+    if (event.origin !== iframeOrigin) {
       return;
     }
 
@@ -81,9 +83,7 @@ export function frameListener(
   globalThis.window.addEventListener('message', handleMessage);
 
   const postMessageToChild = <T>(message: T) => {
-    VALID_ORIGINS.forEach((origin) => {
-      element.contentWindow?.postMessage(message, origin);
-    });
+    element.contentWindow?.postMessage(message, iframeOrigin);
   };
 
   onMount(() => {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2209
- Derives the `targetOrigin` for `postMessage` calls to child frames directly from the iframe's `src` attribute.
- This ensures messages are securely and accurately sent to the specific origin of the loaded content.
- Addresses potential issues with `postMessage` delivery or security concerns that could arise from using a static, predefined list of valid origins.

## 👀 Example 👀
Safari before/after:

https://github.com/user-attachments/assets/2ac8cb70-db5a-40ea-b21d-ef690a0a7bef


https://github.com/user-attachments/assets/03dd9fed-bf90-45e4-a7f4-0b342032aeeb

