### PR TITLE
fix(up-next): always add mark as watched to continue watching items

### DIFF
--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -50,7 +50,7 @@
       return false;
     }
 
-    return !$isWatched;
+    return props.variant === "next" || !$isWatched;
   });
 
   const hasIndicators = $derived.by(() => {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2215
- If something is in `continue watching` you should always be able to mark it as watched.

## 👀 Examples 👀
Before/after:
<img width="1296" height="217" alt="Screenshot 2026-04-29 at 10 44 56" src="https://github.com/user-attachments/assets/07e0b5aa-814c-4199-aa65-637a8f1ab874" />

<img width="1296" height="217" alt="Screenshot 2026-04-29 at 10 44 48" src="https://github.com/user-attachments/assets/e0d92c8e-0dda-42d9-9d44-c557b8ae22d0" />
