### PR TITLE
Fix/removes extra gap in continue watching

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -86,6 +86,7 @@ module.exports = {
         'out-now',
         'parameter',
         'player',
+        'popover',
         'popular',
         'popup',
         'portal',

--- a/projects/client/src/lib/components/popover/Popover.svelte
+++ b/projects/client/src/lib/components/popover/Popover.svelte
@@ -6,9 +6,12 @@
     content: Snippet;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
-  } & ChildrenProps;
+  } & (
+    | { customAnchor: HTMLElement; children?: never }
+    | { children: Snippet; customAnchor?: never }
+  );
 
-  const { children, content, open, onOpenChange }: PopoverProps = $props();
+  const { content, open, onOpenChange, ...rest }: PopoverProps = $props();
 
   const isControlled = $derived(open !== undefined);
 
@@ -25,14 +28,17 @@
 </script>
 
 <Popover.Root bind:open={getOpen, setOpen}>
-  <Popover.Trigger class="trakt-popover-trigger">
-    {@render children()}
-  </Popover.Trigger>
+  {#if rest.children}
+    <Popover.Trigger class="trakt-popover-trigger">
+      {@render rest.children()}
+    </Popover.Trigger>
+  {/if}
   <Popover.Portal>
     <Popover.Content
       sideOffset={8}
       side="top"
       style="z-index: var(--layer-top)"
+      customAnchor={rest.customAnchor}
     >
       {@render content()}
     </Popover.Content>

--- a/projects/client/src/lib/components/snackbar/Snackbar.svelte
+++ b/projects/client/src/lib/components/snackbar/Snackbar.svelte
@@ -18,6 +18,7 @@
     actionLabel: string;
     actionText: string;
     children?: Snippet;
+    anchor?: HTMLElement | Nil;
   };
 
   const {
@@ -30,6 +31,7 @@
     actionLabel,
     actionText,
     children,
+    anchor,
   }: SnackbarProps = $props();
 
   let navbarHeight = $state(0);
@@ -82,30 +84,40 @@
   {/if}
 </RenderFor>
 
+{#snippet popoverContent()}
+  <div class="snackbar-popover" role="status" aria-live="polite">
+    <div class="snackbar-popover-header">
+      <span class="bold title">{title}</span>
+      <AutoCloseButton onclick={onDismiss} label={m.button_label_close()} />
+    </div>
+    <p>{message}</p>
+    <div class="snackbar-popover-actions">
+      <Button
+        size="small"
+        color="default"
+        label={m.button_label_cancel()}
+        onclick={onDismiss}
+      >
+        {m.button_text_cancel()}
+      </Button>
+      {@render actionButton()}
+    </div>
+  </div>
+{/snippet}
+
 <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
-  <Popover {open} {onOpenChange}>
-    {@render children?.()}
-    {#snippet content()}
-      <div class="snackbar-popover" role="status" aria-live="polite">
-        <div class="snackbar-popover-header">
-          <span class="bold title">{title}</span>
-          <AutoCloseButton onclick={onDismiss} label={m.button_label_close()} />
-        </div>
-        <p>{message}</p>
-        <div class="snackbar-popover-actions">
-          <Button
-            size="small"
-            color="default"
-            label={m.button_label_cancel()}
-            onclick={onDismiss}
-          >
-            {m.button_text_cancel()}
-          </Button>
-          {@render actionButton()}
-        </div>
-      </div>
-    {/snippet}
-  </Popover>
+  {#if anchor}
+    <Popover
+      {open}
+      {onOpenChange}
+      customAnchor={anchor}
+      content={popoverContent}
+    />
+  {:else}
+    <Popover {open} {onOpenChange} content={popoverContent}>
+      {@render children?.()}
+    </Popover>
+  {/if}
 </RenderFor>
 
 <style lang="scss">

--- a/projects/client/src/lib/sections/media-actions/_internal/NotePrompt.svelte
+++ b/projects/client/src/lib/sections/media-actions/_internal/NotePrompt.svelte
@@ -15,6 +15,7 @@
     id: number;
     noteType: NoteDrawerType;
     children?: Snippet;
+    customAnchor?: HTMLElement | Nil;
   };
 
   const {
@@ -26,6 +27,7 @@
     id,
     noteType,
     children,
+    customAnchor,
   }: NotePromptProps = $props();
 
   const { open: openNoteDrawer } = useAddNoteDrawer();
@@ -54,4 +56,5 @@
   actionLabel={m.button_label_add_note({ title })}
   actionText={m.button_text_add_note()}
   {children}
+  anchor={customAnchor}
 />

--- a/projects/client/src/lib/sections/media-actions/drop/DropNotePromptProvider.svelte
+++ b/projects/client/src/lib/sections/media-actions/drop/DropNotePromptProvider.svelte
@@ -19,6 +19,8 @@
   const dismiss = () => {
     open = false;
   };
+
+  let promptAnchor = $state<HTMLElement | Nil>(null);
 </script>
 
 <NotePrompt
@@ -34,5 +36,9 @@
   type={target?.type ?? "movie"}
   id={target?.id ?? 0}
   noteType="drop"
+  customAnchor={promptAnchor}
 />
-{@render children()}
+
+<div bind:this={promptAnchor}>
+  {@render children()}
+</div>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2217
- Issue: the popover component was adding an empty button (which caused an extra gap in the flex). In this case it should've just used a custom anchor instead of rendering an empty element.
- Adds support for a custom anchor to the popover component.
- The note prompt for continue watching now uses a custom anchor.

## 👀 Example 👀
Before/after:
<img width="984" height="331" alt="Screenshot 2026-04-29 at 11 34 12" src="https://github.com/user-attachments/assets/d1c14b5e-1cb7-4f23-8c9c-2aac3c6b4294" />

<img width="984" height="310" alt="Screenshot 2026-04-29 at 11 34 25" src="https://github.com/user-attachments/assets/a55af8c0-f605-4d1d-96fa-d376c58eb9ba" />
