### PR TITLE
User: follow private profiles

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2841,7 +2841,7 @@
       ]
     },
     "header_private_profile": {
-      "default": "This profile is private",
+      "default": "This profile is private.",
       "description": "Header for the section that indicates a user's profile is private.",
       "exclude": [
         "android",
@@ -2849,7 +2849,7 @@
       ]
     },
     "text_private_profile_description": {
-      "default": "As if there wasn't enough hidden already. {username}'s secrets remain their own.",
+      "default": "As if there wasn't enough hidden already, {username}'s secrets remain their own.",
       "description": "Description text for a private profile, a lighthearted fun message to indicate that it is a private profile.",
       "variables": {
         "username": {
@@ -3504,6 +3504,27 @@
         "ios"
       ]
     },
+    "button_text_cancel_follow_request": {
+      "default": "Cancel Request",
+      "description": "Text for the button that cancels a pending follow request sent to a private profile.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "button_label_cancel_follow_request": {
+      "default": "Cancel follow request to {username}",
+      "description": "Aria-label for the button that cancels a pending follow request sent to a private profile.",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "warning_prompt_unfollow_user": {
       "default": "Are you sure you want to unfollow {username}?",
       "description": "Warning prompt shown when a user tries to unfollow a profile.",
@@ -3620,6 +3641,14 @@
     "tag_text_blocked_user": {
       "default": "Blocked",
       "description": "Tag shown on another user's profile when the current user has blocked them.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "tag_text_follow_request_pending": {
+      "default": "Pending",
+      "description": "Tag shown on another user's avatar when the current user's follow request is awaiting their approval.",
       "exclude": [
         "android",
         "ios"

--- a/projects/client/src/lib/components/tags/TextTag.svelte
+++ b/projects/client/src/lib/components/tags/TextTag.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
+  import { appendClassList } from "$lib/utils/actions/appendClassList";
   import type { Snippet } from "svelte";
 
-  const { children, icon }: ChildrenProps & { icon?: Snippet } = $props();
+  type TextTagProps = ChildrenProps & {
+    icon?: Snippet;
+    classList?: string;
+  };
+
+  const { children, icon, classList = "" }: TextTagProps = $props();
 </script>
 
-<div class="trakt-text-tag">
+<div class="trakt-text-tag" use:appendClassList={classList}>
   {@render icon?.()}
   {@render children()}
 </div>

--- a/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
@@ -18,7 +18,9 @@ type RatingType = { action: 'added' | 'changed'; rating: number } | {
 type FilterType = { id: string; action: 'set' | 'reset'; mode: FilterMode };
 type FiltersType = { action: 'save' | 'reset' };
 type CheckInType = { type: 'episode' | 'movie'; action: 'start' | 'stop' };
-type FollowType = { action: 'follow' | 'unfollow' };
+type FollowType = {
+  action: 'follow' | 'unfollow' | 'cancel-follow-request';
+};
 type BlockType = { action: 'block' | 'unblock' };
 type ExtrasType = { slug: string; type: MediaVideoType };
 type CommentType = { action: 'post' | 'reply' | 'edit' };

--- a/projects/client/src/lib/features/auth/queries/currentUserPendingFollowsQuery.spec.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserPendingFollowsQuery.spec.ts
@@ -1,0 +1,16 @@
+import { UserFollowingMappedMock } from '$mocks/data/users/mapped/UserFollowingMappedMock.ts';
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { describe, expect, it } from 'vitest';
+import { currentUserPendingFollowsQuery } from './currentUserPendingFollowsQuery.ts';
+
+describe('currentUserPendingFollowsQuery', () => {
+  it('should query for outgoing pending follow requests', async () => {
+    const result = await runQuery({
+      factory: () => createTestBedQuery(currentUserPendingFollowsQuery()),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(UserFollowingMappedMock);
+  });
+});

--- a/projects/client/src/lib/features/auth/queries/currentUserPendingFollowsQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserPendingFollowsQuery.ts
@@ -1,0 +1,24 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { mapToUserProfile } from '$lib/requests/_internal/mapToUserProfile.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { UserProfileSchema } from '$lib/requests/models/UserProfile.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { z } from 'zod';
+
+const currentUserPendingFollowsRequest = ({ fetch }: ApiParams) =>
+  api({ fetch })
+    .users
+    .requests
+    .following();
+
+export const currentUserPendingFollowsQuery = defineQuery({
+  key: 'currentUserPendingFollows',
+  request: currentUserPendingFollowsRequest,
+  invalidations: [InvalidateAction.User.Follow],
+  dependencies: [],
+  mapper: (response) =>
+    response.body.map((request) => mapToUserProfile(request.user)),
+  schema: z.array(UserProfileSchema),
+  ttl: time.hours(12),
+});

--- a/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
@@ -11,16 +11,24 @@
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { DisplayableProfileProps } from "../profile/DisplayableProfileProps";
   import BlockedUserTag from "./_internal/BlockedUserTag.svelte";
+  import PendingFollowTag from "./_internal/PendingFollowTag.svelte";
   import ProfileOverflowMenu from "./_internal/ProfileOverflowMenu.svelte";
+  import { useFollowUserRequest } from "./_internal/useFollowUser";
   import ProfileImage from "./ProfileImage.svelte";
 
-  const { profile, slug }: DisplayableProfileProps = $props();
+  type Props = DisplayableProfileProps & {
+    compact?: boolean;
+  };
+
+  const { profile, slug, compact = false }: Props = $props();
 
   const { user, blocked } = useUser();
   const { isMe } = $derived(useIsMe(slug));
+  const { followStatus } = $derived(useFollowUserRequest(slug));
 
   const shareableSlug = $derived($isMe ? $user.slug : slug);
   const isBlocked = $derived($blocked.has(slug));
+  const isPending = $derived($followStatus === "pending");
 </script>
 
 <div class="profile-page-banner-container">
@@ -37,9 +45,11 @@
         <RenderFor audience="authenticated">
           {#if !$isMe && isBlocked}
             <BlockedUserTag />
+          {:else if !$isMe && isPending}
+            <PendingFollowTag />
           {/if}
         </RenderFor>
-        {#if !isBlocked}
+        {#if !isBlocked && !isPending}
           <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
             {#if profile.isVip}
               <VipBadge isDirector={profile.isDirector} />
@@ -50,16 +60,20 @@
     </ProfileImage>
     <div class="profile-user-details" data-hj-suppress data-sentry-mask>
       <span class="title ellipsis">{toDisplayableName(profile)}</span>
-      <span class="user-location ellipsis">{profile.location}</span>
+      {#if !compact}
+        <span class="user-location ellipsis">{profile.location}</span>
+      {/if}
     </div>
     <div class="profile-actions">
       <div class="profile-icon-actions">
-        <ShareButton
-          title={profile.name.first}
-          urlOverride={UrlBuilder.profile.user(shareableSlug)}
-          textFactory={({ title: name }) => m.text_share_profile({ name })}
-          source={{ id: "profile", type: $isMe ? "own" : "other" }}
-        />
+        {#if !compact}
+          <ShareButton
+            title={profile.name.first}
+            urlOverride={UrlBuilder.profile.user(shareableSlug)}
+            textFactory={({ title: name }) => m.text_share_profile({ name })}
+            source={{ id: "profile", type: $isMe ? "own" : "other" }}
+          />
+        {/if}
         <RenderFor audience="authenticated">
           {#if !$isMe}
             <ProfileOverflowMenu {profile} {slug} />
@@ -71,7 +85,9 @@
     </div>
   </div>
 
-  <ProfileAbout {profile} {slug} />
+  {#if !compact}
+    <ProfileAbout {profile} {slug} />
+  {/if}
 </div>
 
 <style lang="scss">
@@ -115,7 +131,8 @@
       align-items: center;
 
       :global(.trakt-vip-badge),
-      :global(.trakt-blocked-user-tag) {
+      :global(.trakt-blocked-user-tag),
+      :global(.trakt-pending-follow-tag) {
         z-index: var(--layer-base);
         margin-top: var(--ni-neg-16);
       }

--- a/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
@@ -11,16 +11,30 @@
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { DisplayableProfileProps } from "../profile/DisplayableProfileProps";
   import BlockedUserTag from "./_internal/BlockedUserTag.svelte";
+  import PendingFollowTag from "./_internal/PendingFollowTag.svelte";
   import ProfileOverflowMenu from "./_internal/ProfileOverflowMenu.svelte";
+  import { useFollowUserRequest } from "./_internal/useFollowUser";
   import ProfileImage from "./ProfileImage.svelte";
 
-  const { profile, slug }: DisplayableProfileProps = $props();
+  type ProfilePageBannerProps = DisplayableProfileProps & {
+    variant?: "private" | "public";
+  };
+
+  const {
+    profile,
+    slug,
+    variant = "public",
+  }: ProfilePageBannerProps = $props();
 
   const { user, blocked } = useUser();
   const { isMe } = $derived(useIsMe(slug));
+  const { followStatus } = $derived(useFollowUserRequest(slug));
 
   const shareableSlug = $derived($isMe ? $user.slug : slug);
   const isBlocked = $derived($blocked.has(slug));
+  const isPending = $derived($followStatus === "pending");
+
+  const isPublic = $derived(variant === "public");
 </script>
 
 <div class="profile-page-banner-container">
@@ -37,9 +51,11 @@
         <RenderFor audience="authenticated">
           {#if !$isMe && isBlocked}
             <BlockedUserTag />
+          {:else if !$isMe && isPending}
+            <PendingFollowTag />
           {/if}
         </RenderFor>
-        {#if !isBlocked}
+        {#if !isBlocked && !isPending}
           <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
             {#if profile.isVip}
               <VipBadge isDirector={profile.isDirector} />
@@ -50,16 +66,20 @@
     </ProfileImage>
     <div class="profile-user-details" data-hj-suppress data-sentry-mask>
       <span class="title ellipsis">{toDisplayableName(profile)}</span>
-      <span class="user-location ellipsis">{profile.location}</span>
+      {#if isPublic}
+        <span class="user-location ellipsis">{profile.location}</span>
+      {/if}
     </div>
     <div class="profile-actions">
       <div class="profile-icon-actions">
-        <ShareButton
-          title={profile.name.first}
-          urlOverride={UrlBuilder.profile.user(shareableSlug)}
-          textFactory={({ title: name }) => m.text_share_profile({ name })}
-          source={{ id: "profile", type: $isMe ? "own" : "other" }}
-        />
+        {#if isPublic}
+          <ShareButton
+            title={profile.name.first}
+            urlOverride={UrlBuilder.profile.user(shareableSlug)}
+            textFactory={({ title: name }) => m.text_share_profile({ name })}
+            source={{ id: "profile", type: $isMe ? "own" : "other" }}
+          />
+        {/if}
         <RenderFor audience="authenticated">
           {#if !$isMe}
             <ProfileOverflowMenu {profile} {slug} />
@@ -71,7 +91,9 @@
     </div>
   </div>
 
-  <ProfileAbout {profile} {slug} />
+  {#if isPublic}
+    <ProfileAbout {profile} {slug} />
+  {/if}
 </div>
 
 <style lang="scss">
@@ -115,7 +137,8 @@
       align-items: center;
 
       :global(.trakt-vip-badge),
-      :global(.trakt-blocked-user-tag) {
+      :global(.trakt-blocked-user-tag),
+      :global(.trakt-pending-follow-tag) {
         z-index: var(--layer-base);
         margin-top: var(--ni-neg-16);
       }

--- a/projects/client/src/lib/sections/profile-banner/_internal/PendingFollowTag.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/PendingFollowTag.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
-  import BlockIcon from "$lib/components/icons/BlockIcon.svelte";
+  import HourglassIcon from "$lib/components/icons/HourglassIcon.svelte";
   import TextTag from "$lib/components/tags/TextTag.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
 </script>
 
-<div class="trakt-blocked-user-tag">
-  <TextTag classList="blocked-user-tag">
+<div class="trakt-pending-follow-tag">
+  <TextTag classList="pending-follow-tag">
     {#snippet icon()}
-      <BlockIcon />
+      <HourglassIcon />
     {/snippet}
-    <span class="tag bold uppercase">{m.tag_text_blocked_user()}</span>
+    <span class="tag bold uppercase">{m.tag_text_follow_request_pending()}</span>
   </TextTag>
 </div>
 
 <style lang="scss">
-  .trakt-blocked-user-tag {
-    :global(.blocked-user-tag) {
-      background-color: var(--color-foreground-red);
-      color: var(--color-background-red);
+  .trakt-pending-follow-tag {
+    :global(.pending-follow-tag) {
+      background-color: var(--color-foreground-orange);
+      color: var(--color-background-orange);
 
       border-radius: var(--border-radius-xxl);
       padding: var(--ni-8) var(--ni-10);

--- a/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
@@ -22,9 +22,13 @@
   const blockActions = useBlockUser();
   const { isRequestingBlock } = blockActions;
 
-  const { isRequestingFollow, isFollowed, followUser, unfollowUser } = $derived(
-    useFollowUserRequest(slug),
-  );
+  const {
+    isRequestingFollow,
+    followStatus,
+    followUser,
+    unfollowUser,
+    cancelFollowRequest,
+  } = $derived(useFollowUserRequest(slug));
 
   const userDisplayName = $derived(toDisplayableName(profile));
 
@@ -44,6 +48,34 @@
       onConfirm: unfollowUser,
     }),
   );
+
+  const followItem = $derived.by(() => {
+    switch ($followStatus) {
+      case "following":
+        return {
+          label: m.button_label_unfollow({ username: userDisplayName }),
+          text: m.button_text_unfollow(),
+          onClick: confirmUnfollow,
+          iconState: "followed" as const,
+        };
+      case "pending":
+        return {
+          label: m.button_label_cancel_follow_request({
+            username: userDisplayName,
+          }),
+          text: m.button_text_cancel_follow_request(),
+          onClick: cancelFollowRequest,
+          iconState: "unfollowed" as const,
+        };
+      default:
+        return {
+          label: m.button_label_follow({ username: userDisplayName }),
+          text: m.button_text_follow(),
+          onClick: followUser,
+          iconState: "unfollowed" as const,
+        };
+    }
+  });
 
   const {
     color,
@@ -75,15 +107,13 @@
         style="flat"
         color="default"
         variant="secondary"
-        label={$isFollowed
-          ? m.button_label_unfollow({ username: userDisplayName })
-          : m.button_label_follow({ username: userDisplayName })}
-        onclick={$isFollowed ? confirmUnfollow : followUser}
+        label={followItem.label}
+        onclick={followItem.onClick}
         disabled={$isRequestingFollow}
       >
-        {$isFollowed ? m.button_text_unfollow() : m.button_text_follow()}
+        {followItem.text}
         {#snippet icon()}
-          <FollowIcon state={$isFollowed ? "followed" : "unfollowed"} />
+          <FollowIcon state={followItem.iconState} />
         {/snippet}
       </DropdownItem>
     {/if}

--- a/projects/client/src/lib/sections/profile-banner/_internal/useFollowUser.ts
+++ b/projects/client/src/lib/sections/profile-banner/_internal/useFollowUser.ts
@@ -1,32 +1,49 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { currentUserPendingFollowsQuery } from '$lib/features/auth/queries/currentUserPendingFollowsQuery.ts';
+import { useAuth } from '$lib/features/auth/stores/useAuth.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { useQuery } from '$lib/features/query/useQuery.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import type { UserProfile } from '$lib/requests/models/UserProfile.ts';
 import { followUserRequest } from '$lib/requests/queries/users/followUserRequest.ts';
 import { unfollowUserRequest } from '$lib/requests/queries/users/unfollowUserRequest.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject, map, tap } from 'rxjs';
+import { BehaviorSubject, combineLatest, map, of, switchMap, tap } from 'rxjs';
+
+export type FollowStatus = 'none' | 'pending' | 'following';
 
 export function useFollowUserRequest(slug: string) {
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.Follow);
+  const { isAuthorized } = useAuth();
   const { network } = useUser();
+  const pendingFollowsQuerySignal = useQuery(currentUserPendingFollowsQuery());
   const isRequestingFollow = new BehaviorSubject(false);
 
-  const isFollowed = network.pipe(
-    tap(($network) => {
-      if (!$network) {
-        isRequestingFollow.next(true);
-      } else {
-        isRequestingFollow.next(false);
-      }
+  const pendingFollows = isAuthorized.pipe(
+    switchMap((authorized) =>
+      authorized
+        ? pendingFollowsQuerySignal.pipe(map((query) => query.data))
+        : of<UserProfile[]>([])
+    ),
+  );
+
+  const followStatus = combineLatest([network, pendingFollows]).pipe(
+    tap(([$network, $pendingFollows]) => {
+      const isReady = $network != null && $pendingFollows != null;
+      isRequestingFollow.next(!isReady);
     }),
-    map(($network) => {
-      if (!$network) {
-        return false;
+    map(([$network, $pendingFollows]): FollowStatus => {
+      if ($network?.following.some((user) => user.slug === slug)) {
+        return 'following';
       }
 
-      return $network.following.some((user) => user.slug === slug);
+      if ($pendingFollows?.some((user) => user.slug === slug)) {
+        return 'pending';
+      }
+
+      return 'none';
     }),
   );
 
@@ -50,10 +67,21 @@ export function useFollowUserRequest(slug: string) {
     isRequestingFollow.next(false);
   };
 
+  const cancelFollowRequest = async () => {
+    isRequestingFollow.next(true);
+
+    track({ action: 'cancel-follow-request' });
+    await unfollowUserRequest({ slug });
+    await invalidate(InvalidateAction.User.Follow);
+
+    isRequestingFollow.next(false);
+  };
+
   return {
     isRequestingFollow,
-    isFollowed,
+    followStatus,
     followUser,
     unfollowUser,
+    cancelFollowRequest,
   };
 }

--- a/projects/client/src/lib/sections/profile/PrivateProfile.svelte
+++ b/projects/client/src/lib/sections/profile/PrivateProfile.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
+  import ProfilePageBanner from "$lib/sections/profile-banner/ProfilePageBanner.svelte";
   import ProfileContainer from "./components/ProfileContainer.svelte";
   import type { DisplayableProfileProps } from "./DisplayableProfileProps";
 
   const { profile, slug }: DisplayableProfileProps = $props();
-
-  // FIXME: proper design for private profiles
 </script>
 
 <ProfileContainer {profile} {slug}>
+  <ProfilePageBanner {profile} {slug} compact />
   <div class="trakt-private-profile">
     <p class="bold">{m.header_private_profile()}</p>
+    <hr class="trakt-private-profile-divider" />
     <p class="trakt-profile-description">
       {m.text_private_profile_description({ username: profile.username })}
     </p>
@@ -21,13 +22,29 @@
   .trakt-private-profile {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
 
-    gap: var(--gap-m);
+    gap: var(--gap-xs);
 
     p.trakt-profile-description {
-      max-width: var(--ni-224);
+      max-width: var(--ni-320);
       line-height: 150%;
     }
+  }
+
+  .trakt-private-profile-divider {
+    all: unset;
+    display: block;
+    height: 1px;
+    width: var(--ni-320);
+    max-width: 100%;
+    margin: var(--gap-s) 0;
+    background-color: color-mix(
+      in srgb,
+      var(--color-foreground) 10%,
+      transparent
+    );
   }
 </style>

--- a/projects/client/src/lib/sections/profile/PrivateProfile.svelte
+++ b/projects/client/src/lib/sections/profile/PrivateProfile.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
+  import ProfilePageBanner from "$lib/sections/profile-banner/ProfilePageBanner.svelte";
   import ProfileContainer from "./components/ProfileContainer.svelte";
   import type { DisplayableProfileProps } from "./DisplayableProfileProps";
 
   const { profile, slug }: DisplayableProfileProps = $props();
-
-  // FIXME: proper design for private profiles
 </script>
 
 <ProfileContainer {profile} {slug}>
+  <ProfilePageBanner {profile} {slug} variant="private" />
   <div class="trakt-private-profile">
     <p class="bold">{m.header_private_profile()}</p>
+    <hr class="trakt-private-profile-divider" />
     <p class="trakt-profile-description">
       {m.text_private_profile_description({ username: profile.username })}
     </p>
@@ -21,13 +22,29 @@
   .trakt-private-profile {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
 
-    gap: var(--gap-m);
+    gap: var(--gap-xs);
 
     p.trakt-profile-description {
-      max-width: var(--ni-224);
+      max-width: var(--ni-320);
       line-height: 150%;
     }
+  }
+
+  .trakt-private-profile-divider {
+    all: unset;
+    display: block;
+    height: 1px;
+    width: var(--ni-320);
+    max-width: 100%;
+    margin: var(--gap-s) 0;
+    background-color: color-mix(
+      in srgb,
+      var(--color-foreground) 10%,
+      transparent
+    );
   }
 </style>

--- a/projects/client/src/mocks/data/users/response/UserPendingFollowsResponseMock.ts
+++ b/projects/client/src/mocks/data/users/response/UserPendingFollowsResponseMock.ts
@@ -1,0 +1,10 @@
+import type { RequestsResponse } from '@trakt/api';
+import { UserProfileHarryResponseMock } from './UserProfileHarryResponseMock.ts';
+
+export const UserPendingFollowsResponseMock: RequestsResponse[] = [
+  {
+    id: 1,
+    requested_at: '2025-01-31T23:12:41.000Z',
+    user: UserProfileHarryResponseMock,
+  },
+];

--- a/projects/client/src/mocks/handlers/users.ts
+++ b/projects/client/src/mocks/handlers/users.ts
@@ -28,6 +28,7 @@ import { UserBlockedResponseMock } from '../data/users/response/UserBlockedRespo
 import { UserFollowersResponseMock } from '../data/users/response/UserFollowersResponseMock.ts';
 import { UserFollowingResponseMock } from '../data/users/response/UserFollowingResponseMock.ts';
 import { UserMonthInReviewResponseMock } from '../data/users/response/UserMonthInReviewResponseMock.ts';
+import { UserPendingFollowsResponseMock } from '../data/users/response/UserPendingFollowsResponseMock.ts';
 import { UserWatchingResponseMock } from '../data/users/response/UserWatchingResponseMock.ts';
 import { WatchedMoviesResponseMock } from '../data/users/response/WatchedMoviesResponseMock.ts';
 import { WatchedShowsMinimalResponseMock } from '../data/users/response/WatchedShowsMinimalResponseMock.ts';
@@ -56,7 +57,9 @@ export const users = [
     const extended = searchParams.get('extended');
 
     return HttpResponse.json(
-      extended === 'min' ? WatchedShowsMinimalResponseMock : WatchedShowsResponseMock,
+      extended === 'min'
+        ? WatchedShowsMinimalResponseMock
+        : WatchedShowsResponseMock,
     );
   }),
   http.get('http://localhost/users/me/watched/movies', () => {
@@ -112,6 +115,9 @@ export const users = [
   }),
   http.get('http://localhost/users/me/following', () => {
     return HttpResponse.json(UserFollowingResponseMock);
+  }),
+  http.get('http://localhost/users/requests/following', () => {
+    return HttpResponse.json(UserPendingFollowsResponseMock);
   }),
   http.get(
     `http://localhost/users/${UserProfileHarryMappedMock.slug}/lists/${


### PR DESCRIPTION
# Notes

This PR adds the core function of following a private profile and cancelling the follow request. A different PR will add a Notification Center and the ability for the followed user to accept or deny the request.

# Description

- **New query for pending follow requests**: Added [currentUserPendingFollowsQuery.ts](projects/client/src/lib/features/auth/queries/currentUserPendingFollowsQuery.ts) hitting `users/requests/following`, wired through [useUser.ts](projects/client/src/lib/features/auth/stores/useUser.ts) as a new `pendingFollows` observable.
- **Tri-state follow logic**: [useFollowUser.ts](projects/client/src/lib/sections/profile-banner/_internal/useFollowUser.ts) replaces binary `isFollowed` with a `followStatus` of `'none' | 'pending' | 'following'` and adds a `cancelFollowRequest` action (reuses the unfollow endpoint).
- **Three-state overflow menu**: [ProfileOverflowMenu.svelte](projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte) now shows Follow / Pending / Unfollow contextually — pending cancels immediately, following keeps the confirmation dialog.
- **Identity row on private profiles**: Added a `compact` prop to [ProfilePageBanner.svelte](projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte); [PrivateProfile.svelte](projects/client/src/lib/sections/profile/PrivateProfile.svelte) now renders the banner so visitors see avatar, username, and the follow control.
- **Compact mode hides extras**: When `compact` is set, the banner hides the location, the share button, and the about section.
- **Pending avatar tag**: New [PendingFollowTag.svelte](projects/client/src/lib/sections/profile-banner/_internal/PendingFollowTag.svelte) styled like `BlockedUserTag` (orange instead of red, hourglass icon) — appears under the avatar when the viewer has a pending request out to that user.
- **Private profile divider**: Added a horizontal rule with vertical spacing between the "This profile is private" header and the description text.
- **i18n**: Added `button_text_pending`, `button_label_cancel_follow_request`, and `tag_text_follow_request_pending` to the meta source; regenerated messages and Paraglide output.
- **Analytics**: Extended `FollowType` in [AnalyticsEventDataMap.ts](projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts) with a `'cancel-follow-request'` action.
- **Mocks + tests**: Added MSW handler for `users/requests/following`, a [response mock](projects/client/src/mocks/data/users/response/UserPendingFollowsResponseMock.ts), and a [spec](projects/client/src/lib/features/auth/queries/currentUserPendingFollowsQuery.spec.ts) for the new query.

# Screenshots

### Follow Button
<img width="775" height="365" alt="image" src="https://github.com/user-attachments/assets/30b0de4f-c88c-434d-9752-ed84e40dd70d" />

### Pending Status
<img width="771" height="365" alt="image" src="https://github.com/user-attachments/assets/43c6643f-8dfc-494c-9b99-c3e2aa29bf2e" />

# Related Issues

- #1536
