### PR TITLE
feat(errors): Improves error reporting and filters frame errors

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5111,6 +5111,14 @@
         "ios"
       ]
     },
+    "error_text_unexpected_error_include_details": {
+      "default": "Please include these details when reporting the issue:",
+      "description": "Text shown on the unexpected error page, asking the user to include error details when reporting the issue.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "list_placeholder_no_filter_results": {
       "default": "Bummer, no hits. Your filter may have been a little too selective.",
       "description": "Placeholder text shown when there are no results for a filter.",

--- a/projects/client/src/lib/features/errors/ErrorProvider.svelte
+++ b/projects/client/src/lib/features/errors/ErrorProvider.svelte
@@ -5,7 +5,6 @@
   import ErrorLockedAccountPage from "$lib/pages/errors/ErrorLockedAccountPage.svelte";
   import ErrorServicePage from "$lib/pages/errors/ErrorServicePage.svelte";
   import UnexpectedErrorPage from "$lib/pages/errors/UnexpectedErrorPage.svelte";
-  import { writable } from "$lib/utils/store/WritableSubject.ts";
   import * as Sentry from "@sentry/sveltekit";
   import { onMount } from "svelte";
   import { isErrorExempt } from "./_internal/errorExemptions.ts";
@@ -18,14 +17,15 @@
   } from "./models/WellKnownErrors";
 
   const { children }: ChildrenProps = $props();
-  const fetchError = writable<WellKnownError | undefined>(undefined);
-  const unexpectedError = writable<Error | undefined>(undefined);
-  const sessionId = writable<string | undefined>(undefined);
+
+  let fetchError = $state<WellKnownError | undefined>(undefined);
+  let unexpectedError = $state<Error | undefined>(undefined);
+  let sessionId = $state<string | undefined>(undefined);
 
   onMount(() => {
     const handler = (event: Event) => {
       const errorEvent = event as CustomEvent<CustomFetchError>;
-      fetchError.set(mapToWellKnownError(errorEvent.detail));
+      fetchError = mapToWellKnownError(errorEvent.detail);
     };
 
     globalThis.window.addEventListener(FETCH_ERROR_EVENT, handler);
@@ -36,13 +36,13 @@
   });
 
   afterNavigate((_) => {
-    fetchError.set(undefined);
-    unexpectedError.set(undefined);
-    sessionId.set(undefined);
+    fetchError = undefined;
+    unexpectedError = undefined;
+    sessionId = undefined;
   });
 
-  const hasExemption = $derived(isErrorExempt($fetchError, page.route.id));
-  const hasError = $derived($fetchError || $unexpectedError);
+  const hasExemption = $derived(isErrorExempt(fetchError, page.route.id));
+  const hasError = $derived(fetchError || unexpectedError);
 </script>
 
 <svelte:window
@@ -69,7 +69,7 @@
     }
 
     const id = crypto.randomUUID();
-    sessionId.set(id);
+    sessionId = id;
 
     Sentry.captureException(error, {
       tags: {
@@ -77,28 +77,28 @@
         sessionId: id,
       },
     });
-    unexpectedError.set(error);
+    unexpectedError = error;
   }}
 />
 
 {#if !hasExemption}
-  {#if $unexpectedError}
-    <UnexpectedErrorPage error={$unexpectedError} sessionId={$sessionId} />
+  {#if unexpectedError}
+    <UnexpectedErrorPage error={unexpectedError} {sessionId} />
   {/if}
 
-  {#if $fetchError?.type === WellKnownErrorType.LockedAccountError}
+  {#if fetchError?.type === WellKnownErrorType.LockedAccountError}
     <ErrorLockedAccountPage />
   {/if}
 
-  {#if $fetchError?.type === WellKnownErrorType.RateLimitError}
-    <ErrorServicePage message={$fetchError.message} />
+  {#if fetchError?.type === WellKnownErrorType.RateLimitError}
+    <ErrorServicePage message={fetchError.message} />
   {/if}
 
-  {#if $fetchError?.type === WellKnownErrorType.ServerError}
-    <ErrorServicePage message={$fetchError.message} />
+  {#if fetchError?.type === WellKnownErrorType.ServerError}
+    <ErrorServicePage message={fetchError.message} />
   {/if}
 
-  {#if $fetchError?.type === WellKnownErrorType.NotFoundError}
+  {#if fetchError?.type === WellKnownErrorType.NotFoundError}
     <Error404Page />
   {/if}
 {/if}

--- a/projects/client/src/lib/features/errors/ErrorProvider.svelte
+++ b/projects/client/src/lib/features/errors/ErrorProvider.svelte
@@ -20,6 +20,7 @@
   const { children }: ChildrenProps = $props();
   const fetchError = writable<WellKnownError | undefined>(undefined);
   const unexpectedError = writable<Error | undefined>(undefined);
+  const sessionId = writable<string | undefined>(undefined);
 
   onMount(() => {
     const handler = (event: Event) => {
@@ -37,6 +38,7 @@
   afterNavigate((_) => {
     fetchError.set(undefined);
     unexpectedError.set(undefined);
+    sessionId.set(undefined);
   });
 
   const hasExemption = $derived(isErrorExempt($fetchError, page.route.id));
@@ -66,9 +68,13 @@
       return;
     }
 
+    const id = crypto.randomUUID();
+    sessionId.set(id);
+
     Sentry.captureException(error, {
       tags: {
         type: "ErrorProvider",
+        sessionId: id,
       },
     });
     unexpectedError.set(error);
@@ -77,7 +83,7 @@
 
 {#if !hasExemption}
   {#if $unexpectedError}
-    <UnexpectedErrorPage />
+    <UnexpectedErrorPage error={$unexpectedError} sessionId={$sessionId} />
   {/if}
 
   {#if $fetchError?.type === WellKnownErrorType.LockedAccountError}

--- a/projects/client/src/lib/features/errors/ErrorProvider.svelte
+++ b/projects/client/src/lib/features/errors/ErrorProvider.svelte
@@ -55,6 +55,17 @@
       return;
     }
 
+    /*
+      Filter out errors caused by blocked frames e.g.,
+      due to popup blockers or browser privacy settings)
+    */
+    if (
+      error.name === "SecurityError" &&
+      error.message.toLowerCase().includes("blocked a frame")
+    ) {
+      return;
+    }
+
     Sentry.captureException(error, {
       tags: {
         type: "ErrorProvider",

--- a/projects/client/src/lib/pages/errors/UnexpectedErrorPage.svelte
+++ b/projects/client/src/lib/pages/errors/UnexpectedErrorPage.svelte
@@ -1,25 +1,105 @@
-<script>
+<script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
   import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import ErrorPage from "./ErrorPage.svelte";
+
+  type UnexpectedErrorPageProps = {
+    error?: Error;
+    sessionId?: string;
+  };
+
+  const { error, sessionId }: UnexpectedErrorPageProps = $props();
 </script>
 
 <ErrorPage title={m.page_title_unexpected_error()}>
-  <p>
-    <MessageWithLink
-      message={m.error_text_unexpected_error()}
-      href={UrlBuilder.github.reportIssue()}
-      target="_blank"
-    />
-  </p>
-  <Button
-    variant="primary"
-    color="purple"
-    onclick={() => window.location.reload()}
-    label={m.button_label_retry()}
-  >
-    {m.button_text_retry()}
-  </Button>
+  <div class="trakt-unexpected-error">
+    <div class="trakt-error-message">
+      <p>
+        <MessageWithLink
+          message={m.error_text_unexpected_error()}
+          href={UrlBuilder.github.reportIssue()}
+          target="_blank"
+        />
+      </p>
+      <Button
+        variant="primary"
+        color="purple"
+        onclick={() => window.location.reload()}
+        label={m.button_label_retry()}
+      >
+        {m.button_text_retry()}
+      </Button>
+    </div>
+
+    {#if sessionId || error?.stack}
+      <div class="trakt-error-details">
+        <p class="trakt-error-details-header">
+          {m.error_text_unexpected_error_include_details()}
+        </p>
+
+        {#if sessionId}
+          <span class="tag bold">Session ID</span>
+          <code>{sessionId}</code>
+        {/if}
+
+        {#if error?.stack}
+          <span class="tag bold">Stack trace</span>
+          <pre>{error.stack}</pre>
+        {/if}
+      </div>
+    {/if}
+  </div>
 </ErrorPage>
+
+<style>
+  .trakt-unexpected-error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--gap-xxl);
+  }
+
+  .trakt-error-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--gap-l);
+
+    text-align: center;
+  }
+
+  .trakt-error-details {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: baseline;
+    gap: var(--gap-s) var(--gap-m);
+
+    max-width: var(--ni-640);
+
+    padding: var(--ni-16);
+    box-sizing: border-box;
+
+    border-radius: var(--border-radius-m);
+    border: var(--ni-1) solid var(--color-border);
+
+    text-align: left;
+
+    .trakt-error-details-header {
+      grid-column: 1 / -1;
+    }
+
+    code,
+    pre {
+      user-select: all;
+      font-size: var(--font-size-tag);
+    }
+
+    pre {
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+  }
+</style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2068
- Filters out `SecurityError` exceptions that originate from blocked frames, preventing unnecessary error reports.
- Displays technical details, including a unique session ID and the error stack trace, directly on the unexpected error page.

## 👀 Example 👀
<img width="1220" height="894" alt="Screenshot 2026-05-01 at 12 24 59" src="https://github.com/user-attachments/assets/0284c1f3-f5f3-4be1-b5f2-d2d950418dc4" />
