### PR TITLE
Fix/trailer url

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToMovieEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMovieEntry.ts
@@ -8,6 +8,7 @@ import { mapToLogo } from './mapToLogo.ts';
 import { mapToPostCredits } from './mapToPostCredits.ts';
 import { mapToPoster } from './mapToPoster.ts';
 import { mapToSocialMedia } from './mapToSocialMedia.ts';
+import { mapToTrailerUrl } from './mapToTrailerUrl.ts';
 import { mapToTraktRating } from './mapToTraktRating.ts';
 
 function mapMovieCertificationResponse(
@@ -53,9 +54,7 @@ export function mapToMovieEntry(
     genres: movie.genres ?? [],
     status: movie.status ?? 'unknown',
     overview: movie.overview ?? 'TBD',
-    trailer: prependHttps(
-      movie.trailer,
-    ),
+    trailer: mapToTrailerUrl(movie.trailer),
     /**
      * Duplicate for compat with other entities.
      */

--- a/projects/client/src/lib/requests/_internal/mapToShowEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToShowEntry.ts
@@ -8,6 +8,7 @@ import { mapToCover } from './mapToCover.ts';
 import { mapToLogo } from './mapToLogo.ts';
 import { mapToPoster } from './mapToPoster.ts';
 import { mapToSocialMedia } from './mapToSocialMedia.ts';
+import { mapToTrailerUrl } from './mapToTrailerUrl.ts';
 import { mapToTraktRating } from './mapToTraktRating.ts';
 
 export function mapToShowEntry(
@@ -55,9 +56,7 @@ export function mapToShowEntry(
     genres: show.genres ?? [],
     status: show.status ?? 'unknown',
     overview: show.overview ?? 'TBD',
-    trailer: prependHttps(
-      show.trailer,
-    ),
+    trailer: mapToTrailerUrl(show.trailer),
     /**
      * Duplicate for compat with other entities.
      */

--- a/projects/client/src/lib/requests/_internal/mapToTrailerUrl.ts
+++ b/projects/client/src/lib/requests/_internal/mapToTrailerUrl.ts
@@ -1,0 +1,13 @@
+import { prependHttps } from '$lib/utils/url/prependHttps.ts';
+
+export function mapToTrailerUrl(url: string | Nil): HttpsUrl | undefined {
+  const httpsUrl = prependHttps(url);
+  if (!httpsUrl) return undefined;
+
+  try {
+    const parsed = new URL(httpsUrl);
+    return parsed.searchParams.has('v') ? httpsUrl : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/projects/client/src/lib/requests/queries/movies/movieSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieSummaryQuery.ts
@@ -21,7 +21,7 @@ const movieSummaryRequest = (
     });
 
 export const movieSummaryQuery = defineQuery({
-  key: 'movieSummary',
+  key: 'movieSummary:v2',
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: movieSummaryRequest,

--- a/projects/client/src/lib/requests/queries/search/response/toCommonMedia.ts
+++ b/projects/client/src/lib/requests/queries/search/response/toCommonMedia.ts
@@ -1,5 +1,6 @@
 import { unixToDateTime } from '../../../../utils/date/unixToDateTime.ts';
 import { prependHttps } from '../../../../utils/url/prependHttps.ts';
+import { mapToTrailerUrl } from '../../../_internal/mapToTrailerUrl.ts';
 import type { MovieSchema } from '../../../search/schema/MovieSchema.ts';
 import type { ShowSchema } from '../../../search/schema/ShowSchema.ts';
 import { toIds } from './toIds.ts';
@@ -14,7 +15,7 @@ export function toCommonMedia(input: ShowSchema | MovieSchema) {
     overview: input.overview,
     runtime: input.runtime,
     country: input.country,
-    trailer: prependHttps(input.trailer),
+    trailer: mapToTrailerUrl(input.trailer),
     homepage: prependHttps(input.homepage),
     status: input.status,
     rating: input.rating,

--- a/projects/client/src/lib/requests/queries/shows/showSummaryQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSummaryQuery.ts
@@ -21,7 +21,7 @@ const showSummaryRequest = (
     });
 
 export const showSummaryQuery = defineQuery({
-  key: 'showSummary',
+  key: 'showSummary:v2',
   invalidations: [],
   dependencies: (params) => [params.slug],
   request: showSummaryRequest,

--- a/projects/client/src/lib/utils/url/prependHttps.spec.ts
+++ b/projects/client/src/lib/utils/url/prependHttps.spec.ts
@@ -14,6 +14,18 @@ describe('prependHttps', () => {
     expect(prependHttps(input)).toBe('https://example.com');
   });
 
+  it('will return undefined for whitespace-only strings', () => {
+    const input = '   ';
+
+    expect(prependHttps(input)).toBeUndefined();
+  });
+
+  it('will replace http protocol with https', () => {
+    const input = 'http://example.com';
+
+    expect(prependHttps(input)).toBe('https://example.com');
+  });
+
   it('will backfall to provided placeholder if no host is given', () => {
     const input = '';
     const fallback = 'https://fallback.com';

--- a/projects/client/src/lib/utils/url/prependHttps.ts
+++ b/projects/client/src/lib/utils/url/prependHttps.ts
@@ -12,9 +12,16 @@ export function prependHttps(
   url: string | Nil,
   placeholder?: HttpsUrl,
 ): HttpsUrl | Nil {
-  if (!url) {
-    return placeholder;
+  const trimmed = url?.trim();
+  if (!trimmed) return placeholder;
+
+  if (trimmed.startsWith('https://')) {
+    return trimmed as HttpsUrl;
   }
 
-  return url.startsWith('https://') ? url as HttpsUrl : `https://${url}`;
+  if (trimmed.startsWith('http://')) {
+    return trimmed.replace('http://', 'https://') as HttpsUrl;
+  }
+
+  return `https://${trimmed}` as HttpsUrl;
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2108
- Validates trailer url's in the mapper
  - When `TrailerButton.svelte` would preload trailers that have a malformed url, it could result in `TypeError: Invalid URL`
- Small fix to make `prependHttps` more robust.