### PR TITLE
feat(i18n) / add turkish language support

### DIFF
--- a/projects/client/i18n/project.inlang/settings.json
+++ b/projects/client/i18n/project.inlang/settings.json
@@ -33,6 +33,7 @@
     "sv-se",
     "nb-no",
     "da-dk",
-    "zh-cn"
+    "zh-cn",
+    "tr-tr"
   ]
 }

--- a/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
+++ b/projects/client/src/lib/features/i18n/components/LocalePicker.svelte
@@ -50,6 +50,7 @@
     "nb-no": "🇳🇴",
     "da-dk": "🇩🇰",
     "zh-cn": "🇨🇳",
+    "tr-tr": "🇹🇷",
   };
 
   const localeToTitle: Record<AvailableLocale, string> = {
@@ -73,6 +74,7 @@
     "nb-no": "Norsk (Bokmål)",
     "da-dk": "Dansk",
     "zh-cn": "中文 (简体)",
+    "tr-tr": "Türkçe",
   };
 
   const options = $derived(


### PR DESCRIPTION
## Overview
Adds Turkish language support to the application, allowing users to select and view the interface in Turkish.

## Changes
- Registers the Turkish locale in the internationalization configuration settings
- Updates the locale picker component to include the Turkish flag emoji
- Adds the native translation for "Turkish" to the language selection menu

## Testing
- Verified that the Turkish option appears correctly in the locale picker with the associated flag and title.