### PR TITLE
Feat/paginated history

### DIFF
--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -43,6 +43,8 @@ declare global {
   type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K>
     : never;
 
+  type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
+
   type ChildrenProps = {
     children: import('svelte').Snippet;
   };

--- a/projects/client/src/lib/features/auth/stores/useCurrentUserHistory.ts
+++ b/projects/client/src/lib/features/auth/stores/useCurrentUserHistory.ts
@@ -21,7 +21,6 @@ const moviesHistoryLimit = 10000;
 export type UserHistory = {
   movies: Map<number, WatchedMovie>;
   shows: Map<number, WatchedShow>;
-  lastWatchedAt: Date | null;
 };
 
 function toWatchedMap<T extends { id: number }>(
@@ -34,22 +33,6 @@ function toQueryMap<T extends { id: number }>(
   query: { data?: { pages: Array<{ entries: T[] }> } },
 ): Map<number, T> {
   return toWatchedMap(query.data?.pages.flatMap((p) => p.entries) ?? []);
-}
-
-// FIXME: this can go when history is paginated properly
-function getLastWatchedAt(
-  movies: Map<number, WatchedMovie>,
-  shows: Map<number, WatchedShow>,
-): Date | null {
-  if (movies.size === 0 && shows.size === 0) return null;
-
-  const toMax = (max: Date, { watchedAt }: WatchedMovie | WatchedShow) =>
-    watchedAt > max ? watchedAt : max;
-
-  return [...shows.values()].reduce(
-    toMax,
-    [...movies.values()].reduce(toMax, new Date(0)),
-  );
 }
 
 function isSettled(
@@ -88,7 +71,6 @@ export function useCurrentUserHistory(): UseCurrentUserHistoryResult {
       return {
         movies: moviesMap,
         shows: showsMap,
-        lastWatchedAt: getLastWatchedAt(moviesMap, showsMap),
       };
     }),
     distinctUntilChanged((prev, curr) => prev === null && curr === null),

--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -133,7 +133,6 @@ export function useUser() {
           history: of<UserHistory>({
             movies: new Map(),
             shows: new Map(),
-            lastWatchedAt: null,
           }),
           watchlist: of<UserWatchlist>({
             movies: new Set(),

--- a/projects/client/src/lib/features/calendar/Calendar.svelte
+++ b/projects/client/src/lib/features/calendar/Calendar.svelte
@@ -44,14 +44,18 @@
       fingerprint: `${$mode}:${JSON.stringify($filterMap)}`,
     }),
   );
+
+  const navigation = $derived({
+    onNext: next,
+    onPrevious: previous,
+    onReset: reset,
+  });
 </script>
 
 <CalendarLayout
   activeDate={$activeDate}
   isLoading={$isLoading}
-  onNext={next}
-  onPrevious={previous}
-  onReset={reset}
+  {navigation}
   onLoadMore={loadMore}
   {periods}
   {order}

--- a/projects/client/src/lib/features/calendar/CalendarLayout.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarLayout.svelte
@@ -15,9 +15,7 @@
   const {
     activeDate,
     isLoading,
-    onNext,
-    onPrevious,
-    onReset,
+    navigation: externalNavigation,
     item,
     layout = "grid",
     maxDate,
@@ -47,17 +45,15 @@
       ?.scrollIntoView({ block: "start" });
   }
 
-  function handleNext() {
-    handleNavigation(onNext);
-  }
+  const navigation = $derived.by(() => {
+    if (!externalNavigation) return;
 
-  function handlePrevious() {
-    handleNavigation(onPrevious);
-  }
-
-  function handleReset() {
-    handleNavigation(onReset);
-  }
+    return {
+      onNext: () => handleNavigation(externalNavigation.onNext),
+      onPrevious: () => handleNavigation(externalNavigation.onPrevious),
+      onReset: () => handleNavigation(externalNavigation.onReset),
+    };
+  });
 
   const visiblePeriodCalendar = $derived.by(() => {
     const firstPeriod = periods.at(0)?.calendar ?? [];
@@ -81,31 +77,29 @@
   const { observeDimension } = useLazyLoader({ loadMore, parent: null });
 
   const isInitialPeriod = $derived(periods.length <= 1);
+  const isInitialLoad = $derived(isInitialPeriod && isLoading);
 </script>
 
 <div class="calendar-layout-container" use:observeDimension>
-  <div
-    class="calendar-navigation"
-    use:trackWindowScroll={"is-scrolled"}
-    use:trackElementBottom={"--calendar-nav-bottom"}
-  >
-    <CalendarHeader
-      onNext={handleNext}
-      onPrevious={handlePrevious}
-      onReset={handleReset}
-      {maxDate}
-      activeDate={selectedDate}
-    />
-    <CalendarDays
-      calendar={visiblePeriodCalendar}
-      onNext={handleNext}
-      onPrevious={handlePrevious}
-      {maxDate}
-      activeDate={selectedDate}
-    />
-  </div>
+  {#if navigation || !isInitialLoad}
+    <div
+      class="calendar-navigation"
+      use:trackWindowScroll={"is-scrolled"}
+      use:trackElementBottom={"--calendar-nav-bottom"}
+    >
+      {#if navigation}
+        <CalendarHeader {navigation} {maxDate} activeDate={selectedDate} />
+      {/if}
+      <CalendarDays
+        calendar={visiblePeriodCalendar}
+        {navigation}
+        {maxDate}
+        activeDate={selectedDate}
+      />
+    </div>
+  {/if}
 
-  {#if isLoading && isInitialPeriod}
+  {#if isInitialLoad}
     <div class="loading-wrapper">
       <LoadingIndicator />
     </div>

--- a/projects/client/src/lib/features/calendar/_internal/CalendarControls.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarControls.svelte
@@ -8,13 +8,12 @@
   import { isToday } from "date-fns/isToday";
   import type { CalendarNavigationProps } from "../models/CalendarNavigationProps";
 
-  const {
-    onNext,
-    onPrevious,
-    onReset,
-    activeDate,
-    maxDate,
-  }: CalendarNavigationProps = $props();
+  type CalendarControlsProps = WithRequired<
+    CalendarNavigationProps,
+    "navigation"
+  >;
+
+  const { navigation, activeDate, maxDate }: CalendarControlsProps = $props();
 
   const isNextDisabled = $derived(
     maxDate ? isSameWeek(activeDate, maxDate) : false,
@@ -24,7 +23,7 @@
 <div class="calendar-controls">
   <ActionButton
     label={m.button_label_previous_calendar_period()}
-    onclick={onPrevious}
+    onclick={navigation.onPrevious}
     style="ghost"
   >
     <CaretLeftIcon />
@@ -34,7 +33,7 @@
     color="default"
     label={m.button_label_reset_calendar_period()}
     disabled={isToday(activeDate)}
-    onclick={onReset}
+    onclick={navigation.onReset}
     style="ghost"
   >
     {m.button_text_reset_calendar_period()}
@@ -42,7 +41,7 @@
 
   <ActionButton
     label={m.button_label_next_calendar_period()}
-    onclick={onNext}
+    onclick={navigation.onNext}
     style="ghost"
     disabled={isNextDisabled}
   >

--- a/projects/client/src/lib/features/calendar/_internal/CalendarDays.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarDays.svelte
@@ -7,18 +7,10 @@
   import { dateKey } from "./dateKey";
   import Day from "./Day.svelte";
 
-  type CalendarDaysProps = { calendar: Calendar<T> } & Omit<
-    CalendarNavigationProps,
-    "onReset"
-  >;
+  type CalendarDaysProps = { calendar: Calendar<T> } & CalendarNavigationProps;
 
-  const {
-    calendar,
-    activeDate,
-    onNext,
-    onPrevious,
-    maxDate,
-  }: CalendarDaysProps = $props();
+  const { calendar, activeDate, navigation, maxDate }: CalendarDaysProps =
+    $props();
 
   const isNextDisabled = $derived(
     maxDate ? isSameWeek(activeDate, maxDate) : false,
@@ -28,7 +20,7 @@
   );
 </script>
 
-<CalendarSwipe onNextPeriod={onNext} onPreviousPeriod={onPrevious} {directions}>
+{#snippet calendarDays()}
   <div class="trakt-calendar-days">
     {#each calendar as day (dateKey(day.date))}
       <Day
@@ -37,7 +29,19 @@
       />
     {/each}
   </div>
-</CalendarSwipe>
+{/snippet}
+
+{#if navigation}
+  <CalendarSwipe
+    onNextPeriod={navigation.onNext}
+    onPreviousPeriod={navigation.onPrevious}
+    {directions}
+  >
+    {@render calendarDays()}
+  </CalendarSwipe>
+{:else}
+  {@render calendarDays()}
+{/if}
 
 <style>
   .trakt-calendar-days {

--- a/projects/client/src/lib/features/calendar/_internal/CalendarHeader.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarHeader.svelte
@@ -2,7 +2,8 @@
   import type { CalendarNavigationProps } from "../models/CalendarNavigationProps";
   import CalendarControls from "./CalendarControls.svelte";
 
-  const navigationProps: CalendarNavigationProps = $props();
+  const navigationProps: WithRequired<CalendarNavigationProps, "navigation"> =
+    $props();
 </script>
 
 <div class="calendar-header">

--- a/projects/client/src/lib/features/calendar/models/CalendarNavigationProps.ts
+++ b/projects/client/src/lib/features/calendar/models/CalendarNavigationProps.ts
@@ -1,7 +1,9 @@
 export type CalendarNavigationProps = {
   activeDate: Date;
-  onNext: () => void;
-  onPrevious: () => void;
-  onReset: () => void;
   maxDate?: Date;
+  navigation?: {
+    onNext: () => void;
+    onPrevious: () => void;
+    onReset: () => void;
+  };
 };

--- a/projects/client/src/lib/sections/lists/activity/ActivityPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/activity/ActivityPaginatedList.svelte
@@ -45,14 +45,18 @@
       fingerprint: `${$mode}:${JSON.stringify($filterMap)}`,
     }),
   );
+
+  const navigation = $derived({
+    onNext: next,
+    onPrevious: previous,
+    onReset: reset,
+  });
 </script>
 
 <CalendarLayout
   activeDate={$activeDate}
   isLoading={$isLoading}
-  onNext={next}
-  onPrevious={previous}
-  onReset={reset}
+  {navigation}
   onLoadMore={loadMore}
   {periods}
   layout="list"

--- a/projects/client/src/lib/sections/lists/history/PersonalHistoryPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/PersonalHistoryPaginatedList.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import CalendarLayout from "$lib/features/calendar/CalendarLayout.svelte";
   import { useCalendarPeriod } from "$lib/features/calendar/context/useCalendarPeriod";
-  import type { CalendarPeriod } from "$lib/features/calendar/models/CalendarLayoutProps";
   import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
   import { HISTORY_UPPER_LIMIT } from "$lib/utils/constants";
-  import type { HistoryEntry } from "../stores/models/HistoryEntry";
   import { useRecentlyWatchedList } from "../stores/useRecentlyWatchedList";
   import { toRecentlyWatchedType } from "./_internal/toRecentlyWatchedType";
   import RecentlyWatchedItem from "./RecentlyWatchedItem.svelte";
@@ -14,52 +12,36 @@
 
   const order = "reverse-chronological" as const;
 
-  const {
-    startDate,
-    endDate,
-    activeDate,
-    next,
-    previous,
-    reset,
-    loadMore,
-    accumulate,
-  } = useCalendarPeriod({ order });
+  const { activeDate } = useCalendarPeriod({ order });
 
   const historyType = $derived(toRecentlyWatchedType(mode));
 
   const { filterMap } = useFilter();
 
-  const { historyCalendar, isLoading } = $derived(
+  const { periods, isLoading, hasNextPage, fetchNextPage } = $derived(
     useRecentlyWatchedList({
       type: historyType,
       slug: "me",
-      range: {
-        startDate: $startDate,
-        endDate: $endDate,
-      },
       limit: HISTORY_UPPER_LIMIT,
       filter: $filterMap,
     }),
   );
 
-  const periods: CalendarPeriod<HistoryEntry>[] = $derived(
-    accumulate({
-      calendar: $historyCalendar,
-      fingerprint: `${historyType}:${JSON.stringify($filterMap)}`,
-    }),
-  );
+  const loadMore = $derived(() => {
+    if (!$hasNextPage) return;
+    fetchNextPage();
+  });
 
   const now = new Date();
+
+  // FIXME: add support for prev/next/reset to this paginated variant
 </script>
 
 <CalendarLayout
   activeDate={$activeDate}
   isLoading={$isLoading}
-  onNext={next}
-  onPrevious={previous}
-  onReset={reset}
   onLoadMore={loadMore}
-  {periods}
+  periods={$periods}
   layout="list"
   maxDate={now}
   {order}

--- a/projects/client/src/lib/sections/lists/stores/_internal/createHistoryCalendar.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/createHistoryCalendar.ts
@@ -23,6 +23,5 @@ export function createHistoryCalendar<T>(
           getActivityTime(b).getTime() - getActivityTime(a).getTime()
         ),
       };
-    })
-    .sort((a, b) => a.date.getTime() - b.date.getTime());
+    });
 }

--- a/projects/client/src/lib/sections/lists/stores/_internal/createHistoryCalendar.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/createHistoryCalendar.ts
@@ -1,0 +1,28 @@
+import type { ActivityEntry } from '$lib/sections/lists/stores/models/ActivityEntry.ts';
+import { getDayKey } from '$lib/utils/date/getDayKey.ts';
+import { getActivityTime } from './getActivityTime.ts';
+
+const daysInWeek = 7;
+
+export function createHistoryCalendar<T>(
+  groups: Map<string, ActivityEntry<T>[]>,
+  startDate: Date,
+) {
+  if (!startDate) return [];
+
+  return Array.from({ length: daysInWeek })
+    .map((_, i) => {
+      const date = new Date(startDate);
+      date.setDate(date.getDate() + i);
+      const key = getDayKey(date);
+      const items = groups.get(key) ?? [];
+
+      return {
+        date,
+        items: items.toSorted((a, b) =>
+          getActivityTime(b).getTime() - getActivityTime(a).getTime()
+        ),
+      };
+    })
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+}

--- a/projects/client/src/lib/sections/lists/stores/_internal/getActivityTime.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/getActivityTime.ts
@@ -1,0 +1,9 @@
+import type { ActivityEntry } from '$lib/sections/lists/stores/models/ActivityEntry.ts';
+
+export function getActivityTime<T>(entry: ActivityEntry<T>): Date {
+  if ('watchedAt' in entry) {
+    return entry.watchedAt;
+  }
+
+  return entry.activityAt;
+}

--- a/projects/client/src/lib/sections/lists/stores/_internal/groupHistoryByDay.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/groupHistoryByDay.ts
@@ -1,0 +1,15 @@
+import type { ActivityEntry } from '$lib/sections/lists/stores/models/ActivityEntry.ts';
+import { getDayKey } from '$lib/utils/date/getDayKey.ts';
+import { getActivityTime } from './getActivityTime.ts';
+
+export function groupHistoryByDay<T>(items: ActivityEntry<T>[]) {
+  return items.reduce((groups, item) => {
+    const key = getDayKey(getActivityTime(item));
+    const group = groups.get(key) ?? [];
+
+    group.push(item);
+    groups.set(key, group);
+
+    return groups;
+  }, new Map<string, ActivityEntry<T>[]>());
+}

--- a/projects/client/src/lib/sections/lists/stores/_internal/mapToActivityCalendar.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/mapToActivityCalendar.ts
@@ -1,52 +1,7 @@
 import type { Calendar } from '$lib/features/calendar/models/Calendar.ts';
-import { getDayKey } from '$lib/utils/date/getDayKey.ts';
-
-const DAYS_IN_WEEK = 7;
-
-type ActivityEntry<T> = T & ({ watchedAt: Date } | { activityAt: Date });
-
-function getActivityTime<T>(entry: ActivityEntry<T>): Date {
-  if ('watchedAt' in entry) {
-    return entry.watchedAt;
-  }
-
-  return entry.activityAt;
-}
-
-function groupHistoryByDay<T>(items: ActivityEntry<T>[]) {
-  return items.reduce((groups, item) => {
-    const key = getDayKey(getActivityTime(item));
-    const group = groups.get(key) ?? [];
-
-    group.push(item);
-    groups.set(key, group);
-
-    return groups;
-  }, new Map<string, ActivityEntry<T>[]>());
-}
-
-function createHistoryCalendar<T>(
-  groups: Map<string, ActivityEntry<T>[]>,
-  startDate: Date,
-) {
-  if (!startDate) return [];
-
-  return Array.from({ length: DAYS_IN_WEEK })
-    .map((_, i) => {
-      const date = new Date(startDate);
-      date.setDate(date.getDate() + i);
-      const key = getDayKey(date);
-      const items = groups.get(key) ?? [];
-
-      return {
-        date,
-        items: items.toSorted((a, b) =>
-          getActivityTime(b).getTime() - getActivityTime(a).getTime()
-        ),
-      };
-    })
-    .sort((a, b) => a.date.getTime() - b.date.getTime());
-}
+import type { ActivityEntry } from '$lib/sections/lists/stores/models/ActivityEntry.ts';
+import { createHistoryCalendar } from './createHistoryCalendar.ts';
+import { groupHistoryByDay } from './groupHistoryByDay.ts';
 
 export function mapToActivityCalendar<T>(
   items: ActivityEntry<T>[],

--- a/projects/client/src/lib/sections/lists/stores/_internal/mapToCalendarPeriods.spec.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/mapToCalendarPeriods.spec.ts
@@ -1,0 +1,101 @@
+import type { ActivityEntry } from '$lib/sections/lists/stores/models/ActivityEntry.ts';
+import { describe, expect, it } from 'vitest';
+import { mapToCalendarPeriods } from './mapToCalendarPeriods.ts';
+
+type TestEntry = ActivityEntry<{ id: number }>;
+
+function createEntry(id: number, watchedAt: Date): TestEntry {
+  return { id, watchedAt };
+}
+
+// With 'en' locale, weeks start on Sunday.
+// Week A: 2024-03-03 (Sun) – 2024-03-09 (Sat)
+// Week B: 2024-03-10 (Sun) – 2024-03-16 (Sat)
+const WEEK_A_MON = new Date('2024-03-04T12:00:00');
+const WEEK_A_WED = new Date('2024-03-06T12:00:00');
+const WEEK_B_MON = new Date('2024-03-11T12:00:00');
+
+describe('mapToCalendarPeriods', () => {
+  it('returns an empty array for empty input', () => {
+    expect(mapToCalendarPeriods([])).toEqual([]);
+  });
+
+  it('returns a single period for a single item', () => {
+    const result = mapToCalendarPeriods([createEntry(1, WEEK_A_MON)]);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('groups items from the same week into one period', () => {
+    const items = [createEntry(1, WEEK_A_MON), createEntry(2, WEEK_A_WED)];
+
+    const result = mapToCalendarPeriods(items);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('groups items from different weeks into separate periods', () => {
+    const items = [createEntry(1, WEEK_A_MON), createEntry(2, WEEK_B_MON)];
+
+    const result = mapToCalendarPeriods(items);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('sorts periods with the most recent week first', () => {
+    const items = [createEntry(1, WEEK_A_MON), createEntry(2, WEEK_B_MON)];
+
+    const result = mapToCalendarPeriods(items);
+
+    const firstPeriodDate = result.at(0)?.calendar.at(0)?.date.getTime() ?? 0;
+    const secondPeriodDate = result.at(1)?.calendar.at(0)?.date.getTime() ?? 0;
+    expect(firstPeriodDate).toBeGreaterThan(secondPeriodDate);
+  });
+
+  it('generates a period key prefixed with "period-"', () => {
+    const result = mapToCalendarPeriods([createEntry(1, WEEK_A_MON)]);
+
+    expect(result.at(0)?.key).toMatch(/^period-\d+$/);
+  });
+
+  it('each period calendar has 7 days', () => {
+    const items = [createEntry(1, WEEK_A_MON), createEntry(2, WEEK_B_MON)];
+
+    const result = mapToCalendarPeriods(items);
+
+    for (const period of result) {
+      expect(period.calendar).toHaveLength(7);
+    }
+  });
+
+  it('places items on the correct day within the calendar', () => {
+    const result = mapToCalendarPeriods([createEntry(1, WEEK_A_MON)]);
+
+    const calendar = result.at(0)?.calendar;
+    const monday = calendar?.find(
+      (day) => day.date.getDate() === WEEK_A_MON.getDate(),
+    );
+    expect(monday?.items).toHaveLength(1);
+    expect(monday?.items.at(0)).toMatchObject({ id: 1 });
+  });
+
+  it('groups multiple items on the same day', () => {
+    const entry1 = createEntry(1, new Date('2024-03-04T10:00:00'));
+    const entry2 = createEntry(2, new Date('2024-03-04T20:00:00'));
+
+    const result = mapToCalendarPeriods([entry1, entry2]);
+    const calendar = result.at(0)?.calendar;
+    const monday = calendar?.find((day) => day.date.getDate() === 4);
+
+    expect(monday?.items).toHaveLength(2);
+  });
+
+  it('assigns unique keys to separate periods', () => {
+    const items = [createEntry(1, WEEK_A_MON), createEntry(2, WEEK_B_MON)];
+
+    const result = mapToCalendarPeriods(items);
+
+    const keys = result.map((p) => p.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/projects/client/src/lib/sections/lists/stores/_internal/mapToCalendarPeriods.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/mapToCalendarPeriods.ts
@@ -1,0 +1,47 @@
+import type { CalendarPeriod } from '$lib/features/calendar/models/CalendarLayoutProps.ts';
+import { getLocale } from '$lib/features/i18n/index.ts';
+import type { ActivityEntry } from '$lib/sections/lists/stores/models/ActivityEntry.ts';
+import { getDayKey } from '$lib/utils/date/getDayKey.ts';
+import { getStartOfWeek } from '$lib/utils/date/getStartOfWeek.ts';
+import { createHistoryCalendar } from './createHistoryCalendar.ts';
+import { getActivityTime } from './getActivityTime.ts';
+import { groupHistoryByDay } from './groupHistoryByDay.ts';
+
+type WeekGroup<T> = {
+  weekStart: Date;
+  items: ActivityEntry<T>[];
+};
+
+function groupItemsByWeek<T>(
+  items: ActivityEntry<T>[],
+): Map<string, WeekGroup<T>> {
+  return items.reduce((weeks, item) => {
+    const activityDate = getActivityTime(item);
+    const weekStart = getStartOfWeek(activityDate, getLocale());
+    const weekKey = getDayKey(weekStart);
+    const existing = weeks.get(weekKey) ?? { weekStart, items: [] };
+    existing.items.push(item);
+    weeks.set(weekKey, existing);
+    return weeks;
+  }, new Map<string, WeekGroup<T>>());
+}
+
+export function mapToCalendarPeriods<T>(
+  items: ActivityEntry<T>[],
+): CalendarPeriod<ActivityEntry<T>>[] {
+  if (!items.length) return [];
+
+  const weekGroups = groupItemsByWeek(items);
+
+  return Array.from(weekGroups.values())
+    .map(({ weekStart, items: weekItems }) => {
+      const groups = groupHistoryByDay(weekItems);
+      const calendar = createHistoryCalendar(groups, weekStart);
+      return { key: `period-${weekStart.getTime()}`, calendar };
+    })
+    .toSorted((a, b) => {
+      const dateB = b.calendar.at(0)?.date.getTime() ?? 0;
+      const dateA = a.calendar.at(0)?.date.getTime() ?? 0;
+      return dateB - dateA;
+    });
+}

--- a/projects/client/src/lib/sections/lists/stores/models/ActivityEntry.ts
+++ b/projects/client/src/lib/sections/lists/stores/models/ActivityEntry.ts
@@ -1,0 +1,1 @@
+export type ActivityEntry<T> = T & ({ watchedAt: Date } | { activityAt: Date });

--- a/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
@@ -13,33 +13,27 @@ import {
 import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
 import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { map } from 'rxjs';
-import { mapToActivityCalendar } from './_internal/mapToActivityCalendar.ts';
+import { mapToCalendarPeriods } from './_internal/mapToCalendarPeriods.ts';
 import type { HistoryEntry } from './models/HistoryEntry.ts';
 
 export type RecentlyWatchedType = 'movie' | 'show' | 'episode' | 'media';
-
-type DateRange = {
-  startDate: Date;
-  endDate: Date;
-};
 
 type RecentlyWatchedListStoreProps = {
   type: RecentlyWatchedType;
   limit?: number;
   slug?: string;
   id?: number;
-  range?: DateRange;
+  page?: number;
 } & FilterParams;
 
 function typeToQuery(
-  { type, id, slug, range, limit, filter }: RecentlyWatchedListStoreProps,
+  { type, id, slug, page, limit, filter }: RecentlyWatchedListStoreProps,
 ) {
   const params = {
     limit: limit ?? DEFAULT_PAGE_SIZE,
     slug: slug ?? 'me',
     id,
-    startDate: range?.startDate,
-    endDate: range?.endDate,
+    page: page ?? 1,
     filter,
   };
 
@@ -57,6 +51,7 @@ function typeToQuery(
         HistoryEntry
       >;
     default:
+      // FIXME: switch to all endpoint
       return activityHistoryQuery(params) as InfiniteQuery<
         HistoryEntry
       >;
@@ -68,9 +63,9 @@ export function useRecentlyWatchedList(
 ) {
   const { list, ...rest } = usePaginatedListQuery(typeToQuery(params));
 
-  const historyCalendar = list.pipe(
-    map((items) => mapToActivityCalendar(items, params.range?.startDate)),
+  const periods = list.pipe(
+    map((items) => mapToCalendarPeriods(items)),
   );
 
-  return { list, historyCalendar, ...rest };
+  return { list, periods, ...rest };
 }

--- a/projects/client/src/mocks/data/users/mapped/UserHistoryMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/UserHistoryMappedMock.ts
@@ -3,7 +3,6 @@ import type {
 } from '$lib/features/auth/stores/useCurrentUserHistory.ts';
 
 export const UserHistoryMappedMock: UserHistory = {
-  'lastWatchedAt': new Date('2024-12-27T16:28:32.000Z'),
   'movies': new Map([
     [916302, {
       'id': 916302,

--- a/projects/client/src/routes/history/+page.svelte
+++ b/projects/client/src/routes/history/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { useUser } from "$lib/features/auth/stores/useUser";
   import CalendarProvider from "$lib/features/calendar/CalendarProvider.svelte";
   import { useDiscover } from "$lib/features/discover/useDiscover";
   import * as m from "$lib/features/i18n/messages";
@@ -10,7 +9,6 @@
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   const { mode, current } = useDiscover();
-  const { history } = useUser();
 </script>
 
 <TraktPage
@@ -25,9 +23,7 @@
     header={{ title: m.list_title_history(), metaInfo: $current.text() }}
   />
 
-  {#if $history}
-    <CalendarProvider initialDate={$history.lastWatchedAt}>
-      <PersonalHistoryPaginatedList mode={$mode} />
-    </CalendarProvider>
-  {/if}
+  <CalendarProvider>
+    <PersonalHistoryPaginatedList mode={$mode} />
+  </CalendarProvider>
 </TraktPage>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2248
- Refactor: extracts calendar mapping utils.
- Switches personal history to paginate properly; i.e. data is fetched as any other paginated query, results are mapped to a calendar period.
  - This also allows us to get rid of the pre-calculated `lastWatchedAt` date from the user history.
- Adds tests for the new mapping logic.

## 👀 Example 👀

https://github.com/user-attachments/assets/0944c4c5-39a4-45b6-b5dd-faa897219979

