### PR TITLE
fix(i18n): uses left instead of remaining

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -38,8 +38,8 @@
       "exclude": []
     },
     "tag_text_remaining_episodes": {
-      "default": "{count} remaining",
-      "description": "Text for the tag that shows the number of remaining episodes in a show. This should be as short as possible.",
+      "default": "{count} left",
+      "description": "Text for the tag that shows the number of episodes left in a show. This should be as short as possible.",
       "variables": {
         "count": {
           "type": "number"
@@ -6226,7 +6226,7 @@
       ]
     },
     "tag_text_remaining_duration": {
-      "default": "{duration} remaining",
+      "default": "{duration} left",
       "description": "Text for the tag that shows the remaining duration of an episode or movie. This should be as short as possible.",
       "variables": {
         "duration": {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Small change to switch from `remaining` to `left`.

## 👀 Example 👀
<img width="918" height="232" alt="Screenshot 2026-05-04 at 15 04 48" src="https://github.com/user-attachments/assets/b8e457e0-7fc5-4b19-b0d0-8623ddf51d34" />
