### PR TITLE
feat: open graph images for movie and show summary

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -4,6 +4,7 @@
     "jsr:@std/cli@^1.0.24": "1.0.24",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/path@^1.1.3": "1.1.3",
+    "npm:@cloudflare/workers-types@4.20260504.1": "4.20260504.1",
     "npm:@cucumber/cucumber@12.6.0": "12.6.0_@cucumber+gherkin@37.0.1_@cucumber+message-streams@4.0.1__@cucumber+messages@31.2.0_@cucumber+messages@31.2.0",
     "npm:@eslint/js@^10.0.1": "10.0.1_eslint@10.0.0",
     "npm:@ethercorps/sveltekit-og@4.2.1": "4.2.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3",
@@ -11,7 +12,7 @@
     "npm:@jsr/libn__fuzzy@0.4": "0.4.0",
     "npm:@jsr/trakt__api@0.4.11": "0.4.11_openapi3-ts@4.5.0",
     "npm:@playwright/test@1.58.2": "1.58.2",
-    "npm:@sentry/sveltekit@10.45.0": "10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3",
+    "npm:@sentry/sveltekit@10.45.0": "10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_@cloudflare+workers-types@4.20260504.1",
     "npm:@sveltejs/adapter-auto@7.0.1": "7.0.1_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
     "npm:@sveltejs/adapter-cloudflare@7.2.7": "7.2.7_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
     "npm:@sveltejs/kit@^2.55.0": "2.55.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3",
@@ -897,8 +898,8 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@cloudflare/workers-types@4.20260218.0": {
-      "integrity": "sha512-E28uJNJb9J9pca3RaxjXm1JxAjp8td9/cudkY+IT8rio71NlshN7NKMe2Cr/6GN+RufbSnp+N3ZKP74xgUaL0A=="
+    "@cloudflare/workers-types@4.20260504.1": {
+      "integrity": "sha512-x/7BzBXSGBQS0wHdaY0/1bcaRszkkhCjTc5maQvNSHu/pTVdBF2f/L41W8pRSJJSbLL80ynW7O923O7v3PaLtg=="
     },
     "@colors/colors@1.5.0": {
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
@@ -3022,11 +3023,15 @@
       "scripts": true,
       "bin": true
     },
-    "@sentry/cloudflare@10.45.0": {
+    "@sentry/cloudflare@10.45.0_@cloudflare+workers-types@4.20260504.1": {
       "integrity": "sha512-4rXUCSnBu9MITm7Uj27tYxEhmHczamdMLfeipBjvgeFBJ3LUJBKqrfolCOL5d3q9in/CopgyhMxY7pgUwlCJ8w==",
       "dependencies": [
+        "@cloudflare/workers-types",
         "@opentelemetry/api",
         "@sentry/core"
+      ],
+      "optionalPeers": [
+        "@cloudflare/workers-types"
       ]
     },
     "@sentry/core@10.45.0": {
@@ -3124,7 +3129,7 @@
         "svelte"
       ]
     },
-    "@sentry/sveltekit@10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.51.3___acorn@8.15.0__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_svelte@5.51.3__acorn@8.15.0_typescript@5.8.3": {
+    "@sentry/sveltekit@10.45.0_@sveltejs+kit@2.55.0__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.51.3____acorn@8.15.0___vite@8.0.1____esbuild@0.27.4____sass-embedded@1.97.3__svelte@5.51.3___acorn@8.15.0__typescript@5.8.3__vite@8.0.1___esbuild@0.27.4___sass-embedded@1.97.3_vite@8.0.1__esbuild@0.27.4__sass-embedded@1.97.3_@cloudflare+workers-types@4.20260504.1": {
       "integrity": "sha512-owbKr6BlfhODiJzSQrjd+r400PdLjQQkbsNRHBLHjiwrL29Xf8SCM2fzFPh0FZYqgpG/opOi9CAVgNpmq1nWRg==",
       "dependencies": [
         "@babel/parser@7.26.9",
@@ -7583,7 +7588,6 @@
       "dependencies": [
         "@cloudflare/kv-asset-handler",
         "@cloudflare/unenv-preset",
-        "@cloudflare/workers-types",
         "blake3-wasm",
         "esbuild@0.27.3",
         "miniflare",
@@ -7593,9 +7597,6 @@
       ],
       "optionalDependencies": [
         "fsevents@2.3.3"
-      ],
-      "optionalPeers": [
-        "@cloudflare/workers-types"
       ],
       "bin": true
     },
@@ -7715,6 +7716,7 @@
         ],
         "packageJson": {
           "dependencies": [
+            "npm:@cloudflare/workers-types@4.20260504.1",
             "npm:@cucumber/cucumber@12.6.0",
             "npm:@eslint/js@^10.0.1",
             "npm:@ethercorps/sveltekit-og@4.2.1",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -29,6 +29,7 @@
     "i18n:generate:watch": "deno run --allow-read --allow-write i18n/generator/cli.ts -i i18n/meta/ -o i18n/ --watch"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "4.20260504.1",
     "@cucumber/cucumber": "12.6.0",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "1.58.2",

--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -203,6 +203,11 @@ declare global {
       preservedFilters?: Record<string, string>;
     }
     // interface Platform {}
+    interface Platform {
+      env: {
+        R2_WALTER: import('@cloudflare/workers-types').R2Bucket;
+      };
+    }
   }
 
   namespace svelteHTML {

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -9,6 +9,7 @@
   import Redirect from "../../components/router/Redirect.svelte";
   import Footer from "../footer/Footer.svelte";
   import NavbarStateSetter from "../navbar/NavbarStateSetter.svelte";
+  import { openGraphUrlBuilder } from "./_internal/openGraphUrlBuilder";
 
   type TraktPageProps = {
     title: string | undefined;
@@ -36,8 +37,22 @@
   const websiteName = "Trakt Web";
   const websiteTitle = "Track Your Shows & Movies";
   const twitterHandle = "@trakt";
+  const slug = $derived(page.params.slug);
 
-  const image = $derived(_image ?? DEFAULT_SHARE_COVER);
+  const image = $derived.by(() => {
+    const isMediaPage = type === "movie" || type === "show";
+    if (isMediaPage && slug) {
+      return openGraphUrlBuilder({
+        url: page.url,
+        type,
+        slug,
+        shareType: "open-graph",
+      });
+    }
+
+    return _image ?? DEFAULT_SHARE_COVER;
+  });
+
   const displayTitle = $derived(`${websiteName}: ${_title || websiteTitle}`);
   const defaultOgTitle = `${websiteName}: ${websiteTitle}`;
 

--- a/projects/client/src/lib/sections/layout/_internal/openGraphUrlBuilder.ts
+++ b/projects/client/src/lib/sections/layout/_internal/openGraphUrlBuilder.ts
@@ -1,0 +1,26 @@
+import type { ShareType } from '$lib/features/share/models/ShareType.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
+
+type OpenGraphUrlBuilderProps = {
+  url: URL;
+  type: MediaType;
+  slug: string;
+  shareType: ShareType;
+};
+
+function toUrlBuilder(type: ShareType) {
+  switch (type) {
+    case 'open-graph':
+      return UrlBuilder.api.shareableImage.openGraph;
+  }
+}
+
+export function openGraphUrlBuilder(
+  { url, type, slug, shareType }: OpenGraphUrlBuilderProps,
+): HttpsUrl {
+  const root = url.origin;
+  const urlBuilder = toUrlBuilder(shareType);
+
+  return `${root}${urlBuilder(type, slug)}` as HttpsUrl;
+}

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -326,4 +326,10 @@ export const UrlBuilder = {
     wikipedia: (id: string) => `https://en.wikipedia.org/wiki/${id}`,
   },
   feedback: () => 'https://roadmap.trakt.tv',
+  api: {
+    shareableImage: {
+      openGraph: (type: 'movie' | 'show', slug: string) =>
+        `/api/shareable-image?type=${type}&slug=${slug}&variant=open-graph`,
+    },
+  },
 };

--- a/projects/client/src/routes/api/shareable-image/+server.ts
+++ b/projects/client/src/routes/api/shareable-image/+server.ts
@@ -7,15 +7,17 @@ import { error } from '$lib/utils/console/print.ts';
 import { IS_DEV } from '$lib/utils/env/index.ts';
 import { ImageResponse } from '@ethercorps/sveltekit-og';
 import type { RequestHandler } from '@sveltejs/kit';
+import { buildImagePath } from './_internal/buildImagePath.ts';
 import { fetchMediaData } from './_internal/fetchMediaData.ts';
 import { fetchPosterDataUri } from './_internal/fetchPosterDataUri.ts';
 import { fetchWithUserAgent } from './_internal/fetchWithUserAgent.ts';
 
-export const GET: RequestHandler = async ({ request, url, fetch }) => {
-  if (!IS_DEV) {
-    return new Response('Not found', { status: 404 });
-  }
+const cacheControl = 'public, max-age=604800';
 
+// FIXME: add support for HMAC signed urls
+export const GET: RequestHandler = async (
+  { request, url, fetch, platform },
+) => {
   const type = url.searchParams.get('type');
   const slug = url.searchParams.get('slug');
   const variant = url.searchParams.get('variant');
@@ -28,8 +30,35 @@ export const GET: RequestHandler = async ({ request, url, fetch }) => {
     return new Response('Invalid type parameter', { status: 400 });
   }
 
+  if (!/^[\w-]+$/.test(slug)) {
+    return new Response('Invalid slug parameter', { status: 400 });
+  }
+
   if (!(variant in SHARE_TYPE_DIMENSIONS)) {
     return new Response('Invalid variant parameter', { status: 400 });
+  }
+
+  if (!IS_DEV && !platform?.env?.R2_WALTER) {
+    return new Response('Server configuration error', { status: 500 });
+  }
+
+  const shareType = variant as ShareType;
+  const imagePath = buildImagePath({ shareType, slug, type });
+
+  if (!IS_DEV && platform) {
+    const cachedImage = await platform.env.R2_WALTER.get(imagePath);
+    if (cachedImage) {
+      /*
+        Cast needed due to structural mismatch between Cloudflare's ReadableStream
+        and the DOM ReadableStream, they're the same at runtime.
+      */
+      return new Response(cachedImage.body as BodyInit, {
+        headers: {
+          'Content-Type': 'image/png',
+          'Cache-Control': cacheControl,
+        },
+      });
+    }
   }
 
   const fetchFn = fetchWithUserAgent({
@@ -57,7 +86,6 @@ export const GET: RequestHandler = async ({ request, url, fetch }) => {
     return new Response('Failed to fetch poster', { status: 500 });
   }
 
-  const shareType = variant as ShareType;
   const { width, height } = SHARE_TYPE_DIMENSIONS[shareType];
 
   try {
@@ -66,18 +94,28 @@ export const GET: RequestHandler = async ({ request, url, fetch }) => {
       {
         width,
         height,
-        debug: url.searchParams.get('debug') === 'true',
+        debug: IS_DEV && url.searchParams.get('debug') === 'true',
       },
-      {
-        media,
-        crew,
-        ratings,
-        posterUrl: posterDataUri,
-        variant: shareType,
-      },
+      { media, crew, ratings, posterUrl: posterDataUri, variant: shareType },
     );
+
     const buffer = await imageResponse.arrayBuffer();
-    return new Response(buffer, { headers: imageResponse.headers });
+
+    if (!IS_DEV && platform) {
+      try {
+        await platform.env.R2_WALTER.put(imagePath, buffer, {
+          httpMetadata: { contentType: 'image/png' },
+          customMetadata: { cachedAt: String(Date.now()) },
+        });
+      } catch (e) {
+        error('Failed to cache image in R2:', e);
+      }
+    }
+
+    const responseHeaders = new Headers(imageResponse.headers);
+    responseHeaders.set('Cache-Control', cacheControl);
+
+    return new Response(buffer, { headers: responseHeaders });
   } catch (e) {
     error('ImageResponse error:', e);
     return new Response('Failed to generate image', { status: 500 });

--- a/projects/client/src/routes/api/shareable-image/_internal/buildImagePath.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/buildImagePath.ts
@@ -1,0 +1,33 @@
+import type { ShareType } from '$lib/features/share/models/ShareType.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+
+const rootPath = 'images';
+
+type BuildImagePathProps = {
+  shareType: ShareType;
+  slug: string;
+  type: MediaType;
+};
+
+function toShareTypePath(shareType: ShareType): string {
+  switch (shareType) {
+    case 'open-graph':
+      return 'og';
+  }
+}
+
+function toMediaPath(type: MediaType, slug: string): string {
+  switch (type) {
+    case 'movie':
+      return `movie/${slug}`;
+    case 'show':
+      return `show/${slug}`;
+  }
+}
+
+export function buildImagePath({ shareType, slug, type }: BuildImagePathProps) {
+  const shareTypePath = toShareTypePath(shareType);
+  const mediaPath = toMediaPath(type, slug);
+
+  return `${rootPath}/${shareTypePath}/${mediaPath}/image.png`;
+}

--- a/projects/client/wrangler.jsonc
+++ b/projects/client/wrangler.jsonc
@@ -20,5 +20,11 @@
   "vars": {
     "TYPESENSE_SERVER": "search.trakt.tv"
   },
-  "upload_source_maps": true
+  "upload_source_maps": true,
+  "r2_buckets": [
+    {
+      "binding": "R2_WALTER",
+      "bucket_name": "walter"
+    }
+  ]
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #1936
- For movie and show pages, open graph images are generated dynamically (see https://github.com/trakt/trakt-web/pull/1996).
- If an image doesn't exist: it's generated and stored in an r2 bucket.
- If in image does exist in the bucket, that's used directly.
- On local dev, this is omitted to make debugging easier (also enable support for the debug=true param).
- I left a FIXME in there for HMAC signing, but for now it should be fine, because worst case, third party usage would just generate images for in the cache.

## 👀 Example 👀
<img width="418" height="50" alt="image" src="https://github.com/user-attachments/assets/713d7add-e0a9-423c-b26e-0a3e8d6d2d40" />
