### PR TITLE
Enhances bot cache control and share prefetching

### DIFF
--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -9,6 +9,7 @@ import { handle as handleImage } from '$lib/features/image/handle.ts';
 import { handle as handleMobileOperatingSystem } from '$lib/features/mobile-os/handle.ts';
 import { handle as handleSearchConfig } from '$lib/features/search/handle.ts';
 import { handle as handleTheme } from '$lib/features/theme/handle.ts';
+import { isBotAgent } from '$lib/utils/devices/isBotAgent.ts';
 
 import { SENTRY_DSN } from '$lib/utils/constants.ts';
 import {
@@ -32,11 +33,22 @@ export const handleCacheControl: Handle = async ({ event, resolve }) => {
     return response;
   }
 
-  const clonedHeaders = new Headers(response.headers);
-  const cacheControl = event.locals.isLegitimateBot
-    ? 'public, max-age=3600, s-maxage=3600'
-    : 'private, no-store, no-cache, must-revalidate';
+  function toCacheControl() {
+    // Verified search engine crawlers (via Cloudflare), full CDN caching for SEO
+    if (event.locals.isLegitimateBot) {
+      return 'public, max-age=3600, s-maxage=3600';
+    }
 
+    // Social bots (Discord, Slack, etc.), "public" so embeds work, but no CDN caching
+    if (isBotAgent(event.request.headers.get('user-agent'))) {
+      return 'public, max-age=0, must-revalidate';
+    }
+
+    return 'private, no-store, no-cache, must-revalidate';
+  }
+
+  const clonedHeaders = new Headers(response.headers);
+  const cacheControl = toCacheControl();
   clonedHeaders.set('Cache-Control', cacheControl);
 
   return new Response(response.body, {

--- a/projects/client/src/lib/components/buttons/share/ShareButton.svelte
+++ b/projects/client/src/lib/components/buttons/share/ShareButton.svelte
@@ -5,6 +5,7 @@
   import ShareIcon from "$lib/components/icons/ShareIcon.svelte";
   import * as m from "$lib/features/i18n/messages";
   import type { DrilldownSource } from "$lib/sections/lists/components/models/DrilldownSource";
+  import { PREFETCH_SHARE_PARAM } from "$lib/utils/requests/shouldPrefetch";
   import ActionButton from "../ActionButton.svelte";
   import { useShare } from "./useShare";
 
@@ -26,10 +27,16 @@
     variant = "secondary",
   }: ShareButtonProps = $props();
 
+  const shareUrl = $derived.by(() => {
+    const url = new URL(urlOverride ?? page.url.toString());
+    url.searchParams.set(PREFETCH_SHARE_PARAM, "true");
+    return url.toString();
+  });
+
   const data = $derived({
     title,
     text: textFactory({ title }),
-    url: urlOverride ?? page.url.toString(),
+    url: shareUrl,
   });
 
   const isShareable = $derived(

--- a/projects/client/src/lib/utils/requests/shouldPrefetch.ts
+++ b/projects/client/src/lib/utils/requests/shouldPrefetch.ts
@@ -1,0 +1,10 @@
+type ShouldPrefetchParams = {
+  isBot: boolean;
+  url: URL;
+};
+
+export const PREFETCH_SHARE_PARAM = 'share';
+
+export function shouldPrefetch({ isBot, url }: ShouldPrefetchParams): boolean {
+  return isBot || url.searchParams.has(PREFETCH_SHARE_PARAM);
+}

--- a/projects/client/src/routes/movies/[slug]/+page.ts
+++ b/projects/client/src/routes/movies/[slug]/+page.ts
@@ -1,11 +1,12 @@
 import { movieSummaryQuery } from '$lib/requests/queries/movies/movieSummaryQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { shouldPrefetch } from '$lib/utils/requests/shouldPrefetch.ts';
 import type { PageLoad } from '$types/movies/[slug]/$types.d.ts';
 
-export const load: PageLoad = async ({ parent, params, fetch }) => {
+export const load: PageLoad = async ({ parent, params, fetch, url }) => {
   const { queryClient, isBot } = await parent();
 
-  if (isBot) {
+  if (shouldPrefetch({ isBot, url })) {
     await queryClient.prefetchQuery(
       movieSummaryQuery({
         slug: assertDefined(params.slug, 'Slug is required'),

--- a/projects/client/src/routes/people/[slug]/+page.ts
+++ b/projects/client/src/routes/people/[slug]/+page.ts
@@ -1,11 +1,12 @@
 import { peopleSummaryQuery } from '$lib/requests/queries/people/peopleSummaryQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { shouldPrefetch } from '$lib/utils/requests/shouldPrefetch.ts';
 import type { PageLoad } from '$types/people/[slug]/$types.d.ts';
 
-export const load: PageLoad = async ({ parent, params, fetch }) => {
+export const load: PageLoad = async ({ parent, params, fetch, url }) => {
   const { queryClient, isBot } = await parent();
 
-  if (isBot) {
+  if (shouldPrefetch({ isBot, url })) {
     await queryClient.prefetchQuery(
       peopleSummaryQuery({
         slug: assertDefined(params.slug, 'Slug is required'),

--- a/projects/client/src/routes/shows/[slug]/+page.ts
+++ b/projects/client/src/routes/shows/[slug]/+page.ts
@@ -1,11 +1,12 @@
 import { showSummaryQuery } from '$lib/requests/queries/shows/showSummaryQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { shouldPrefetch } from '$lib/utils/requests/shouldPrefetch.ts';
 import type { PageLoad } from '$types/shows/[slug]/$types.d.ts';
 
-export const load: PageLoad = async ({ parent, params, fetch }) => {
+export const load: PageLoad = async ({ parent, params, fetch, url }) => {
   const { queryClient, isBot } = await parent();
 
-  if (isBot) {
+  if (shouldPrefetch({ isBot, url })) {
     await queryClient.prefetchQuery(
       showSummaryQuery({
         slug: assertDefined(params.slug, 'Slug is required'),

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.ts
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.ts
@@ -1,11 +1,12 @@
 import { episodeSummaryQuery } from '$lib/requests/queries/episode/episodeSummaryQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { shouldPrefetch } from '$lib/utils/requests/shouldPrefetch.ts';
 import type { PageLoad } from '$types/shows/[slug]/seasons/[season]/episodes/[episode]/$types.d.ts';
 
-export const load: PageLoad = async ({ parent, params, fetch }) => {
+export const load: PageLoad = async ({ parent, params, fetch, url }) => {
   const { queryClient, isBot } = await parent();
 
-  if (isBot) {
+  if (shouldPrefetch({ isBot, url })) {
     await queryClient.prefetchQuery(
       episodeSummaryQuery({
         slug: assertDefined(params.slug, 'Slug is required'),


### PR DESCRIPTION
## 🎶 Notes 🎶

Small updates to better deal with link previews and link sharing:
- Applies specific cache control headers for social media bots, setting `public, max-age=0, must-revalidate` to facilitate link embeds without CDN caching.
- Introduces a new `?share=true` URL parameter for shared links, triggering server-side data prefetching for improved initial page load performance.