### PR TITLE
fix: move preload attributes to div

### DIFF
--- a/projects/client/src/app.html
+++ b/projects/client/src/app.html
@@ -59,10 +59,13 @@
 
     %sveltekit.head%
   </head>
-  <body
-    data-sveltekit-preload-code="viewport"
-    data-sveltekit-preload-data="tap"
-  >
-    <div style="display: contents">%sveltekit.body%</div>
+  <body>
+    <div
+      style="display: contents"
+      data-sveltekit-preload-code="viewport"
+      data-sveltekit-preload-data="tap"
+    >
+      %sveltekit.body%
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2108
- The extension was adding an `a` element without an `href` to the body. sveltekit's preloader was trying to parse that in an internsectionobserver.
- This fix moves the preload data attributes to our content div.