### PR TITLE
fix(summary): use indicator tag colors for tags on poster

### DIFF
--- a/projects/client/src/lib/components/media/tags/PostCreditsTag.svelte
+++ b/projects/client/src/lib/components/media/tags/PostCreditsTag.svelte
@@ -6,8 +6,8 @@
 </script>
 
 <StemTag
-  --color-background-stem-tag="var(--shade-10)"
-  --color-foreground-stem-tag="var(--shade-920)"
+  --color-background-stem-tag="var(--color-background-indicator-tag)"
+  --color-foreground-stem-tag="var(--color-text-indicator-tag)"
 >
   <p class="bold uppercase no-wrap">
     {i18n.postCredits(count)}

--- a/projects/client/src/lib/sections/summary/components/_internal/DroppedTag.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/DroppedTag.svelte
@@ -7,8 +7,8 @@
 </script>
 
 <StemTag
-  --color-background-stem-tag="var(--shade-10)"
-  --color-foreground-stem-tag="var(--shade-920)"
+  --color-background-stem-tag="var(--color-background-indicator-tag)"
+  --color-foreground-stem-tag="var(--color-text-indicator-tag)"
 >
   {#snippet icon()}
     <DropIcon />

--- a/projects/client/src/lib/sections/summary/components/_internal/WatchCountTag.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/WatchCountTag.svelte
@@ -21,8 +21,8 @@
 <watch-count-tag>
   <Link {...buildDrawerLink(SummaryDrawers.History)}>
     <StemTag
-      --color-background-stem-tag="var(--shade-10)"
-      --color-foreground-stem-tag="var(--shade-920)"
+      --color-background-stem-tag="var(--color-background-indicator-tag)"
+      --color-foreground-stem-tag="var(--color-text-indicator-tag)"
     >
       <TrackIcon />
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2278
- Standardizes tags on posters

## 👀 Example 👀
Both in lists and summary pages, the tags now share the same colors:
<img width="330" height="349" alt="Screenshot 2026-05-07 at 15 32 08" src="https://github.com/user-attachments/assets/c9b56561-fc87-42ab-8372-c74845f6ab98" />

<img width="350" height="518" alt="Screenshot 2026-05-07 at 15 32 16" src="https://github.com/user-attachments/assets/e055a1bf-3d05-4b07-8fe3-363dc2c3dca7" />
