### PR TITLE
chore(sentry): update Sentry source map upload configuration

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -277,6 +277,7 @@ jobs:
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
           FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
           FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       
       # Add this new step to copy the .npmrc file
       - name: The Ancient Scroll of JSR aka Copy .npmrc

--- a/projects/client/vite.config.ts
+++ b/projects/client/vite.config.ts
@@ -86,10 +86,8 @@ export default defineConfig(({ mode }) => ({
 
   plugins: [
     sentrySvelteKit({
-      sourceMapsUploadOptions: {
-        org: 'trakt-tv',
-        project: 'trakt-web',
-      },
+      org: 'trakt-tv',
+      project: 'trakt-web',
     }),
     sveltekit(),
     sveltekitOG(),


### PR DESCRIPTION
## 🎶 Notes 🎶

Small ci change to fix Sentry source maps:

- `sourceMapsUploadOptions` is deprecated, these no longer need to be nested (docs: https://docs.sentry.io/platforms/javascript/guides/sveltekit/sourcemaps/)
- The SvelteKit SDK uses Sentry Vite Plugin under the hood. Setting it as an env variable should be enough for it to be picked up (docs: https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/vite/)