### PR TITLE
Fix/episode page types

### DIFF
--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -3,7 +3,7 @@
   import { getLanguageAndRegion } from "$lib/features/i18n";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import RenderFor from "$lib/guards/RenderFor.svelte";
-  import type { MediaType } from "$lib/requests/models/MediaType";
+  import type { ExtendedMediaType } from "$lib/requests/models/ExtendedMediaType";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import Redirect from "../../components/router/Redirect.svelte";
@@ -13,7 +13,7 @@
 
   type TraktPageProps = {
     title: string | undefined;
-    type?: MediaType | "webpage" | "home";
+    type?: ExtendedMediaType | "webpage" | "home";
     image: string | Nil;
     info?: {
       overview: string;
@@ -72,6 +72,7 @@
       case "movie":
         return "video.movie";
       case "show":
+      case "episode":
         return "video.tv_show";
       case "webpage":
       default:
@@ -139,10 +140,23 @@
       url,
     });
 
+  // FIXME: extend with season and episode information
+  const createEpisodeLd = (title: string, url: string) =>
+    JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "TVEpisode",
+      name: title,
+      description: _info?.overview,
+      image: _image,
+      url,
+    });
+
   const jsonLd = $derived.by(() => {
     if (type === "home") return createWebsiteLd(canonicalUrl);
     if (type === "movie" && _title) return createMovieLd(_title, canonicalUrl);
     if (type === "show" && _title) return createShowLd(_title, canonicalUrl);
+    if (type === "episode" && _title)
+      return createEpisodeLd(_title, canonicalUrl);
     return null;
   });
 

--- a/projects/client/src/routes/api/shareable-image/+server.ts
+++ b/projects/client/src/routes/api/shareable-image/+server.ts
@@ -66,15 +66,17 @@ export const GET: RequestHandler = async (
     fetch,
   });
 
-  const [media, ratings, crew] = await fetchMediaData({
+  const mediaData = await fetchMediaData({
     type,
     slug,
     fetch: fetchFn,
-  });
+  }).catch(() => null);
 
-  if (!media || !ratings || !crew) {
+  if (!mediaData) {
     return new Response('Data not found', { status: 404 });
   }
+
+  const { media, ratings, crew } = mediaData;
 
   const posterUrl = media.poster.url.medium.replace(/\.webp$/i, '');
 

--- a/projects/client/src/routes/api/shareable-image/_internal/fetchMediaData.ts
+++ b/projects/client/src/routes/api/shareable-image/_internal/fetchMediaData.ts
@@ -12,7 +12,7 @@ type FetchMediaDataParams = {
   slug: string;
 } & ApiParams;
 
-export function fetchMediaData({ type, slug, fetch }: FetchMediaDataParams) {
+function resolveMediaData({ type, slug, fetch }: FetchMediaDataParams) {
   if (type === 'movie') {
     return Promise.all(
       [
@@ -30,4 +30,14 @@ export function fetchMediaData({ type, slug, fetch }: FetchMediaDataParams) {
       showPeopleQuery({ slug, fetch }).execute(),
     ] as const,
   );
+}
+
+export async function fetchMediaData(params: FetchMediaDataParams) {
+  const [media, ratings, crew] = await resolveMediaData(params);
+
+  if (!media || !ratings || !crew) {
+    throw new Error('Incomplete media data');
+  }
+
+  return { media, ratings, crew };
 }

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.svelte
@@ -23,7 +23,7 @@
   title={$intl?.title ?? $episode?.title}
   info={$episode}
   image={$episode?.cover.url}
-  type="movie"
+  type="episode"
   hasDynamicContent={true}
 >
   <RenderFor audience="authenticated">


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2283
- Episode pages were using `TraktPage` with `type="movie"` 🥲
  - This caused the url for the og images to be wrong...
  - And also the Ld objects.
  - For now I made it more similar to shows, but left a fixme in there to follow up on this.
- Also a small fix to the share-image endpoint to make it more robust.