### PR TITLE
YIR: default template uses svelte links

### DIFF
--- a/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CalendarIcon from "$lib/components/icons/CalendarIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
   import { languageTag } from "$lib/features/i18n";
   import { m } from "$lib/paraglide/messages";
   import type { YirWatchedItem } from "$lib/requests/models/YirDetail";
@@ -27,6 +28,8 @@
   );
 
   const itemUrl = $derived(UrlBuilder.media(item.entry.type, item.entry.slug));
+  const logoUrl = $derived(item.entry.logo.url.medium);
+  const hasLogo = $derived(!PLACEHOLDERS.includes(logoUrl));
 
   const headerText = $derived(
     how === "first"
@@ -47,23 +50,25 @@
       {headerText}
     </YirSectionHeader>
 
-    <a href={itemUrl} class="yir-calendar-media">
-      {#if !PLACEHOLDERS.includes(item.entry.logo.url.medium)}
-        <div class="yir-logo-wrapper">
-          <img
-            class="yir-calendar-logo"
-            src={item.entry.logo.url.medium}
-            alt={item.entry.title}
-          />
-        </div>
-      {:else}
-        <h3 class="yir-calendar-title">{item.entry.title}</h3>
-      {/if}
+    <div class="yir-calendar-media">
+      <Link href={itemUrl}>
+        {#if hasLogo}
+          <div class="yir-logo-wrapper">
+            <img
+              class="yir-calendar-logo"
+              src={logoUrl}
+              alt={item.entry.title}
+            />
+          </div>
+        {:else}
+          <h3 class="yir-calendar-title">{item.entry.title}</h3>
+        {/if}
 
-      {#if item.type === "episode"}
-        <h4 class="yir-calendar-episode">{item.episode.title}</h4>
-      {/if}
-    </a>
+        {#if item.type === "episode"}
+          <h4 class="yir-calendar-episode">{item.episode.title}</h4>
+        {/if}
+      </Link>
+    </div>
 
     <div class="yir-calendar-date">
       <span class="yir-calendar-icon"><CalendarIcon /></span>
@@ -107,9 +112,11 @@
   }
 
   .yir-calendar-media {
-    display: block;
-    text-decoration: none;
-    color: var(--shade-10);
+    :global(.trakt-link) {
+      display: block;
+      text-decoration: none;
+      color: var(--shade-10);
+    }
   }
 
   .yir-logo-wrapper {

--- a/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
   import { languageTag } from "$lib/features/i18n";
   import { m } from "$lib/paraglide/messages";
   import type { YirMostWatchedItem } from "$lib/requests/models/YirDetail";
@@ -46,19 +47,21 @@
             {m.yir_label_most_watched({ type: typeLabel })}
           </YirSectionHeader>
 
-          <a href={itemUrl(item)} class="yir-card-media">
-            <div class="yir-logo-wrapper">
-              {#if !PLACEHOLDERS.includes(item.entry.logo.url.medium)}
-                <img
-                  class="yir-card-logo"
-                  src={item.entry.logo.url.medium}
-                  alt={item.entry.title}
-                />
-              {:else}
-                <h3 class="yir-card-title">{item.entry.title}</h3>
-              {/if}
-            </div>
-          </a>
+          <div class="yir-card-media">
+            <Link href={itemUrl(item)} color="inherit">
+              <div class="yir-logo-wrapper">
+                {#if !PLACEHOLDERS.includes(item.entry.logo.url.medium)}
+                  <img
+                    class="yir-card-logo"
+                    src={item.entry.logo.url.medium}
+                    alt={item.entry.title}
+                  />
+                {:else}
+                  <h3 class="yir-card-title">{item.entry.title}</h3>
+                {/if}
+              </div>
+            </Link>
+          </div>
 
           <div class="yir-card-stats">
             <div class="yir-stat-line">
@@ -77,22 +80,24 @@
   <!-- Thumbnail grid -->
   <div class="yir-most-watched-grid">
     {#each items as item, index (item.entry.id)}
-      <a
-        href={itemUrl(item)}
-        class="yir-grid-item"
-        onmouseenter={() => {
-          activeIndex = index;
-        }}
-      >
-        <div class="yir-rank-wrapper">
-          <span class="yir-rank">{index + 1}</span>
-        </div>
-        <img
-          class="yir-grid-thumb"
-          src={item.entry.thumb.url}
-          alt={item.entry.title}
-        />
-      </a>
+      <div class="yir-grid-item">
+        <Link
+          href={itemUrl(item)}
+          onmouseenter={() => {
+            activeIndex = index;
+          }}
+          color="inherit"
+        >
+          <div class="yir-rank-wrapper">
+            <span class="yir-rank">{index + 1}</span>
+          </div>
+          <img
+            class="yir-grid-thumb"
+            src={item.entry.thumb.url}
+            alt={item.entry.title}
+          />
+        </Link>
+      </div>
     {/each}
   </div>
 </section>
@@ -150,9 +155,13 @@
   }
 
   .yir-card-media {
-    text-decoration: none;
-    color: var(--shade-10);
     margin-top: var(--ni-20);
+    color: var(--shade-10);
+
+    :global(.trakt-link) {
+      display: block;
+      text-decoration: none;
+    }
   }
 
   .yir-logo-wrapper {
@@ -215,6 +224,11 @@
           opacity: 1;
         }
       }
+    }
+
+    :global(.trakt-link) {
+      display: block;
+      text-decoration: none;
     }
 
     @include for-tablet-sm-and-below {
@@ -283,6 +297,8 @@
   }
 
   .yir-rank {
+    --rank-size: var(--ni-22);
+
     background-color: var(--shade-800);
     color: var(--shade-10);
     display: inline-block;
@@ -290,9 +306,9 @@
     font-weight: bold;
     border: var(--border-thickness-xs) solid var(--shade-10);
     border-radius: 50%;
-    height: var(--ni-22);
-    width: var(--ni-22);
-    line-height: 2.2;
+    height: var(--rank-size);
+    width: var(--rank-size);
+    line-height: var(--rank-size);
   }
 
   .yir-grid-thumb {

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
   import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
   import { m } from "$lib/paraglide/messages";
   import type {
@@ -132,36 +133,40 @@
                 </div>
               {/each}
             {/snippet}
-            <a href={personUrl(person)} class="yir-person-link">
-              <div class="yir-person">
-                <span class="yir-rank">{index + 1}</span>
-                <div class="yir-headshot">
-                  <img
-                    src={isDefault ? DEFAULT_AVATAR : person.headshot.url.thumb}
-                    alt={person.name}
-                    class="yir-headshot-img"
-                    class:is-default={isDefault}
-                  />
+            <div class="yir-person-link">
+              <Link href={personUrl(person)}>
+                <div class="yir-person">
+                  <span class="yir-rank">{index + 1}</span>
+                  <div class="yir-headshot">
+                    <img
+                      src={isDefault
+                        ? DEFAULT_AVATAR
+                        : person.headshot.url.thumb}
+                      alt={person.name}
+                      class="yir-headshot-img"
+                      class:is-default={isDefault}
+                    />
+                  </div>
+                  <h2 class="yir-person-name">{person.name}</h2>
+                  <h3 class="yir-person-count">
+                    {#if person.count.movies > 0}
+                      {person.count.movies}
+                      {person.count.movies === 1 ? "movie" : "movies"}
+                    {:else}
+                      &nbsp;
+                    {/if}
+                  </h3>
+                  <h3 class="yir-person-count">
+                    {#if person.count.shows > 0}
+                      {person.count.shows}
+                      {person.count.shows === 1 ? "show" : "shows"}
+                    {:else}
+                      &nbsp;
+                    {/if}
+                  </h3>
                 </div>
-                <h2 class="yir-person-name">{person.name}</h2>
-                <h3 class="yir-person-count">
-                  {#if person.count.movies > 0}
-                    {person.count.movies}
-                    {person.count.movies === 1 ? "movie" : "movies"}
-                  {:else}
-                    &nbsp;
-                  {/if}
-                </h3>
-                <h3 class="yir-person-count">
-                  {#if person.count.shows > 0}
-                    {person.count.shows}
-                    {person.count.shows === 1 ? "show" : "shows"}
-                  {:else}
-                    &nbsp;
-                  {/if}
-                </h3>
-              </div>
-            </a>
+              </Link>
+            </div>
           </Tooltip>
         {/each}
       </div>
@@ -253,9 +258,13 @@
   }
 
   .yir-person-link {
-    text-decoration: none;
-    color: var(--shade-10);
     width: 100%;
+
+    :global(.trakt-link) {
+      display: block;
+      text-decoration: none;
+      color: var(--shade-10);
+    }
 
     @include for-mouse {
       &:hover {

--- a/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
   import { m } from "$lib/paraglide/messages";
   import type { YirTopRatedItem } from "$lib/requests/models/YirDetail";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
@@ -46,25 +47,26 @@
     <YirPageInner>
       <div class="yir-posters">
         {#each items as item, index (item.entry.id)}
-          <a
-            href={itemUrl(item)}
-            class="yir-grid-item"
-            title={item.entry.title}
-            onmouseenter={() => {
-              activeIndex = index;
-            }}
-          >
-            <div class="yir-poster">
-              <div class="yir-corner-rating">
-                <span>{item.rating}</span>
+          <div class="yir-grid-item" title={item.entry.title}>
+            <Link
+              href={itemUrl(item)}
+              label={item.entry.title}
+              onmouseenter={() => {
+                activeIndex = index;
+              }}
+            >
+              <div class="yir-poster">
+                <div class="yir-corner-rating">
+                  <span>{item.rating}</span>
+                </div>
+                <img
+                  class="yir-poster-img"
+                  src={item.entry.poster.url.thumb}
+                  alt={item.entry.title}
+                />
               </div>
-              <img
-                class="yir-poster-img"
-                src={item.entry.poster.url.thumb}
-                alt={item.entry.title}
-              />
-            </div>
-          </a>
+            </Link>
+          </div>
         {/each}
       </div>
     </YirPageInner>
@@ -120,7 +122,11 @@
     display: inline-block;
     padding: 0;
     margin: 0;
-    text-decoration: none;
+
+    :global(.trakt-link) {
+      display: block;
+      text-decoration: none;
+    }
 
     @include for-mobile {
       width: 20%;

--- a/projects/client/src/lib/sections/yir/default/_internal/YirTitleSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirTitleSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import { useQuery } from "$lib/features/query/useQuery";
   import { m } from "$lib/paraglide/messages";
@@ -39,18 +40,20 @@
     <div class="yir-titles">
       {#if $profile}
         <div class="yir-user">
-          <a href={UrlBuilder.profile.user(slug)} class="yir-avatar-link">
-            <div class="yir-avatar">
-              <CrossOriginImage
-                src={$profile.avatar.url}
-                alt={$profile.name.full ?? slug}
-              />
-            </div>
-          </a>
+          <span class="yir-avatar-link">
+            <Link href={UrlBuilder.profile.user(slug)} color="inherit">
+              <div class="yir-avatar">
+                <CrossOriginImage
+                  src={$profile.avatar.url}
+                  alt={$profile.name.full ?? slug}
+                />
+              </div>
+            </Link>
+          </span>
           <span class="yir-display-name">
-            <a href={UrlBuilder.profile.user(slug)}>
+            <Link href={UrlBuilder.profile.user(slug)} color="inherit">
               {$profile.name.full || $profile.username}
-            </a>
+            </Link>
           </span>
         </div>
         <div class="yir-under-user"></div>
@@ -119,6 +122,11 @@
   .yir-avatar-link {
     display: flex;
     flex-shrink: 0;
+
+    :global(.trakt-link) {
+      display: flex;
+      text-decoration: none;
+    }
   }
 
   .yir-avatar {
@@ -146,7 +154,7 @@
     display: inline-block;
     font-size: var(--ni-24);
 
-    a {
+    :global(.trakt-link) {
       color: var(--shade-10);
       text-decoration: none;
     }


### PR DESCRIPTION
## Summary
- Replaces raw `<a>` tags with the shared `Link` component across the default YIR template, so these links benefit from the same active-state tracking, sveltekit data attributes, dpad navigation, and global parameter forwarding as the rest of the app.
- Affects `YirTitleSection`, `YirCalendarSection`, `YirMostWatchedSection`, `YirPeopleGroup`, and `YirRatedSection`. Anchor-specific styling (`text-decoration`, `color`, `display`) was moved under `:global(.trakt-link)` selectors on a parent wrapper, matching the existing pattern used in `ProfileLink` and `SentimentCard`.
- No behavior changes intended — purely a refactor toward the canonical link component.