### PR TITLE
ci: increases e2e test stability

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -223,6 +223,7 @@ jobs:
         run: |
           deno task preview &
           echo $! > server.pid
+          timeout 30 bash -c 'until curl -sf http://localhost:4173/ > /dev/null; do sleep 1; done'
         env:
           TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}
@@ -230,7 +231,7 @@ jobs:
       - name: The Verdict on the Interface aka E2E Tests
         uses: nick-fields/retry@v3
         with:
-          timeout_seconds: 15
+          timeout_seconds: 30
           max_attempts: 10
           command: |
             cd projects/client


### PR DESCRIPTION
## 🎶 Notes 🎶

- Small ci change to make e2e tests more robust (🤞)
  - `deno task preview &` starts the preview server in the background, but we then start running the e2e tests right away. Which is the likely culprit of why they often timeout. This adds a small polling step to wait until the preview is available.
  - And increased the timeout to 30 secs just in case.