### PR TITLE
chore(errors): exempts server error on advanced settings

### DIFF
--- a/projects/client/src/lib/features/errors/_internal/errorExemptions.ts
+++ b/projects/client/src/lib/features/errors/_internal/errorExemptions.ts
@@ -13,6 +13,10 @@ const exemptions: Exemption[] = [
     errorType: WellKnownErrorType.LockedAccountError,
     routes: new Set([UrlBuilder.settings.advanced()]),
   },
+  {
+    errorType: WellKnownErrorType.ServerError,
+    routes: new Set([UrlBuilder.settings.advanced()]),
+  },
 ];
 
 export function isErrorExempt(


### PR DESCRIPTION
## 🎶 Notes 🎶

- Small chore to add server errors to the exemptions for the advanced settings page.
  - Users with a lot of data could get server errors depending on their data. But they should still be able to access the iframed advanced settings to be able to clean up their data.
  - Serves as a temporary exemption to unblock users; the underlying queries should be made faster, and the cleanup logic should be natively available.