### PR TITLE
feat(summary): uses episode images in episodes drawer

### DIFF
--- a/projects/client/src/lib/components/card/CardActionBar.svelte
+++ b/projects/client/src/lib/components/card/CardActionBar.svelte
@@ -2,11 +2,16 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { Snippet } from "svelte";
 
-  const { actions }: { actions: Snippet } = $props();
+  type CardActionBarProps = {
+    actions: Snippet;
+    variant?: "default" | "standalone";
+  };
+
+  const { actions, variant = "default" }: CardActionBarProps = $props();
 </script>
 
 <RenderFor audience="authenticated">
-  <div class="trakt-card-action-bar">
+  <div class="trakt-card-action-bar" data-variant={variant}>
     {@render actions()}
   </div>
 </RenderFor>
@@ -25,23 +30,25 @@
 
     pointer-events: none;
 
-    &::before {
-      content: "";
+    &[data-variant="default"] {
+      &::before {
+        content: "";
 
-      width: var(--height-action-bar);
-      height: var(--height-action-bar);
+        width: var(--height-action-bar);
+        height: var(--height-action-bar);
 
-      position: absolute;
-      top: 0;
-      right: 0;
+        position: absolute;
+        top: 0;
+        right: 0;
 
-      border-top-right-radius: var(--border-radius-m);
+        border-top-right-radius: var(--border-radius-m);
 
-      background-image: radial-gradient(
-        circle at top right,
-        color-mix(in srgb, var(--color-shadow) 30%, transparent) 15%,
-        transparent 65%
-      );
+        background-image: radial-gradient(
+          circle at top right,
+          color-mix(in srgb, var(--color-shadow) 30%, transparent) 15%,
+          transparent 65%
+        );
+      }
     }
 
     :global(.trakt-popup-menu-button) {

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -11,6 +11,7 @@
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import TagBar from "$lib/components/tags/TagBar.svelte";
   import TextTag from "$lib/components/tags/TextTag.svelte";
+  import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
@@ -62,6 +63,14 @@
 
     return standAloneVariants.includes(props.variant) ? $isWatched : false;
   });
+
+  const src = $derived(
+    useEpisodeSpoilerImage({
+      episode: props.episode,
+      show: props.media,
+      variant: props.variant,
+    }),
+  );
 </script>
 
 {#snippet indicatorTags()}
@@ -197,7 +206,7 @@
       popupActions={props.popupActions}
       layout={isCompact ? "compact" : "default"}
       context={"context" in props ? props.context : undefined}
-      coverUrl={"coverUrl" in props ? props.coverUrl : undefined}
+      coverUrl={"coverUrl" in props ? props.coverUrl : $src}
       {tag}
       badge={action}
       {sortTag}

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -82,7 +82,7 @@
       const posterOverride = "coverUrl" in rest ? rest.coverUrl : undefined;
 
       return {
-        background: episodeCover,
+        background: !isCompact ? episodeCover : undefined,
         poster: posterOverride ?? media.poster.url.thumb,
         title: rest.episode.title,
       };
@@ -152,7 +152,7 @@
   --poster-aspect-ratio="0.6667"
 >
   {#if popupActions}
-    <CardActionBar>
+    <CardActionBar variant={isCompact ? "standalone" : "default"}>
       {#snippet actions()}
         <PopupMenu
           label={m.button_label_popup_menu({ title: media.title })}
@@ -166,10 +166,12 @@
     </CardActionBar>
   {/if}
 
-  <SummaryCardBackgroundImage
-    src={coverData.background}
-    alt={`Background for ${coverData.title}`}
-  />
+  {#if coverData.background}
+    <SummaryCardBackgroundImage
+      src={coverData.background}
+      alt={`Background for ${coverData.title}`}
+    />
+  {/if}
 
   <Link
     {href}
@@ -365,15 +367,26 @@
 
   :global(.trakt-summary-card-compact) {
     .trakt-card-title {
-      font-size: var(--font-size-title);
+      font-size: var(--font-size-text);
     }
 
     .trakt-summary-poster {
+      --padding-compact-poster: calc(
+        (
+            var(--height-summary-card-compact) - var(
+                --height-summary-card-cover-compact
+              )
+          ) *
+          0.5
+      );
       --poster-width: calc(
         var(--height-summary-card-cover-compact) * var(--poster-aspect-ratio)
       );
 
-      height: var(--height-summary-card-cover-compact);
+      padding: var(--padding-compact-poster);
+      box-sizing: border-box;
+
+      height: var(--height-summary-card-compact);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/season/SeasonList.svelte
+++ b/projects/client/src/lib/sections/lists/season/SeasonList.svelte
@@ -35,10 +35,6 @@
     seasons.filter((s) => s.number > 0 && s.number < currentSeason),
   );
 
-  const seasonPosterUrl = $derived(
-    seasons.find((s) => s.number === currentSeason)?.poster?.url.thumb,
-  );
-
   const episodeProps = $derived.by(() => {
     if (hasSingleSeason) return { title, subtitle };
     return isLargeScreen ? { title } : {};
@@ -66,7 +62,6 @@
   {show}
   {previousSeasons}
   episodes={$episodes}
-  coverUrl={seasonPosterUrl}
   headerActions={isLargeScreen && !hasSingleSeason ? headerActions : undefined}
   {...episodeProps}
 />

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -19,7 +19,6 @@
     isWatchedLoading: boolean;
     style?: BaseItemProps["style"];
     source: string;
-    coverUrl?: string;
   };
 
   const {
@@ -31,7 +30,6 @@
     isWatchedLoading,
     style,
     source,
-    coverUrl,
   }: SeasonEpisodeItemProps = $props();
 
   const isFuture = $derived(episode.effectiveReleaseDate > new Date());
@@ -82,7 +80,6 @@
   {episode}
   media={show}
   {style}
-  {coverUrl}
   popupActions={isActionable ? popupActions : undefined}
   variant={isFuture ? "upcoming" : "default"}
   context="show"

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
@@ -22,7 +22,6 @@
     title?: string;
     headerActions?: Snippet;
     subtitle?: string;
-    coverUrl?: string;
   };
 
   const {
@@ -32,7 +31,6 @@
     title,
     subtitle,
     headerActions,
-    coverUrl,
   }: SeasonEpisodeListProps = $props();
 
   const { history } = useUser();
@@ -71,7 +69,6 @@
       {hasUnseenEpisodes}
       watchedBySeason={$watchedBySeason}
       isWatchedLoading={$isWatchedLoading}
-      {coverUrl}
       source="season-episode-list"
     />
   {/snippet}

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
@@ -50,10 +50,6 @@
     seasons.filter((s) => s.number > 0 && s.number < currentSeason),
   );
 
-  const seasonPosterUrl = $derived(
-    seasons.find((s) => s.number === currentSeason)?.poster?.url.thumb,
-  );
-
   const buildSeasonLink = (seasonNumber: number) => {
     const url = new URL(page.url);
     url.searchParams.set("season", String(seasonNumber));
@@ -124,7 +120,6 @@
                 {hasUnseenEpisodes}
                 watchedBySeason={$watchedBySeason}
                 isWatchedLoading={$isWatchedLoading}
-                coverUrl={seasonPosterUrl}
                 style="compact"
                 source="seasons-drawer"
               />
@@ -180,6 +175,10 @@
     :global(.trakt-list-items) {
       grid-template-columns: 1fr;
       grid-row-gap: var(--gap-s);
+    }
+
+    :global(.trakt-summary-card-compact) {
+      --poster-aspect-ratio: 1.778;
     }
 
     :global(.trakt-list-inset-title) {

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -244,8 +244,8 @@
   --font-size-text: var(--ni-14);
 
   --width-summary-card-compact: 100%;
-  --height-summary-card-cover-compact: var(--ni-112);
-  --height-summary-card-compact: var(--height-summary-card-cover-compact);
+  --height-summary-card-cover-compact: var(--ni-88);
+  --height-summary-card-compact: var(--ni-96);
 
   @include for-tablet-sm-and-below {
     --width-summary-card: var(--width-summary-card-compact);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2300
- Episodes in the episode drawer are now more consistent with the episodes shown on the summary page:
  - The episode screenshot is used.
  - Has same spoiler behavior; e.g. if showing spoiler is disabled, for unseen episodes it won't show the screenshot.

## 👀 Example 👀
Before/after:
<img width="463" height="663" alt="Screenshot 2026-05-11 at 11 36 08" src="https://github.com/user-attachments/assets/ae483199-d04e-4f86-8e99-7558a88a94a1" />

<img width="463" height="586" alt="Screenshot 2026-05-11 at 11 36 21" src="https://github.com/user-attachments/assets/6fffb4e0-b15f-4fad-abcb-24b37a435103" />
