### PR TITLE
fix: uses correct image for drilled down episodes

### DIFF
--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -206,7 +206,7 @@
       popupActions={props.popupActions}
       layout={isCompact ? "compact" : "default"}
       context={"context" in props ? props.context : undefined}
-      coverUrl={"coverUrl" in props ? props.coverUrl : $src}
+      coverUrl={"coverUrl" in props ? props.coverUrl : undefined}
       {tag}
       badge={action}
       {sortTag}

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { Season } from "$lib/requests/models/Season";
@@ -42,6 +43,15 @@
   );
 
   const isActionable = $derived(isWatchable || hasBulkMarkAsWatched);
+  const variant = $derived(isFuture ? "upcoming" : "default");
+
+  const src = $derived(
+    useEpisodeSpoilerImage({
+      episode,
+      show,
+      variant,
+    }),
+  );
 </script>
 
 {#snippet popupActions()}
@@ -84,4 +94,5 @@
   variant={isFuture ? "upcoming" : "default"}
   context="show"
   {source}
+  coverUrl={$src}
 />

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -248,8 +248,8 @@
   --height-summary-card-compact: var(--ni-96);
 
   @include for-tablet-sm-and-below {
-    --width-summary-card: var(--width-summary-card-compact);
-    --height-summary-card-cover: var(--height-summary-card-cover-compact);
+    --width-summary-card: 100%;
+    --height-summary-card-cover: var(--ni-112);
   }
 
   --font-size-title: var(--ni-18);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2308
- Episode summary items now use the correct image for the cover again.
- On smaller screens, the size is fixed also, it was erroneously using the compact height.

## 👀 Example 👀
Before/after:
<img width="1060" height="775" alt="Screenshot 2026-05-11 at 16 38 08" src="https://github.com/user-attachments/assets/928c329f-bb1b-4ab1-9dd4-21bcab304012" />

<img width="1060" height="775" alt="Screenshot 2026-05-11 at 16 38 17" src="https://github.com/user-attachments/assets/edee5257-f547-4d07-82ba-6a9f55364b60" />
