### PR TITLE
feat: add rate-now rating and toast content

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6676,6 +6676,38 @@
       "default": "Unavailable",
       "description": "Label shown when an option or content is unavailable to display."
     },
+    "text_rating_prompt_1": {
+      "default": "What's the verdict?",
+      "description": "Verdict-style rating prompt rotated in the Rate Now toast."
+    },
+    "text_rating_prompt_2": {
+      "default": "What did you think?",
+      "description": "Thoughts-style rating prompt rotated in the Rate Now toast."
+    },
+    "text_rating_prompt_3": {
+      "default": "Well, how was it?",
+      "description": "Conversational rating prompt rotated in the Rate Now toast."
+    },
+    "text_rating_prompt_4": {
+      "default": "Thoughts?",
+      "description": "Short rating prompt rotated in the Rate Now toast."
+    },
+    "text_rating_prompt_5": {
+      "default": "Out of five stars?",
+      "description": "Stars-out-of-five rating prompt rotated in the Rate Now toast."
+    },
+    "text_rating_prompt_6": {
+      "default": "How many stars does it earn?",
+      "description": "How-many-stars rating prompt rotated in the Rate Now toast."
+    },
+    "text_rating_prompt_7": {
+      "default": "Rate your experience.",
+      "description": "Rate-your-experience prompt rotated in the Rate Now toast."
+    },
+    "text_rating_prompt_8": {
+      "default": "Give it a grade.",
+      "description": "Grade-style rating prompt rotated in the Rate Now toast."
+    },
     "text_plex_tv_library_description": {
       "default": "Enable Trakt Plex Sync to access your Plex server media library.",
       "description": "Description shown when a user has no Plex libraries connected. This should be a short sentence."

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -14,6 +14,7 @@
   const {
     variant = "guard",
     onclick,
+    style = "default",
     ...props
   }: RateNowProps & { variant?: "allow" | "guard" } = $props();
 
@@ -56,7 +57,9 @@
     data-dpad-navigation={DpadNavigationType.List}
     transition:slide={{ duration: 150 }}
   >
-    <span class="bold">{m.header_rate_now()}</span>
+    {#if style !== "minimal"}
+      <span class="bold">{m.header_rate_now()}</span>
+    {/if}
     <div
       class="trakt-rate-actions"
       transition:fade={{ duration: 150, delay: 150 }}

--- a/projects/client/src/lib/sections/summary/components/rating/models/RateNowProps.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/models/RateNowProps.ts
@@ -16,4 +16,5 @@ type RateableMedia = {
 
 export type RateNowProps = (RateableEpisode | RateableMedia) & {
   onclick?: () => void;
+  style?: 'default' | 'minimal';
 };

--- a/projects/client/src/lib/sections/toast/_internal/RateNowContent.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/RateNowContent.svelte
@@ -8,6 +8,7 @@
   import type { LastWatchedItem } from "$lib/features/toast/models/LastWatchedItem";
   import { useLastWatched } from "$lib/features/toast/useLastWatched";
   import RateNow from "$lib/sections/summary/components/rating/RateNow.svelte";
+  import { shuffle } from "$lib/utils/array/shuffle";
   import { time } from "$lib/utils/timing/time.ts";
   import { getToastTitle } from "./getToastTitle";
   import ToastItemCard from "./ToastItemCard.svelte";
@@ -26,7 +27,19 @@
     onConfirm: suppress,
   });
 
+  const ratingPrompts = [
+    m.text_rating_prompt_1(),
+    m.text_rating_prompt_2(),
+    m.text_rating_prompt_3(),
+    m.text_rating_prompt_4(),
+    m.text_rating_prompt_5(),
+    m.text_rating_prompt_6(),
+    m.text_rating_prompt_7(),
+    m.text_rating_prompt_8(),
+  ] as const;
+
   const title = $derived(getToastTitle(lastWatched));
+  const ratingPrompt = $derived(shuffle(ratingPrompts).at(0));
 
   const handleDismiss = () => {
     dismiss(lastWatched.media.id, lastWatched.type, "manual");
@@ -38,37 +51,43 @@
 
   <div class="trakt-now-playing-content">
     <div class="trakt-rate-now-header">
-      <p class="ellipsis">{title}</p>
-      {#if interactionCounter > 0}
-        {#key interactionCounter}
-          <AutoCloseButton
-            onclick={handleDismiss}
-            label={m.button_label_dismiss()}
-            durationMs={lingerDuration}
-          />
-        {/key}
-      {:else}
-        <ActionButton
-          onclick={() => {
-            handleDismiss();
-            if (!$isAtLimit) {
-              return;
-            }
+      <div class="trakt-rate-now-titles">
+        <span class="trakt-verdict secondary">{ratingPrompt}</span>
+        <p class="trakt-title ellipsis bold">{title}</p>
+      </div>
+      <div class="trakt-rate-now-actions">
+        {#if interactionCounter > 0}
+          {#key interactionCounter}
+            <AutoCloseButton
+              onclick={handleDismiss}
+              label={m.button_label_dismiss()}
+              durationMs={lingerDuration}
+            />
+          {/key}
+        {:else}
+          <ActionButton
+            onclick={() => {
+              handleDismiss();
+              if (!$isAtLimit) {
+                return;
+              }
 
-            confirmSuppression();
-          }}
-          label={m.button_label_dismiss()}
-          style="ghost"
-          size="small"
-        >
-          <CloseIcon />
-        </ActionButton>
-      {/if}
+              confirmSuppression();
+            }}
+            label={m.button_label_dismiss()}
+            style="ghost"
+            size="small"
+          >
+            <CloseIcon />
+          </ActionButton>
+        {/if}
+      </div>
     </div>
     <div class="trakt-rate-now-container">
       <RateNow
         {...lastWatched}
         variant="allow"
+        style="minimal"
         onclick={() => (interactionCounter += 1)}
       />
     </div>
@@ -98,12 +117,21 @@
   .trakt-rate-now-header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+    gap: var(--gap-m);
+  }
+
+  .trakt-rate-now-titles {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xxs);
+    flex: 1;
+    min-width: 0;
   }
 
   .trakt-rate-now-container {
     :global(.trakt-rate-now) {
-      justify-content: space-between;
+      justify-content: flex-start;
     }
 
     :global(svg) {


### PR DESCRIPTION
## Summary

Tightens up the Rate Now toast and Where-to-Watch empty state with shared building blocks.

- **Rate Now toast** (`sections/toast/_internal/RateNowContent.svelte`)
  - Rotates the verdict prompt heading across visits so users see a fresher CTA each time the toast appears.
  - Adjusts layout to better handle long titles and constrained widths.
- **`RateNow` component** (`sections/summary/components/rating/RateNow.svelte`)
  - Adds a `hideLabel` prop so callers (like the toast) can render the stars without the helper label, while consuming pages keep the label.
- **Where-to-Watch empty state** (`sections/lists/where-to-watch/_internal/WhereToWatchEmptyItem.svelte`)
  - New empty-state card surfaced from `WhereToWatchList` and `WhereToWatchDrawer` when there are no streaming sources for the user's region.

## Test plan

- [ ] Trigger the Rate Now toast on a movie/episode you haven't rated — verdict prompt rotates between visits, stars submit a rating, toast dismisses on success.
- [ ] Rate Now without label: open the toast variant — stars render full-width with no helper text underneath.
- [ ] Where-to-Watch with no sources for the active region — card shows the empty-state placeholder both in the page list and the drawer.
- [ ] `deno task client:check` and `deno task client:test` both pass.