### PR TITLE
feat: allows short cache for social bot requests

### DIFF
--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -39,9 +39,10 @@ export const handleCacheControl: Handle = async ({ event, resolve }) => {
       return 'public, max-age=3600, s-maxage=3600';
     }
 
-    // Social bots (Discord, Slack, etc.), "public" so embeds work, but no CDN caching
+    // Social bots (Discord, Slack, etc.), allow a short cache so strict crawlers (Discord) will render embeds
     if (isBotAgent(event.request.headers.get('user-agent'))) {
-      return 'public, max-age=0, must-revalidate';
+      // 120 seconds is enough to satisfy Discord without heavily caching stale content
+      return 'public, max-age=120, s-maxage=120';
     }
 
     return 'private, no-store, no-cache, must-revalidate';


### PR DESCRIPTION
## 🎶 Notes 🎶
- Previously, social bot requests were served with a `Cache-Control` header of `public, max-age=0, must-revalidate`, preventing any caching.
- This change updates the `Cache-Control` header for identified social bot requests to `public, max-age=120, s-maxage=120`.
- The introduction of a 120-second cache duration aims to improve the rendering of embeds by strict crawlers, such as Discord, without heavily caching potentially stale content.