### PR TITLE
fix: recover stale chunk failures from client runtime

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -90,15 +90,73 @@ function isDynamicImportError(error: unknown): boolean {
   );
 }
 
-function reloadOnceForStaleDeploy(error: unknown): void {
-  if (!isDynamicImportError(error)) return;
+function hasChunkPath(path?: string): boolean {
+  if (!path) {
+    return false;
+  }
+
+  return path.includes('/app/immutable/chunks/');
+}
+
+function getRejectionUrl(reason: unknown): string | undefined {
+  if (typeof reason !== 'object' || reason === null) return undefined;
+  if (!('url' in reason)) return undefined;
+  return String((reason as { url?: unknown }).url ?? '');
+}
+
+function shouldReloadForRejection(event: PromiseRejectionEvent): boolean {
+  if (isDynamicImportError(event.reason)) return true;
+  return hasChunkPath(getRejectionUrl(event.reason));
+}
+
+function shouldReloadForError(event: ErrorEvent): boolean {
+  if (isDynamicImportError(event.error ?? event.message)) return true;
+  if (event.target instanceof HTMLScriptElement) {
+    return hasChunkPath(event.target.src);
+  }
+  return hasChunkPath(event.filename);
+}
+
+function shouldReloadForClientEvent(
+  event: ErrorEvent | PromiseRejectionEvent,
+): boolean {
+  if ('reason' in event) return shouldReloadForRejection(event);
+  return shouldReloadForError(event);
+}
+
+function buildReloadUrl() {
+  const url = new URL(window.location.href);
+  url.searchParams.set('_cb', Date.now().toString());
+  return url.toString();
+}
+
+function triggerReloadOnce(): void {
   if (sessionStorage.getItem(DYNAMIC_IMPORT_RELOAD_KEY)) return;
 
   sessionStorage.setItem(DYNAMIC_IMPORT_RELOAD_KEY, '1');
-  window.location.reload();
+  window.location.replace(buildReloadUrl());
+}
+
+function reloadOnceForStaleDeploy(error: unknown): void {
+  if (!isDynamicImportError(error)) return;
+  triggerReloadOnce();
+}
+
+function reloadOnceFromClientEvent(
+  event: ErrorEvent | PromiseRejectionEvent,
+): void {
+  if (!shouldReloadForClientEvent(event)) return;
+  triggerReloadOnce();
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('error', reloadOnceFromClientEvent);
+  window.addEventListener('unhandledrejection', reloadOnceFromClientEvent);
 }
 
 // If you have a custom error handler, pass it to `handleErrorWithSentry`
-export const handleError = handleErrorWithSentry(({ error }: { error: unknown }) => {
-  reloadOnceForStaleDeploy(error);
-});
+export const handleError = handleErrorWithSentry(
+  ({ error }: { error: unknown }) => {
+    reloadOnceForStaleDeploy(error);
+  },
+);

--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -66,22 +66,13 @@ function removeNavigationCache() {
 }
 
 // Force immediate activation for new service worker
-self.addEventListener('install', (event) => {
+self.addEventListener('install', () => {
   self.skipWaiting();
 });
 
-// Bust all caches on new service worker activation
+// Claim clients without deleting all caches to avoid churn and race conditions.
 self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    (async () => {
-      const cacheNames = await caches.keys();
-      await Promise.all(cacheNames.map((name) => caches.delete(name)));
-      // Optionally, claim clients immediately
-      if (self.clients && self.clients.claim) {
-        await self.clients.claim();
-      }
-    })()
-  );
+  event.waitUntil(self.clients.claim());
 });
 
 addEventListener('message', (event) => {
@@ -96,6 +87,11 @@ precacheAndRoute(self.__WB_MANIFEST);
 // Navigation routes
 const navigationHandler = new StaleWhileRevalidate({
   cacheName: CacheKey.navigation,
+  plugins: [
+    new ExpirationPlugin({
+      maxAgeSeconds: time.hours(12) / time.seconds(1),
+    }),
+  ],
 });
 
 registerRoute(


### PR DESCRIPTION
## Summary
- move stale deploy chunk recovery to the client runtime in `hooks.client.ts`
- add global `error` and `unhandledrejection` handlers that detect chunk/dynamic-import failures
- perform a one-time reload using `?_cb=<timestamp>` so existing service worker cache-bust flow is reused
- keep service worker catch handler focused on network fallback (remove SW-driven client reload side effect)
- keep `StaleWhileRevalidate` navigation strategy while bounding navigation cache age

## Why
Some users could land on a blank page after a deploy due to stale chunk references. Handling recovery in page runtime gives better visibility and catches module/script load errors that may not surface through service worker route handler failures.

## Testing
- manually validated logic paths and one-time reload guard in client runtime
- no type issues introduced in `hooks.client.ts` via workspace diagnostics
