### PR TITLE
YIR: 2024 stats

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -15,6 +15,7 @@
     "npm:@jsr/trakt__api@0.4.11": "0.4.11_openapi3-ts@4.5.0",
     "npm:@playwright/test@1.59.1": "1.59.1",
     "npm:@sentry/sveltekit@10.51.0": "10.51.0_@sveltejs+kit@2.59.1__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.55.5___vite@8.0.10____esbuild@0.28.0____sass-embedded@1.99.0__svelte@5.55.5__typescript@5.8.3__vite@8.0.10___esbuild@0.28.0___sass-embedded@1.99.0_vite@8.0.10__esbuild@0.28.0__sass-embedded@1.99.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.55.5__vite@8.0.10___esbuild@0.28.0___sass-embedded@1.99.0",
+    "npm:@svelte-put/shortcut@^4.1.0": "4.1.0_svelte@5.55.5",
     "npm:@sveltejs/adapter-auto@7.0.1": "7.0.1_@sveltejs+kit@2.59.1__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.55.5___vite@8.0.10____esbuild@0.28.0____sass-embedded@1.99.0__svelte@5.55.5__typescript@5.8.3__vite@8.0.10___esbuild@0.28.0___sass-embedded@1.99.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.55.5__vite@8.0.10___esbuild@0.28.0___sass-embedded@1.99.0",
     "npm:@sveltejs/adapter-cloudflare@7.2.8": "7.2.8_@sveltejs+kit@2.59.1__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.55.5___vite@8.0.10____esbuild@0.28.0____sass-embedded@1.99.0__svelte@5.55.5__typescript@5.8.3__vite@8.0.10___esbuild@0.28.0___sass-embedded@1.99.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.55.5__vite@8.0.10___esbuild@0.28.0___sass-embedded@1.99.0",
     "npm:@sveltejs/kit@^2.59.1": "2.59.1_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.55.5__vite@8.0.10___esbuild@0.28.0___sass-embedded@1.99.0_svelte@5.55.5_typescript@5.8.3_vite@8.0.10__esbuild@0.28.0__sass-embedded@1.99.0",
@@ -3196,6 +3197,12 @@
         "json5",
         "magic-string@0.25.9",
         "string.prototype.matchall"
+      ]
+    },
+    "@svelte-put/shortcut@4.1.0_svelte@5.55.5": {
+      "integrity": "sha512-wImNEIkbxAIWFqlfuhcbC+jRPDeRa/uJGIXHMEVVD+jqL9xCwWNnkGQJ6Qb2XVszuRLHlb8SGZDL3Io/h3vs8w==",
+      "dependencies": [
+        "svelte"
       ]
     },
     "@sveltejs/acorn-typescript@1.0.9_acorn@8.16.0": {
@@ -8234,6 +8241,7 @@
             "npm:@jsr/trakt__api@0.4.11",
             "npm:@playwright/test@1.59.1",
             "npm:@sentry/sveltekit@10.51.0",
+            "npm:@svelte-put/shortcut@^4.1.0",
             "npm:@sveltejs/adapter-auto@7.0.1",
             "npm:@sveltejs/adapter-cloudflare@7.2.8",
             "npm:@sveltejs/kit@^2.59.1",

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7677,6 +7677,155 @@
         "ios"
       ]
     },
+    "yir_2024_stats_intro_shows": {
+      "default": "In {year}, you watched",
+      "description": "Lead-in line above the big '{hours} hours of {count} Shows' headline on the 2024 Year in Review TV stats section.",
+      "variables": {
+        "year": { "type": "number" }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_intro_movies": {
+      "default": "In {year}, you watched",
+      "description": "Lead-in line above the big '{hours} hours of {count} Movies' headline on the 2024 Year in Review movie stats section.",
+      "variables": {
+        "year": { "type": "number" }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_summary_shows": {
+      "default": "{hours} hours of {count} Shows",
+      "description": "Big headline summarising hours watched and number of distinct shows on the 2024 Year in Review TV stats section.",
+      "variables": {
+        "hours": { "type": "string" },
+        "count": { "type": "string" }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_summary_movies": {
+      "default": "{hours} hours of {count} Movies",
+      "description": "Big headline summarising hours watched and number of distinct movies on the 2024 Year in Review movie stats section.",
+      "variables": {
+        "hours": { "type": "string" },
+        "count": { "type": "string" }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_most_active_week": {
+      "default": "Your most active week was <b>{start} - {end}</b> with <b>{count} plays</b>.",
+      "description": "Info line on the 2024 Year in Review stats section reporting the user's busiest watching week. The <b> tags wrap dynamic values that render as bold purple highlights — keep them around the same content when translating.",
+      "variables": {
+        "start": { "type": "string" },
+        "end": { "type": "string" },
+        "count": { "type": "string" }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_most_popular_time": {
+      "default": "The most popular time you watched was <b>{time}</b>.",
+      "description": "Info line on the 2024 Year in Review stats section reporting the user's busiest hour of day. The <b> tags wrap the time value as a bold purple highlight — keep them around the time when translating.",
+      "variables": {
+        "time": { "type": "string" }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_card_hours": {
+      "default": "{count} Hours",
+      "description": "Title on the hours-watched chart card on the 2024 Year in Review stats section.",
+      "variables": {
+        "count": { "type": "string" }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_card_plays": {
+      "default": "{count} Plays",
+      "description": "Title on the plays chart card on the 2024 Year in Review stats section.",
+      "variables": {
+        "count": { "type": "string" }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_per_month": {
+      "default": "Per Month",
+      "description": "Stat-line label for the monthly average row on the 2024 Year in Review stats card.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_per_week": {
+      "default": "Per Week",
+      "description": "Stat-line label for the weekly average row on the 2024 Year in Review stats card.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_per_day": {
+      "default": "Per Day",
+      "description": "Stat-line label for the daily average row on the 2024 Year in Review stats card.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_tooltip_plays": {
+      "default": "{count} Plays",
+      "description": "Tooltip headline for play-count points on the 2024 Year in Review stats charts.",
+      "variables": {
+        "count": { "type": "string" }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_tooltip_hours": {
+      "default": "{count} Hours",
+      "description": "Tooltip headline for hours-watched points on the 2024 Year in Review stats charts.",
+      "variables": {
+        "count": { "type": "string" }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "yir_2024_stats_tooltip_week_label": {
+      "default": "Week {week}",
+      "description": "Tooltip secondary label naming the week number on the 2024 Year in Review weekly chart.",
+      "variables": {
+        "week": { "type": "string" }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "vip_feature_title_mir": {
       "default": "Month in Review",
       "description": "Title for the Month in Review VIP feature.",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -70,6 +70,7 @@
     "@libn/fuzzy": "npm:@jsr/libn__fuzzy@^0.4.0",
     "@sentry/sveltekit": "10.51.0",
     "@sveltejs/kit": "^2.59.1",
+    "@svelte-put/shortcut": "^4.1.0",
     "@tanstack/svelte-query": "5.90.2",
     "@tanstack/svelte-query-devtools": "5.90.2",
     "@tanstack/svelte-query-persist-client": "5.90.2",

--- a/projects/client/src/lib/components/charts/AreaChart.svelte
+++ b/projects/client/src/lib/components/charts/AreaChart.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
+  import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
+  import { time } from "$lib/utils/timing/time";
+  import { ScaleTypes } from "@carbon/charts";
+  import { AreaChart, type AreaChartOptions } from "@carbon/charts-svelte";
+  import "@carbon/charts-svelte/styles.css";
+  import { flushSync } from "svelte";
+  import type { AreaChartProps, TooltipArgs } from "./models/AreaChartProps";
+
+  const dotRadius = 7;
+  const chartPaddingVar = "var(--ni-12)";
+
+  const {
+    data,
+    tooltip,
+    lineColor = "var(--color-text-primary)",
+    fillColor = "transparent",
+    dotColor,
+    dotHaloColor = "transparent",
+  }: AreaChartProps = $props();
+
+  // Default the dot to the line color so a consumer that just picks a line
+  // color gets a coherent hover marker without extra plumbing.
+  const resolvedDotColor = $derived(dotColor ?? lineColor);
+
+  // Carbon Charts groups area data by `group`; everything sits in a single
+  // group so the area is one continuous shape.
+  const carbonData = $derived(
+    data.map((d) => ({ group: "value", date: d.label, value: d.value })),
+  );
+  const labels = $derived(data.map((d) => d.label));
+
+  const chartPadding = useVarToPixels(chartPaddingVar);
+  const { observedDimension: observedContainerDimension, observeDimension } =
+    useDimensionObserver("width", time.fps(30));
+
+  const observedDimension = $derived(
+    $observedContainerDimension - $chartPadding * 2,
+  );
+
+  let tooltipContainer: HTMLDivElement | undefined = $state();
+  let tooltipArgs: TooltipArgs | null = $state(null);
+
+  const customHTML = $derived(
+    (points: Array<{ value: number; date: string }>) => {
+      if (!tooltip || !tooltipContainer || !points?.length) return "";
+      const point = points[0];
+      const index = labels.indexOf(point.date);
+      tooltipArgs = { value: point.value, label: point.date, index };
+      flushSync();
+      return tooltipContainer.innerHTML;
+    },
+  );
+
+  const options: AreaChartOptions = $derived({
+    axes: {
+      bottom: {
+        mapsTo: "date",
+        scaleType: ScaleTypes.LABELS,
+      },
+      left: {
+        mapsTo: "value",
+        visible: false,
+      },
+    },
+    grid: {
+      x: { enabled: false },
+      y: { enabled: false },
+    },
+    // Points render at a fixed radius but invisible by default
+    // (fillOpacity: 0). The CSS below fades them in on hover so we get a
+    // stable pin at the active data point. Keeping `r` constant avoids
+    // fighting Carbon's own hover animation, which writes inline `r`
+    // attributes that would clobber a CSS transition.
+    points: { enabled: true, radius: dotRadius, fillOpacity: 0 },
+    legend: { enabled: false },
+    toolbar: { enabled: false },
+    tooltip: {
+      enabled: tooltip != null,
+      customHTML,
+    },
+    resizable: false,
+    width: `${observedDimension}px`,
+    height: "var(--height-area-chart)",
+    // Colors are passed as resolved CSS strings (props), not via wrapper-set
+    // CSS vars, because Carbon resolves `color.scale.value` at chart-init
+    // context where the wrapper's scoped vars aren't accessible. Passing
+    // globally-defined references (e.g. `var(--shade-10)`) keeps the values
+    // theme-aware while still resolving anywhere.
+    color: {
+      scale: { value: lineColor },
+    },
+    getStrokeColor: () => lineColor,
+    getFillColor: () => fillColor,
+  });
+</script>
+
+<div
+  class="trakt-area-chart"
+  use:observeDimension
+  style="--chart-padding: {$chartPadding}px; --area-chart-dot: {resolvedDotColor}; --area-chart-dot-halo: {dotHaloColor};"
+>
+  <AreaChart data={carbonData} {options} />
+
+  <!--
+    CarbonCharts does not support snippets as tooltips. So we render them to a
+    hidden container and pull the HTML into Carbon's custom tooltip renderer.
+    This way, at least from a consumer pov, a snippet can be passed in.
+  -->
+  <div bind:this={tooltipContainer} style="display:none" aria-hidden="true">
+    {#if tooltip && tooltipArgs}
+      {@render tooltip(tooltipArgs)}
+    {/if}
+  </div>
+</div>
+
+<style lang="scss">
+  .trakt-area-chart {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    padding: var(--chart-padding);
+    box-sizing: border-box;
+
+    :global(.cds--chart-holder) {
+      --cds-grid-bg: transparent;
+      --cds-text-primary: var(
+        --color-area-chart-text-primary,
+        var(--color-text-primary)
+      );
+      --cds-text-secondary: var(
+        --color-area-chart-text-secondary,
+        var(--color-text-secondary)
+      );
+    }
+
+    // Area + line colors come from Carbon's getFillColor / getStrokeColor
+    // callbacks (see options above), so we only need width + opacity here.
+    :global(.area) {
+      fill-opacity: 1;
+    }
+
+    :global(.line) {
+      stroke-width: var(--width-area-chart-line, var(--ni-2));
+    }
+
+    // Hover marker for the active data point. Hidden by default (radius is
+    // set via Carbon's points option but opacity stays 0 so the dots are
+    // invisible). On `.hovered` the dot fades in. We avoid any CSS
+    // `transform` here because Safari's SVG transform handling fights
+    // Carbon's own inline `r` updates, causing the dot to flicker.
+    :global(circle.dot) {
+      fill: var(--area-chart-dot);
+      stroke: var(--area-chart-dot-halo);
+      stroke-width: var(--ni-2);
+      fill-opacity: 0;
+      stroke-opacity: 0;
+      transition:
+        fill-opacity var(--transition-increment) ease-out,
+        stroke-opacity var(--transition-increment) ease-out;
+    }
+
+    :global(circle.dot.hovered) {
+      fill-opacity: 1;
+      stroke-opacity: 0.8;
+    }
+
+    :global(.tick line),
+    :global(.domain) {
+      stroke: transparent;
+    }
+  }
+
+  // Carbon mounts the tooltip wrapper outside .cds--chart-holder, so consumer
+  // tooltip styles can't reach it through the normal cascade. Flatten the
+  // wrapper here so consumer tooltip styling shows through cleanly.
+  :global(.cds--cc--tooltip) {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+  }
+</style>

--- a/projects/client/src/lib/components/charts/BarChart.svelte
+++ b/projects/client/src/lib/components/charts/BarChart.svelte
@@ -8,10 +8,14 @@
   import { flushSync } from "svelte";
   import type { BarChartProps, TooltipArgs } from "./models/BarChartProps";
 
-  const barSpacing = 2;
   const chartPaddingVar = "var(--ni-12)";
 
-  const { data, tooltip, tickLabels }: BarChartProps = $props();
+  const {
+    data,
+    tooltip,
+    tickLabels,
+    barSpacing = 2,
+  }: BarChartProps = $props();
 
   // Carbon Charts keys bars by `group`; remap label → group so D3 join is stable on resize.
   const carbonData = $derived(

--- a/projects/client/src/lib/components/charts/models/AreaChartProps.ts
+++ b/projects/client/src/lib/components/charts/models/AreaChartProps.ts
@@ -1,0 +1,21 @@
+import type { Snippet } from 'svelte';
+
+type AreaChartData = {
+  value: number;
+  label: string;
+};
+
+export type TooltipArgs = { value: number; label: string; index: number };
+
+export type AreaChartProps = {
+  data: AreaChartData[];
+  tooltip?: Snippet<[TooltipArgs]>;
+  /** CSS color used for the line stroke. */
+  lineColor?: string;
+  /** CSS color used to fill the area beneath the line. */
+  fillColor?: string;
+  /** CSS color used for the hover marker dot. Falls back to `lineColor`. */
+  dotColor?: string;
+  /** CSS color used for the hover marker dot's outer halo. */
+  dotHaloColor?: string;
+};

--- a/projects/client/src/lib/components/charts/models/BarChartProps.ts
+++ b/projects/client/src/lib/components/charts/models/BarChartProps.ts
@@ -11,4 +11,6 @@ export type BarChartProps = {
   data: BarChartData[];
   tickLabels?: string[];
   tooltip?: Snippet<[TooltipArgs]>;
+  /** Pixel gap between bars. Defaults to 2px. */
+  barSpacing?: number;
 };

--- a/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
+++ b/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
@@ -9,10 +9,12 @@
 
   const {
     detail,
+    isLoading,
     slug,
     year,
   }: {
     detail: YirDetail | null;
+    isLoading: boolean;
     slug: string;
     year: number;
   } = $props();
@@ -63,7 +65,7 @@
         />
       </Yir2024PageInner>
     {/if}
-  {:else}
+  {:else if isLoading}
     <!-- Detail query in flight: hero has already painted above; show a
          small inline indicator where the rest of the sections will mount. -->
     <div class="yir-2024-loading">

--- a/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
+++ b/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import { m } from "$lib/paraglide/messages";
   import type { YirDetail } from "$lib/requests/models/YirDetail";
   import Yir2024PageInner from "./_internal/Yir2024PageInner.svelte";
   import Yir2024PlayCard from "./_internal/Yir2024PlayCard.svelte";
+  import Yir2024StatsSection from "./_internal/Yir2024StatsSection.svelte";
   import Yir2024TopSection from "./_internal/Yir2024TopSection.svelte";
 
   const {
@@ -10,24 +12,63 @@
     slug,
     year,
   }: {
-    detail: YirDetail;
+    detail: YirDetail | null;
     slug: string;
     year: number;
   } = $props();
 </script>
 
+<svelte:head>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Spline+Sans:wght@300..700&display=swap"
+    rel="stylesheet"
+  />
+</svelte:head>
+
 <div class="yir-2024">
+  <!-- Top section paints immediately; the Hero core (year, name, label,
+       membership) renders without the detail query, while the posters /
+       watched-stats / first-play parts gate on `detail` being present. -->
   <Yir2024TopSection {detail} {slug} {year} />
 
-  <p class="yir-2024-pending">More sections coming soon&hellip;</p>
+  {#if detail}
+    {#if detail.firstWatched}
+      <Yir2024PageInner>
+        <Yir2024PlayCard
+          item={detail.firstWatched}
+          headerLabel={m.yir_2024_first_play_of({ year })}
+        />
+      </Yir2024PageInner>
+    {/if}
 
-  {#if detail.lastWatched}
-    <Yir2024PageInner>
-      <Yir2024PlayCard
-        item={detail.lastWatched}
-        headerLabel={m.yir_2024_last_play_of({ year })}
-      />
-    </Yir2024PageInner>
+    {#if detail.stats.shows.playCounts.total > 0}
+      <Yir2024PageInner>
+        <Yir2024StatsSection type="shows" stats={detail.stats.shows} {year} />
+      </Yir2024PageInner>
+    {/if}
+
+    {#if detail.stats.movies.playCounts.total > 0}
+      <Yir2024PageInner>
+        <Yir2024StatsSection type="movies" stats={detail.stats.movies} {year} />
+      </Yir2024PageInner>
+    {/if}
+
+    <p class="yir-2024-pending">More sections coming soon&hellip;</p>
+
+    {#if detail.lastWatched}
+      <Yir2024PageInner>
+        <Yir2024PlayCard
+          item={detail.lastWatched}
+          headerLabel={m.yir_2024_last_play_of({ year })}
+        />
+      </Yir2024PageInner>
+    {/if}
+  {:else}
+    <!-- Detail query in flight: hero has already painted above; show a
+         small inline indicator where the rest of the sections will mount. -->
+    <div class="yir-2024-loading">
+      <LoadingIndicator />
+    </div>
   {/if}
 </div>
 
@@ -42,6 +83,9 @@
     gap: var(--content-gap);
     background-color: var(--shade-950);
     color: var(--shade-10);
+    // Scoped to the 2024 template so the Spline Sans face only swaps in
+    // here and the rest of the app keeps the global Roboto stack.
+    font-family: "Spline Sans", Helvetica, Arial, sans-serif;
   }
 
   .yir-2024-pending {
@@ -49,5 +93,12 @@
     padding: var(--ni-20);
     text-align: center;
     color: var(--shade-500);
+  }
+
+  .yir-2024-loading {
+    display: flex;
+    justify-content: center;
+    padding: var(--ni-72) 0;
+    color: var(--shade-300);
   }
 </style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte
@@ -21,7 +21,7 @@
   }: {
     slug: string;
     year: number;
-    detail: YirDetail;
+    detail: YirDetail | null;
   } = $props();
 
   const profileQuery = $derived(useQuery(userProfileQuery({ slug })));
@@ -35,11 +35,16 @@
       : m.yir_2024_huge_label_year_in_review(),
   );
 
+  // Posters need the YIR detail; render an empty list while it loads so the
+  // rest of the hero (year row, label, directed-by, membership) paints
+  // immediately and the posters fade in once the query lands.
   const heroPosters = $derived(
-    [
-      ...detail.mostWatched.shows.slice(0, 3),
-      ...detail.mostWatched.movies.slice(0, 3),
-    ].map((item) => item.entry),
+    detail
+      ? [
+        ...detail.mostWatched.shows.slice(0, 3),
+        ...detail.mostWatched.movies.slice(0, 3),
+      ].map((item) => item.entry)
+      : [],
   );
 
   const displayName = $derived(
@@ -191,11 +196,11 @@
 
   .yir-2024-by-label,
   .yir-2024-name-label {
-    font-size: var(--ni-18);
+    font-size: var(--font-size-title);
     text-align: start;
 
     @include for-mobile {
-      font-size: var(--ni-14);
+      font-size: var(--font-size-text);
     }
   }
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024LineChart.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024LineChart.svelte
@@ -1,180 +1,39 @@
 <script lang="ts">
-  import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
-  import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
-  import { time } from "$lib/utils/timing/time";
-  import { ScaleTypes } from "@carbon/charts";
-  import { AreaChart, type AreaChartOptions } from "@carbon/charts-svelte";
-  import "@carbon/charts-svelte/styles.css";
-  import { flushSync, type Snippet } from "svelte";
+  import AreaChart from "$lib/components/charts/AreaChart.svelte";
+  import type { AreaChartProps } from "$lib/components/charts/models/AreaChartProps";
 
-  type Datum = { value: number; label: string };
-  type TooltipArgs = { value: number; label: string; index: number };
-
-  const {
-    data,
-    tooltip,
-  }: {
-    data: Datum[];
-    tooltip?: Snippet<[TooltipArgs]>;
-  } = $props();
-
-  const chartPadding = useVarToPixels("var(--ni-12)");
-  const { observedDimension: observedContainerDimension, observeDimension } =
-    useDimensionObserver("width", time.fps(30));
-
-  const observedDimension = $derived(
-    $observedContainerDimension - $chartPadding * 2,
-  );
-
-  // Carbon Charts groups area data by `group`; everything sits in a single
-  // group so the area is one continuous shape.
-  const carbonData = $derived(
-    data.map((d) => ({ group: "value", date: d.label, value: d.value })),
-  );
-  const labels = $derived(data.map((d) => d.label));
-
-  let tooltipContainer: HTMLDivElement | undefined = $state();
-  let tooltipArgs: TooltipArgs | null = $state(null);
-
-  const customHTML = $derived(
-    (points: Array<{ value: number; date: string }>) => {
-      if (!tooltip || !tooltipContainer || !points?.length) return "";
-      const point = points[0];
-      const index = labels.indexOf(point.date);
-      tooltipArgs = { value: point.value, label: point.date, index };
-      flushSync();
-      return tooltipContainer.innerHTML;
-    },
-  );
-
-  const options: AreaChartOptions = $derived({
-    axes: {
-      bottom: {
-        mapsTo: "date",
-        scaleType: ScaleTypes.LABELS,
-      },
-      left: {
-        mapsTo: "value",
-        visible: false,
-      },
-    },
-    grid: {
-      x: { enabled: false },
-      y: { enabled: false },
-    },
-    // Points are rendered at a fixed small radius but invisible by default
-    // (fillOpacity: 0). The CSS below fades + scales them in on hover so
-    // we get a stable purple dot at the active data point. Keeping `r`
-    // constant avoids fighting Carbon's own hover animation, which writes
-    // inline `r` attributes that would clobber a CSS transition.
-    points: { enabled: true, radius: 7, fillOpacity: 0 },
-    legend: { enabled: false },
-    toolbar: { enabled: false },
-    tooltip: {
-      enabled: tooltip != null,
-      customHTML,
-    },
-    resizable: false,
-    width: `${observedDimension}px`,
-    height: "var(--height-yir-2024-line-chart)",
-    // Colors are configured through Carbon's option callbacks so we don't
-    // have to fight its inline-style writes from CSS. Carbon then emits the
-    // attributes directly on the area / line / dot SVG elements, leaving
-    // the stylesheet free of !important overrides.
-    color: {
-      scale: { value: "var(--color-yir-2024-line, var(--shade-10))" },
-    },
-    getStrokeColor: () => "var(--color-yir-2024-line, var(--shade-10))",
-    getFillColor: () => "var(--color-yir-2024-area, var(--shade-920))",
-  });
+  const { data, tooltip }: AreaChartProps = $props();
 </script>
 
-<div
-  class="yir-2024-line-chart"
-  use:observeDimension
-  style="--chart-padding: {$chartPadding}px"
->
-  <AreaChart data={carbonData} {options} />
-
-  <div bind:this={tooltipContainer} style="display:none" aria-hidden="true">
-    {#if tooltip && tooltipArgs}
-      {@render tooltip(tooltipArgs)}
-    {/if}
-  </div>
+<div class="yir-2024-line-chart">
+  <!--
+    2024 palette: white line, dark fill (~v2's #222 → shade-920), and a
+    purple-500 hover pin with a faint white halo. Colors are passed as props
+    (rather than via CSS vars on the wrapper) because Carbon resolves
+    `color.scale.value` at chart-init context, where Svelte-scoped wrapper
+    vars aren't accessible.
+  -->
+  <AreaChart
+    {data}
+    {tooltip}
+    lineColor="var(--shade-10)"
+    fillColor="var(--shade-920)"
+    dotColor="var(--purple-500)"
+    dotHaloColor="var(--shade-10)"
+  />
 </div>
 
 <style lang="scss">
   .yir-2024-line-chart {
-    --color-yir-2024-line: var(--shade-10);
-    // shade-920 (#212427) is the closest semantic match for v2's #222222
-    // area fill below the line.
-    --color-yir-2024-area: var(--shade-920);
-
     width: 100%;
     height: 100%;
-    overflow: hidden;
-    padding: var(--chart-padding);
-    box-sizing: border-box;
 
+    // Match the 2024 template's body font; the shared AreaChart wrapper
+    // defaults to whatever Carbon picks otherwise.
     :global(.cds--chart-holder) {
-      --cds-grid-bg: transparent;
-      --cds-text-primary: var(--shade-10);
-      --cds-text-secondary: var(--shade-300);
-      // Match the 2024 template's body font instead of falling through to
-      // Carbon's default Roboto.
       --cds-charts-font-family: "Spline Sans", Helvetica, Arial, sans-serif;
       --cds-charts-font-family-condensed:
         "Spline Sans", Helvetica, Arial, sans-serif;
     }
-
-    // Area + line colors come from Carbon's getFillColor / getStrokeColor
-    // callbacks (see options above), so we only need width + opacity here.
-    :global(.area) {
-      fill-opacity: 1;
-    }
-
-    :global(.line) {
-      stroke-width: var(--ni-2);
-    }
-
-    // Hover marker for the active data point. Hidden by default (radius 7
-    // is set via Carbon's points option but opacity stays 0 so the dots
-    // are invisible). On `.hovered`, the dot fades and scales in to a
-    // purple pin with a faint white halo.
-    :global(circle.dot) {
-      fill: var(--purple-500);
-      stroke: var(--shade-10);
-      stroke-width: var(--ni-2);
-      fill-opacity: 0;
-      stroke-opacity: 0;
-      transform-box: fill-box;
-      transform-origin: center;
-      transform: scale(0.4);
-      transition:
-        transform 80ms ease-out,
-        fill-opacity 80ms ease-out,
-        stroke-opacity 80ms ease-out;
-    }
-
-    :global(circle.dot.hovered) {
-      fill-opacity: 1;
-      stroke-opacity: 0.8;
-      transform: scale(1);
-    }
-
-    :global(.tick line),
-    :global(.domain) {
-      stroke: transparent;
-    }
-  }
-
-  // Carbon mounts the tooltip wrapper outside .cds--chart-holder, so the
-  // YirTooltip styles can't reach it through the normal cascade. Flatten the
-  // wrapper here so the (purple-pill) tooltip styling shows through cleanly.
-  :global(.cds--cc--tooltip) {
-    background: transparent;
-    border: none;
-    box-shadow: none;
-    padding: 0;
   }
 </style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024LineChart.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024LineChart.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
+  import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
+  import { time } from "$lib/utils/timing/time";
+  import { ScaleTypes } from "@carbon/charts";
+  import { AreaChart, type AreaChartOptions } from "@carbon/charts-svelte";
+  import "@carbon/charts-svelte/styles.css";
+  import { flushSync, type Snippet } from "svelte";
+
+  type Datum = { value: number; label: string };
+  type TooltipArgs = { value: number; label: string; index: number };
+
+  const {
+    data,
+    tooltip,
+  }: {
+    data: Datum[];
+    tooltip?: Snippet<[TooltipArgs]>;
+  } = $props();
+
+  const chartPadding = useVarToPixels("var(--ni-12)");
+  const { observedDimension: observedContainerDimension, observeDimension } =
+    useDimensionObserver("width", time.fps(30));
+
+  const observedDimension = $derived(
+    $observedContainerDimension - $chartPadding * 2,
+  );
+
+  // Carbon Charts groups area data by `group`; everything sits in a single
+  // group so the area is one continuous shape.
+  const carbonData = $derived(
+    data.map((d) => ({ group: "value", date: d.label, value: d.value })),
+  );
+  const labels = $derived(data.map((d) => d.label));
+
+  let tooltipContainer: HTMLDivElement | undefined = $state();
+  let tooltipArgs: TooltipArgs | null = $state(null);
+
+  const customHTML = $derived(
+    (points: Array<{ value: number; date: string }>) => {
+      if (!tooltip || !tooltipContainer || !points?.length) return "";
+      const point = points[0];
+      const index = labels.indexOf(point.date);
+      tooltipArgs = { value: point.value, label: point.date, index };
+      flushSync();
+      return tooltipContainer.innerHTML;
+    },
+  );
+
+  const options: AreaChartOptions = $derived({
+    axes: {
+      bottom: {
+        mapsTo: "date",
+        scaleType: ScaleTypes.LABELS,
+      },
+      left: {
+        mapsTo: "value",
+        visible: false,
+      },
+    },
+    grid: {
+      x: { enabled: false },
+      y: { enabled: false },
+    },
+    // Points are rendered at a fixed small radius but invisible by default
+    // (fillOpacity: 0). The CSS below fades + scales them in on hover so
+    // we get a stable purple dot at the active data point. Keeping `r`
+    // constant avoids fighting Carbon's own hover animation, which writes
+    // inline `r` attributes that would clobber a CSS transition.
+    points: { enabled: true, radius: 7, fillOpacity: 0 },
+    legend: { enabled: false },
+    toolbar: { enabled: false },
+    tooltip: {
+      enabled: tooltip != null,
+      customHTML,
+    },
+    resizable: false,
+    width: `${observedDimension}px`,
+    height: "var(--height-yir-2024-line-chart)",
+    // Colors are configured through Carbon's option callbacks so we don't
+    // have to fight its inline-style writes from CSS. Carbon then emits the
+    // attributes directly on the area / line / dot SVG elements, leaving
+    // the stylesheet free of !important overrides.
+    color: {
+      scale: { value: "var(--color-yir-2024-line, var(--shade-10))" },
+    },
+    getStrokeColor: () => "var(--color-yir-2024-line, var(--shade-10))",
+    getFillColor: () => "var(--color-yir-2024-area, var(--shade-920))",
+  });
+</script>
+
+<div
+  class="yir-2024-line-chart"
+  use:observeDimension
+  style="--chart-padding: {$chartPadding}px"
+>
+  <AreaChart data={carbonData} {options} />
+
+  <div bind:this={tooltipContainer} style="display:none" aria-hidden="true">
+    {#if tooltip && tooltipArgs}
+      {@render tooltip(tooltipArgs)}
+    {/if}
+  </div>
+</div>
+
+<style lang="scss">
+  .yir-2024-line-chart {
+    --color-yir-2024-line: var(--shade-10);
+    // shade-920 (#212427) is the closest semantic match for v2's #222222
+    // area fill below the line.
+    --color-yir-2024-area: var(--shade-920);
+
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    padding: var(--chart-padding);
+    box-sizing: border-box;
+
+    :global(.cds--chart-holder) {
+      --cds-grid-bg: transparent;
+      --cds-text-primary: var(--shade-10);
+      --cds-text-secondary: var(--shade-300);
+      // Match the 2024 template's body font instead of falling through to
+      // Carbon's default Roboto.
+      --cds-charts-font-family: "Spline Sans", Helvetica, Arial, sans-serif;
+      --cds-charts-font-family-condensed:
+        "Spline Sans", Helvetica, Arial, sans-serif;
+    }
+
+    // Area + line colors come from Carbon's getFillColor / getStrokeColor
+    // callbacks (see options above), so we only need width + opacity here.
+    :global(.area) {
+      fill-opacity: 1;
+    }
+
+    :global(.line) {
+      stroke-width: var(--ni-2);
+    }
+
+    // Hover marker for the active data point. Hidden by default (radius 7
+    // is set via Carbon's points option but opacity stays 0 so the dots
+    // are invisible). On `.hovered`, the dot fades and scales in to a
+    // purple pin with a faint white halo.
+    :global(circle.dot) {
+      fill: var(--purple-500);
+      stroke: var(--shade-10);
+      stroke-width: var(--ni-2);
+      fill-opacity: 0;
+      stroke-opacity: 0;
+      transform-box: fill-box;
+      transform-origin: center;
+      transform: scale(0.4);
+      transition:
+        transform 80ms ease-out,
+        fill-opacity 80ms ease-out,
+        stroke-opacity 80ms ease-out;
+    }
+
+    :global(circle.dot.hovered) {
+      fill-opacity: 1;
+      stroke-opacity: 0.8;
+      transform: scale(1);
+    }
+
+    :global(.tick line),
+    :global(.domain) {
+      stroke: transparent;
+    }
+  }
+
+  // Carbon mounts the tooltip wrapper outside .cds--chart-holder, so the
+  // YirTooltip styles can't reach it through the normal cascade. Flatten the
+  // wrapper here so the (purple-pill) tooltip styling shows through cleanly.
+  :global(.cds--cc--tooltip) {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024SectionHeader.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024SectionHeader.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  // Shared header pattern for 2024 section panels: a small uppercase intro
+  // line above a huge headline. Reused across the stats sections (and any
+  // future section that follows the same intro/title rhythm).
+  const {
+    intro,
+    title,
+  }: {
+    intro: string;
+    title: string;
+  } = $props();
+</script>
+
+<header class="yir-2024-section-header">
+  <p class="bold yir-2024-section-header-intro">{intro}</p>
+  <h2 class="bold yir-2024-section-header-title">{title}</h2>
+</header>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-2024-section-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+
+  .yir-2024-section-header-intro {
+    margin: 0;
+    font-size: var(--ni-24);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--shade-10);
+
+    @include for-mobile {
+      font-size: var(--ni-12);
+    }
+  }
+
+  .yir-2024-section-header-title {
+    margin: 0;
+    font-size: clamp(var(--ni-32), 5vw, var(--ni-56));
+    line-height: 1.05;
+
+    @include for-mobile {
+      font-size: var(--ni-28);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
@@ -390,7 +390,7 @@
   // bottom padding to a tighter value so the watermark sits closer to the
   // averages list above it (no big empty gap between the two).
   .yir-2024-stats-card {
-    --height-yir-2024-line-chart: var(--ni-104);
+    --height-area-chart: var(--ni-104);
     --panel-padding-bottom: var(--ni-64);
 
     display: flex;
@@ -398,7 +398,7 @@
     min-width: 0;
 
     @include for-mobile {
-      --height-yir-2024-line-chart: var(--ni-72);
+      --height-area-chart: var(--ni-72);
       --panel-padding-bottom: var(--ni-40);
     }
   }

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
@@ -1,0 +1,524 @@
+<script lang="ts">
+  import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
+  import PlayIcon from "$lib/components/icons/PlayIcon.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { m } from "$lib/paraglide/messages";
+  import type { YirStatsCategory } from "$lib/requests/models/YirDetail";
+  import { formatNumber } from "$lib/utils/format/formatNumber";
+  import { toHumanClockTime } from "$lib/utils/formatting/date/toHumanClockTime";
+  import { toHumanMonth } from "$lib/utils/formatting/date/toHumanMonth";
+  import { toHumanShortDate } from "$lib/utils/formatting/date/toHumanShortDate";
+  import { addDays } from "date-fns/addDays";
+  import { setMonth } from "date-fns/setMonth";
+  import { startOfYear } from "date-fns/startOfYear";
+
+  import YirTooltip from "../../_internal/YirTooltip.svelte";
+  import Yir2024LineChart from "./Yir2024LineChart.svelte";
+  import Yir2024SectionHeader from "./Yir2024SectionHeader.svelte";
+  import Yir2024WeeklyPlaysChart from "./Yir2024WeeklyPlaysChart.svelte";
+
+  const {
+    type,
+    stats,
+    year,
+  }: {
+    type: "shows" | "movies";
+    stats: YirStatsCategory;
+    year: number;
+  } = $props();
+
+  const formatDecimal = (value: number) => value.toFixed(1);
+
+  const itemsCount = $derived(stats.itemsCount ?? 0);
+  const hoursTotal = $derived(Math.round(stats.minutes.total / 60));
+  const playsTotal = $derived(stats.playCounts.total);
+
+  const hoursMonthly = $derived(stats.minutes.monthly / 60);
+  const hoursWeekly = $derived(stats.minutes.weekly / 60);
+  const hoursDaily = $derived(stats.minutes.daily / 60);
+
+  const peakWeek = $derived.by(() => {
+    const weekly = stats.distributions?.weekly ?? [];
+    if (weekly.length === 0) return null;
+    const maxValue = Math.max(...weekly);
+    const maxIndex = weekly.indexOf(maxValue);
+    const start = addDays(startOfYear(new Date(year, 0, 1)), maxIndex * 7);
+    const end = addDays(start, 6);
+    const locale = languageTag();
+    return {
+      count: maxValue,
+      start: toHumanShortDate(start, locale),
+      end: toHumanShortDate(end, locale),
+    };
+  });
+
+  const peakHour = $derived.by(() => {
+    const hourly = stats.distributions?.hourly;
+    if (!hourly || hourly.length === 0) return null;
+    const maxValue = Math.max(...hourly);
+    const hour = hourly.indexOf(maxValue);
+    return toHumanClockTime(new Date(2000, 0, 1, hour), languageTag());
+  });
+
+  const introMessage = $derived(
+    type === "shows"
+      ? m.yir_2024_stats_intro_shows({ year })
+      : m.yir_2024_stats_intro_movies({ year }),
+  );
+  const summaryMessage = $derived(
+    type === "shows"
+      ? m.yir_2024_stats_summary_shows({
+          hours: formatNumber(hoursTotal),
+          count: formatNumber(itemsCount),
+        })
+      : m.yir_2024_stats_summary_movies({
+          hours: formatNumber(hoursTotal),
+          count: formatNumber(itemsCount),
+        }),
+  );
+
+  const hoursCardTitle = $derived(
+    m.yir_2024_stats_card_hours({ count: formatNumber(hoursTotal) }),
+  );
+  const playsCardTitle = $derived(
+    m.yir_2024_stats_card_plays({ count: formatNumber(playsTotal) }),
+  );
+
+  // Hours chart data — 12 monthly buckets in user's locale.
+  const monthlyHoursData = $derived.by(() => {
+    const locale = languageTag();
+    const monthly = stats.distributions?.monthly ?? [];
+    return monthly.map((value, index) => ({
+      // The distribution stores minutes per bucket; the card frames hours so
+      // we convert before rendering.
+      value: Math.round(value / 60),
+      label: toHumanMonth(setMonth(new Date(0), index), locale, "short"),
+    }));
+  });
+
+  // Plays chart data — 7 day-of-week buckets, with day names rendered in
+  // the user's locale via Intl. Reference dates pinned to a known week
+  // starting on Sunday (Jan 4, 2026 was a Sunday) so index 0 = Sun, …,
+  // 6 = Sat regardless of the current date.
+  const weekdayLabels = $derived.by(() => {
+    const formatter = new Intl.DateTimeFormat(languageTag(), {
+      weekday: "short",
+    });
+    return Array.from(
+      { length: 7 },
+      (_, i) => formatter.format(new Date(2026, 0, 4 + i)),
+    );
+  });
+  const dailyPlaysData = $derived.by(() => {
+    const days = stats.distributions?.days ?? [];
+    return days.map((value, index) => ({
+      value: Math.round(value),
+      label: weekdayLabels[index] ?? "",
+    }));
+  });
+</script>
+
+<section class="yir-2024-stats" id="section-{type}-stats">
+  <div class="yir-2024-stats-stack">
+    <article class="yir-2024-stats-panel yir-2024-stats-summary">
+      <div class="yir-2024-stats-summary-text">
+        <Yir2024SectionHeader intro={introMessage} title={summaryMessage} />
+
+        <div class="yir-2024-stats-info">
+          {#if peakWeek}
+            <p>
+              <!-- The i18n message embeds <b> wrappers around dynamic
+                values; render as HTML so the bold purple highlight applies. -->
+              {@html m.yir_2024_stats_most_active_week({
+                start: peakWeek.start,
+                end: peakWeek.end,
+                count: formatNumber(peakWeek.count),
+              })}
+            </p>
+          {/if}
+          {#if peakHour}
+            <p>
+              {@html m.yir_2024_stats_most_popular_time({ time: peakHour })}
+            </p>
+          {/if}
+        </div>
+      </div>
+
+      {#if stats.distributions?.weekly}
+        <div class="yir-2024-stats-summary-chart">
+          <Yir2024WeeklyPlaysChart data={stats.distributions.weekly} {year} />
+        </div>
+      {/if}
+
+      <div class="yir-2024-stats-watermark" aria-hidden="true">
+        <span>{summaryMessage}</span>
+      </div>
+    </article>
+
+    <article
+      class="yir-2024-stats-panel yir-2024-stats-card yir-2024-stats-card-hours"
+    >
+      <header class="yir-2024-stats-card-header">
+        <h3 class="bold yir-2024-stats-card-title">{hoursCardTitle}</h3>
+        <span class="yir-2024-stats-card-icon"><ClockIcon /></span>
+      </header>
+
+      <div class="yir-2024-stats-card-chart">
+        <Yir2024LineChart data={monthlyHoursData}>
+          {#snippet tooltip({ value, label })}
+            <YirTooltip
+              main={m.yir_2024_stats_tooltip_hours({
+                count: formatNumber(value),
+              })}
+              sub={label}
+            />
+          {/snippet}
+        </Yir2024LineChart>
+      </div>
+
+      <dl class="yir-2024-stats-averages">
+        <div class="yir-2024-stats-average-row">
+          <dt>{m.yir_2024_stats_per_month()}</dt>
+          <dd class="bold">{formatDecimal(hoursMonthly)}</dd>
+        </div>
+        <div class="yir-2024-stats-average-row">
+          <dt>{m.yir_2024_stats_per_week()}</dt>
+          <dd class="bold">{formatDecimal(hoursWeekly)}</dd>
+        </div>
+        <div class="yir-2024-stats-average-row">
+          <dt>{m.yir_2024_stats_per_day()}</dt>
+          <dd class="bold">{formatDecimal(hoursDaily)}</dd>
+        </div>
+      </dl>
+
+      <div class="yir-2024-stats-watermark" aria-hidden="true">
+        <span>{hoursCardTitle}</span>
+      </div>
+    </article>
+
+    <article
+      class="yir-2024-stats-panel yir-2024-stats-card yir-2024-stats-card-plays"
+    >
+      <header class="yir-2024-stats-card-header">
+        <h3 class="bold yir-2024-stats-card-title">{playsCardTitle}</h3>
+        <span class="yir-2024-stats-card-icon"><PlayIcon /></span>
+      </header>
+
+      <div class="yir-2024-stats-card-chart">
+        <Yir2024LineChart data={dailyPlaysData}>
+          {#snippet tooltip({ value, label })}
+            <YirTooltip
+              main={m.yir_2024_stats_tooltip_plays({
+                count: formatNumber(value),
+              })}
+              sub={label}
+            />
+          {/snippet}
+        </Yir2024LineChart>
+      </div>
+
+      <dl class="yir-2024-stats-averages">
+        <div class="yir-2024-stats-average-row">
+          <dt>{m.yir_2024_stats_per_month()}</dt>
+          <dd class="bold">{formatDecimal(stats.playCounts.monthly)}</dd>
+        </div>
+        <div class="yir-2024-stats-average-row">
+          <dt>{m.yir_2024_stats_per_week()}</dt>
+          <dd class="bold">{formatDecimal(stats.playCounts.weekly)}</dd>
+        </div>
+        <div class="yir-2024-stats-average-row">
+          <dt>{m.yir_2024_stats_per_day()}</dt>
+          <dd class="bold">{formatDecimal(stats.playCounts.daily)}</dd>
+        </div>
+      </dl>
+
+      <div class="yir-2024-stats-watermark" aria-hidden="true">
+        <span>{playsCardTitle}</span>
+      </div>
+    </article>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-2024-stats {
+    width: 100%;
+  }
+
+  // Summary panel sits at full width on its own row; the two chart cards
+  // share the row beneath in a 2-column grid that collapses to a single
+  // column at tablet-sm-and-below. Tight 10px gap so the three panels
+  // read as one continuous unit.
+  .yir-2024-stats-stack {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: var(--ni-10);
+  }
+
+  .yir-2024-stats-summary {
+    grid-column: 1 / -1;
+  }
+
+  @include for-tablet-sm-and-below {
+    .yir-2024-stats-stack {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  // Shared panel chrome: rounded card with overflow:hidden so the watermark
+  // text below clips at the bottom edge. --panel-padding-x exposes the
+  // horizontal padding so children can bleed (negative margin) to the
+  // panel edges and the watermark can match the inset.
+  // The three panels (summary on top, hours + plays beneath) only round
+  // their outer corners so they read as one continuous unit. Each panel
+  // exposes --panel-radius so the size can step down on smaller screens.
+  .yir-2024-stats-panel {
+    --panel-padding-x: var(--ni-44);
+    --panel-padding-top: var(--ni-44);
+    --panel-padding-bottom: var(--ni-104);
+    --panel-radius: var(--ni-64);
+
+    position: relative;
+    overflow: hidden;
+    padding: var(--panel-padding-top) var(--panel-padding-x)
+      var(--panel-padding-bottom);
+    // Approximates v2's #112836 → #191C1E radial: a faint blue-tinged
+    // center at the top fading out to a darker charcoal everywhere else.
+    background: radial-gradient(
+      50% 39.27% at 50% 0%,
+      color-mix(in srgb, var(--shade-950) 90%, var(--blue-500) 10%) 0%,
+      color-mix(in srgb, var(--shade-950) 70%, var(--shade-900) 30%) 100%
+    );
+
+    @include for-mobile {
+      --panel-padding-x: var(--ni-20);
+      --panel-padding-top: var(--ni-20);
+      --panel-padding-bottom: var(--ni-72);
+      --panel-radius: var(--ni-32);
+    }
+  }
+
+  // Summary panel sits on top of the row pair: pill-rounded only on top.
+  .yir-2024-stats-summary {
+    border-top-left-radius: var(--panel-radius);
+    border-top-right-radius: var(--panel-radius);
+  }
+
+  // Hours card is the bottom-left of the desktop row.
+  .yir-2024-stats-card-hours {
+    border-bottom-left-radius: var(--panel-radius);
+  }
+
+  // Plays card is the bottom-right of the desktop row.
+  .yir-2024-stats-card-plays {
+    border-bottom-right-radius: var(--panel-radius);
+  }
+
+  // Once the cards stack vertically (tablet-sm-and-below), the hours card
+  // becomes the *middle* panel of the stack — drop its bottom corners — and
+  // the plays card becomes the bottom of the stack, so both its bottom
+  // corners pick up --panel-radius.
+  @include for-tablet-sm-and-below {
+    .yir-2024-stats-card-hours {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    .yir-2024-stats-card-plays {
+      border-bottom-left-radius: var(--panel-radius);
+      border-bottom-right-radius: var(--panel-radius);
+    }
+  }
+
+  // Summary panel: heading + info on the left, weekly bar chart on the right.
+  // Stacks to a single column at tablet-sm-and-below.
+  .yir-2024-stats-summary {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    gap: var(--ni-32);
+
+    @include for-tablet-sm-and-below {
+      grid-template-columns: 1fr;
+      gap: var(--ni-24);
+    }
+  }
+
+  .yir-2024-stats-summary-text {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: var(--ni-32);
+  }
+
+  .yir-2024-stats-info {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xxs);
+    color: var(--shade-300);
+
+    p {
+      margin: 0;
+      font-size: var(--font-size-text);
+      line-height: 1.3;
+    }
+
+    // The i18n strings embed <b> around dynamic values; render those as
+    // bold purple inline highlights.
+    :global(b) {
+      color: var(--purple-300);
+      font-weight: 700;
+    }
+  }
+
+  // The chart bleeds to the panel edges (negative horizontal margin) so the
+  // bar grid spans the full width of its column rather than sitting inside
+  // the panel's content padding.
+  .yir-2024-stats-summary-chart {
+    min-width: 0;
+    width: auto;
+    margin: 0 calc(-1 * var(--panel-padding-x));
+
+    @include for-tablet-sm-and-below {
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
+  // Each chart card stretches to the full inner width — line chart inside
+  // gets the entire row to render across. The card overrides the panel's
+  // bottom padding to a tighter value so the watermark sits closer to the
+  // averages list above it (no big empty gap between the two).
+  .yir-2024-stats-card {
+    --height-yir-2024-line-chart: var(--ni-104);
+    --panel-padding-bottom: var(--ni-64);
+
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+
+    @include for-mobile {
+      --height-yir-2024-line-chart: var(--ni-72);
+      --panel-padding-bottom: var(--ni-40);
+    }
+  }
+
+  .yir-2024-stats-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gap-m);
+  }
+
+  .yir-2024-stats-card-title {
+    margin: 0;
+    font-size: var(--ni-32);
+
+    @include for-mobile {
+      font-size: var(--ni-22);
+    }
+  }
+
+  .yir-2024-stats-card-icon {
+    display: inline-flex;
+    color: var(--shade-10);
+
+    :global(svg) {
+      width: var(--ni-28);
+      height: var(--ni-28);
+    }
+  }
+
+  // Same bleed treatment as the summary chart — let the line fill the
+  // entire card width.
+  .yir-2024-stats-card-chart {
+    margin: var(--ni-16) calc(-1 * var(--panel-padding-x)) 0;
+    min-width: 0;
+  }
+
+  // Averages list: each row's separator stretches edge-to-edge of the
+  // panel. The list itself bleeds outward; rows pull the inset back in
+  // via their own horizontal padding so the labels and values line up
+  // with the rest of the panel content.
+  .yir-2024-stats-averages {
+    margin: var(--ni-16) calc(-1 * var(--panel-padding-x)) 0;
+    padding: 0;
+  }
+
+  .yir-2024-stats-average-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: var(--ni-10) var(--panel-padding-x);
+    border-bottom: var(--border-thickness-xxs) solid var(--shade-800);
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    dt {
+      margin: 0;
+      font-size: var(--font-size-title);
+      color: var(--shade-300);
+
+      @include for-mobile {
+        font-size: var(--font-size-text);
+      }
+    }
+
+    dd {
+      margin: 0;
+      font-size: var(--font-size-title);
+      color: var(--shade-10);
+
+      @include for-mobile {
+        font-size: var(--font-size-text);
+      }
+    }
+  }
+
+  // Faint repeated title at the bottom of each panel, partially clipped by
+  // overflow:hidden. Plain font-size that steps down at smaller viewports
+  // — no clamp / cqw cleverness so the size is predictable at every break.
+  .yir-2024-stats-watermark {
+    --watermark-inset: 0;
+    --watermark-font-size: var(--ni-104);
+
+    position: absolute;
+    bottom: 0;
+    left: var(--watermark-inset);
+    right: var(--watermark-inset);
+    transform: translateY(35%);
+    text-align: center;
+    font-family: inherit;
+    font-weight: 600;
+    font-size: var(--watermark-font-size);
+    line-height: 1;
+    letter-spacing: -0.02em;
+    color: var(--shade-10);
+    opacity: 0.05;
+    pointer-events: none;
+    user-select: none;
+
+    @include for-tablet-lg-and-below {
+      --watermark-font-size: var(--ni-72);
+    }
+
+    @include for-tablet-sm-and-below {
+      --watermark-font-size: var(--ni-52);
+    }
+
+    @include for-mobile {
+      --watermark-font-size: var(--ni-40);
+    }
+
+    span {
+      display: block;
+      font-family: inherit;
+      white-space: nowrap;
+      overflow: hidden;
+      font-size: inherit;
+      font-weight: inherit;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TopSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TopSection.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import { m } from "$lib/paraglide/messages";
   import type { YirDetail } from "$lib/requests/models/YirDetail";
 
   import Yir2024Hero from "./Yir2024Hero.svelte";
   import Yir2024PageInner from "./Yir2024PageInner.svelte";
-  import Yir2024PlayCard from "./Yir2024PlayCard.svelte";
   import Yir2024WatchedStats from "./Yir2024WatchedStats.svelte";
 
   const {
@@ -12,12 +10,10 @@
     slug,
     year,
   }: {
-    detail: YirDetail;
+    detail: YirDetail | null;
     slug: string;
     year: number;
   } = $props();
-
-  const hasWatched = $derived(detail.stats.all.playCounts.total > 0);
 </script>
 
 <section class="yir-2024-top" id="section-totals">
@@ -27,13 +23,8 @@
     <div class="yir-2024-top-stack">
       <Yir2024Hero {slug} {year} {detail} />
 
-      <Yir2024WatchedStats stats={detail.stats.all} {slug} />
-
-      {#if hasWatched && detail.firstWatched}
-        <Yir2024PlayCard
-          item={detail.firstWatched}
-          headerLabel={m.yir_2024_first_play_of({ year })}
-        />
+      {#if detail}
+        <Yir2024WatchedStats stats={detail.stats.all} {slug} />
       {/if}
     </div>
   </Yir2024PageInner>
@@ -42,7 +33,7 @@
 <style lang="scss">
   .yir-2024-top {
     position: relative;
-    padding: var(--ni-104) 0;
+    padding: var(--ni-104) 0 0 0;
     overflow: hidden;
   }
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WatchedStats.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WatchedStats.svelte
@@ -192,7 +192,7 @@
   }
 
   .yir-2024-stat-label {
-    font-size: var(--ni-14);
+    font-size: var(--font-size-text);
     color: var(--shade-300);
     text-transform: uppercase;
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WeeklyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WeeklyPlaysChart.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import { m } from "$lib/paraglide/messages";
+  import { formatNumber } from "$lib/utils/format/formatNumber";
+  import { toHumanShortDate } from "$lib/utils/formatting/date/toHumanShortDate";
+  import { addDays } from "date-fns/addDays";
+  import { startOfYear } from "date-fns/startOfYear";
+  import YirTooltip from "../../_internal/YirTooltip.svelte";
+
+  const {
+    data,
+    year,
+  }: {
+    data: number[];
+    year: number;
+  } = $props();
+
+  function getWeekDateRange(weekNumber: number): string {
+    const locale = languageTag();
+    const weekStart = addDays(
+      startOfYear(new Date(year, 0, 1)),
+      (weekNumber - 1) * 7,
+    );
+    const weekEnd = addDays(weekStart, 6);
+    return `${toHumanShortDate(weekStart, locale)} - ${
+      toHumanShortDate(weekEnd, locale)
+    }`;
+  }
+
+  const chartData = $derived(
+    data.map((value, index) => ({
+      value,
+      label: `${index + 1}`,
+    })),
+  );
+
+  const isDesktop = useMedia(WellKnownMediaQuery.desktop);
+  const isTabletLarge = useMedia(WellKnownMediaQuery.tabletLarge);
+  const isTabletSmall = useMedia(WellKnownMediaQuery.tabletSmall);
+
+  // Tick density steps down with viewport so 52-53 week labels never collide.
+  // Even at full desktop width every-other looks cleaner than every label.
+  //   desktop ≥1024      → every 2nd
+  //   tablet-lg 769-1023 → every 4th
+  //   tablet-sm 481-768  → every 8th
+  //   mobile  ≤480       → every 12th
+  const tickStep = $derived.by(() => {
+    if ($isDesktop) return 2;
+    if ($isTabletLarge) return 4;
+    if ($isTabletSmall) return 8;
+    return 12;
+  });
+
+  const tickLabels = $derived(
+    chartData.map((d, i) => (i % tickStep === 0 ? d.label : "")),
+  );
+</script>
+
+<div class="yir-2024-weekly-chart">
+  <BarChart data={chartData} {tickLabels} barSpacing={1}>
+    {#snippet tooltip({ value, label })}
+      {@const weekNumber = parseInt(label, 10)}
+      <YirTooltip
+        main={m.yir_2024_stats_tooltip_plays({ count: formatNumber(value) })}
+        sub={m.yir_2024_stats_tooltip_week_label({ week: label })}
+        extra={getWeekDateRange(weekNumber)}
+      />
+    {/snippet}
+  </BarChart>
+</div>
+
+<style lang="scss">
+  // 2024 palette: bars use the lightest cool gray (shade-100, exactly
+  // matches v2's #d2d6d9); peak week pops in the lighter purple-300, and
+  // hover lands on purple-500 (#9f42c6, exactly matches v2's hover).
+  .yir-2024-weekly-chart {
+    --color-bar-custom-default: var(--shade-100);
+    --color-bar-custom-highlight: var(--purple-300);
+    --color-bar-custom-hover: var(--purple-500);
+    --height-bar-chart: var(--ni-300);
+    width: 100%;
+
+    // Match the 2024 template's body font; the shared BarChart wrapper
+    // defaults to Roboto otherwise.
+    :global(.cds--chart-holder) {
+      --cds-charts-font-family: "Spline Sans", Helvetica, Arial, sans-serif;
+      --cds-charts-font-family-condensed:
+        "Spline Sans", Helvetica, Arial, sans-serif;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WeeklyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WeeklyPlaysChart.svelte
@@ -1,13 +1,8 @@
 <script lang="ts">
-  import BarChart from "$lib/components/charts/BarChart.svelte";
-  import { languageTag } from "$lib/features/i18n";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { m } from "$lib/paraglide/messages";
   import { formatNumber } from "$lib/utils/format/formatNumber";
-  import { toHumanShortDate } from "$lib/utils/formatting/date/toHumanShortDate";
-  import { addDays } from "date-fns/addDays";
-  import { startOfYear } from "date-fns/startOfYear";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
+  import YirWeeklyPlaysChart from "../../_internal/YirWeeklyPlaysChart.svelte";
 
   const {
     data,
@@ -16,59 +11,18 @@
     data: number[];
     year: number;
   } = $props();
-
-  function getWeekDateRange(weekNumber: number): string {
-    const locale = languageTag();
-    const weekStart = addDays(
-      startOfYear(new Date(year, 0, 1)),
-      (weekNumber - 1) * 7,
-    );
-    const weekEnd = addDays(weekStart, 6);
-    return `${toHumanShortDate(weekStart, locale)} - ${
-      toHumanShortDate(weekEnd, locale)
-    }`;
-  }
-
-  const chartData = $derived(
-    data.map((value, index) => ({
-      value,
-      label: `${index + 1}`,
-    })),
-  );
-
-  const isDesktop = useMedia(WellKnownMediaQuery.desktop);
-  const isTabletLarge = useMedia(WellKnownMediaQuery.tabletLarge);
-  const isTabletSmall = useMedia(WellKnownMediaQuery.tabletSmall);
-
-  // Tick density steps down with viewport so 52-53 week labels never collide.
-  // Even at full desktop width every-other looks cleaner than every label.
-  //   desktop ≥1024      → every 2nd
-  //   tablet-lg 769-1023 → every 4th
-  //   tablet-sm 481-768  → every 8th
-  //   mobile  ≤480       → every 12th
-  const tickStep = $derived.by(() => {
-    if ($isDesktop) return 2;
-    if ($isTabletLarge) return 4;
-    if ($isTabletSmall) return 8;
-    return 12;
-  });
-
-  const tickLabels = $derived(
-    chartData.map((d, i) => (i % tickStep === 0 ? d.label : "")),
-  );
 </script>
 
 <div class="yir-2024-weekly-chart">
-  <BarChart data={chartData} {tickLabels} barSpacing={1}>
-    {#snippet tooltip({ value, label })}
-      {@const weekNumber = parseInt(label, 10)}
+  <YirWeeklyPlaysChart {data} {year} barSpacing={1}>
+    {#snippet tooltip({ value, week, dateRange })}
       <YirTooltip
         main={m.yir_2024_stats_tooltip_plays({ count: formatNumber(value) })}
-        sub={m.yir_2024_stats_tooltip_week_label({ week: label })}
-        extra={getWeekDateRange(weekNumber)}
+        sub={m.yir_2024_stats_tooltip_week_label({ week: String(week) })}
+        extra={dateRange}
       />
     {/snippet}
-  </BarChart>
+  </YirWeeklyPlaysChart>
 </div>
 
 <style lang="scss">

--- a/projects/client/src/lib/sections/yir/YirPage.svelte
+++ b/projects/client/src/lib/sections/yir/YirPage.svelte
@@ -5,7 +5,7 @@
 
   const { slug, year }: { slug: string; year: number } = $props();
 
-  const { detail } = $derived(useYirDetail({ slug, year }));
+  const { detail, isLoading } = $derived(useYirDetail({ slug, year }));
   const Template = $derived(getYirTemplate(year));
 </script>
 
@@ -14,7 +14,12 @@
   <!-- Always mount the template so its scaffold (header text, hero shell)
        paints immediately; detail-dependent sections inside the template
        gate on `detail` and fill in once the query lands. -->
-  <Template detail={$detail ?? null} {slug} {year} />
+  <Template
+    detail={$detail ?? null}
+    isLoading={$isLoading}
+    {slug}
+    {year}
+  />
 </div>
 
 <style lang="scss">

--- a/projects/client/src/lib/sections/yir/YirPage.svelte
+++ b/projects/client/src/lib/sections/yir/YirPage.svelte
@@ -1,25 +1,20 @@
 <script lang="ts">
-  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import YirHeader from "./_internal/YirHeader.svelte";
   import { useYirDetail } from "./_internal/useYirDetail";
   import { getYirTemplate } from "./getYirTemplate";
 
   const { slug, year }: { slug: string; year: number } = $props();
 
-  const { detail, isLoading } = $derived(useYirDetail({ slug, year }));
+  const { detail } = $derived(useYirDetail({ slug, year }));
   const Template = $derived(getYirTemplate(year));
 </script>
 
 <div class="yir-page" id="year-in-review">
   <YirHeader {slug} {year} />
-
-  {#if $isLoading}
-    <div class="yir-loading">
-      <LoadingIndicator />
-    </div>
-  {:else if $detail}
-    <Template detail={$detail} {slug} {year} />
-  {/if}
+  <!-- Always mount the template so its scaffold (header text, hero shell)
+       paints immediately; detail-dependent sections inside the template
+       gate on `detail` and fill in once the query lands. -->
+  <Template detail={$detail ?? null} {slug} {year} />
 </div>
 
 <style lang="scss">
@@ -50,13 +45,5 @@
     @include for-tablet-sm-and-below {
       --layout-sidebar-distance: 0;
     }
-  }
-
-  .yir-loading {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: var(--ni-96) 0;
-    color: var(--shade-10);
   }
 </style>

--- a/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
@@ -2,6 +2,7 @@
   import { browser } from "$app/environment";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
+  import { shortcut } from "@svelte-put/shortcut";
   import { map } from "rxjs";
 
   import { useShare } from "$lib/components/buttons/share/useShare";
@@ -9,7 +10,6 @@
   import { useQuery } from "$lib/features/query/useQuery";
   import { m } from "$lib/paraglide/messages";
   import { userProfileQuery } from "$lib/requests/queries/users/userProfileQuery";
-  import { GlobalEventBus } from "$lib/utils/events/GlobalEventBus";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
   import VipBadge from "$lib/components/badge/VipBadge.svelte";
@@ -53,24 +53,6 @@
     );
   }
 
-  $effect(() => {
-    return GlobalEventBus.getInstance().register("keydown", (event) => {
-      if (event.metaKey || event.ctrlKey || event.altKey) return;
-      if (isTextInputTarget(event.target)) return;
-
-      if (event.key === "ArrowLeft") {
-        event.preventDefault();
-        goto(prevYearUrl);
-        return;
-      }
-
-      if (event.key === "ArrowRight" && canGoNext) {
-        event.preventDefault();
-        goto(nextYearUrl);
-      }
-    });
-  });
-
   const { share } = $derived(useShare({ id: "yir" }));
 
   const shareData = $derived({
@@ -83,6 +65,32 @@
     browser && !!navigator.canShare && navigator.canShare(shareData),
   );
 </script>
+
+<svelte:window
+  use:shortcut={{
+    trigger: [
+      {
+        key: "ArrowLeft",
+        modifier: false,
+        preventDefault: true,
+        callback: ({ originalEvent }) => {
+          if (isTextInputTarget(originalEvent.target)) return;
+          goto(prevYearUrl);
+        },
+      },
+      {
+        key: "ArrowRight",
+        modifier: false,
+        enabled: canGoNext,
+        preventDefault: true,
+        callback: ({ originalEvent }) => {
+          if (isTextInputTarget(originalEvent.target)) return;
+          goto(nextYearUrl);
+        },
+      },
+    ],
+  }}
+/>
 
 <header class="yir-header" use:trackWindowScroll={"scrolled"}>
   <nav class="yir-header-section yir-header-center">

--- a/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { browser } from "$app/environment";
+  import { goto } from "$app/navigation";
   import { page } from "$app/state";
   import { map } from "rxjs";
 
@@ -8,6 +9,7 @@
   import { useQuery } from "$lib/features/query/useQuery";
   import { m } from "$lib/paraglide/messages";
   import { userProfileQuery } from "$lib/requests/queries/users/userProfileQuery";
+  import { GlobalEventBus } from "$lib/utils/events/GlobalEventBus";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
   import VipBadge from "$lib/components/badge/VipBadge.svelte";
@@ -37,6 +39,37 @@
 
   const prevYearUrl = $derived(UrlBuilder.users(slug).yearToDate(year - 1));
   const nextYearUrl = $derived(UrlBuilder.users(slug).yearToDate(year + 1));
+
+  // Arrow-key navigation between years. Skip when the user is typing in an
+  // input/textarea/contenteditable so we don't hijack form-field navigation.
+  function isTextInputTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false;
+    const tag = target.tagName;
+    return (
+      tag === "INPUT" ||
+      tag === "TEXTAREA" ||
+      tag === "SELECT" ||
+      target.isContentEditable
+    );
+  }
+
+  $effect(() => {
+    return GlobalEventBus.getInstance().register("keydown", (event) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isTextInputTarget(event.target)) return;
+
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        goto(prevYearUrl);
+        return;
+      }
+
+      if (event.key === "ArrowRight" && canGoNext) {
+        event.preventDefault();
+        goto(nextYearUrl);
+      }
+    });
+  });
 
   const { share } = $derived(useShare({ id: "yir" }));
 
@@ -127,6 +160,9 @@
       background-color 0.2s,
       backdrop-filter 0.2s;
 
+    // The "scrolled" treatment also applies on hover so the bar lights up
+    // when the user is interacting with it, even before they scroll.
+    &:hover,
     &:global(.scrolled) {
       background: var(--color-background-mobile-navbar);
       box-shadow: var(--shadow-navbar);

--- a/projects/client/src/lib/sections/yir/_internal/YirWeeklyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirWeeklyPlaysChart.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import { toHumanShortDate } from "$lib/utils/formatting/date/toHumanShortDate";
+  import { addDays } from "date-fns/addDays";
+  import { startOfYear } from "date-fns/startOfYear";
+  import type { Snippet } from "svelte";
+
+  type WeekTooltipArgs = {
+    value: number;
+    week: number;
+    dateRange: string;
+  };
+
+  const {
+    data,
+    year,
+    barSpacing = 2,
+    tooltip: tooltipSnippet,
+  }: {
+    data: number[];
+    year: number;
+    /** Pixel gap between bars. Defaults to 2px. */
+    barSpacing?: number;
+    /**
+     * Receives the resolved week info so consumers can localize / style the
+     * tooltip without re-implementing the date-range math.
+     */
+    tooltip: Snippet<[WeekTooltipArgs]>;
+  } = $props();
+
+  function getWeekDateRange(weekNumber: number): string {
+    const locale = languageTag();
+    const weekStart = addDays(
+      startOfYear(new Date(year, 0, 1)),
+      (weekNumber - 1) * 7,
+    );
+    const weekEnd = addDays(weekStart, 6);
+    return `${toHumanShortDate(weekStart, locale)} - ${
+      toHumanShortDate(weekEnd, locale)
+    }`;
+  }
+
+  const chartData = $derived(
+    data.map((value, index) => ({
+      value,
+      label: `${index + 1}`,
+    })),
+  );
+
+  const isDesktop = useMedia(WellKnownMediaQuery.desktop);
+  const isTabletLarge = useMedia(WellKnownMediaQuery.tabletLarge);
+  const isTabletSmall = useMedia(WellKnownMediaQuery.tabletSmall);
+
+  // Tick density steps down with viewport so 52-53 week labels never collide.
+  // Even at full desktop width every-other looks cleaner than every label.
+  //   desktop ≥1024      → every 2nd
+  //   tablet-lg 769-1023 → every 4th
+  //   tablet-sm 481-768  → every 8th
+  //   mobile  ≤480       → every 12th
+  const tickStep = $derived.by(() => {
+    if ($isDesktop) return 2;
+    if ($isTabletLarge) return 4;
+    if ($isTabletSmall) return 8;
+    return 12;
+  });
+
+  const tickLabels = $derived(
+    chartData.map((d, i) => (i % tickStep === 0 ? d.label : "")),
+  );
+</script>
+
+<BarChart data={chartData} {tickLabels} {barSpacing}>
+  {#snippet tooltip({ value, label })}
+    {@const week = parseInt(label, 10)}
+    {@render tooltipSnippet({
+      value,
+      week,
+      dateRange: getWeekDateRange(week),
+    })}
+  {/snippet}
+</BarChart>

--- a/projects/client/src/lib/sections/yir/default/YirDefault.svelte
+++ b/projects/client/src/lib/sections/yir/default/YirDefault.svelte
@@ -17,67 +17,71 @@
     slug,
     year,
   }: {
-    detail: YirDetail;
+    detail: YirDetail | null;
     slug: string;
     year: number;
   } = $props();
 </script>
 
-<YirTitleSection {slug} {year} coverImage={detail.images.cover} />
+<!-- Title section paints immediately (cover image falls back to the
+     DEFAULT_COVER constant inside the component when unavailable). -->
+<YirTitleSection {slug} {year} coverImage={detail?.images.cover} />
 
-<YirTotalsSection stats={detail.stats.all} {year} />
+{#if detail}
+  <YirTotalsSection stats={detail.stats.all} {year} />
 
-{#if detail.firstWatched}
-  <YirCalendarSection how="first" item={detail.firstWatched} {year} />
+  {#if detail.firstWatched}
+    <YirCalendarSection how="first" item={detail.firstWatched} {year} />
+  {/if}
+
+  <!-- TV Shows -->
+  {#if detail.stats.shows.playCounts.total > 0}
+    <YirStatsSection type="shows" stats={detail.stats.shows} {year} />
+  {/if}
+
+  {#if detail.mostWatched.shows.length > 0}
+    <YirMostWatchedSection type="shows" items={detail.mostWatched.shows} />
+  {/if}
+
+  {#if detail.genres.shows.itemCount > 0}
+    <YirGenresSection type="shows" genres={detail.genres.shows} />
+  {/if}
+
+  {#if detail.networks.length > 0}
+    <YirNetworksSection networks={detail.networks} />
+  {/if}
+
+  {#if detail.topRated.shows.length > 0}
+    <YirRatedSection type="shows" items={detail.topRated.shows} />
+  {/if}
+
+  <!-- Movies -->
+  {#if detail.stats.movies.playCounts.total > 0}
+    <YirStatsSection type="movies" stats={detail.stats.movies} {year} />
+  {/if}
+
+  {#if detail.mostWatched.movies.length > 0}
+    <YirMostWatchedSection type="movies" items={detail.mostWatched.movies} />
+  {/if}
+
+  {#if detail.genres.movies.itemCount > 0}
+    <YirGenresSection type="movies" genres={detail.genres.movies} />
+  {/if}
+
+  {#if detail.productionCompanies.length > 0}
+    <YirStudiosSection studios={detail.productionCompanies} />
+  {/if}
+
+  {#if detail.topRated.movies.length > 0}
+    <YirRatedSection type="movies" items={detail.topRated.movies} />
+  {/if}
+
+  <!-- People -->
+  <YirPeopleSection {slug} {year} />
+
+  {#if detail.lastWatched}
+    <YirCalendarSection how="last" item={detail.lastWatched} {year} />
+  {/if}
+
+  <YirUpgradeSection />
 {/if}
-
-<!-- TV Shows -->
-{#if detail.stats.shows.playCounts.total > 0}
-  <YirStatsSection type="shows" stats={detail.stats.shows} {year} />
-{/if}
-
-{#if detail.mostWatched.shows.length > 0}
-  <YirMostWatchedSection type="shows" items={detail.mostWatched.shows} />
-{/if}
-
-{#if detail.genres.shows.itemCount > 0}
-  <YirGenresSection type="shows" genres={detail.genres.shows} />
-{/if}
-
-{#if detail.networks.length > 0}
-  <YirNetworksSection networks={detail.networks} />
-{/if}
-
-{#if detail.topRated.shows.length > 0}
-  <YirRatedSection type="shows" items={detail.topRated.shows} />
-{/if}
-
-<!-- Movies -->
-{#if detail.stats.movies.playCounts.total > 0}
-  <YirStatsSection type="movies" stats={detail.stats.movies} {year} />
-{/if}
-
-{#if detail.mostWatched.movies.length > 0}
-  <YirMostWatchedSection type="movies" items={detail.mostWatched.movies} />
-{/if}
-
-{#if detail.genres.movies.itemCount > 0}
-  <YirGenresSection type="movies" genres={detail.genres.movies} />
-{/if}
-
-{#if detail.productionCompanies.length > 0}
-  <YirStudiosSection studios={detail.productionCompanies} />
-{/if}
-
-{#if detail.topRated.movies.length > 0}
-  <YirRatedSection type="movies" items={detail.topRated.movies} />
-{/if}
-
-<!-- People -->
-<YirPeopleSection {slug} {year} />
-
-{#if detail.lastWatched}
-  <YirCalendarSection how="last" item={detail.lastWatched} {year} />
-{/if}
-
-<YirUpgradeSection />

--- a/projects/client/src/lib/sections/yir/default/YirDefault.svelte
+++ b/projects/client/src/lib/sections/yir/default/YirDefault.svelte
@@ -18,6 +18,11 @@
     year,
   }: {
     detail: YirDetail | null;
+    /**
+     * Accepted for prop-type compatibility with the template registry; the
+     * default template doesn't render an inline loading indicator.
+     */
+    isLoading: boolean;
     slug: string;
     year: number;
   } = $props();

--- a/projects/client/src/lib/sections/yir/default/_internal/YirWeeklyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirWeeklyPlaysChart.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
-  import BarChart from "$lib/components/charts/BarChart.svelte";
-  import { languageTag } from "$lib/features/i18n";
-  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
-  import { toHumanShortDate } from "$lib/utils/formatting/date/toHumanShortDate";
-  import { addDays } from "date-fns/addDays";
-  import { startOfYear } from "date-fns/startOfYear";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
+  import YirWeeklyPlaysChart from "../../_internal/YirWeeklyPlaysChart.svelte";
 
   const {
     data,
@@ -14,40 +9,14 @@
     data: number[];
     year: number;
   } = $props();
-
-  function getWeekDateRange(weekNumber: number): string {
-    const locale = languageTag();
-    const weekStart = addDays(
-      startOfYear(new Date(year, 0, 1)),
-      (weekNumber - 1) * 7,
-    );
-    const weekEnd = addDays(weekStart, 6);
-
-    return `${toHumanShortDate(weekStart, locale)} - ${toHumanShortDate(weekEnd, locale)}`;
-  }
-
-  const chartData = $derived(
-    data.map((value, index) => ({
-      value,
-      label: `${index + 1}`,
-    })),
-  );
-
-  const isDesktop = useMedia(WellKnownMediaQuery.desktop);
-
-  const tickLabels = $derived.by(() => {
-    if ($isDesktop) return chartData.map((d) => d.label);
-    return chartData.map((d, i) => (i % 4 === 0 ? d.label : ""));
-  });
 </script>
 
-<BarChart data={chartData} {tickLabels}>
-  {#snippet tooltip({ value, label })}
-    {@const weekNumber = parseInt(label, 10)}
+<YirWeeklyPlaysChart {data} {year}>
+  {#snippet tooltip({ value, week, dateRange })}
     <YirTooltip
       main="{value} {value === 1 ? 'play' : 'plays'}"
-      sub="Week {weekNumber}"
-      extra={getWeekDateRange(weekNumber)}
+      sub="Week {week}"
+      extra={dateRange}
     />
   {/snippet}
-</BarChart>
+</YirWeeklyPlaysChart>

--- a/projects/client/src/lib/sections/yir/getYirTemplate.ts
+++ b/projects/client/src/lib/sections/yir/getYirTemplate.ts
@@ -4,7 +4,12 @@ import Yir2024 from './2024/Yir2024.svelte';
 import YirDefault from './default/YirDefault.svelte';
 
 type YirTemplateProps = {
-  detail: YirDetail;
+  /**
+   * Null while the YIR detail query is in flight. Templates render their
+   * scaffold (header / hero / etc) immediately and gate detail-dependent
+   * sections so the page progressively fills in as data lands.
+   */
+  detail: YirDetail | null;
   slug: string;
   year: number;
 };

--- a/projects/client/src/lib/sections/yir/getYirTemplate.ts
+++ b/projects/client/src/lib/sections/yir/getYirTemplate.ts
@@ -10,6 +10,11 @@ type YirTemplateProps = {
    * sections so the page progressively fills in as data lands.
    */
   detail: YirDetail | null;
+  /**
+   * True while the underlying query is loading. Lets templates distinguish
+   * "still fetching" from "loaded but empty" (e.g. a user with no plays).
+   */
+  isLoading: boolean;
   slug: string;
   year: number;
 };


### PR DESCRIPTION
# Summary

Adds the three stat charts (weekly bar + monthly hours line + weekday plays line) to the YIR 2024 template, plus a few global YIR experience improvements: keyboard year-navigation, a hover state on the static header, and progressive loading so the hero paints immediately while the rest of the page fills in below.

# Screenshots

<img width="1260" height="1019" alt="image" src="https://github.com/user-attachments/assets/0285131d-8bf8-41c5-ae98-c179ea7e9bca" />

# Details

- **Stats section** — three panels stacked into one rounded "unit": a summary panel with the weekly bar chart and "most active week / most popular time" insights, and two cards beneath with hours and plays line charts plus per-month/week/day averages.

- **Charts** — wrapped behind YIR-2024 components built on top of the existing Carbon chart wrappers. Hover marker is a purple-pill dot that fades and scales in; weekly chart tick density steps down per breakpoint.

- **Reusable section header** — drop-in component for any future 2024 section that follows the small-uppercase-intro + huge-headline rhythm.

- **Header improvements**
  - Hover applies the same backdrop-filter / shadow / background as the scrolled state.
  - ←/→ arrow keys navigate between years (skipped while a modifier is held or a form input is focused).

- **Progressive loading** — the YIR page no longer shows a centered spinner. Both the 2024 and default templates render their hero scaffold (year, name, label, membership) immediately, with a small inline indicator below while the detail query is in flight.

- **Spline Sans** wired into the 2024 template only.