### PR TITLE
fix: renamed Upcoming Schedule to Calendar

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -12,7 +12,7 @@
   },
   "messages": {
     "list_title_upcoming_schedule": {
-      "default": "Upcoming Schedule",
+      "default": "Calendar",
       "description": "Title for lists containing upcoming episodes. This title should be as short and concise as possible.",
       "exclude": []
     },


### PR DESCRIPTION
Renames `upcoming schedule` to `calendar` for better consistency.