### PR TITLE
fix: polyfill Array.prototype.toSorted for older browsers

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -1,3 +1,4 @@
+import '$lib/polyfills/toSorted.ts';
 import { SENTRY_DSN } from '$lib/utils/constants.ts';
 import * as Sentry from '@sentry/sveltekit';
 import { handleErrorWithSentry, replayIntegration } from '@sentry/sveltekit';
@@ -99,6 +100,8 @@ function reloadOnceForStaleDeploy(error: unknown): void {
 }
 
 // If you have a custom error handler, pass it to `handleErrorWithSentry`
-export const handleError = handleErrorWithSentry(({ error }: { error: unknown }) => {
-  reloadOnceForStaleDeploy(error);
-});
+export const handleError = handleErrorWithSentry(
+  ({ error }: { error: unknown }) => {
+    reloadOnceForStaleDeploy(error);
+  },
+);

--- a/projects/client/src/lib/polyfills/toSorted.spec.ts
+++ b/projects/client/src/lib/polyfills/toSorted.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import './toSorted.ts';
+
+describe('Array.prototype.toSorted polyfill', () => {
+  it('returns a sorted copy without mutating the source', () => {
+    const source = [3, 1, 2];
+    const sorted = source.toSorted();
+
+    expect(sorted).toEqual([1, 2, 3]);
+    expect(source).toEqual([3, 1, 2]);
+  });
+
+  it('applies a custom comparator', () => {
+    const sorted = [1, 2, 3].toSorted((a, b) => b - a);
+
+    expect(sorted).toEqual([3, 2, 1]);
+  });
+});

--- a/projects/client/src/lib/polyfills/toSorted.ts
+++ b/projects/client/src/lib/polyfills/toSorted.ts
@@ -1,0 +1,12 @@
+// Polyfill for Array.prototype.toSorted (ES2023).
+// Sentry: TRAKT-WEB-5VC, TRAKT-WEB-6V7 — older Safari/Chrome/Firefox
+// builds reach the app and crash on uses like `list.toSorted(...)`.
+if (typeof Array.prototype.toSorted !== 'function') {
+  Object.defineProperty(Array.prototype, 'toSorted', {
+    value<T>(this: ArrayLike<T>, compareFn?: (a: T, b: T) => number): T[] {
+      return Array.from(this).sort(compareFn);
+    },
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## Summary
- Add a polyfill for `Array.prototype.toSorted` (ES2023) in `lib/polyfills/toSorted.ts`
- Import it at the top of `hooks.client.ts` so it runs before any app code
- Spec covers immutability and custom comparator behavior

## Why
Older Safari / Chrome / Firefox builds reach the app and crash on the 30+ `list.toSorted(...)` call sites throughout the codebase. Recent Sentry activity:

- [TRAKT-WEB-5VC](https://trakt-tv.sentry.io/issues/TRAKT-WEB-5VC) — 361 events
- [TRAKT-WEB-6V7](https://trakt-tv.sentry.io/issues/TRAKT-WEB-6V7) — 113 events
- [TRAKT-WEB-9AP](https://trakt-tv.sentry.io/issues/TRAKT-WEB-9AP) — 1 event

Polyfilling at the entry point was preferred over refactoring 30 call sites — surgical, no semantic risk, easy to remove once the baseline browser cohort supports the method.

## Test plan
- [ ] `deno task client:test` passes the new `toSorted.spec.ts`
- [ ] App boots in a browser without `Array.prototype.toSorted` (simulate by `delete Array.prototype.toSorted` in devtools before the polyfill loads)