### PR TITLE
fix: polyfill Map.groupBy for older browsers

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -1,3 +1,4 @@
+import '$lib/polyfills/mapGroupBy.ts';
 import '$lib/polyfills/toSorted.ts';
 import { SENTRY_DSN } from '$lib/utils/constants.ts';
 import * as Sentry from '@sentry/sveltekit';

--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -1,3 +1,4 @@
+import '$lib/polyfills/mapGroupBy.ts';
 import { handle as handleAuth } from '$lib/features/auth/handle.ts';
 import { handle as handleBotVerification } from '$lib/features/bot-verification/handle.ts';
 import { handle as handleCacheBust } from '$lib/features/cache-bust/handle.ts';

--- a/projects/client/src/lib/polyfills/mapGroupBy.spec.ts
+++ b/projects/client/src/lib/polyfills/mapGroupBy.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { groupByPolyfill } from './mapGroupBy.ts';
+
+describe('groupByPolyfill', () => {
+  it('groups items by key', () => {
+    const items = [
+      { source: 'netflix', label: 'a' },
+      { source: 'hbo', label: 'b' },
+      { source: 'netflix', label: 'c' },
+    ];
+
+    const grouped = groupByPolyfill(items, (item) => item.source);
+
+    expect(grouped.get('netflix')).toEqual([
+      { source: 'netflix', label: 'a' },
+      { source: 'netflix', label: 'c' },
+    ]);
+    expect(grouped.get('hbo')).toEqual([{ source: 'hbo', label: 'b' }]);
+  });
+
+  it('passes index to the key function', () => {
+    const indices: number[] = [];
+
+    groupByPolyfill(['a', 'b', 'c'], (_item, index) => {
+      indices.push(index);
+      return index;
+    });
+
+    expect(indices).toEqual([0, 1, 2]);
+  });
+});

--- a/projects/client/src/lib/polyfills/mapGroupBy.ts
+++ b/projects/client/src/lib/polyfills/mapGroupBy.ts
@@ -1,0 +1,29 @@
+// Polyfill for Map.groupBy (ES2024).
+// Sentry: TRAKT-WEB-86X, TRAKT-WEB-7TN — older browsers crash when
+// streaming providers are grouped by source.
+
+export function groupByPolyfill<K, T>(
+  items: Iterable<T>,
+  keyFn: (item: T, index: number) => K,
+): Map<K, T[]> {
+  const result = new Map<K, T[]>();
+  let index = 0;
+
+  for (const item of items) {
+    const key = keyFn(item, index++);
+    const existing = result.get(key);
+
+    if (existing) {
+      existing.push(item);
+      continue;
+    }
+
+    result.set(key, [item]);
+  }
+
+  return result;
+}
+
+if (typeof Map.groupBy !== 'function') {
+  Map.groupBy = groupByPolyfill;
+}


### PR DESCRIPTION
## Summary
- Add a polyfill for `Map.groupBy` (ES2024) in `lib/polyfills/mapGroupBy.ts`
- Import it at the top of `hooks.client.ts`
- Spec covers grouping by key and index argument behavior

## Why
The streaming-services grouping path (`lib/sections/lists/where-to-watch/_internal/getGroupedServices.ts`) uses `Map.groupBy`, which is ES2024 and not available in older Chrome/Safari/Firefox.

- [TRAKT-WEB-86X](https://trakt-tv.sentry.io/issues/TRAKT-WEB-86X) — 2 events
- [TRAKT-WEB-7TN](https://trakt-tv.sentry.io/issues/TRAKT-WEB-7TN) — 2 events

Volume is low but the failure is total for affected users on movie/show detail pages with streaming data.

## Test plan
- [ ] `deno task client:test` passes the new `mapGroupBy.spec.ts`
- [ ] Streaming services list renders in a browser without `Map.groupBy` support