### PR TITLE
fix: guard Intl.Segmenter construction with feature detection

### DIFF
--- a/projects/client/src/lib/sections/summary/components/comments/drawers/isReviewValid.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/drawers/isReviewValid.ts
@@ -1,9 +1,35 @@
 const wordCountThreshold = 5;
-const segmenter = new Intl.Segmenter(undefined, { granularity: 'word' });
+
+// Languages that don't separate words with whitespace — each character is
+// roughly one morpheme, so we count them individually in the fallback path.
+const CjkPattern =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/gu;
+const wordPattern = /[\p{L}\p{N}]+/gu;
+
+const segmenter = typeof Intl.Segmenter === 'function'
+  ? new Intl.Segmenter(undefined, { granularity: 'word' })
+  : null;
+
+function countWithSegmenter(
+  review: string,
+  segmenter: Intl.Segmenter,
+): number {
+  return [...segmenter.segment(review)]
+    .filter((segment) => segment.isWordLike)
+    .length;
+}
+
+function countWithoutSegmenter(review: string): number {
+  const cjkCharacters = review.match(CjkPattern)?.length ?? 0;
+  const remaining = review.replace(CjkPattern, ' ');
+  const words = remaining.match(wordPattern)?.length ?? 0;
+  return cjkCharacters + words;
+}
 
 export function isReviewValid(review: string): boolean {
-  const words = [...segmenter.segment(review)]
-    .filter((segment) => segment.isWordLike);
+  const count = segmenter
+    ? countWithSegmenter(review, segmenter)
+    : countWithoutSegmenter(review);
 
-  return words.length >= wordCountThreshold;
+  return count >= wordCountThreshold;
 }


### PR DESCRIPTION
## Summary
- Defer the `Intl.Segmenter` constructor and feature-detect at module load
- Fall back to a `\p{L}\p{N}` regex word match when `Intl.Segmenter` is unavailable
- Existing specs still run in the segmenter-enabled path (Node has it)

## Why
The module-level `new Intl.Segmenter(...)` crashed at import time in browsers without `Intl.Segmenter` (older Firefox, older Safari), breaking the review-validation path entirely.

- [TRAKT-WEB-8BM](https://trakt-tv.sentry.io/issues/TRAKT-WEB-8BM) — 30 events

The regex fallback is approximate — it loses correct Japanese segmentation — but is strictly better than crashing the comment drawer for the affected cohort.

## Test plan
- [ ] `deno task client:test` continues to pass `isReviewValid.spec.ts`
- [ ] Comment drawer loads in a browser without `Intl.Segmenter` (simulate by `delete globalThis.Intl.Segmenter`)