### PR TITLE
fix: swallow concurrent navigator.share() InvalidStateError

### DIFF
--- a/projects/client/src/lib/components/buttons/share/useShare.ts
+++ b/projects/client/src/lib/components/buttons/share/useShare.ts
@@ -9,6 +9,13 @@ type ShareData = {
   text: string;
 };
 
+const IgnoredShareErrors: ReadonlySet<string> = new Set([
+  // User dismissed the share sheet.
+  'AbortError',
+  // The browser already serializes shares, a previous share is still active.
+  'InvalidStateError',
+]);
+
 export function useShare(source: DrilldownSource) {
   const { track } = useTrack(AnalyticsEvent.Share);
 
@@ -20,10 +27,10 @@ export function useShare(source: DrilldownSource) {
     }
 
     try {
-      track({ source: source.id, type: source.type });
       await navigator.share(data);
+      track({ source: source.id, type: source.type });
     } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
+      if (error instanceof Error && IgnoredShareErrors.has(error.name)) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- Catch `InvalidStateError` alongside the existing `AbortError` in `useShare.ts`
- Extract the ignored error names into a `ReadonlySet`
- No mutable in-flight state — the browser already serialises `navigator.share()`

## Why
Rapid double-clicks on the share button trigger `InvalidStateError: Failed to execute 'share' on 'Navigator': An earlier share has not yet completed.`

- [TRAKT-WEB-3TJ](https://trakt-tv.sentry.io/issues/TRAKT-WEB-3TJ) — 180 events

The first attempted fix tracked an `inFlight` boolean, but the browser already serialises `share()` calls — so the cleaner solution is to treat the resulting `InvalidStateError` the same as a user-triggered abort and silently return.

## Test plan
- [ ] `deno task client:test` passes
- [ ] Manual: trigger two share clicks back-to-back, confirm no console error and the second invocation resolves silently