### PR TITLE
fix: silence iOS 16.3 service worker module-type Sentry noise

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -30,6 +30,7 @@ Sentry.init({
     'AbortError',
     'Failed to register a ServiceWorker',
     'service-worker.js load failed',
+    "type 'module' in RegistrationOptions is not implemented yet",
     'Failed to fetch dynamically imported module',
     'error loading dynamically imported module',
     'Importing a module script failed',


### PR DESCRIPTION
## Summary
- Add `\"type 'module' in RegistrationOptions is not implemented yet\"` to Sentry `ignoreErrors`

## Why
Mobile Safari ≤16.3 doesn't support `type: 'module'` in service worker registration options (Apple added it in 16.4). The rejection has no stacktrace, so it bypasses the existing `beforeSend` filter that requires a service-worker frame.

- [TRAKT-WEB-8TP](https://trakt-tv.sentry.io/issues/TRAKT-WEB-8TP) — 745 events at 0.1 sample rate (≈7.5k actual)

The PWA degrades cleanly on these browsers — no SW means no offline caching or install prompt, but the app itself loads. The error is pure noise; silencing it in Sentry is the right move.

## Test plan
- [ ] `deno task client:test` passes
- [ ] Verify no other call paths surface this exact message that we'd want to keep visible