### PR TITLE
fix: harden safeStorage against null and SecurityError access

### DIFF
--- a/projects/client/src/lib/utils/storage/safeStorage.spec.ts
+++ b/projects/client/src/lib/utils/storage/safeStorage.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+describe('safeStorage', () => {
+  it('returns a working storage when localStorage is available', async () => {
+    vi.resetModules();
+    vi.doMock('$app/environment', () => ({ browser: true }));
+
+    const { safeLocalStorage } = await import('./safeStorage.ts');
+
+    safeLocalStorage.setItem('test-key', 'test-value');
+    expect(safeLocalStorage.getItem('test-key')).toBe('test-value');
+    safeLocalStorage.removeItem('test-key');
+  });
+
+  it('falls back to a noop storage when accessing localStorage throws', async () => {
+    vi.resetModules();
+    vi.doMock('$app/environment', () => ({ browser: true }));
+
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'localStorage',
+    );
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new Error('SecurityError: localStorage is blocked');
+      },
+    });
+
+    const { safeLocalStorage } = await import('./safeStorage.ts');
+
+    expect(safeLocalStorage.getItem('test-key')).toBeNull();
+    expect(() => safeLocalStorage.setItem('test-key', 'x')).not.toThrow();
+
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, 'localStorage', originalDescriptor);
+    }
+  });
+
+  it('falls back to a noop storage when localStorage is null', async () => {
+    vi.resetModules();
+    vi.doMock('$app/environment', () => ({ browser: true }));
+
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'localStorage',
+    );
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: null,
+      writable: true,
+    });
+
+    const { safeLocalStorage } = await import('./safeStorage.ts');
+
+    expect(safeLocalStorage.getItem('test-key')).toBeNull();
+
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, 'localStorage', originalDescriptor);
+    }
+  });
+
+  it('returns a noop storage in non-browser environments', async () => {
+    vi.resetModules();
+    vi.doMock('$app/environment', () => ({ browser: false }));
+
+    const { safeLocalStorage, safeSessionStorage } = await import(
+      './safeStorage.ts'
+    );
+
+    expect(safeLocalStorage.getItem('any')).toBeNull();
+    expect(safeSessionStorage.getItem('any')).toBeNull();
+  });
+});

--- a/projects/client/src/lib/utils/storage/safeStorage.ts
+++ b/projects/client/src/lib/utils/storage/safeStorage.ts
@@ -1,12 +1,30 @@
 import { browser } from '$app/environment';
 import { NOOP_FN } from '../constants.ts';
 
-const NOOP_STORAGE = {
+const Noop_storage: Storage = {
+  length: 0,
+  key: () => null,
   getItem: () => null,
   setItem: NOOP_FN,
   removeItem: NOOP_FN,
   clear: NOOP_FN,
 };
 
-export const safeLocalStorage = !browser ? NOOP_STORAGE : localStorage;
-export const safeSessionStorage = !browser ? NOOP_STORAGE : sessionStorage;
+function resolveStorage(getStorage: () => Storage | null): Storage {
+  if (!browser) {
+    return Noop_storage;
+  }
+
+  try {
+    return getStorage() ?? Noop_storage;
+  } catch {
+    return Noop_storage;
+  }
+}
+
+export const safeLocalStorage: Storage = resolveStorage(() =>
+  globalThis.localStorage
+);
+export const safeSessionStorage: Storage = resolveStorage(() =>
+  globalThis.sessionStorage
+);

--- a/projects/client/test/mocks/ls.mock.ts
+++ b/projects/client/test/mocks/ls.mock.ts
@@ -11,9 +11,18 @@ Object.defineProperty(window, 'localStorage', {
       setItem: vi.fn(function (key: string, value: string) {
         return store.set(key, value);
       }),
+      removeItem: vi.fn(function (key: string) {
+        return store.delete(key);
+      }),
       clear: vi.fn(function () {
         return store.clear();
       }),
+      key: vi.fn(function (index: number) {
+        return Array.from(store.keys())[index] ?? null;
+      }),
+      get length() {
+        return store.size;
+      },
     };
   })(),
 });


### PR DESCRIPTION
## Summary
- Wrap `localStorage` / `sessionStorage` access in `try/catch` with a null fallback
- Resolve to a fully-typed `Storage` noop in both error paths
- Spec covers happy path, SecurityError throw, null assignment, and SSR

## Why
Android WebView and locked-down browsing contexts behave inconsistently:
- accessing `globalThis.localStorage` can **throw `SecurityError`**
- the property can be **`null`**

The previous implementation took the raw access value and ran with it, producing two of the highest-volume Sentry issues:

- [TRAKT-WEB-M](https://trakt-tv.sentry.io/issues/TRAKT-WEB-M) — 12,936 events (`SecurityError`)
- [TRAKT-WEB-3X6](https://trakt-tv.sentry.io/issues/TRAKT-WEB-3X6) — 4,478 events (`safeLocalStorage.getItem` on null)

Combined: **~17,400 events resolved by one file change.**

## Test plan
- [ ] `deno task client:test` passes the new `safeStorage.spec.ts`
- [ ] Smoke test: app boots in Android Chrome WebView with localStorage blocked (no toast dismissals persisted, but no crash)