### PR TITLE
fix: guard show summary against transient nullish data

### DIFF
--- a/projects/client/src/routes/shows/[slug]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/+page.svelte
@@ -56,7 +56,11 @@
     goToSeason($show.slug, activeSeason);
   });
 
-  const isReady = $derived(!$isLoading && !isNaN(currentSeason));
+  const hasCoreData = $derived(
+    $show != null && $intl != null && $studios != null && $crew != null &&
+      $seasons != null,
+  );
+  const isReady = $derived(!$isLoading && !isNaN(currentSeason) && hasCoreData);
 </script>
 
 <TraktPage


### PR DESCRIPTION
## Summary
- Tighten the show-page \`isReady\` predicate to require \`$show\`, \`$intl\`, \`$studios\`, \`$crew\`, **and \`$seasons\`** alongside \`!\$isLoading\`
- Drop the \`!\` non-null assertions from the prop pass to \`<ShowSummary>\`
- \`SeasonList\` keeps its non-nullable \`Season[]\` contract

## Why
The route gated rendering on \`!\$isLoading\` only and then asserted every store non-null with \`!\`. During a navigation transition the query can settle with \`isLoading=false\` before all derived stores repopulate — \`undefined\` reached \`SeasonList\` and crashed at \`seasons.length\`.

- [TRAKT-WEB-87F](https://trakt-tv.sentry.io/issues/TRAKT-WEB-87F) — 100 events

Same shape as #2357 (movies / episodes pages).

## Test plan
- [ ] \`deno task client:test\` passes
- [ ] Navigate rapidly between two show pages; placeholder shows briefly, no crash