### PR TITLE
fix: skip findActiveSeason when show has no usable seasons

### DIFF
--- a/projects/client/src/routes/shows/[slug]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/+page.svelte
@@ -47,6 +47,7 @@
   $effect.pre(() => {
     if (!isNaN(currentSeason)) return;
     if ($seasons == null || $show == null) return;
+    if ($seasons.length === 0) return;
 
     const activeSeason = findActiveSeason({
       seasons: $seasons,


### PR DESCRIPTION
## Summary
- Add an `if ($seasons.length === 0) return;` guard in `routes/shows/[slug]/+page.svelte` before calling `findActiveSeason`
- **Keep** `findActiveSeason`'s `assertDefined` invariant intact

## Why
The auto-redirect effect runs `findActiveSeason` whenever the URL has no `?season=`. The function intentionally throws — its invariant is that any show has at least one of: a last-watched match, season 1, or a non-special season. When the caller ran it before \`\$seasons\` had populated (or for empty-season data states), the throw propagated through the \`\$derived\` chain and crashed the page.

Original take was to soften the assertion to return `FIRST_SEASON`, but that just moves the crash downstream into `useSeasonEpisodes(currentSeason)` and loses the signal on data-quality issues.

This version guards the **caller** instead. Empty \`\$seasons\` → skip the redirect, fall through to the page's existing empty placeholder. \`findActiveSeason\` keeps its invariant so genuine data anomalies still surface in Sentry as real findings.

- [TRAKT-WEB-19W](https://trakt-tv.sentry.io/issues/TRAKT-WEB-19W) — 439 events

## Test plan
- [ ] `deno task client:test` passes
- [ ] Show page with empty \`\$seasons\` no longer crashes; placeholder renders
- [ ] Normal show with populated seasons still auto-redirects to the active one