### PR TITLE
fix: silence Sentry replay cross-origin iframe noise

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -38,6 +38,10 @@ Sentry.init({
     // Firebase Installations rejects when the device loses connectivity
     // — we use it solely for analytics, so the outage isn't actionable.
     'installations/app-offline',
+    // Sentry's own replay integration touches cross-origin frames
+    // injected by ad-blockers / privacy extensions.
+    'Blocked a frame with origin',
+    "Failed to read a named property 'Element' from 'Window'",
   ],
   beforeSend(event) {
     const isWellKnownRejection = event.exception?.values?.some(


### PR DESCRIPTION
## Summary
- Add `"Blocked a frame with origin"` and the related cross-origin Element message to Sentry `ignoreErrors`

## Why
Sentry's `@sentry-internal/replay` attaches a load handler to every iframe and tries to mirror its DOM. When the iframe belongs to an ad-blocker (`iframe.pp-blocker`) and lives on a different origin, the shadow-DOM observer access throws `SecurityError`. The error originates in Sentry's own code — our request paths are unaffected.

- [TRAKT-WEB-68F](https://trakt-tv.sentry.io/issues/TRAKT-WEB-68F) — 1,390 events

## Test plan
- [ ] `deno task client:test` passes