### PR TITLE
fix: defer toObservable emissions to escape Svelte mutation context

### DIFF
--- a/projects/client/src/lib/utils/store/toObservable.spec.ts
+++ b/projects/client/src/lib/utils/store/toObservable.spec.ts
@@ -18,8 +18,11 @@ function mockWritable<T>(initial: T) {
   };
 }
 
+const flushMicrotasks = () =>
+  new Promise<void>((resolve) => queueMicrotask(resolve));
+
 describe('toObservable', () => {
-  it('should emit initial value from readable store', () => {
+  it('should emit initial value synchronously from readable store', () => {
     const store = mockWritable('initial');
     const observable = toObservable(store);
     let emittedValue: string | undefined;
@@ -32,7 +35,7 @@ describe('toObservable', () => {
     subscription.unsubscribe();
   });
 
-  it('should emit updated values from writable store', () => {
+  it('should emit updated values from writable store (deferred)', async () => {
     const store = mockWritable('initial');
     const observable = toObservable(store);
     const emittedValues: string[] = [];
@@ -43,12 +46,13 @@ describe('toObservable', () => {
 
     store.set('updated');
     store.set('final');
+    await flushMicrotasks();
 
     expect(emittedValues).toEqual(['initial', 'updated', 'final']);
     subscription.unsubscribe();
   });
 
-  it('should handle multiple subscribers independently', () => {
+  it('should handle multiple subscribers independently', async () => {
     const store = mockWritable(1);
     const observable = toObservable(store);
     const values1: number[] = [];
@@ -59,6 +63,7 @@ describe('toObservable', () => {
 
     store.set(2);
     store.set(3);
+    await flushMicrotasks();
 
     expect(values1).toEqual([1, 2, 3]);
     expect(values2).toEqual([1, 2, 3]);
@@ -67,7 +72,7 @@ describe('toObservable', () => {
     sub2.unsubscribe();
   });
 
-  it('should stop emitting after unsubscription', () => {
+  it('should stop emitting after unsubscription', async () => {
     const store = mockWritable('start');
     const observable = toObservable(store);
     const emittedValues: string[] = [];
@@ -77,8 +82,12 @@ describe('toObservable', () => {
     });
 
     store.set('middle');
+    // Flush so the deferred 'middle' lands before we unsubscribe;
+    // anything emitted after unsubscribe must not be delivered.
+    await flushMicrotasks();
     subscription.unsubscribe();
     store.set('end');
+    await flushMicrotasks();
 
     expect(emittedValues).toEqual(['start', 'middle']);
   });

--- a/projects/client/src/lib/utils/store/toObservable.ts
+++ b/projects/client/src/lib/utils/store/toObservable.ts
@@ -9,8 +9,21 @@ interface Readable<T> {
 
 export function toObservable<T>(store: Readable<T>): Observable<T> {
   return new Observable((observer) => {
+    let hasEmittedInitial = false;
+
     const unsubscribe = store.subscribe((value) => {
-      observer.next(value);
+      if (!hasEmittedInitial) {
+        // Keep the initial emission synchronous so consumers that read
+        // the value during their first render don't see undefined.
+        hasEmittedInitial = true;
+        observer.next(value);
+        return;
+      }
+
+      // Defer subsequent emissions so synchronous downstream subscribers
+      // can't write back into a Svelte source while its effect is still
+      // executing — that path triggers state_unsafe_mutation.
+      queueMicrotask(() => observer.next(value));
     });
 
     return unsubscribe;


### PR DESCRIPTION
## Summary
- Wrap `observer.next(value)` in `queueMicrotask` so it runs after the Svelte effect that triggered it

## Why
TanStack Query's notify manager synchronously flushes its callbacks during a store update. The downstream subscribers can write back into a Svelte source while its effect is still executing, which Svelte 5 reports as `state_unsafe_mutation`.

- [TRAKT-WEB-3SS](https://trakt-tv.sentry.io/issues/TRAKT-WEB-3SS) — 114 events

## Test plan
- [ ] `deno task client:test` passes
- [ ] Smoke test on `/`: scroll lists, change filters, no console warnings