### PR TITLE
fix: gate movie/episode isLoading on core data presence

### DIFF
--- a/projects/client/src/routes/movies/[slug]/+page.svelte
+++ b/projects/client/src/routes/movies/[slug]/+page.svelte
@@ -24,12 +24,12 @@
     <NavbarStateSetter mode="minimal" />
   </RenderFor>
 
-  {#if !$isLoading}
+  {#if !$isLoading && $movie && $studios && $crew && $intl}
     <MovieSummary
-      media={$movie!}
-      studios={$studios!}
-      crew={$crew!}
-      intl={$intl!}
+      media={$movie}
+      studios={$studios}
+      crew={$crew}
+      intl={$intl}
       streamOn={$streamOn}
       videos={$videos}
       sentiment={$sentiment}

--- a/projects/client/src/routes/movies/[slug]/useMovie.ts
+++ b/projects/client/src/routes/movies/[slug]/useMovie.ts
@@ -91,8 +91,18 @@ export function useMovie(slug: string | undefined) {
   const isSentimentLoading = sentiment.pipe(
     map((query) => query ? toLoadingState(query) : false),
   );
-  const isLoading = combineLatest([isQueriesLoading, isSentimentLoading]).pipe(
-    map((states) => states.some(Boolean)),
+  // Keep isLoading true until the core movie payload is present —
+  // queries can flip to !fetching while `data` is still undefined
+  // (errored or empty), which would otherwise let the page render
+  // a half-populated summary.
+  const isLoading = combineLatest([
+    isQueriesLoading,
+    isSentimentLoading,
+    movie,
+  ]).pipe(
+    map(([queriesLoading, sentimentLoading, $movie]) =>
+      queriesLoading || sentimentLoading || $movie.data == null
+    ),
   );
 
   return {

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/+page.svelte
@@ -30,15 +30,15 @@
     <NavbarStateSetter mode="minimal" />
   </RenderFor>
 
-  {#if !$isLoading}
+  {#if !$isLoading && $show && $showIntl && $episode && $intl && $seasons && $crew}
     <EpisodeSummary
-      show={$show!}
-      showIntl={$showIntl!}
-      episode={$episode!}
-      episodeIntl={$intl!}
-      seasons={$seasons!}
+      show={$show}
+      showIntl={$showIntl}
+      episode={$episode}
+      episodeIntl={$intl}
+      seasons={$seasons}
       streamOn={$streamOn}
-      crew={$crew!}
+      crew={$crew}
     />
   {:else}
     <!-- TODO: remove this when we have empty state, currently prevents content jumps -->

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/useEpisode.ts
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/useEpisode.ts
@@ -57,8 +57,20 @@ export function useEpisode(
     crew,
   ];
 
-  const isLoading = combineLatest(queries).pipe(
-    map(($queries) => $queries.some(toLoadingState)),
+  const coreQueries = [episode, show];
+
+  // Keep isLoading true until episode + show payloads are present —
+  // queries can flip to !fetching while `data` is still undefined
+  // (errored or empty), which would otherwise let the page render
+  // a half-populated summary.
+  const isLoading = combineLatest([
+    combineLatest(queries),
+    combineLatest(coreQueries),
+  ]).pipe(
+    map(([$queries, $coreQueries]) =>
+      $queries.some(toLoadingState) ||
+      $coreQueries.some(($query) => $query.data == null)
+    ),
   );
 
   return {


### PR DESCRIPTION
## Summary
- **\`useMovie.ts\`**: keep \`isLoading\` true until \`movie.data\` is present (not just until fetching stops)
- **\`useEpisode.ts\`**: same — also requires \`show.data\`
- **Pages**: replace \`media={\$movie!}\` non-null assertions with truthy guards in the \`{#if}\` clause

## Why
TanStack's \`isLoading\` only reflects fetch state — a query that resolves with \`data === undefined\` (errored or empty body) flips loading to false while the data is still missing. The pages trusted \`!\$isLoading\` and asserted every prop non-null with \`!\`. During a navigation transition or after an error the summary mounted with \`undefined\` \`media\` and crashed at \`media.slug\`.

Per review feedback, the right fix lives in the hooks: \`isLoading\` now encodes "core payload is ready," not just "the network has settled." The page-level truthy guards stay as a belt-and-suspenders and let us drop the non-null assertions for honesty.

- [TRAKT-WEB-4MS](https://trakt-tv.sentry.io/issues/TRAKT-WEB-4MS) — 1,131 events (movies)
- [TRAKT-WEB-4MR](https://trakt-tv.sentry.io/issues/TRAKT-WEB-4MR) — 4 events (episodes)

## Test plan
- [ ] \`deno task client:test\` passes
- [ ] Movie / episode pages render correctly on slow network
- [ ] Error response on movie summary: page stays in loader (instead of crashing) — confirm acceptable before merge