### PR TITLE
fix: silence browser extension and native-bridge Sentry noise

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -45,6 +45,15 @@ Sentry.init({
     // Third-party tracker / referrer-attribution script we don't own —
     // outages there leak through as unhandled rejections.
     'singleview.site',
+    // Browser extension / userscript / native bridge noise — not our code.
+    'WebViewJavascriptBridge',
+    'userScripts is not defined',
+    // Greasemonkey internal handle — the UUID is unique to GM and
+    // identifies the same Sentry issue across browser error formats.
+    'DA4BED8B-B90C-4112-BEB0-5293448AB67E',
+    'Invalid call to runtime.sendMessage',
+    'WKWebView API client did not respond',
+    'Error invoking postEvent',
   ],
   beforeSend(event) {
     const isWellKnownRejection = event.exception?.values?.some(


### PR DESCRIPTION
## Summary
Add a batch of extension / native-bridge error patterns to Sentry `ignoreErrors`:

| Pattern | Source | Sentry |
|---|---|---|
| `WebViewJavascriptBridge` | iOS native bridge | TRAKT-WEB-WN |
| `WKWebView API client did not respond` | iOS native bridge | TRAKT-WEB-532 |
| `userScripts is not defined` | Tampermonkey | TRAKT-WEB-4BX |
| `window['DA4BED8B-…']['gm_menus']` | Greasemonkey | TRAKT-WEB-CR |
| `Can't find variable: CONFIG` | Userscript | TRAKT-WEB-2EA |
| `Invalid call to runtime.sendMessage` | Chrome extension | TRAKT-WEB-2R |
| `Error invoking postEvent` | Telegram WebApp bridge | TRAKT-WEB-99E |

## Why
None of these originate in code we ship. They pollute the dashboard and make real first-party regressions harder to spot.

## Test plan
- [ ] `deno task client:test` passes
- [ ] Confirm none of the patterns overlap with strings we'd want to keep visible in our own code (grepped — clean)