### PR TITLE
fix: silence third-party singleview.site fetch noise

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -42,6 +42,9 @@ Sentry.init({
     // injected by ad-blockers / privacy extensions.
     'Blocked a frame with origin',
     "Failed to read a named property 'Element' from 'Window'",
+    // Third-party tracker / referrer-attribution script we don't own —
+    // outages there leak through as unhandled rejections.
+    'singleview.site',
   ],
   beforeSend(event) {
     const isWellKnownRejection = event.exception?.values?.some(


### PR DESCRIPTION
## Summary
- Add `singleview.site` to Sentry `ignoreErrors`

## Why
`singleview.site` is a referrer-attribution script we don't own. Failures originate inside its loader, not our request path.

- TRAKT-WEB-336 (3 events), TRAKT-WEB-9AR (1), TRAKT-WEB-WF (2)

## Test plan
- [ ] `deno task client:test` passes