### PR TITLE
fix: silence Firebase Installations offline noise

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -34,6 +34,9 @@ Sentry.init({
     'error loading dynamically imported module',
     'Importing a module script failed',
     'Unable to preload CSS for',
+    // Firebase Installations rejects when the device loses connectivity
+    // — we use it solely for analytics, so the outage isn't actionable.
+    'installations/app-offline',
   ],
   beforeSend(event) {
     const isWellKnownRejection = event.exception?.values?.some(


### PR DESCRIPTION
## Summary
- Add `installations/app-offline` to Sentry `ignoreErrors`

## Why
Firebase Installations rejects with `Could not process request. Application offline (installations/app-offline)` whenever the device loses connectivity. We use Firebase solely for analytics, so the rejection is not actionable.

- [TRAKT-WEB-3Y](https://trakt-tv.sentry.io/issues/TRAKT-WEB-3Y) — 11 events

## Test plan
- [ ] `deno task client:test` passes