### PR TITLE
fix: reduce worker 404 + disconnect noise from observability

### DIFF
--- a/projects/client/src/routes/api/store-token/+server.ts
+++ b/projects/client/src/routes/api/store-token/+server.ts
@@ -5,8 +5,14 @@ import { time } from '$lib/utils/timing/time.ts';
 import { json, type RequestHandler } from '@sveltejs/kit';
 
 export const POST: RequestHandler = async ({ request, cookies }) => {
-  const { token, expiresAt }: OidcAuthToken = await request.json();
+  // Client disconnected before the body finished streaming
+  // ("Network connection lost." in CF Workers). Nothing to persist.
+  const body: OidcAuthToken | null = await request.json().catch(() => null);
+  if (!body) {
+    return new Response(null, { status: 499 });
+  }
 
+  const { token, expiresAt } = body;
   const maxAge = expiresAt ? time.years(1) / time.seconds(1) : 0;
   const cookieContent = JSON.stringify({ token, expiresAt });
 

--- a/projects/client/svelte.config.js
+++ b/projects/client/svelte.config.js
@@ -38,6 +38,9 @@ const config = {
     serviceWorker: {
       register: false,
     },
+    paths: {
+      relative: false,
+    },
     alias: {
       '$mocks': './src/mocks',
       '$worker': './src/worker',


### PR DESCRIPTION
## Summary

Two unrelated worker errors surfaced while auditing Cloudflare observability for the last 24h. Both have actionable root causes.

### 1. `kit.paths.relative` default produces nested asset 404s

SvelteKit 2 defaults `paths.relative` to `true`, so the SSR HTML emits `<link href=\"_app/immutable/assets/<hash>.css\">` (no leading slash). When the browser resolves that against a nested page URL like `/users/<x>/lists/`, it fetches `/users/<x>/lists/_app/immutable/assets/<hash>.css`, which the worker has no route for and 404s.

Worker logs surfaced ~370 such 404s across many hashed assets and routes over 24h. Examples in the logs:

- `/users/majeed_pk/lists/_app/immutable/assets/MediaSummaryCard.D_5KQ1a0.css`
- `/users/xeexex/lists/_app/immutable/assets/RatingIcon.JXdoCijI.css`
- `/profile/_app/immutable/assets/FilterTabs.DwX-os1x.css`
- `/shows/_app/immutable/assets/LoadingIndicator.BBybgCbo.css`

Forcing `paths.relative: false` brings asset URLs back to `/_app/immutable/...` regardless of the page URL.

### 2. `POST /api/store-token` blows up on client disconnect

The endpoint reads the OIDC token via `await request.json()`. If the client disconnects before the body finishes streaming, CF Workers throws \"Network connection lost.\" which bubbles out as an unhandled worker error. ~480 of these on this endpoint alone over 24h.

Catch the body-read failure and return 499 (client closed request). There is nothing to persist when the client is gone, so this is the correct quiet response.

## Test plan

- [ ] Deploy to staging, navigate to `/users/<x>/lists` and confirm asset `<link>` hrefs use absolute paths (`/_app/immutable/...`) in the SSR HTML.
- [ ] Confirm no new 404s for `<route>/_app/immutable/...` in worker logs after rollout.
- [ ] Confirm `POST /api/store-token` \"Network connection lost.\" rate drops in worker observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)