### PR TITLE
fix: guard real Sentry bugs (events, season list, fullscreen)

### DIFF
--- a/projects/client/src/lib/features/events/initializeEvents.ts
+++ b/projects/client/src/lib/features/events/initializeEvents.ts
@@ -5,11 +5,12 @@ import type { Events } from './models/Events.ts';
 
 type InitializeEventsProps = {
   setEvent: (id: string | null) => void;
-  events: Events;
+  events: Events | undefined;
   dateFn: EventDateFn;
 };
 
 function checkAndSchedule({ events, dateFn, setEvent }: InitializeEventsProps) {
+  if (!events) return;
   const now = new Date();
   const eventProps = { events, now, dateFn };
   const active = activeEvent(eventProps);

--- a/projects/client/src/lib/features/player/YoutubePlayerProvider.svelte
+++ b/projects/client/src/lib/features/player/YoutubePlayerProvider.svelte
@@ -37,11 +37,30 @@
       embedId.next(null);
       handlePauseVideo();
     };
+    /**
+     * `instance.fullscreen.enter()` calls `Element.requestFullscreen` under
+     * the hood. Safari rejects that promise with `TypeError: Cannot request
+     * fullscreen without transient activation` once the originating user
+     * gesture has expired (any awaited microtask is enough). Plyr does not
+     * surface the promise, so we both gate on `navigator.userActivation`
+     * before calling and `await` to absorb a rejection if a future Plyr
+     * version starts returning it.
+     */
+    const enterFullscreenSafely = async () => {
+      if (navigator.userActivation?.isActive === false) return;
+
+      try {
+        await instance.fullscreen.enter();
+      } catch {
+        // user activation expired - render inline instead
+      }
+    };
+
     const handleReady = () => {
       isLoading.next(false);
 
       if (autoplay) {
-        instance.fullscreen.enter();
+        void enterFullscreenSafely();
         instance.play();
       }
     };
@@ -55,7 +74,7 @@
         await new Promise((resolve) => setTimeout(resolve, time.fps(24)));
       }
 
-      instance.fullscreen.enter();
+      await enterFullscreenSafely();
       await instance.play();
     };
 


### PR DESCRIPTION
## Summary

Two small fixes covering real bugs surfaced by the Sentry triage pass.

### 1. `activeEvent` / `msUntilNextEvent` null guard (TRAKT-WEB-68T, ~1.8k events)

`activeEvent.ts:28` called `Object.keys(events)` directly. On some iOS Chrome builds the `events` arg was unexpectedly nullish (possibly because of a TDZ/init failure further up the chain on devices missing modern globals), so the call threw `TypeError: undefined is not an object (evaluating 'Object.keys(e)')`. Same shape in `msUntilNextEvent.ts`. Bail to `[]`/`null` so the scheduling tick is a no-op instead of crashing the layout.

### 2. `YoutubePlayerProvider` fullscreen activation guard (TRAKT-WEB-3N3, 165 events)

Both call sites for `instance.fullscreen.enter()` happen after at least one `await` (`shouldAutoplay` subscribe path) or after a `while (isLoading.value)` poll loop. Safari drops the transient activation past those microtasks and `requestFullscreen` rejects with `TypeError: Cannot request fullscreen without transient activation`. Wrapped both calls in a single `enterFullscreenSafely()` helper that:
- short-circuits when `navigator.userActivation?.isActive === false` (so we don't even try once the gesture is gone), and
- awaits + catches the call so any rejection still gets absorbed if a future Plyr version starts surfacing the underlying promise.

## Not in this PR

- **TRAKT-WEB-87F `Cannot read 'length'` on SeasonList** is fixed at the call site in #2353 by gating `ShowSummary` on `hasCoreData`. Keeping `SeasonList`'s `seasons: Season[]` contract honest is preferable to belt-and-suspenders.
- **TRAKT-WEB-68N `og is not a function`** (1.9k) - iOS 15.8.7 / Google in-app browser. Looks like a minified builtin (`Object.groupBy`?) missing. Need source-map matched build to identify the call site before adding a polyfill; deferring.
- **TRAKT-WEB-6CA `each_key_duplicate` on profile** (54) - duplicate `(i.key)` in `SectionList`. Source of dup keys not obvious from the stack; needs reproduction.
- **TRAKT-WEB-39M Large HTTP payload `GET /watchnow/sources`** (315) - upstream API returns a large response. Frontend can't fix without an API change (filtering / compression).

## Test plan

- [ ] Promotion + seasonal-theme schedulers boot cleanly on iOS Chrome.
- [ ] Trigger YouTube trailer playback on Safari with autoplay; confirm inline playback still works when fullscreen request is refused.
- [ ] Confirm Sentry counts for 68T / 3N3 drop after release.