### PR TITLE
fix(client): hide play/watcher/favorite stats for unreleased media

### DIFF
--- a/projects/client/src/lib/sections/summary/components/details/_internal/getDisplayableStats.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/getDisplayableStats.spec.ts
@@ -1,0 +1,78 @@
+import type { MediaStats } from '$lib/requests/models/MediaStats.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { describe, expect, it } from 'vitest';
+import type { EpisodeEntry } from '../../../../../requests/models/EpisodeEntry.ts';
+import type { MovieEntry } from '../../../../../requests/models/MovieEntry.ts';
+import type { EpisodeStats } from '../../../../../requests/models/EpisodeStats.ts';
+import {
+  EMPTY_EPISODE_STATS,
+  EMPTY_MEDIA_STATS,
+  getDisplayableStats,
+} from './getDisplayableStats.ts';
+
+describe('getDisplayableStats', () => {
+  const mediaStats: MediaStats = {
+    watchers: 100,
+    plays: 200,
+    collectors: 50,
+    comments: 10,
+    lists: 25,
+    favorited: 15,
+    votes: 80,
+  };
+
+  const episodeStats: EpisodeStats = {
+    watchers: 100,
+    plays: 200,
+    collectors: 50,
+    comments: 10,
+    lists: 25,
+  };
+
+  it('should return stats for aired media entries', () => {
+    const entry = {
+      effectiveReleaseDate: new Date(Date.now() - time.years(1)),
+      type: 'movie',
+    } as unknown as MovieEntry;
+
+    expect(getDisplayableStats({ stats: mediaStats, entry })).to.deep.equal(
+      mediaStats,
+    );
+  });
+
+  it('should return empty media stats preserving list count for unaired media entries', () => {
+    const entry = {
+      effectiveReleaseDate: new Date(Date.now() + time.years(1)),
+      type: 'movie',
+    } as unknown as MovieEntry;
+
+    expect(getDisplayableStats({ stats: mediaStats, entry })).to.deep.equal({
+      ...EMPTY_MEDIA_STATS,
+      lists: mediaStats.lists,
+    });
+  });
+
+  it('should return empty episode stats preserving list count for unaired episode entries', () => {
+    const entry = {
+      effectiveReleaseDate: new Date(Date.now() + time.years(1)),
+      type: 'episode',
+    } as unknown as EpisodeEntry;
+
+    expect(getDisplayableStats({ stats: episodeStats, entry })).to.deep.equal({
+      ...EMPTY_EPISODE_STATS,
+      lists: episodeStats.lists,
+    });
+  });
+
+  it('should return stats for a movie released before its air date', () => {
+    const entry = {
+      effectiveReleaseDate: new Date(Date.now() + time.days(7)),
+      type: 'movie',
+      status: 'released',
+    } as unknown as MovieEntry;
+
+    expect(getDisplayableStats({ stats: mediaStats, entry })).to.deep.equal(
+      mediaStats,
+    );
+  });
+});

--- a/projects/client/src/lib/sections/summary/components/details/_internal/getDisplayableStats.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/getDisplayableStats.ts
@@ -1,0 +1,40 @@
+import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
+import type { EpisodeStats } from '$lib/requests/models/EpisodeStats.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { MediaStats } from '$lib/requests/models/MediaStats.ts';
+import { hasAired } from '$lib/utils/media/hasAired.ts';
+
+type Stats = MediaStats | EpisodeStats;
+
+type GetDisplayableStatsProps = {
+  stats: Stats;
+  entry: MediaEntry | EpisodeEntry;
+};
+
+export const EMPTY_EPISODE_STATS: EpisodeStats = Object.freeze({
+  watchers: 0,
+  plays: 0,
+  collectors: 0,
+  comments: 0,
+  lists: 0,
+});
+
+export const EMPTY_MEDIA_STATS: MediaStats = Object.freeze({
+  ...EMPTY_EPISODE_STATS,
+  favorited: 0,
+  votes: 0,
+});
+
+export function getDisplayableStats(
+  { stats, entry }: GetDisplayableStatsProps,
+): Stats {
+  if (hasAired(entry)) {
+    return stats;
+  }
+
+  if ('favorited' in stats) {
+    return { ...EMPTY_MEDIA_STATS, lists: stats.lists };
+  }
+
+  return { ...EMPTY_EPISODE_STATS, lists: stats.lists };
+}

--- a/projects/client/src/lib/sections/summary/components/details/_internal/useStats.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/useStats.ts
@@ -1,5 +1,7 @@
 import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
 import type { EpisodeStats } from '$lib/requests/models/EpisodeStats.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
 import type { MediaStats } from '$lib/requests/models/MediaStats.ts';
 import { episodeStatsQuery } from '$lib/requests/queries/episode/episodeStatsQuery.ts';
 import { movieStatsQuery } from '$lib/requests/queries/movies/movieStatsQuery.ts';
@@ -8,24 +10,15 @@ import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import type { CreateQueryOptions } from '@tanstack/svelte-query';
 import { map } from 'rxjs';
 import type { MediaDetailsProps } from '../MediaDetailsProps.ts';
+import {
+  EMPTY_EPISODE_STATS,
+  EMPTY_MEDIA_STATS,
+  getDisplayableStats,
+} from './getDisplayableStats.ts';
 
 type Stats = MediaStats | EpisodeStats;
 
 type UseStatsProps = MediaDetailsProps;
-
-const emptyStats: EpisodeStats = {
-  watchers: 0,
-  plays: 0,
-  collectors: 0,
-  comments: 0,
-  lists: 0,
-};
-
-const emptyMediaStats: MediaStats = {
-  ...emptyStats,
-  favorited: 0,
-  votes: 0,
-};
 
 function toQuery(props: UseStatsProps) {
   switch (props.type) {
@@ -46,16 +39,23 @@ function toQuery(props: UseStatsProps) {
   }
 }
 
+function toEntry(props: UseStatsProps): MediaEntry | EpisodeEntry {
+  return props.type === 'episode' ? props.episode : props.media;
+}
+
 export function useStats(props: UseStatsProps) {
   const query = useQuery(toQuery(props));
+  const entry = toEntry(props);
 
   return {
     stats: query.pipe(map(($query) => {
       if (!$query.data) {
-        return props.type === 'episode' ? emptyStats : emptyMediaStats;
+        return props.type === 'episode'
+          ? EMPTY_EPISODE_STATS
+          : EMPTY_MEDIA_STATS;
       }
 
-      return $query.data;
+      return getDisplayableStats({ stats: $query.data, entry });
     })),
     isLoading: query.pipe(map(toLoadingState)),
   };


### PR DESCRIPTION
## Summary

- Mirrors the rating hide pattern for media stats. Unreleased movies, shows, and episodes return zeroed play/watcher/favorite/collector/comment/vote counts instead of whatever the API reports.
- List counts are preserved across the aired/unaired boundary - those reflect legitimate user anticipation rather than playback abuse.
- New helper `getDisplayableStats` lives next to `useStats` and reuses the existing `hasAired` check.

## Test plan

- [x] Unit tests for aired/unaired movie and episode entries
- [x] Released-before-air-date movie still shows real stats
- [x] Manual verify: pick an unreleased show, confirm plays/watchers/favorited render as 0 while list count stays