### PR TITLE
fix(tags): hide stale mid-season episode tags and surface type in details drawer

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -30,6 +30,48 @@
         "ios"
       ]
     },
+    "tag_text_series_premiere": {
+      "default": "Series Premiere",
+      "description": "Text for the tag that indicates the first ever episode of a show. Shown on episode detail surfaces.",
+      "exclude": [
+        "ios"
+      ]
+    },
+    "tag_text_series_finale": {
+      "default": "Series Finale",
+      "description": "Text for the tag that indicates the last ever episode of a show. Shown on episode detail surfaces.",
+      "exclude": [
+        "ios"
+      ]
+    },
+    "tag_text_season_premiere": {
+      "default": "Season Premiere",
+      "description": "Text for the tag that indicates the first episode of a season. Shown on episode detail surfaces.",
+      "exclude": [
+        "ios"
+      ]
+    },
+    "tag_text_season_finale": {
+      "default": "Season Finale",
+      "description": "Text for the tag that indicates the last episode of a season. Shown on episode detail surfaces.",
+      "exclude": [
+        "ios"
+      ]
+    },
+    "tag_text_mid_season_premiere": {
+      "default": "Mid-Season Premiere",
+      "description": "Text for the tag that indicates the first episode after a mid-season break. Shown on episode detail surfaces.",
+      "exclude": [
+        "ios"
+      ]
+    },
+    "tag_text_mid_season_finale": {
+      "default": "Mid-Season Finale",
+      "description": "Text for the tag that indicates the last episode before a mid-season break. Shown on episode detail surfaces.",
+      "exclude": [
+        "ios"
+      ]
+    },
     "list_title_up_next": {
       "default": "Continue Watching",
       "description": "Title for lists containing the next episodes and in progress movies. This title should be as short and concise as possible.",
@@ -891,6 +933,11 @@
     "header_runtime": {
       "default": "Runtime",
       "description": "Header for the runtime section.",
+      "exclude": []
+    },
+    "header_episode_type": {
+      "default": "Type",
+      "description": "Header for the episode type section in the details drawer. Indicates the role of the episode within the show or season (e.g. Mid-Season Finale).",
       "exclude": []
     },
     "header_network": {

--- a/projects/client/src/lib/components/episode/EpisodeIntl.ts
+++ b/projects/client/src/lib/components/episode/EpisodeIntl.ts
@@ -8,6 +8,7 @@ type TimestampMetaData = {
 export type EpisodeIntl = {
   premiereText: () => string;
   finaleText: () => string;
+  episodeTypeText: (type: EpisodeType) => string | Nil;
   timestampText: (metadata: TimestampMetaData) => string;
   durationText: (duration: number) => string;
   remainingText: (remaining: number) => string;

--- a/projects/client/src/lib/components/episode/EpisodeIntlProvider.ts
+++ b/projects/client/src/lib/components/episode/EpisodeIntlProvider.ts
@@ -1,14 +1,39 @@
 import { getLocale, languageTag } from '$lib/features/i18n/index.ts';
 import * as m from '$lib/features/i18n/messages.ts';
-import { EpisodeComputedType } from '$lib/requests/models/EpisodeType.ts';
+import {
+  EpisodeComputedType,
+  EpisodeFinaleType,
+  EpisodePremiereType,
+  type EpisodeType,
+} from '$lib/requests/models/EpisodeType.ts';
 import { toHumanDate } from '$lib/utils/formatting/date/toHumanDate.ts';
 import { toHumanDuration } from '$lib/utils/formatting/date/toHumanDuration.ts';
 import { toRelativeHumanDay } from '$lib/utils/formatting/date/toRelativeHumanDay.ts';
 import type { EpisodeIntl } from './EpisodeIntl.ts';
 
+function episodeTypeText(type: EpisodeType): string | Nil {
+  switch (type) {
+    case EpisodePremiereType.series_premiere:
+      return m.tag_text_series_premiere();
+    case EpisodePremiereType.season_premiere:
+      return m.tag_text_season_premiere();
+    case EpisodePremiereType.mid_season_premiere:
+      return m.tag_text_mid_season_premiere();
+    case EpisodeFinaleType.series_finale:
+      return m.tag_text_series_finale();
+    case EpisodeFinaleType.season_finale:
+      return m.tag_text_season_finale();
+    case EpisodeFinaleType.mid_season_finale:
+      return m.tag_text_mid_season_finale();
+    default:
+      return;
+  }
+}
+
 export const EpisodeIntlProvider: EpisodeIntl = {
   premiereText: () => m.tag_text_premiere(),
   finaleText: () => m.tag_text_finale(),
+  episodeTypeText,
   timestampText: ({ date, type }) => {
     const now = new Date();
 

--- a/projects/client/src/lib/components/episode/getEpisodeStatus.spec.ts
+++ b/projects/client/src/lib/components/episode/getEpisodeStatus.spec.ts
@@ -33,4 +33,37 @@ describe('getEpisodeStatus', () => {
       expect(getEpisodeStatus(type)).toBeUndefined();
     });
   });
+
+  describe('mid-season staleness gate', () => {
+    it.each([
+      EpisodeFinaleType.mid_season_finale,
+      EpisodePremiereType.mid_season_premiere,
+    ])('returns undefined for %s when not the latest aired', (type) => {
+      expect(
+        getEpisodeStatus(type, { isLatestAired: false }),
+      ).toBeUndefined();
+    });
+
+    it.each([
+      [EpisodeFinaleType.mid_season_finale, 'finale'],
+      [EpisodePremiereType.mid_season_premiere, 'premiere'],
+    ] as const)(
+      'returns %s status for %s when it is the latest aired',
+      (type, expected) => {
+        expect(
+          getEpisodeStatus(type, { isLatestAired: true }),
+        ).toBe(expected);
+      },
+    );
+
+    it.each([
+      EpisodeFinaleType.series_finale,
+      EpisodeFinaleType.season_finale,
+      EpisodePremiereType.series_premiere,
+      EpisodePremiereType.season_premiere,
+    ])('does not gate non-mid-season %s', (type) => {
+      expect(getEpisodeStatus(type, { isLatestAired: false }))
+        .toBe(type.endsWith('finale') ? 'finale' : 'premiere');
+    });
+  });
 });

--- a/projects/client/src/lib/components/episode/getEpisodeStatus.ts
+++ b/projects/client/src/lib/components/episode/getEpisodeStatus.ts
@@ -6,7 +6,19 @@ import {
 
 type EpisodeStatus = 'premiere' | 'finale';
 
-export function getEpisodeStatus(type: EpisodeType): EpisodeStatus | Nil {
+type GetEpisodeStatusOptions = {
+  isLatestAired?: boolean;
+};
+
+const MID_SEASON_TYPES: ReadonlySet<EpisodeType> = new Set([
+  EpisodeFinaleType.mid_season_finale,
+  EpisodePremiereType.mid_season_premiere,
+]);
+
+export function getEpisodeStatus(
+  type: EpisodeType,
+  options: GetEpisodeStatusOptions = {},
+): EpisodeStatus | Nil {
   const isPremiere = Object
     .values<EpisodeType>(EpisodePremiereType)
     .includes(type);
@@ -16,6 +28,11 @@ export function getEpisodeStatus(type: EpisodeType): EpisodeStatus | Nil {
     .includes(type);
 
   if (!isPremiere && !isFinale) {
+    return;
+  }
+
+  const isMidSeason = MID_SEASON_TYPES.has(type);
+  if (isMidSeason && options.isLatestAired === false) {
     return;
   }
 

--- a/projects/client/src/lib/components/episode/tags/EpisodeStatusTag.spec.ts
+++ b/projects/client/src/lib/components/episode/tags/EpisodeStatusTag.spec.ts
@@ -62,6 +62,38 @@ describe('EpisodeStatusTag', () => {
     expect(tagLabel).toBeInTheDocument();
   });
 
+  test('it hides the mid season finale tag when not the latest aired', () => {
+    render(
+      EpisodeStatusTag,
+      {
+        props: {
+          i18n: EpisodeIntlProvider,
+          episodeType: EpisodeFinaleType.mid_season_finale,
+          isLatestAired: false,
+        },
+      },
+    );
+
+    expect(screen.queryByText(EpisodeIntlProvider.finaleText()))
+      .not.toBeInTheDocument();
+  });
+
+  test('it hides the mid season premiere tag when not the latest aired', () => {
+    render(
+      EpisodeStatusTag,
+      {
+        props: {
+          i18n: EpisodeIntlProvider,
+          episodeType: EpisodePremiereType.mid_season_premiere,
+          isLatestAired: false,
+        },
+      },
+    );
+
+    expect(screen.queryByText(EpisodeIntlProvider.premiereText()))
+      .not.toBeInTheDocument();
+  });
+
   test('it renders the season premiere tag', () => {
     render(
       EpisodeStatusTag,

--- a/projects/client/src/lib/components/episode/tags/EpisodeStatusTag.svelte
+++ b/projects/client/src/lib/components/episode/tags/EpisodeStatusTag.svelte
@@ -10,11 +10,17 @@
     i18n: EpisodeIntl;
     episodeType: EpisodeType;
     type?: TagType;
+    isLatestAired?: boolean;
   };
 
-  const { i18n, episodeType, type = "text" }: EpisodeStatusProps = $props();
+  const {
+    i18n,
+    episodeType,
+    type = "text",
+    isLatestAired,
+  }: EpisodeStatusProps = $props();
 
-  const status = $derived(getEpisodeStatus(episodeType));
+  const status = $derived(getEpisodeStatus(episodeType, { isLatestAired }));
 </script>
 
 {#snippet tagContent(text: string)}

--- a/projects/client/src/lib/requests/_internal/isLatestAiredEpisode.spec.ts
+++ b/projects/client/src/lib/requests/_internal/isLatestAiredEpisode.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { isLatestAiredEpisode } from './isLatestAiredEpisode.ts';
+
+describe('isLatestAiredEpisode', () => {
+  it('returns false when episode is missing', () => {
+    expect(isLatestAiredEpisode(null, { season: 1, number: 1 })).toBe(false);
+  });
+
+  it('returns true when latest is missing', () => {
+    expect(isLatestAiredEpisode({ season: 1, number: 1 }, null)).toBe(true);
+  });
+
+  it('returns true when episode matches latest', () => {
+    expect(
+      isLatestAiredEpisode(
+        { season: 3, number: 10 },
+        { season: 3, number: 10 },
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when a later episode in same season has aired', () => {
+    expect(
+      isLatestAiredEpisode(
+        { season: 3, number: 10 },
+        { season: 3, number: 11 },
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when a later season has aired', () => {
+    expect(
+      isLatestAiredEpisode(
+        { season: 3, number: 10 },
+        { season: 4, number: 1 },
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true when episode is in a future season', () => {
+    expect(
+      isLatestAiredEpisode(
+        { season: 4, number: 1 },
+        { season: 3, number: 10 },
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true when episode is later in the same season', () => {
+    expect(
+      isLatestAiredEpisode(
+        { season: 3, number: 11 },
+        { season: 3, number: 10 },
+      ),
+    ).toBe(true);
+  });
+});

--- a/projects/client/src/lib/requests/_internal/isLatestAiredEpisode.ts
+++ b/projects/client/src/lib/requests/_internal/isLatestAiredEpisode.ts
@@ -1,0 +1,14 @@
+type EpisodeRef = { season: number; number: number } | null | undefined;
+
+export function isLatestAiredEpisode(
+  episode: EpisodeRef,
+  latest: EpisodeRef,
+): boolean {
+  if (!episode) return false;
+  if (!latest) return true;
+
+  if (episode.season > latest.season) return true;
+  if (episode.season < latest.season) return false;
+
+  return episode.number >= latest.number;
+}

--- a/projects/client/src/lib/requests/models/EpisodeProgressEntry.ts
+++ b/projects/client/src/lib/requests/models/EpisodeProgressEntry.ts
@@ -6,5 +6,6 @@ export const EpisodeProgressEntrySchema = EpisodeEntrySchema.merge(z.object({
   completed: z.number(),
   remaining: z.number(),
   minutesLeft: z.number(),
+  isLatestAired: z.boolean(),
 }));
 export type EpisodeProgressEntry = z.infer<typeof EpisodeProgressEntrySchema>;

--- a/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
@@ -14,6 +14,7 @@ import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import type { ShowProgressResponse } from '@trakt/api';
+import { isLatestAiredEpisode } from '../../_internal/isLatestAiredEpisode.ts';
 import { mapToPostCredits } from '../../_internal/mapToPostCredits.ts';
 
 const showProgressRequest = (
@@ -66,6 +67,7 @@ function mapShowProgressResponse(
     completed: item.completed,
     remaining: item.aired - item.completed,
     minutesLeft: item.stats?.minutes_left ?? 0,
+    isLatestAired: isLatestAiredEpisode(episode, item.last_episode),
     type: episode?.episode_type as EpisodeType ?? EpisodeUnknownType.unknown,
     genres: [],
     overview: episode?.overview ?? '',

--- a/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
@@ -9,6 +9,7 @@ import type { SortDirection } from '$lib/sections/lists/user/models/SortDirectio
 import { time } from '$lib/utils/timing/time.ts';
 import { type UpNextResponse } from '@trakt/api';
 import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
+import { isLatestAiredEpisode } from '../../_internal/isLatestAiredEpisode.ts';
 import { mapToEpisodeEntry } from '../../_internal/mapToEpisodeEntry.ts';
 import { mapToShowEntry } from '../../_internal/mapToShowEntry.ts';
 import { mapToShowProgress } from '../../_internal/mapToShowProgress.ts';
@@ -33,11 +34,16 @@ export function mapUpNextResponse(item: UpNextResponse): UpNextEntry {
   episode.runtime = isNaN(episode.runtime) ? show.runtime : episode.runtime;
 
   const progress = mapToShowProgress(item.progress);
+  const isLatestAired = isLatestAiredEpisode(
+    item.progress.next_episode,
+    item.progress.last_episode,
+  );
 
   return {
     show,
     ...episode,
     ...progress,
+    isLatestAired,
   };
 }
 

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -40,7 +40,13 @@
     isNaN(props.episode.runtime) ? props.media.runtime : props.episode.runtime,
   );
 
-  const status = $derived(getEpisodeStatus(props.episode.type));
+  const status = $derived(
+    getEpisodeStatus(props.episode.type, {
+      isLatestAired: props.variant === "next"
+        ? props.episode.isLatestAired
+        : undefined,
+    }),
+  );
 
   const { isWatched } = $derived(
     useIsWatched({ type: "episode", media: props.episode, show: props.media }),
@@ -117,6 +123,7 @@
           <EpisodeStatusTag
             i18n={EpisodeIntlProvider}
             episodeType={props.episode.type}
+            isLatestAired={props.episode.isLatestAired}
           />
         {/snippet}
 

--- a/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/useMediaDetails.ts
@@ -1,3 +1,4 @@
+import { EpisodeIntlProvider } from '$lib/components/episode/EpisodeIntlProvider.ts';
 import { GenreIntlProvider } from '$lib/components/summary/GenreIntlProvider.ts';
 import { getLocale, languageTag } from '$lib/features/i18n/index.ts';
 import * as m from '$lib/features/i18n/messages.ts';
@@ -59,6 +60,15 @@ function mediaStatus(media: MediaEntry) {
     values: media.year && media.type === 'movie'
       ? undefined
       : [toTranslatedStatus(media.status)],
+  };
+}
+
+function episodeType(episode: EpisodeEntry): MediaDetail {
+  const label = EpisodeIntlProvider.episodeTypeText(episode.type);
+
+  return {
+    title: m.header_episode_type(),
+    values: label ? [label] : undefined,
   };
 }
 
@@ -231,6 +241,7 @@ export function useMediaDetails(props: MediaDetailsProps): MediaDetail[] {
       episodeAirDate(props.episode),
       networks(props.networks),
       runtime(props.episode),
+      episodeType(props.episode),
       ...mainCredits(props.type, props.crew),
       postCredits(props.episode),
     ];

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloProgressMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloProgressMappedMock.ts
@@ -22,6 +22,7 @@ export const ShowSiloProgressMappedMock: EpisodeProgressEntry = {
   'completed': 11,
   'remaining': 6,
   'minutesLeft': 301,
+  'isLatestAired': true,
   'type': EpisodeStandardType.standard,
   'year': 2024,
   'postCredits': [],

--- a/projects/client/src/mocks/data/sync/mapped/UpNextMappedMock.ts
+++ b/projects/client/src/mocks/data/sync/mapped/UpNextMappedMock.ts
@@ -10,6 +10,7 @@ export const UpNextMappedMock: UpNextEntry[] = [
     'total': 20,
     'minutesLeft': 471,
     'lastWatchedAt': new Date('2025-01-28T12:53:21.000Z'),
+    'isLatestAired': false,
     ...EpisodeSiloMappedMock,
   },
 ];


### PR DESCRIPTION
## Summary

- Mid-season finale/premiere tags on episode cards now drop off once a newer episode has aired. Real series/season finales+premieres still always tag (unchanged).
- The episode details drawer gets a new "Type" row that surfaces the exact variant (Series Finale, Season Finale, Mid-Season Finale, etc.), so the full TMDB-style metadata is one tap away even when the card tag is generic or hidden.

Staleness is derived from the show progress endpoint's \`last_episode\`: an episode is considered the latest aired if it is \`>= last_episode\` by (season, number).

## Test plan

- [ ] Show with a mid-season finale as the user's up-next episode renders the "Finale" tag.
- [ ] Same show, after a newer episode airs, no longer renders the tag.
- [ ] Series/season finales+premieres still render their tag on cards.
- [ ] Upcoming/calendar episodes that are mid-season finales+premieres still render the tag (they are by definition the latest aired or future).
- [ ] Episode details drawer shows a "Type" row with the exact variant for all 6 finale/premiere variants.
- [ ] Standard episodes do not show a "Type" row.

Refs #2146