### PR TITLE
fix(credits): surface additional show creators in summary title

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/mapToMainCredit.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/mapToMainCredit.ts
@@ -16,13 +16,16 @@ type MainCredit = {
 };
 
 function mapToCreator(crew: MediaCrew): MainCredit | null {
-  const creator = crew.creators?.at(0);
-  if (!creator) return null;
+  const [first, ...rest] = crew.creators ?? [];
+  if (!first) return null;
 
   return {
-    text: m.text_created_by({ name: creator.name }),
-    key: creator.key,
+    text: m.text_created_by({ name: first.name }),
+    key: first.key,
     positions: { shows: 'created by' },
+    others: rest.length > 0
+      ? rest.map(({ name, key }) => ({ name, key }))
+      : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

- `mapToCreator` only returned the first creator; movies/episodes already render all directors via `others` (see `mapToDirector`).
- Mirror the director shape so shows with multiple creators render the full list in `SummaryTitle.svelte`.

Closes #1721 (creator side; the director side was already handled).

## Test plan

- [x] Open a show with multiple credited creators - all names render in the summary title, comma separated, each linking to the people page.
- [x] Open a show with a single creator - unchanged.
- [x] Open a show with no creators - line hidden as before.