### PR TITLE
fix(spoiler): respect spoiler setting on episode summary cover

### DIFF
--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -49,7 +49,7 @@
   if available. This approach ensures visual consistency between a show and its
   episodes.
 -->
-<SummaryCover src={episode.cover.url ?? ""} colors={show.colors} type="show" />
+<SummaryCover src={$posterSrc} colors={show.colors} type="show" />
 
 <RenderFor audience="all" device={["mobile", "tablet-sm"]}>
   <EpisodeSummaryV2


### PR DESCRIPTION
## Summary

- `SummaryCover` was using `episode.cover.url` unconditionally, leaking the episode screenshot as the page background even with spoilers hidden.
- Reuse the already spoiler-aware `$posterSrc` store (already used for the inline poster) so the cover falls back to the show cover when needed.

Closes #2211.

## Test plan

- [ ] Disable episode spoilers in settings.
- [ ] Open an unwatched episode - background uses show cover, not episode screenshot.
- [ ] Watch the episode, reload - background switches back to the episode screenshot.
- [ ] Toggle spoilers off again - background falls back to show cover live.