### PR TITLE
fix(drawer): improve actor drawer name overflow and alignment

### DIFF
--- a/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
@@ -13,9 +13,14 @@
   type CastMemberCardProps = {
     castMember: CastMember;
     type: ExtendedMediaType;
+    variant?: "default" | "multi-line";
   };
 
-  const { castMember, type }: CastMemberCardProps = $props();
+  const {
+    castMember,
+    type,
+    variant = "default",
+  }: CastMemberCardProps = $props();
 
   const params = $derived({
     [`${type}s`]: "acting" as const,
@@ -32,21 +37,58 @@
   {/if}
 {/snippet}
 
-<PersonCard>
-  <Link focusable={false} href={UrlBuilder.people(castMember.key, params)}>
-    <CardCover
-      title={castMember.name}
-      src={castMember.headshot.url.thumb}
-      alt={`${m.image_alt_person_headshot({ person: castMember.name })}`}
-      {tag}
-    />
-  </Link>
-  <CardFooter>
-    <p class="trakt-card-title ellipsis">
-      {castMember.name}
-    </p>
-    <p class="trakt-card-subtitle ellipsis">
-      {castMember.characterName}
-    </p>
-  </CardFooter>
-</PersonCard>
+<div class="cast-member-item" data-variant={variant}>
+  <PersonCard>
+    <Link focusable={false} href={UrlBuilder.people(castMember.key, params)}>
+      <CardCover
+        title={castMember.name}
+        src={castMember.headshot.url.thumb}
+        alt={`${m.image_alt_person_headshot({ person: castMember.name })}`}
+        {tag}
+      />
+    </Link>
+    <CardFooter>
+      <p class="trakt-card-title trakt-cast-name" title={castMember.name}>
+        {castMember.name}
+      </p>
+      <p
+        class="trakt-card-subtitle trakt-cast-name"
+        title={castMember.characterName}
+      >
+        {castMember.characterName}
+      </p>
+    </CardFooter>
+  </PersonCard>
+</div>
+
+<style lang="scss">
+  .cast-member-item {
+    display: contents;
+  }
+
+  .trakt-cast-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .cast-member-item[data-variant="multi-line"] {
+    .trakt-cast-name {
+      display: -webkit-box;
+
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      line-clamp: 2;
+
+      overflow: hidden;
+      overflow-wrap: anywhere;
+      text-overflow: unset;
+      white-space: unset;
+      word-break: break-word;
+    }
+
+    :global(.trakt-card-footer) {
+      align-items: flex-start;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/cast/CastDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/cast/CastDrawer.svelte
@@ -34,7 +34,7 @@
         --width-item="var(--width-person-card)"
       >
         {#snippet item(item)}
-          <CastMemberItem castMember={item} {type} />
+          <CastMemberItem castMember={item} {type} variant="multi-line" />
         {/snippet}
       </GridList>
     </div>
@@ -47,6 +47,8 @@
   .cast-drawer-content {
     display: contents;
 
+    --height-cast-footer: var(--ni-56);
+
     --container-width: calc(var(--drawer-size) - 2 * var(--drawer-padding));
     --width-override-card: calc(
       (var(--container-width) - 3 * var(--list-gap)) / 3
@@ -58,7 +60,7 @@
       var(--width-override-card) * var(--card-aspect-ratio)
     );
     --height-override-card: calc(
-      var(--height-override-card-cover) + var(--height-card-footer)
+      var(--height-override-card-cover) + var(--height-cast-footer)
     );
 
     @include for-mobile {
@@ -71,6 +73,7 @@
 
     :global(.trakt-list-items) {
       grid-template-columns: repeat(3, 1fr);
+      justify-items: center;
     }
   }
 </style>


### PR DESCRIPTION
## Summary

- Long actor or character names in the actor drawer were single-line ellipsis only, with no way to read the full text.
- The first column also appeared shifted slightly left because grid items aligned to the column start instead of center.

Changes:
- Add native `title` tooltips on cast names and character names so the full string is reachable on hover everywhere `CastMemberItem` is used.
- Inside the drawer only, allow the name and character lines to wrap to two lines with ellipsis fallback, and bump `--height-card-footer` to give the second line room.
- Add `justify-items: center` to the drawer grid so cards center within their columns.

Closes #2222.

## Test plan

- [ ] Open a show with long cast names (e.g. "Benedict Cumberbatch" / very long character names) and open the actor drawer.
- [ ] Names render on up to two lines, with ellipsis if still too long.
- [ ] Hovering any name or character shows the full text as a native tooltip.
- [ ] First column visually centered with the rest, no longer shifted left.
- [ ] Inline cast list on the summary page (`CastList`) still renders single-line with hover tooltip; layout unchanged.