### PR TITLE
fix(calendar): filter and sort upcoming calendar by effective release date

### DIFF
--- a/projects/client/src/lib/requests/queries/calendars/upcomingMediaQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingMediaQuery.ts
@@ -63,9 +63,9 @@ export const upcomingMediaQuery = defineQuery({
     );
 
     return [...episodes, ...movies]
-      .toSorted((a, b) => {
-        return new Date(a.airDate).getTime() - new Date(b.airDate).getTime();
-      });
+      .toSorted((a, b) =>
+        a.effectiveReleaseDate.getTime() - b.effectiveReleaseDate.getTime()
+      );
   },
   schema: UpcomingMediaSchema.array(),
   ttl: time.minutes(30),

--- a/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
@@ -60,10 +60,7 @@ export function useUpcomingItems(props: UseUpcomingItemsProps) {
   const list = query.pipe(
     map(($query) =>
       ($query.data ?? [])
-        .filter((d) => {
-          const distanceFromNow = d.airDate.getTime() - Date.now();
-          return distanceFromNow > 0;
-        })
+        .filter((d) => d.effectiveReleaseDate.getTime() > Date.now())
         .slice(0, props.limit)
     ),
   );


### PR DESCRIPTION
## Summary

- `useUpcomingItems` filtered out items whose `airDate` (mapped from `first_aired`) was in the past, but for episodes that have already broadcast yet are still upcoming for the user (different regional/effective release), this dropped them from the home calendar widget.
- Switch the filter to `effectiveReleaseDate` so the home calendar reflects when the item actually becomes available to the user.

## Test plan

- [x] Episodes with `first_aired` in the past but `effective_release_date` in the future now appear under the home calendar widget.
- [x] Already-effectively-released items no longer leak into the upcoming widget.
- [x] Movies (which set both `airDate` and `effectiveReleaseDate` to the same value) behave unchanged.