### PR TITLE
fix(summary): always allows where to watch drilldowns

### DIFF
--- a/projects/client/src/lib/components/lists/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/SectionList.svelte
@@ -93,7 +93,7 @@
     <ViewAllButton
       href={drilldown.href}
       label={drilldown.label}
-      disabled={items.length === 0}
+      disabled={items.length === 0 && drilldown.mode !== "always"}
       source={drilldown.source}
       noscroll={drilldown.noscroll}
       replacestate={drilldown.replacestate}

--- a/projects/client/src/lib/components/lists/section-list/models/ListDrilldownLinkProps.ts
+++ b/projects/client/src/lib/components/lists/section-list/models/ListDrilldownLinkProps.ts
@@ -6,4 +6,5 @@ export type ListDrilldownLinkProps = {
   noscroll?: boolean;
   replacestate?: boolean;
   source: DrilldownSource;
+  mode?: 'default' | 'always';
 };

--- a/projects/client/src/lib/sections/lists/where-to-watch/WhereToWatchList.svelte
+++ b/projects/client/src/lib/sections/lists/where-to-watch/WhereToWatchList.svelte
@@ -67,6 +67,7 @@
         ...buildDrawerLink(SummaryDrawers.WhereToWatch),
         source: { id: "where-to-watch" },
         label: m.button_label_view_all_where_to_watch(),
+        mode: "always",
       }}
       {metaInfo}
       {variant}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2291
- If the where to watch data was empty for your country, the view all button would be disabled, since it's done based on the data. However, in this case, a drill down here should be possible since there might be data for other countries.
- For now, I simply made it always clickable, since I don't think it makes sense to query all sources on every summary page. This way the data will still be loaded on demand.
- For unreleased/unaired items this should not be an issue, since the entire list is omitted in those cases.