### PR TITLE
feat(summary): adds support for drilldowns in people summary

### DIFF
--- a/projects/client/src/lib/sections/lists/CreditsList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsList.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
-  import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import * as m from "$lib/features/i18n/messages";
   import type {
@@ -11,9 +9,9 @@
   import type { MediaType } from "$lib/requests/models/MediaType";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
   import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
-  import { toTranslatedPosition } from "$lib/utils/formatting/string/toTranslatedPosition";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CreditMediaItem from "./components/CreditMediaItem.svelte";
+  import CreditsPositionDropdown from "./components/CreditsPositionDropdown.svelte";
   import { useCreditsList } from "./stores/useCreditsList";
   import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
 
@@ -22,9 +20,11 @@
     type: MediaType;
     person: PersonSummary;
     positions?: CrewPositions;
+    drilldownLink?: string;
   };
 
-  const { title, type, person, positions }: CreditsListProps = $props();
+  const { title, type, person, positions, drilldownLink }: CreditsListProps =
+    $props();
 
   const selectedPosition = $derived.by(() => {
     const defaultPosition = person.knownFor ?? "acting";
@@ -45,6 +45,10 @@
   const list = $derived(getPositionList($credits));
   const defaultVariant = $derived(useDefaultCardVariant(type));
 
+  const drilldownHref = $derived(
+    drilldownLink ? `${drilldownLink}?${type}s=${selectedPosition}` : undefined,
+  );
+
   const buildPositionHref = (position: CrewPosition) => {
     const params = positions ?? {};
     return UrlBuilder.people(person.slug, {
@@ -58,6 +62,13 @@
   id={`credits-list-${person.slug}-${type}-${selectedPosition}`}
   items={list}
   {title}
+  drilldown={drilldownHref
+    ? {
+        href: drilldownHref,
+        label: m.button_text_view_all(),
+        source: { id: "credits" },
+      }
+    : undefined}
   --height-list={mediaListHeightResolver($defaultVariant)}
 >
   {#snippet item(entry)}
@@ -65,27 +76,10 @@
   {/snippet}
 
   {#snippet actions()}
-    <DropdownList
-      label={m.dropdown_label_person_position()}
-      preferNative
-      style="flat"
-      variant="primary"
-      color="blue"
-      size="small"
-      disabled={$allPositions.length <= 1}
-    >
-      {toTranslatedPosition(selectedPosition)}
-      {#snippet items()}
-        {#each $allPositions as position (position)}
-          <DropdownItem
-            color="blue"
-            href={buildPositionHref(position)}
-            noscroll
-          >
-            {toTranslatedPosition(position)}
-          </DropdownItem>
-        {/each}
-      {/snippet}
-    </DropdownList>
+    <CreditsPositionDropdown
+      {selectedPosition}
+      allPositions={$allPositions}
+      {buildPositionHref}
+    />
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/lists/CreditsPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsPaginatedList.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import GridList from "$lib/components/lists/grid-list/GridList.svelte";
+  import {
+    crewPositionSchema,
+    type CrewPosition,
+  } from "$lib/requests/models/CrewPosition";
+  import type { MediaCredits } from "$lib/requests/models/MediaCredits";
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import CreditMediaItem from "./components/CreditMediaItem.svelte";
+  import { useCreditsList } from "./stores/useCreditsList";
+
+  type CreditsPaginatedListProps = {
+    slug: string;
+    type: MediaType;
+  };
+
+  const { slug, type }: CreditsPaginatedListProps = $props();
+
+  const selectedPosition = $derived<CrewPosition>(
+    crewPositionSchema.safeParse(
+      page.url.searchParams.get(`${type}s`)?.toLowerCase(),
+    ).data ?? "acting",
+  );
+
+  const { credits } = $derived(useCreditsList({ type, slug }));
+
+  const getPositionList = (mediaCredits?: MediaCredits) => {
+    if (!mediaCredits) return [];
+    return mediaCredits.get(selectedPosition) ?? [];
+  };
+
+  const list = $derived(getPositionList($credits));
+</script>
+
+<GridList
+  id={`credits-list-${slug}-${type}-${selectedPosition}`}
+  items={list}
+  sizing="auto"
+  --width-item="var(--width-summary-card)"
+>
+  {#snippet item(entry)}
+    <CreditMediaItem
+      mediaCredit={entry}
+      source="credits"
+      mode="standalone"
+      style="summary"
+    />
+  {/snippet}
+</GridList>

--- a/projects/client/src/lib/sections/lists/components/CreditMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditMediaItem.svelte
@@ -12,10 +12,12 @@
     mediaCredit,
     source,
     mode,
+    style = "cover",
   }: {
     mediaCredit: MediaCredit;
     source: string;
     mode?: "standalone" | "mixed";
+    style?: "summary" | "cover";
   } = $props();
 
   const toCharacter = (character?: string) => {
@@ -51,7 +53,8 @@
   {source}
   variant="credit"
   {mode}
-  {tag}
+  {style}
+  tag={style === "cover" ? tag : undefined}
   role={mediaCredit.type === "cast"
     ? toCharacter(mediaCredit.character)
     : toJob(mediaCredit.job)}

--- a/projects/client/src/lib/sections/lists/components/CreditsPositionDropdown.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditsPositionDropdown.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import type { CrewPosition } from "$lib/requests/models/CrewPosition";
+  import { toTranslatedPosition } from "$lib/utils/formatting/string/toTranslatedPosition";
+
+  type CreditsPositionDropdownProps = {
+    selectedPosition: CrewPosition;
+    allPositions: CrewPosition[];
+    buildPositionHref: (position: CrewPosition) => string;
+  };
+
+  const {
+    selectedPosition,
+    allPositions,
+    buildPositionHref,
+  }: CreditsPositionDropdownProps = $props();
+</script>
+
+<DropdownList
+  label={m.dropdown_label_person_position()}
+  preferNative
+  style="flat"
+  variant="primary"
+  color="blue"
+  size="small"
+  disabled={allPositions.length <= 1}
+>
+  {toTranslatedPosition(selectedPosition)}
+  {#snippet items()}
+    {#each allPositions as position (position)}
+      <DropdownItem color="blue" href={buildPositionHref(position)} noscroll>
+        {toTranslatedPosition(position)}
+      </DropdownItem>
+    {/each}
+  {/snippet}
+</DropdownList>

--- a/projects/client/src/lib/sections/lists/components/CreditsPositionSelector.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditsPositionSelector.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import {
+    crewPositionSchema,
+    type CrewPosition,
+  } from "$lib/requests/models/CrewPosition";
+  import type { MediaType } from "$lib/requests/models/MediaType";
+  import { useCreditsList } from "../stores/useCreditsList";
+  import CreditsPositionDropdown from "./CreditsPositionDropdown.svelte";
+
+  type CreditsPositionSelectorProps = {
+    slug: string;
+    type: MediaType;
+  };
+
+  const { slug, type }: CreditsPositionSelectorProps = $props();
+
+  const selectedPosition = $derived<CrewPosition>(
+    crewPositionSchema.safeParse(
+      page.url.searchParams.get(`${type}s`)?.toLowerCase(),
+    ).data ?? "acting",
+  );
+
+  const { positions: allPositions } = $derived(useCreditsList({ type, slug }));
+
+  const buildPositionHref = (position: CrewPosition) => {
+    const url = new URL(page.url.toString());
+    url.searchParams.set(`${type}s`, position);
+    return url.toString();
+  };
+</script>
+
+<CreditsPositionDropdown
+  {selectedPosition}
+  allPositions={$allPositions}
+  {buildPositionHref}
+/>

--- a/projects/client/src/lib/sections/lists/history/CreditsHistoryList.svelte
+++ b/projects/client/src/lib/sections/lists/history/CreditsHistoryList.svelte
@@ -6,7 +6,10 @@
   import { mediaListHeightResolver } from "../utils/mediaListHeightResolver";
   import { useHistoryCreditsList } from "./_internal/useHistoryCreditsList";
 
-  const { person }: { person: PersonSummary } = $props();
+  const {
+    person,
+    drilldownLink,
+  }: { person: PersonSummary; drilldownLink?: string } = $props();
 
   const { list, isLoading } = $derived(
     useHistoryCreditsList({ slug: person.slug }),
@@ -17,6 +20,13 @@
   id={`credits-history-list-${person.slug}`}
   items={$list}
   title={m.list_title_from_my_history()}
+  drilldown={drilldownLink
+    ? {
+        href: drilldownLink,
+        label: m.button_text_view_all(),
+        source: { id: "credits-history" },
+      }
+    : undefined}
   --height-list={mediaListHeightResolver("portrait")}
 >
   {#snippet item(entry)}

--- a/projects/client/src/lib/sections/lists/history/CreditsHistoryPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/CreditsHistoryPaginatedList.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
+  import GridList from "$lib/components/lists/grid-list/GridList.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import CreditMediaItem from "../components/CreditMediaItem.svelte";
+  import { useHistoryCreditsList } from "./_internal/useHistoryCreditsList";
+
+  type CreditsHistoryPaginatedListProps = {
+    slug: string;
+    name: string;
+  };
+
+  const { slug, name }: CreditsHistoryPaginatedListProps = $props();
+
+  const { list, isLoading } = $derived(useHistoryCreditsList({ slug }));
+</script>
+
+<GridList
+  id={`credits-history-list-${slug}`}
+  items={$list}
+  sizing="auto"
+  --width-item="var(--width-summary-card)"
+>
+  {#snippet item(entry)}
+    <CreditMediaItem
+      mediaCredit={entry}
+      source="credits-history"
+      mode="mixed"
+      style="summary"
+    />
+  {/snippet}
+
+  {#snippet empty()}
+    {#if $isLoading}
+      <LoadingIndicator />
+    {:else}
+      <p class="secondary">
+        {m.list_placeholder_from_my_history({ name })}
+      </p>
+    {/if}
+  {/snippet}
+</GridList>

--- a/projects/client/src/lib/sections/lists/history/_internal/useHistoryCreditsList.ts
+++ b/projects/client/src/lib/sections/lists/history/_internal/useHistoryCreditsList.ts
@@ -78,9 +78,10 @@ export function useHistoryCreditsList(
 
   return {
     list: list$,
-    isLoading: combineLatest([movies$, shows$]).pipe(
+    isLoading: combineLatest([movies$, shows$, history$]).pipe(
       map(
-        ([movies, shows]) => toLoadingState(movies) || toLoadingState(shows),
+        ([movies, shows, history]) =>
+          toLoadingState(movies) || toLoadingState(shows) || !history,
       ),
     ),
   };

--- a/projects/client/src/lib/sections/summary/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/PeopleSummary.svelte
@@ -3,6 +3,7 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { CrewPositions } from "$lib/requests/models/CrewPosition";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CreditsList from "../lists/CreditsList.svelte";
   import CreditsHistoryList from "../lists/history/CreditsHistoryList.svelte";
   import PeopleSummary from "./components/people/PeopleSummary.svelte";
@@ -30,11 +31,16 @@
   type="movie"
   {person}
   {positions}
+  drilldownLink={UrlBuilder.credits.movies(person.slug)}
 />
 <CreditsList
   title={m.list_title_show_credits()}
   type="show"
   {person}
   {positions}
+  drilldownLink={UrlBuilder.credits.shows(person.slug)}
 />
-<CreditsHistoryList {person} />
+<CreditsHistoryList
+  {person}
+  drilldownLink={UrlBuilder.credits.history(person.slug)}
+/>

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -199,6 +199,11 @@ export const UrlBuilder = {
     `/people/${id}${buildParamString(positions ?? {})}`,
   episode: (id: string, season: number, episode: number) =>
     `/shows/${id}/seasons/${season}/episodes/${episode}`,
+  credits: {
+    movies: (slug: string) => `/people/${slug}/movies`,
+    shows: (slug: string) => `/people/${slug}/shows`,
+    history: (slug: string) => `/people/${slug}/history`,
+  },
   related: {
     movie: (slug: string) => `/movies/${slug}/related`,
     show: (slug: string) => `/shows/${slug}/related`,

--- a/projects/client/src/routes/people/[slug]/history/+page.svelte
+++ b/projects/client/src/routes/people/[slug]/history/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import CreditsHistoryPaginatedList from "$lib/sections/lists/history/CreditsHistoryPaginatedList.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
+  import { usePerson } from "../usePerson";
+  import type { PageProps } from "./$types";
+
+  const { params }: PageProps = $props();
+
+  const { person, isLoading } = $derived(usePerson(params.slug));
+
+  const title = $derived.by(() => {
+    if ($isLoading || !$person) return m.list_title_from_my_history();
+
+    return `${$person.name} - ${m.list_title_from_my_history()}`;
+  });
+</script>
+
+<TraktPage audience="authenticated" {title} image={DEFAULT_SHARE_COVER}>
+  <NavbarStateSetter
+    header={{
+      title,
+    }}
+  />
+
+  {#if $isLoading || !$person}
+    <LoadingIndicator />
+  {:else}
+    <CreditsHistoryPaginatedList slug={params.slug} name={$person.name} />
+  {/if}
+</TraktPage>

--- a/projects/client/src/routes/people/[slug]/movies/+page.svelte
+++ b/projects/client/src/routes/people/[slug]/movies/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import CreditsPaginatedList from "$lib/sections/lists/CreditsPaginatedList.svelte";
+  import CreditsPositionSelector from "$lib/sections/lists/components/CreditsPositionSelector.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
+  import { usePerson } from "../usePerson";
+  import type { PageProps } from "./$types";
+
+  const { params }: PageProps = $props();
+
+  const { person, isLoading } = $derived(usePerson(params.slug));
+
+  const title = $derived.by(() => {
+    if ($isLoading || !$person) return m.list_title_movie_credits();
+
+    return `${$person.name} - ${m.list_title_movie_credits()}`;
+  });
+</script>
+
+{#snippet headerActions()}
+  <CreditsPositionSelector slug={params.slug} type="movie" />
+{/snippet}
+
+<TraktPage audience="all" {title} image={DEFAULT_SHARE_COVER}>
+  <NavbarStateSetter
+    header={{
+      title,
+      actions: headerActions,
+    }}
+  />
+
+  <CreditsPaginatedList slug={params.slug} type="movie" />
+</TraktPage>

--- a/projects/client/src/routes/people/[slug]/shows/+page.svelte
+++ b/projects/client/src/routes/people/[slug]/shows/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import CreditsPaginatedList from "$lib/sections/lists/CreditsPaginatedList.svelte";
+  import CreditsPositionSelector from "$lib/sections/lists/components/CreditsPositionSelector.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
+  import { usePerson } from "../usePerson";
+  import type { PageProps } from "./$types";
+
+  const { params }: PageProps = $props();
+
+  const { person, isLoading } = $derived(usePerson(params.slug));
+
+  const title = $derived.by(() => {
+    if ($isLoading || !$person) return m.list_title_show_credits();
+
+    return `${$person.name} - ${m.list_title_show_credits()}`;
+  });
+</script>
+
+{#snippet headerActions()}
+  <CreditsPositionSelector slug={params.slug} type="show" />
+{/snippet}
+
+<TraktPage audience="all" {title} image={DEFAULT_SHARE_COVER}>
+  <NavbarStateSetter
+    header={{
+      title,
+      actions: headerActions,
+    }}
+  />
+
+  <CreditsPaginatedList slug={params.slug} type="show" />
+</TraktPage>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2302
- Adds drilldowns to the lists in the people summary pages.

## 👀 Example 👀

https://github.com/user-attachments/assets/c0547af9-0b7c-4170-9a49-e76ef556562b

