### PR TITLE
feat(summary): adds seasons dropdown to drawer

### DIFF
--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -43,29 +43,36 @@
     useIsWatched({ type: "season", media: season, show: media }),
   );
 
-  const scrollToItem = (element: HTMLElement) => {
-    if (!isCurrentSeason || variant === "list-item") return;
+  const scrollToItem = (element: HTMLElement, active: boolean) => {
+    const doScroll = (active: boolean, behavior: "smooth" | "instant") => {
+      if (!active || variant === "list-item") return;
 
-    const parent = element.parentElement;
-    if (!parent) {
-      return;
-    }
+      const parent = element.parentElement;
+      if (!parent) return;
 
-    const parentRight = parent.scrollLeft + parent.clientWidth;
-    const elementLeft = element.offsetLeft;
-    const elementRight = elementLeft + element.offsetWidth;
-    const isOutOfView = elementRight > parentRight;
+      const parentRight = parent.scrollLeft + parent.clientWidth;
+      const elementLeft = element.offsetLeft;
+      const elementRight = elementLeft + element.offsetWidth;
+      const isOutOfView =
+        elementRight > parentRight || elementLeft < parent.scrollLeft;
 
-    if (!isOutOfView) {
-      return;
-    }
+      if (!isOutOfView) return;
 
-    requestAnimationFrame(() => {
-      parent.scrollTo({
-        left: elementLeft - scrollOffset,
-        behavior: "instant",
+      requestAnimationFrame(() => {
+        parent.scrollTo({
+          left: elementLeft - scrollOffset,
+          behavior,
+        });
       });
-    });
+    };
+
+    doScroll(active, "instant");
+
+    return {
+      update: (active: boolean) => {
+        doScroll(active, "smooth");
+      },
+    };
   };
 </script>
 
@@ -77,7 +84,7 @@
   class="trakt-season-item"
   class:is-current-season={isCurrentSeason}
   data-variant={variant}
-  use:scrollToItem
+  use:scrollToItem={isCurrentSeason}
 >
   {#if style === "cover"}
     {#snippet tag()}

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonDropdown.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonDropdown.svelte
@@ -9,9 +9,19 @@
     showSlug: string;
     seasons: Season[];
     currentSeason: number;
+    urlBuilder?: (seasonNumber: number) => string;
   };
 
-  const { showSlug, seasons, currentSeason }: SeasonDropdownProps = $props();
+  const { showSlug, seasons, currentSeason, urlBuilder }: SeasonDropdownProps =
+    $props();
+
+  const buildUrl = $derived(
+    urlBuilder ?? ((n: number) => UrlBuilder.show(showSlug, { season: n })),
+  );
+
+  const seasonText = (seasonNumber: number) => {
+    return seasonNumber === 0 ? m.text_season_specials() : `${seasonNumber}`;
+  };
 </script>
 
 <DropdownList
@@ -23,15 +33,11 @@
   size="small"
   disabled={seasons.length < 2}
 >
-  {currentSeason}
+  {seasonText(currentSeason)}
   {#snippet items()}
     {#each seasons as season (season.id)}
-      <DropdownItem
-        color="blue"
-        href={UrlBuilder.show(showSlug, { season: season.number })}
-        noscroll
-      >
-        {season.number}
+      <DropdownItem color="blue" href={buildUrl(season.number)} noscroll>
+        {seasonText(season.number)}
       </DropdownItem>
     {/each}
   {/snippet}

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
@@ -3,11 +3,13 @@
   import Drawer from "$lib/components/drawer/Drawer.svelte";
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
+  import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { Season } from "$lib/requests/models/Season";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import SeasonItem from "$lib/sections/lists/components/SeasonItem.svelte";
+  import SeasonDropdown from "$lib/sections/lists/season/_internal/SeasonDropdown.svelte";
   import SeasonEpisodeItem from "$lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte";
   import SeasonPopupMenu from "$lib/sections/lists/season/_internal/SeasonPopupMenu.svelte";
   import { useShowWatchedEpisodes } from "$lib/sections/lists/season/_internal/useShowWatchedEpisodes";
@@ -58,6 +60,13 @@
 </script>
 
 {#snippet badge()}
+  <SeasonDropdown
+    showSlug={show.slug}
+    {seasons}
+    {currentSeason}
+    urlBuilder={buildSeasonLink}
+  />
+
   <SeasonPopupMenu
     title={seasonLabel(currentSeason)}
     episodes={$episodes}
@@ -72,16 +81,16 @@
   onOpened={() => (isOpen = true)}
   title={m.list_title_seasons()}
   size="large"
-  metaInfo={seasonLabel(currentSeason)}
 >
   {#if isOpen}
     <div class="seasons-drawer-content" transition:fade={{ duration: 150 }}>
       {#if seasons.length > 1}
         <div class="seasons-section">
-          <GridList
-            id={`seasons-list-${show.slug}`}
+          <SectionList
+            id={`season-poster-list-${show.slug}`}
             items={seasons}
-            --width-item="var(--width-portrait-card)"
+            title={null}
+            variant="inline"
           >
             {#snippet item(season)}
               <SeasonItem
@@ -91,7 +100,7 @@
                 urlBuilder={() => buildSeasonLink(season.number)}
               />
             {/snippet}
-          </GridList>
+          </SectionList>
         </div>
       {/if}
 
@@ -137,7 +146,7 @@
   .seasons-drawer-content {
     display: flex;
     flex-direction: column;
-    gap: var(--gap-xl);
+    gap: var(--gap-m);
 
     padding-bottom: var(--ni-8);
 
@@ -150,7 +159,7 @@
     --column-count: 4;
 
     --container-width: calc(
-      var(--drawer-size) - 2 * var(--drawer-padding) - var(--list-gap) * 2
+      var(--drawer-size) - 2 * var(--drawer-padding) - var(--list-gap)
     );
     --width-override-card: calc(
       (var(--container-width) - (var(--column-count) - 1) * var(--list-gap)) /
@@ -161,13 +170,15 @@
       var(--height-override-card-cover) + var(--height-card-footer-sm)
     );
 
-    @include for-mobile {
-      --container-width: calc(100dvw - 2 * var(--drawer-padding));
-    }
+    --height-list: calc(
+      var(--height-override-card) + var(--layout-scrollbar-width)
+    );
 
-    :global(.trakt-list-items) {
-      grid-row-gap: var(--gap-s);
-      grid-template-columns: repeat(var(--column-count), 1fr);
+    @include for-mobile {
+      --column-count: 3;
+      --container-width: calc(
+        100dvw - 2 * var(--drawer-padding) - var(--list-gap)
+      );
     }
   }
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2299
- Drilling down on episodes no longer shows a huge grid of season posters.
  - It is now a horizontal list and has a dropdown to choose the season (or you can scroll).

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/c9c722cb-2c71-44db-b205-085c84b067e5


After:

https://github.com/user-attachments/assets/eef4b0fc-a44c-4f9f-98c1-c526cd978124

