### PR TITLE
fix: Uses unified endpoint for activity history

### DIFF
--- a/projects/client/src/lib/requests/queries/users/activityHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/activityHistoryQuery.ts
@@ -1,6 +1,6 @@
 import { defineInfiniteQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
-import { type ApiParams } from '$lib/requests/api.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
 import { time } from '$lib/utils/timing/time.ts';
@@ -9,13 +9,11 @@ import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDepe
 import type { FilterParams } from '../../models/FilterParams.ts';
 import type { PaginationParams } from '../../models/PaginationParams.ts';
 import {
-  episodeActivityHistoryRequest,
   EpisodeActivityHistorySchema,
   mapToEpisodeActivityHistory,
 } from './episodeActivityHistoryQuery.ts';
 import {
   mapToMovieActivityHistory,
-  movieActivityHistoryRequest,
   MovieActivityHistorySchema,
 } from './movieActivityHistoryQuery.ts';
 
@@ -35,8 +33,27 @@ const HistorySchema = z.discriminatedUnion('type', [
 ]);
 export type ActivityHistory = z.infer<typeof HistorySchema>;
 
+export function activityHistoryRequest(
+  { fetch, slug, startDate, endDate, limit, page, filter }:
+    ActivityHistoryParams,
+) {
+  const queryParams = {
+    extended: 'full,images' as const,
+    start_at: startDate?.toISOString(),
+    end_at: endDate?.toISOString(),
+    limit,
+    page,
+    ...filter,
+  };
+
+  return api({ fetch }).users.history.all({
+    params: { id: slug },
+    query: queryParams,
+  });
+}
+
 export const activityHistoryQuery = defineInfiniteQuery({
-  key: 'activityHistory',
+  key: 'activityHistory:v2',
   invalidations: [
     InvalidateAction.MarkAsWatched('episode'),
     InvalidateAction.MarkAsWatched('movie'),
@@ -50,24 +67,15 @@ export const activityHistoryQuery = defineInfiniteQuery({
     params.slug,
     ...getGlobalFilterDependencies(params.filter),
   ],
-  request: (params) =>
-    Promise.all([
-      movieActivityHistoryRequest(params),
-      episodeActivityHistoryRequest(params),
-    ]),
-  mapper: ([movieResponse, episodeResponse]) => {
-    const movies = movieResponse.body.map(mapToMovieActivityHistory);
-    const episodes = episodeResponse.body.map(mapToEpisodeActivityHistory);
-
-    const watched = [...movies, ...episodes].toSorted((a, b) =>
-      b.watchedAt.getTime() - a.watchedAt.getTime()
-    );
-
-    return {
-      entries: watched,
-      page: extractPageMeta(episodeResponse.headers),
-    };
-  },
+  request: activityHistoryRequest,
+  mapper: (response) => ({
+    entries: response.body.map((item) =>
+      item.type === 'movie'
+        ? mapToMovieActivityHistory(item)
+        : mapToEpisodeActivityHistory(item)
+    ),
+    page: extractPageMeta(response.headers),
+  }),
   schema: PaginatableSchemaFactory(HistorySchema),
   ttl: time.hours(1),
 });

--- a/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
@@ -1,4 +1,5 @@
 import type { InfiniteQuery } from '$lib/features/query/models/InfiniteQuery.ts';
+import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
 import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
 import { activityHistoryQuery } from '$lib/requests/queries/users/activityHistoryQuery.ts';
 import {
@@ -16,42 +17,59 @@ import { map } from 'rxjs';
 import { mapToCalendarPeriods } from './_internal/mapToCalendarPeriods.ts';
 import type { HistoryEntry } from './models/HistoryEntry.ts';
 
-export type RecentlyWatchedType = 'movie' | 'show' | 'episode' | 'media';
+export type RecentlyWatchedType = ExtendedMediaType | 'media';
 
-type RecentlyWatchedListStoreProps = {
-  type: RecentlyWatchedType;
-  limit?: number;
-  slug?: string;
+type SpecificHistory = {
+  type: ExtendedMediaType;
   id?: number;
-  page?: number;
-} & FilterParams;
+};
+
+type MediaHistory = {
+  type: 'media';
+};
+
+type RecentlyWatchedListStoreProps =
+  & {
+    limit?: number;
+    slug?: string;
+    page?: number;
+  }
+  & FilterParams
+  & (SpecificHistory | MediaHistory);
 
 function typeToQuery(
-  { type, id, slug, page, limit, filter }: RecentlyWatchedListStoreProps,
+  props: RecentlyWatchedListStoreProps,
 ) {
   const params = {
-    limit: limit ?? DEFAULT_PAGE_SIZE,
-    slug: slug ?? 'me',
-    id,
-    page: page ?? 1,
-    filter,
+    limit: props.limit ?? DEFAULT_PAGE_SIZE,
+    slug: props.slug ?? 'me',
+    page: props.page ?? 1,
+    filter: props.filter,
   };
 
-  switch (type) {
+  switch (props.type) {
     case 'movie':
-      return movieActivityHistoryQuery(params) as InfiniteQuery<
+      return movieActivityHistoryQuery({
+        ...params,
+        id: props.id,
+      }) as InfiniteQuery<
         HistoryEntry
       >;
     case 'episode':
-      return episodeActivityHistoryQuery(params) as InfiniteQuery<
+      return episodeActivityHistoryQuery({
+        ...params,
+        id: props.id,
+      }) as InfiniteQuery<
         HistoryEntry
       >;
     case 'show':
-      return showActivityHistoryQuery(params) as InfiniteQuery<
+      return showActivityHistoryQuery({
+        ...params,
+        id: props.id,
+      }) as InfiniteQuery<
         HistoryEntry
       >;
     default:
-      // FIXME: switch to all endpoint
       return activityHistoryQuery(params) as InfiniteQuery<
         HistoryEntry
       >;

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/HistorySlotDrawer.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/HistorySlotDrawer.svelte
@@ -98,7 +98,7 @@
 
       <ShadowScroller>
         <PaginatedList
-          type="media"
+          type={"media" as const}
           target="parent"
           useList={useRecentlyWatchedList}
         >


### PR DESCRIPTION
## 🎶 Notes 🎶
- Refactors `activityHistoryQuery` to use a single unified endpoint for fetching all user activity history (movies and episodes).
- Updates the query mapper to correctly process and discriminate between different media types from the unified response.
- Modifies `useRecentlyWatchedList` to utilize the new unified activity history query when requesting a general 'media' type.
- Ensures that specific media type queries (`movie`, `episode`, `show`) within `useRecentlyWatchedList` correctly pass their respective IDs.
