### PR TITLE
feat(dialogs): redesign confirmation popup

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6981,6 +6981,98 @@
     "match_label_different_universe": {
       "default": "Different universe",
       "description": "Tonal label for the lowest match band (<25%). Anchor of the six-tier ladder. Reads as 'no shared world' without being harsh."
+    },
+    "confirmation_title_mark_as_watched": {
+      "default": "Mark as watched?",
+      "description": "Title of the confirmation dialog shown before marking a movie, show, or episode as watched."
+    },
+    "confirmation_title_remove_from_watched": {
+      "default": "Remove from history?",
+      "description": "Title of the confirmation dialog shown before removing a movie, show, or episode from the user's watched history."
+    },
+    "confirmation_title_remove_play": {
+      "default": "Remove play?",
+      "description": "Title of the confirmation dialog shown before removing a single play from the user's watched history."
+    },
+    "confirmation_title_drop_show": {
+      "default": "Drop show?",
+      "description": "Title of the confirmation dialog shown before dropping a show from the user's tracked shows."
+    },
+    "confirmation_title_drop_movie": {
+      "default": "Drop movie?",
+      "description": "Title of the confirmation dialog shown before dropping a movie from the user's tracked movies."
+    },
+    "confirmation_title_restore_show": {
+      "default": "Restore show?",
+      "description": "Title of the confirmation dialog shown before restoring a previously dropped show back to tracked."
+    },
+    "confirmation_title_delete_list": {
+      "default": "Delete list?",
+      "description": "Title of the confirmation dialog shown before permanently deleting a user's custom list."
+    },
+    "confirmation_title_remove_favorite": {
+      "default": "Remove favorite?",
+      "description": "Title of the confirmation dialog shown before removing a movie or show from the user's favorites."
+    },
+    "confirmation_title_remove_from_watchlist": {
+      "default": "Remove from watchlist?",
+      "description": "Title of the confirmation dialog shown before removing a movie, show, or episode from the user's watchlist."
+    },
+    "confirmation_title_remove_from_list": {
+      "default": "Remove from list?",
+      "description": "Title of the confirmation dialog shown before removing an item from a user's custom list."
+    },
+    "confirmation_title_unfollow_user": {
+      "default": "Unfollow user?",
+      "description": "Title of the confirmation dialog shown before unfollowing another user."
+    },
+    "confirmation_title_block_user": {
+      "default": "Block user?",
+      "description": "Title of the confirmation dialog shown before blocking another user."
+    },
+    "confirmation_title_stop_checkin": {
+      "default": "Stop check-in?",
+      "description": "Title of the confirmation dialog shown before stopping an active check-in."
+    },
+    "confirmation_title_delete_comment": {
+      "default": "Delete review?",
+      "description": "Title of the confirmation dialog shown before permanently deleting the user's review or comment."
+    },
+    "confirmation_title_delete_note": {
+      "default": "Delete note?",
+      "description": "Title of the confirmation dialog shown before permanently deleting one of the user's notes."
+    },
+    "confirmation_title_suppress_ratings_toast": {
+      "default": "Stop asking?",
+      "description": "Title of the confirmation dialog shown before suppressing future ratings prompts."
+    },
+    "confirmation_title_log_out": {
+      "default": "Log out?",
+      "description": "Title of the confirmation dialog shown before logging the user out of their account."
+    },
+    "confirmation_title_reset_filters": {
+      "default": "Reset filters?",
+      "description": "Title of the confirmation dialog shown before resetting all active list filters."
+    },
+    "confirmation_title_cancel_vip": {
+      "default": "Cancel VIP?",
+      "description": "Title of the confirmation dialog shown before cancelling the user's VIP subscription."
+    },
+    "confirmation_title_cancel_import": {
+      "default": "Cancel import?",
+      "description": "Title of the confirmation dialog shown before cancelling an in-progress import."
+    },
+    "confirmation_title_stop_clear": {
+      "default": "Stop clearing?",
+      "description": "Title of the confirmation dialog shown before stopping an in-progress clear-data operation."
+    },
+    "confirmation_title_clear_data": {
+      "default": "Clear data?",
+      "description": "Title of the confirmation dialog shown before clearing the user's data for a specific source (watchlist, ratings, etc.)."
+    },
+    "confirmation_title_hide_recommendation": {
+      "default": "Hide recommendation?",
+      "description": "Title of the confirmation dialog shown before hiding a recommendation."
     }
   }
 }

--- a/projects/client/src/lib/components/dialogs/ConfirmationDialog.svelte
+++ b/projects/client/src/lib/components/dialogs/ConfirmationDialog.svelte
@@ -6,53 +6,105 @@
   import Modal from "./Modal.svelte";
 
   const {
+    title,
     message,
     detail,
     buttonText,
     onAction,
     operation,
   }: {
+    title: string;
     message: string;
     detail?: string;
     buttonText: string;
     operation: ConfirmationOperation;
     onAction: (action: ConfirmationAction) => void;
   } = $props();
+
+  const isDestructive = $derived(operation === "destructive");
+  const cancelText = $derived(m.button_text_cancel());
 </script>
 
 <Modal onClose={() => onAction("cancel")}>
   <div class="trakt-confirmation-content">
-    <p>{message}</p>
+    <h2 class="title bold">{title}</h2>
+    <p class="trakt-confirmation-message secondary">{message}</p>
     {#if detail}
-      <p>{detail}</p>
+      <p class="trakt-confirmation-message secondary">{detail}</p>
     {/if}
   </div>
 
   {#snippet footer()}
-    <Button
-      size="small"
-      color="default"
-      label={m.button_text_cancel()}
-      onclick={() => onAction("cancel")}
-    >
-      {m.button_text_cancel()}
-    </Button>
-    <Button
-      size="small"
-      variant={operation === "destructive" ? "secondary" : "primary"}
-      color={operation === "destructive" ? "red" : "purple"}
-      label={buttonText}
-      onclick={() => onAction("confirm")}
-    >
-      {buttonText}
-    </Button>
+    <div class="trakt-confirmation-actions" data-operation={operation}>
+      <Button
+        size="small"
+        style="ghost"
+        color="custom"
+        label={cancelText}
+        onclick={() => onAction("cancel")}
+      >
+        {cancelText}
+      </Button>
+      <Button
+        size="small"
+        style={isDestructive ? "flat" : "ghost"}
+        variant="primary"
+        color="custom"
+        label={buttonText}
+        onclick={() => onAction("confirm")}
+      >
+        {buttonText}
+      </Button>
+    </div>
   {/snippet}
 </Modal>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .trakt-confirmation-content {
     display: flex;
     flex-direction: column;
-    gap: var(--gap-m);
+    gap: var(--ni-8);
+  }
+
+  .trakt-confirmation-actions {
+    display: inline-grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--ni-8);
+  }
+
+  .trakt-confirmation-actions :global(.trakt-button) {
+    padding-inline: var(--ni-10);
+    justify-content: center;
+  }
+
+  /* FIXME: make this design leading for the new button styles */
+  .trakt-confirmation-actions :global(.trakt-button[data-style="ghost"]) {
+    transform: none;
+    margin: 0;
+
+    color: var(--color-text-secondary);
+    background: var(--color-confirmation-cancel-background);
+
+    border-radius: calc(var(--border-radius-m) * 0.8);
+  }
+
+  .trakt-confirmation-actions
+    :global(.trakt-button[data-style="ghost"]:hover:not([disabled])),
+  .trakt-confirmation-actions
+    :global(.trakt-button[data-style="ghost"]:focus-visible:not([disabled])) {
+    background: var(--color-confirmation-cancel-background-hover);
+    color: var(--color-text-primary);
+  }
+
+  .trakt-confirmation-actions
+    :global(.trakt-button[data-style="ghost"]:active:not([disabled])) {
+    transform: scale(0.97);
+  }
+
+  .trakt-confirmation-actions[data-operation="destructive"] {
+    --color-background-custom: var(--color-confirmation-destructive-background);
+    --color-foreground-custom: var(--color-confirmation-destructive-foreground);
   }
 </style>

--- a/projects/client/src/lib/components/dialogs/Modal.svelte
+++ b/projects/client/src/lib/components/dialogs/Modal.svelte
@@ -59,7 +59,8 @@
   :global(.trakt-modal) {
     padding: var(--ni-24);
     border-radius: var(--border-radius-l);
-    border: none;
+    border: var(--border-thickness-xxs) solid
+      color-mix(in srgb, var(--color-text-primary) 8%, transparent);
     outline: none;
     background-color: var(--color-modal-background);
     color: var(--color-text-primary);
@@ -96,12 +97,12 @@
   :global(.trakt-modal-footer) {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
+    gap: var(--ni-8);
 
     @include for-mobile {
       flex-direction: column-reverse;
       align-items: stretch;
-      gap: var(--ni-8);
     }
   }
 </style>

--- a/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
+++ b/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
@@ -11,6 +11,7 @@
 
 {#if $activeConfirmation?.message}
   <ConfirmationDialog
+    title={$activeConfirmation.title}
     message={$activeConfirmation.message}
     detail={$activeConfirmation.detail}
     buttonText={$activeConfirmation.buttonText}

--- a/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
@@ -4,6 +4,7 @@ import type { ConfirmationOperation } from '../models/ConfirmationOperation.ts';
 export type ConfirmationRequest = {
   onConfirm: () => void;
   onCancel?: () => void;
+  title: string;
   message: string | Nil;
   detail?: string;
   buttonText: string;

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
@@ -5,6 +5,7 @@ import { ConfirmationType } from '../models/ConfirmationType.ts';
 import { getWarningMessage } from './getWarningMessage.ts';
 
 type Confirmation = {
+  title: string;
   message: string | Nil;
   detail?: string;
   buttonText: string;
@@ -17,60 +18,70 @@ export function mapToConfirmation<T extends ConfirmationType>(
   switch (props.type) {
     case ConfirmationType.MarkAsWatched:
       return {
+        title: m.confirmation_title_mark_as_watched(),
         buttonText: m.button_text_mark_as_watched(),
         message: getWarningMessage(props.title, props.target),
         operation: 'destructive',
       };
     case ConfirmationType.RemoveFromWatched:
       return {
+        title: m.confirmation_title_remove_from_watched(),
         buttonText: m.button_text_remove_from_history(),
         message: m.warning_prompt_remove_from_watched({ title: props.title }),
         operation: 'destructive',
       };
     case ConfirmationType.RemoveFromHistory:
       return {
+        title: m.confirmation_title_remove_play(),
         buttonText: m.button_text_remove_from_history(),
         message: m.warning_prompt_remove_single_watched({ title: props.title }),
         operation: 'destructive',
       };
     case ConfirmationType.DropShow:
       return {
+        title: m.confirmation_title_drop_show(),
         buttonText: m.button_text_drop_show(),
         message: m.warning_prompt_drop_show({ title: props.title }),
         operation: 'destructive',
       };
     case ConfirmationType.DropMovie:
       return {
+        title: m.confirmation_title_drop_movie(),
         buttonText: m.button_text_drop_movie(),
         message: m.warning_prompt_drop_movie({ title: props.title }),
         operation: 'destructive',
       };
     case ConfirmationType.RestoreShow:
       return {
+        title: m.confirmation_title_restore_show(),
         buttonText: m.button_text_restore_show(),
         message: m.warning_prompt_restore_show({ title: props.title }),
         operation: 'affirmative',
       };
     case ConfirmationType.DeleteList:
       return {
+        title: m.confirmation_title_delete_list(),
         buttonText: m.button_text_delete_list(),
         message: m.warning_prompt_delete_list({ name: props.name }),
         operation: 'destructive',
       };
     case ConfirmationType.RemoveFavorite:
       return {
+        title: m.confirmation_title_remove_favorite(),
         buttonText: m.button_text_remove_from_favorites(),
         message: m.warning_prompt_remove_from_favorites({ title: props.title }),
         operation: 'destructive',
       };
     case ConfirmationType.RemoveFromWatchList:
       return {
+        title: m.confirmation_title_remove_from_watchlist(),
         buttonText: m.button_text_remove_from_watchlist(),
         message: m.warning_prompt_remove_from_watchlist({ title: props.title }),
         operation: 'destructive',
       };
     case ConfirmationType.RemoveFromList:
       return {
+        title: m.confirmation_title_remove_from_list(),
         buttonText: m.button_text_remove_from_list(),
         message: m.warning_prompt_remove_from_personal_list({
           list: props.name,
@@ -80,12 +91,14 @@ export function mapToConfirmation<T extends ConfirmationType>(
       };
     case ConfirmationType.UnfollowUser:
       return {
+        title: m.confirmation_title_unfollow_user(),
         buttonText: m.button_text_unfollow(),
         message: m.warning_prompt_unfollow_user({ username: props.username }),
         operation: 'destructive',
       };
     case ConfirmationType.BlockUser:
       return {
+        title: m.confirmation_title_block_user(),
         buttonText: m.button_text_block(),
         message: m.warning_prompt_block_user({ username: props.username }),
         detail: m.warning_prompt_block_user_detail(),
@@ -93,66 +106,77 @@ export function mapToConfirmation<T extends ConfirmationType>(
       };
     case ConfirmationType.StopCheckin:
       return {
+        title: m.confirmation_title_stop_checkin(),
         buttonText: m.button_text_stop_check_in(),
         message: m.warning_prompt_stop_checkin({ title: props.title }),
         operation: 'destructive',
       };
     case ConfirmationType.DeleteComment:
       return {
+        title: m.confirmation_title_delete_comment(),
         buttonText: m.button_text_delete_comment(),
         message: m.warning_prompt_delete_comment(),
         operation: 'destructive',
       };
     case ConfirmationType.DeleteNote:
       return {
+        title: m.confirmation_title_delete_note(),
         buttonText: m.button_text_delete_note(),
         message: m.warning_prompt_delete_note(),
         operation: 'destructive',
       };
     case ConfirmationType.SuppressRatingsToast:
       return {
+        title: m.confirmation_title_suppress_ratings_toast(),
         buttonText: m.button_text_stop_asking(),
         message: m.warning_prompt_suppress_ratings_toast(),
         operation: 'destructive',
       };
     case ConfirmationType.Logout:
       return {
+        title: m.confirmation_title_log_out(),
         buttonText: m.button_text_logout(),
         message: m.warning_prompt_log_out(),
         operation: 'destructive',
       };
     case ConfirmationType.SimpleFilters:
       return {
+        title: m.confirmation_title_reset_filters(),
         buttonText: m.button_text_reset_all_filters(),
         message: m.warning_prompt_simple_filters(),
         operation: 'destructive',
       };
     case ConfirmationType.CancelVip:
       return {
+        title: m.confirmation_title_cancel_vip(),
         buttonText: m.button_text_cancel_vip(),
         message: m.warning_prompt_cancel_vip(),
         operation: 'destructive',
       };
     case ConfirmationType.CancelImport:
       return {
+        title: m.confirmation_title_cancel_import(),
         buttonText: m.button_text_cancel_import(),
         message: m.warning_prompt_cancel_import(),
         operation: 'destructive',
       };
     case ConfirmationType.CancelClear:
       return {
+        title: m.confirmation_title_stop_clear(),
         buttonText: m.button_text_stop_clear(),
         message: m.warning_prompt_cancel_clear(),
         operation: 'destructive',
       };
     case ConfirmationType.ClearData:
       return {
+        title: m.confirmation_title_clear_data(),
         buttonText: m.button_text_clear_now(),
         message: m.warning_prompt_clear_data({ source: props.sourceText }),
         operation: 'destructive',
       };
     case ConfirmationType.HideRecommendation:
       return {
+        title: m.confirmation_title_hide_recommendation(),
         buttonText: m.button_text_hide_recommendation(),
         message: m.warning_prompt_hide_recommendation({ title: props.title }),
         operation: 'destructive',

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -251,6 +251,14 @@
   --color-bar-chart-bar-default: var(--shade-200);
   --color-bar-chart-bar-highlight: var(--shade-800);
   --color-bar-chart-bar-hover: var(--purple-500);
+
+  /*
+   * Confirmation
+   */
+  --color-confirmation-cancel-background: var(--shade-60);
+  --color-confirmation-cancel-background-hover: var(--shade-80);
+  --color-confirmation-destructive-background: var(--red-300);
+  --color-confirmation-destructive-foreground: var(--red-1000);
 }
 
 // Define theme variables for dark mode
@@ -504,6 +512,14 @@
   --color-bar-chart-bar-default: var(--shade-300);
   --color-bar-chart-bar-highlight: var(--shade-10);
   --color-bar-chart-bar-hover: var(--purple-500);
+
+  /*
+   * Confirmation
+   */
+  --color-confirmation-cancel-background: var(--shade-950);
+  --color-confirmation-cancel-background-hover: var(--shade-1000);
+  --color-confirmation-destructive-background: var(--red-200);
+  --color-confirmation-destructive-foreground: var(--red-1000);
 }
 
 // Apply themes to selectors


### PR DESCRIPTION
## Summary

- Adds a dedicated `<h2>` title above the message in `ConfirmationDialog` (sourced from new `confirmation_title_*` i18n keys, one per `ConfirmationType`).
- Reworks the message/detail to 14px regular `--color-text-secondary` body copy beneath the title.
- Replaces the bright `--red-500` destructive button with a soft pastel red (`--red-200` on dark / `--red-300` on light, near-black `--red-1000` foreground) so removing/deleting reads intentional rather than alarming.
- Cancel and the affirmative confirm share a sunken fill one shade deeper than the modal background (`--shade-60` on light, `--shade-950` on dark) — no stroke.
- Both buttons always render at the same width via an inline-grid mirror trick (hidden anchor label of the other button sets a shared `max-content`), with the visible label centered in the cell.
- Footer right-aligns the cluster with tighter horizontal padding.
- Title sized at `--ni-18` (one increment below the previous version), letter-spacing tightened.

## Test plan

- [ ] Open a destructive confirmation (delete a list, drop a show, log out, remove from watchlist) and verify the title shows "Delete list?" / "Drop show?" / "Log out?" / "Remove from watchlist?" in the top-left.
- [ ] Confirm body text renders at 14px regular below the title.
- [ ] Confirm Cancel and the destructive CTA render at identical width with the destructive button in pastel coral and Cancel in a sunken neutral fill.
- [ ] Trigger the only affirmative confirmation (`Restore show`) — both buttons should look identical except for label.
- [ ] Switch between light and dark themes; verify the destructive red shifts to a more saturated `--red-300` in light theme and stays as `--red-200` in dark theme.
- [ ] On mobile width, footer stacks column-reverse with full-width buttons; confirm CTA sits above Cancel.
- [ ] Run `deno task client:check` and `deno task client:test` — both pass.