### PR TITLE
fix(list): deduplicate personal lists

### DIFF
--- a/projects/client/src/lib/sections/lists/user/usePersonalListsSummary.ts
+++ b/projects/client/src/lib/sections/lists/user/usePersonalListsSummary.ts
@@ -1,5 +1,6 @@
 import { collaborationListsQuery } from '$lib/requests/queries/users/collaborationListsQuery.ts';
 import { personalListsQuery } from '$lib/requests/queries/users/personalListsQuery.ts';
+import { dedupe } from '$lib/utils/array/dedupe.ts';
 import { map } from 'rxjs';
 import type { PaginationParams } from '../../../requests/models/PaginationParams.ts';
 import { likedListsQuery } from '../../../requests/queries/users/likedListsQuery.ts';
@@ -40,11 +41,14 @@ export function usePersonalListsSummary(
     list: list.pipe(
       map(
         ($list) => {
+          // FIXME: figure out the root cause of duplicates
+          const deduped = dedupe((item) => item.id, $list);
+
           if (sortBy === 'none') {
-            return $list;
+            return deduped;
           }
 
-          return $list.toSorted((a, b) =>
+          return deduped.toSorted((a, b) =>
             // FIXME: update when we add sorting options
             b.updatedAt.getTime() - a.updatedAt.getTime()
           );


### PR DESCRIPTION
## 🎶 Notes 🎶

- When opening the personal lists page, in some cases it could lead to `Error https://svelte.dev/e/each_key_duplicate`.
- The exact root cause is TBD, but for now this 'fix' should unblock users in the mean time.