### PR TITLE
fix(profile): fixes image and color in this month section

### DIFF
--- a/projects/client/src/lib/sections/components/MonthInReviewLink.svelte
+++ b/projects/client/src/lib/sections/components/MonthInReviewLink.svelte
@@ -36,7 +36,7 @@
 
 <div class="trakt-month-in-review-link">
   {#if variant === "link"}
-    <Link {href} {onclick}>
+    <Link {href} {onclick} color="inherit">
       <ExternalLinkIcon />
       <p class="uppercase bold">{previousMonth}</p>
     </Link>

--- a/projects/client/src/lib/sections/components/ReviewContent.svelte
+++ b/projects/client/src/lib/sections/components/ReviewContent.svelte
@@ -71,6 +71,8 @@
 
     transition: var(--transition-increment) ease-in-out;
     transition-property: background, height, padding, gap;
+
+    z-index: var(--layer-base);
   }
 
   .trakt-review-content[data-variant="gradient"] {

--- a/projects/client/src/lib/sections/profile/components/YearToDateLink.svelte
+++ b/projects/client/src/lib/sections/profile/components/YearToDateLink.svelte
@@ -24,7 +24,7 @@
 </script>
 
 <trakt-year-to-date-link>
-  <Link {href} onclick={() => track({ source, target: href })}>
+  <Link {href} onclick={() => track({ source, target: href })} color="inherit">
     <div class="ytd-link-content">
       <span class="bold ytd-year">{currentYear}</span>
       <ExternalLinkIcon />
@@ -32,12 +32,9 @@
   </Link>
 </trakt-year-to-date-link>
 
-<style lang="scss">
-  @use "$style/scss/mixins/index" as *;
-
+<style>
   trakt-year-to-date-link {
-    :global(.trakt-link[data-color="default"]) {
-      color: inherit;
+    :global(.trakt-link) {
       text-decoration: none;
 
       display: flex;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2401
- Fixes the background image and colors used in the `This month` section

## 👀 Example 👀
Before/after:
<img width="431" height="410" alt="Screenshot 2026-05-26 at 20 40 57" src="https://github.com/user-attachments/assets/b4a4527d-ecf0-474e-be7f-db0aeb8bdaee" />

<img width="431" height="410" alt="Screenshot 2026-05-26 at 20 46 13" src="https://github.com/user-attachments/assets/41e4069b-5484-41c7-bb4b-1de479dbefa0" />
