### PR TITLE
Fix/toggler values

### DIFF
--- a/projects/client/src/lib/components/toggles/useToggler.spec.ts
+++ b/projects/client/src/lib/components/toggles/useToggler.spec.ts
@@ -1,0 +1,116 @@
+import {
+  resetGlobalStore,
+  useToggler,
+} from '$lib/components/toggles/useToggler.ts';
+import { renderStore } from '$test/beds/store/renderStore.ts';
+import { firstValueFrom } from 'rxjs';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const ACTIVITY_KEY = 'trakt_toggler_activity';
+
+describe('useToggler', () => {
+  beforeEach(() => {
+    resetGlobalStore();
+    localStorage.clear();
+  });
+
+  describe('initial value', () => {
+    it('uses the default value when localStorage is empty', async () => {
+      const { current } = await renderStore(() => useToggler('activity'));
+
+      const value = await firstValueFrom(current);
+
+      expect(value.value).toBe('reviews');
+    });
+
+    it('uses the stored value when localStorage has a valid option', async () => {
+      localStorage.setItem(ACTIVITY_KEY, JSON.stringify('ratings'));
+      const { current } = await renderStore(() => useToggler('activity'));
+
+      const value = await firstValueFrom(current);
+
+      expect(value.value).toBe('ratings');
+    });
+
+    it('falls back to default when stored value is not a valid option', async () => {
+      localStorage.setItem(ACTIVITY_KEY, JSON.stringify('comments'));
+
+      const { current } = await renderStore(() => useToggler('activity'));
+
+      const value = await firstValueFrom(current);
+
+      expect(value.value).toBe('reviews');
+    });
+
+    it('falls back to default when stored value is invalid JSON', async () => {
+      localStorage.setItem(ACTIVITY_KEY, '{not valid json}');
+
+      const { current } = await renderStore(() => useToggler('activity'));
+
+      const value = await firstValueFrom(current);
+
+      expect(value.value).toBe('reviews');
+    });
+  });
+
+  describe('current stream', () => {
+    it('emits an object with value and text', async () => {
+      const { current } = await renderStore(() => useToggler('activity'));
+
+      const emission = await firstValueFrom(current);
+
+      expect(emission.value).toBe('reviews');
+      expect(typeof emission.text).toBe('function');
+    });
+
+    it('falls back to default when BehaviorSubject holds a stale value', async () => {
+      const toggler = await renderStore(() => useToggler('activity'));
+
+      (toggler.set as (v: unknown) => void)('stale-option');
+      const value = await firstValueFrom(toggler.current);
+
+      expect(value.value).toBe('reviews');
+    });
+  });
+
+  describe('set', () => {
+    it('updates the emitted value', async () => {
+      const { current, set } = await renderStore(() => useToggler('activity'));
+
+      set('ratings');
+      const value = await firstValueFrom(current);
+
+      expect(value.value).toBe('ratings');
+    });
+
+    it('persists the new value to localStorage', async () => {
+      const { set } = await renderStore(() => useToggler('activity'));
+
+      set('ratings');
+
+      expect(localStorage.getItem(ACTIVITY_KEY)).toBe(
+        JSON.stringify('ratings'),
+      );
+    });
+  });
+
+  describe('options', () => {
+    it('returns all available option values', async () => {
+      const { options } = await renderStore(() => useToggler('activity'));
+
+      expect(options.map((o) => o.value)).toEqual(['reviews', 'ratings']);
+    });
+  });
+
+  describe('shared state', () => {
+    it('reuses the same store across multiple calls with the same id', async () => {
+      const togglerA = await renderStore(() => useToggler('activity'));
+      const togglerB = await renderStore(() => useToggler('activity'));
+
+      togglerA.set('ratings');
+      const value = await firstValueFrom(togglerB.current);
+
+      expect(value.value).toBe('ratings');
+    });
+  });
+});

--- a/projects/client/src/lib/components/toggles/useToggler.ts
+++ b/projects/client/src/lib/components/toggles/useToggler.ts
@@ -12,6 +12,10 @@ const TOGGLER_PREFIX = 'trakt_toggler';
 
 const globalStores = new Map<string, BehaviorSubject<unknown>>();
 
+export function resetGlobalStore() {
+  globalStores.clear();
+}
+
 export function useToggler<T extends TogglerId, K = TogglerValueMap[T]>(id: T) {
   const toggler = TOGGLERS[id];
   const storageKey = `${TOGGLER_PREFIX}_${toggler.id}`;

--- a/projects/client/src/lib/components/toggles/useToggler.ts
+++ b/projects/client/src/lib/components/toggles/useToggler.ts
@@ -17,10 +17,20 @@ export function useToggler<T extends TogglerId, K = TogglerValueMap[T]>(id: T) {
   const storageKey = `${TOGGLER_PREFIX}_${toggler.id}`;
 
   if (!globalStores.has(storageKey)) {
-    const initialValue = JSON.parse(
-      safeLocalStorage.getItem(storageKey) ??
-        JSON.stringify(toggler.default),
-    );
+    const initialValue = (() => {
+      try {
+        const stored = safeLocalStorage.getItem(storageKey);
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          if (toggler.options.some((o) => o.value === parsed)) {
+            return parsed;
+          }
+        }
+      } catch {
+        // ignore parse errors and use default
+      }
+      return toggler.default;
+    })();
 
     globalStores.set(storageKey, new BehaviorSubject<unknown>(initialValue));
   }
@@ -30,13 +40,14 @@ export function useToggler<T extends TogglerId, K = TogglerValueMap[T]>(id: T) {
   return {
     options: toggler.options,
     current: current.pipe(
-      map(($current) => ({
-        value: $current,
-        text: assertDefined(
-          toggler.options.find((o) => o.value === $current),
-          'Toggler option must exist',
-        ).text,
-      })),
+      map(($current) => {
+        const option = toggler.options.find((o) => o.value === $current) ??
+          assertDefined(
+            toggler.options.find((o) => o.value === toggler.default),
+            'Default toggler option must exist',
+          );
+        return { value: option.value as K, text: option.text };
+      }),
     ),
     set: (value: K) => {
       current.next(value);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2406
- In some cases the toggler could result in a state where `Toggler option must exist` error was thrown.
- Could not reproduce it locally, but this fix makes it more robust and should counter edge cases.
- Also added tests for it.