### PR TITLE
feat(calendar): redesign page with persistent filter sidebar and week…

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2913,7 +2913,7 @@
       "description": "Label for the button that navigates to the selected calendar day.",
       "variables": {
         "day": {
-          "type": "number"
+          "type": "string"
         }
       }
     },

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5436,6 +5436,72 @@
       "default": "The screen is dark. No movies. No episodes. Just you and the silence.",
       "description": "Text for the placeholder when there are no entries in a calendar period."
     },
+    "calendar_view_day": {
+      "default": "Day",
+      "description": "Label for the Day option in the calendar view selector dropdown.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "calendar_view_week": {
+      "default": "Week",
+      "description": "Label for the Week option in the calendar view selector dropdown (month grid view).",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "button_label_calendar_view": {
+      "default": "Calendar view",
+      "description": "Accessibility label for the calendar view selector dropdown (Day / Week).",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "button_label_expand_calendar_month": {
+      "default": "Expand to month view",
+      "description": "Accessibility label for the chevron button at the bottom of the calendar navigation that expands the day strip into a month grid.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "button_label_collapse_calendar_month": {
+      "default": "Collapse to day view",
+      "description": "Accessibility label for the chevron button at the bottom of the calendar navigation when in month view; clicking collapses back to the day strip.",
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "calendar_day_item_count_one": {
+      "default": "{count} Item",
+      "description": "Count of media items scheduled on a given calendar day (singular), shown in the day row header.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
+    "calendar_day_item_count_other": {
+      "default": "{count} Items",
+      "description": "Count of media items scheduled on a given calendar day (plural), shown in the day row header.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      },
+      "exclude": [
+        "android",
+        "ios"
+      ]
+    },
     "warning_prompt_simple_filters": {
       "default": "Switching to simple filters will reset all your current filters. Are you sure you want to proceed?",
       "description": "Text for the warning prompt that appears when a user attempts to switch to simple filters, which would reset all their current filters."

--- a/projects/client/src/lib/components/select/MultiSelect.svelte
+++ b/projects/client/src/lib/components/select/MultiSelect.svelte
@@ -54,8 +54,13 @@
   @use "$style/scss/mixins/index.scss" as *;
 
   :global(.trakt-select-trigger) {
-    --color-background-select: var(--shade-50);
-    --color-foreground-select: var(--shade-700);
+    --color-background-select: var(--color-background);
+    --color-foreground-select: var(--color-foreground);
+    --color-border-select: color-mix(
+      in srgb,
+      var(--purple-400) 20%,
+      transparent
+    );
     --button-height: var(--ni-40);
 
     all: unset;
@@ -69,30 +74,39 @@
     height: var(--button-height);
     min-width: 0;
 
-    padding: var(--ni-12);
+    padding: 0 var(--ni-12);
     box-sizing: border-box;
 
-    border-radius: var(--border-radius-m);
+    border: var(--border-thickness-xxs) solid var(--color-border-select);
+    border-radius: var(--ni-10);
 
     background-color: var(--color-background-select);
     color: var(--color-foreground-select);
 
     transition: var(--transition-increment) ease-in-out;
-    transition-property: background-color, color;
+    transition-property: background-color, border-color;
 
     -webkit-tap-highlight-color: transparent;
   }
 
+  :global(.trakt-select-trigger) span {
+    font-size: var(--ni-12);
+    letter-spacing: 0.04em;
+    opacity: 0.8;
+  }
+
   :global(.trakt-select-trigger:not([data-disabled])) {
     @include for-mouse {
-      &:hover,
-      &:focus-visible {
-        background-color: var(--color-foreground-select);
-        color: var(--color-background-select);
+      &:hover {
+        --color-border-select: color-mix(
+          in srgb,
+          var(--purple-400) 45%,
+          transparent
+        );
       }
 
       &:focus-visible {
-        outline: var(--border-thickness-xs) solid var(--color-foreground-select);
+        outline: var(--border-thickness-xxs) solid var(--purple-400);
       }
     }
   }

--- a/projects/client/src/lib/components/slider/Slider.svelte
+++ b/projects/client/src/lib/components/slider/Slider.svelte
@@ -79,8 +79,8 @@
   }
 
   :global(.trakt-slider) {
-    --slider-thumb-size: var(--ni-20);
-    --slider-track-height: var(--ni-10);
+    --slider-thumb-size: var(--ni-32);
+    --slider-track-height: var(--ni-20);
 
     position: relative;
 
@@ -115,13 +115,13 @@
     cursor: pointer;
     overflow: hidden;
 
-    border-radius: var(--border-radius-xl);
-    background-color: var(--shade-100);
+    border-radius: var(--border-radius-xxl);
+    background-color: var(--shade-900);
 
     :global(.trakt-slider-range) {
       position: absolute;
       height: 100%;
-      background-color: var(--blue-500);
+      background-color: var(--purple-600);
     }
   }
 
@@ -139,7 +139,7 @@
     cursor: pointer;
     border-radius: 50%;
 
-    background-color: var(--blue-500);
+    background-color: var(--purple-600);
     box-shadow: var(--shadow-raised);
 
     transition: var(--transition-increment) ease-in-out;
@@ -154,7 +154,7 @@
     }
 
     &:hover {
-      background-color: var(--blue-600);
+      background-color: var(--purple-500);
     }
 
     &:focus-visible {

--- a/projects/client/src/lib/features/calendar/Calendar.svelte
+++ b/projects/client/src/lib/features/calendar/Calendar.svelte
@@ -14,7 +14,7 @@
   import { endOfWeek } from "date-fns/endOfWeek";
   import { startOfMonth } from "date-fns/startOfMonth";
   import { startOfWeek as dfStartOfWeek } from "date-fns/startOfWeek";
-  import { onMount } from "svelte";
+  import { tick } from "svelte";
   import { useFilter } from "../filters/useFilter";
   import CalendarDays from "./_internal/CalendarDays.svelte";
   import CalendarHeader from "./_internal/CalendarHeader.svelte";
@@ -82,8 +82,9 @@
     return match?.calendar ?? firstPeriod;
   });
 
-  function handleNavigation(action: () => void) {
+  async function handleNavigation(action: () => void) {
     action();
+    await tick();
     document
       .getElementById(dateKey(activeDate.value))
       ?.scrollIntoView({ block: "start" });
@@ -147,9 +148,6 @@
 
   $effect(() => {
     set({ filterPanelHeader: calendarNavigation });
-  });
-
-  onMount(() => {
     return () => set({ filterPanelHeader: null });
   });
 

--- a/projects/client/src/lib/features/calendar/Calendar.svelte
+++ b/projects/client/src/lib/features/calendar/Calendar.svelte
@@ -1,15 +1,36 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
+  import { getLocale } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
   import { useDiscover } from "$lib/features/discover/useDiscover";
+  import FilterSidebar from "$lib/sections/navbar/components/filter/FilterSidebar.svelte";
+  import { useNavbarState } from "$lib/sections/navbar/useNavbarState";
   import { getDaysDifference } from "$lib/utils/date/getDaysDifference";
+  import { LOCALE_MAP } from "$lib/utils/formatting/date/LOCALE_MAP.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+  import { NOOP_FN } from "$lib/utils/constants.ts";
+  import { differenceInDays } from "date-fns/differenceInDays";
+  import { endOfMonth } from "date-fns/endOfMonth";
+  import { endOfWeek } from "date-fns/endOfWeek";
+  import { startOfMonth } from "date-fns/startOfMonth";
+  import { startOfWeek as dfStartOfWeek } from "date-fns/startOfWeek";
+  import { onMount } from "svelte";
   import { useFilter } from "../filters/useFilter";
+  import CalendarDays from "./_internal/CalendarDays.svelte";
+  import CalendarHeader from "./_internal/CalendarHeader.svelte";
+  import CalendarMonthGrid from "./_internal/CalendarMonthGrid.svelte";
+  import CalendarWeekdayRow from "./_internal/CalendarWeekdayRow.svelte";
+  import { dateKey } from "./_internal/dateKey";
   import {
     useCalendar,
     type CalendarItem as CalendarItemEntry,
   } from "./_internal/useCalendar";
   import CalendarItem from "./CalendarItem.svelte";
   import CalendarLayout from "./CalendarLayout.svelte";
+  import { getCalendarContext } from "./context/getCalendarContext";
   import { useCalendarPeriod } from "./context/useCalendarPeriod";
   import type { CalendarPeriod } from "./models/CalendarLayoutProps";
+  import type { CalendarView } from "./models/CalendarView.ts";
 
   const order = "chronological" as const;
 
@@ -45,22 +66,251 @@
     }),
   );
 
-  const navigation = $derived({
-    onNext: next,
-    onPrevious: previous,
-    onReset: reset,
+  const { visibleDate } = getCalendarContext();
+
+  const selectedDate = $derived($visibleDate ?? $activeDate);
+
+  const visiblePeriodCalendar = $derived.by(() => {
+    const firstPeriod = periods.at(0)?.calendar ?? [];
+    if (!$visibleDate) return firstPeriod;
+
+    const scrollKey = dateKey($visibleDate);
+    const match = periods.find((p) =>
+      p.calendar.some((d) => dateKey(d.date) === scrollKey),
+    );
+
+    return match?.calendar ?? firstPeriod;
   });
+
+  function handleNavigation(action: () => void) {
+    action();
+    document
+      .getElementById(dateKey(activeDate.value))
+      ?.scrollIntoView({ block: "start" });
+  }
+
+  const navigation = $derived({
+    onNext: () => handleNavigation(next),
+    onPrevious: () => handleNavigation(previous),
+    onReset: () => handleNavigation(reset),
+  });
+
+  let calendarView = $state<CalendarView>("day");
+
+  const toggleView = () => {
+    calendarView = calendarView === "day" ? "week" : "day";
+  };
+
+  // Week view leans into upcoming content. Each `period` is one week, so
+  // pulling three additional weeks via `loadMore()` lands the user on the
+  // current week + the next three already populated. Past weeks remain
+  // reachable through the chevrons or by scrolling up.
+  const WEEK_VIEW_PRELOAD_TARGET = 4;
+
+  $effect(() => {
+    if (calendarView !== "week") return;
+    if (periods.length >= WEEK_VIEW_PRELOAD_TARGET) return;
+    if ($isLoading) return;
+    loadMore();
+  });
+
+  // Month-wide calendar fetch — feeds the week-view month grid so every
+  // day in the displayed month is coloured by has-items, not just the
+  // weeks the day-view's infinite scroll has accumulated.
+  const monthRange = $derived.by(() => {
+    const locale = LOCALE_MAP[getLocale()] ?? LOCALE_MAP["en"];
+    const reference = endOfWeek(selectedDate, { locale });
+    const gridStart = dfStartOfWeek(startOfMonth(reference), { locale });
+    const monthEnd = endOfMonth(reference);
+    return {
+      start: gridStart,
+      days: differenceInDays(monthEnd, gridStart) + 1,
+    };
+  });
+
+  const { calendar: monthCalendar } = $derived(
+    useCalendar({
+      start: monthRange.start,
+      days: monthRange.days,
+      type: $mode,
+      filter: $filterMap,
+    }),
+  );
+
+  const monthAllDays = $derived($monthCalendar ?? []);
+
+  // Push the calendar navigation (Today / chevrons / Day-Week toggle +
+  // day strip + month grid) into the FilterSidebar via navbar state so
+  // the docked sidebar renders it at the top of its content — same hook
+  // the overlay drawer uses elsewhere.
+  const { set } = useNavbarState();
+
+  $effect(() => {
+    set({ filterPanelHeader: calendarNavigation });
+  });
+
+  onMount(() => {
+    return () => set({ filterPanelHeader: null });
+  });
+
+  const closeToHome = () => goto(UrlBuilder.home());
 </script>
 
-<CalendarLayout
-  activeDate={$activeDate}
-  isLoading={$isLoading}
-  {navigation}
-  onLoadMore={loadMore}
-  {periods}
-  {order}
->
-  {#snippet item(media)}
-    <CalendarItem item={media} variant="summary" />
-  {/snippet}
-</CalendarLayout>
+{#snippet calendarNavigation()}
+  <div class="calendar-filter-navigation" data-view={calendarView}>
+    <CalendarHeader
+      {navigation}
+      activeDate={selectedDate}
+      view={calendarView}
+      onToggleView={toggleView}
+    />
+    <div class="calendar-filter-divider" aria-hidden="true"></div>
+    <CalendarWeekdayRow />
+    {#if calendarView === "day"}
+      <CalendarDays
+        calendar={visiblePeriodCalendar}
+        {navigation}
+        activeDate={selectedDate}
+      />
+    {:else}
+      <CalendarMonthGrid
+        allDays={monthAllDays}
+        activeDate={selectedDate}
+      />
+    {/if}
+    <button
+      type="button"
+      class="calendar-filter-expand"
+      aria-label={calendarView === "week"
+        ? m.button_label_collapse_calendar_month()
+        : m.button_label_expand_calendar_month()}
+      onclick={toggleView}
+    >
+      <svg
+        aria-hidden="true"
+        width="16"
+        height="16"
+        viewBox="0 0 17 16"
+        fill="none"
+      >
+        <path stroke="currentColor" stroke-width="2" d="m1.5 4.5 7 7 7-7" />
+      </svg>
+    </button>
+  </div>
+{/snippet}
+
+<div class="calendar-page-layout" data-view={calendarView}>
+  <div class="calendar-main">
+    <CalendarLayout
+      activeDate={$activeDate}
+      isLoading={$isLoading}
+      {navigation}
+      onLoadMore={loadMore}
+      {periods}
+      {order}
+      view={calendarView}
+    >
+      {#snippet item(media)}
+        <CalendarItem item={media} variant="summary" />
+      {/snippet}
+    </CalendarLayout>
+  </div>
+
+  <FilterSidebar
+    hasAutoClose={false}
+    onClose={closeToHome}
+    onSaveFilter={NOOP_FN}
+  />
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .calendar-page-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) var(--ni-380);
+    gap: var(--gap-l);
+
+    margin: 0 var(--layout-distance-side);
+
+    @include for-tablet-sm-and-below {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .calendar-main {
+    min-width: 0;
+  }
+
+  /* The shared CalendarLayout adds its own page-side margin; zero it out
+     inside the calendar page so the outer grid owns the layout edge. */
+  .calendar-page-layout :global(.calendar-layout-container) {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  /* The calendar-navigation block is the snippet pushed to the docked
+     filter sidebar via navbar state; styles match the overlay flow. */
+  .calendar-filter-navigation {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+
+    width: 100%;
+    padding: var(--ni-12) var(--ni-8);
+    box-sizing: border-box;
+
+    border: var(--border-thickness-xxs) solid var(--shade-800);
+    border-radius: var(--border-radius-m);
+
+    background-color: var(--shade-900);
+  }
+
+  .calendar-filter-divider {
+    height: var(--border-thickness-xxs);
+    width: 100%;
+
+    background-color: var(--shade-800);
+  }
+
+  .calendar-filter-expand {
+    all: unset;
+    cursor: pointer;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: var(--ni-24);
+    height: var(--ni-24);
+
+    margin: 0 auto;
+
+    color: var(--color-text-secondary);
+
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: color, transform;
+
+    -webkit-tap-highlight-color: transparent;
+
+    svg {
+      width: var(--ni-16);
+      height: var(--ni-16);
+
+      transition: transform var(--transition-increment) ease-in-out;
+    }
+
+    &:hover {
+      color: var(--color-foreground);
+    }
+
+    &:focus-visible {
+      outline: var(--border-thickness-xxs) solid var(--purple-400);
+      border-radius: var(--ni-4);
+    }
+  }
+
+  .calendar-filter-navigation[data-view="week"] .calendar-filter-expand svg {
+    transform: rotate(180deg);
+  }
+</style>

--- a/projects/client/src/lib/features/calendar/CalendarLayout.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarLayout.svelte
@@ -1,11 +1,8 @@
 <script lang="ts" generics="T extends { key: string }">
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import { useLazyLoader } from "$lib/sections/lists/drilldown/_internal/useLazyLoader";
-  import { trackElementBottom } from "$lib/utils/actions/trackElementBottom";
-  import { trackWindowScroll } from "$lib/utils/actions/trackWindowScroll";
-  import CalendarDays from "./_internal/CalendarDays.svelte";
-  import CalendarHeader from "./_internal/CalendarHeader.svelte";
   import CalendarItems from "./_internal/CalendarItems.svelte";
+  import CalendarWeekItems from "./_internal/CalendarWeekItems.svelte";
   import { dateKey } from "./_internal/dateKey";
   import EmptyPeriod from "./_internal/EmptyPeriod.svelte";
   import ScrollSpy from "./_internal/ScrollSpy.svelte";
@@ -15,59 +12,23 @@
   const {
     activeDate,
     isLoading,
-    navigation: externalNavigation,
     item,
     layout = "grid",
-    maxDate,
     order = "chronological",
+    view = "day",
     periods,
     onLoadMore,
   }: CalendarLayoutProps<T> = $props();
 
   const { visibleDate } = getCalendarContext();
 
-  let activeScrollDate = $state<Date | null>(null);
-
   const allDays = $derived(periods.flatMap((p) => p.calendar));
 
   function handleScrollSpyUpdate(id: string) {
     const entry = allDays.find((d) => dateKey(d.date) === id);
     if (!entry) return;
-    activeScrollDate = entry.date;
     visibleDate.next(entry.date);
   }
-
-  function handleNavigation(action: () => void) {
-    activeScrollDate = null;
-    action();
-    document
-      .getElementById(dateKey(activeDate))
-      ?.scrollIntoView({ block: "start" });
-  }
-
-  const navigation = $derived.by(() => {
-    if (!externalNavigation) return;
-
-    return {
-      onNext: () => handleNavigation(externalNavigation.onNext),
-      onPrevious: () => handleNavigation(externalNavigation.onPrevious),
-      onReset: () => handleNavigation(externalNavigation.onReset),
-    };
-  });
-
-  const visiblePeriodCalendar = $derived.by(() => {
-    const firstPeriod = periods.at(0)?.calendar ?? [];
-    if (!activeScrollDate) return firstPeriod;
-
-    const scrollKey = dateKey(activeScrollDate);
-    const match = periods.find((p) =>
-      p.calendar.some((d) => dateKey(d.date) === scrollKey),
-    );
-
-    return match?.calendar ?? firstPeriod;
-  });
-
-  const selectedDate = $derived(activeScrollDate ?? activeDate);
 
   const loadMore = () => {
     if (isLoading) return;
@@ -81,24 +42,6 @@
 </script>
 
 <div class="calendar-layout-container" use:observeDimension>
-  {#if navigation || !isInitialLoad}
-    <div
-      class="calendar-navigation"
-      use:trackWindowScroll={"is-scrolled"}
-      use:trackElementBottom={"--calendar-nav-bottom"}
-    >
-      {#if navigation}
-        <CalendarHeader {navigation} {maxDate} activeDate={selectedDate} />
-      {/if}
-      <CalendarDays
-        calendar={visiblePeriodCalendar}
-        {navigation}
-        {maxDate}
-        activeDate={selectedDate}
-      />
-    </div>
-  {/if}
-
   {#if isInitialLoad}
     <div class="loading-wrapper">
       <LoadingIndicator />
@@ -110,13 +53,17 @@
       onUpdate={handleScrollSpyUpdate}
     >
       {#each periods as period (period.key)}
-        <CalendarItems calendar={period.calendar} {order} {item} {layout}>
-          {#snippet empty()}
-            {#if !isLoading}
-              <EmptyPeriod />
-            {/if}
-          {/snippet}
-        </CalendarItems>
+        {#if view === "week"}
+          <CalendarWeekItems calendar={period.calendar} {item} />
+        {:else}
+          <CalendarItems calendar={period.calendar} {order} {item} {layout}>
+            {#snippet empty()}
+              {#if !isLoading}
+                <EmptyPeriod />
+              {/if}
+            {/snippet}
+          </CalendarItems>
+        {/if}
       {/each}
     </ScrollSpy>
 
@@ -141,56 +88,6 @@
     margin-right: var(--layout-distance-side);
 
     flex-grow: 1;
-  }
-
-  .calendar-navigation {
-    --sticky-top: calc(
-      var(--navbar-actions-bottom, env(safe-area-inset-top, 0))
-    );
-
-    box-shadow: var(--shadow-raised);
-
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-s);
-
-    overflow: hidden;
-
-    max-width: var(--ni-480);
-
-    padding: var(--ni-10);
-    border-radius: var(--border-radius-m);
-
-    position: sticky;
-    top: var(--sticky-top);
-    z-index: var(--layer-overlay);
-
-    background-color: var(--color-calendar-background);
-
-    transition: var(--transition-increment) ease-in-out;
-    transition-property: gap, top;
-
-    backdrop-filter: blur(var(--ni-8));
-
-    @include for-mobile {
-      --sticky-top: calc(env(safe-area-inset-top, 0) + var(--ni-4));
-
-      :global(.calendar-header) {
-        transition: height var(--transition-increment) ease-in-out;
-      }
-
-      &:global(.is-scrolled) {
-        gap: var(--ni-0);
-
-        :global(.calendar-header) {
-          height: var(--ni-0);
-        }
-      }
-    }
-
-    @include for-tablet-sm-and-below {
-      top: calc(var(--navbar-height) + var(--sticky-top));
-    }
   }
 
   .loading-wrapper {

--- a/projects/client/src/lib/features/calendar/_internal/CalendarControls.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarControls.svelte
@@ -7,13 +7,24 @@
   import { isSameWeek } from "date-fns";
   import { isToday } from "date-fns/isToday";
   import type { CalendarNavigationProps } from "../models/CalendarNavigationProps";
+  import type { CalendarView } from "../models/CalendarView.ts";
+  import CalendarViewSelector from "./CalendarViewSelector.svelte";
 
   type CalendarControlsProps = WithRequired<
     CalendarNavigationProps,
     "navigation"
-  >;
+  > & {
+    view: CalendarView;
+    onToggleView: () => void;
+  };
 
-  const { navigation, activeDate, maxDate }: CalendarControlsProps = $props();
+  const {
+    navigation,
+    activeDate,
+    maxDate,
+    view,
+    onToggleView,
+  }: CalendarControlsProps = $props();
 
   const isNextDisabled = $derived(
     maxDate ? isSameWeek(activeDate, maxDate) : false,
@@ -21,39 +32,52 @@
 </script>
 
 <div class="calendar-controls">
-  <ActionButton
-    label={m.button_label_previous_calendar_period()}
-    onclick={navigation.onPrevious}
-    style="ghost"
-  >
-    <CaretLeftIcon />
-  </ActionButton>
+  <div class="calendar-controls-left">
+    <Button
+      color="default"
+      label={m.button_label_reset_calendar_period()}
+      disabled={isToday(activeDate)}
+      onclick={navigation.onReset}
+      style="ghost"
+    >
+      {m.button_text_reset_calendar_period()}
+    </Button>
 
-  <Button
-    color="default"
-    label={m.button_label_reset_calendar_period()}
-    disabled={isToday(activeDate)}
-    onclick={navigation.onReset}
-    style="ghost"
-  >
-    {m.button_text_reset_calendar_period()}
-  </Button>
+    <ActionButton
+      label={m.button_label_previous_calendar_period()}
+      onclick={navigation.onPrevious}
+      style="ghost"
+    >
+      <CaretLeftIcon />
+    </ActionButton>
 
-  <ActionButton
-    label={m.button_label_next_calendar_period()}
-    onclick={navigation.onNext}
-    style="ghost"
-    disabled={isNextDisabled}
-  >
-    <CaretRightIcon />
-  </ActionButton>
+    <ActionButton
+      label={m.button_label_next_calendar_period()}
+      onclick={navigation.onNext}
+      style="ghost"
+      disabled={isNextDisabled}
+    >
+      <CaretRightIcon />
+    </ActionButton>
+  </div>
+
+  <CalendarViewSelector {view} onToggle={onToggleView} />
 </div>
 
-<style>
+<style lang="scss">
   .calendar-controls {
     display: flex;
     align-items: center;
+    justify-content: space-between;
 
+    gap: var(--gap-s);
+
+    width: 100%;
+  }
+
+  .calendar-controls-left {
+    display: flex;
+    align-items: center;
     gap: var(--gap-xs);
   }
 </style>

--- a/projects/client/src/lib/features/calendar/_internal/CalendarDayHeader.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarDayHeader.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { getLocale } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { toCalendarDayParts } from "./toCalendarDayParts.ts";
+
+  const { date, count }: { date: Date; count: number } = $props();
+
+  const parts = $derived(toCalendarDayParts(date, getLocale()));
+  const itemCountLabel = $derived(
+    count === 1
+      ? m.calendar_day_item_count_one({ count })
+      : m.calendar_day_item_count_other({ count }),
+  );
+</script>
+
+<div class="trakt-calendar-day-header">
+  <span class="day-of-month">{parts.dayOfMonth}</span>
+  <span class="day-meta">
+    <span class="month bold">{parts.month}</span>
+    <span class="weekday">{parts.weekday}</span>
+  </span>
+  <span class="item-count secondary">{itemCountLabel}</span>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-calendar-day-header {
+    position: sticky;
+    top: var(--calendar-nav-bottom, 0px);
+    z-index: var(--layer-base);
+
+    display: flex;
+    align-items: center;
+    gap: var(--gap-s);
+
+    height: var(--ni-55);
+    padding: 0 var(--gap-s);
+
+    background-color: color-mix(
+      in srgb,
+      var(--color-calendar-active-background) 50%,
+      transparent
+    );
+    backdrop-filter: blur(var(--ni-8));
+  }
+
+  .day-of-month {
+    font-size: var(--ni-30);
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.04em;
+  }
+
+  .day-meta {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    line-height: 1;
+
+    .month,
+    .weekday {
+      font-size: var(--ni-12);
+      letter-spacing: 0.04em;
+    }
+  }
+
+  .item-count {
+    font-size: var(--font-size-text);
+  }
+</style>

--- a/projects/client/src/lib/features/calendar/_internal/CalendarDays.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarDays.svelte
@@ -48,16 +48,17 @@
     position: relative;
     width: 100%;
 
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    align-items: start;
 
     gap: var(--gap-micro);
 
     border-radius: var(--border-radius-s);
 
     :global(.trakt-calendar-day-button) {
-      flex: 1;
+      width: 100%;
+      min-width: 0;
     }
   }
 </style>

--- a/projects/client/src/lib/features/calendar/_internal/CalendarHeader.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarHeader.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
   import type { CalendarNavigationProps } from "../models/CalendarNavigationProps";
+  import type { CalendarView } from "../models/CalendarView.ts";
   import CalendarControls from "./CalendarControls.svelte";
 
-  const navigationProps: WithRequired<CalendarNavigationProps, "navigation"> =
-    $props();
+  const {
+    view,
+    onToggleView,
+    ...navigationProps
+  }: WithRequired<CalendarNavigationProps, "navigation"> & {
+    view: CalendarView;
+    onToggleView: () => void;
+  } = $props();
 </script>
 
 <div class="calendar-header">
-  <CalendarControls {...navigationProps} />
+  <CalendarControls {...navigationProps} {view} {onToggleView} />
 </div>
 
 <style>

--- a/projects/client/src/lib/features/calendar/_internal/CalendarItems.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarItems.svelte
@@ -1,8 +1,7 @@
 <script lang="ts" generics="T extends { key: string }">
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
-  import { getLocale } from "$lib/features/i18n";
-  import { toHumanDay } from "$lib/utils/formatting/date/toHumanDay";
   import type { Snippet } from "svelte";
+  import CalendarDayHeader from "./CalendarDayHeader.svelte";
   import { dateKey } from "./dateKey";
 
   const {
@@ -32,12 +31,8 @@
     {#each orderedCalendar as day (dateKey(day.date))}
       {#if day.items.length > 0}
         <div id={dateKey(day.date)} class="calendar-day-anchor">
-          <GridList
-            title={toHumanDay({ date: day.date, locale: getLocale() })}
-            items={day.items}
-            id={dateKey(day.date)}
-            {item}
-          />
+          <CalendarDayHeader date={day.date} count={day.items.length} />
+          <GridList items={day.items} id={dateKey(day.date)} {item} />
         </div>
       {/if}
     {/each}
@@ -49,6 +44,10 @@
 
   .calendar-day-anchor {
     scroll-margin-top: var(--calendar-nav-bottom, 0px);
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-m);
   }
 
   .trakt-calendar-items {

--- a/projects/client/src/lib/features/calendar/_internal/CalendarMonthGrid.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarMonthGrid.svelte
@@ -74,7 +74,7 @@
             <span class="month-day-number">{cell.date.getDate()}</span>
             {#if cell.items.length > 0}
               <span class="month-day-indicator" aria-hidden="true">
-                {#each Array(Math.min(cell.items.length, MAX_INDICATOR_DOTS)) as _, i (i)}
+                {#each Array.from({ length: Math.min(cell.items.length, MAX_INDICATOR_DOTS) }) as _, i (i)}
                   <span class="dot"></span>
                 {/each}
               </span>

--- a/projects/client/src/lib/features/calendar/_internal/CalendarMonthGrid.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarMonthGrid.svelte
@@ -1,0 +1,174 @@
+<script lang="ts" generics="T extends { key: string }">
+  import { getLocale } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { toHumanDay } from "$lib/utils/formatting/date/toHumanDay";
+  import { LOCALE_MAP } from "$lib/utils/formatting/date/LOCALE_MAP.ts";
+  import { endOfWeek } from "date-fns/endOfWeek";
+  import { isBefore } from "date-fns/isBefore";
+  import { startOfDay } from "date-fns/startOfDay";
+  import type { Calendar } from "../models/Calendar.ts";
+  import { buildMonthMatrix } from "./buildMonthMatrix.ts";
+  import { dateKey } from "./dateKey.ts";
+
+  const {
+    allDays,
+    activeDate,
+    skipActiveWeek = false,
+  }: {
+    allDays: Calendar<T>;
+    activeDate: Date;
+    /**
+     * When `true`, the week containing `activeDate` is omitted from the
+     * grid — useful when a rich day-strip already renders that week above.
+     * When `false` (default) the active week is shown inline and the row
+     * itself is wrapped via the `.is-active-week` modifier.
+     */
+    skipActiveWeek?: boolean;
+  } = $props();
+
+  const MAX_INDICATOR_DOTS = 3;
+
+  const referenceDate = $derived(
+    endOfWeek(activeDate, {
+      locale: LOCALE_MAP[getLocale()] ?? LOCALE_MAP["en"],
+    }),
+  );
+
+  const matrix = $derived(
+    buildMonthMatrix({
+      referenceDate,
+      activeDate,
+      allDays,
+      localeKey: getLocale(),
+    }),
+  );
+
+  const todayStart = $derived(startOfDay(new Date()));
+
+  const scrollToDay = (date: Date) => {
+    const element = document.getElementById(dateKey(date));
+    element?.scrollIntoView({ block: "start", behavior: "smooth" });
+  };
+</script>
+
+<div class="calendar-month-grid">
+  {#each matrix.weeks as week, weekIndex (weekIndex)}
+    {#if !(skipActiveWeek && weekIndex === matrix.activeWeekIndex)}
+      <div
+        class="week-row"
+        class:is-active-week={!skipActiveWeek &&
+          weekIndex === matrix.activeWeekIndex}
+      >
+        {#each week as cell (dateKey(cell.date))}
+          <button
+            type="button"
+            class="month-day"
+            class:has-items={cell.items.length > 0}
+            class:is-past={isBefore(cell.date, todayStart)}
+            aria-label={m.button_label_go_to_calendar_day({
+              day: toHumanDay({ date: cell.date, locale: getLocale() }),
+            })}
+            disabled={cell.items.length === 0}
+            onclick={() => scrollToDay(cell.date)}
+          >
+            <span class="month-day-number">{cell.date.getDate()}</span>
+            {#if cell.items.length > 0}
+              <span class="month-day-indicator" aria-hidden="true">
+                {#each Array(Math.min(cell.items.length, MAX_INDICATOR_DOTS)) as _, i (i)}
+                  <span class="dot"></span>
+                {/each}
+              </span>
+            {/if}
+          </button>
+        {/each}
+      </div>
+    {/if}
+  {/each}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .calendar-month-grid {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+
+    width: 100%;
+  }
+
+  .week-row {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: var(--gap-xs);
+
+    border-radius: var(--ni-10);
+  }
+
+  .week-row.is-active-week {
+    outline: var(--border-thickness-xxs) solid var(--purple-400);
+    outline-offset: var(--ni-2);
+  }
+
+  .month-day {
+    all: unset;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--ni-2);
+
+    aspect-ratio: 1 / 1;
+
+    border-radius: var(--ni-10);
+
+    background-color: var(--shade-800);
+    color: var(--color-text-secondary);
+
+    font-size: var(--font-size-text);
+
+    cursor: pointer;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: background-color, color;
+  }
+
+  .month-day.has-items {
+    background-color: var(--purple-700);
+    color: var(--shade-10);
+  }
+
+  .month-day[disabled] {
+    cursor: not-allowed;
+  }
+
+  .month-day.is-past {
+    opacity: 0.3;
+  }
+
+  .month-day-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--ni-2);
+
+    height: var(--ni-4);
+
+    .dot {
+      width: var(--ni-4);
+      height: var(--ni-4);
+
+      border-radius: 50%;
+      background-color: var(--shade-10);
+    }
+  }
+
+  @include for-mouse {
+    .month-day.has-items:hover {
+      background-color: var(--purple-600);
+    }
+  }
+</style>

--- a/projects/client/src/lib/features/calendar/_internal/CalendarViewSelector.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarViewSelector.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { CalendarView } from "../models/CalendarView.ts";
+
+  const {
+    view,
+    onToggle,
+  }: {
+    view: CalendarView;
+    onToggle: () => void;
+  } = $props();
+
+  const select = (target: CalendarView) => {
+    if (target !== view) onToggle();
+  };
+</script>
+
+<div
+  class="trakt-calendar-view-selector"
+  role="group"
+  aria-label={m.button_label_calendar_view()}
+>
+  <button
+    type="button"
+    class="segment"
+    class:is-active={view === "day"}
+    aria-pressed={view === "day"}
+    onclick={() => select("day")}
+  >
+    {m.calendar_view_day()}
+  </button>
+  <button
+    type="button"
+    class="segment"
+    class:is-active={view === "week"}
+    aria-pressed={view === "week"}
+    onclick={() => select("week")}
+  >
+    {m.calendar_view_week()}
+  </button>
+</div>
+
+<style lang="scss">
+  .trakt-calendar-view-selector {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--ni-2);
+
+    height: var(--ni-40);
+    padding: var(--ni-4);
+
+    box-sizing: border-box;
+
+    border-radius: var(--border-radius-m);
+    background-color: var(--shade-900);
+  }
+
+  .segment {
+    all: unset;
+    cursor: pointer;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    height: var(--ni-32);
+    padding: 0 var(--ni-12);
+
+    border-radius: var(--border-radius-s);
+
+    color: var(--shade-10);
+    opacity: 0.45;
+
+    font-size: var(--font-size-text);
+    font-weight: 600;
+
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: background-color, opacity;
+
+    -webkit-tap-highlight-color: transparent;
+
+    &.is-active {
+      background-color: var(--purple-700);
+      opacity: 1;
+    }
+
+    &:hover:not(.is-active) {
+      background-color: color-mix(
+        in srgb,
+        var(--purple-700) 35%,
+        transparent
+      );
+      opacity: 1;
+    }
+
+    &:focus-visible {
+      outline: var(--border-thickness-xxs) solid var(--purple-400);
+      opacity: 1;
+    }
+  }
+</style>

--- a/projects/client/src/lib/features/calendar/_internal/CalendarWeekItems.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarWeekItems.svelte
@@ -1,0 +1,69 @@
+<script lang="ts" generics="T extends { key: string }">
+  import type { Snippet } from "svelte";
+  import type { Calendar } from "../models/Calendar.ts";
+  import CalendarDayHeader from "./CalendarDayHeader.svelte";
+  import { dateKey } from "./dateKey.ts";
+
+  const {
+    calendar,
+    item,
+  }: {
+    calendar: Calendar<T>;
+    item: Snippet<[T]>;
+  } = $props();
+</script>
+
+<div class="calendar-week-row">
+  {#each calendar as day (dateKey(day.date))}
+    <div id={dateKey(day.date)} class="calendar-day-column calendar-day-anchor">
+      <CalendarDayHeader date={day.date} count={day.items.length} />
+      <div class="calendar-day-items">
+        {#each day.items as media (media.key)}
+          {@render item(media)}
+        {/each}
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .calendar-week-row {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 0;
+  }
+
+  .calendar-day-column {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+    min-width: 0;
+
+    scroll-margin-top: var(--calendar-nav-bottom, 0px);
+
+    /* 1px vertical separators between adjacent day columns. The headers
+       sit on top of the column so the line also runs between them
+       visually, uniting the header band into a single strip. */
+    border-right: var(--border-thickness-xxs) solid var(--shade-800);
+
+    &:last-child {
+      border-right: none;
+    }
+  }
+
+  .calendar-day-items {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+
+    /* Cards inside the column should respect the column width — let any
+       fixed-width card scale down so the 7-col grid never overflows. */
+    :global(.trakt-card),
+    :global(trakt-calendar-item) {
+      width: 100%;
+      max-width: 100%;
+    }
+  }
+</style>

--- a/projects/client/src/lib/features/calendar/_internal/CalendarWeekdayRow.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarWeekdayRow.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { getLocale } from "$lib/features/i18n";
+  import { LOCALE_MAP } from "$lib/utils/formatting/date/LOCALE_MAP.ts";
+  import { toHumanDayOfWeek } from "$lib/utils/formatting/date/toHumanDayOfWeek";
+  import { addDays } from "date-fns/addDays";
+  import { startOfWeek } from "date-fns/startOfWeek";
+
+  /**
+   * Locale-aware weekday header row (SUN MON TUE…) that sits above the
+   * day strip and the month grid. Anchored to the locale's first day so the
+   * column under each label always matches the date in the row below.
+   */
+  const weekdayLabels = $derived.by(() => {
+    const locale = LOCALE_MAP[getLocale()] ?? LOCALE_MAP["en"];
+    const reference = startOfWeek(new Date(), { locale });
+    return Array.from({ length: 7 }, (_, i) =>
+      toHumanDayOfWeek(addDays(reference, i), getLocale()),
+    );
+  });
+</script>
+
+<div class="calendar-weekday-row" aria-hidden="true">
+  {#each weekdayLabels as label, i (i)}
+    <span class="calendar-weekday-label">{label}</span>
+  {/each}
+</div>
+
+<style lang="scss">
+  .calendar-weekday-row {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: var(--gap-micro);
+
+    width: 100%;
+  }
+
+  .calendar-weekday-label {
+    text-align: center;
+
+    font-size: var(--ni-12);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+
+    color: var(--color-text-secondary);
+  }
+</style>

--- a/projects/client/src/lib/features/calendar/_internal/Day.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/Day.svelte
@@ -2,8 +2,9 @@
   import { getLocale, languageTag } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import { toHumanDay } from "$lib/utils/formatting/date/toHumanDay";
-  import { toHumanDayOfWeek } from "$lib/utils/formatting/date/toHumanDayOfWeek";
   import { toHumanMonth } from "$lib/utils/formatting/date/toHumanMonth";
+  import { isBefore } from "date-fns/isBefore";
+  import { startOfDay } from "date-fns/startOfDay";
   import ContentIndicator from "./ContentIndicator.svelte";
   import { dateKey } from "./dateKey";
 
@@ -16,6 +17,7 @@
   } = $props();
 
   const itemCount = $derived(day.items.length);
+  const isPast = $derived(isBefore(day.date, startOfDay(new Date())));
 
   const scrollToDay = () => {
     const key = dateKey(day.date);
@@ -33,13 +35,13 @@
   })}
   class:has-items={itemCount > 0}
   class:is-active={isActiveDate}
+  class:is-past={isPast}
   onclick={scrollToDay}
 >
-  <span>
-    {toHumanMonth(day.date, languageTag(), "short")}
+  <span class="day-cell">
+    <span class="day-of-month">{day.date.getDate()}</span>
+    <span class="month">{toHumanMonth(day.date, languageTag(), "short")}</span>
   </span>
-  <span class="bold">{day.date.getDate()}</span>
-  <span>{toHumanDayOfWeek(day.date, getLocale())}</span>
 
   <ContentIndicator {itemCount} />
 </button>
@@ -54,34 +56,70 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    gap: var(--gap-xs);
 
     min-width: var(--ni-44);
     box-sizing: border-box;
+  }
 
-    border-radius: var(--border-radius-s);
+  .day-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
-    transition: background-color var(--transition-increment) ease-in-out;
-    background-color: var(--color-calendar-inactive-background);
+    width: 100%;
+    padding: var(--ni-4) var(--ni-2);
+    box-sizing: border-box;
 
-    padding: var(--ni-8);
-    gap: var(--gap-xs);
+    border: var(--border-thickness-xxs) solid transparent;
+    border-radius: var(--ni-10);
 
-    &:not(.has-items) {
-      pointer-events: none;
+    color: var(--color-text-secondary);
 
-      span {
-        opacity: 0.5;
-      }
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: background-color, border-color, color;
+
+    .day-of-month,
+    .month {
+      font-size: var(--font-size-text);
+      line-height: var(--ni-24);
+      letter-spacing: 0.025em;
     }
 
-    &.is-active {
-      background-color: var(--color-calendar-active-background);
+    .day-of-month {
+      font-weight: 600;
     }
+  }
 
-    @include for-mouse() {
-      &.has-items:not(.is-active):hover {
-        cursor: pointer;
-        background-color: var(--color-calendar-background-hover);
+  .trakt-calendar-day-button:not(.has-items) {
+    pointer-events: none;
+
+    .day-cell {
+      opacity: 0.6;
+    }
+  }
+
+  .trakt-calendar-day-button.is-active .day-cell {
+    background-color: var(--purple-900);
+    border-color: var(--purple-700);
+    color: var(--shade-10);
+  }
+
+  .trakt-calendar-day-button.is-past {
+    opacity: 0.3;
+  }
+
+  @include for-mouse {
+    .trakt-calendar-day-button.has-items:not(.is-active):hover {
+      cursor: pointer;
+
+      .day-cell {
+        background-color: color-mix(
+          in srgb,
+          var(--purple-900) 35%,
+          transparent
+        );
+        color: var(--shade-10);
       }
     }
   }

--- a/projects/client/src/lib/features/calendar/_internal/buildMonthMatrix.ts
+++ b/projects/client/src/lib/features/calendar/_internal/buildMonthMatrix.ts
@@ -1,0 +1,84 @@
+import type { AvailableLocale } from '$lib/features/i18n/index.ts';
+import { LOCALE_MAP } from '$lib/utils/formatting/date/LOCALE_MAP.ts';
+import { addDays } from 'date-fns/addDays';
+import { endOfMonth } from 'date-fns/endOfMonth';
+import { isSameDay } from 'date-fns/isSameDay';
+import { startOfMonth } from 'date-fns/startOfMonth';
+import { startOfWeek } from 'date-fns/startOfWeek';
+import { dateKey } from './dateKey.ts';
+
+export type MonthCell<T> = {
+  date: Date;
+  items: T[];
+  isOutsideMonth: boolean;
+};
+
+export type MonthMatrix<T> = {
+  weeks: MonthCell<T>[][];
+  activeWeekIndex: number;
+};
+
+type BuildMonthMatrixParams<T> = {
+  referenceDate: Date;
+  activeDate: Date;
+  allDays: ReadonlyArray<{ date: Date; items: T[] }>;
+  localeKey?: AvailableLocale;
+};
+
+/**
+ * Builds a month-grid matrix for the month containing `referenceDate`.
+ *
+ * - Rows are full weeks starting at the locale's first weekday.
+ * - The first row may include trailing days from the previous month (these
+ *   carry `isOutsideMonth: true`).
+ * - The last row is truncated at the month's last day, matching the design.
+ * - `activeWeekIndex` is the row index whose week contains `activeDate`,
+ *   or `-1` if no row does.
+ */
+export function buildMonthMatrix<T>(
+  { referenceDate, activeDate, allDays, localeKey = 'en' }:
+    BuildMonthMatrixParams<T>,
+): MonthMatrix<T> {
+  const locale = LOCALE_MAP[localeKey] ?? LOCALE_MAP['en'];
+
+  const monthStart = startOfMonth(referenceDate);
+  const monthEnd = endOfMonth(referenceDate);
+  const gridStart = startOfWeek(monthStart, { locale });
+
+  const dayMap = new Map(
+    allDays.map((day) => [dateKey(day.date), day.items] as const),
+  );
+
+  const weeks: MonthCell<T>[][] = [];
+  let activeWeekIndex = -1;
+  let cursor = gridStart;
+
+  while (cursor <= monthEnd) {
+    const week: MonthCell<T>[] = [];
+    let weekHasActive = false;
+
+    for (let i = 0; i < 7; i++) {
+      const d = addDays(cursor, i);
+      if (d > monthEnd) break;
+
+      week.push({
+        date: d,
+        items: dayMap.get(dateKey(d)) ?? [],
+        isOutsideMonth: d.getMonth() !== referenceDate.getMonth(),
+      });
+
+      if (isSameDay(d, activeDate)) {
+        weekHasActive = true;
+      }
+    }
+
+    if (weekHasActive) {
+      activeWeekIndex = weeks.length;
+    }
+
+    weeks.push(week);
+    cursor = addDays(cursor, 7);
+  }
+
+  return { weeks, activeWeekIndex };
+}

--- a/projects/client/src/lib/features/calendar/_internal/toCalendarDayParts.ts
+++ b/projects/client/src/lib/features/calendar/_internal/toCalendarDayParts.ts
@@ -1,0 +1,22 @@
+import type { AvailableLocale } from '$lib/features/i18n/index.ts';
+import { LOCALE_MAP } from '$lib/utils/formatting/date/LOCALE_MAP.ts';
+import { format } from 'date-fns/format';
+
+type CalendarDayParts = {
+  dayOfMonth: string;
+  month: string;
+  weekday: string;
+};
+
+export function toCalendarDayParts(
+  date: Date,
+  localeKey: AvailableLocale = 'en',
+): CalendarDayParts {
+  const locale = LOCALE_MAP[localeKey] ?? LOCALE_MAP['en'];
+
+  return {
+    dayOfMonth: format(date, 'dd', { locale }),
+    month: format(date, 'MMM', { locale }),
+    weekday: format(date, 'EEE', { locale }),
+  };
+}

--- a/projects/client/src/lib/features/calendar/_internal/toCalendarDayParts.ts
+++ b/projects/client/src/lib/features/calendar/_internal/toCalendarDayParts.ts
@@ -15,7 +15,7 @@ export function toCalendarDayParts(
   const locale = LOCALE_MAP[localeKey] ?? LOCALE_MAP['en'];
 
   return {
-    dayOfMonth: format(date, 'dd', { locale }),
+    dayOfMonth: format(date, 'd', { locale }),
     month: format(date, 'MMM', { locale }),
     weekday: format(date, 'EEE', { locale }),
   };

--- a/projects/client/src/lib/features/calendar/context/useCalendarPeriod.ts
+++ b/projects/client/src/lib/features/calendar/context/useCalendarPeriod.ts
@@ -69,6 +69,7 @@ export function useCalendarPeriod(
     const referenceDate = visibleDate.value ?? startDate.value;
 
     if (isCurrentWeek(referenceDate, getLocale())) {
+      visibleDate.next(null);
       activeDate.next(new Date());
       return;
     }

--- a/projects/client/src/lib/features/calendar/models/CalendarLayoutProps.ts
+++ b/projects/client/src/lib/features/calendar/models/CalendarLayoutProps.ts
@@ -2,6 +2,7 @@ import type { Snippet } from 'svelte';
 import type { Calendar } from './Calendar.ts';
 import type { CalendarNavigationProps } from './CalendarNavigationProps.ts';
 import type { CalendarOrder } from './CalendarOrder.ts';
+import type { CalendarView } from './CalendarView.ts';
 
 export type CalendarPeriod<T = unknown> = {
   key: string;
@@ -13,6 +14,7 @@ export type CalendarLayoutProps<T> = {
   item: Snippet<[T]>;
   layout?: 'list' | 'grid';
   order?: CalendarOrder;
+  view?: CalendarView;
   periods: ReadonlyArray<CalendarPeriod<T>>;
   onLoadMore: () => void;
 } & CalendarNavigationProps;

--- a/projects/client/src/lib/features/calendar/models/CalendarView.ts
+++ b/projects/client/src/lib/features/calendar/models/CalendarView.ts
@@ -1,0 +1,1 @@
+export type CalendarView = 'day' | 'week';

--- a/projects/client/src/lib/sections/navbar/components/filter/FilterSidebar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/FilterSidebar.svelte
@@ -5,12 +5,35 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import { useNavbarState } from "$lib/sections/navbar/useNavbarState";
   import FiltersPopupMenu from "./filters/FiltersPopupMenu.svelte";
   import FilterTabs from "./FilterTabs.svelte";
 
-  const { onClose }: { onClose: () => void } = $props();
+  const {
+    onClose,
+    hasAutoClose = true,
+    onSaveFilter = onClose,
+  }: {
+    onClose: () => void;
+    /**
+     * Forwarded to the underlying `Drawer`. Defaults to `true` (overlay
+     * portal + underlay). Pass `false` to render inline so the drawer
+     * sits within a parent grid cell (e.g. the docked calendar sidebar) —
+     * mirrors the `SmartListCreator` pattern.
+     */
+    hasAutoClose?: boolean;
+    /**
+     * Fires after the user saves a filter preset from the popup menu.
+     * Defaults to `onClose` so the overlay drawer closes after saving.
+     * Pass a no-op when rendered inline so the panel stays put.
+     */
+    onSaveFilter?: () => void;
+  } = $props();
 
   const { activeMode, setActiveMode } = useStoredFilters();
+
+  const { state } = useNavbarState();
+  const filterPanelHeader = $derived($state.filterPanelHeader);
 
   const isMobile = useMedia(WellKnownMediaQuery.mobile);
   const isSmallTablet = useMedia(WellKnownMediaQuery.tabletSmall);
@@ -24,22 +47,36 @@
   </div>
 
   {#if $activeMode === FilterMode.Simple}
-    <FiltersPopupMenu {onClose} />
+    <FiltersPopupMenu onClose={onSaveFilter} />
   {/if}
 {/snippet}
 
 <Drawer
   {onClose}
   {badge}
+  {hasAutoClose}
   title={m.header_filters()}
   trapSelector=".trakt-filter"
   size="auto"
 >
+  {#if filterPanelHeader}
+    <div class="trakt-filter-panel-header">
+      {@render filterPanelHeader()}
+    </div>
+  {/if}
+
   <FilterTabs activeMode={$activeMode} {setActiveMode} {tabPosition} />
 </Drawer>
 
 <style>
   .trakt-filter-toggles {
     display: flex;
+  }
+
+  .trakt-filter-panel-header {
+    display: flex;
+    flex-direction: column;
+
+    padding-bottom: var(--gap-m);
   }
 </style>

--- a/projects/client/src/lib/sections/navbar/components/filter/FilterTabs.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/FilterTabs.svelte
@@ -83,28 +83,75 @@
   </div>
 {/snippet}
 
-<TabView
-  {tabPosition}
-  value={activeMode}
-  tabs={[
-    {
-      value: FilterMode.Simple,
-      label: m.tab_text_simple_filters(),
-      content: simpleFilters,
-    },
-    {
-      value: FilterMode.Advanced,
-      label: m.tab_text_advanced_filters(),
-      content: advancedFilters,
-    },
-  ]}
-  {onChange}
-/>
+<div class="trakt-filter-tabs">
+  <TabView
+    {tabPosition}
+    value={activeMode}
+    tabs={[
+      {
+        value: FilterMode.Simple,
+        label: m.tab_text_simple_filters(),
+        content: simpleFilters,
+      },
+      {
+        value: FilterMode.Advanced,
+        label: m.tab_text_advanced_filters(),
+        content: advancedFilters,
+      },
+    ]}
+    {onChange}
+  />
+</div>
 
-<style>
+<style lang="scss">
   .trakt-filters-content {
     display: flex;
     flex-direction: column;
     gap: var(--gap-xl);
+  }
+
+  /* Filters selector pill — restyles the shared TabView for the filter panel only. */
+  .trakt-filter-tabs :global(.trakt-tab-view) {
+    --tab-border-radius: var(--border-radius-m);
+  }
+
+  .trakt-filter-tabs :global(.trakt-tabs-list) {
+    background-color: var(--shade-900);
+    padding: var(--ni-4);
+  }
+
+  .trakt-filter-tabs :global(.trakt-tab-indicator) {
+    background-color: var(--purple-700);
+  }
+
+  .trakt-filter-tabs :global(.trakt-tab-trigger) {
+    height: var(--ni-32);
+    color: var(--shade-10);
+  }
+
+  .trakt-filter-tabs :global(.trakt-tab-trigger[data-state="inactive"]) {
+    opacity: 0.45;
+  }
+
+  .trakt-filter-tabs
+    :global(.trakt-tab-trigger:hover:not([data-state="active"])) {
+    background-color: color-mix(in srgb, var(--purple-700) 35%, transparent);
+    opacity: 1;
+  }
+
+  .trakt-filter-tabs :global(.trakt-tab-trigger:focus-visible) {
+    outline: var(--border-thickness-xxs) solid var(--purple-400);
+    background-color: transparent;
+    color: var(--shade-10);
+  }
+
+  .trakt-filter-tabs :global(.trakt-tab-trigger span) {
+    text-transform: none;
+    font-weight: 400;
+  }
+
+  .trakt-filter-tabs
+    :global(.trakt-tab-trigger[data-state="active"] span) {
+    font-weight: 600;
   }
 </style>

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/ToggleFilter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/ToggleFilter.svelte
@@ -13,24 +13,71 @@
   const { getFilterValue } = useFilter();
   const currentValue = $derived(getFilterValue(filter.key));
 
+  const isHidden = $derived($currentValue === "true");
+
   const handler = () => {
     gotoFilteredState({
       key: filter.key,
-      value: $currentValue === "true" ? "false" : "true",
+      value: isHidden ? "false" : "true",
       mode: FilterMode.Simple,
     });
   };
-
-  // FIXME: either add explicit clear, or make indeterminate state selectable
 </script>
 
-<Filter title={filter.label()}>
-  <Switch
-    label={filter.label()}
-    checked={$currentValue === "true"}
-    indeterminate={$currentValue == null}
-    color="blue"
-    onclick={handler}
-    navigationType={DpadNavigationType.Item}
-  />
-</Filter>
+<div class="hide-toggle">
+  <Filter title={filter.label()} variant="inline">
+    <Switch
+      label={filter.label()}
+      checked={isHidden}
+      indeterminate={false}
+      color="purple"
+      onclick={handler}
+      navigationType={DpadNavigationType.Item}
+    />
+  </Filter>
+</div>
+
+<style lang="scss">
+  .hide-toggle {
+    grid-column: 1 / -1;
+
+    :global(.trakt-filter[data-variant="inline"]) {
+      flex-direction: row-reverse;
+      justify-content: flex-end;
+      gap: var(--gap-m);
+    }
+
+    :global(.trakt-filter span) {
+      text-transform: none;
+      opacity: 1;
+    }
+
+    :global(.trakt-switch) {
+      --button-width: var(--ni-44);
+      --button-height: var(--ni-24);
+      --tick-size: var(--ni-16);
+      --tick-offset: var(--ni-4);
+
+      box-shadow: none;
+      border-radius: var(--border-radius-xxl);
+      background-color: var(--shade-800);
+    }
+
+    :global(.trakt-switch:has(input:checked:not(:indeterminate))) {
+      background-color: var(--purple-700);
+    }
+
+    :global(.trakt-switch .trakt-switch-tick) {
+      background: var(--shade-10);
+      box-shadow: none;
+    }
+
+    :global(.trakt-switch .trakt-switch-tick::before) {
+      display: none;
+    }
+
+    :global(.trakt-switch .trakt-switch-tick svg) {
+      display: none;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/DropdownFilter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/DropdownFilter.svelte
@@ -1,50 +1,47 @@
 <script lang="ts">
-  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
-  import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
-  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
-  import { useTrack } from "$lib/features/analytics/useTrack";
+  import MultiSelect from "$lib/components/select/MultiSelect.svelte";
   import { FilterMode } from "$lib/features/filters/models/FilterMode";
   import * as m from "$lib/features/i18n/messages.ts";
-  import GlobalParameterSetter from "$lib/features/parameters/GlobalParameterSetter.svelte";
-  import { buildParamString } from "$lib/utils/url/buildParamString";
   import type { ListFilterProps } from "../ListFilterProps";
+  import { useFilterSetter } from "./useFilterSetter";
 
-  const { color, value, display, filter }: ListFilterProps = $props();
+  const resetValue = "__reset_filter__";
 
-  const { track } = useTrack(AnalyticsEvent.Filter);
+  const { value, filter }: ListFilterProps = $props();
+
+  const selectedValues = $derived(value ? value.split(",") : []);
+
+  const { gotoFilteredState } = useFilterSetter();
+
+  const onChange = (values: string[]) => {
+    const hasReset = values.includes(resetValue);
+    const hasValues = values.length > 0;
+
+    const nextValue = !hasReset && hasValues ? values.join(",") : null;
+
+    gotoFilteredState({
+      value: nextValue,
+      key: filter.key,
+      mode: FilterMode.Simple,
+    });
+  };
+
+  const options = $derived(
+    filter.options.map((option) => ({
+      label: option.label(),
+      value: option.value,
+    })),
+  );
+
+  const optionsWithAll = $derived([
+    { label: m.button_label_reset_filter(), value: resetValue },
+    ...options,
+  ]);
 </script>
 
-<GlobalParameterSetter parameter={filter.key}>
-  <DropdownList
-    label={filter.label()}
-    variant="secondary"
-    size="small"
-    style="flat"
-    {color}
-  >
-    {display}
-    {#snippet items()}
-      <DropdownItem
-        color="red"
-        href="?"
-        onclick={() =>
-          track({ id: filter.key, action: "reset", mode: FilterMode.Simple })}
-        replacestate
-      >
-        {m.button_label_reset_filter()}
-      </DropdownItem>
-      {#each filter.options as option (option.value)}
-        <DropdownItem
-          color="blue"
-          disabled={option.value === value}
-          href={`${buildParamString({ [filter.key]: option.value })}`}
-          onclick={() =>
-            track({ id: filter.key, action: "set", mode: FilterMode.Simple })}
-          replacestate
-        >
-          {option.label()}
-        </DropdownItem>
-      {/each}
-    {/snippet}
-  </DropdownList>
-</GlobalParameterSetter>
+<MultiSelect
+  options={optionsWithAll}
+  value={selectedValues}
+  placeholder={m.option_text_all()}
+  {onChange}
+/>

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/Filter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/Filter.svelte
@@ -28,6 +28,14 @@
 
     min-width: 0;
 
+    span {
+      font-size: var(--font-size-text);
+      letter-spacing: 0.04em;
+      text-transform: capitalize;
+
+      opacity: 0.8;
+    }
+
     &[data-variant="inline"] {
       flex-direction: row;
       align-items: center;

--- a/projects/client/src/lib/sections/navbar/useNavbarState.ts
+++ b/projects/client/src/lib/sections/navbar/useNavbarState.ts
@@ -9,6 +9,7 @@ type NavbarState = {
   contextualActions: Snippet | undefined;
   hasFilters: boolean;
   showFilters: boolean;
+  filterPanelHeader?: Snippet | null;
   headerActions?: Snippet;
   header?: {
     title: string;
@@ -35,6 +36,7 @@ const initialNavbarState: NavbarState = {
   contextualActions: undefined,
   hasFilters: false,
   showFilters: true,
+  filterPanelHeader: undefined,
   headerActions: undefined,
   header: undefined,
   sidebar: {

--- a/projects/client/src/routes/calendar/+page.svelte
+++ b/projects/client/src/routes/calendar/+page.svelte
@@ -19,7 +19,7 @@
   <TraktPageCoverSetter />
 
   <NavbarStateSetter
-    hasFilters
+    showFilters={false}
     header={{ title: m.header_calendar(), metaInfo: $current.text() }}
   />
 


### PR DESCRIPTION
## Summary

Reworks the calendar page around a persistent filter sidebar (mirroring the SmartListCreator layout) and introduces a Week view alongside the existing Day view. The calendar navigation (Today / chevrons / Day-Week toggle, day strip, and month grid) is hoisted into the top of that sidebar through navbar state, so the user navigates dates and filters from a single panel.

### Views

- **Day view** — keeps the original chronological day rows.
- **Week view** — lays each period out as a 7-column grid with united day headers and 1px vertical column separators; eagerly pre-loads upcoming weeks via `loadMore()` so the default landing leans forward. Past weeks remain reachable through the up-chevron and scroll-up.

### Navigation

- New Day / Week segmented toggle (`CalendarViewSelector`).
- Persistent SUN-SAT weekday row (`CalendarWeekdayRow`) above the date content; the row below swaps between the active-week day strip and the full month grid (`CalendarMonthGrid`) with the active week wrapped and days that have items marked with small dots beneath the date.

### Filter panel restyle

- Simple / Advanced segmented pill (purple-700 selector, regular vs bold weight).
- Dropdowns aligned with the Figma Certification spec via the existing `MultiSelect`.
- Sliders restyled to match the Release Window thumb.
- Hide section toggles switched to the purple pill in sentence case.

## Test plan

- [ ] Day view: navigating dates via Today / chevrons / day-strip scrolls the body to the right anchor (no silent no-op from stale DOM).
- [ ] Week view: chevrons advance/retreat by full weeks; eager `loadMore()` keeps the next 2-3 weeks rendered ahead of the active week.
- [ ] Month grid: the active week is wrapped, days with items show indicator dots, and tapping a day jumps to it in the active view.
- [ ] Day-of-month numerals render without leading zeros across day strip and month grid.
- [ ] Filter panel: Simple/Advanced toggle, MultiSelect dropdowns, restyled sliders, and Hide toggles all render correctly in light + dark theme.
- [ ] `deno task client:check` and `deno task client:test` both pass.