### PR TITLE
feat(history): rate unrated items from card via popover

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7097,6 +7097,15 @@
     "confirmation_title_hide_recommendation": {
       "default": "Hide recommendation?",
       "description": "Title of the confirmation dialog shown before hiding a recommendation."
+    },
+    "button_label_rate": {
+      "default": "Rate \"{title}\"",
+      "description": "Aria label for the button that allows users to rate a movie, show, or episode.",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/projects/client/src/lib/components/popover/Popover.svelte
+++ b/projects/client/src/lib/components/popover/Popover.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Popover } from "bits-ui";
   import type { Snippet } from "svelte";
+  import { scale } from "svelte/transition";
 
   type PopoverProps = {
     content: Snippet;
@@ -35,12 +36,24 @@
   {/if}
   <Popover.Portal>
     <Popover.Content
+      forceMount
       sideOffset={8}
       side="top"
-      style="z-index: var(--layer-top)"
       customAnchor={rest.customAnchor}
     >
-      {@render content()}
+      {#snippet child({ wrapperProps, props, open })}
+        {#if open}
+          <div {...wrapperProps}>
+            <div
+              {...props}
+              style="z-index: var(--layer-top)"
+              transition:scale={{ duration: 250 }}
+            >
+              {@render content()}
+            </div>
+          </div>
+        {/if}
+      {/snippet}
     </Popover.Content>
   </Popover.Portal>
 </Popover.Root>

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedItem.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
+  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import StarIcon from "$lib/components/icons/StarIcon.svelte";
+  import Popover from "$lib/components/popover/Popover.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
+  import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import UserRating from "$lib/sections/components/UserRating.svelte";
   import RemoveFromHistoryAction from "$lib/sections/media-actions/remove-from-history/RemoveFromHistoryAction.svelte";
   import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
+  import RateNow from "$lib/sections/summary/components/rating/RateNow.svelte";
+  import type { RateNowProps } from "$lib/sections/summary/components/rating/models/RateNowProps";
+  import { NOOP_FN } from "$lib/utils/constants";
+  import { episodeActivityTitle } from "$lib/utils/intl/episodeActivityTitle";
   import ActivityItem from "../components/ActivityItem.svelte";
   import ActivitySummaryCard from "../components/ActivitySummaryCard.svelte";
   import type { HistoryEntry } from "../stores/models/HistoryEntry";
@@ -31,7 +39,28 @@
     return data?.rating;
   });
 
+  const rateTarget = $derived<RateNowProps>(
+    activity.type === "episode"
+      ? {
+          type: "episode",
+          media: activity.episode,
+          show: activity.show,
+        }
+      : {
+          type: "movie",
+          media: activity.movie,
+        },
+  );
+
   const activityType = $derived(isActionable ? "personal" : "social");
+
+  const targetTitle = $derived.by(() => {
+    if (activity.type === "episode") {
+      return episodeActivityTitle(activity.episode);
+    }
+
+    return activity.movie.title;
+  });
 </script>
 
 {#snippet popupActions()}
@@ -58,9 +87,28 @@
   </RenderFor>
 {/snippet}
 
+{#snippet rateContent()}
+  <div class="trakt-history-rate-popover">
+    <RateNow {...rateTarget} variant="allow" />
+  </div>
+{/snippet}
+
 {#snippet action()}
   {#if userRating}
     <UserRating rating={userRating} />
+  {:else}
+    <RenderFor audience="authenticated">
+      <Popover content={rateContent}>
+        <ActionButton
+          style="ghost"
+          size="small"
+          onclick={NOOP_FN}
+          label={m.button_label_rate({ title: targetTitle })}
+        >
+          <StarIcon fill="none" />
+        </ActionButton>
+      </Popover>
+    </RenderFor>
   {/if}
 {/snippet}
 
@@ -85,3 +133,20 @@
     {activityType}
   />
 {/if}
+
+<style>
+  .trakt-history-rate-popover {
+    padding: var(--ni-12) var(--ni-16);
+    border-radius: var(--border-radius-l);
+    background-color: var(--color-modal-background);
+    box-shadow: var(--shadow-menu);
+
+    :global(svg) {
+      --icon-color: var(--color-text-primary);
+    }
+
+    :global(.is-current-rating svg) {
+      --icon-fill-color: var(--color-text-primary);
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary

Adds an empty-star trigger on history cards for unrated items that opens a popover hosting the canonical `RateNow` component (same drag/tap behaviour as the summary pages).

- For episode entries, the popover targets the **episode** rating (not the show's), so the stars open empty instead of pre-filling with whatever rating the show carries.
- Once a rating is submitted, the parent re-renders `<UserRating>` in place of the trigger; the popover unmounts with it. Outside-click dismissal is handled by bits-ui.

## Test plan

- [ ] On a movie history card with no movie rating: tap the empty star → popover opens → pick 1-10 → card swaps to filled rating, popover closes.
- [ ] On an episode history card with no episode rating but **the show is rated**: tap the empty star → popover opens with empty stars (no pre-fill from the show), confirm submitting writes to the episode rating and the show rating is untouched.
- [ ] Tap outside the popover → it dismisses without committing a rating.
- [ ] Repeat above on touch / mobile viewport.