### PR TITLE
style(card): shrink subtitle to 12px and bump footer tag to 12px

### DIFF
--- a/projects/client/src/lib/components/card/CardFooter.svelte
+++ b/projects/client/src/lib/components/card/CardFooter.svelte
@@ -55,11 +55,18 @@
     }
 
     .trakt-card-footer-tag {
+      font-size: var(--font-size-text-small);
+
       width: 100%;
       overflow: hidden;
 
       display: flex;
       gap: var(--gap-micro);
+
+      :global(span),
+      :global(p) {
+        font-size: var(--font-size-text-small);
+      }
     }
 
     .trakt-card-footer-information {
@@ -87,6 +94,7 @@
         color: var(--color-text-secondary);
         margin: 0;
         font-weight: 500;
+        font-size: var(--font-size-text-small);
       }
     }
   }

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -200,7 +200,7 @@
         <p class="trakt-card-title ellipsis">
           {media.title}
         </p>
-        <p class="trakt-card-subtitle secondary ellipsis">
+        <p class="trakt-card-subtitle small secondary ellipsis">
           {seasonLabel(rest.season.number)}
         </p>
       {:else if rest.variant === "activity"}
@@ -218,7 +218,7 @@
             {media.title}
           </p>
         {/if}
-        <p class="trakt-card-subtitle secondary ellipsis capitalize">
+        <p class="trakt-card-subtitle small secondary ellipsis capitalize">
           {#if rest.activityType === "social"}
             {toRelativeHumanDay(new Date(), rest.date, getLocale())}
           {:else}
@@ -231,14 +231,14 @@
             {rest.episode.title}
           </Spoiler>
         </p>
-        <p class="trakt-card-subtitle secondary ellipsis">
+        <p class="trakt-card-subtitle small secondary ellipsis">
           {episodeSubtitle(rest.episode)}
         </p>
       {:else if rest.type === "episode" || (rest.variant === "start" && "episode" in rest)}
         <p class="trakt-card-title ellipsis">
           {media.title}
         </p>
-        <p class="trakt-card-subtitle secondary ellipsis">
+        <p class="trakt-card-subtitle small secondary ellipsis">
           {episodeNumberLabel({
             seasonNumber: rest.episode.season,
             episodeNumber: rest.episode.number,
@@ -253,7 +253,7 @@
         <p class="trakt-card-title ellipsis">
           {media.title}
         </p>
-        <p class="trakt-card-subtitle secondary ellipsis">
+        <p class="trakt-card-subtitle small secondary ellipsis">
           {rest.role}
         </p>
       {:else}
@@ -266,7 +266,7 @@
           </p>
         {/if}
         <GenreList
-          classList="trakt-card-subtitle smaller ellipsis secondary"
+          classList="trakt-card-subtitle small ellipsis secondary"
           separator=", "
           genres={media.genres}
         />


### PR DESCRIPTION
## Summary

Aligns the small-tag/subtitle typography across cards with the design spec by routing them through the existing `--font-size-text-small` token (12px).

- `CardFooter.svelte` — sets `--font-size-tag` to `--font-size-text-small` so footer tags render at 12px.
- `MediaSummaryCard.svelte` — drops the subtitle paragraph to `--font-size-text-small` so it matches the rest of the card hierarchy.

## Test plan

- [ ] List, history, and search media cards: subtitle and footer tag render at 12px.
- [ ] Light and dark theme both inherit the small-text size correctly — no fallback to the default body size.