### PR TITLE
YIR: 2024 most watched

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4689,6 +4689,22 @@
       "default": "Watched At",
       "description": "Label above the watched-at timestamp on the first/last-play cards on the 2024 Year in Review template."
     },
+    "yir_2024_most_watched_shows": {
+      "default": "Most Watched Shows",
+      "description": "Section header above the top-10 most-watched shows list on the 2024 Year in Review template."
+    },
+    "yir_2024_most_watched_movies": {
+      "default": "Most Watched Movies",
+      "description": "Section header above the top-10 most-watched movies list on the 2024 Year in Review template."
+    },
+    "yir_2024_plays_label": {
+      "default": "Plays",
+      "description": "Stat label under the play count on the 2024 Year in Review most-watched cards."
+    },
+    "yir_2024_time_watched_label": {
+      "default": "Time Watched",
+      "description": "Stat label under the time-watched duration on the 2024 Year in Review most-watched cards."
+    },
     "yir_2024_stats_intro_shows": {
       "default": "In {year}, you watched",
       "description": "Lead-in line above the big '{hours} hours of {count} Shows' headline on the 2024 Year in Review TV stats section.",

--- a/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
+++ b/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
@@ -2,6 +2,7 @@
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import { m } from "$lib/paraglide/messages";
   import type { YirDetail } from "$lib/requests/models/YirDetail";
+  import Yir2024MostPlayedSection from "./_internal/Yir2024MostPlayedSection.svelte";
   import Yir2024PageInner from "./_internal/Yir2024PageInner.svelte";
   import Yir2024PlayCard from "./_internal/Yir2024PlayCard.svelte";
   import Yir2024StatsSection from "./_internal/Yir2024StatsSection.svelte";
@@ -49,9 +50,27 @@
       </Yir2024PageInner>
     {/if}
 
+    {#if detail.mostWatched.shows.length > 0}
+      <Yir2024PageInner>
+        <Yir2024MostPlayedSection
+          type="shows"
+          items={detail.mostWatched.shows}
+        />
+      </Yir2024PageInner>
+    {/if}
+
     {#if detail.stats.movies.playCounts.total > 0}
       <Yir2024PageInner>
         <Yir2024StatsSection type="movies" stats={detail.stats.movies} {year} />
+      </Yir2024PageInner>
+    {/if}
+
+    {#if detail.mostWatched.movies.length > 0}
+      <Yir2024PageInner>
+        <Yir2024MostPlayedSection
+          type="movies"
+          items={detail.mostWatched.movies}
+        />
       </Yir2024PageInner>
     {/if}
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedCard.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedCard.svelte
@@ -1,0 +1,297 @@
+<script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { m } from "$lib/paraglide/messages";
+  import type { YirMostWatchedItem } from "$lib/requests/models/YirDetail";
+  import { formatNumber } from "$lib/utils/format/formatNumber";
+  import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+
+  const {
+    item,
+    rank,
+  }: {
+    item: YirMostWatchedItem;
+    rank: number;
+  } = $props();
+
+  const itemUrl = $derived(UrlBuilder.media(item.entry.type, item.entry.slug));
+
+  const playsLabel = $derived(formatNumber(item.plays));
+  const timeWatchedLabel = $derived(
+    toHumanDuration({ minutes: item.minutes }, languageTag()),
+  );
+</script>
+
+<li
+  class="yir-2024-most-played-card"
+  role="article"
+  data-rank-position={(rank - 1) % 4}
+>
+  <div class="yir-2024-most-played-cover">
+    <CrossOriginImage src={item.entry.cover?.url?.medium} alt="" />
+  </div>
+  <div class="yir-2024-most-played-shade"></div>
+
+  <div class="yir-2024-most-played-grid">
+    <span class="bold yir-2024-most-played-rank" aria-hidden="true"
+      >.{rank}</span
+    >
+
+    <div class="yir-2024-most-played-details">
+      <div class="yir-2024-most-played-stats">
+        <div class="yir-2024-most-played-stat">
+          <span class="bold yir-2024-most-played-stat-value">{playsLabel}</span>
+          <span class="bold uppercase yir-2024-most-played-stat-label">
+            {m.yir_2024_plays_label()}
+          </span>
+        </div>
+        <div class="yir-2024-most-played-stat">
+          <span class="bold yir-2024-most-played-stat-value">
+            {timeWatchedLabel}
+          </span>
+          <span class="bold uppercase yir-2024-most-played-stat-label">
+            {m.yir_2024_time_watched_label()}
+          </span>
+        </div>
+      </div>
+
+      <Link href={itemUrl} color="inherit">
+        <h3 class="bold yir-2024-most-played-title">{item.entry.title}</h3>
+      </Link>
+    </div>
+
+    <!-- Duplicate link to itemUrl: the title Link above is the accessible
+         entry point. `focusable={false}` drops the redundant tab stop and
+         `alt=""` on the image keeps the link nameless so screen readers
+         skip it. (`aria-hidden` would need a type extension on
+         Link.svelte that's out of scope here.) -->
+    <Link href={itemUrl} color="inherit" focusable={false}>
+      <div class="yir-2024-most-played-poster">
+        <CrossOriginImage src={item.entry.poster?.url?.medium} alt="" />
+      </div>
+    </Link>
+  </div>
+</li>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  // 90% width with alternating horizontal alignment so the stacked cards
+  // visually sway across the section as you scroll (matches v2's every-4
+  // rotation: center / end / center / start). Alignment is driven by
+  // `align-self` on the flex-column parent so spacing between cards still
+  // comes from the parent's `gap` — no per-card margin.
+  .yir-2024-most-played-card {
+    position: relative;
+    width: 90%;
+    height: var(--ni-640);
+    overflow: hidden;
+    border-radius: var(--border-radius-xxl);
+    color: var(--shade-10);
+
+    &[data-rank-position="0"] {
+      align-self: center;
+    }
+    &[data-rank-position="1"] {
+      align-self: flex-end;
+    }
+    &[data-rank-position="2"] {
+      align-self: center;
+    }
+    &[data-rank-position="3"] {
+      align-self: flex-start;
+    }
+
+    @include for-tablet-sm-and-below {
+      width: 100%;
+      height: var(--ni-560);
+
+      // Stop alternating once the cards span full width; align-self has
+      // nothing left to position.
+      &[data-rank-position] {
+        align-self: stretch;
+      }
+    }
+
+    @include for-mobile {
+      border-radius: var(--border-radius-xl);
+    }
+  }
+
+  .yir-2024-most-played-cover {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+
+  // Match v2's purple wash on top of the fanart so the photo reads through
+  // tinted but the white type stays legible across the full card.
+  .yir-2024-most-played-shade {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    background: linear-gradient(
+      to top,
+      color-mix(in srgb, var(--purple-700) 95%, var(--shade-1000)) 0%,
+      color-mix(in srgb, var(--purple-700) 70%, transparent) 40%,
+      color-mix(in srgb, var(--purple-700) 35%, transparent) 70%,
+      color-mix(in srgb, var(--purple-700) 10%, transparent) 100%
+    );
+  }
+
+  // Desktop layout: rank in the top-left, details (stats + title) in the
+  // bottom-left, poster spanning the right column. Parent-driven spacing
+  // via grid `gap`; children carry no margin.
+  .yir-2024-most-played-grid {
+    position: relative;
+    z-index: 2;
+    height: 100%;
+    box-sizing: border-box;
+    padding: var(--ni-44) var(--ni-52);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-rows: 1fr auto;
+    grid-template-areas:
+      "rank    poster"
+      "details poster";
+    column-gap: var(--ni-32);
+    row-gap: var(--ni-20);
+    align-items: end;
+
+    @include for-tablet-sm-and-below {
+      // v2 mobile reflow: rank pairs with poster on top, details span full
+      // width on the row beneath.
+      grid-template-areas:
+        "rank    poster"
+        "details details";
+      padding: var(--ni-32);
+    }
+
+    @include for-mobile {
+      padding: var(--ni-20);
+      column-gap: var(--ni-16);
+      row-gap: var(--ni-12);
+    }
+  }
+
+  .yir-2024-most-played-rank {
+    grid-area: rank;
+    align-self: end;
+    // Tight line-height so the giant numeral's box doesn't add visual
+    // padding under it — the rank is meant to sit flush against the
+    // details row.
+    line-height: 0.8;
+    font-size: var(--ni-160);
+    color: color-mix(in srgb, var(--shade-10) 30%, transparent);
+
+    @include for-tablet-sm-and-below {
+      font-size: var(--ni-104);
+    }
+
+    @include for-mobile {
+      font-size: var(--ni-72);
+    }
+  }
+
+  .yir-2024-most-played-details {
+    grid-area: details;
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-16);
+    min-width: 0;
+  }
+
+  .yir-2024-most-played-stats {
+    display: flex;
+    gap: var(--ni-32);
+
+    @include for-mobile {
+      gap: var(--ni-16);
+    }
+  }
+
+  .yir-2024-most-played-stat {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-2);
+  }
+
+  .yir-2024-most-played-stat-value {
+    font-size: var(--ni-22);
+
+    @include for-mobile {
+      font-size: var(--font-size-title);
+    }
+  }
+
+  .yir-2024-most-played-stat-label {
+    font-size: var(--font-size-text);
+    color: var(--shade-300);
+
+    @include for-mobile {
+      font-size: var(--font-size-tag);
+    }
+  }
+
+  // Title link wrapper: keep the title block visually plain (no underline,
+  // inherit white) but stay clickable through the Link.
+  :global(.yir-2024-most-played-details > .trakt-link) {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .yir-2024-most-played-title {
+    font-size: clamp(var(--ni-32), 4vw, var(--ni-52));
+
+    @include for-mobile {
+      font-size: var(--ni-24);
+    }
+  }
+
+  // Poster: fixed dimensions matching v2's 322×483 with subtle shadow lift
+  // so it visually floats off the fanart. Steps down at smaller viewports.
+  :global(.yir-2024-most-played-grid > .trakt-link) {
+    grid-area: poster;
+    align-self: end;
+    justify-self: end;
+    display: block;
+    text-decoration: none;
+  }
+
+  .yir-2024-most-played-poster {
+    width: var(--ni-300);
+    aspect-ratio: 2 / 3;
+    overflow: hidden;
+    border-radius: var(--border-radius-s);
+    box-shadow: 0 var(--ni-16) var(--ni-48)
+      color-mix(in srgb, var(--shade-1000) 50%, transparent);
+    transition: transform 0.25s var(--transition-increment) ease-out;
+
+    &:hover {
+      transform: scale(1.05);
+    }
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    @include for-tablet-sm-and-below {
+      width: var(--ni-260);
+    }
+
+    @include for-mobile {
+      width: var(--ni-160);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedSection.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { YirMostWatchedItem } from "$lib/requests/models/YirDetail";
+  import Yir2024MostPlayedCard from "./Yir2024MostPlayedCard.svelte";
+
+  const {
+    type,
+    items,
+  }: {
+    type: "shows" | "movies";
+    items: YirMostWatchedItem[];
+  } = $props();
+
+  const heading = $derived(
+    type === "shows"
+      ? m.yir_2024_most_watched_shows()
+      : m.yir_2024_most_watched_movies(),
+  );
+</script>
+
+<section class="yir-2024-most-played" id="section-{type}-most-watched">
+  <header class="yir-2024-most-played-header">
+    <h2 class="bold yir-2024-most-played-heading">{heading}</h2>
+  </header>
+
+  <ol class="yir-2024-most-played-stack">
+    {#each items as item, index (item.entry.id)}
+      <Yir2024MostPlayedCard {item} rank={index + 1} />
+    {/each}
+  </ol>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-2024-most-played {
+    position: relative;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-32);
+
+    @include for-mobile {
+      gap: var(--ni-20);
+    }
+  }
+
+  .yir-2024-most-played-header {
+    padding-inline: var(--ni-12);
+  }
+
+  .yir-2024-most-played-heading {
+    margin: 0;
+    font-size: clamp(var(--ni-28), 3.5vw, var(--ni-44));
+    color: var(--shade-10);
+
+    @include for-mobile {
+      font-size: var(--ni-22);
+    }
+  }
+
+  // Ordered list for ranked semantics (screen readers announce "1 of 10").
+  // Reset the browser defaults so the list lays out with our own gap-driven
+  // flex column.
+  .yir-2024-most-played-stack {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-24);
+
+    @include for-mobile {
+      gap: var(--ni-16);
+    }
+  }
+</style>


### PR DESCRIPTION
# Summary

Ports the v2 "Most Watched Shows" / "Most Watched Movies" section into the 2024 YIR template. Renders the top 10 shows and top 10 movies as stacked fanart cards with rank, plays, time-watched, title, and poster — slotted in after each type's stats section.


# Screenshot

<img width="1183" height="836" alt="image" src="https://github.com/user-attachments/assets/79ace534-bec3-4997-b3c6-087513138871" />

# What

- **`Yir2024MostPlayedCard.svelte`** — single card: fanart cover + purple gradient overlay (matches existing 2024 palette), rank (`.1`–`.10`), plays + time-watched stat-pair, title, and poster on the right. Poster gets a smooth `scale(1.05)` on hover.
- **`Yir2024MostPlayedSection.svelte`** — section header ("Most Watched Shows" / "Movies") above a stack of 10 cards. Gated in `Yir2024.svelte` on `mostWatched.{shows,movies}.length > 0`.
- **Alternating alignment** matching v2: cards alternate `align-self: center / flex-end / center / flex-start` every 4 (via `data-rank-position` attribute on a flex-column parent — no per-card margin).
- **Mobile reflow** matching v2: cards go full-width, rank pairs with poster on the top row, details span the second row.
- **i18n**: `yir_2024_most_watched_shows`, `yir_2024_most_watched_movies`, `yir_2024_plays_label`, `yir_2024_time_watched_label`.

# Conventions

- Reuses `Link.svelte`, `CrossOriginImage`, `UrlBuilder.media`, `formatNumber`, `toHumanDuration`, `languageTag`.
- Typography utility classes (`.bold`, `.uppercase`) instead of manual `font-weight` / `text-transform`.
- Semantic font-size tokens (`--font-size-text`, `--font-size-tag`, `--font-size-title`) where they fit; raw `--ni-*` only for hero-scale (32–160px) display sizes.
- Parent-driven spacing throughout — grid/flex `gap` on parents; child elements carry no margin for sibling spacing.
- No `letter-spacing` or non-meaningful `line-height` (kept `line-height: 0.8` on the rank with a comment explaining why).

# Test plan

- [ ] `/users/{user}/year/2024` renders 10 most-watched shows after the shows stats section, and 10 most-watched movies after the movies stats section.
- [ ] Cards alternate center / right / center / left on desktop; switch to full-width stacking at tablet-sm.
- [ ] Mobile: rank + poster on top row, details (stats + title) on the row beneath.
- [ ] Poster scales up smoothly on hover.
- [ ] Empty case: section is hidden when `mostWatched.{type}.length === 0`.
- [ ] Title and poster both link to the show/movie page.
- [ ] Safari: no visual glitches on the poster transform.