### PR TITLE
ci: tighten supply chain egress to block mode

### DIFF
--- a/.github/workflows/supply_chain.yml
+++ b/.github/workflows/supply_chain.yml
@@ -24,7 +24,16 @@ jobs:
       - name: Sealing the Outbound Gates aka Harden Runner
         uses: step-security/harden-runner@v2
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            codeload.github.com:443
+            deno.com:443
+            github.com:443
+            jsr.io:443
+            npm.jsr.io:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
 
       - name: Secure the Evidence aka Checkout Code
         uses: actions/checkout@v4
@@ -100,7 +109,16 @@ jobs:
       - name: Sealing the Outbound Gates aka Harden Runner
         uses: step-security/harden-runner@v2
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            codeload.github.com:443
+            deno.com:443
+            github.com:443
+            jsr.io:443
+            npm.jsr.io:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
 
       - name: Secure the Evidence aka Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Three days of audit-mode telemetry from step-security insights produced a stable endpoint set for the supply-chain workflow. This PR flips \`egress-policy\` from \`audit\` to \`block\` with an explicit allowlist.

Allowlisted:
- \`api.github.com\`, \`github.com\`, \`codeload.github.com\`, \`release-assets.githubusercontent.com\` - actions runtime, git checkout, action tarball downloads
- \`deno.com\` - \`denoland/setup-deno\` fetches the deno binary (this was the missing endpoint that forced the first block attempt to fall back to audit)
- \`jsr.io\`, \`npm.jsr.io\`, \`registry.npmjs.org\` - \`deno install\` resolves jsr + npm specifiers

Intentionally NOT allowlisted:
- \`www-api.ibm.com\` - \`@carbon/charts\` ships fire-and-forget telemetry to IBM. Blocking it is non-functional; charts still render. If a future use of carbon depends on telemetry being reachable, the diff that adds it back will state why.

Auto-allowed by harden-runner (do not need to list): GitHub Actions runner heartbeat (\`*.githubapp.com\`, \`results-receiver.actions.githubusercontent.com\`) and step-security's own telemetry (\`prod.app-api.stepsecurity.io\`).

## Test plan

- [ ] supply-chain workflow green on this PR (proves the allowlist is complete)
- [ ] no new \`Anomalous outbound call detected\` annotations from harden-runner
- [ ] manual check on the step-security insights dashboard after a few PR runs to confirm no \`www-api.ibm.com\` activity affects job outcome