### PR TITLE
Simplifies list component IDs

### DIFF
--- a/projects/client/src/lib/sections/lists/CastList.svelte
+++ b/projects/client/src/lib/sections/lists/CastList.svelte
@@ -4,26 +4,25 @@
   import type { ExtendedMediaType } from "$lib/requests/models/ExtendedMediaType";
   import type { CastMember } from "$lib/requests/models/MediaCrew";
   import {
-    SummaryDrawers,
-    summaryDrawerNavigation,
+      SummaryDrawers,
+      summaryDrawerNavigation,
   } from "../summary/_internal/summaryDrawerNavigation";
   import CastMemberItem from "./components/CastMemberItem.svelte";
 
   type CastListProps = {
     title: string;
     cast: CastMember[];
-    slug: string;
     type: ExtendedMediaType;
   };
 
-  const { title, cast, slug, type }: CastListProps = $props();
+  const { title, cast, type }: CastListProps = $props();
 
   const { buildDrawerLink } = summaryDrawerNavigation();
   const castDrawerLink = $derived(buildDrawerLink(SummaryDrawers.Cast));
 </script>
 
 <SectionList
-  id={`cast-list-${slug}`}
+  id={`cast-list-${type}`}
   items={cast}
   {title}
   drilldown={{

--- a/projects/client/src/lib/sections/lists/CreditsList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsList.svelte
@@ -59,7 +59,7 @@
 </script>
 
 <SectionList
-  id={`credits-list-${person.slug}-${type}-${selectedPosition}`}
+  id={`credits-list-${type}`}
   items={list}
   {title}
   drilldown={drilldownHref

--- a/projects/client/src/lib/sections/lists/RelatedList.svelte
+++ b/projects/client/src/lib/sections/lists/RelatedList.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <MediaList
-  id={`related-list-${type}-${slug}`}
+  id={`related-list-${type}`}
   useList={(params) => useRelatedList({ ...params, slug })}
   {type}
   {title}

--- a/projects/client/src/lib/sections/lists/VideoList.svelte
+++ b/projects/client/src/lib/sections/lists/VideoList.svelte
@@ -2,6 +2,7 @@
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
+  import type { MediaType } from "$lib/requests/models/MediaType";
   import type { MediaVideo } from "$lib/requests/models/MediaVideo";
   import {
     summaryDrawerNavigation,
@@ -15,9 +16,10 @@
   type VideoListProps = {
     slug: string;
     videos: MediaVideo[];
+    type: MediaType;
   };
 
-  const { slug, videos }: VideoListProps = $props();
+  const { slug, videos, type }: VideoListProps = $props();
 
   const { record, types, active } = $derived(useVideoTypes(videos));
   const items = $derived(record[$active] ?? []);
@@ -28,7 +30,7 @@
 
 {#if videos.length > 0}
   <SectionList
-    id={`video-list-${slug}`}
+    id={`video-list-${type}`}
     {items}
     title={m.list_title_extras()}
     drilldown={{

--- a/projects/client/src/lib/sections/lists/history/CreditsHistoryList.svelte
+++ b/projects/client/src/lib/sections/lists/history/CreditsHistoryList.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <SectionList
-  id={`credits-history-list-${person.slug}`}
+  id="credits-history-list"
   items={$list}
   title={m.list_title_from_my_history()}
   drilldown={drilldownLink

--- a/projects/client/src/lib/sections/lists/history/RecentlyWatchedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/RecentlyWatchedList.svelte
@@ -17,7 +17,7 @@
 
 <DrillableMediaList
   {title}
-  id={`recently-watched-list-${slug}-${mode}`}
+  id={`recently-watched-list-${mode}`}
   type={mode}
   useList={({ limit }: { limit: number }) =>
     useRecentlyWatchedList({

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
@@ -50,7 +50,7 @@
 </script>
 
 <SectionList
-  id={`season-episode-list-${show.slug}`}
+  id="season-episode-list"
   items={episodes}
   {title}
   {subtitle}

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
@@ -36,7 +36,7 @@
 <SectionList
   {title}
   {subtitle}
-  id={`season-poster-list-${show.slug}`}
+  id="season-poster-list"
   items={seasons}
   drilldown={{
     ...buildDrawerLink(SummaryDrawers.Seasons),

--- a/projects/client/src/lib/sections/lists/where-to-watch/WhereToWatchList.svelte
+++ b/projects/client/src/lib/sections/lists/where-to-watch/WhereToWatchList.svelte
@@ -60,7 +60,7 @@
 {#if isAired}
   <div transition:slide={{ duration: 150 }}>
     <SectionList
-      id={`where-to-watch-${target.media.slug}`}
+      id={`where-to-watch-${target.type}`}
       items={services}
       title={m.list_title_where_to_watch()}
       drilldown={{

--- a/projects/client/src/lib/sections/profile/components/ProfilesList.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfilesList.svelte
@@ -34,7 +34,7 @@
 
 <div class="trakt-profiles-list">
   <SectionList
-    id={`profiles-list-${slug}-${$current.value}`}
+    id="profiles-list"
     items={$profiles}
     title={m.list_title_social()}
     --height-list="var(--height-profile-list)"

--- a/projects/client/src/lib/sections/profile/components/ProgressList.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProgressList.svelte
@@ -34,7 +34,7 @@
     <DrillableMediaList
       --height-override-card="var(--height-portrait-card-sm)"
       --height-override-list="var(--height-poster-list-sm)"
-      id="progress-list-{$current.value}"
+      id="progress-list"
       source={{ id: "progress", type: $current.value }}
       title={m.list_title_progress()}
       drilldownLabel={m.button_label_view_all_progress()}

--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -90,12 +90,7 @@
   <WhereToWatchList type="episode" {episode} media={show} {streamOn} />
 </RenderFor>
 
-<CastList
-  title={m.list_title_actors()}
-  cast={crew.cast}
-  slug={show.slug}
-  type="episode"
-/>
+<CastList title={m.list_title_actors()} cast={crew.cast} type="episode" />
 
 <Comments
   media={show}

--- a/projects/client/src/lib/sections/summary/MovieSummary.svelte
+++ b/projects/client/src/lib/sections/summary/MovieSummary.svelte
@@ -15,7 +15,7 @@
   import Lists from "./components/lists/Lists.svelte";
   import MediaSummary from "./components/media/MediaSummary.svelte";
   import MediaSummaryV2 from "./components/media/v2/MediaSummary.svelte";
-  import CommunitySentiment from "./components/sentiment/Sentiment.svelte";
+  import Sentiment from "./components/sentiment/Sentiment.svelte";
   import TriviaList from "./components/trivia/TriviaList.svelte";
   import type { CommonMediaSummaryProps } from "./models/CommonMediaSummaryProps";
   import SummaryDrawer from "./SummaryDrawer.svelte";
@@ -50,7 +50,7 @@
     {#snippet contextualContent()}
       <RenderFor audience="all" device={["desktop"]}>
         <WhereToWatchList type="movie" {media} {streamOn} variant="inline" />
-        <CommunitySentiment {sentiment} slug={media.slug} variant="inline" />
+        <Sentiment {sentiment} type={media.type} variant="inline" />
       </RenderFor>
     {/snippet}
   </MediaSummary>
@@ -58,19 +58,14 @@
 
 <RenderFor audience="all" device={["mobile", "tablet-sm", "tablet-lg"]}>
   <WhereToWatchList type="movie" {media} {streamOn} />
-  <CommunitySentiment {sentiment} slug={media.slug} />
+  <Sentiment {sentiment} type={media.type} />
 </RenderFor>
 
-<CastList
-  title={m.list_title_actors()}
-  cast={crew.cast}
-  slug={media.slug}
-  type={media.type}
-/>
+<CastList title={m.list_title_actors()} cast={crew.cast} type={media.type} />
 
 <Comments {media} type="movie" />
 
-<VideoList slug={media.slug} {videos} />
+<VideoList slug={media.slug} {videos} type="movie" />
 
 <RelatedList
   title={m.list_title_related_movies()}

--- a/projects/client/src/lib/sections/summary/ShowSummary.svelte
+++ b/projects/client/src/lib/sections/summary/ShowSummary.svelte
@@ -78,7 +78,7 @@
     {#snippet contextualContent()}
       <RenderFor audience="all" device={["desktop"]}>
         <WhereToWatchList type="show" {media} {streamOn} variant="inline" />
-        <Sentiment {sentiment} slug={media.slug} variant="inline" />
+        <Sentiment {sentiment} type={media.type} variant="inline" />
       </RenderFor>
     {/snippet}
   </MediaSummary>
@@ -86,19 +86,14 @@
 
 <RenderFor audience="all" device={["mobile", "tablet-sm", "tablet-lg"]}>
   <WhereToWatchList type="show" {media} {streamOn} />
-  <Sentiment {sentiment} slug={media.slug} />
+  <Sentiment {sentiment} type={media.type} />
 </RenderFor>
 
-<CastList
-  title={m.list_title_actors()}
-  cast={crew.cast}
-  slug={media.slug}
-  type={media.type}
-/>
+<CastList title={m.list_title_actors()} cast={crew.cast} type={media.type} />
 
 <Comments {media} type="show" />
 
-<VideoList slug={media.slug} {videos} />
+<VideoList slug={media.slug} {videos} type="show" />
 
 <SeasonList show={media} {seasons} {currentSeason} />
 

--- a/projects/client/src/lib/sections/summary/components/comments/Comments.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/Comments.svelte
@@ -47,7 +47,7 @@
 
 <RenderFor audience="all">
   <SectionList
-    id={`comments-list-${media.slug}-${$sortType.value}`}
+    id={`comments-list-${props.type}`}
     items={$comments}
     title={m.list_title_comments()}
     --height-list="var(--height-comments-list)"

--- a/projects/client/src/lib/sections/summary/components/sentiment/Sentiment.svelte
+++ b/projects/client/src/lib/sections/summary/components/sentiment/Sentiment.svelte
@@ -2,23 +2,24 @@
   import type { ListVariant } from "$lib/components/lists/section-list/ListVariant";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import type { MediaType } from "$lib/requests/models/MediaType";
   import type { SentimentAnalysis } from "$lib/requests/models/SentimentAnalysis.ts";
   import SentimentCard from "./_internal/SentimentCard.svelte";
 
   const {
     sentiment,
-    slug,
     variant,
+    type,
   }: {
     sentiment: SentimentAnalysis | Nil;
-    slug: string;
     variant?: ListVariant;
+    type: MediaType;
   } = $props();
 </script>
 
 {#if sentiment}
   <SectionList
-    id={`sentiment-${slug}`}
+    id={`sentiment-${type}`}
     items={[{ ...sentiment, key: "sentiment" }]}
     title={m.header_community_sentiment()}
     {variant}

--- a/projects/client/src/lib/sections/summary/components/trivia/TriviaList.svelte
+++ b/projects/client/src/lib/sections/summary/components/trivia/TriviaList.svelte
@@ -41,7 +41,7 @@
 {#if summaryItem.text.length > 0}
   <div class="trivia-list-container" transition:slide={{ duration: 150 }}>
     <SectionList
-      id={`trivia-list-${media.slug}-${media.type}`}
+      id={`trivia-list-${media.type}`}
       items={[summaryItem]}
       title={m.list_title_trivia()}
       --height-list="var(--height-trivia-list)"


### PR DESCRIPTION
## 🎶 Notes 🎶
- Refactors list components to standardize and simplify their `id` attributes.
  - The id's should be at most unique on type; collapsing/hiding should not be on a slug level.