### PR TITLE
YIR: 2024 network and studios

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4705,6 +4705,30 @@
       "default": "Time Watched",
       "description": "Stat label under the time-watched duration on the 2024 Year in Review most-watched cards."
     },
+    "yir_2024_most_watched_networks": {
+      "default": "Most watched networks",
+      "description": "Section heading above the networks bubble chart on the 2024 Year in Review template."
+    },
+    "yir_2024_most_watched_studios": {
+      "default": "Most watched studios",
+      "description": "Section heading above the studios bubble chart on the 2024 Year in Review template."
+    },
+    "yir_2024_companies_most_watched": {
+      "default": "Most Watched",
+      "description": "Row label above the user's top-watched network/studio name on the 2024 Year in Review companies section."
+    },
+    "yir_2024_companies_least_watched": {
+      "default": "Least Watched",
+      "description": "Row label above the user's least-watched network/studio name on the 2024 Year in Review companies section."
+    },
+    "yir_2024_network_count": {
+      "default": "Network Count",
+      "description": "Row label for the total number of distinct networks watched on the 2024 Year in Review networks section."
+    },
+    "yir_2024_studio_count": {
+      "default": "Studio Count",
+      "description": "Row label for the total number of distinct studios watched on the 2024 Year in Review studios section."
+    },
     "yir_2024_stats_intro_shows": {
       "default": "In {year}, you watched",
       "description": "Lead-in line above the big '{hours} hours of {count} Shows' headline on the 2024 Year in Review TV stats section.",

--- a/projects/client/src/lib/components/charts/BubbleChart.svelte
+++ b/projects/client/src/lib/components/charts/BubbleChart.svelte
@@ -28,10 +28,17 @@
   const filterId = `bubble-chart-whiteimage-${crypto.randomUUID()}`;
 
   const minContentRadius = useVarToPixels("var(--min-radius-bubble-chart)");
-  const observedHeight = useVarToPixels("var(--height-bubble-chart)");
 
-  const { observedDimension: observedWidth, observeDimension } =
+  // Width and height are both read from the container element so consumers
+  // can size the chart however they like (CSS var token, fixed px, percent
+  // of parent, etc.) without needing a global CSS variable lookup. Using
+  // `useVarToPixels` for height previously meant any local override of
+  // `--height-bubble-chart` was ignored, since that helper resolves vars
+  // against `document.body`, not the chart container.
+  const { observedDimension: observedWidth, observeDimension: observeWidth } =
     useDimensionObserver("width");
+  const { observedDimension: observedHeight, observeDimension: observeHeight } =
+    useDimensionObserver("height");
 
   let hovered = $state<PackedNode | null>(null);
   let pointer = $state({ x: 0, y: 0 });
@@ -101,7 +108,8 @@
 
 <div
   class="bubble-chart"
-  use:observeDimension
+  use:observeWidth
+  use:observeHeight
   onpointermove={handlePointerMove}
   onpointerleave={handlePointerLeave}
   role="presentation"

--- a/projects/client/src/lib/requests/_internal/mapToYirDetail.ts
+++ b/projects/client/src/lib/requests/_internal/mapToYirDetail.ts
@@ -231,7 +231,7 @@ export function mapToYirDetail(response: RawYirResponse): YirDetail {
       ),
     },
     networks: mapCompanies(response.networks ?? []),
-    productionCompanies: mapCompanies(response.production_companies ?? []),
+    studios: mapCompanies(response.production_companies ?? []),
     topRated: {
       shows: mapTopRatedShows(response.top_rated?.shows ?? []),
       movies: mapTopRatedMovies(response.top_rated?.movies ?? []),

--- a/projects/client/src/lib/requests/models/YirDetail.ts
+++ b/projects/client/src/lib/requests/models/YirDetail.ts
@@ -101,7 +101,7 @@ export const YirDetailSchema = z.object({
     movies: YirGenresGroupSchema,
   }),
   networks: YirCompanySchema.array(),
-  productionCompanies: YirCompanySchema.array(),
+  studios: YirCompanySchema.array(),
   topRated: z.object({
     shows: YirTopRatedItemSchema.array(),
     movies: YirTopRatedItemSchema.array(),

--- a/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
+++ b/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
@@ -2,6 +2,7 @@
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import { m } from "$lib/paraglide/messages";
   import type { YirDetail } from "$lib/requests/models/YirDetail";
+  import Yir2024CompaniesSection from "./_internal/Yir2024CompaniesSection.svelte";
   import Yir2024MostPlayedSection from "./_internal/Yir2024MostPlayedSection.svelte";
   import Yir2024PageInner from "./_internal/Yir2024PageInner.svelte";
   import Yir2024PlayCard from "./_internal/Yir2024PlayCard.svelte";
@@ -59,6 +60,12 @@
       </Yir2024PageInner>
     {/if}
 
+    {#if detail.networks.length > 0}
+      <Yir2024PageInner>
+        <Yir2024CompaniesSection type="shows" companies={detail.networks} />
+      </Yir2024PageInner>
+    {/if}
+
     {#if detail.stats.movies.playCounts.total > 0}
       <Yir2024PageInner>
         <Yir2024StatsSection type="movies" stats={detail.stats.movies} {year} />
@@ -70,6 +77,15 @@
         <Yir2024MostPlayedSection
           type="movies"
           items={detail.mostWatched.movies}
+        />
+      </Yir2024PageInner>
+    {/if}
+
+    {#if detail.studios.length > 0}
+      <Yir2024PageInner>
+        <Yir2024CompaniesSection
+          type="movies"
+          companies={detail.studios}
         />
       </Yir2024PageInner>
     {/if}

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CompaniesSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CompaniesSection.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { YirCompany } from "$lib/requests/models/YirDetail.ts";
+  import { formatNumber } from "$lib/utils/format/formatNumber.ts";
+  import YirCompaniesBubbleChart from "../../_internal/YirCompaniesBubbleChart.svelte";
+  import YirTooltip from "../../_internal/YirTooltip.svelte";
+
+  type Yir2024CompaniesSectionProps = {
+    type: "shows" | "movies";
+    companies: YirCompany[];
+  };
+
+  const { type, companies }: Yir2024CompaniesSectionProps = $props();
+
+  const heading = $derived(
+    type === "shows"
+      ? m.yir_2024_most_watched_networks()
+      : m.yir_2024_most_watched_studios(),
+  );
+
+  const countLabel = $derived(
+    type === "shows" ? m.yir_2024_network_count() : m.yir_2024_studio_count(),
+  );
+
+  const mostWatched = $derived(companies[0]);
+  const leastWatched = $derived(companies[companies.length - 1]);
+  const companyCount = $derived(companies.length);
+
+  // FIXME(i18n): hardcoded English plurals match the existing convention
+  // across the YIR module (default template uses the same pattern in
+  // YirStatsSection, YirTotalsSection, YirMostWatchedSection, etc.).
+  // Migrate holistically when i18n keys are added across all YIR sections.
+  function itemUnit(count: number): string {
+    if (type === "movies") return count === 1 ? "movie" : "movies";
+    return count === 1 ? "show" : "shows";
+  }
+</script>
+
+<section class="yir-2024-companies" id="section-{type}-companies">
+  <div class="yir-2024-companies-panel">
+    <div class="yir-2024-companies-text">
+      <h2 class="bold yir-2024-companies-heading">{heading}</h2>
+
+      <dl class="yir-2024-companies-stats">
+        {#if mostWatched}
+          <div class="yir-2024-companies-row">
+            <dt>{m.yir_2024_companies_most_watched()}</dt>
+            <dd>
+              <span class="ellipsis yir-2024-companies-name">
+                {mostWatched.name}
+              </span>
+              <span class="bold uppercase tag yir-2024-companies-count">
+                {formatNumber(mostWatched.count)}
+                {itemUnit(mostWatched.count)}
+              </span>
+            </dd>
+          </div>
+        {/if}
+
+        {#if leastWatched && leastWatched.id !== mostWatched?.id}
+          <div class="yir-2024-companies-row">
+            <dt>{m.yir_2024_companies_least_watched()}</dt>
+            <dd>
+              <span class="ellipsis yir-2024-companies-name">
+                {leastWatched.name}
+              </span>
+              <span class="bold uppercase tag yir-2024-companies-count">
+                {formatNumber(leastWatched.count)}
+                {itemUnit(leastWatched.count)}
+              </span>
+            </dd>
+          </div>
+        {/if}
+
+        <div class="yir-2024-companies-row">
+          <dt>{countLabel}</dt>
+          <dd class="yir-2024-companies-total">{formatNumber(companyCount)}</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="yir-2024-companies-chart">
+      <YirCompaniesBubbleChart {companies}>
+        {#snippet tooltip({ company })}
+          <YirTooltip
+            main={company.name}
+            sub="{formatNumber(company.count)} {itemUnit(company.count)}"
+          />
+        {/snippet}
+      </YirCompaniesBubbleChart>
+    </div>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-2024-companies {
+    width: 100%;
+  }
+
+  // Transparent two-column layout: text on the left, bubble chart on the
+  // right. Collapses to a single column on smaller viewports.
+  .yir-2024-companies-panel {
+    --panel-padding-x: var(--ni-44);
+    --panel-padding-y: var(--ni-44);
+
+    padding: var(--panel-padding-y) var(--panel-padding-x);
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    gap: var(--ni-32);
+    align-items: center;
+
+    @include for-tablet-lg-and-below {
+      grid-template-columns: minmax(0, 1fr);
+      gap: var(--ni-24);
+    }
+
+    @include for-mobile {
+      --panel-padding-x: var(--ni-20);
+      --panel-padding-y: var(--ni-20);
+    }
+  }
+
+  .yir-2024-companies-text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-32);
+
+    @include for-tablet-lg {
+      flex-direction: row;
+      align-items: center;
+
+      .yir-2024-companies-heading {
+        flex: 0 0 auto;
+        width: min-content;
+      }
+
+      .yir-2024-companies-stats {
+        flex: 1;
+        min-width: 0;
+      }
+    }
+  }
+
+  .yir-2024-companies-heading {
+    font-size: clamp(var(--ni-32), 5vw, var(--ni-56));
+    color: var(--shade-10);
+
+    @include for-mobile {
+      font-size: var(--ni-28);
+    }
+  }
+
+  .yir-2024-companies-stats {
+    display: flex;
+    flex-direction: column;
+  }
+
+  // Each row has a light divider under it (matching v2's stat-line) so the
+  // three rows read as a list. Last row drops the divider.
+  .yir-2024-companies-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--ni-32);
+    padding: var(--ni-16) 0;
+    border-bottom: var(--border-thickness-xxs) solid var(--shade-800);
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    @include for-tablet-sm-and-below {
+      gap: var(--ni-16);
+    }
+
+    dt {
+      font-size: var(--font-size-title);
+      color: var(--shade-10);
+    }
+
+    dd {
+      display: flex;
+      align-items: center;
+      gap: var(--gap-xs);
+      font-size: var(--font-size-title);
+      color: var(--shade-10);
+      min-width: 0;
+    }
+  }
+
+  // Network/studio name pops in the YIR purple so it visually links back to
+  // the bubble chart's highlight color (also matches v2's link styling).
+  // Truncation handled by the `.ellipsis` utility class on the markup.
+  .yir-2024-companies-name {
+    color: var(--purple-300);
+  }
+
+  // Pill-shaped count badge with white background + dark text — matches
+  // the v2 design exactly. `--border-radius-xxl` is the established YIR /
+  // v3 token for pill-shaped tags (used by VIP badges, MostPopularTag, etc).
+  // Font sizing is handled by the `.tag` utility class on the markup.
+  .yir-2024-companies-count {
+    background: var(--shade-10);
+    color: var(--shade-900);
+    border-radius: var(--border-radius-xxl);
+    padding: var(--ni-4) var(--ni-10);
+    white-space: nowrap;
+  }
+
+  .yir-2024-companies-total {
+    color: var(--shade-10);
+  }
+
+  .yir-2024-companies-chart {
+    width: 100%;
+    min-width: 0;
+    height: var(--ni-480);
+
+    @include for-mobile {
+      height: var(--ni-380);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/_internal/YirCompaniesBubbleChart.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirCompaniesBubbleChart.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import BubbleChart from "$lib/components/charts/BubbleChart.svelte";
+  import type { YirCompany } from "$lib/requests/models/YirDetail.ts";
+  import type { Snippet } from "svelte";
+
+  type CompanyTooltipArgs = {
+    company: YirCompany;
+  };
+
+  type YirCompaniesBubbleChartProps = {
+    companies: YirCompany[];
+    /**
+     * Receives the resolved company so consumers can format the tooltip
+     * (label + plural unit) however they need without re-implementing the
+     * lookup back from BubbleChart's generic item shape.
+     */
+    tooltip: Snippet<[CompanyTooltipArgs]>;
+  };
+
+  const {
+    companies,
+    tooltip: tooltipSnippet,
+  }: YirCompaniesBubbleChartProps = $props();
+
+  // Companies with no brand color or with a pure-black brand color would
+  // collapse onto the panel background; fall back to a neutral semantic
+  // gray so the bubble still reads. Carbon writes the value as an inline
+  // SVG fill, so `var(...)` strings resolve at render time at the SVG node.
+  const fallbackColor = "var(--shade-800)";
+  const blackPattern = /^#0{3}(?:0{3})?$/i;
+
+  function colorFor(company: YirCompany): string {
+    const raw = (company.color ?? "").toLowerCase();
+    if (!raw || blackPattern.test(raw)) return fallbackColor;
+    return company.color ?? fallbackColor;
+  }
+
+  const items = $derived(
+    companies.map((c) => ({
+      id: c.id,
+      label: c.name,
+      value: c.count,
+      imageUrl: c.imageUrl,
+      color: colorFor(c),
+    })),
+  );
+
+  const companyById = $derived(
+    new Map(companies.map((c) => [c.id, c] as const)),
+  );
+</script>
+
+<BubbleChart {items}>
+  {#snippet tooltip({ item })}
+    {@const company = companyById.get(item.id)}
+    {#if company}
+      {@render tooltipSnippet({ company })}
+    {/if}
+  {/snippet}
+</BubbleChart>

--- a/projects/client/src/lib/sections/yir/default/YirDefault.svelte
+++ b/projects/client/src/lib/sections/yir/default/YirDefault.svelte
@@ -73,8 +73,8 @@
     <YirGenresSection type="movies" genres={detail.genres.movies} />
   {/if}
 
-  {#if detail.productionCompanies.length > 0}
-    <YirStudiosSection studios={detail.productionCompanies} />
+  {#if detail.studios.length > 0}
+    <YirStudiosSection studios={detail.studios} />
   {/if}
 
   {#if detail.topRated.movies.length > 0}

--- a/projects/client/src/lib/sections/yir/default/_internal/YirNetworksChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirNetworksChart.svelte
@@ -1,34 +1,14 @@
 <script lang="ts">
-  import BubbleChart from "$lib/components/charts/BubbleChart.svelte";
-  import type { YirCompany } from "$lib/requests/models/YirDetail";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
+  import YirCompaniesBubbleChart from "../../_internal/YirCompaniesBubbleChart.svelte";
+  import type { YirCompany } from "$lib/requests/models/YirDetail.ts";
 
-  const {
-    companies,
-    type = "shows",
-  }: {
+  type YirNetworksChartProps = {
     companies: YirCompany[];
     type?: "shows" | "movies";
-  } = $props();
+  };
 
-  const fallbackColor = "#333";
-  const blackPattern = /^#0{3}(?:0{3})?$/i;
-
-  function colorFor(company: YirCompany): string {
-    const raw = (company.color ?? "").toLowerCase();
-    if (!raw || blackPattern.test(raw)) return fallbackColor;
-    return company.color ?? fallbackColor;
-  }
-
-  const items = $derived(
-    companies.map((c) => ({
-      id: c.id,
-      label: c.name,
-      value: c.count,
-      imageUrl: c.imageUrl,
-      color: colorFor(c),
-    })),
-  );
+  const { companies, type = "shows" }: YirNetworksChartProps = $props();
 
   function itemLabelFor(count: number): string {
     if (type === "movies") return count === 1 ? "movie" : "movies";
@@ -37,14 +17,14 @@
 </script>
 
 <div class="yir-networks-chart">
-  <BubbleChart {items}>
-    {#snippet tooltip({ item })}
+  <YirCompaniesBubbleChart {companies}>
+    {#snippet tooltip({ company })}
       <YirTooltip
-        main={item.label}
-        sub="{item.value} {itemLabelFor(item.value)}"
+        main={company.name}
+        sub="{company.count} {itemLabelFor(company.count)}"
       />
     {/snippet}
-  </BubbleChart>
+  </YirCompaniesBubbleChart>
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
## Summary

Ports the v2 "Most watched networks" (TV) and "Most watched studios" (movies) sections into the 2024 YIR template. Renders the existing YIR network/studio data as a panel with stat rows on the left and a bubble chart on the right.

## What

- **`Yir2024CompaniesSection.svelte`** — transparent rounded panel with a two-column grid: two-line heading + stat rows (Most Watched / Least Watched / Network or Studio Count) on the left, bubble chart on the right. Collapses to one column on tablet-sm-and-below. Used for both shows (networks) and movies (studios) via a `type` prop.
- **`YirCompaniesBubbleChart.svelte`** (shared, `yir/_internal/`) — wraps the existing `BubbleChart` with `YirCompany` color-fallback + mapping + snippet-tooltip API. Same extraction pattern as `YirWeeklyPlaysChart`.
- **`default/_internal/YirNetworksChart.svelte`** — collapsed to a thin wrapper around the new shared component (default tooltip + height).
- **`BubbleChart.svelte`** — height is now read from the container via `useDimensionObserver("height")` instead of `useVarToPixels("--height-bubble-chart")`. The old helper resolves CSS vars against `document.body`, so local overrides were silently ignored and the chart rendered at the global 640px default regardless of container size — clipping content in any panel narrower than that.
- **`YirDetail.studios`** — renamed from `productionCompanies` for clarity; raw API field `production_companies` still maps in.
- **i18n**: `yir_2024_most_watched_networks`, `yir_2024_most_watched_studios`, `yir_2024_companies_most_watched`, `yir_2024_companies_least_watched`, `yir_2024_network_count`, `yir_2024_studio_count`.

## Conventions

- Shared chart logic lives in `yir/_internal/` so both templates can consume it (per the `_internal/` visibility rule).
- Typography utility classes (`.bold`, `.uppercase`, `.tag`, `.ellipsis`) instead of manual `font-weight` / `text-transform` / `font-size` / overflow rules.
- Semantic font-size tokens (`--font-size-title`, `--font-size-tag`); raw `--ni-*` only for the hero-scale heading.
- Parent-driven spacing (grid / flex `gap`); row padding kept for the intra-row divider rhythm (matches `Yir2024StatsSection`).
- All colors are semantic CSS vars (`--purple-300`, `--shade-10`, `--shade-900`, `--shade-800`) — no raw hex, including the bubble-chart fallback.
- Heading break uses `\n` + `white-space: pre-line` so translators can re-balance the two-line wrap.
- Network / studio names render as styled text rather than links (`UrlBuilder` has no history-by-network/studio helper yet); follow-up if/when one lands.
- "show/shows" / "movie/movies" pluralization uses English ternary, same as the existing default template (Paraglide doesn't honor the ICU plural syntax in our setup).

## Test plan

- [ ] `/users/{user}/year/2024` renders the networks panel after the shows stats section and the studios panel after the movies stats section.
- [ ] Three stat rows: Most Watched, Least Watched, Network/Studio Count. Single-company edge case hides the duplicate Least Watched row.
- [ ] Bubble chart shows all companies without clipping at the bottom; bubbles scale to fit the container at desktop, tablet-sm, and mobile widths.
- [ ] Bubble hover tooltip shows the company name and "{n} show(s)" / "{n} movie(s)" in natural case.
- [ ] Heading wraps as two lines ("Most watched" / "networks" — and "studios").
- [ ] Company names use the purple highlight and ellipsize on overflow; count badges render as white pills with uppercase text.
- [ ] Default template's networks/studios still render correctly through the refactored chart wrapper (no visual regression).
- [ ] Theme switch does not affect colors (YIR is dark-only).
