### PR TITLE
YIR: 2024 genres

### DIFF
--- a/projects/client/i18n/messages/bg-BG.json
+++ b/projects/client/i18n/messages/bg-BG.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Сигурни ли сте, че искате да прекратите следването на {username}?",
   "warning_prompt_younify_unlink": "Сигурни ли сте, че искате да откачите {service}?",
   "warning_smart_lists_limit": "Достигнали сте лимита си за интелигентни списъци",
-  "yir_2024_companies_least_watched": "Най-малко гледани",
-  "yir_2024_companies_most_watched": "Най-гледани",
   "yir_2024_directed_by": "Режисиран от",
   "yir_2024_first_play": "Първо пускане",
   "yir_2024_huge_label_year_in_review": "годишен преглед",

--- a/projects/client/i18n/messages/ca-ES.json
+++ b/projects/client/i18n/messages/ca-ES.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Estàs segur que vols deixar de seguir {username}?",
   "warning_prompt_younify_unlink": "Estàs segur que vols desvincular {service}?",
   "warning_smart_lists_limit": "Has arribat al límit de llistes intel·ligents",
-  "yir_2024_companies_least_watched": "Menys vist",
-  "yir_2024_companies_most_watched": "Més vist",
   "yir_2024_directed_by": "Dirigit per",
   "yir_2024_first_play": "Primera reproducció",
   "yir_2024_huge_label_year_in_review": "resum de l'any",

--- a/projects/client/i18n/messages/da-DK.json
+++ b/projects/client/i18n/messages/da-DK.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Er du sikker på, at du vil stoppe med at følge {username}?",
   "warning_prompt_younify_unlink": "Er du sikker på, at du vil frakoble {service}?",
   "warning_smart_lists_limit": "Du har nået din grænse for smarte lister",
-  "yir_2024_companies_least_watched": "Mindst sete",
-  "yir_2024_companies_most_watched": "Mest sete",
   "yir_2024_directed_by": "Instrueret af",
   "yir_2024_first_play": "Første afspilning",
   "yir_2024_huge_label_year_in_review": "årsresumé",

--- a/projects/client/i18n/messages/de-DE.json
+++ b/projects/client/i18n/messages/de-DE.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Möchten Sie {username} wirklich entfolgen?",
   "warning_prompt_younify_unlink": "Möchten Sie {service} wirklich entknüpfen?",
   "warning_smart_lists_limit": "Sie haben Ihr Smart List-Limit erreicht",
-  "yir_2024_companies_least_watched": "Am wenigsten angesehene",
-  "yir_2024_companies_most_watched": "Meistgesehene",
   "yir_2024_directed_by": "Regie von",
   "yir_2024_first_play": "Erste Wiedergabe",
   "yir_2024_huge_label_year_in_review": "jahresrückblick",

--- a/projects/client/i18n/messages/el-GR.json
+++ b/projects/client/i18n/messages/el-GR.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Είστε σίγουροι ότι θέλετε να διακόψετε την παρακολούθηση του {username};",
   "warning_prompt_younify_unlink": "Είστε σίγουροι ότι θέλετε να αποσυνδέσετε το {service};",
   "warning_smart_lists_limit": "Έχετε φτάσει το όριο έξυπνων λιστών σας",
-  "yir_2024_companies_least_watched": "Τα λιγότερο παρακολουθούμενα",
-  "yir_2024_companies_most_watched": "Τα πιο παρακολουθούμενα",
   "yir_2024_directed_by": "Σκηνοθεσία",
   "yir_2024_first_play": "Πρώτη Προβολή",
   "yir_2024_huge_label_year_in_review": "ανασκόπηση έτους",

--- a/projects/client/i18n/messages/en-AU.json
+++ b/projects/client/i18n/messages/en-AU.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Are you sure you want to unfollow {username}?",
   "warning_prompt_younify_unlink": "Are you sure you want to unlink {service}?",
   "warning_smart_lists_limit": "You've reached your smart list limit",
-  "yir_2024_companies_least_watched": "Least Watched",
-  "yir_2024_companies_most_watched": "Most Watched",
   "yir_2024_directed_by": "Directed By",
   "yir_2024_first_play": "First Play",
   "yir_2024_huge_label_year_in_review": "year in review",

--- a/projects/client/i18n/messages/es-ES.json
+++ b/projects/client/i18n/messages/es-ES.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "¿Estás seguro de que quieres dejar de seguir a {username}?",
   "warning_prompt_younify_unlink": "¿Estás seguro de que quieres desvincular {service}?",
   "warning_smart_lists_limit": "Has alcanzado tu límite de listas inteligentes",
-  "yir_2024_companies_least_watched": "Menos vistas",
-  "yir_2024_companies_most_watched": "Más vistas",
   "yir_2024_directed_by": "Dirigido por",
   "yir_2024_first_play": "Primera Reproducción",
   "yir_2024_huge_label_year_in_review": "tu año en Trakt",

--- a/projects/client/i18n/messages/es-MX.json
+++ b/projects/client/i18n/messages/es-MX.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "¿Estás seguro de que quieres dejar de seguir a {username}?",
   "warning_prompt_younify_unlink": "¿Estás seguro de que quieres desvincular {service}?",
   "warning_smart_lists_limit": "Has alcanzado tu límite de listas inteligentes",
-  "yir_2024_companies_least_watched": "Menos visto",
-  "yir_2024_companies_most_watched": "Más visto",
   "yir_2024_directed_by": "Dirigido por",
   "yir_2024_first_play": "Primera Reproducción",
   "yir_2024_huge_label_year_in_review": "resumen anual",

--- a/projects/client/i18n/messages/fa-IR.json
+++ b/projects/client/i18n/messages/fa-IR.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "آیا مطمئن هستید که می‌خواهید {username} را لغو دنبال کنید؟",
   "warning_prompt_younify_unlink": "آیا مطمئن هستید که می‌خواهید {service} را قطع پیوند کنید؟",
   "warning_smart_lists_limit": "به حداکثر تعداد لیست‌های هوشمند خود رسیده‌اید",
-  "yir_2024_companies_least_watched": "کم بیننده‌ترین",
-  "yir_2024_companies_most_watched": "پر بیننده‌ترین",
   "yir_2024_directed_by": "کارگردانی شده توسط",
   "yir_2024_first_play": "اولین پخش",
   "yir_2024_huge_label_year_in_review": "مرور سال",

--- a/projects/client/i18n/messages/fr-CA.json
+++ b/projects/client/i18n/messages/fr-CA.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Voulez-vous vraiment ne plus suivre {username}?",
   "warning_prompt_younify_unlink": "Voulez-vous vraiment dissocier {service}?",
   "warning_smart_lists_limit": "Vous avez atteint votre limite de listes intelligentes",
-  "yir_2024_companies_least_watched": "Les moins regardés",
-  "yir_2024_companies_most_watched": "Les plus regardés",
   "yir_2024_directed_by": "Réalisé par",
   "yir_2024_first_play": "Première lecture",
   "yir_2024_huge_label_year_in_review": "rétrospective annuelle",

--- a/projects/client/i18n/messages/fr-FR.json
+++ b/projects/client/i18n/messages/fr-FR.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Êtes-vous sûr de vouloir ne plus suivre {username} ?",
   "warning_prompt_younify_unlink": "Êtes-vous sûr de vouloir délier {service} ?",
   "warning_smart_lists_limit": "Vous avez atteint la limite de vos listes intelligentes",
-  "yir_2024_companies_least_watched": "Les moins visionnés",
-  "yir_2024_companies_most_watched": "Les plus visionnés",
   "yir_2024_directed_by": "Réalisé par",
   "yir_2024_first_play": "Première lecture",
   "yir_2024_huge_label_year_in_review": "bilan annuel",

--- a/projects/client/i18n/messages/hu-HU.json
+++ b/projects/client/i18n/messages/hu-HU.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Biztosan megszünteti {username} követését?",
   "warning_prompt_younify_unlink": "Biztosan leválasztod a(z) {service} szolgáltatást?",
   "warning_smart_lists_limit": "Elérted az okos listák korlátját",
-  "yir_2024_companies_least_watched": "Legkevésbé nézett",
-  "yir_2024_companies_most_watched": "Legnézettebb",
   "yir_2024_directed_by": "Rendezte",
   "yir_2024_first_play": "Első lejátszás",
   "yir_2024_huge_label_year_in_review": "éves összefoglaló",

--- a/projects/client/i18n/messages/id-ID.json
+++ b/projects/client/i18n/messages/id-ID.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Anda yakin ingin berhenti mengikuti {username}?",
   "warning_prompt_younify_unlink": "Anda yakin ingin melepaskan tautan {service}?",
   "warning_smart_lists_limit": "Anda telah mencapai batas daftar cerdas Anda",
-  "yir_2024_companies_least_watched": "Paling Sedikit Ditonton",
-  "yir_2024_companies_most_watched": "Paling Banyak Ditonton",
   "yir_2024_directed_by": "Disutradarai Oleh",
   "yir_2024_first_play": "Tontonan Pertama",
   "yir_2024_huge_label_year_in_review": "kilas balik tahunan",

--- a/projects/client/i18n/messages/it-IT.json
+++ b/projects/client/i18n/messages/it-IT.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Sei sicuro di voler smettere di seguire {username}?",
   "warning_prompt_younify_unlink": "Sei sicuro di voler scollegare {service}?",
   "warning_smart_lists_limit": "Hai raggiunto il limite di liste intelligenti",
-  "yir_2024_companies_least_watched": "Meno Visti",
-  "yir_2024_companies_most_watched": "Più Visti",
   "yir_2024_directed_by": "Diretto da",
   "yir_2024_first_play": "Prima riproduzione",
   "yir_2024_huge_label_year_in_review": "riepilogo dell'anno",

--- a/projects/client/i18n/messages/ja-JP.json
+++ b/projects/client/i18n/messages/ja-JP.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "{username}のフォローを解除しますか？",
   "warning_prompt_younify_unlink": "{service}のリンクを解除してもよろしいですか？",
   "warning_smart_lists_limit": "スマートリストの制限に達しました",
-  "yir_2024_companies_least_watched": "最も視聴回数が少ない",
-  "yir_2024_companies_most_watched": "最も視聴された",
   "yir_2024_directed_by": "監督",
   "yir_2024_first_play": "初再生",
   "yir_2024_huge_label_year_in_review": "年間レビュー",

--- a/projects/client/i18n/messages/nb-NO.json
+++ b/projects/client/i18n/messages/nb-NO.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Er du sikker på at du vil slutte å følge {username}?",
   "warning_prompt_younify_unlink": "Er du sikker på at du vil frakoble {service}?",
   "warning_smart_lists_limit": "Du har nådd grensen for smarte lister",
-  "yir_2024_companies_least_watched": "Minst sette",
-  "yir_2024_companies_most_watched": "Mest sette",
   "yir_2024_directed_by": "Regissert av",
   "yir_2024_first_play": "Første avspilling",
   "yir_2024_huge_label_year_in_review": "året i retrospekt",

--- a/projects/client/i18n/messages/nl-NL.json
+++ b/projects/client/i18n/messages/nl-NL.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Weet je zeker dat je {username} wilt ontvolgen?",
   "warning_prompt_younify_unlink": "Weet je zeker dat je {service} wilt ontkoppelen?",
   "warning_smart_lists_limit": "U heeft de limiet voor slimme lijsten bereikt",
-  "yir_2024_companies_least_watched": "Minste bekeken",
-  "yir_2024_companies_most_watched": "Meest bekeken",
   "yir_2024_directed_by": "Geregisseerd door",
   "yir_2024_first_play": "Eerste afspeling",
   "yir_2024_huge_label_year_in_review": "jaaroverzicht",

--- a/projects/client/i18n/messages/pl-PL.json
+++ b/projects/client/i18n/messages/pl-PL.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Czy na pewno chcesz przestać obserwować {username}?",
   "warning_prompt_younify_unlink": "Czy na pewno chcesz rozłączyć {service}?",
   "warning_smart_lists_limit": "Osiągnąłeś limit inteligentnych list",
-  "yir_2024_companies_least_watched": "Najrzadziej oglądane",
-  "yir_2024_companies_most_watched": "Najczęściej oglądane",
   "yir_2024_directed_by": "Reżyseria",
   "yir_2024_first_play": "Pierwsze odtworzenie",
   "yir_2024_huge_label_year_in_review": "podsumowanie roku",

--- a/projects/client/i18n/messages/pt-BR.json
+++ b/projects/client/i18n/messages/pt-BR.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Tem certeza que deseja deixar de seguir {username}?",
   "warning_prompt_younify_unlink": "Tem certeza que deseja desvincular {service}?",
   "warning_smart_lists_limit": "Você atingiu seu limite de listas inteligentes",
-  "yir_2024_companies_least_watched": "Menos assistidos",
-  "yir_2024_companies_most_watched": "Mais assistidos",
   "yir_2024_directed_by": "Dirigido por",
   "yir_2024_first_play": "Primeira Reprodução",
   "yir_2024_huge_label_year_in_review": "retrospectiva do ano",

--- a/projects/client/i18n/messages/pt-PT.json
+++ b/projects/client/i18n/messages/pt-PT.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Tem certeza de que deseja deixar de seguir {username}?",
   "warning_prompt_younify_unlink": "Tem certeza de que deseja desvincular {service}?",
   "warning_smart_lists_limit": "Você atingiu o limite da sua lista inteligente",
-  "yir_2024_companies_least_watched": "Menos Assistidos",
-  "yir_2024_companies_most_watched": "Mais Assistidos",
   "yir_2024_directed_by": "Dirigido Por",
   "yir_2024_first_play": "Primeira Reprodução",
   "yir_2024_huge_label_year_in_review": "retrospectiva do ano",

--- a/projects/client/i18n/messages/ro-RO.json
+++ b/projects/client/i18n/messages/ro-RO.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Ești sigur că vrei să nu-l mai urmărești pe {username}?",
   "warning_prompt_younify_unlink": "Ești sigur că vrei să deconectezi {service}?",
   "warning_smart_lists_limit": "Ai atins limita de liste inteligente",
-  "yir_2024_companies_least_watched": "Cele mai puțin vizionate",
-  "yir_2024_companies_most_watched": "Cele mai vizionate",
   "yir_2024_directed_by": "Regizat de",
   "yir_2024_first_play": "Prima Redare",
   "yir_2024_huge_label_year_in_review": "retrospectiva anului",

--- a/projects/client/i18n/messages/ru-RU.json
+++ b/projects/client/i18n/messages/ru-RU.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Вы уверены, что хотите отписаться от {username}?",
   "warning_prompt_younify_unlink": "Вы уверены, что хотите отключить {service}?",
   "warning_smart_lists_limit": "Вы достигли лимита умных списков",
-  "yir_2024_companies_least_watched": "Наименее просматриваемые",
-  "yir_2024_companies_most_watched": "Самые просматриваемые",
   "yir_2024_directed_by": "Режиссер",
   "yir_2024_first_play": "Первый просмотр",
   "yir_2024_huge_label_year_in_review": "обзор года",

--- a/projects/client/i18n/messages/sv-SE.json
+++ b/projects/client/i18n/messages/sv-SE.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Är du säker på att du vill sluta följa {username}?",
   "warning_prompt_younify_unlink": "Är du säker på att du vill avlänka {service}?",
   "warning_smart_lists_limit": "Du har nått din gräns för smarta listor",
-  "yir_2024_companies_least_watched": "Minst sedda",
-  "yir_2024_companies_most_watched": "Mest sedda",
   "yir_2024_directed_by": "Regisserad av",
   "yir_2024_first_play": "Första uppspelningen",
   "yir_2024_huge_label_year_in_review": "årsöversikt",

--- a/projects/client/i18n/messages/tr-TR.json
+++ b/projects/client/i18n/messages/tr-TR.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "{username} takibi bırakmak istediğinizden emin misiniz?",
   "warning_prompt_younify_unlink": "{service} bağlantısını kesmek istediğinizden emin misiniz?",
   "warning_smart_lists_limit": "Akıllı liste limitinize ulaştınız",
-  "yir_2024_companies_least_watched": "En az izlenen",
-  "yir_2024_companies_most_watched": "En çok izlenen",
   "yir_2024_directed_by": "Yönetmen",
   "yir_2024_first_play": "İlk Oynatma",
   "yir_2024_huge_label_year_in_review": "yılın incelemesi",

--- a/projects/client/i18n/messages/uk-UA.json
+++ b/projects/client/i18n/messages/uk-UA.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "Ви впевнені, що хочете відписатися від {username}?",
   "warning_prompt_younify_unlink": "Ви впевнені, що хочете відв'язати {service}?",
   "warning_smart_lists_limit": "Ви досягли ліміту розумних списків",
-  "yir_2024_companies_least_watched": "Найменш переглядувані",
-  "yir_2024_companies_most_watched": "Найпереглядуваніші",
   "yir_2024_directed_by": "Режисер",
   "yir_2024_first_play": "Перший перегляд",
   "yir_2024_huge_label_year_in_review": "рік у Підсумках",

--- a/projects/client/i18n/messages/zh-CN.json
+++ b/projects/client/i18n/messages/zh-CN.json
@@ -1428,8 +1428,6 @@
   "warning_prompt_unfollow_user": "你确定要取消关注 {username} 吗？",
   "warning_prompt_younify_unlink": "你确定要取消关联 {service} 吗？",
   "warning_smart_lists_limit": "您已达到智能列表限制",
-  "yir_2024_companies_least_watched": "观看次数最少的",
-  "yir_2024_companies_most_watched": "观看次数最多的",
   "yir_2024_directed_by": "导演",
   "yir_2024_first_play": "首次播放",
   "yir_2024_huge_label_year_in_review": "年度回顾",

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4765,13 +4765,13 @@
       "default": "Most watched studios",
       "description": "Section heading above the studios bubble chart on the 2024 Year in Review template."
     },
-    "yir_2024_companies_most_watched": {
+    "yir_2024_stat_most_watched": {
       "default": "Most Watched",
-      "description": "Row label above the user's top-watched network/studio name on the 2024 Year in Review companies section."
+      "description": "Row label above the user's top-watched entry (network / studio / genre) in the 2024 Year in Review stat summary lists."
     },
-    "yir_2024_companies_least_watched": {
+    "yir_2024_stat_least_watched": {
       "default": "Least Watched",
-      "description": "Row label above the user's least-watched network/studio name on the 2024 Year in Review companies section."
+      "description": "Row label above the user's least-watched entry (network / studio / genre) in the 2024 Year in Review stat summary lists."
     },
     "yir_2024_network_count": {
       "default": "Network Count",
@@ -4780,6 +4780,26 @@
     "yir_2024_studio_count": {
       "default": "Studio Count",
       "description": "Row label for the total number of distinct studios watched on the 2024 Year in Review studios section."
+    },
+    "yir_2024_genre_count": {
+      "default": "Genre Count",
+      "description": "Row label for the total number of distinct genres watched on the 2024 Year in Review genres section."
+    },
+    "yir_2024_most_watched_show_genres": {
+      "default": "Most Watched Show Genres",
+      "description": "Section heading above the show-genres bar chart on the 2024 Year in Review template."
+    },
+    "yir_2024_most_watched_movie_genres": {
+      "default": "Most Watched Movie Genres",
+      "description": "Section heading above the movie-genres bar chart on the 2024 Year in Review template."
+    },
+    "yir_2024_genres_watermark_show": {
+      "default": "show genres",
+      "description": "Faint background watermark text behind the show-genres section heading on the 2024 Year in Review template."
+    },
+    "yir_2024_genres_watermark_movie": {
+      "default": "movie genres",
+      "description": "Faint background watermark text behind the movie-genres section heading on the 2024 Year in Review template."
     },
     "yir_2024_stats_intro_shows": {
       "default": "In {year}, you watched",

--- a/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
+++ b/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
@@ -3,6 +3,7 @@
   import { m } from "$lib/paraglide/messages";
   import type { YirDetail } from "$lib/requests/models/YirDetail";
   import Yir2024CompaniesSection from "./_internal/Yir2024CompaniesSection.svelte";
+  import Yir2024GenresSection from "./_internal/Yir2024GenresSection.svelte";
   import Yir2024MostPlayedSection from "./_internal/Yir2024MostPlayedSection.svelte";
   import Yir2024PageInner from "./_internal/Yir2024PageInner.svelte";
   import Yir2024PlayCard from "./_internal/Yir2024PlayCard.svelte";
@@ -67,6 +68,12 @@
       </Yir2024PageInner>
     {/if}
 
+    {#if detail.genres.shows.itemCount > 0}
+      <Yir2024PageInner>
+        <Yir2024GenresSection type="shows" genres={detail.genres.shows} />
+      </Yir2024PageInner>
+    {/if}
+
     {#if detail.stats.movies.playCounts.total > 0}
       <Yir2024PageInner>
         <Yir2024StatsSection type="movies" stats={detail.stats.movies} {year} />
@@ -88,6 +95,12 @@
           type="movies"
           companies={detail.studios}
         />
+      </Yir2024PageInner>
+    {/if}
+
+    {#if detail.genres.movies.itemCount > 0}
+      <Yir2024PageInner>
+        <Yir2024GenresSection type="movies" genres={detail.genres.movies} />
       </Yir2024PageInner>
     {/if}
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CompaniesSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CompaniesSection.svelte
@@ -4,6 +4,7 @@
   import { formatNumber } from "$lib/utils/format/formatNumber.ts";
   import YirCompaniesBubbleChart from "../../_internal/YirCompaniesBubbleChart.svelte";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
+  import Yir2024StatSummary from "./Yir2024StatSummary.svelte";
 
   type Yir2024CompaniesSectionProps = {
     type: "shows" | "movies";
@@ -23,8 +24,9 @@
   );
 
   const mostWatched = $derived(companies[0]);
-  const leastWatched = $derived(companies[companies.length - 1]);
-  const companyCount = $derived(companies.length);
+  const leastWatched = $derived(
+    companies.length > 1 ? companies[companies.length - 1] : undefined,
+  );
 
   // FIXME(i18n): hardcoded English plurals match the existing convention
   // across the YIR module (default template uses the same pattern in
@@ -41,42 +43,13 @@
     <div class="yir-2024-companies-text">
       <h2 class="bold yir-2024-companies-heading">{heading}</h2>
 
-      <dl class="yir-2024-companies-stats">
-        {#if mostWatched}
-          <div class="yir-2024-companies-row">
-            <dt>{m.yir_2024_companies_most_watched()}</dt>
-            <dd>
-              <span class="ellipsis yir-2024-companies-name">
-                {mostWatched.name}
-              </span>
-              <span class="bold uppercase tag yir-2024-companies-count">
-                {formatNumber(mostWatched.count)}
-                {itemUnit(mostWatched.count)}
-              </span>
-            </dd>
-          </div>
-        {/if}
-
-        {#if leastWatched && leastWatched.id !== mostWatched?.id}
-          <div class="yir-2024-companies-row">
-            <dt>{m.yir_2024_companies_least_watched()}</dt>
-            <dd>
-              <span class="ellipsis yir-2024-companies-name">
-                {leastWatched.name}
-              </span>
-              <span class="bold uppercase tag yir-2024-companies-count">
-                {formatNumber(leastWatched.count)}
-                {itemUnit(leastWatched.count)}
-              </span>
-            </dd>
-          </div>
-        {/if}
-
-        <div class="yir-2024-companies-row">
-          <dt>{countLabel}</dt>
-          <dd class="yir-2024-companies-total">{formatNumber(companyCount)}</dd>
-        </div>
-      </dl>
+      <Yir2024StatSummary
+        {mostWatched}
+        {leastWatched}
+        {countLabel}
+        total={companies.length}
+        unit={itemUnit}
+      />
     </div>
 
     <div class="yir-2024-companies-chart">
@@ -136,7 +109,9 @@
         width: min-content;
       }
 
-      .yir-2024-companies-stats {
+      // Stat list is rendered by Yir2024StatSummary (its own scope), so it
+      // has to be reached with :global to take the remaining row width.
+      :global(.yir-2024-stat-summary) {
         flex: 1;
         min-width: 0;
       }
@@ -150,67 +125,6 @@
     @include for-mobile {
       font-size: var(--ni-28);
     }
-  }
-
-  .yir-2024-companies-stats {
-    display: flex;
-    flex-direction: column;
-  }
-
-  // Each row has a light divider under it (matching v2's stat-line) so the
-  // three rows read as a list. Last row drops the divider.
-  .yir-2024-companies-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: var(--ni-32);
-    padding: var(--ni-16) 0;
-    border-bottom: var(--border-thickness-xxs) solid var(--shade-800);
-
-    &:last-child {
-      border-bottom: none;
-    }
-
-    @include for-tablet-sm-and-below {
-      gap: var(--ni-16);
-    }
-
-    dt {
-      font-size: var(--font-size-title);
-      color: var(--shade-10);
-    }
-
-    dd {
-      display: flex;
-      align-items: center;
-      gap: var(--gap-xs);
-      font-size: var(--font-size-title);
-      color: var(--shade-10);
-      min-width: 0;
-    }
-  }
-
-  // Network/studio name pops in the YIR purple so it visually links back to
-  // the bubble chart's highlight color (also matches v2's link styling).
-  // Truncation handled by the `.ellipsis` utility class on the markup.
-  .yir-2024-companies-name {
-    color: var(--purple-300);
-  }
-
-  // Pill-shaped count badge with white background + dark text — matches
-  // the v2 design exactly. `--border-radius-xxl` is the established YIR /
-  // v3 token for pill-shaped tags (used by VIP badges, MostPopularTag, etc).
-  // Font sizing is handled by the `.tag` utility class on the markup.
-  .yir-2024-companies-count {
-    background: var(--shade-10);
-    color: var(--shade-900);
-    border-radius: var(--border-radius-xxl);
-    padding: var(--ni-4) var(--ni-10);
-    white-space: nowrap;
-  }
-
-  .yir-2024-companies-total {
-    color: var(--shade-10);
   }
 
   .yir-2024-companies-chart {

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024GenresSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024GenresSection.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { YirGenresGroup } from "$lib/requests/models/YirDetail.ts";
+  import YirGenreBars from "../../_internal/YirGenreBars.svelte";
+  import Yir2024StatSummary from "./Yir2024StatSummary.svelte";
+
+  type Yir2024GenresSectionProps = {
+    type: "shows" | "movies";
+    genres: YirGenresGroup;
+  };
+
+  const { type, genres }: Yir2024GenresSectionProps = $props();
+
+  const heading = $derived(
+    type === "shows"
+      ? m.yir_2024_most_watched_show_genres()
+      : m.yir_2024_most_watched_movie_genres(),
+  );
+
+  const watermark = $derived(
+    type === "shows"
+      ? m.yir_2024_genres_watermark_show()
+      : m.yir_2024_genres_watermark_movie(),
+  );
+
+  const mostWatched = $derived(genres.genres[0]);
+  const leastWatched = $derived(
+    genres.genres.length > 1
+      ? genres.genres[genres.genres.length - 1]
+      : undefined,
+  );
+
+  // FIXME(i18n): hardcoded English plurals match the existing convention
+  // across the YIR module. Migrate holistically when i18n keys are added
+  // across all YIR sections.
+  function itemUnit(count: number): string {
+    if (type === "movies") return count === 1 ? "movie" : "movies";
+    return count === 1 ? "show" : "shows";
+  }
+</script>
+
+<section class="yir-2024-genres" id="section-{type}-genres">
+  <div class="yir-2024-genres-panel">
+    <span class="bold yir-2024-genres-watermark" aria-hidden="true">
+      {watermark}
+    </span>
+
+    <div class="yir-2024-genres-top">
+      <h2 class="bold yir-2024-genres-heading">{heading}</h2>
+
+      <Yir2024StatSummary
+        {mostWatched}
+        {leastWatched}
+        countLabel={m.yir_2024_genre_count()}
+        total={genres.genres.length}
+        unit={itemUnit}
+      />
+    </div>
+
+    <div class="yir-2024-genres-bars">
+      <YirGenreBars {type} {genres} variant="filled" />
+    </div>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-2024-genres {
+    width: 100%;
+  }
+
+  // Rounded panel sharing the stats section's blue-tinted radial fill so
+  // the two sections read as a set. overflow:hidden clips the oversized
+  // watermark to the panel bounds.
+  .yir-2024-genres-panel {
+    --panel-padding-x: var(--ni-44);
+    --panel-padding-y: var(--ni-44);
+    --panel-radius: var(--ni-64);
+
+    position: relative;
+    overflow: hidden;
+    padding: var(--panel-padding-y) var(--panel-padding-x);
+    border-radius: var(--panel-radius);
+    background: radial-gradient(
+      50% 39.27% at 50% 0%,
+      color-mix(in srgb, var(--shade-950) 90%, var(--blue-500) 10%) 0%,
+      color-mix(in srgb, var(--shade-950) 70%, var(--shade-900) 30%) 100%
+    );
+
+    @include for-mobile {
+      --panel-padding-x: var(--ni-20);
+      --panel-padding-y: var(--ni-20);
+      --panel-radius: var(--ni-32);
+    }
+  }
+
+  // Faint oversized label sitting behind the heading; clipped on the right
+  // by the panel's overflow. Tonal-only (low-opacity white over the dark
+  // panel), matching the stats section watermark treatment.
+  .yir-2024-genres-watermark {
+    position: absolute;
+    top: var(--ni-72);
+    left: var(--panel-padding-x);
+    right: 0;
+    font-size: clamp(var(--ni-72), 12vw, var(--ni-160));
+    line-height: 1;
+    white-space: nowrap;
+    text-transform: lowercase;
+    color: var(--shade-10);
+    opacity: 0.04;
+    pointer-events: none;
+    user-select: none;
+
+    @include for-mobile {
+      top: var(--ni-44);
+    }
+  }
+
+  // Heading on the left, stat summary on the right. Stacks on smaller
+  // screens.
+  .yir-2024-genres-top {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--ni-44);
+
+    @include for-tablet-sm-and-below {
+      flex-direction: column;
+      gap: var(--ni-24);
+    }
+  }
+
+  .yir-2024-genres-heading {
+    flex: 1;
+    min-width: 0;
+    font-size: clamp(var(--ni-32), 5vw, var(--ni-56));
+    line-height: 1.05;
+    color: var(--shade-10);
+
+    @include for-mobile {
+      font-size: var(--ni-28);
+    }
+  }
+
+  // Stat list rendered by Yir2024StatSummary (its own scope), reached with
+  // :global to constrain its column width on desktop.
+  .yir-2024-genres-top :global(.yir-2024-stat-summary) {
+    flex: 0 1 var(--ni-360);
+    min-width: 0;
+
+    @include for-tablet-sm-and-below {
+      flex: none;
+      width: 100%;
+    }
+  }
+
+  // Genre names arrive lowercase from the API; title-case them in the stat
+  // rows (companies names are already proper, so this stays scoped to the
+  // genres section rather than the shared stat-summary component).
+  .yir-2024-genres-top :global(.yir-2024-stat-name) {
+    text-transform: capitalize;
+  }
+
+  // Bars span the full panel width beneath the top row. Negative inline
+  // margin bleeds past the panel padding so the bar strip reaches closer to
+  // the panel edges (the bar component carries its own small inset).
+  .yir-2024-genres-bars {
+    position: relative;
+    z-index: 1;
+    margin: var(--ni-32) calc(-1 * var(--panel-padding-x)) 0;
+
+    @include for-mobile {
+      margin-top: var(--ni-20);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatSummary.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatSummary.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import { formatNumber } from "$lib/utils/format/formatNumber.ts";
+  import type { Yir2024StatSummaryProps } from "./Yir2024StatSummaryProps.ts";
+
+  const {
+    mostWatched,
+    leastWatched,
+    countLabel,
+    total,
+    unit,
+  }: Yir2024StatSummaryProps = $props();
+</script>
+
+<dl class="yir-2024-stat-summary">
+  {#if mostWatched}
+    <div class="yir-2024-stat-row">
+      <dt>{m.yir_2024_stat_most_watched()}</dt>
+      <dd>
+        <span class="ellipsis yir-2024-stat-name">{mostWatched.name}</span>
+        <span class="bold uppercase tag yir-2024-stat-count">
+          {formatNumber(mostWatched.count)}
+          {unit(mostWatched.count)}
+        </span>
+      </dd>
+    </div>
+  {/if}
+
+  {#if leastWatched}
+    <div class="yir-2024-stat-row">
+      <dt>{m.yir_2024_stat_least_watched()}</dt>
+      <dd>
+        <span class="ellipsis yir-2024-stat-name">{leastWatched.name}</span>
+        <span class="bold uppercase tag yir-2024-stat-count">
+          {formatNumber(leastWatched.count)}
+          {unit(leastWatched.count)}
+        </span>
+      </dd>
+    </div>
+  {/if}
+
+  <div class="yir-2024-stat-row">
+    <dt>{countLabel}</dt>
+    <dd class="yir-2024-stat-total">{formatNumber(total)}</dd>
+  </div>
+</dl>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-2024-stat-summary {
+    display: flex;
+    flex-direction: column;
+  }
+
+  // Each row has a light divider under it (matching v2's stat-line) so the
+  // rows read as a list. Last row drops the divider.
+  .yir-2024-stat-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--ni-32);
+    padding: var(--ni-16) 0;
+    border-bottom: var(--border-thickness-xxs) solid var(--shade-800);
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    @include for-tablet-sm-and-below {
+      gap: var(--ni-16);
+    }
+
+    dt {
+      font-size: var(--font-size-title);
+      color: var(--shade-10);
+    }
+
+    dd {
+      display: flex;
+      align-items: center;
+      gap: var(--gap-xs);
+      font-size: var(--font-size-title);
+      color: var(--shade-10);
+      min-width: 0;
+    }
+  }
+
+  // Entry name pops in the YIR purple so it visually links back to the
+  // chart's highlight color (matches v2's link styling). Truncation handled
+  // by the `.ellipsis` utility class on the markup.
+  .yir-2024-stat-name {
+    color: var(--purple-300);
+  }
+
+  // Pill-shaped count badge with white background + dark text — matches the
+  // v2 design. `--border-radius-xxl` is the established v3 token for
+  // pill-shaped tags; `.tag` utility class handles font sizing.
+  .yir-2024-stat-count {
+    background: var(--shade-10);
+    color: var(--shade-900);
+    border-radius: var(--border-radius-xxl);
+    padding: var(--ni-4) var(--ni-10);
+    white-space: nowrap;
+  }
+
+  .yir-2024-stat-total {
+    color: var(--shade-10);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatSummaryProps.ts
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatSummaryProps.ts
@@ -1,0 +1,20 @@
+export type Yir2024StatEntry = {
+  name: string;
+  count: number;
+};
+
+export type Yir2024StatSummaryProps = {
+  /** Top-ranked entry (rendered first). */
+  mostWatched: Yir2024StatEntry | undefined;
+  /**
+   * Bottom-ranked entry. Pass `undefined` when it would duplicate
+   * `mostWatched` (e.g. a single-item list) so the row is omitted.
+   */
+  leastWatched: Yir2024StatEntry | undefined;
+  /** Label for the total-count row, e.g. "Genre Count" / "Network Count". */
+  countLabel: string;
+  /** Total number of distinct entries. */
+  total: number;
+  /** Resolves the singular/plural unit for a given count, e.g. "13 shows". */
+  unit: (count: number) => string;
+};

--- a/projects/client/src/lib/sections/yir/_internal/YirGenreBars.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirGenreBars.svelte
@@ -1,0 +1,266 @@
+<script lang="ts">
+  import type { YirGenresGroup } from "$lib/requests/models/YirDetail.ts";
+
+  type YirGenreBarsProps = {
+    type: "shows" | "movies";
+    genres: YirGenresGroup;
+    /**
+     * `default` — colored left-border label (legacy template).
+     * `filled` — opaque bar-colored label with uppercase text (2024 template).
+     */
+    variant?: "default" | "filled";
+  };
+
+  const { type, genres, variant = "default" }: YirGenreBarsProps = $props();
+
+  const typeLabel = $derived(type === "shows" ? "show" : "movie");
+
+  // Top genre drives the relative (mobile) bar widths; computed once rather
+  // than per-row inside the loop.
+  const maxCount = $derived(genres.genres[0]?.count ?? 1);
+
+  // Categorical palette for the stacked segments. These are intentionally
+  // fixed brand-neutral hues (no semantic theme token maps to "genre #3"),
+  // matching the v2 YIR genre bar colors.
+  const chartColors = [
+    "#CC333F",
+    "#00A0B0",
+    "#EB6841",
+    "#6A4A3C",
+    "#EDC951",
+    "#AB3E5B",
+    "#B3CC57",
+    "#EF746F",
+    "#3E4147",
+    "#FFBE40",
+    "#7B3B3B",
+  ];
+
+  function getBarColor(index: number): string {
+    return chartColors[index % chartColors.length] ?? "#222";
+  }
+
+  function unitLabel(count: number): string {
+    return count === 1 ? typeLabel : `${typeLabel}s`;
+  }
+
+  /*
+    FIXME: the horizontal version should deal better with responsiveness,
+    without users having to scroll.
+    */
+</script>
+
+<div class="yir-genre-bars" data-variant={variant}>
+  {#each genres.genres as genre, index (genre.name)}
+    {@const percentage = (genre.count / genres.itemCount) * 100}
+    {@const relativePercentage = (genre.count / maxCount) * 100}
+    <div
+      class="yir-genre-row"
+      data-index={index}
+      style:--genre-color={getBarColor(index)}
+    >
+      <div class="yir-genre-info">
+        <span class="yir-genre-name">{genre.name}</span>
+        <span class="yir-genre-count">
+          {genre.count.toLocaleString()}
+          {unitLabel(genre.count)}
+        </span>
+      </div>
+      <div
+        class="yir-genre-bar"
+        style:--bar-width="{Math.max(percentage, 5)}%"
+        style:--mobile-bar-width="{relativePercentage}%"
+      >
+        <span class="yir-genre-percentage">{Math.round(percentage)}%</span>
+        <span class="yir-genre-label">
+          <span class="yir-genre-name-desktop">{genre.name}</span>
+          <span class="yir-genre-count-desktop">
+            {genre.count.toLocaleString()}
+            {unitLabel(genre.count)}
+          </span>
+        </span>
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-genre-bars {
+    display: flex;
+    padding: var(--ni-40) var(--ni-16) var(--ni-60) var(--ni-16);
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    &:hover .yir-genre-bar:not(:hover) {
+      opacity: 0.5;
+    }
+
+    &:hover .yir-genre-bar .yir-genre-percentage {
+      opacity: 1;
+    }
+
+    @include for-tablet-sm-and-below {
+      flex-direction: column;
+      padding: 0 var(--ni-16);
+      overflow: visible;
+    }
+  }
+
+  .yir-genre-row {
+    display: contents;
+
+    @include for-tablet-sm-and-below {
+      display: flex;
+      flex-direction: column;
+      margin-bottom: var(--ni-16);
+    }
+  }
+
+  .yir-genre-info {
+    display: none;
+
+    @include for-tablet-sm-and-below {
+      display: flex;
+      flex-direction: column;
+      margin-bottom: var(--ni-2);
+      padding-left: var(--ni-6);
+      border-left: var(--border-thickness-xxs) solid var(--genre-color);
+    }
+  }
+
+  .yir-genre-name {
+    font-size: var(--font-size-text);
+    text-transform: capitalize;
+    color: var(--shade-10);
+    font-weight: 500;
+    line-height: 1.2;
+  }
+
+  .yir-genre-name-desktop {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-transform: capitalize;
+    font-size: var(--font-size-text);
+  }
+
+  .yir-genre-bar {
+    height: var(--ni-30);
+    margin-left: var(--ni-2);
+    position: relative;
+    min-width: var(--ni-44);
+    width: var(--bar-width);
+    background-color: var(--genre-color);
+    transition: all 0.5s;
+    cursor: pointer;
+
+    @include for-tablet-lg {
+      min-width: var(--ni-32);
+    }
+
+    @include for-tablet-sm-and-below {
+      height: var(--ni-30);
+      min-height: var(--ni-30);
+      width: var(--mobile-bar-width);
+      margin-left: 0;
+      margin-bottom: 0;
+      display: block;
+    }
+  }
+
+  .yir-genre-row:first-child .yir-genre-bar {
+    margin-left: 0;
+  }
+
+  .yir-genre-percentage {
+    color: var(--shade-1000);
+    position: absolute;
+    width: 100%;
+    text-align: center;
+    left: 0;
+    top: var(--ni-8);
+    font-size: var(--font-size-text-small);
+    opacity: 0;
+    transition: opacity 0.5s;
+
+    @include for-tablet-sm-and-below {
+      display: none;
+    }
+  }
+
+  .yir-genre-label {
+    position: absolute;
+    left: 0;
+    bottom: var(--ni-30);
+    width: 200%;
+    box-sizing: border-box;
+    font-size: var(--font-size-text-small);
+    white-space: nowrap;
+    padding: var(--ni-4) var(--ni-6);
+    color: var(--shade-10);
+    border-left: var(--border-thickness-xs) solid var(--genre-color);
+    pointer-events: none;
+
+    @include for-tablet-sm-and-below {
+      display: none;
+    }
+  }
+
+  .yir-genre-row[data-index]:nth-child(even) .yir-genre-label {
+    top: var(--ni-30);
+    bottom: auto;
+  }
+
+  .yir-genre-count {
+    font-size: var(--font-size-text-small);
+    color: var(--shade-400);
+  }
+
+  .yir-genre-count-desktop {
+    display: block;
+    font-size: var(--font-size-tag);
+    color: var(--shade-400);
+  }
+
+  // Filled variant (2024): the label becomes a translucent box tinted with
+  // the bar's color and uppercase text, instead of the transparent
+  // left-border style. ~31% matches v2's `#RRGGBB50` (0x50 alpha) tint so
+  // the panel reads through the label.
+  .yir-genre-bars[data-variant="filled"] {
+    .yir-genre-label {
+      width: max-content;
+      max-width: 200%;
+      background-color: color-mix(in srgb, var(--genre-color) 31%, transparent);
+      // Full-color 1px left border on top of the translucent fill (matches
+      // v2: solid border-color + `#RRGGBB50` background tint).
+      border-left: var(--border-thickness-xxs) solid var(--genre-color);
+      text-transform: uppercase;
+    }
+
+    .yir-genre-name-desktop,
+    .yir-genre-name {
+      text-transform: uppercase;
+    }
+
+    // v2's label name is normal-weight and only marginally larger than the
+    // count, not a heavier heading — drop the default's larger ni-14 name
+    // down to match the count line and remove the visual weight.
+    .yir-genre-name-desktop {
+      font-size: var(--font-size-tag);
+      font-weight: 400;
+    }
+
+    // Count (line 2) reads as a muted gray — white at 60% opacity over the
+    // tinted box (matches v2's lighter count text).
+    .yir-genre-count-desktop {
+      color: color-mix(in srgb, var(--shade-10) 60%, transparent);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirGenresSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirGenresSection.svelte
@@ -1,42 +1,22 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
-  import type { YirGenresGroup } from "$lib/requests/models/YirDetail";
+  import type { YirGenresGroup } from "$lib/requests/models/YirDetail.ts";
+  import YirGenreBars from "../../_internal/YirGenreBars.svelte";
   import YirPageInner from "./YirPageInner.svelte";
   import YirSectionHeader from "./YirSectionHeader.svelte";
 
-  const {
-    type,
-    genres,
-  }: {
+  type YirGenresSectionProps = {
     type: "shows" | "movies";
     genres: YirGenresGroup;
-  } = $props();
+  };
+
+  const { type, genres }: YirGenresSectionProps = $props();
 
   const sectionTitle = $derived(
     type === "shows"
       ? m.yir_section_title_show_genres()
       : m.yir_section_title_movie_genres(),
   );
-
-  const typeLabel = $derived(type === "shows" ? "show" : "movie");
-
-  const chartColors = [
-    "#CC333F",
-    "#00A0B0",
-    "#EB6841",
-    "#6A4A3C",
-    "#EDC951",
-    "#AB3E5B",
-    "#B3CC57",
-    "#EF746F",
-    "#3E4147",
-    "#FFBE40",
-    "#7B3B3B",
-  ];
-
-  function getBarColor(index: number): string {
-    return chartColors[index % chartColors.length] ?? "#222";
-  }
 </script>
 
 <section class="yir-genres-section" id="section-{type}-genres">
@@ -45,43 +25,7 @@
       {sectionTitle}
     </YirSectionHeader>
 
-    <div class="yir-genre-bars">
-      {#each genres.genres as genre, index (genre.name)}
-        {@const percentage = (genre.count / genres.itemCount) * 100}
-        {@const maxCount = genres.genres[0]?.count ?? 1}
-        {@const relativePercentage = (genre.count / maxCount) * 100}
-        <div class="yir-genre-row" data-index={index}>
-          <div
-            class="yir-genre-info"
-            style:border-left-color={getBarColor(index)}
-          >
-            <span class="yir-genre-name">{genre.name}</span>
-            <span class="yir-genre-count">
-              {genre.count.toLocaleString()}
-              {genre.count === 1 ? typeLabel : `${typeLabel}s`}
-            </span>
-          </div>
-          <div
-            class="yir-genre-bar"
-            style:--bar-width="{Math.max(percentage, 5)}%"
-            style:--mobile-bar-width="{relativePercentage}%"
-            style:background-color={getBarColor(index)}
-          >
-            <span class="yir-genre-percentage">{Math.round(percentage)}%</span>
-            <span
-              class="yir-genre-label"
-              style:border-color={getBarColor(index)}
-            >
-              <span class="yir-genre-name-desktop">{genre.name}</span>
-              <span class="yir-genre-count-desktop">
-                {genre.count.toLocaleString()}
-                {genre.count === 1 ? typeLabel : `${typeLabel}s`}
-              </span>
-            </span>
-          </div>
-        </div>
-      {/each}
-    </div>
+    <YirGenreBars {type} {genres} />
   </YirPageInner>
 </section>
 
@@ -95,146 +39,5 @@
     @include for-mobile {
       padding-bottom: var(--ni-40);
     }
-  }
-
-  .yir-genre-bars {
-    display: flex;
-    padding: var(--ni-40) var(--ni-16) var(--ni-60) var(--ni-16);
-    overflow-x: auto;
-    overflow-y: hidden;
-    scrollbar-width: none;
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
-
-    &:hover .yir-genre-bar:not(:hover) {
-      opacity: 0.5;
-    }
-
-    &:hover .yir-genre-bar .yir-genre-percentage {
-      opacity: 1;
-    }
-
-    @include for-tablet-sm-and-below {
-      flex-direction: column;
-      padding: 0 var(--ni-16);
-      overflow: visible;
-    }
-  }
-
-  .yir-genre-row {
-    display: contents;
-
-    @include for-tablet-sm-and-below {
-      display: flex;
-      flex-direction: column;
-      margin-bottom: var(--ni-16);
-    }
-  }
-
-  .yir-genre-info {
-    display: none;
-
-    @include for-tablet-sm-and-below {
-      display: flex;
-      flex-direction: column;
-      margin-bottom: var(--ni-2);
-      padding-left: var(--ni-6);
-      border-left: var(--border-thickness-xxs) solid;
-    }
-  }
-
-  .yir-genre-name {
-    font-size: var(--ni-14);
-    text-transform: capitalize;
-    color: var(--shade-10);
-    font-weight: 500;
-    line-height: 1.2;
-  }
-
-  .yir-genre-name-desktop {
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-transform: capitalize;
-    font-size: var(--ni-14);
-  }
-
-  .yir-genre-bar {
-    height: var(--ni-30);
-    margin-left: var(--ni-2);
-    position: relative;
-    min-width: var(--ni-44);
-    width: var(--bar-width);
-    transition: all 0.5s;
-    cursor: pointer;
-
-    @include for-tablet-lg {
-      min-width: var(--ni-32);
-    }
-
-    @include for-tablet-sm-and-below {
-      height: var(--ni-30);
-      min-height: var(--ni-30);
-      width: var(--mobile-bar-width);
-      margin-left: 0;
-      margin-bottom: 0;
-      display: block;
-    }
-  }
-
-  .yir-genre-row:first-child .yir-genre-bar {
-    margin-left: 0;
-  }
-
-  .yir-genre-percentage {
-    color: var(--shade-1000);
-    position: absolute;
-    width: 100%;
-    text-align: center;
-    left: 0;
-    top: var(--ni-8);
-    font-size: 12px;
-    opacity: 0;
-    transition: opacity 0.5s;
-
-    @include for-tablet-sm-and-below {
-      display: none;
-    }
-  }
-
-  .yir-genre-label {
-    position: absolute;
-    left: 0;
-    bottom: var(--ni-30);
-    width: 200%;
-    box-sizing: border-box;
-    font-size: 12px;
-    white-space: nowrap;
-    padding: var(--ni-4) var(--ni-6);
-    color: var(--shade-10);
-    border-left: var(--border-thickness-xs) solid;
-    pointer-events: none;
-
-    @include for-tablet-sm-and-below {
-      display: none;
-    }
-  }
-
-  .yir-genre-row[data-index]:nth-child(even) .yir-genre-label {
-    top: var(--ni-30);
-    bottom: auto;
-  }
-
-  .yir-genre-count {
-    font-size: 12px;
-    color: var(--shade-400);
-  }
-
-  .yir-genre-count-desktop {
-    display: block;
-    font-size: 10px;
-    color: var(--shade-400);
   }
 </style>


### PR DESCRIPTION
# Summary

Ports the v2 "Most Watched Show Genres" / "Most Watched Movie Genres" section into the 2024 YIR template — a panel with a watermark, heading + stat summary, and a horizontal stacked genre bar chart. Extracts the genre bars and the most/least/count stat list into shared components reused by both the 2024 and default templates.

# Screenshot

<img width="1255" height="562" alt="image" src="https://github.com/user-attachments/assets/9bb0f1cb-9885-49da-a708-975eda6da3cb" />

# What

- **`Yir2024GenresSection.svelte`** — flat-radial panel (shares the stats section's blue-tinted background), faint oversized watermark ("show genres" / "movie genres") clipped behind the heading, heading + stat summary on the top row, full-width genre bars beneath.
- **`YirGenreBars.svelte`** (shared, `yir/_internal/`) — horizontal stacked genre bar chart extracted from the default's `YirGenresSection` (desktop stacked / mobile rows, hover dimming, categorical palette). Adds a `variant` prop:
  - `default` — transparent label with colored left border (legacy template).
  - `filled` (2024) — translucent label tinted with the bar color (`color-mix … 31%`, matching v2's `#RRGGBB50`), 1px full-color left border, uppercase normal-weight name sized to match the count line, count at 60% white.
- **`Yir2024StatSummary.svelte`** (+ `Yir2024StatSummaryProps.ts`) — shared Most Watched / Least Watched / Count list (purple name + white pill badge). Now used by both the genres and companies sections.

## Refactors / reuse

- `default/YirGenresSection` → consumes shared `YirGenreBars`.
- `Yir2024CompaniesSection` → consumes shared `Yir2024StatSummary` (dropped ~80 lines of duplicated stat-row markup/styles).
- Single `--genre-color` CSS var per row drives the bar fill, mobile info border, and label color (was three separate inline styles).

# i18n

- Renamed `yir_2024_companies_most_watched` / `_least_watched` → generic `yir_2024_stat_*` (now shared by companies + genres).
- Added `yir_2024_genre_count`, `yir_2024_most_watched_show_genres` / `_movie_genres`, `yir_2024_genres_watermark_show` / `_movie`.
- Locale message files left to the Crowdin sync (matches how prior YIR feature commits were structured).

# Conventions

- Named PascalCase props types; `.ts` import extensions; typography utility classes (`.bold` / `.uppercase` / `.tag` / `.ellipsis`); semantic font-size tokens (raw `--ni-*` only for hero-scale headings); `<dl>`/`<dt>`/`<dd>` semantics; `data-variant` for the bar variant; parent-driven spacing.
- Genre names render as styled text, not links (`UrlBuilder` has no genre-filter history route yet) — consistent with the networks/studios section.
- "show/shows" / "movie/movies" pluralization uses English ternary, matching the existing YIR module convention (FIXME noted).

# Test plan

- [ ] `/users/{user}/year/2024` renders the show-genres section after networks and the movie-genres section after studios; gated on `genres.{type}.itemCount > 0`.
- [ ] Stat summary shows Most Watched / Least Watched / Genre Count; genre names are title-cased; single-genre edge case hides the Least Watched row.
- [ ] Filled bar labels: translucent color fill, 1px full-color left border, uppercase name matching the count line size, count in muted gray; labels alternate above/below bars without overlap.
- [ ] Watermark sits behind the heading and clips at the panel edge.
- [ ] Default template's genres section still renders correctly through the shared `YirGenreBars` (no regression), and the companies section still renders through the shared `Yir2024StatSummary`.
- [ ] Mobile (≤480) and tablet-sm: bars switch to vertical rows; top row stacks heading over stats.
- [ ] Theme switch doesn't affect colors (YIR is dark-only).
