### PR TITLE
Episode: allow all seasons to be viewed in the drawer

### DIFF
--- a/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/EpisodeSummary.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import * as m from "$lib/features/i18n/messages";
 
   import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage";
@@ -32,6 +33,19 @@
   const posterSrc = $derived(
     useEpisodeSpoilerImage({ episode, show, variant: "default" }),
   );
+
+  const currentSeasonOnly = $derived(
+    seasons.filter((s) => s.number === episode.season),
+  );
+
+  // The seasons drawer can switch seasons via the `season` search param
+  // (set by the dropdown / poster links), independent of the episode's own
+  // season shown in the page body.
+  const drawerSeason = $derived.by(() => {
+    const param = page.url.searchParams.get("season");
+    const seasonNumber = param ? parseInt(param, 10) : NaN;
+    return isNaN(seasonNumber) ? episode.season : seasonNumber;
+  });
 
   const networks = $derived(
     (() => {
@@ -105,7 +119,7 @@
   id={episode.id}
 />
 
-<SeasonList {show} {seasons} currentSeason={episode.season} />
+<SeasonList {show} seasons={currentSeasonOnly} currentSeason={episode.season} />
 
 <RelatedList
   title={m.list_title_related_shows()}
@@ -118,7 +132,7 @@
   {crew}
   {episode}
   {seasons}
-  currentSeason={episode.season}
+  currentSeason={drawerSeason}
   {show}
   {networks}
   type="episode"

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/useEpisode.ts
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/useEpisode.ts
@@ -77,13 +77,7 @@ export function useEpisode(
     isLoading,
     episode: episode.pipe(map(($episode) => $episode.data)),
     show: show.pipe(map(($show) => $show.data)),
-    seasons: combineLatest([seasons, episode]).pipe(
-      map(([$seasons, $episode]) =>
-        $seasons.data?.filter((season) =>
-          season.number === $episode.data?.season
-        )
-      ),
-    ),
+    seasons: seasons.pipe(map(($seasons) => $seasons.data)),
     crew: crew.pipe(map(($crew) => $crew.data ?? EMPTY_CREW)),
     intl: combineLatest([intl, episode]).pipe(
       map(([$intl, $episode]) =>


### PR DESCRIPTION
## Enable season switching in the episode page's seasons drawer

### Quality of life improvement

Closes #2399

On an episode detail page (e.g. `/shows/rick-and-morty/seasons/9/episodes/1?view=seasons&mode=media`), opening the **Seasons / Episodes drawer** showed a season dropdown that was disabled — you couldn't jump to another season's episodes without backing out to the series page first. The same drawer opened from the series page works fine.

This is a small but nice quality-of-life fix: the drawer now behaves identically no matter where you open it from. You can browse straight from one season's episodes to another's, with the season poster grid and dropdown both available — no separate, degraded view for episode pages.

<img width="620" height="595" alt="image" src="https://github.com/user-attachments/assets/1cd232d5-c9d2-4915-a731-83869f862efa" />

### Root cause

The episode page filtered the seasons list down to just the current season in `useEpisode`, and that single-element array was shared by both the in-page episode list **and** the drawer. With only one season in the list:

- the dropdown disabled itself (`seasons.length < 2`), and
- the drawer's season poster grid hid itself (`seasons.length > 1`).

Even after enabling the dropdown, selecting a season did nothing: the dropdown navigates by setting `?season=N`, but the episode page hardcoded the drawer's `currentSeason` to the episode's own season and never read that param. The series page works because it derives `currentSeason` from `?season=`.

### Changes

- **`useEpisode.ts`** — return the full seasons list (matching `useShow`) instead of filtering to the current season.
- **`EpisodeSummary.svelte`** — keep the in-page `SeasonList` pinned to the episode's own season (so the page body is unchanged), and give the drawer a `drawerSeason` derived from the `?season=` param, falling back to `episode.season`. The drawer now reloads episodes, updates highlighting, and refreshes the poster grid reactively when you switch seasons.

### Testing

- `deno task check` passes (0 errors).
- Manual: open the seasons drawer from an episode page, switch seasons via both the dropdown and the poster thumbnails, and confirm the in-page episode content is unaffected.
