### PR TITLE
feat(list): add my_rating sort option

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -3834,6 +3834,14 @@
       "default": "Sort by rating",
       "description": "Aria-label for the button that allows users to sort items by their rating."
     },
+    "button_text_sort_my_rating": {
+      "default": "My Rating",
+      "description": "Text for the button that allows users to sort items by their own rating."
+    },
+    "button_label_sort_my_rating": {
+      "default": "Sort by my rating",
+      "description": "Aria-label for the button that allows users to sort items by their own rating."
+    },
     "button_text_sort_release_date": {
       "default": "Release Date",
       "description": "Text for the button that allows users to sort items by their release date."

--- a/projects/client/src/lib/sections/lists/user/_internal/SortIcon.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SortIcon.svelte
@@ -21,6 +21,10 @@
   <RatingIcon />
 {/if}
 
+{#if sortBy === "my_rating"}
+  <StarIcon fill="full" />
+{/if}
+
 {#if sortBy === "runtime"}
   <ClockIcon />
 {/if}

--- a/projects/client/src/lib/sections/lists/user/_internal/SortValue.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SortValue.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
+  import { useUser } from "$lib/features/auth/stores/useUser";
   import type { FavoritedEntry } from "$lib/requests/models/FavoritedEntry";
   import type { ListItem } from "$lib/requests/models/ListItem";
   import type { SortBy } from "../models/SortBy";
   import { formatSortValue } from "./formatSortValue";
+  import { getUserRatingForItem } from "./getUserRatingForItem";
   import SortIcon from "./SortIcon.svelte";
 
   const { item, sortBy }: { item: ListItem | FavoritedEntry; sortBy?: SortBy } =
     $props();
 
-  const valueText = $derived(formatSortValue(item, sortBy));
+  const { ratings } = useUser();
+  const userRating = $derived(
+    sortBy === "my_rating" ? getUserRatingForItem(item, $ratings) : undefined,
+  );
+  const valueText = $derived(formatSortValue(item, sortBy, userRating));
 </script>
 
 <div class="trakt-sort-value">

--- a/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.spec.ts
@@ -83,6 +83,21 @@ describe('formatSortValue', () => {
     });
   });
 
+  describe('sortBy: my_rating', () => {
+    const item = {
+      type: 'movie',
+      entry: { id: 1 },
+    } as unknown as ListItem;
+
+    it('should return formatted user rating when provided', () => {
+      expect(formatSortValue(item, 'my_rating', 8)).toBe('4');
+    });
+
+    it('should return undefined when user rating is missing', () => {
+      expect(formatSortValue(item, 'my_rating')).toBeUndefined();
+    });
+  });
+
   describe('sortBy: title', () => {
     it('should return first letter of movie title', () => {
       const movieItem = {

--- a/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
@@ -6,6 +6,7 @@ import { isMaxDate } from '../../../../utils/date/isMaxDate.ts';
 import { toHumanDay } from '../../../../utils/formatting/date/toHumanDay.ts';
 import { toHumanDuration } from '../../../../utils/formatting/date/toHumanDuration.ts';
 import { toTraktRating } from '../../../../utils/formatting/number/toTraktRating.ts';
+import { toUserRating } from '../../../../utils/formatting/number/toUserRating.ts';
 import type { SortBy } from '../models/SortBy.ts';
 
 export type SortInput = ListItem | FavoritedEntry;
@@ -74,7 +75,11 @@ function getRating(item: SortInput): number | null | undefined {
   return getListItemEntry(item).rating;
 }
 
-export function formatSortValue(item: SortInput, sortBy?: SortBy) {
+export function formatSortValue(
+  item: SortInput,
+  sortBy?: SortBy,
+  userRating?: number,
+) {
   if (!sortBy) {
     return;
   }
@@ -100,6 +105,10 @@ export function formatSortValue(item: SortInput, sortBy?: SortBy) {
       const rating = getRating(item);
       return rating ? `${toTraktRating(rating, getLocale())}` : undefined;
     }
+    case 'my_rating':
+      return userRating != null
+        ? toUserRating(userRating, getLocale())
+        : undefined;
     case 'title':
       return getTitle(item)[0]?.toUpperCase();
   }

--- a/projects/client/src/lib/sections/lists/user/_internal/getUserRatingForItem.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/getUserRatingForItem.ts
@@ -1,0 +1,30 @@
+import type { UserRatings } from '$lib/features/auth/queries/currentUserRatingsQuery.ts';
+import type { FavoritedEntry } from '$lib/requests/models/FavoritedEntry.ts';
+import type { SortInput } from './formatSortValue.ts';
+
+function isFavorited(item: SortInput): item is FavoritedEntry {
+  return 'favoritedAt' in item;
+}
+
+export function getUserRatingForItem(
+  item: SortInput,
+  ratings: UserRatings | undefined,
+): number | undefined {
+  if (!ratings) return undefined;
+
+  if (isFavorited(item)) {
+    const id = item.item.id;
+    return (ratings.movies.get(id) ?? ratings.shows.get(id))?.rating;
+  }
+
+  switch (item.type) {
+    case 'movie':
+      return ratings.movies.get(item.entry.id)?.rating;
+    case 'show':
+      return ratings.shows.get(item.entry.id)?.rating;
+    case 'episode':
+      return ratings.episodes.get(item.entry.episode.id)?.rating;
+    default:
+      return undefined;
+  }
+}

--- a/projects/client/src/lib/sections/lists/user/constants/index.ts
+++ b/projects/client/src/lib/sections/lists/user/constants/index.ts
@@ -23,6 +23,11 @@ export const LIST_SORT_OPTIONS: Sorting[] = [
     label: m.button_label_sort_rating,
   },
   {
+    value: 'my_rating',
+    text: m.button_text_sort_my_rating,
+    label: m.button_label_sort_my_rating,
+  },
+  {
     value: 'released',
     text: m.button_text_sort_release_date,
     label: m.button_label_sort_release_date,

--- a/projects/client/src/lib/sections/lists/user/models/SortBy.ts
+++ b/projects/client/src/lib/sections/lists/user/models/SortBy.ts
@@ -2,5 +2,6 @@ export type SortBy =
   | 'added'
   | 'runtime'
   | 'percentage'
+  | 'my_rating'
   | 'released'
   | 'title';


### PR DESCRIPTION
## Summary

- Adds `My Rating` to the sort dropdown on user lists, favorites, and watchlist
- Wires the value through as `sort_by=my_rating` so the server handles ordering
- The sort tag on each item resolves the rating from the current user's ratings store (defaults to no tag when the user hasn't rated the item)

## Test plan

- [ ] Open a personal list, favorites, and watchlist; verify `My Rating` shows up in the sort menu
- [ ] Pick `My Rating` and confirm the URL updates to `?sort_by=my_rating&sort_how=desc`
- [ ] Verify rated items render a star tag with the user's rating value; unrated items render no tag
- [ ] Switch between `Rating` and `My Rating` and confirm tags reflect the correct value source