### PR TITLE
feat(profile): add compatibility match pill

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6886,6 +6886,66 @@
     "button_label_edit_mode": {
       "default": "Edit mode",
       "description": "Aria-label for the button that allows users to enter edit mode to customize their dashboard."
+    },
+    "match_pill_aria_label": {
+      "default": "{score}% match, {label}. Open match details.",
+      "description": "Aria-label for the compatibility pill in the profile banner. Announces the match score, the tonal label (e.g. 'Soul twin'), and that the pill opens a drawer with more detail.",
+      "variables": {
+        "score": {
+          "type": "number"
+        },
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "match_drawer_title": {
+      "default": "Match details",
+      "description": "Header of the drawer that opens when the compatibility pill is tapped."
+    },
+    "match_drawer_breakdown_header": {
+      "default": "How this adds up",
+      "description": "Section header inside the match drawer, above the per-signal bars that explain how the overall score is composed."
+    },
+    "match_drawer_breakdown_topics": {
+      "default": "Topics",
+      "description": "Label for the per-signal bar that shows what fraction of media topics (subgenres) the two users share."
+    },
+    "match_drawer_breakdown_favorites": {
+      "default": "Favorites",
+      "description": "Label for the per-signal bar that shows what fraction of favorited movies and shows the two users share."
+    },
+    "match_drawer_breakdown_caption": {
+      "default": "Score blends topic taste (70%) and shared favorites (30%).",
+      "description": "Small caption under the breakdown bars, explaining the weighting used to compute the overall match score."
+    },
+    "match_drawer_shared_topics_header": {
+      "default": "Shared topics",
+      "description": "Section header above the list of subgenre chips that both users have watched a lot of. 'Topics' is the user-facing label for the technical concept of subgenres."
+    },
+    "match_label_soul_twin": {
+      "default": "Soul twin",
+      "description": "Tonal label for the highest match band (75%+). Reads as 'we like the exact same stuff'."
+    },
+    "match_label_strong_match": {
+      "default": "Strong match",
+      "description": "Tonal label for a high match band (55-74%). Reads as 'lots in common'."
+    },
+    "match_label_aligned_tastes": {
+      "default": "Aligned tastes",
+      "description": "Tonal label for a solid-mid match band (35-54%). Reads as 'meaningful overlap'."
+    },
+    "match_label_common_ground": {
+      "default": "Common ground",
+      "description": "Tonal label for a mid match band (20-34%). Reads as 'some overlap worth exploring'."
+    },
+    "match_label_light_overlap": {
+      "default": "Light overlap",
+      "description": "Tonal label for a low match band (8-19%). Reads as 'a little in common'."
+    },
+    "match_label_different_scenes": {
+      "default": "Different scenes",
+      "description": "Tonal label for the lowest match band (<8%). Reads as 'we watch very different things' without being harsh."
     }
   }
 }

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -2,4 +2,5 @@ export enum FeatureFlag {
   MyStats = 'my-stats',
   YearInReview = 'year-in-review',
   EditMode = 'edit-mode',
+  UserMatch = 'user-match',
 }

--- a/projects/client/src/lib/requests/models/UserMatch.ts
+++ b/projects/client/src/lib/requests/models/UserMatch.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const UserMatchSharedSubgenreSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  slug: z.string(),
+});
+
+export const UserMatchSchema = z.object({
+  score: z.number().min(0).max(100),
+  breakdown: z.object({
+    subgenres: z.number().min(0).max(100),
+    favorites: z.number().min(0).max(100),
+  }),
+  shared: z.object({
+    subgenres: z.array(UserMatchSharedSubgenreSchema),
+    favorites: z.object({
+      movies: z.array(z.number()),
+      shows: z.array(z.number()),
+    }),
+  }),
+});
+
+export type UserMatch = z.infer<typeof UserMatchSchema>;
+export type UserMatchSharedSubgenre = z.infer<
+  typeof UserMatchSharedSubgenreSchema
+>;

--- a/projects/client/src/lib/requests/queries/users/userMatchQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userMatchQuery.ts
@@ -1,0 +1,54 @@
+import type { DiscoverMode } from '$lib/features/discover/models/DiscoverMode.ts';
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import {
+  type UserMatch,
+  UserMatchSchema,
+} from '$lib/requests/models/UserMatch.ts';
+import { time } from '$lib/utils/timing/time.ts';
+
+type UserMatchParams = {
+  slug: string;
+  mode: DiscoverMode;
+} & ApiParams;
+
+const emptyMatch: UserMatch = {
+  score: 0,
+  breakdown: { subgenres: 0, favorites: 0 },
+  shared: { subgenres: [], favorites: { movies: [], shows: [] } },
+};
+
+const userMatchRequest = async ({ fetch, slug, mode }: UserMatchParams) => {
+  // mode='media' means no axis filter — omit the query param so the server
+  // returns both movie and show signals. Otherwise pass the specific type
+  // so the server skips the unused axis (cheaper) and the score reflects
+  // only the active media type.
+  const search = mode === 'media' ? '' : `?type=${mode}`;
+  const response = await rawApiFetch({
+    fetch,
+    path: `/v3/users/${encodeURIComponent(slug)}/match${search}`,
+  });
+
+  if (!response.ok) {
+    return { body: emptyMatch, status: response.status };
+  }
+
+  return {
+    body: (await response.json()) as UserMatch,
+    status: response.status,
+  };
+};
+
+export const userMatchQuery = defineQuery({
+  key: 'userMatch',
+  invalidations: [
+    InvalidateAction.Favorited('movie'),
+    InvalidateAction.Favorited('show'),
+  ],
+  dependencies: (params) => [params.slug, params.mode],
+  request: userMatchRequest,
+  mapper: (response) => response.body,
+  schema: UserMatchSchema,
+  ttl: time.minutes(30),
+});

--- a/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
@@ -4,8 +4,11 @@
   import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import { useIsMe } from "$lib/features/auth/stores/useIsMe";
   import { useUser } from "$lib/features/auth/stores/useUser";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
+  import MatchPill from "$lib/sections/profile/components/MatchPill.svelte";
   import ProfileAbout from "$lib/sections/profile/components/ProfileAbout.svelte";
   import { toDisplayableName } from "$lib/utils/profile/toDisplayableName";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
@@ -68,6 +71,15 @@
       <span class="title ellipsis">{toDisplayableName(profile)}</span>
       {#if isPublic}
         <span class="user-location ellipsis">{profile.location}</span>
+      {/if}
+      {#if !$isMe && !isBlocked}
+        <RenderFor audience="authenticated">
+          <RenderForFeature flag={FeatureFlag.UserMatch}>
+            {#snippet enabled()}
+              <MatchPill {slug} />
+            {/snippet}
+          </RenderForFeature>
+        </RenderFor>
       {/if}
     </div>
     <div class="profile-actions">

--- a/projects/client/src/lib/sections/profile/components/MatchPill.svelte
+++ b/projects/client/src/lib/sections/profile/components/MatchPill.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import { useDiscover } from "$lib/features/discover/useDiscover.ts";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import MatchDrawer from "./_internal/MatchDrawer.svelte";
+  import { matchLabel } from "./_internal/matchLabel";
+  import { useMatch } from "./_internal/useMatch.ts";
+
+  const { slug }: { slug: string } = $props();
+
+  const { mode } = useDiscover();
+  const { match, isLoading, band } = $derived(useMatch({ slug, mode: $mode }));
+
+  const score = $derived($match?.score ?? 0);
+  const label = $derived(matchLabel(score));
+
+  let isOpen = $state(false);
+</script>
+
+{#if !$isLoading && $match}
+  <!-- FIXME: use Link component for this + build drawer link -->
+  <button
+    class="trakt-match-pill"
+    type="button"
+    onclick={() => (isOpen = true)}
+    aria-label={m.match_pill_aria_label({ score, label })}
+    data-band={band}
+    style:--fill={`${score}%`}
+  >
+    <span class="score bold">{score}<span class="suffix small">%</span></span>
+    <span class="label bold">{label}</span>
+  </button>
+{/if}
+
+{#if isOpen && $match}
+  <MatchDrawer match={$match} onClose={() => (isOpen = false)} />
+{/if}
+
+<style lang="scss">
+  .trakt-match-pill {
+    --pill-accent: var(--color-foreground);
+    --fill: 0%;
+
+    align-self: flex-start;
+    margin-top: var(--gap-xxs);
+
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-xxs);
+    padding: var(--ni-4) var(--ni-12);
+    border-radius: var(--border-radius-xxl);
+
+    // Background is the progress encoding: the score percent of the pill
+    // width is filled with a soft accent tint, the rest is neutral. Reads
+    // like a score bar without needing a separate UI element.
+    background: linear-gradient(
+      to right,
+      color-mix(in srgb, var(--pill-accent) 22%, transparent) 0%,
+      color-mix(in srgb, var(--pill-accent) 22%, transparent) var(--fill),
+      color-mix(in srgb, var(--color-foreground) 5%, transparent) var(--fill),
+      color-mix(in srgb, var(--color-foreground) 5%, transparent) 100%
+    );
+
+    border: var(--ni-1) solid
+      color-mix(in srgb, var(--color-border) 40%, transparent);
+    color: inherit;
+
+    cursor: pointer;
+
+    font-family: inherit;
+    white-space: nowrap;
+
+    transition:
+      transform var(--transition-increment) ease-out,
+      border-color var(--transition-increment) ease-out;
+
+    &[data-band="high"] {
+      border-color: color-mix(in srgb, var(--pill-accent) 60%, transparent);
+    }
+
+    &[data-band="mid"] {
+      border-color: color-mix(in srgb, var(--pill-accent) 30%, transparent);
+    }
+
+    &:active {
+      transform: scale(0.97);
+    }
+  }
+
+  .score {
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .suffix {
+    opacity: 0.7;
+    margin-left: 1px;
+  }
+
+  .label {
+    white-space: nowrap;
+  }
+</style>

--- a/projects/client/src/lib/sections/profile/components/_internal/MatchDrawer.svelte
+++ b/projects/client/src/lib/sections/profile/components/_internal/MatchDrawer.svelte
@@ -1,0 +1,298 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { UserMatch } from "$lib/requests/models/UserMatch";
+  import { toPercentage } from "$lib/utils/formatting/number/toPercentage";
+  import { matchLabel } from "./matchLabel";
+  import SharedMediaPoster from "./SharedMediaPoster.svelte";
+
+  const {
+    onClose,
+    match,
+  }: {
+    onClose: () => void;
+    match: UserMatch;
+  } = $props();
+
+  const score = $derived(match.score);
+  const label = $derived(matchLabel(score));
+
+  // Cap rendered shared favorites so the drawer doesn't fan out into
+  // dozens of summary fetches on open. Server already returns at most
+  // 20 per type; we trim further to a compact grid.
+  const maxSharedPerType = 6;
+
+  const sharedMovies = $derived(
+    match.shared.favorites.movies.slice(0, maxSharedPerType),
+  );
+  const sharedShows = $derived(
+    match.shared.favorites.shows.slice(0, maxSharedPerType),
+  );
+
+  const dasharray = $derived(`${score}, 100`);
+</script>
+
+<Drawer {onClose} title={m.match_drawer_title()} size="auto">
+  <div class="trakt-match-drawer">
+    <div class="hero">
+      <div class="gauge">
+        <svg viewBox="0 0 36 36" aria-hidden="true">
+          <path
+            class="gauge-track"
+            d="M18 2.5a 15.5 15.5 0 0 1 0 31 a 15.5 15.5 0 0 1 0 -31"
+          />
+          <path
+            class="gauge-fill"
+            pathLength="100"
+            stroke-dasharray={dasharray}
+            d="M18 2.5a 15.5 15.5 0 0 1 0 31 a 15.5 15.5 0 0 1 0 -31"
+          />
+        </svg>
+        <div class="readout">
+          <span class="score bold">{score}</span><span class="suffix">%</span>
+        </div>
+      </div>
+      <p class="hero-label bold">{label}</p>
+    </div>
+
+    <section class="block">
+      <header>
+        <h3 class="section-title secondary bold">
+          {m.match_drawer_breakdown_header()}
+        </h3>
+      </header>
+      <div class="breakdown">
+        <div class="breakdown-row">
+          <span class="breakdown-label secondary">
+            {m.match_drawer_breakdown_topics()}
+          </span>
+          <div class="bar">
+            <span style:width={`${match.breakdown.subgenres}%`}></span>
+          </div>
+          <span class="breakdown-value">
+            {toPercentage(match.breakdown.subgenres / 100, languageTag())}
+          </span>
+        </div>
+        <div class="breakdown-row">
+          <span class="breakdown-label secondary">
+            {m.match_drawer_breakdown_favorites()}
+          </span>
+          <div class="bar">
+            <span style:width={`${match.breakdown.favorites}%`}></span>
+          </div>
+          <span class="breakdown-value">
+            {toPercentage(match.breakdown.favorites / 100, languageTag())}
+          </span>
+        </div>
+      </div>
+      <p class="caption secondary">{m.match_drawer_breakdown_caption()}</p>
+    </section>
+
+    {#if match.shared.subgenres.length > 0}
+      <section class="block">
+        <header>
+          <h3 class="section-title secondary">
+            {m.match_drawer_shared_topics_header()}
+          </h3>
+          <span class="count secondary">{match.shared.subgenres.length}</span>
+        </header>
+        <ul class="chips">
+          {#each match.shared.subgenres as item (item.id)}
+            <li class="chip small"><span>{item.name}</span></li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    {#if sharedMovies.length > 0}
+      <section class="block">
+        <header>
+          <h3 class="section-title secondary">{m.tag_text_movies()}</h3>
+          <span class="count secondary">
+            {match.shared.favorites.movies.length}
+          </span>
+        </header>
+        <div class="posters">
+          {#each sharedMovies as id (`movie-${id}`)}
+            <SharedMediaPoster {id} type="movie" />
+          {/each}
+        </div>
+      </section>
+    {/if}
+
+    {#if sharedShows.length > 0}
+      <section class="block">
+        <header>
+          <h3 class="section-title secondary">{m.tag_text_shows()}</h3>
+          <span class="count secondary">
+            {match.shared.favorites.shows.length}
+          </span>
+        </header>
+        <div class="posters">
+          {#each sharedShows as id (`show-${id}`)}
+            <SharedMediaPoster {id} type="show" />
+          {/each}
+        </div>
+      </section>
+    {/if}
+  </div>
+</Drawer>
+
+<style lang="scss">
+  .trakt-match-drawer {
+    --stroke-width-match-gauge: var(--ni-3);
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-l);
+  }
+
+  .hero {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--gap-s);
+
+    padding-top: var(--gap-m);
+  }
+
+  .gauge {
+    position: relative;
+    width: var(--ni-160);
+    height: var(--ni-160);
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    svg {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      transform: rotate(-90deg);
+    }
+  }
+
+  .gauge-track {
+    fill: none;
+    stroke: color-mix(in srgb, var(--color-foreground) 10%, transparent);
+    stroke-width: var(--stroke-width-match-gauge);
+  }
+
+  .gauge-fill {
+    fill: none;
+    stroke: var(--color-foreground);
+    stroke-width: var(--stroke-width-match-gauge);
+    stroke-linecap: round;
+    transition: stroke-dasharray calc(var(--transition-increment) * 2) ease-out;
+  }
+
+  .readout {
+    position: relative;
+    display: inline-flex;
+    align-items: baseline;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+
+  .score {
+    font-size: 2.5rem;
+  }
+
+  .suffix {
+    font-size: var(--font-size-separator);
+    opacity: 0.6;
+    margin-left: 2px;
+  }
+
+  .hero-label {
+    margin: 0;
+    text-align: center;
+    font-size: var(--font-size-separator);
+  }
+
+  .block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+
+  header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--gap-xs);
+  }
+
+  .section-title {
+    margin: 0;
+    font-size: var(--font-size-tag);
+  }
+
+  .count {
+    font-variant-numeric: tabular-nums;
+    font-size: var(--font-size-text-small);
+  }
+
+  .breakdown {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+
+  .breakdown-row {
+    display: grid;
+    grid-template-columns: var(--ni-128) 1fr var(--ni-40);
+    align-items: center;
+    gap: var(--gap-xs);
+    font-size: var(--font-size-text-small);
+  }
+
+  .breakdown-value {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .bar {
+    position: relative;
+    height: var(--ni-6);
+    border-radius: var(--ni-6);
+    background: color-mix(in srgb, var(--color-foreground) 8%, transparent);
+    overflow: hidden;
+
+    span {
+      position: absolute;
+      inset: 0 auto 0 0;
+      background: var(--color-foreground);
+      transition: width calc(var(--transition-increment) * 2) ease-out;
+    }
+  }
+
+  .chips {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--ni-4);
+  }
+
+  .chip {
+    padding: var(--ni-4) var(--ni-10);
+    border-radius: var(--ni-12);
+    background: color-mix(in srgb, var(--color-foreground) 6%, transparent);
+  }
+
+  .caption {
+    margin: 0;
+    font-size: var(--font-size-text-small);
+  }
+
+  .posters {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--gap-s);
+  }
+</style>

--- a/projects/client/src/lib/sections/profile/components/_internal/SharedMediaPoster.svelte
+++ b/projects/client/src/lib/sections/profile/components/_internal/SharedMediaPoster.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
+  import { useQuery } from "$lib/features/query/useQuery";
+  import { movieSummaryQuery } from "$lib/requests/queries/movies/movieSummaryQuery";
+  import { showSummaryQuery } from "$lib/requests/queries/shows/showSummaryQuery";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { map } from "rxjs";
+
+  const { id, type }: { id: number; type: "movie" | "show" } = $props();
+
+  // Trakt's id-extractor accepts a numeric trakt id as the `slug` param, so we
+  // can hydrate by id without first looking up a slug.
+  const slugParam = $derived(id.toString());
+
+  const query = $derived(
+    type === "movie"
+      ? useQuery(movieSummaryQuery({ slug: slugParam }))
+      : useQuery(showSummaryQuery({ slug: slugParam })),
+  );
+
+  const media = $derived(query.pipe(map(($q) => $q.data)));
+</script>
+
+<div class="trakt-shared-media-poster">
+  {#if $media}
+    <Link href={UrlBuilder.media(type, $media.slug)} color="inherit">
+      <img
+        src={$media.poster.url.medium}
+        alt={$media.title}
+        loading="lazy"
+        decoding="async"
+      />
+      <span class="title ellipsis bold small">{$media.title}</span>
+    </Link>
+  {:else}
+    <div class="placeholder"></div>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-shared-media-poster {
+    min-width: 0;
+
+    :global(a) {
+      display: flex;
+      flex-direction: column;
+      gap: var(--gap-xxs);
+      text-decoration: none;
+    }
+
+    img {
+      width: 100%;
+      aspect-ratio: 2 / 3;
+      border-radius: var(--border-radius-s, var(--ni-8));
+      object-fit: cover;
+      background: color-mix(in srgb, var(--color-foreground) 5%, transparent);
+      transition: transform 200ms ease-out;
+    }
+
+    @include for-mouse {
+      :global(a:hover img) {
+        transform: translateY(-2px);
+      }
+    }
+  }
+
+  .title {
+    line-height: 1.2;
+  }
+
+  .placeholder {
+    width: 100%;
+    aspect-ratio: 2 / 3;
+    border-radius: var(--border-radius-s, var(--ni-8));
+    background: color-mix(in srgb, var(--color-foreground) 5%, transparent);
+  }
+</style>

--- a/projects/client/src/lib/sections/profile/components/_internal/matchLabel.ts
+++ b/projects/client/src/lib/sections/profile/components/_internal/matchLabel.ts
@@ -1,0 +1,17 @@
+import * as m from '$lib/features/i18n/messages.ts';
+
+/**
+ * Tonal label for a 0-100 match score. Bands tuned to how real Trakt
+ * users actually score against each other - subgenre overlap is broad
+ * and most paired users land in the 20-60 zone even when their taste
+ * meaningfully aligns. Generous on purpose: 30-40% should read positive,
+ * not "you have nothing in common".
+ */
+export function matchLabel(score: number): string {
+  if (score >= 75) return m.match_label_soul_twin();
+  if (score >= 55) return m.match_label_strong_match();
+  if (score >= 35) return m.match_label_aligned_tastes();
+  if (score >= 20) return m.match_label_common_ground();
+  if (score >= 8) return m.match_label_light_overlap();
+  return m.match_label_different_scenes();
+}

--- a/projects/client/src/lib/sections/profile/components/_internal/useMatch.ts
+++ b/projects/client/src/lib/sections/profile/components/_internal/useMatch.ts
@@ -1,0 +1,27 @@
+import type { DiscoverMode } from '$lib/features/discover/models/DiscoverMode.ts';
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import { userMatchQuery } from '$lib/requests/queries/users/userMatchQuery.ts';
+import { map } from 'rxjs';
+
+type UseMatchProps = {
+  slug: string;
+  mode: DiscoverMode;
+};
+
+type MatchBand = 'high' | 'mid' | 'low';
+
+function toMatchBand(score: number): MatchBand {
+  if (score >= 70) return 'high';
+  if (score >= 40) return 'mid';
+  return 'low';
+}
+
+export function useMatch({ slug, mode }: UseMatchProps) {
+  const query = useQuery(userMatchQuery({ slug, mode }));
+
+  return {
+    match: query.pipe(map(($query) => $query.data)),
+    isLoading: query.pipe(map(($query) => $query.isLoading)),
+    band: query.pipe(map(($query) => toMatchBand($query.data?.score ?? 0))),
+  };
+}

--- a/projects/client/src/style/numeric-increments/index.css
+++ b/projects/client/src/style/numeric-increments/index.css
@@ -6,6 +6,7 @@
   --ni-0: 0rem;
   --ni-1: 0.0625rem;
   --ni-2: 0.125rem;
+  --ni-3: 0.1875rem;
   --ni-4: 0.25rem;
   --ni-6: 0.3125rem;
   --ni-8: 0.375rem;
@@ -105,6 +106,7 @@
    */
   --ni-neg-0: 0rem;
   --ni-neg-2: -0.125rem;
+  --ni-neg-3: -0.1875rem;
   --ni-neg-4: -0.25rem;
   --ni-neg-6: -0.3125rem;
   --ni-neg-7: -0.4375rem;


### PR DESCRIPTION
## Summary

- Adds a clickable compatibility pill in the profile banner that surfaces a 0-100 match score against the authenticated viewer, plus a drawer with the breakdown, shared topics (subgenres), and shared favorite posters.
- Powered by the new `GET /v3/users/:slug/match` endpoint from trakt/trakt-workers#811. Honors the global discover-mode toggle (Media / Movies / Shows) - server skips the unused axis on a typed request.
- All copy lives in `i18n/meta/en.json`. Typography utility classes (`.bold`, `.ellipsis`, `.small`, `.secondary`) and semantic font-size tokens used throughout - no manual font-weight or raw `--ni-*` sizes.
- Shared favorite posters lazy-hydrate via existing `movieSummaryQuery` / `showSummaryQuery` (cached 3h per id, so opening the drawer is cheap on repeat visits).
- Gated behind `FeatureFlag.UserMatch` so the rollout can be staged.

### Screenshots

Pill in the profile banner (under name + location):

<img width="2000" height="1060" alt="image" src="https://github.com/user-attachments/assets/393e7b87-09d8-410d-93d1-c9411e85919e" />

Match details drawer (gauge, breakdown bars, shared topics, shared favorite posters):

<img width="2000" height="1060" alt="image" src="https://github.com/user-attachments/assets/3755c389-833c-4fd5-8ed2-079f68986074" />

## Test plan

- [ ] Visit another VIP / non-VIP profile while logged in - pill renders under name + location, never replaces them
- [ ] Pill respects the global Media / Movies / Shows toggle - score and breakdown bars update on switch
- [ ] Click the pill -> drawer opens with the gauge, breakdown bars, shared topic chips, and per-type poster grids
- [ ] Shared movie + show posters lazy-load and link to their respective pages
- [ ] Pill is hidden for self (`/profile/me`), blocked users, and anonymous viewers
- [ ] Pill is hidden when `FeatureFlag.UserMatch` is off

## Notes

- Workers side is trakt/trakt-workers#811 - merging this without the worker change deployed will return a 404 on the match endpoint, but the query falls back to a zeroed payload so the pill simply renders 0%. The feature flag is the real gate.
- Screenshots live on a separate `assets/pr-2442-screenshots` orphan branch in this repo (since the GitHub REST API does not expose PR body image uploads).