### PR TITLE
fix(cta): aligns card footer with regular cards

### DIFF
--- a/projects/client/src/lib/sections/lists/components/cta/_internal/CtaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/CtaCard.svelte
@@ -68,7 +68,7 @@
     align-items: center;
 
     height: calc(var(--height-card) - var(--height-card-cover));
-    padding: var(--ni-8);
+    padding-top: var(--ni-8);
     box-sizing: border-box;
 
     :global(.trakt-button) {

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -45,6 +45,8 @@
   );
   --height-landscape-card-cover: calc(var(--width-landscape-card) / 1.786);
   --height-landscape-card: calc(var(--height-landscape-card-cover) + var(--height-card-footer));
+  --height-landscape-card-sm: calc(var(--height-landscape-card-cover) + var(--height-card-footer-sm));
+
 
   --min-person-card-width: var(--ni-120);
   --max-list-person-item-count: 15;
@@ -116,11 +118,11 @@
   }
 
   --width-cta-landscape-card: var(--width-landscape-card);
-  --height-cta-landscape-card: var(--height-landscape-card);
+  --height-cta-landscape-card: var(--height-landscape-card-sm);
   --height-cta-landscape-card-cover: var(--height-landscape-card-cover);
 
   --width-cta-portrait-card: var(--width-portrait-card);
-  --height-cta-portrait-card: var(--height-portrait-card);
+  --height-cta-portrait-card: var(--height-portrait-card-sm);
   --height-cta-portrait-card-cover: var(--height-portrait-card-cover);
 
   --width-cta-activity-card: var(--ni-340);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2444
- In certain lists, cta items could cause vertical scroll due to being larger that regular cards. This fix aligns the sizing of cta items with cards that have small footers.