### PR TITLE
User Activity: display episode screenshots in the user ratings activity

### DIFF
--- a/.github/workflows/supply_chain.yml
+++ b/.github/workflows/supply_chain.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            api.deps.dev:443
             api.github.com:443
             codeload.github.com:443
             deno.com:443
@@ -119,6 +120,7 @@ jobs:
             npm.jsr.io:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
+            www-api.ibm.com:443
 
       - name: Secure the Evidence aka Checkout Code
         uses: actions/checkout@v4

--- a/deno.lock
+++ b/deno.lock
@@ -12,7 +12,7 @@
     "npm:@ethercorps/sveltekit-og@4.2.1": "4.2.1_@sveltejs+kit@2.59.1__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.55.5___vite@8.0.10____esbuild@0.28.0____sass-embedded@1.99.0__svelte@5.55.5__typescript@5.8.3__vite@8.0.10___esbuild@0.28.0___sass-embedded@1.99.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.55.5__vite@8.0.10___esbuild@0.28.0___sass-embedded@1.99.0",
     "npm:@inlang/paraglide-js@2.18.0": "2.18.0_typescript@5.8.3",
     "npm:@jsr/libn__fuzzy@0.4.0": "0.4.0",
-    "npm:@jsr/trakt__api@0.4.12": "0.4.12_openapi3-ts@4.5.0",
+    "npm:@jsr/trakt__api@0.4.13": "0.4.13_openapi3-ts@4.6.0",
     "npm:@playwright/test@1.59.1": "1.59.1",
     "npm:@sentry/sveltekit@10.51.0": "10.51.0_@sveltejs+kit@2.59.1__@sveltejs+vite-plugin-svelte@7.0.0___svelte@5.55.5___vite@8.0.10____esbuild@0.28.0____sass-embedded@1.99.0__svelte@5.55.5__typescript@5.8.3__vite@8.0.10___esbuild@0.28.0___sass-embedded@1.99.0_vite@8.0.10__esbuild@0.28.0__sass-embedded@1.99.0_@sveltejs+vite-plugin-svelte@7.0.0__svelte@5.55.5__vite@8.0.10___esbuild@0.28.0___sass-embedded@1.99.0",
     "npm:@svelte-put/shortcut@4.1.0": "4.1.0_svelte@5.55.5",
@@ -96,7 +96,7 @@
     "@adobe/css-tools@4.4.4": {
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="
     },
-    "@anatine/zod-openapi@2.2.8_openapi3-ts@4.5.0_zod@3.25.76": {
+    "@anatine/zod-openapi@2.2.8_openapi3-ts@4.6.0_zod@3.25.76": {
       "integrity": "sha512-iyM8mB556KdiZ6a1GTZ67ACLnJakU1hrzzXoh7PLaReldAdMq88MlZn/Ir/U56/TBuQctBhh/4seo0b0B343uw==",
       "dependencies": [
         "openapi3-ts",
@@ -2299,14 +2299,14 @@
       "integrity": "sha512-aD9yjW6CMt37S3AMTc95LeuRXcKor69Zkr0aWOhYvinTOEAhEIuaJhP4pQqyQGaAC9HIrQcKh1PtRTK85kkVjA==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/libn__fuzzy/0.4.0.tgz"
     },
-    "@jsr/trakt__api@0.4.12_openapi3-ts@4.5.0": {
-      "integrity": "sha512-zDeEzNDT2ofi+AF04DJsitp4lFY92DywkT3FXwLdGWZMKc9x36CROHVGA575lXowEboMoyltpEnXakudKvawdA==",
+    "@jsr/trakt__api@0.4.13_openapi3-ts@4.6.0": {
+      "integrity": "sha512-drJK9omWBQevJWtEO6GdcFTG8zf95TWwzFC2W2j3AUDR4ecAPRuf0ChAxhihjytHnvY4tXiEkXxEqK8nT5J53A==",
       "dependencies": [
         "@anatine/zod-openapi",
         "@ts-rest/core",
         "zod"
       ],
-      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.4.12.tgz"
+      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.4.13.tgz"
     },
     "@lix-js/sdk@0.4.10": {
       "integrity": "sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==",
@@ -6224,10 +6224,10 @@
         "jwt-decode"
       ]
     },
-    "openapi3-ts@4.5.0": {
-      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+    "openapi3-ts@4.6.0": {
+      "integrity": "sha512-a4sfn6L2sIShhtzJqmjGrARvxAW/3F2BJDdyRVvNF9VhAsZSh5hSyI3a9TNvmzBxXmq66nY5LNT5bQcBxYAZZg==",
       "dependencies": [
-        "yaml@2.8.2"
+        "yaml@2.9.0"
       ]
     },
     "optionator@0.9.4": {
@@ -8162,6 +8162,10 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "bin": true
     },
+    "yaml@2.9.0": {
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "bin": true
+    },
     "yargs-parser@21.1.1": {
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     },
@@ -8239,7 +8243,7 @@
             "npm:@ethercorps/sveltekit-og@4.2.1",
             "npm:@inlang/paraglide-js@2.18.0",
             "npm:@jsr/libn__fuzzy@0.4.0",
-            "npm:@jsr/trakt__api@0.4.12",
+            "npm:@jsr/trakt__api@0.4.13",
             "npm:@playwright/test@1.59.1",
             "npm:@sentry/sveltekit@10.51.0",
             "npm:@svelte-put/shortcut@4.1.0",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -74,7 +74,7 @@
     "@tanstack/svelte-query": "5.90.2",
     "@tanstack/svelte-query-devtools": "5.90.2",
     "@tanstack/svelte-query-persist-client": "5.90.2",
-    "@trakt/api": "npm:@jsr/trakt__api@0.4.12",
+    "@trakt/api": "npm:@jsr/trakt__api@0.4.13",
     "@ts-rest/core": "3.52.1",
     "@use-gesture/vanilla": "10.3.1",
     "bits-ui": "2.18.1",

--- a/projects/client/src/lib/requests/queries/users/droppedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/droppedShowsQuery.ts
@@ -9,6 +9,7 @@ import {
   type DroppedProgressEntry,
   DroppedProgressEntrySchema,
 } from '$lib/requests/models/ProgressEntry.ts';
+import { MAX_DATE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { HiddenShowItemResponse } from '@trakt/api';
 
@@ -23,7 +24,7 @@ function mapToDroppedProgressEntry(
     key: show.key,
     type: 'dropped',
     show,
-    hiddenAt: new Date(item.hidden_at),
+    hiddenAt: new Date(item.hidden_at ?? MAX_DATE),
   };
 }
 

--- a/projects/client/src/lib/requests/queries/users/hiddenShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/hiddenShowsQuery.ts
@@ -6,6 +6,7 @@ import {
   HiddenShowSchema,
 } from '$lib/requests/models/HiddenShow.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { MAX_DATE } from '$lib/utils/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { HiddenShowItemResponse } from '@trakt/api';
 import type { LimitParams } from '../../models/LimitParams.ts';
@@ -14,7 +15,7 @@ type HiddenShowsParams = LimitParams & ApiParams;
 
 function mapToHiddenShowItem(item: HiddenShowItemResponse): HiddenShow {
   return {
-    hiddenAt: new Date(item.hidden_at),
+    hiddenAt: new Date(item.hidden_at ?? MAX_DATE),
     show: mapToShowEntry(item.show),
   };
 }

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -29,10 +29,13 @@
   const isActivity = $derived(props.variant === "activity");
   const isHidden = $derived(props.status === "hidden");
   const isListItem = $derived(props.variant === "list-item");
+
   const style = $derived(props.style ?? "cover");
-  const isCompact = $derived(style === "compact");
   const resolvedStyle: "cover" | "summary" = $derived(
-    style === "compact" ? "summary" : style,
+    style === "compact" || style === "minimal" ? "summary" : style,
+  );
+  const summaryCardLayout = $derived(
+    style === "compact" || style === "minimal" ? style : "default",
   );
 
   const runtime = $derived(
@@ -189,7 +192,7 @@
 {/snippet}
 
 {#snippet card()}
-  {#if style === "summary" || style === "compact"}
+  {#if resolvedStyle === "summary"}
     <MediaSummaryCard
       {...props.variant === "activity"
         ? {
@@ -212,7 +215,7 @@
         },
       }}
       popupActions={props.popupActions}
-      layout={isCompact ? "compact" : "default"}
+      layout={summaryCardLayout}
       badge={action}
       {sortTag}
       type="episode"

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -12,11 +12,14 @@
     sortTag,
     ...props
   }: MediaCardProps & { contextualTag?: Snippet; sortTag?: Snippet } = $props();
+
   const style = $derived(props.style ?? "cover");
   const resolvedStyle = $derived<"cover" | "summary">(
-    style === "compact" ? "summary" : style,
+    style === "compact" || style === "minimal" ? "summary" : style,
   );
-  const isCompact = $derived(style === "compact");
+  const summaryCardLayout = $derived(
+    style === "compact" || style === "minimal" ? style : "default",
+  );
 
   const isCover = $derived(resolvedStyle === "cover");
 </script>
@@ -55,7 +58,7 @@
   <MediaSummaryCard
     {...props}
     style={resolvedStyle}
-    layout={isCompact ? "compact" : "default"}
+    layout={summaryCardLayout}
     {contextualTag}
     {sortTag}
     badge={props.action}

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -27,6 +27,7 @@
   import type { EpisodeCardProps } from "./models/EpisodeCardProps";
   import type { MediaCardProps } from "./models/MediaCardProps";
   import type { SeasonCardProps } from "./models/SeasonCardProps";
+  import type { SummaryCardLayout } from "./models/SummaryCardLayout";
 
   type EpisodeSummaryProps = {
     type: "episode";
@@ -45,7 +46,7 @@
     contextualTag?: Snippet;
     badge?: Snippet;
     sortTag?: Snippet;
-    layout?: "default" | "compact";
+    layout?: SummaryCardLayout;
   } & DistributiveOmit<ItemCardProps, "badge" | "action">;
 
   const {
@@ -67,9 +68,10 @@
   const isDesktop = useMedia(WellKnownMediaQuery.desktop);
 
   const isCompact = $derived(layout === "compact");
+  const isMinimal = $derived(layout === "minimal");
 
   const hasMultiLineTitles = $derived(
-    !isCompact && ($isTabletLarge || $isDesktop),
+    !isCompact && !isMinimal && ($isTabletLarge || $isDesktop),
   );
 
   const isShowContext = $derived(
@@ -82,7 +84,7 @@
       const posterOverride = "coverUrl" in rest ? rest.coverUrl : undefined;
 
       return {
-        background: !isCompact ? episodeCover : undefined,
+        background: !isMinimal ? episodeCover : undefined,
         poster: posterOverride ?? media.poster.url.thumb,
         title: rest.episode.title,
       };
@@ -152,7 +154,7 @@
   --poster-aspect-ratio="0.6667"
 >
   {#if popupActions}
-    <CardActionBar variant={isCompact ? "standalone" : "default"}>
+    <CardActionBar variant={isCompact || isMinimal ? "standalone" : "default"}>
       {#snippet actions()}
         <PopupMenu
           label={m.button_label_popup_menu({ title: media.title })}
@@ -365,6 +367,7 @@
     }
   }
 
+  :global(.trakt-summary-card-minimal),
   :global(.trakt-summary-card-compact) {
     .trakt-card-title {
       font-size: var(--font-size-text);

--- a/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSwipe.svelte
@@ -10,7 +10,7 @@
 
   type MediaSwipeProps = BaseMediaInput &
     ChildrenProps & {
-      style?: "cover" | "summary" | "compact";
+      style?: "cover" | "summary" | "compact" | "minimal";
     };
 
   const { type, media, style, children }: MediaSwipeProps = $props();

--- a/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBottomBar.svelte
+++ b/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBottomBar.svelte
@@ -2,6 +2,7 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { Snippet } from "svelte";
   import { fade } from "svelte/transition";
+  import type { SummaryCardLayout } from "../models/SummaryCardLayout";
 
   const {
     children,
@@ -11,10 +12,10 @@
   }: ChildrenProps & {
     tag?: Snippet;
     contextualTag?: Snippet;
-    layout?: "default" | "compact";
+    layout?: SummaryCardLayout;
   } = $props();
 
-  const isCompact = $derived(layout === "compact");
+  const isSmall = $derived(layout === "compact" || layout === "minimal");
 </script>
 
 <div
@@ -22,14 +23,14 @@
   class:has-contextualTag={Boolean(contextualTag)}
   data-layout={layout}
 >
-  {#if contextualTag && !isCompact}
+  {#if contextualTag && !isSmall}
     <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
       {@render contextualTag()}
     </RenderFor>
   {/if}
 
   {#if tag}
-    {#if isCompact}
+    {#if isSmall}
       <div class="trakt-summary-bottom-bar-tags" in:fade={{ duration: 150 }}>
         {@render tag()}
       </div>
@@ -70,6 +71,7 @@
       justify-content: space-between;
     }
 
+    &[data-layout="minimal"],
     &[data-layout="compact"] {
       --poster-width: calc(
         var(--height-summary-card-cover-compact) * var(--poster-aspect-ratio, 0)

--- a/projects/client/src/lib/sections/lists/components/_internal/SummaryCardDetails.svelte
+++ b/projects/client/src/lib/sections/lists/components/_internal/SummaryCardDetails.svelte
@@ -3,6 +3,7 @@
   import { appendClassList } from "$lib/utils/actions/appendClassList";
   import type { Snippet } from "svelte";
   import { fade } from "svelte/transition";
+  import type { SummaryCardLayout } from "../models/SummaryCardLayout";
 
   const {
     children,
@@ -12,10 +13,10 @@
   }: {
     tag?: Snippet;
     classList?: string;
-    layout?: "default" | "compact";
+    layout?: SummaryCardLayout;
   } & ChildrenProps = $props();
 
-  const isCompact = $derived(layout === "compact");
+  const isSmall = $derived(layout === "compact" || layout === "minimal");
 </script>
 
 <div class="trakt-summary-card-details" use:appendClassList={classList}>
@@ -23,7 +24,7 @@
     {@render children()}
   </div>
 
-  {#if tag && !isCompact}
+  {#if tag && !isSmall}
     <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
       <div class="trakt-summary-card-tags" in:fade={{ duration: 150 }}>
         {@render tag()}

--- a/projects/client/src/lib/sections/lists/components/models/BaseItemProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/BaseItemProps.ts
@@ -4,7 +4,7 @@ export type BaseItemProps = {
   badge?: Snippet;
   action?: Snippet;
   tag?: Snippet;
-  style?: 'cover' | 'summary' | 'compact';
+  style?: 'cover' | 'summary' | 'compact' | 'minimal';
   source?: string;
   popupActions?: Snippet;
   indicators?: Snippet;

--- a/projects/client/src/lib/sections/lists/components/models/SummaryCardLayout.ts
+++ b/projects/client/src/lib/sections/lists/components/models/SummaryCardLayout.ts
@@ -1,0 +1,1 @@
+export type SummaryCardLayout = 'default' | 'compact' | 'minimal';

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
@@ -132,7 +132,7 @@
                 {hasUnseenEpisodes}
                 watchedBySeason={$watchedBySeason}
                 isWatchedLoading={$isWatchedLoading}
-                style="compact"
+                style="minimal"
                 source="seasons-drawer"
               />
             {/snippet}
@@ -191,7 +191,7 @@
       grid-row-gap: var(--gap-s);
     }
 
-    :global(.trakt-summary-card-compact) {
+    :global(.trakt-summary-card-minimal) {
       --poster-aspect-ratio: 1.778;
     }
 


### PR DESCRIPTION
# Summary

Episode rating items in the Activity → Ratings views had no background image,
while movies and shows did. This restores episode screenshots (with show fanart
as a fallback).

Closes #2403.

# ⚠️ Depends on trakt/trakt-api#802 — merge & publish that first

The real cause was in the `@trakt/api` SDK: `RatedItemResponseSchema` typed
episode/season rating items with a minimal `episode`/`show` shape that omitted
`images`, so Zod stripped the screenshot/fanart the API actually returns. No
client-side change could surface data that was discarded at parse time.

trakt/trakt-api#802 fixes the schema and ships as `@trakt/api@0.4.13`. **That PR
must be merged and 0.4.13 published before this one can land**, otherwise
`deno install` cannot resolve the dependency.

After 0.4.13 is published:
1. `deno install` to regenerate `deno.lock` (this PR bumps `package.json` to
   `0.4.13` but intentionally does not touch the lockfile yet).

# Screenshots

<img width="562" height="681" alt="image" src="https://github.com/user-attachments/assets/5e3dd5d8-f10b-4244-99b8-e4c8f2f7511e" />

# Changes

- `package.json`: `@trakt/api` `0.4.12` → `0.4.13`
- `MediaSummaryCard.svelte`:
  - Render the episode background in the compact (drawer) layout — previously
    suppressed via `!isCompact`, so movies/shows showed a background but
    episodes didn't.
  - Fall back to the show's cover fanart instead of a blank placeholder when an
    episode screenshot is absent (mirrors `useEpisodeSpoilerImage`).

# Testing

- `deno task check` — 144 files, 0 errors, 0 warnings.
- Verified locally against live `/users/:id/ratings?extended=full,images`: the
  patched schema retains `episode.images.screenshot` and `show.images.fanart`
  for all episode rating items, and the drawer now shows episode screenshots.
