### PR TITLE
fix: update useStableArray.ts to promote newly added items to server

### DIFF
--- a/projects/client/src/lib/sections/lists/stores/useStableArray.spec.ts
+++ b/projects/client/src/lib/sections/lists/stores/useStableArray.spec.ts
@@ -96,12 +96,42 @@ describe('useStableArray', () => {
     expect(await firstValueFrom(store.list)).toEqual([item1]);
   });
 
-  it('should add new items at the end of the list', async () => {
+  it('should insert new item at its server-sorted position when it leads the update', async () => {
     const source = new BehaviorSubject<MockItem[]>([]);
     const store = useStableArray(compareFn, source);
 
     source.next([item1, item2]);
     source.next([item3, item1, item2]);
+
+    queueMicrotask(() => source.complete());
+    expect(await lastValueFrom(store.list, { defaultValue: [] })).toEqual([
+      item3,
+      item1,
+      item2,
+    ]);
+  });
+
+  it('should insert new item at its server-sorted position when it is in the middle', async () => {
+    const source = new BehaviorSubject<MockItem[]>([]);
+    const store = useStableArray(compareFn, source);
+
+    source.next([item1, item3]);
+    source.next([item1, item2, item3]);
+
+    queueMicrotask(() => source.complete());
+    expect(await lastValueFrom(store.list, { defaultValue: [] })).toEqual([
+      item1,
+      item2,
+      item3,
+    ]);
+  });
+
+  it('should append new item at the end when server places it last', async () => {
+    const source = new BehaviorSubject<MockItem[]>([]);
+    const store = useStableArray(compareFn, source);
+
+    source.next([item1, item2]);
+    source.next([item1, item2, item3]);
 
     queueMicrotask(() => source.complete());
     expect(await lastValueFrom(store.list, { defaultValue: [] })).toEqual([

--- a/projects/client/src/lib/sections/lists/stores/useStableArray.ts
+++ b/projects/client/src/lib/sections/lists/stores/useStableArray.ts
@@ -9,13 +9,24 @@ export function useStableArray<T>(
       (prevItem) => update.some((newItem) => compareFn(prevItem, newItem)),
     );
 
-    update.forEach((newItem) => {
+    update.forEach((newItem, updateIndex) => {
       const index = updatedList.findIndex((item) => compareFn(item, newItem));
       if (index !== -1) {
         updatedList[index] = newItem;
-      } else {
-        updatedList.push(newItem);
+        return;
       }
+
+      const successor = update
+        .slice(updateIndex + 1)
+        .find((nextItem) =>
+          updatedList.some((item) => compareFn(item, nextItem))
+        );
+
+      const insertAt = successor
+        ? updatedList.findIndex((item) => compareFn(item, successor))
+        : updatedList.length;
+
+      updatedList.splice(insertAt, 0, newItem);
     });
 
     return updatedList;


### PR DESCRIPTION
Possible fix for #1477 

This pull request improves the `useStableArray` hook to ensure that new items are inserted into the local list at the correct position according to the server-provided order, rather than always being appended. It also adds comprehensive tests to verify this behavior in various scenarios.

### Stable array update logic:

* Updated `useStableArray` in `useStableArray.ts` to insert new items at their correct server-sorted positions, not just at the end, by determining the position relative to succeeding items in the update.

### Test coverage:

* Added new tests in `useStableArray.spec.ts` to confirm that new items are inserted at the correct positions (beginning, middle, or end) according to server order.