### PR TITLE
fix(calendar): group drilldown by effective release date

### DIFF
--- a/projects/client/src/lib/features/calendar/_internal/useCalendar.ts
+++ b/projects/client/src/lib/features/calendar/_internal/useCalendar.ts
@@ -67,7 +67,8 @@ export function useCalendar(
   const allItems = combineLatest(queries).pipe(
     map(($queries) => {
       return $queries.flatMap((query) => query.data ?? []).toSorted((a, b) => {
-        return new Date(a.airDate).getTime() - new Date(b.airDate).getTime();
+        return a.effectiveReleaseDate.getTime() -
+          b.effectiveReleaseDate.getTime();
       });
     }),
   );
@@ -81,7 +82,7 @@ export function useCalendar(
           date.setDate(props.start.getDate() + i);
 
           const items = $allItems.filter(
-            (item) => isSameDay(item.airDate, date),
+            (item) => isSameDay(item.effectiveReleaseDate, date),
           );
 
           return { date, items };


### PR DESCRIPTION
## Summary

- Calendar drilldown sorted and grouped items by `airDate`. Movies already mapped `airDate = effectiveReleaseDate`, but episodes set `airDate = first_aired`, so episode drilldown landed on the original air day rather than the user's local release day.
- Switched the drilldown sort and same-day filter in `useCalendar` to `effectiveReleaseDate`. Both media types now group on the same field, matching `coalesceEpisodes`.

## Test plan

- [ ] Open calendar drilldown with a mix of movies and shows that have differing `first_aired` vs `effective_release_date` (e.g. region-shifted releases)
- [ ] Episodes appear under the effective release day, not the original aired day
- [ ] Movies unaffected (already keyed off effective release date)