### PR TITLE
fix: use parseLocalDate for people birthday

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToPersonSummary.ts
+++ b/projects/client/src/lib/requests/_internal/mapToPersonSummary.ts
@@ -1,6 +1,7 @@
 import type { PersonResponse } from '@trakt/api';
 import { crewPositionSchema } from '../models/CrewPosition.ts';
 import type { PersonSummary } from '../models/PersonSummary.ts';
+import { parseLocalDate } from '$lib/utils/date/parseLocalDate.ts';
 import { mapToHeadshot } from './mapToHeadshot.ts';
 import { mapToSocialMedia } from './mapToSocialMedia.ts';
 
@@ -21,8 +22,8 @@ export const mapToPersonSummary = (
      * FIXME: @seferturan remove cast once @trakt/api is updated
      */
     height: (response as unknown as { height: number }).height,
-    birthday: response.birthday ? new Date(response.birthday) : null,
+    birthday: response.birthday ? parseLocalDate(response.birthday) : null,
     socialMedia: mapToSocialMedia(response),
-    deathDate: response.death ? new Date(response.death) : null,
+    deathDate: response.death ? parseLocalDate(response.death) : null,
   };
 };


### PR DESCRIPTION
Small fix for: #1491 

This pull request updates the way date fields are parsed in the `mapToPersonSummary` function to improve date handling consistency. Instead of using the native `Date` constructor, the code now uses the custom `parseLocalDate` utility function for parsing `birthday` and `deathDate` fields. Similarly to mapUserSettingsResponse dob parsing.