### PR TITLE
chore(agents): trim rule cascade and compress prose

### DIFF
--- a/.agents/rules/code-principles.md
+++ b/.agents/rules/code-principles.md
@@ -9,21 +9,21 @@ applyTo: "**"
 
 ## Functional Programming
 
-- **Write functional code**: Prefer pure functions that avoid side effects when possible.
-  - Functions should return consistent output for the same input.
-  - Minimize state mutation and favor immutable data structures.
+- **Write functional code**: prefer pure functions, avoid side effects when possible.
+  - Same input -> same output.
+  - Minimize mutation; favor immutable data.
   - Keep Svelte stores minimal; use `$derived()` for computed values.
-- **Separation of Concerns**: Keep core logic pure and deterministic.
-  - API calls, local storage, and DOM manipulation are side effects.
-  - Pure functions should handle data transformation only.
-  - Side effects should live in the outer layers (components, hooks, server functions).
+- **Separation of Concerns**: keep core logic pure and deterministic.
+  - API calls, local storage, DOM manipulation = side effects.
+  - Pure functions handle data transformation only.
+  - Side effects live in outer layers (components, hooks, server functions).
 
 ## Immutability
 
-- **Prefer `const` over `let`**: Use `const` whenever possible.
+- **Prefer `const` over `let`** whenever possible.
 - Avoid reassigning variables.
-- Use array methods like `map`, `filter`, and `reduce` instead of mutating loops.
-- Use TypeScript's `readonly` types: `Readonly<T>`, `ReadonlyArray<T>`, `ReadonlyMap`, `ReadonlySet`.
+- Use `map`, `filter`, `reduce` instead of mutating loops.
+- Use TypeScript `readonly` types: `Readonly<T>`, `ReadonlyArray<T>`, `ReadonlyMap`, `ReadonlySet`.
 
 **Bad:**
 ```typescript
@@ -40,8 +40,8 @@ const result = items.map(transform);
 
 ## Early Exits
 
-- **Use guard clauses and early returns**: Check error conditions first and return early.
-- Avoid deep nesting by handling edge cases at the start of functions.
+- **Use guard clauses and early returns**: check error conditions first, return early.
+- Avoid deep nesting; handle edge cases at function start.
 
 **Bad:**
 ```typescript
@@ -70,17 +70,17 @@ function processData(data: Data | null) {
 
 ## Code Smells to Avoid
 
-- **No nested if statements**: Nested conditionals indicate poor architecture.
+- **No nested if statements**: nested conditionals signal poor architecture.
   - Refactor into separate functions with clear responsibilities.
   - Use guard clauses and early returns instead.
-- **No abstraction leaks**: Ensure abstractions hide implementation details completely.
-- **No "god functions"**: Each function should have a single, clear responsibility.
+- **No abstraction leaks**: abstractions must hide implementation details fully.
+- **No "god functions"**: each function has a single, clear responsibility.
 
 ## Function Design
 
-- **Single Responsibility Principle**: Each function should do one thing well.
-- Function names should clearly describe what they do.
-- When a function takes 3+ parameters, use a single object parameter.
+- **Single Responsibility**: each function does one thing well.
+- Function names describe what they do.
+- 3+ parameters -> use a single object parameter.
 
 **Bad:**
 ```typescript
@@ -94,9 +94,9 @@ fetchData({ url, token, retry, timeout });
 
 ## Dependency Injection
 
-- **Pass dependencies as parameters**: Don't instantiate external services inside functions.
+- **Pass dependencies as parameters**: don't instantiate external services inside functions.
 - Makes functions testable without mocking.
-- Use interface types to define the shape of dependencies.
+- Use interface types for dependency shape.
 
 **Bad:**
 ```typescript
@@ -120,13 +120,13 @@ export function fetchUser({ api, id }: FetchUserParams) {
 
 ## Simplicity
 
-- **Keep it simple**: Simple code is maintainable code.
-- Suggestions should be simple and functional with low visual complexity.
-- Split up into smaller functions when needed.
+- **Keep it simple**: simple code is maintainable code.
+- Suggestions should be simple, functional, low visual complexity.
+- Split into smaller functions when needed.
 - Favor readability over cleverness.
-- If a solution feels complex, step back and reconsider the approach.
+- If a solution feels complex, step back and reconsider.
 
 ## Iteration Patterns
 
-- **Prefer functional methods over imperative loops**: Use `map`, `filter`, `reduce`.
+- **Prefer functional methods over imperative loops**: `map`, `filter`, `reduce`.
 - Avoid mutable loop counters when possible.

--- a/.agents/rules/components.md
+++ b/.agents/rules/components.md
@@ -9,13 +9,13 @@ applyTo: 'projects/client/src/lib/{components,features,sections,guards}/**'
 
 ## Overview
 
-UI code is split across four directories, each with a distinct role:
+UI code split across four directories, each with distinct role:
 
 | Directory        | Role                                                          |
 | ---------------- | ------------------------------------------------------------- |
-| `lib/components` | Generic, reusable UI primitives — zero domain knowledge       |
+| `lib/components` | Generic, reusable UI primitives - zero domain knowledge       |
 | `lib/features`   | Stateful feature modules: providers, contexts, store hooks    |
-| `lib/sections`   | Page-level composition — orchestrates features + components   |
+| `lib/sections`   | Page-level composition - orchestrates features + components   |
 | `lib/guards`     | Conditional rendering gates (`RenderFor`, `RenderForFeature`) |
 
 ---
@@ -24,36 +24,30 @@ UI code is split across four directories, each with a distinct role:
 
 ### `lib/components/`
 
-Purely presentational, reusable across the entire app. No awareness of API
-shapes or app state.
+Purely presentational, reusable across app. No awareness of API shapes or app state.
 
 ### `lib/features/`
 
-Each subdirectory is a self-contained feature. Features own their state,
-providers, contexts, and domain-specific sub-components.
+Each subdirectory is self-contained feature. Features own their state, providers, contexts, and domain-specific sub-components.
 
 ### `lib/sections/`
 
-Page-level composition components. Sections know about domain data shapes and
-compose features and `lib/components` together to form page regions.
+Page-level composition components. Sections know domain data shapes and compose features + `lib/components` into page regions.
 
 ### `lib/guards/`
 
-Thin conditional-rendering wrappers — use these instead of inline `{#if}` for
-auth / feature / audience / device gating.
+Thin conditional-rendering wrappers - use instead of inline `{#if}` for auth / feature / audience / device gating.
 
 ---
 
 ## The `_internal/` Rule
 
-`_internal/` folders enforce file-private visibility. The rule is strict:
+`_internal/` folders enforce file-private visibility. Strict rule:
 
-> **A file inside `folderA/_internal/` may only be imported by files inside
+> **File inside `folderA/_internal/` may only be imported by files inside
 > `folderA/` or `folderA/_internal/` itself.**
 
-If a helper, sub-component, or context factory is needed outside its parent
-folder, it must be **uplifted** — moved to `folderA/` (and exported) or to a
-higher-level shared location.
+If a helper, sub-component, or context factory is needed outside its parent folder, it must be **uplifted** - moved to `folderA/` (and exported) or to a higher-level shared location.
 
 **Never import from another folder's `_internal/`.**
 
@@ -72,7 +66,7 @@ sections/
         SummaryTitleMapper.ts ← only used inside summary/components/
       SummaryTitle.svelte     ← imports _internal/SummaryTitleMapper ✔
 
-# WRONG — do not do this:
+# WRONG - do not do this:
 features/upsell/UpsellCta.svelte  ← importing search/_internal/createSearchContext ✗
 ```
 
@@ -80,8 +74,7 @@ features/upsell/UpsellCta.svelte  ← importing search/_internal/createSearchCon
 
 ## Svelte 5 Runes
 
-All components use Svelte 5 runes mode. Never use `export let`, `$:`, or
-`createEventDispatcher`.
+All components use Svelte 5 runes mode. Never use `export let`, `$:`, or `createEventDispatcher`.
 
 ```svelte
 <script lang="ts">
@@ -107,9 +100,7 @@ Key runes:
 
 ## Props Type Files
 
-For components with more than 2-3 props, define a separate
-`ComponentNameProps.ts` file (usually inside the component folder or
-`_internal/`).
+For components with 3+ props, define separate `ComponentNameProps.ts` file (usually inside component folder or `_internal/`).
 
 ```typescript
 // buttons/_internal/TraktButtonProps.ts
@@ -123,14 +114,13 @@ export type TraktButtonProps = {
 };
 ```
 
-Use `Snippet` (from `svelte`) for slot-like composition — never use the legacy
-slot API.
+Use `Snippet` (from `svelte`) for slot-like composition - never the legacy slot API.
 
 ---
 
 ## Snippets for Composition
 
-Use `{#snippet}` and the `Snippet` type for flexible content injection.
+Use `{#snippet}` and `Snippet` type for flexible content injection.
 
 ```svelte
 <!-- In the component -->
@@ -159,7 +149,7 @@ Use `{#snippet}` and the `Snippet` type for flexible content injection.
 
 ## Provider Pattern
 
-Feature providers are thin shells that call a context factory from `_internal/`.
+Feature providers are thin shells calling a context factory from `_internal/`.
 
 ```svelte
 <!-- features/search/SearchProvider.svelte -->
@@ -176,8 +166,7 @@ Feature providers are thin shells that call a context factory from `_internal/`.
 {@render children()}
 ```
 
-The matching `getXxxContext()` function is called by child components to access
-the shared state:
+Matching `getXxxContext()` function called by child components to access shared state:
 
 ```typescript
 // features/search/_internal/getSearchContext.ts
@@ -196,14 +185,13 @@ Naming conventions:
 | `XxxProvider.svelte`            | Provider shell component                   |
 | `_internal/createXxxContext.ts` | Calls `setContext`, returns context object |
 | `_internal/getXxxContext.ts`    | Wraps `getContext` with proper typing      |
-| `_internal/XxxContext.ts`       | TypeScript type for the context object     |
+| `_internal/XxxContext.ts`       | TypeScript type for context object         |
 
 ---
 
 ## `use*` Hooks (Feature Stores)
 
-Feature state is often exposed via `use*` composable functions that return
-reactive RxJS-based state.
+Feature state often exposed via `use*` composable functions returning reactive RxJS-based state.
 
 ```typescript
 // features/auth/stores/useUser.ts
@@ -220,8 +208,7 @@ export function useUser() {
 - Live in `features/{domain}/stores/` (or `features/{domain}/stores/_internal/`)
 - Name always starts with `use` (e.g., `useUser`, `useTheme`, `useFilters`)
 - Return `$derived` values, not raw observables
-- Do **not** import across feature boundaries — if sharing is needed, expose via
-  context or a shared section
+- Do **not** import across feature boundaries - if sharing needed, expose via context or shared section
 
 ---
 
@@ -243,27 +230,24 @@ Use guards instead of inline `{#if auth.isLoggedIn}` or `{#if isDesktop}`:
 </RenderForFeature>
 ```
 
-`RenderFor` props: `audience`, `device`, `input` (can be combined).
+`RenderFor` props: `audience`, `device`, `input` (combinable).
 
 ---
 
 ## Font Styling
 
-Use the global typography utility classes from `style/typography/index.css` for
-font styling. Do **not** write custom font-size or font-weight declarations when
-a utility class already covers the need.
+Use global typography utility classes from `style/typography/index.css` for font styling. Do **not** write custom font-size or font-weight declarations when a utility class covers it.
 
 ```svelte
 <!-- Good -->
 <span class="bold ellipsis">Movie title</span>
 <span class="tag secondary">2024</span>
 
-<!-- Bad — manual override when a class exists -->
+<!-- Bad - manual override when a class exists -->
 <span style="font-weight: 600">Movie title</span>
 ```
 
-When a manual `font-size` override is unavoidable (e.g. responsive tweaks),
-prefer semantic font-size variables over raw sizing tokens:
+When manual `font-size` override is unavoidable (e.g. responsive tweaks), prefer semantic font-size variables over raw sizing tokens:
 
 ```scss
 // Good
@@ -277,8 +261,7 @@ font-size: var(--ni-10); // raw value, no semantic meaning
 
 ## `data-*` Attributes for Variants
 
-Components use `data-*` attributes for styling variants instead of class
-concatenation.
+Components use `data-*` attributes for styling variants instead of class concatenation.
 
 ```svelte
 <button data-variant="primary" data-style="filled">
@@ -302,8 +285,7 @@ Common attributes:
 
 ## Lazy Rendering on Cards
 
-Cards that render below the fold should defer rendering until visible. The
-`whenInViewport` action takes a plain callback (no object param):
+Cards rendering below the fold should defer rendering until visible. `whenInViewport` action takes a plain callback (no object param):
 
 ```svelte
 <script lang="ts">
@@ -322,8 +304,7 @@ Cards that render below the fold should defer rendering until visible. The
 
 ## i18n in Components
 
-Always import the Paraglide messages namespace as `m` and call messages as
-functions. Never inline literal user-facing strings.
+Always import Paraglide messages namespace as `m` and call messages as functions. Never inline literal user-facing strings.
 
 ```svelte
 <script lang="ts">
@@ -353,8 +334,8 @@ functions. Never inline literal user-facing strings.
 
 - [ ] Correct layer: primitive → `components`, stateful/context → `features`,
       composition → `sections`
-- [ ] Never import from another folder's `_internal/` — uplift if needed
-- [ ] Using Svelte 5 runes (`$props`, `$derived`, `$effect`) — no `export let`
+- [ ] Never import from another folder's `_internal/` - uplift if needed
+- [ ] Using Svelte 5 runes (`$props`, `$derived`, `$effect`) - no `export let`
       or `$:`
 - [ ] Snippets used for slot-like composition, not legacy `<slot>`
 - [ ] Props type file created for components with 3+ props
@@ -364,9 +345,9 @@ functions. Never inline literal user-facing strings.
 - [ ] Guards (`RenderFor`, `RenderForFeature`) used instead of raw `{#if}` for
       auth/feature/device gating
 - [ ] Variants expressed via `data-*` attributes, not dynamic class strings
-- [ ] SCSS uses CSS custom properties (`--ni-*`, `--color-*`) — no raw hex
+- [ ] SCSS uses CSS custom properties (`--ni-*`, `--color-*`) - no raw hex
       values
 - [ ] Font styling uses typography utility classes (`.bold`, `.ellipsis`,
-      `.tag`, etc.) — no manual `font-weight`/`font-size` when a class covers it
+      `.tag`, etc.) - no manual `font-weight`/`font-size` when a class covers it
 - [ ] When `font-size` overrides are needed, uses semantic variables
       (`--font-size-tag`, `--font-size-text`) not raw tokens (`--ni-10`)

--- a/.agents/rules/implementation.md
+++ b/.agents/rules/implementation.md
@@ -9,45 +9,35 @@ applyTo: '**'
 
 ## Before Writing Code
 
-- **Search for existing patterns first.** This codebase has conventions — follow
-  them.
-- Check how similar functionality is implemented elsewhere in the project before
-  creating something new.
+- **Search for existing patterns first.** This codebase has conventions - follow them.
+- Check how similar functionality is implemented elsewhere before creating something new.
 - Prefer referencing real files as examples over abstract descriptions.
 
 ## When Establishing New Patterns
 
-- When you establish a new pattern that diverges from or extends existing
-  conventions, note it so documentation can be updated.
-- If you find yourself writing a helper used in 2+ places, consider whether it
-  belongs in `lib/utils/`.
+- When you establish a new pattern that diverges from or extends existing conventions, note it so documentation can be updated.
+- If you find yourself writing a helper used in 2+ places, consider whether it belongs in `lib/utils/`.
 - If you refactor shared logic, document the new pattern.
 
 ## Naming Conventions
 
-- **PascalCase**: Component names, interfaces, and type aliases
-- **camelCase**: Variables, functions, and methods
-- **ALL_CAPS**: Global constants only (not local constants)
+- **PascalCase**: component names, interfaces, type aliases
+- **camelCase**: variables, functions, methods
+- **ALL_CAPS**: global constants only (not local constants)
 - Components: PascalCase files (e.g., `ClampedText.svelte`, `MoreButton.svelte`)
 - Utilities/helpers: camelCase files (e.g., `lineClamp.ts`, `clickOutside.ts`)
-- Type definitions: PascalCase files (e.g., `MediaStoreProps.ts`,
-  `FilterParams.ts`)
+- Type definitions: PascalCase files (e.g., `MediaStoreProps.ts`, `FilterParams.ts`)
 
 ## TypeScript Standards
 
 - Always use TypeScript with strict mode.
 - No `any` types; use specific types or utility types.
-- Use Zod for runtime validation and type inference. Define schema first, then
-  derive type with `z.infer`.
+- Use Zod for runtime validation and type inference. Define schema first, then derive type with `z.infer`.
 - Use `Nil` type for `null | undefined`.
 - Use `.nullish()` in Zod schemas for optional nullable fields.
 - Use optional chaining (`?.`) and nullish coalescing (`??`).
 
 ## URL & State Management
 
-- Use URL search parameters to represent UI state (e.g., active tabs, filters,
-  drawers) to make those states shareable via links.
-- When updating URL search parameters for state changes, avoid polluting
-  navigation history by replacing the current state instead of pushing a new one
-  (e.g., use `replaceState: true` in SvelteKit's `goto` or the `replacestate`
-  property).
+- Use URL search parameters to represent UI state (e.g., active tabs, filters, drawers) to make those states shareable via links.
+- When updating URL search parameters for state changes, avoid polluting navigation history by replacing the current state instead of pushing a new one (e.g., use `replaceState: true` in SvelteKit's `goto` or the `replacestate` property).

--- a/.agents/rules/project.md
+++ b/.agents/rules/project.md
@@ -9,8 +9,7 @@ applyTo: '**'
 
 ## Tech Stack
 
-SvelteKit + TypeScript app (Svelte 5, runes mode) deployed to Cloudflare Pages.
-Monorepo using Deno workspaces with the app at `projects/client/`.
+SvelteKit + TypeScript app (Svelte 5, runes mode) deployed to Cloudflare Pages. Monorepo using Deno workspaces with app at `projects/client/`.
 
 ## Project Structure
 
@@ -19,17 +18,17 @@ projects/client/src/
   routes/          # SvelteKit file-based routing
   lib/
     components/    # Reusable UI components (buttons, forms, dialogs, media, etc.)
-    features/      # Feature modules — self-contained domains (auth, calendar, theme, i18n, etc.)
-    sections/      # Page composition — navbar, lists, profile, layout shells
+    features/      # Feature modules - self-contained domains (auth, calendar, theme, i18n, etc.)
+    sections/      # Page composition - navbar, lists, profile, layout shells
     guards/        # Conditional rendering (RenderFor, RenderForFeature, RenderForAudience)
     requests/      # API request mappers and query definitions
     stores/        # Reactive state (RxJS BehaviorSubject + localStorage)
     models/        # TypeScript type definitions
     utils/         # Utility functions organized by domain (actions/, array/, date/, string/, etc.)
     pages/         # Page-specific logic and error pages
-    paraglide/     # Generated i18n messages (do not edit — auto-generated)
+    paraglide/     # Generated i18n messages (do not edit - auto-generated)
     pwa/           # PWA manifest and service worker config
-  style/           # Global SCSS — design tokens, theme, animations
+  style/           # Global SCSS - design tokens, theme, animations
   mocks/           # MSW request mocking (handlers + test data)
 ```
 
@@ -46,59 +45,43 @@ projects/client/src/
 
 ### Pages are thin shells
 
-Route pages compose features and sections. Business logic lives in
-`lib/features/`, not in route files. Layouts wrap children with providers (e.g.,
-`CalendarProvider`).
+Route pages compose features and sections. Business logic lives in `lib/features/`, not in route files. Layouts wrap children with providers (e.g., `CalendarProvider`).
 
 ### Features are self-contained
 
-Each feature directory in `lib/features/` owns its state, components, and
-queries. Features expose a public API and keep internals in `_internal/`
-subdirectories.
+Each feature directory in `lib/features/` owns its state, components, queries. Features expose a public API; keep internals in `_internal/` subdirectories.
 
 ### Components use data attributes for variants
 
-Components use `data-variant`, `data-style`, `data-color` attributes for styling
-variants rather than prop-driven class concatenation.
+Components use `data-variant`, `data-style`, `data-color` attributes for styling variants rather than prop-driven class concatenation.
 
 ### Snippets for flexible content
 
-Use Svelte 5 `{#snippet}` for reusable template fragments and component slot
-alternatives.
+Use Svelte 5 `{#snippet}` for reusable template fragments and component slot alternatives.
 
 ### Guards for conditional rendering
 
-Use `RenderFor`, `RenderForFeature`, `RenderForAudience` components instead of
-inline `{#if}` blocks for auth/feature/audience gating.
+Use `RenderFor`, `RenderForFeature`, `RenderForAudience` components instead of inline `{#if}` blocks for auth/feature/audience gating.
 
 ### Stores use RxJS + localStorage
 
-State management uses `BehaviorSubject` from RxJS, often backed by
-`localStorage` for persistence. Prefer `$derived()` for computed values over
-additional stores.
+State management uses `BehaviorSubject` from RxJS, often backed by `localStorage` for persistence. Prefer `$derived()` for computed values over additional stores.
 
 ### API requests use mappers
 
-`lib/requests/` contains query definitions via `defineQuery()` and pure mapper
-functions that transform API responses to domain models. Zod validates at the
-boundary.
+`lib/requests/` contains query definitions via `defineQuery()` and pure mapper functions that transform API responses to domain models. Zod validates at the boundary.
 
 ### i18n via Paraglide
 
-Internationalization uses Paraglide JS (Inlang). Messages are type-safe
-functions: `m.page_title_home()`. Source definitions live in `i18n/meta/`,
-generated output in `lib/paraglide/`. Never edit generated files.
+Internationalization uses Paraglide JS (Inlang). Messages are type-safe functions: `m.page_title_home()`. Source definitions live in `i18n/meta/`, generated output in `lib/paraglide/`. Never edit generated files.
 
 ## Styling
 
 - SCSS with scoped Svelte `<style lang="scss">` blocks.
-- All values via CSS custom properties (`--ni-*`, `--color-*`, `--gap-*`,
-  `--border-radius-*`).
-- Responsive mixins: `for-mobile`, `for-tablet-sm`, `for-desktop`, `for-mouse`,
-  `for-touch`.
+- All values via CSS custom properties (`--ni-*`, `--color-*`, `--gap-*`, `--border-radius-*`).
+- Responsive mixins: `for-mobile`, `for-tablet-sm`, `for-desktop`, `for-mouse`, `for-touch`.
 - Import mixins as: `@use "$style/scss/mixins/index" as *;`
-- Full light/dark theme support. Never use raw hex values — use semantic CSS
-  variables.
+- Full light/dark theme support. Never use raw hex values - use semantic CSS variables.
 - Use kebab-case for CSS class names.
 - Component-scoped styles preferred.
 
@@ -118,8 +101,6 @@ Always use aliases over deep relative paths (`../../../`).
 ## Tooling
 
 - **Formatter**: Use `deno fmt`, not prettier.
-- **Linter**: ESLint with TypeScript + Svelte plugins. Config at
-  `eslint.config.js`.
-- **Build**: Vite + SvelteKit adapter-cloudflare. Paraglide generates i18n
-  before build.
+- **Linter**: ESLint with TypeScript + Svelte plugins. Config at `eslint.config.js`.
+- **Build**: Vite + SvelteKit adapter-cloudflare. Paraglide generates i18n before build.
 - **Dev**: `deno task client:dev` starts the dev server.

--- a/.agents/rules/requests.md
+++ b/.agents/rules/requests.md
@@ -11,10 +11,8 @@ applyTo: 'projects/client/src/lib/requests/**'
 
 `lib/requests/` integrates with two sources:
 
-- **`@trakt/api`** — Typed SDK for the Trakt v2 REST API. Use `api({ fetch })`
-  to call it.
-- **`v3/` endpoints** — Untyped internal endpoints accessed via `rawApiFetch`.
-  Always define a local Zod schema for their response.
+- **`@trakt/api`** - Typed SDK for Trakt v2 REST API. Use `api({ fetch })` to call it.
+- **`v3/` endpoints** - Untyped internal endpoints accessed via `rawApiFetch`. Always define a local Zod schema for their response.
 
 ---
 
@@ -30,9 +28,9 @@ applyTo: 'projects/client/src/lib/requests/**'
 
 ---
 
-## Pattern 1 — `@trakt/api` Query (`defineQuery`)
+## Pattern 1 - `@trakt/api` Query (`defineQuery`)
 
-Use this for standard single-fetch queries backed by the typed SDK.
+Use for standard single-fetch queries backed by the typed SDK.
 
 ```ts
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
@@ -68,21 +66,17 @@ export const someQuery = defineQuery({
 
 ### Key rules
 
-- The `request` function receives the full `params` object — destructure only
-  what you need.
-- `mapper` transforms `response.body` (typed by the SDK) into the domain model.
-- `schema` is the Zod schema for the **output** — it validates what `mapper`
-  returns.
-- `dependencies` must list every param that, when changed, should refetch. Use
-  spread helpers for filters/search (see below).
-- `invalidations` lists `InvalidateAction.*` tokens that bust this cache when
-  mutations fire.
+- `request` receives full `params` object - destructure only what you need.
+- `mapper` transforms `response.body` (typed by SDK) into domain model.
+- `schema` is Zod schema for **output** - validates what `mapper` returns.
+- `dependencies` must list every param that, when changed, should refetch. Use spread helpers for filters/search (see below).
+- `invalidations` lists `InvalidateAction.*` tokens that bust this cache when mutations fire.
 
 ---
 
-## Pattern 2 — `@trakt/api` Paginated Query (`defineInfiniteQuery`)
+## Pattern 2 - `@trakt/api` Paginated Query (`defineInfiniteQuery`)
 
-Use this for list endpoints that support pagination.
+Use for list endpoints supporting pagination.
 
 ```ts
 import { defineInfiniteQuery } from '$lib/features/query/defineQuery.ts';
@@ -121,17 +115,15 @@ export const someListQuery = defineInfiniteQuery({
 
 ### Key rules
 
-- Always use `PaginatableSchemaFactory(EntrySchema)` for the schema.
-- Always call `extractPageMeta(response.headers)` to populate the `page` field.
+- Always use `PaginatableSchemaFactory(EntrySchema)` for schema.
+- Always call `extractPageMeta(response.headers)` to populate `page` field.
 - Include `params.page` and `params.limit` in `dependencies`.
 
 ---
 
-## Pattern 3 — `v3/` Endpoint Query
+## Pattern 3 - `v3/` Endpoint Query
 
-`v3/` endpoints are not covered by `@trakt/api`'s type system. **Always** define
-a Zod schema locally for their response, and parse with it before returning from
-the request function.
+`v3/` endpoints not covered by `@trakt/api`'s type system. **Always** define a Zod schema locally for their response, parse with it before returning from request function.
 
 ```ts
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
@@ -181,20 +173,16 @@ export const someV3Query = defineQuery({
 
 ### Key rules
 
-- **Always** `.parse()` the raw JSON — never trust unvalidated `v3/` responses.
-- If the endpoint can return an empty/error body, guard with `response.ok` and
-  return `{ body: undefined, status: 200 }` as the fallback so `mapper` receives
-  `undefined` and can handle it gracefully.
-- Export the `ResponseSchema` when other files need to reference it.
-- Keep the raw response schema (`...ResponseSchema`) and domain schema
-  (`...Schema`) separate.
+- **Always** `.parse()` raw JSON - never trust unvalidated `v3/` responses.
+- If endpoint can return empty/error body, guard with `response.ok` and return `{ body: undefined, status: 200 }` as fallback so `mapper` receives `undefined` and handles it gracefully.
+- Export `ResponseSchema` when other files need to reference it.
+- Keep raw response schema (`...ResponseSchema`) and domain schema (`...Schema`) separate.
 
 ---
 
-## Pattern 4 — Mutation Request
+## Pattern 4 - Mutation Request
 
-Use for write operations (add, remove, update). These are plain async functions
-— not queries.
+Use for write operations (add, remove, update). Plain async functions - not queries.
 
 ```ts
 import { api, type ApiParams } from '$lib/requests/api.ts';
@@ -214,19 +202,16 @@ export function someActionRequest(
 }
 ```
 
-For `v3/` mutations use `rawApiFetch` with `method: 'POST'` / `'DELETE'` and
-validate with Zod if the response body matters.
+For `v3/` mutations use `rawApiFetch` with `method: 'POST'` / `'DELETE'` and validate with Zod if response body matters.
 
 ---
 
 ## Mapper Functions
 
-- Pure functions — no side effects, no API calls.
+- Pure functions - no side effects, no API calls.
 - Named `mapTo{DomainType}(apiResponse): DomainType`.
-- Live in `_internal/` if reused across queries; inline or exported from the
-  query file if used only once or twice.
-- When extending an existing mapper (e.g., adding a field), prefer `.extend()`
-  on the schema rather than duplicating.
+- Live in `_internal/` if reused across queries; inline or exported from query file if used only once or twice.
+- When extending existing mapper (e.g., adding a field), prefer `.extend()` on schema rather than duplicating.
 
 ```ts
 // _internal/mapToEntry.ts
@@ -243,11 +228,9 @@ export function mapToEntry(response: EntryResponse): Entry {
 
 ## Models
 
-- Define Zod schema first; derive the TypeScript type with `z.infer`.
-- Use `.nullish()` for optional nullable fields, `.optional()` for fields that
-  may be absent.
-- Export both the schema (`EntitySchema`) and the type (`Entity`) from the same
-  file.
+- Define Zod schema first; derive TypeScript type with `z.infer`.
+- Use `.nullish()` for optional nullable fields, `.optional()` for fields that may be absent.
+- Export both schema (`EntitySchema`) and type (`Entity`) from same file.
 
 ```ts
 // models/Entry.ts
@@ -267,7 +250,7 @@ export type Entry = z.infer<typeof EntrySchema>;
 
 ## Invalidations
 
-Use `InvalidateAction.*` to declare which mutations should bust a query's cache.
+Use `InvalidateAction.*` to declare which mutations bust a query's cache.
 
 ```ts
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
@@ -285,7 +268,7 @@ Leave `invalidations: []` for queries that never need external cache busting.
 
 ## TTL Reference
 
-`Infinity` should never be used used for TTL.
+`Infinity` should never be used for TTL.
 
 | Data freshness                    | Value                                    |
 | --------------------------------- | ---------------------------------------- |
@@ -298,8 +281,7 @@ Leave `invalidations: []` for queries that never need external cache busting.
 
 ## Filter & Search Dependencies
 
-When a query accepts `FilterParams` or `SearchParams`, spread the helper
-functions in `dependencies`:
+When a query accepts `FilterParams` or `SearchParams`, spread the helper functions in `dependencies`:
 
 ```ts
 import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
@@ -317,7 +299,7 @@ dependencies: (params) => [
 
 ## Conditional Queries
 
-Use `enabled` to skip fetching when required params are absent:
+Use `enabled` to skip fetching when required params absent:
 
 ```ts
 export const someQuery = defineQuery({
@@ -332,9 +314,9 @@ export const someQuery = defineQuery({
 
 | Client                         | When to use                                          |
 | ------------------------------ | ---------------------------------------------------- |
-| `api({ fetch })`               | Default — attaches Bearer token if user is signed in |
+| `api({ fetch })`               | Default - attaches Bearer token if user is signed in |
 | `unauthorizedApi({ fetch })`   | Public endpoints that must not send auth headers     |
-| `rawApiFetch({ fetch, path })` | `v3/` and other non-SDK endpoints — authenticated    |
+| `rawApiFetch({ fetch, path })` | `v3/` and other non-SDK endpoints - authenticated    |
 
 ---
 
@@ -342,14 +324,14 @@ export const someQuery = defineQuery({
 
 Before submitting a new query or request, verify:
 
-- [ ] File is in the correct subfolder (`queries/{domain}/`, `sync/`, `vip/`)
-- [ ] File name matches the exported symbol (`movieSummaryQuery.ts` →
+- [ ] File is in correct subfolder (`queries/{domain}/`, `sync/`, `vip/`)
+- [ ] File name matches exported symbol (`movieSummaryQuery.ts` →
       `movieSummaryQuery`)
 - [ ] Params type intersects `ApiParams`
 - [ ] `@trakt/api` endpoint: SDK chain via `api({ fetch })`
 - [ ] `v3/` endpoint: `rawApiFetch` + local `ResponseSchema.parse()`
-- [ ] `schema` matches the **output** of `mapper`, not the raw API response
+- [ ] `schema` matches **output** of `mapper`, not raw API response
 - [ ] `dependencies` lists every param that should trigger a refetch
 - [ ] `invalidations` lists relevant `InvalidateAction.*` tokens
-- [ ] Mapper is a pure function — no side effects
-- [ ] `ttl` is appropriate for the data's freshness requirements
+- [ ] Mapper is pure function - no side effects
+- [ ] `ttl` is appropriate for data's freshness requirements

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -13,14 +13,10 @@ Vitest + `@testing-library/svelte` in jsdom environment.
 
 ## File Organization
 
-- **Colocated tests**: Place `*.spec.ts` or `*.test.ts` next to the source file
-  being tested.
-- **Test beds**: `test/beds/` has factories for queries, stores, and component
-  renders.
-- **Mocks**: MSW for request mocking (`src/mocks/`), environment mocks in
-  `test/mocks/`.
-- **Setup**: `vitest-setup.ts` initializes MSW, mocks browser APIs
-  (IntersectionObserver, matchMedia, localStorage, etc.).
+- **Colocated tests**: place `*.spec.ts` or `*.test.ts` next to source file.
+- **Test beds**: `test/beds/` has factories for queries, stores, component renders.
+- **Mocks**: MSW for request mocking (`src/mocks/`); env mocks in `test/mocks/`.
+- **Setup**: `vitest-setup.ts` initializes MSW, mocks browser APIs (IntersectionObserver, matchMedia, localStorage, etc.).
 
 ## Running Tests
 
@@ -31,23 +27,19 @@ vitest                   # from projects/client/
 
 ## Testing Philosophy
 
-- **Test pure functions**: Focus testing on business logic and data
-  transformations.
-- **Test behavior, not implementation**: Tests should verify what code does, not
-  how it does it.
+- **Test pure functions**: focus on business logic and data transformations.
+- **Test behavior, not implementation**: verify what code does, not how.
 - Pure functions are easy to test without mocks.
-- Side effects should be tested at integration level, not unit level.
+- Side effects belong at integration level, not unit.
 - Use MSW to mock API responses rather than mocking fetch directly.
 
 ## Test Beds
 
-Always use the helpers in `test/beds/` instead of constructing the underlying
-RxJS / Svelte machinery by hand.
+Always use helpers in `test/beds/` instead of constructing underlying RxJS / Svelte machinery by hand.
 
-### Queries & stores — `runQuery`
+### Queries & stores - `runQuery`
 
-Use `runQuery` to await the first (or first matching) emission from any RxJS
-`Observable` returned by a `use*` hook or composable.
+Use `runQuery` to await the first (or first matching) emission from any RxJS `Observable` returned by a `use*` hook or composable.
 
 ```ts
 import { runQuery } from '$test/beds/query/runQuery.ts';
@@ -59,11 +51,9 @@ const result = await runQuery({
 });
 ```
 
-### Standalone queries — `createTestBedQuery`
+### Standalone queries - `createTestBedQuery`
 
-For testing `defineQuery` / `defineInfiniteQuery` outputs directly, wrap them
-with `createTestBedQuery` (or `createTestBedInfiniteQuery`) before passing to
-`runQuery`.
+For testing `defineQuery` / `defineInfiniteQuery` outputs directly, wrap with `createTestBedQuery` (or `createTestBedInfiniteQuery`) before passing to `runQuery`.
 
 ```ts
 import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
@@ -74,17 +64,13 @@ const result = await runQuery({
 });
 ```
 
-### Components — `renderComponent`
+### Components - `renderComponent`
 
-Use `renderComponent` (which wraps `@testing-library/svelte`'s `render` via a
-`ComponentTestBed`) when a component needs context providers from the test bed.
-Plain `render(...)` from `@testing-library/svelte` is acceptable for simple
-prop-driven components.
+Use `renderComponent` (wraps `@testing-library/svelte`'s `render` via `ComponentTestBed`) when a component needs context providers from the test bed. Plain `render(...)` from `@testing-library/svelte` is acceptable for simple prop-driven components.
 
 ## MSW Mock Data Conventions
 
-Mock files live in `src/mocks/` and follow a strict shape — preserve it when
-adding new fixtures.
+Mock files live in `src/mocks/` and follow a strict shape - preserve it when adding new fixtures.
 
 ```
 src/mocks/
@@ -96,10 +82,9 @@ src/mocks/
       mapped/{Entity}MappedMock.ts       # post-mapper domain model shape
 ```
 
-- **`response/`** mocks mirror the raw API payload — used by MSW handlers.
-- **`mapped/`** mocks mirror the output of the corresponding `mapTo*` function —
-  used as the expected value in assertions.
-- Handler URLs use the `http://localhost/...` origin and match the SDK path.
+- **`response/`** mocks mirror raw API payload - used by MSW handlers.
+- **`mapped/`** mocks mirror output of the corresponding `mapTo*` function - used as expected value in assertions.
+- Handler URLs use `http://localhost/...` origin and match the SDK path.
 
 ```ts
 // mocks/handlers/movies.ts
@@ -111,11 +96,8 @@ http.get(
 
 ## Describe / It Conventions
 
-- Top-level `describe` labels the unit under test, optionally prefixed by kind:
-  `describe('store: useMovie', ...)`, `describe('util: findRegionalIntl', ...)`,
-  `describe('streamingSourcesQuery', ...)`.
-- Nested `describe` blocks group by scenario (e.g. `'movie: Heretic (2024)'`,
-  `'for shows'`).
+- Top-level `describe` labels the unit under test, optionally prefixed by kind: `describe('store: useMovie', ...)`, `describe('util: findRegionalIntl', ...)`, `describe('streamingSourcesQuery', ...)`.
+- Nested `describe` blocks group by scenario (e.g. `'movie: Heretic (2024)'`, `'for shows'`).
 - `it` titles read as sentences starting with `'should ...'`.
 
 ## Path Aliases (test-specific)

--- a/.agents/rules/utils.md
+++ b/.agents/rules/utils.md
@@ -9,16 +9,16 @@ applyTo: 'projects/client/src/lib/utils/**'
 
 ## Overview
 
-`lib/utils/` contains pure helper functions, browser-specific utilities, Svelte
-actions, and shared constants. Everything is organized by domain. Before writing
-a new helper, check whether the domain folder already has something equivalent.
+`lib/utils/` holds pure helpers, browser utilities, Svelte actions, shared
+constants. Organized by domain. Before adding a helper, check if domain
+folder has an equivalent.
 
 ---
 
 ## Pure Functions (most of `utils/`)
 
-All utilities that do not touch the DOM or external state must be pure — same
-input always produces the same output.
+Utilities that don't touch DOM or external state must be pure - same input
+always yields same output.
 
 ```ts
 // Good
@@ -26,9 +26,9 @@ export function getDayKey(date: Date): string {
   return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
 }
 
-// Bad — side effect inside a utility
+// Bad - side effect inside utility
 export function getDayKey(date: Date): string {
-  console.log(date); // ← side effect, belongs at the call site
+  console.log(date); // side effect, belongs at call site
   return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
 }
 ```
@@ -37,8 +37,8 @@ export function getDayKey(date: Date): string {
 
 ## Svelte Actions (`actions/`)
 
-Svelte actions manage DOM lifecycle. They always receive an `HTMLElement` as the
-first argument and return a destroy object.
+Manage DOM lifecycle. Receive `HTMLElement` as first argument, return destroy
+object.
 
 ```ts
 export function myAction(node: HTMLElement, param?: SomeType) {
@@ -59,19 +59,18 @@ export function myAction(node: HTMLElement, param?: SomeType) {
 
 **Rules:**
 
-- Actions that need global window events must register through
-  `GlobalEventBus.getInstance().register()` — never attach listeners to `window`
-  directly.
-- Actions should dispatch semantic `CustomEvent`s rather than imperatively
-  mutating state.
+- Actions needing global window events must register via
+  `GlobalEventBus.getInstance().register()` - never attach listeners to
+  `window` directly.
+- Dispatch semantic `CustomEvent`s over imperatively mutating state.
 - Clean up all listeners in `destroy()`.
 
 ---
 
 ## GlobalEventBus (`events/GlobalEventBus.ts`)
 
-Use for shared window-level event handling inside actions or utilities. Never
-instantiate directly — always use `GlobalEventBus.getInstance()`.
+For shared window-level event handling in actions or utilities. Never
+instantiate directly - use `GlobalEventBus.getInstance()`.
 
 ```ts
 const unregister = GlobalEventBus.getInstance().register('scroll', handler);
@@ -83,8 +82,8 @@ unregister();
 
 ## Formatting (`formatting/`)
 
-Formatting functions are locale-aware and always accept a locale parameter
-(last, optional, defaults to `'en'`).
+Formatters are locale-aware; always accept locale param (last, optional,
+defaults to `'en'`).
 
 ```ts
 // date
@@ -96,7 +95,7 @@ toRelativeHumanDay(today, date, localeKey);
 
 // number
 toHumanNumber(value, locale); // compact notation: 1.2k, 4.5M
-toPercentage(value, locale); // 0.75 → "75%"
+toPercentage(value, locale); // 0.75 -> "75%"
 toTraktRating(rating, locale); // alias for toPercentage
 toHumanCurrency({ price, currency, locale });
 
@@ -107,17 +106,17 @@ toCountryName(code, languageTag);
 
 **Rules:**
 
-- Import `LOCALE_MAP` and resolve a `date-fns` locale object when using
+- Import `LOCALE_MAP` and resolve `date-fns` locale object when using
   `date-fns` functions.
-- Use `Intl.*` APIs for runtime locale resolution — never hard-code locale
+- Use `Intl.*` APIs for runtime locale resolution - never hard-code locale
   strings inside functions.
 
 ---
 
 ## Translation Lookup Maps (`formatting/string/toTranslated*.ts`)
 
-When an API value needs to be surfaced as translated UI text, use a lookup map
-of i18n message functions.
+When API value needs translated UI text, use lookup map of i18n message
+functions.
 
 ```ts
 const FOO_MAP = {
@@ -141,7 +140,7 @@ lookup when keys may differ in case or separators.
 
 ## Time Constants (`timing/time.ts`)
 
-Use the `time` helper for all millisecond values — never write raw numbers.
+Use `time` helper for all millisecond values - never raw numbers.
 
 ```ts
 import { time } from '$lib/utils/timing/time.ts';
@@ -165,8 +164,8 @@ import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 const value = assertDefined(map.get(key), 'Expected key to be present');
 ```
 
-Never use `assertDefined` to validate external data (use Zod instead). It is
-only for internal invariants.
+Never use `assertDefined` to validate external data (use Zod). Internal
+invariants only.
 
 ---
 
@@ -176,14 +175,14 @@ only for internal invariants.
 | -------------------------- | ------------------------------------------------------------------------- |
 | `WritableSubject<T>`       | `BehaviorSubject` with `.set()` / `.update()` like Svelte writable stores |
 | `writable<T>(initial)`     | Factory shorthand for `new WritableSubject(initial)`                      |
-| `resolve(stream, timeout)` | Await the first defined value from an RxJS `Observable`                   |
-| `toObservable(store)`      | Bridge a Svelte-compatible readable store into an RxJS `Observable`       |
+| `resolve(stream, timeout)` | Await first defined value from RxJS `Observable`                          |
+| `toObservable(store)`      | Bridge Svelte-compatible readable store into RxJS `Observable`            |
 
 ---
 
 ## Safe Storage (`storage/safeStorage.ts`)
 
-Always use `safeLocalStorage` / `safeSessionStorage` instead of `localStorage` /
+Always use `safeLocalStorage` / `safeSessionStorage` over `localStorage` /
 `sessionStorage` to avoid SSR crashes.
 
 ```ts
@@ -199,42 +198,42 @@ safeLocalStorage.setItem('key', value);
 
 | Export                            | Purpose                                                               |
 | --------------------------------- | --------------------------------------------------------------------- |
-| `UrlBuilder`                      | Centralised app route factory — use for all internal navigation paths |
-| `buildParamString(params)`        | Serialise a record into a query string (`?foo=bar&baz=1`)             |
-| `prependHttps(url, placeholder?)` | Ensure a URL starts with `https://`                                   |
+| `UrlBuilder`                      | Centralised app route factory - use for all internal navigation paths |
+| `buildParamString(params)`        | Serialise record into query string (`?foo=bar&baz=1`)                 |
+| `prependHttps(url, placeholder?)` | Ensure URL starts with `https://`                                     |
 | `prependHttpOrHttps(url)`         | Same, but allows `http://` for localhost                              |
 | `setCacheBuster(url)`             | Append `_cb` timestamp to bust CDN caches                             |
-| `buildOAuthUrl(clientId, origin)` | Construct the OAuth redirect URL                                      |
+| `buildOAuthUrl(clientId, origin)` | Construct OAuth redirect URL                                          |
 
 **Rules:**
 
-- All internal app routes must go through `UrlBuilder` — do not construct path
+- Internal app routes must go through `UrlBuilder` - don't construct path
   strings by hand.
-- Never hard-code `https://` prefixes on URLs coming from the API; always pass
-  them through `prependHttps`.
+- Never hard-code `https://` prefixes on URLs from API; pass through
+  `prependHttps`.
 
 ---
 
 ## Constants (`constants.ts`, `assets.ts`)
 
-- `constants.ts` — global values (dates, sizes, limits, `NOOP_FN`). Add new
+- `constants.ts` - global values (dates, sizes, limits, `NOOP_FN`). Add new
   global constants here.
-- `assets.ts` — placeholder image URLs derived from `$app/paths`. Do not
+- `assets.ts` - placeholder image URLs derived from `$app/paths`. Don't
   hard-code placeholder paths elsewhere.
 
 ---
 
 ## Quick Checklist
 
-Before adding a new utility:
+Before adding a utility:
 
-- [ ] Check for an existing equivalent in the relevant domain folder first
-- [ ] File name and exported function name are camelCase and match each other
-- [ ] Function is pure (unless it's an action or intentional side-effect helper)
-- [ ] Internal helpers that don't need to be public live in `_internal/`
-- [ ] Locale-aware formatters accept `locale` as an optional last parameter,
+- [ ] Check for existing equivalent in relevant domain folder first
+- [ ] File name and exported function name are camelCase and match
+- [ ] Function is pure (unless action or intentional side-effect helper)
+- [ ] Internal helpers not needing public exposure live in `_internal/`
+- [ ] Locale-aware formatters accept `locale` as optional last param,
       defaulting to `'en'`
-- [ ] No direct `window.addEventListener` — use `GlobalEventBus` instead
-- [ ] No direct `localStorage` / `sessionStorage` — use `safeLocalStorage` /
+- [ ] No direct `window.addEventListener` - use `GlobalEventBus`
+- [ ] No direct `localStorage` / `sessionStorage` - use `safeLocalStorage` /
       `safeSessionStorage`
 - [ ] Time values use `time.seconds/minutes/hours/days(n)`, not raw numbers

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,32 +4,32 @@ applyTo: "**"
 # Project Coding Standards
 
 ## Tech Stack
-- This is a SvelteKit + TypeScript project, using Svelte 5 in runes mode.
+- SvelteKit + TypeScript project, using Svelte 5 in runes mode.
 
 ## Naming Conventions
-- Use PascalCase for component names, interfaces, and type aliases.
-- Use camelCase for variables, functions, and methods.
-- Use ALL_CAPS for global constants only (not local constants).
+- PascalCase for component names, interfaces, type aliases.
+- camelCase for variables, functions, methods.
+- ALL_CAPS for global constants only (not local constants).
 
 ## Commit Standards
-- **Follow Conventional Commits**: All commits must adhere to the [Conventional Commits](https://www.conventionalcommits.org/) specification.
-  - Use types: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:`, etc.
+- **Follow Conventional Commits**: All commits must adhere to [Conventional Commits](https://www.conventionalcommits.org/).
+  - Types: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:`, etc.
   - Example: `feat: add user profile component`
   - Example: `fix: correct date formatting in calendar view`
 
 ## Code Principles
 
 ### Functional Programming
-- **Write functional code**: Prefer pure functions that avoid side effects when possible.
-- Functions should return consistent output for the same input.
-- Minimize state mutation and favor immutable data structures.
+- **Write functional code**: Prefer pure functions; avoid side effects when possible.
+- Functions return consistent output for same input.
+- Minimize state mutation; favor immutable data structures.
 - Keep Svelte stores minimal; use `$derived()` for computed values.
 
 ### Immutability
 - **Prefer `const` over `let`**: Use `const` whenever possible.
 - Avoid reassigning variables.
-- Use array methods like `map`, `filter`, and `reduce` instead of mutating loops.
-- Use TypeScript's `readonly` types: `Readonly<T>`, `ReadonlyArray<T>`, `ReadonlyMap`, `ReadonlySet`.
+- Use `map`, `filter`, `reduce` over mutating loops.
+- Use TypeScript `readonly` types: `Readonly<T>`, `ReadonlyArray<T>`, `ReadonlyMap`, `ReadonlySet`.
 
 **Bad:**
 ```typescript
@@ -45,8 +45,8 @@ const result = items.map(transform);
 ```
 
 ### Early Exits
-- **Use guard clauses and early returns**: Check error conditions first and return early.
-- Avoid deep nesting by handling edge cases at the start of functions.
+- **Use guard clauses and early returns**: Check error conditions first, return early.
+- Avoid deep nesting by handling edge cases at function start.
 
 **Bad:**
 ```typescript
@@ -74,16 +74,16 @@ function processData(data: Data | null) {
 ```
 
 ### Code Smells to Avoid
-- **No nested if statements**: Nested conditionals indicate poor architecture.
+- **No nested if statements**: Nested conditionals signal poor architecture.
   - Refactor into separate functions with clear responsibilities.
-  - Use guard clauses and early returns instead.
-- **No abstraction leaks**: Ensure abstractions hide implementation details completely.
-- **No "god functions"**: Each function should have a single, clear responsibility.
+  - Use guard clauses and early returns.
+- **No abstraction leaks**: Abstractions must hide implementation details fully.
+- **No "god functions"**: Each function has a single, clear responsibility.
 
 ### Function Design
-- **Single Responsibility Principle**: Each function should do one thing well.
-- Function names should clearly describe what they do.
-- When a function takes 3+ parameters, use a single object parameter.
+- **Single Responsibility Principle**: Each function does one thing well.
+- Function names clearly describe what they do.
+- 3+ parameters -> use single object parameter.
 - Pass dependencies as parameters (dependency injection).
 
 **Bad:**
@@ -99,7 +99,7 @@ fetchData({ url, token, retry, timeout });
 ### Dependency Injection
 - **Pass dependencies as parameters**: Don't instantiate external services inside functions.
 - Makes functions testable without mocking.
-- Use interface types to define the shape of dependencies.
+- Use interface types to define dependency shape.
 
 **Bad:**
 ```typescript
@@ -122,19 +122,19 @@ export function fetchUser({ api, id }: FetchUserParams) {
 ```
 
 ### Separation of Concerns
-- **Push side effects to the edges**: Keep core logic pure and deterministic.
-- API calls, local storage, and DOM manipulation are side effects.
-- Pure functions should handle data transformation only.
-- Side effects should live in the outer layers (components, hooks, server functions).
+- **Push side effects to edges**: Keep core logic pure and deterministic.
+- API calls, local storage, DOM manipulation are side effects.
+- Pure functions handle data transformation only.
+- Side effects live in outer layers (components, hooks, server functions).
 
 ### Simplicity
 - **Keep it simple**: Simple code is maintainable code.
 - Suggestions should be simple and functional.
-- Suggestions should have a low visual complexity.
-- Split up suggestions in smaller functions if need be.
-- Suggestions should not be over-engineered.
+- Suggestions should have low visual complexity.
+- Split suggestions into smaller functions when needed.
+- Don't over-engineer.
 - Favor readability over cleverness.
-- If a solution feels complex, step back and reconsider the approach.
+- If a solution feels complex, step back and reconsider.
 
 ### Iteration Patterns
 - **Prefer functional methods over imperative loops**: Use `map`, `filter`, `reduce`.
@@ -148,15 +148,15 @@ export function fetchUser({ api, id }: FetchUserParams) {
 ## Svelte 5 Specific Guidelines
 
 ### Reactive State
-- Use `$derived()` for computed values (they're cached).
-- Minimize use of stores; prefer local reactive state with runes.
+- Use `$derived()` for computed values (cached).
+- Minimize stores; prefer local reactive state with runes.
 - Use early returns in `$derived()` expressions when appropriate.
 
 ### Component Structure
 - Keep components focused and single-purpose.
 - Extract complex logic into separate utility functions.
 - Use snippets for reusable template fragments.
-- Actions should handle DOM manipulation, not reactive statements.
+- Actions handle DOM manipulation, not reactive statements.
 
 ## Summary
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
+# Always-loaded core (small, project-wide)
+
 @.agents/rules/project.md
 
 @.agents/rules/code-principles.md
@@ -6,8 +8,15 @@
 
 @.agents/rules/testing.md
 
-@.agents/rules/components.md
+# Domain rules - load on demand
 
-@.agents/rules/requests.md
+Domain-specific rules are NOT auto-imported to keep baseline context small.
+Read them when the work touches the matching area. CLAUDE.md routes the
+mapping; the rule files live at `.agents/rules/`:
 
-@.agents/rules/utils.md
+- `components.md` - UI surface (lib/components, lib/features, lib/sections, lib/guards)
+- `requests.md` - API requests, queries, mutations, mappers (lib/requests)
+- `utils.md` - shared utilities (lib/utils)
+
+Read with the Read tool when the task enters the domain. Re-read after long
+gaps if context was compacted.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,14 @@
 Before implementing anything, identify which domain you are working in and
-actively apply the corresponding rule file for that domain:
+read the corresponding rule file from `.agents/rules/` (only the core rules
+auto-load via AGENTS.md; domain rules load on demand):
 
-- UI surface (lib/components, lib/features, lib/sections, lib/guards): apply
+- UI surface (lib/components, lib/features, lib/sections, lib/guards): read
   components.md
-- API requests, queries, mutations, mappers (lib/requests): apply requests.md
-- Shared utilities (lib/utils): apply utils.md
-- Tests (`*.test.ts`, `*.spec.ts`, files under `test/`): apply testing.md
-- All other source code: apply project.md, code-principles.md, and
-  implementation.md (always-on baseline).
-
-All rule files are referenced below via AGENTS.md.
+- API requests, queries, mutations, mappers (lib/requests): read requests.md
+- Shared utilities (lib/utils): read utils.md
+- Tests (`*.test.ts`, `*.spec.ts`, files under `test/`): testing.md (already
+  loaded as core)
+- All other source code: project.md, code-principles.md, implementation.md
+  (always-on baseline, already loaded as core).
 
 @AGENTS.md


### PR DESCRIPTION
## Summary

- `AGENTS.md` previously eager-imported all 7 rule files via `@`-imports on every Claude Code session. Restructured to load only the 4 always-relevant core rules (`project`, `code-principles`, `implementation`, `testing`) and turned the 3 domain rules (`components`, `requests`, `utils`) into a router table.
- Domain rules are now read on demand via the `Read` tool when the work touches the matching area; `CLAUDE.md` keeps the routing.
- Also tightened prose in every rule file and in `.github/copilot-instructions.md` (dropped articles, filler, hedging) while preserving all code blocks, frontmatter, file paths, URLs, tables, and checklists verbatim. Removed em-dashes everywhere including inside code-comment examples.

Mirror of trakt-workers#842.

## Test plan

- [ ] New Claude Code session starts with smaller baseline context (only 4 core rules auto-loaded)
- [ ] Work in `lib/components`, `lib/features`, `lib/sections`, or `lib/guards` still triggers reading `components.md`
- [ ] Work in `lib/requests` still triggers reading `requests.md`
- [ ] Work in `lib/utils` still triggers reading `utils.md`
- [ ] Copilot picks up the compressed `.github/copilot-instructions.md` without losing rule substance
- [ ] No information lost: `git diff main` shows prose tightening only, all checklists/examples intact