### PR TITLE
Expands details button hit target

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryTitle.svelte
@@ -88,6 +88,13 @@
       :global(.trakt-action-button) {
         width: var(--ni-32);
         height: var(--ni-32);
+        position: relative;
+
+        &::after {
+          content: "";
+          position: absolute;
+          inset: calc(var(--ni-neg-8) * 1.5);
+        }
       }
     }
   }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2478
- Expands the clickable area for the details action button within the summary title component.
