### PR TITLE
Feat/season progress

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6479,7 +6479,7 @@
       "description": "Text for the button that allows users to filter the list to only display shows that are in progress. This title should be as short and concise as possible."
     },
     "button_text_progress_completed": {
-      "default": "Completed",
+      "default": "Up to date",
       "description": "Text for the button that allows users to filter the list to only display shows that are completed. This title should be as short and concise as possible."
     },
     "button_text_progress_dropped": {

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -1028,6 +1028,27 @@
       "default": "Seasons",
       "description": "Title for lists containing seasons of a show. This title should be as short and concise as possible."
     },
+    "section_title_season_progress": {
+      "default": "Season {number} progress",
+      "description": "Title for the season progress card shown in the seasons drawer. Shows the season number.",
+      "variables": {
+        "number": {
+          "type": "number"
+        }
+      }
+    },
+    "section_title_specials_progress": {
+      "default": "Specials progress",
+      "description": "Title for the season progress card when the selected season is the specials season (season 0)."
+    },
+    "text_season_complete": {
+      "default": "All caught up",
+      "description": "Text shown when a user has watched all episodes in a season."
+    },
+    "text_season_not_started": {
+      "default": "Not started",
+      "description": "Text shown when a user has not watched any episodes in a season."
+    },
     "text_season_number": {
       "default": "Season {number}",
       "description": "Text for the season number of a show. This should be as short and concise as possible.",

--- a/projects/client/src/lib/components/media/tags/ProgressTag.svelte
+++ b/projects/client/src/lib/components/media/tags/ProgressTag.svelte
@@ -73,6 +73,7 @@
         border-radius: inherit;
 
         width: calc(var(--progress-width) - var(--progress-bar-offset));
+        max-width: calc(100% - var(--progress-bar-spacing));
         background-color: var(--color-background-progress-tag);
 
         transition: width var(--transition-increment) ease-in;

--- a/projects/client/src/lib/sections/summary/components/_internal/StartedTag.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/StartedTag.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import TrackIcon from "$lib/components/icons/TrackIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import StemTag from "$lib/components/tags/StemTag.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import {
+    SummaryDrawers,
+    summaryDrawerNavigation,
+  } from "../../_internal/summaryDrawerNavigation.ts";
+
+  const { buildDrawerLink } = summaryDrawerNavigation();
+</script>
+
+<started-tag>
+  <Link {...buildDrawerLink(SummaryDrawers.Seasons)}>
+    <StemTag
+      --color-background-stem-tag="var(--color-background-indicator-tag)"
+      --color-foreground-stem-tag="var(--color-text-indicator-tag)"
+    >
+      <TrackIcon />
+
+      <p class="bold uppercase no-wrap">{m.tag_text_started()}</p>
+    </StemTag>
+  </Link>
+</started-tag>
+
+<style>
+  started-tag {
+    :global(.trakt-tag) {
+      position: relative;
+
+      :global(svg) {
+        width: var(--ni-12);
+        height: var(--ni-12);
+      }
+    }
+
+    :global(.trakt-link) {
+      text-decoration: none;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
@@ -2,14 +2,22 @@
   import PostCreditsTag from "$lib/components/media/tags/PostCreditsTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import DroppedTag from "./DroppedTag.svelte";
+  import StartedTag from "./StartedTag.svelte";
   import WatchCountTag from "./WatchCountTag.svelte";
+
+  type SummaryPosterTagsProps = {
+    postCreditsCount: number;
+    watchCount: number;
+    isDropped?: boolean;
+    isStarted?: boolean;
+  };
 
   const {
     postCreditsCount,
     watchCount,
     isDropped,
-  }: { postCreditsCount: number; watchCount: number; isDropped?: boolean } =
-    $props();
+    isStarted,
+  }: SummaryPosterTagsProps = $props();
 </script>
 
 {#if isDropped}
@@ -22,4 +30,8 @@
 
 {#if watchCount > 0}
   <WatchCountTag count={watchCount} i18n={TagIntlProvider} />
+{/if}
+
+{#if isStarted && watchCount === 0 && !isDropped}
+  <StartedTag />
 {/if}

--- a/projects/client/src/lib/sections/summary/components/_internal/useIsStarted.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/useIsStarted.ts
@@ -1,0 +1,30 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import { map, of } from 'rxjs';
+
+type IsStartedProps = MediaStoreProps;
+
+export function useIsStarted(props: IsStartedProps) {
+  const { type } = props;
+  const media = Array.isArray(props.media) ? props.media : [props.media];
+  const { history } = useUser();
+
+  if (type === 'show') {
+    return {
+      isStarted: history.pipe(
+        map(($history) => {
+          if (!$history) {
+            return false;
+          }
+
+          return media.every((m) => {
+            const show = $history.shows.get(m.id);
+            return show?.episodes.some((e) => e.season !== 0) ?? false;
+          });
+        }),
+      ),
+    };
+  }
+
+  return { isStarted: of(false) };
+}

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -3,10 +3,12 @@
   import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import { useWatchCount } from "$lib/stores/useWatchCount";
   import SummaryCover from "../_internal/SummaryCover.svelte";
   import SummaryPosterTags from "../_internal/SummaryPosterTags.svelte";
   import SummaryTitle from "../_internal/SummaryTitle.svelte";
+  import { useIsStarted } from "../_internal/useIsStarted";
   import StreamOnOverlay from "../overlay/StreamOnOverlay.svelte";
   import TrailerOverlay from "../overlay/TrailerOverlay.svelte";
   import RateNow from "../rating/RateNow.svelte";
@@ -14,7 +16,6 @@
   import SummaryContainer from "../summary/SummaryContainer.svelte";
   import SummaryHeader from "../summary/SummaryHeader.svelte";
   import SummaryOverview from "../summary/SummaryOverview.svelte";
-  import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import type { MediaSummaryProps } from "./MediaSummaryProps";
   import { useMediaMetaInfo } from "./useMediaMetaInfo";
   import MediaActions from "./v2/_internal/MediaActions.svelte";
@@ -36,6 +37,7 @@
 
   const { ratings } = $derived(useMediaMetaInfo(target));
   const { isDropped } = $derived(useIsDropped(media));
+  const { isStarted } = $derived(useIsStarted(target));
 
   const posterUrl = $derived(streamOn?.preferred?.link ?? media.trailer);
 </script>
@@ -45,6 +47,7 @@
     {postCreditsCount}
     watchCount={$watchCount}
     isDropped={$isDropped}
+    isStarted={$isStarted}
   />
 {/snippet}
 

--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -6,6 +6,7 @@
   import type { MediaCrew } from "$lib/requests/models/MediaCrew";
   import type { MediaIntl } from "$lib/requests/models/MediaIntl";
   import type { MediaStudio } from "$lib/requests/models/MediaStudio";
+  import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { useWatchCount } from "$lib/stores/useWatchCount";
   import SpoilerSection from "../../_internal/SpoilerSection.svelte";
@@ -13,8 +14,8 @@
   import SummaryPosterTags from "../../_internal/SummaryPosterTags.svelte";
   import SummaryRateNow from "../../_internal/SummaryRateNow.svelte";
   import SummaryTitle from "../../_internal/SummaryTitle.svelte";
+  import { useIsStarted } from "../../_internal/useIsStarted";
   import { useIsRateable } from "../../rating/_internal/useIsRateable";
-  import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import type { MediaSummaryEntry } from "../models/MediaSummaryEntry";
   import { useMediaMetaInfo } from "../useMediaMetaInfo";
   import MediaActions from "./_internal/MediaActions.svelte";
@@ -40,6 +41,7 @@
 
   const { isRateable } = $derived(useIsRateable(target));
   const { isDropped } = $derived(useIsDropped(media));
+  const { isStarted } = $derived(useIsStarted(target));
 </script>
 
 {#snippet tags()}
@@ -47,6 +49,7 @@
     {postCreditsCount}
     watchCount={$watchCount}
     isDropped={$isDropped}
+    isStarted={$isStarted}
   />
 {/snippet}
 

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonProgressCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonProgressCard.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+  import { EpisodeIntlProvider } from "$lib/components/episode/EpisodeIntlProvider.ts";
+  import EpisodeDurationTag from "$lib/components/episode/tags/EpisodeDurationTag.svelte";
+  import EpisodeRemainingTag from "$lib/components/episode/tags/EpisodeRemainingTag.svelte";
+  import ProgressTag from "$lib/components/media/tags/ProgressTag.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { toPercentage } from "$lib/utils/formatting/number/toPercentage.ts";
+  import { stretchedPercentage } from "$lib/utils/number/stretchedPercentage.ts";
+
+  type SeasonProgressCardProps = {
+    seasonNumber: number;
+    watched: number;
+    total: number;
+    totalRuntime: number;
+    loading?: boolean;
+  };
+
+  const {
+    seasonNumber,
+    watched,
+    total,
+    totalRuntime,
+    loading = false,
+  }: SeasonProgressCardProps = $props();
+
+  const barPercentage = $derived.by(() => {
+    if (total === 0) return 0;
+    if (watched >= total) return 100;
+    return stretchedPercentage({ value: watched, total });
+  });
+
+  const progressPercentage = $derived(
+    total === 0 ? 0 : Math.min(1.0, watched / total),
+  );
+
+  const remaining = $derived(Math.max(0, total - watched));
+  const isComplete = $derived(total > 0 && watched >= total);
+  const isStarted = $derived(watched > 0);
+  const minutesLeft = $derived(
+    !isNaN(totalRuntime) && remaining > 0 && total > 0
+      ? Math.round((totalRuntime / total) * remaining)
+      : 0,
+  );
+</script>
+
+{#snippet tags()}
+  {#if !isComplete && remaining > 0}
+    <EpisodeRemainingTag i18n={EpisodeIntlProvider} {remaining} />
+    {#if !isNaN(totalRuntime) && minutesLeft > 0}
+      <EpisodeDurationTag i18n={EpisodeIntlProvider} {minutesLeft} />
+    {/if}
+  {/if}
+{/snippet}
+
+<div class="season-progress-card" class:is-complete={isComplete}>
+  <div class="progress-header">
+    <p class="bold capitalize">
+      {seasonNumber === 0
+        ? m.section_title_specials_progress()
+        : m.section_title_season_progress({ number: seasonNumber })}
+    </p>
+    <div class="progress-header-right">
+      {#if loading}
+        <div class="skeleton skeleton-badge"></div>
+      {:else if isComplete}
+        <p class="tag secondary capitalize complete-label">
+          {m.text_season_complete()}
+        </p>
+      {:else if isStarted}
+        <p class="tag secondary">
+          {toPercentage(progressPercentage, languageTag())}
+        </p>
+      {:else}
+        <p class="tag secondary capitalize">
+          {m.text_season_not_started()}
+        </p>
+      {/if}
+    </div>
+  </div>
+
+  {#if loading}
+    <div class="progress-skeleton skeleton"></div>
+  {:else}
+    <ProgressTag progress={barPercentage} {tags}>
+      {m.tag_text_number_of_episodes({ count: watched })}
+    </ProgressTag>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .season-progress-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+
+    padding: var(--ni-16);
+
+    background: var(--color-card-background);
+    border-radius: var(--border-radius-m);
+    box-shadow: var(--shadow-base);
+  }
+
+  .progress-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gap-s);
+  }
+
+  .progress-header-right {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+
+    .complete-label {
+      color: var(--color-text-emphasis);
+    }
+  }
+
+  .progress-skeleton {
+    height: var(--ni-20);
+    border-radius: var(--border-radius-m);
+  }
+
+  .skeleton {
+    position: relative;
+    overflow: hidden;
+    border-radius: var(--border-radius-s);
+    background: color-mix(in srgb, var(--color-text-primary) 8%, transparent);
+  }
+
+  .skeleton::after {
+    content: "";
+
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    width: 300%;
+    height: 100%;
+
+    transform: translateX(100%);
+
+    animation: slide calc(10 * var(--transition-increment)) infinite;
+
+    background: linear-gradient(
+      110deg,
+      transparent 0%,
+      transparent 30%,
+      color-mix(in srgb, var(--color-foreground) 50%, transparent) 50%,
+      transparent 70%,
+      transparent 100%
+    );
+
+    opacity: 0.2;
+  }
+
+  .skeleton-badge {
+    width: var(--ni-56);
+    height: var(--ni-16);
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
@@ -6,6 +6,7 @@
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { Season } from "$lib/requests/models/Season";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import SeasonItem from "$lib/sections/lists/components/SeasonItem.svelte";
@@ -14,6 +15,7 @@
   import SeasonPopupMenu from "$lib/sections/lists/season/_internal/SeasonPopupMenu.svelte";
   import { useShowWatchedEpisodes } from "$lib/sections/lists/season/_internal/useShowWatchedEpisodes";
   import { useSeasonEpisodes } from "$lib/sections/lists/stores/useSeasonEpisodes";
+  import SeasonProgressCard from "$lib/sections/summary/components/seasons/SeasonProgressCard.svelte";
   import { seasonLabel } from "$lib/utils/intl/seasonLabel";
   import { countWatchedEpisodes } from "$lib/utils/media/countWatchedEpisodes";
   import { fade } from "svelte/transition";
@@ -50,6 +52,13 @@
 
   const previousSeasons = $derived(
     seasons.filter((s) => s.number > 0 && s.number < currentSeason),
+  );
+
+  const currentSeasonData = $derived(
+    seasons.find((s) => s.number === currentSeason),
+  );
+  const currentSeasonWatched = $derived(
+    $watchedBySeason?.get(currentSeason)?.size ?? 0,
   );
 
   const buildSeasonLink = (seasonNumber: number) => {
@@ -106,6 +115,18 @@
           </SectionList>
         </div>
       {/if}
+
+      <RenderFor audience="authenticated">
+        {#if currentSeasonData && currentSeasonData.episodes.count > 0}
+          <SeasonProgressCard
+            seasonNumber={currentSeason}
+            watched={currentSeasonWatched}
+            total={currentSeasonData.episodes.count}
+            totalRuntime={currentSeasonData.totalRuntime}
+            loading={$isWatchedLoading}
+          />
+        {/if}
+      </RenderFor>
 
       <div class="episodes-section">
         {#snippet metaInfo()}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2482
- The season drawer now shows progress per season.
  - Design is kept minimal and re-uses the progress bar we also use in `Continue watching`
- Small change to rename `completed` to `up to date` in the progress list
- Also adds a `Started` tag on show posters if it's started but not yet completed.
  - This tag is clickable and will also take users to the seasons drawer

## 👀 Example 👀

https://github.com/user-attachments/assets/8e9f4a0f-331b-4b30-83fb-7c9d9fbd4de4

