### PR TITLE
Moderation: media item reporting

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6535,6 +6535,26 @@
       "default": "Report review",
       "description": "Aria-label for the button in the review action menu that opens the report dialog."
     },
+    "button_text_report": {
+      "default": "Report",
+      "description": "Text for the button in an action menu that opens the report dialog for a movie, show, person, list, or user."
+    },
+    "button_label_report_media": {
+      "default": "Report {title}",
+      "description": "Aria-label for the action-menu button that opens the report dialog for a movie, show, season, or episode. {title} is the media title."
+    },
+    "button_label_report_person": {
+      "default": "Report {name}",
+      "description": "Aria-label for the action-menu button that opens the report dialog for a person. {name} is the person's name."
+    },
+    "button_label_report_list": {
+      "default": "Report {name}",
+      "description": "Aria-label for the action-menu button that opens the report dialog for a list. {name} is the list name."
+    },
+    "button_label_report_user": {
+      "default": "Report {username}",
+      "description": "Aria-label for the action-menu button that opens the report dialog for a user. {username} is the user's display name."
+    },
     "label_report_reason_spoilers": {
       "default": "Spoilers",
       "description": "Report reason: the content contains undisclosed spoilers."

--- a/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
+++ b/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
@@ -32,7 +32,7 @@
   {#if icon}
     {@render icon()}
   {:else}
-    <MoreIcon />
+    <MoreIcon {size} />
   {/if}
 </button>
 
@@ -109,6 +109,15 @@
         &:hover {
           background-color: var(--active-background-color);
           color: var(--active-color);
+        }
+
+        &[data-mode="standalone"]:not([data-popup-state="opened"]):hover {
+          color: var(--color-text-primary);
+          background-color: color-mix(
+            in srgb,
+            var(--color-foreground) 10%,
+            transparent
+          );
         }
       }
     }

--- a/projects/client/src/lib/features/report/ReportButton.svelte
+++ b/projects/client/src/lib/features/report/ReportButton.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import FlagIcon from "$lib/components/icons/FlagIcon.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { ReportParams } from "./models/ReportParams.ts";
+  import { useReportDialog } from "./useReportDialog.ts";
+
+  type ReportButtonProps = {
+    params: ReportParams;
+    label: string;
+    variant?: "primary" | "secondary";
+  };
+
+  const { params, label, variant = "secondary" }: ReportButtonProps = $props();
+
+  const report = useReportDialog();
+
+  const handleReport = () => {
+    report.open(params);
+  };
+</script>
+
+<DropdownItem
+  onclick={handleReport}
+  {label}
+  color="default"
+  style="flat"
+  {variant}
+>
+  {m.button_text_report()}
+  {#snippet icon()}
+    <FlagIcon />
+  {/snippet}
+</DropdownItem>

--- a/projects/client/src/lib/features/report/_internal/reasonsFor.spec.ts
+++ b/projects/client/src/lib/features/report/_internal/reasonsFor.spec.ts
@@ -58,6 +58,23 @@ describe('reasonsFor', () => {
     expect(result).not.toContain(ReportReason.DataRefresh);
   });
 
+  it('returns the person reason set for Person (media set without runtime)', () => {
+    const result = reasonsFor(ReportableType.Person);
+
+    expect(result).toEqual([
+      ReportReason.Duplicate,
+      ReportReason.Remove,
+      ReportReason.DataRefresh,
+      ReportReason.Metadata,
+      ReportReason.Adult,
+      ReportReason.Language,
+      ReportReason.Spam,
+      ReportReason.Tmdb,
+      ReportReason.Other,
+    ]);
+    expect(result).not.toContain(ReportReason.Runtime);
+  });
+
   it('returns the user reason set for User', () => {
     const result = reasonsFor(ReportableType.User);
 

--- a/projects/client/src/lib/features/report/_internal/reasonsFor.ts
+++ b/projects/client/src/lib/features/report/_internal/reasonsFor.ts
@@ -25,6 +25,18 @@ const mediaReasons: ReadonlyArray<ReportReason> = [
   ReportReason.Other,
 ];
 
+const personReasons: ReadonlyArray<ReportReason> = [
+  ReportReason.Duplicate,
+  ReportReason.Remove,
+  ReportReason.DataRefresh,
+  ReportReason.Metadata,
+  ReportReason.Adult,
+  ReportReason.Language,
+  ReportReason.Spam,
+  ReportReason.Tmdb,
+  ReportReason.Other,
+];
+
 const listReasons: ReadonlyArray<ReportReason> = [
   ReportReason.Duplicate,
   ReportReason.Remove,
@@ -48,6 +60,7 @@ const reasonsMap: Record<ReportableType, ReadonlyArray<ReportReason>> = {
   [ReportableType.Show]: mediaReasons,
   [ReportableType.Season]: mediaReasons,
   [ReportableType.Episode]: mediaReasons,
+  [ReportableType.Person]: personReasons,
   [ReportableType.List]: listReasons,
   [ReportableType.User]: userReasons,
 };

--- a/projects/client/src/lib/features/report/models/ReportParams.ts
+++ b/projects/client/src/lib/features/report/models/ReportParams.ts
@@ -25,6 +25,11 @@ type ReportParamsMap = {
     id: number;
     title: string;
   };
+  [ReportableType.Person]: {
+    type: ReportableType.Person;
+    id: number;
+    title: string;
+  };
   [ReportableType.List]: {
     type: ReportableType.List;
     id: number;

--- a/projects/client/src/lib/features/report/models/ReportableType.ts
+++ b/projects/client/src/lib/features/report/models/ReportableType.ts
@@ -4,6 +4,7 @@ export enum ReportableType {
   Show = 'show',
   Season = 'season',
   Episode = 'episode',
+  Person = 'person',
   List = 'list',
   User = 'user',
 }

--- a/projects/client/src/lib/requests/queries/reports/reportRequest.ts
+++ b/projects/client/src/lib/requests/queries/reports/reportRequest.ts
@@ -1,3 +1,4 @@
+import { ReportableType } from '$lib/features/report/models/ReportableType.ts';
 import type { ReportParams } from '$lib/features/report/models/ReportParams.ts';
 import type { ReportReason } from '$lib/features/report/models/ReportReason.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
@@ -12,10 +13,24 @@ export type ReportRequestResult =
   | { ok: true }
   | { ok: false; status: number };
 
+// The SDK router is the pluralized type for every reportable except person,
+// which lives under the `people` router. Mapped explicitly so the key stays a
+// string literal the typed API proxy can index.
+const reportRouter = {
+  [ReportableType.Comment]: 'comments',
+  [ReportableType.Movie]: 'movies',
+  [ReportableType.Show]: 'shows',
+  [ReportableType.Season]: 'seasons',
+  [ReportableType.Episode]: 'episodes',
+  [ReportableType.Person]: 'people',
+  [ReportableType.List]: 'lists',
+  [ReportableType.User]: 'users',
+} as const satisfies Record<ReportableType, string>;
+
 export async function reportRequest(
   { fetch, params, reason, message }: ReportRequestParams,
 ): Promise<ReportRequestResult> {
-  const response = await api({ fetch })[`${params.type}s`]
+  const response = await api({ fetch })[reportRouter[params.type]]
     .report({
       params: { id: `${params.id}` },
       // FIXME: typings here need to be tied to the type, e.g. if type

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonPopupMenu.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonPopupMenu.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import ReportButton from "$lib/features/report/ReportButton.svelte";
+  import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
@@ -9,10 +12,12 @@
     title: string;
     episodes: EpisodeEntry[];
     show: ShowEntry;
+    seasonId?: number;
     disabled?: boolean;
   };
 
-  const { title, episodes, show, disabled }: SeasonPopupMenuProps = $props();
+  const { title, episodes, show, seasonId, disabled }: SeasonPopupMenuProps =
+    $props();
 </script>
 
 <PopupMenu
@@ -28,5 +33,14 @@
       media={episodes}
       {show}
     />
+
+    {#if seasonId != null}
+      <RenderFor audience="authenticated">
+        <ReportButton
+          params={{ type: ReportableType.Season, id: seasonId, title }}
+          label={m.button_label_report_media({ title })}
+        />
+      </RenderFor>
+    {/if}
   {/snippet}
 </PopupMenu>

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
@@ -31,6 +31,10 @@
   }: SeasonListProps = $props();
 
   const { buildDrawerLink } = summaryDrawerNavigation();
+
+  const currentSeasonId = $derived(
+    seasons.find((s) => s.number === currentSeason)?.id,
+  );
 </script>
 
 <SectionList
@@ -58,6 +62,11 @@
     />
   {/snippet}
   {#snippet actions()}
-    <SeasonPopupMenu title={subtitle} {episodes} {show} />
+    <SeasonPopupMenu
+      title={subtitle}
+      {episodes}
+      {show}
+      seasonId={currentSeasonId}
+    />
   {/snippet}
 </SectionList>

--- a/projects/client/src/lib/sections/lists/user/ListActions.svelte
+++ b/projects/client/src/lib/sections/lists/user/ListActions.svelte
@@ -5,6 +5,8 @@
   import Redirect from "$lib/components/router/Redirect.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
+  import ReportButton from "$lib/features/report/ReportButton.svelte";
+  import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
@@ -51,12 +53,12 @@
     {list}
   />
 
-  {#if isListOwner}
-    <PopupMenu
-      label={m.button_label_popup_menu({ title: list.name })}
-      mode="standalone"
-    >
-      {#snippet items()}
+  <PopupMenu
+    label={m.button_label_popup_menu({ title: list.name })}
+    mode="standalone"
+  >
+    {#snippet items()}
+      {#if isListOwner}
         <ShareButton
           title={list.name}
           style="dropdown-item"
@@ -73,9 +75,14 @@
           isDeleting={$isDeleting}
           onDelete={deleteList}
         />
-      {/snippet}
-    </PopupMenu>
-  {/if}
+      {:else}
+        <ReportButton
+          params={{ type: ReportableType.List, id: list.id, title: list.name }}
+          label={m.button_label_report_list({ name: list.name })}
+        />
+      {/if}
+    {/snippet}
+  </PopupMenu>
 </RenderFor>
 
 {#if showEditList}

--- a/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
@@ -9,6 +9,9 @@
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import * as m from "$lib/features/i18n/messages.ts";
+  import ReportButton from "$lib/features/report/ReportButton.svelte";
+  import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { DisplayableProfileProps } from "$lib/sections/profile/DisplayableProfileProps";
   import { toDisplayableName } from "$lib/utils/profile/toDisplayableName";
   import { useBlockUser } from "./useBlockUser";
@@ -139,5 +142,12 @@
         {/snippet}
       </DropdownItem>
     {/if}
+
+    <RenderFor audience="authenticated">
+      <ReportButton
+        params={{ type: ReportableType.User, id: slug }}
+        label={m.button_label_report_user({ username: userDisplayName })}
+      />
+    </RenderFor>
   {/snippet}
 </PopupMenu>

--- a/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
@@ -4,7 +4,6 @@
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import BlockIcon from "$lib/components/icons/BlockIcon.svelte";
   import FollowIcon from "$lib/components/icons/FollowIcon.svelte";
-  import MoreIcon from "$lib/components/icons/MoreIcon.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
@@ -101,9 +100,6 @@
   mode="standalone"
   size="normal"
 >
-  {#snippet icon()}
-    <MoreIcon size="normal" />
-  {/snippet}
   {#snippet items()}
     {#if !isBlocked}
       <DropdownItem

--- a/projects/client/src/lib/sections/summary/components/_internal/SummarySideActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummarySideActions.svelte
@@ -21,6 +21,8 @@
     :global(.trakt-action-button) {
       :global(svg) {
         color: var(--color-foreground);
+        width: var(--ni-24);
+        height: var(--ni-24);
       }
     }
   }

--- a/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+  import ReportButton from "$lib/features/report/ReportButton.svelte";
+  import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
   import SetCoverImageAction from "$lib/sections/media-actions/cover-image/SetCoverImageAction.svelte";
@@ -52,3 +56,11 @@
 />
 
 <HistoryButton />
+
+<RenderFor audience="authenticated">
+  <ReportButton
+    params={{ type: ReportableType.Episode, id: episode.id, title }}
+    label={m.button_label_report_media({ title })}
+    variant="primary"
+  />
+</RenderFor>

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
@@ -1,4 +1,9 @@
 <script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+  import ReportButton from "$lib/features/report/ReportButton.svelte";
+  import type { ReportParams } from "$lib/features/report/models/ReportParams.ts";
+  import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import ListAction from "$lib/sections/components/lists-drawer/ListAction.svelte";
   import ListsDrawer from "$lib/sections/components/lists-drawer/ListsDrawer.svelte";
@@ -15,6 +20,12 @@
   const { isWatched } = $derived(useIsWatched({ media, type: media.type }));
   const { isDropped } = $derived(useIsDropped(media));
   let isListsDrawerOpen = $state(false);
+
+  const reportParams = $derived<ReportParams>(
+    media.type === "show"
+      ? { type: ReportableType.Show, id: media.id, title }
+      : { type: ReportableType.Movie, id: media.id, title },
+  );
 </script>
 
 {#if $isWatched}
@@ -62,6 +73,14 @@
     {title}
   />
 {/if}
+
+<RenderFor audience="authenticated">
+  <ReportButton
+    params={reportParams}
+    label={m.button_label_report_media({ title })}
+    variant="primary"
+  />
+</RenderFor>
 
 {#if isListsDrawerOpen}
   <ListsDrawer

--- a/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
@@ -2,6 +2,8 @@
   import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import ReportButton from "$lib/features/report/ReportButton.svelte";
+  import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
   import PersonTitle from "../_internal/PersonTitle.svelte";
   import SummaryContainer from "./../summary/SummaryContainer.svelte";
@@ -32,6 +34,17 @@
           title={person.name}
           textFactory={({ title: name }) => m.text_share_person({ name })}
           source={{ id: "person" }}
+        />
+      {/snippet}
+
+      {#snippet popupActions()}
+        <ReportButton
+          params={{
+            type: ReportableType.Person,
+            id: person.id,
+            title: person.name,
+          }}
+          label={m.button_label_report_person({ name: person.name })}
         />
       {/snippet}
 

--- a/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+  import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
   import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
+  import MoreIcon from "$lib/components/icons/MoreIcon.svelte";
   import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import ReportButton from "$lib/features/report/ReportButton.svelte";
+  import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
   import PersonTitle from "../../_internal/PersonTitle.svelte";
   import Summary from "./../../_internal/Summary.svelte";
@@ -31,6 +36,26 @@
       source={{ id: "person" }}
     />
     <SocialMediaLinks {person} />
+    <RenderFor audience="authenticated">
+      <PopupMenu
+        label={m.button_label_popup_menu({ title: person.name })}
+        mode="standalone"
+      >
+        {#snippet icon()}
+          <MoreIcon />
+        {/snippet}
+        {#snippet items()}
+          <ReportButton
+            params={{
+              type: ReportableType.Person,
+              id: person.id,
+              title: person.name,
+            }}
+            label={m.button_label_report_person({ name: person.name })}
+          />
+        {/snippet}
+      </PopupMenu>
+    </RenderFor>
   {/snippet}
 
   {#snippet meta()}

--- a/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
   import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
-  import MoreIcon from "$lib/components/icons/MoreIcon.svelte";
   import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import ReportButton from "$lib/features/report/ReportButton.svelte";
@@ -40,10 +39,8 @@
       <PopupMenu
         label={m.button_label_popup_menu({ title: person.name })}
         mode="standalone"
+        size="normal"
       >
-        {#snippet icon()}
-          <MoreIcon />
-        {/snippet}
         {#snippet items()}
           <ReportButton
             params={{

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawer.svelte
@@ -54,6 +54,10 @@
     seasons.filter((s) => s.number > 0 && s.number < currentSeason),
   );
 
+  const currentSeasonId = $derived(
+    seasons.find((s) => s.number === currentSeason)?.id,
+  );
+
   const currentSeasonData = $derived(
     seasons.find((s) => s.number === currentSeason),
   );
@@ -80,6 +84,7 @@
     title={seasonLabel(currentSeason)}
     episodes={$episodes}
     {show}
+    seasonId={currentSeasonId}
     disabled={$isLoading}
   />
 {/snippet}

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
@@ -58,6 +58,11 @@
     gap: var(--gap-xs);
 
     flex: 1;
+
+    :global(svg) {
+      width: var(--ni-24);
+      height: var(--ni-24);
+    }
   }
 
   .trakt-summary-header-children {

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
@@ -21,24 +21,28 @@
     {@render children()}
   </div>
 
-  {#if headerActions}
-    <RenderFor audience="all">
-      <div class="trakt-summary-action-header">
-        {@render headerActions()}
-      </div>
-    </RenderFor>
-  {/if}
+  {#if headerActions || popupActions}
+    <div class="trakt-summary-action-header">
+      {#if headerActions}
+        <RenderFor audience="all">
+          {@render headerActions()}
+        </RenderFor>
+      {/if}
 
-  {#if popupActions}
-    <RenderFor audience="all">
-      <div class="trakt-summary-action-header">
-        <PopupMenu label={m.button_label_popup_menu({ title })} size="normal">
-          {#snippet items()}
-            {@render popupActions()}
-          {/snippet}
-        </PopupMenu>
-      </div>
-    </RenderFor>
+      {#if popupActions}
+        <RenderFor audience="all">
+          <PopupMenu
+            label={m.button_label_popup_menu({ title })}
+            size="normal"
+            mode="standalone"
+          >
+            {#snippet items()}
+              {@render popupActions()}
+            {/snippet}
+          </PopupMenu>
+        </RenderFor>
+      {/if}
+    </div>
   {/if}
 </div>
 
@@ -50,6 +54,7 @@
 
     display: flex;
     justify-content: flex-end;
+    align-items: center;
     gap: var(--gap-xs);
 
     flex: 1;


### PR DESCRIPTION
# Background

[PR #2171](https://github.com/trakt/trakt-web/pull/2171) introduced content reporting for comments, and the [API](https://github.com/trakt/trakt-api/pull/764) exposes report endpoints for every major entity. This PR closes the gap by surfacing reporting across the rest of the app, so users can flag bad metadata, duplicates, or inappropriate content wherever they encounter it.

Closes #1899.

# Screenshots

<img width="1089" height="919" alt="image" src="https://github.com/user-attachments/assets/58ca4286-a207-40f6-9f18-8a26aff60c1f" />

# What's new

Reporting is now available from the `…` menu on every relevant surface, reusing the existing report dialog/form:

- **Movies & shows** – summary page action menu.
- **Episodes** – episode summary action menu.
- **Seasons** – the season `…` menu (both the seasons drawer and the season list on the show page).
- **People** – a new `…` menu next to the share icon (desktop and mobile).
- **Lists** – non-owners now get a `…` menu with a report option (owners keep share/edit/delete).
- **Users** – added to the existing profile overflow menu.

In each case the report dialog automatically shows the reasons appropriate to that entity type.

# Implementation notes

- **Person support added to the report feature** – `person` wasn't previously a reportable type. Added it to the model, params, and reason set (the API's person reasons mirror the media set, minus `runtime`), and mapped `person → people` in the request since the SDK namespace doesn't pluralize.
- **Shared `ReportButton`** – a single dropdown-item component drives every surface, taking the report params and an aria label. It accepts an optional `variant` so it matches its container: filled (`primary`) in the summary menus, lighter (`secondary`) in the card/standalone menus to stay consistent with neighboring items.
- **Auth gating** – all report actions are wrapped in `RenderFor audience="authenticated"`; the list and user menus only offer report for content you don't own.

# Testing

Unit tests cover the per-type reason sets (including the new person set). Reporting verified manually across movies, shows, episodes, seasons, people, lists, and users.

# Notes / follow-ups

- The report button reuses one i18n label (`button_label_report_media`) across movies/shows/seasons/episodes; can split per-surface if translators prefer.
- Only English copy is added; other locales need a translation run.
