### PR TITLE
fix(settings): lower raw export page size to 250

### DIFF
--- a/projects/client/src/lib/sections/settings/export/fetchWithRetry.ts
+++ b/projects/client/src/lib/sections/settings/export/fetchWithRetry.ts
@@ -12,8 +12,8 @@ export function fetchWithRetry(
   return retryAsync(
     async () => {
       const pageUrl = url.includes('?')
-        ? `${url}&page=${page}&limit=1000`
-        : `${url}?page=${page}&limit=1000`;
+        ? `${url}&page=${page}&limit=250`
+        : `${url}?page=${page}&limit=250`;
 
       const response = await rawApiFetch({ path: `/${pageUrl}` });
 


### PR DESCRIPTION
## Summary

- Raw export was paginating `/users/:slug/watched/*` with `limit=1000`, which timed out on heavy accounts and stalled the export with repeated 500s.
- Lower the export page size to `250` so each page stays within the API's query timeout. The export issues more requests but each completes reliably.

## Test plan

- [ ] Trigger raw export on a heavy account and confirm paginated endpoints no longer 500
- [ ] Confirm progress UI advances through the extra pages without regressions
- [ ] Spot-check resulting ZIP for completeness vs. prior exports