### PR TITLE
feat(profile): clarify match pill + drawer for first-time visitors

### DIFF
--- a/.agents/rules/components.md
+++ b/.agents/rules/components.md
@@ -318,6 +318,34 @@ Always import Paraglide messages namespace as `m` and call messages as functions
 
 ---
 
+## Displaying User Names
+
+Always use `toDisplayableName` from `$lib/utils/profile/toDisplayableName.ts` when rendering a user's name. It returns the full name when available, or falls back to `@username`.
+
+```svelte
+<script lang="ts">
+  import { toDisplayableName } from '$lib/utils/profile/toDisplayableName.ts';
+</script>
+
+<!-- Good -->
+<span>{toDisplayableName(profile)}</span>
+
+<!-- Bad - bypass the utility and re-implement the fallback logic inline -->
+<span>{profile.name.full || `@${profile.username}`}</span>
+```
+
+When passing a name into an i18n message, pass the result of `toDisplayableName` as the variable, never construct the `@`-prefixed string inside the message key itself, as `@` in message strings breaks the generated JSDoc output.
+
+```svelte
+<!-- Good -->
+{m.some_message({ username: toDisplayableName(profile) })}
+
+<!-- Bad - @ inside the message default value causes a JSDoc parse error -->
+{m.some_message({ username: profile.username })}
+```
+
+---
+
 ## Where to Place a New Component
 
 | Question                                              | Place in                                     |

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6979,9 +6979,26 @@
       "default": "Computing match score",
       "description": "Aria-label for the compatibility pill placeholder shown while the match score is loading."
     },
+    "match_pill_anchor": {
+      "default": "match",
+      "description": "Anchor word rendered between the score and the tonal label on the compatibility pill (e.g. '74% match · Crossover'). Frames the percentage in plain language so first-time visitors can parse the pill at a glance without opening the drawer."
+    },
     "match_drawer_title": {
       "default": "Match details",
       "description": "Header of the drawer that opens when the compatibility pill is tapped."
+    },
+    "match_drawer_subject": {
+      "default": "You & {username}",
+      "description": "Subject line shown above the score gauge in the match drawer. Frames the metric as a comparison between the viewer and the profile owner so first-time visitors immediately understand who is being matched. Renders the profile owner's @-handle verbatim.",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "match_drawer_overlap_caption": {
+      "default": "How your taste overlaps",
+      "description": "One-line subtitle shown under the tonal match label (e.g. 'Co-stars'). Explains in plain language what the score and label actually measure, so the cinematic vocabulary doesn't leave first-time visitors guessing."
     },
     "match_drawer_breakdown_header": {
       "default": "How this adds up",

--- a/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
@@ -76,7 +76,7 @@
         <RenderFor audience="authenticated">
           <RenderForFeature flag={FeatureFlag.UserMatch}>
             {#snippet enabled()}
-              <MatchPill {slug} />
+              <MatchPill {slug} {profile} />
             {/snippet}
           </RenderForFeature>
         </RenderFor>

--- a/projects/client/src/lib/sections/profile/components/MatchPill.svelte
+++ b/projects/client/src/lib/sections/profile/components/MatchPill.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
   import { useDiscover } from "$lib/features/discover/useDiscover.ts";
   import * as m from "$lib/features/i18n/messages.ts";
+  import type { DisplayableProfileProps } from "../DisplayableProfileProps.ts";
   import MatchDrawer from "./_internal/MatchDrawer.svelte";
   import { matchLabel } from "./_internal/matchLabel";
   import { useMatch } from "./_internal/useMatch.ts";
 
-  const { slug }: { slug: string } = $props();
+  const { profile, slug }: DisplayableProfileProps = $props();
 
   const { mode } = useDiscover();
   const { match, isLoading, band } = $derived(useMatch({ slug, mode: $mode }));
@@ -41,12 +43,17 @@
     style:--fill={`${score}%`}
   >
     <span class="score bold">{score}<span class="suffix small">%</span></span>
+    <span class="anchor">{m.match_pill_anchor()}</span>
+    <span class="separator" aria-hidden="true">·</span>
     <span class="label bold">{label}</span>
+    <span class="caret" aria-hidden="true">
+      <CaretRightIcon />
+    </span>
   </button>
 {/if}
 
 {#if isOpen && $match}
-  <MatchDrawer match={$match} onClose={() => (isOpen = false)} />
+  <MatchDrawer match={$match} onClose={() => (isOpen = false)} {profile} />
 {/if}
 
 <style lang="scss">
@@ -61,7 +68,9 @@
     display: inline-flex;
     align-items: center;
     gap: var(--gap-xxs);
-    padding: var(--ni-4) var(--ni-12);
+    height: var(--ni-28);
+    padding: 0 var(--ni-12);
+    box-sizing: border-box;
     border-radius: var(--border-radius-xxl);
 
     // Background is the progress encoding: the score percent of the pill
@@ -121,9 +130,37 @@
     margin-left: 1px;
   }
 
+  .anchor {
+    white-space: nowrap;
+    opacity: 0.85;
+    height: var(--height-match-label);
+  }
+
+  .separator {
+    opacity: 0.5;
+    height: var(--height-match-label);
+  }
+
   .label {
     white-space: nowrap;
     height: var(--height-match-label);
+  }
+
+  .caret {
+    display: inline-flex;
+    align-items: center;
+    opacity: 0.55;
+    margin-left: var(--ni-6);
+    font-size: var(--font-size-tag);
+    transition:
+      transform var(--transition-increment) ease-out,
+      opacity var(--transition-increment) ease-out;
+  }
+
+  .trakt-match-pill:hover .caret,
+  .trakt-match-pill:focus-visible .caret {
+    opacity: 0.9;
+    transform: translateX(var(--ni-2));
   }
 
   // Skeleton inner blocks sized to typical pill content so the outer

--- a/projects/client/src/lib/sections/profile/components/_internal/MatchDrawer.svelte
+++ b/projects/client/src/lib/sections/profile/components/_internal/MatchDrawer.svelte
@@ -4,17 +4,18 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import type { UserMatch } from "$lib/requests/models/UserMatch";
   import { toPercentage } from "$lib/utils/formatting/number/toPercentage";
-  import { matchLabel } from "./matchLabel";
+  import { toDisplayableName } from "$lib/utils/profile/toDisplayableName.ts";
+  import type { DisplayableProfileProps } from "../../DisplayableProfileProps.ts";
   import { chipTier } from "./chipTier.ts";
+  import { matchLabel } from "./matchLabel";
   import SharedMediaPoster from "./SharedMediaPoster.svelte";
 
-  const {
-    onClose,
-    match,
-  }: {
+  type MatchDrawerProps = {
     onClose: () => void;
     match: UserMatch;
-  } = $props();
+  } & Pick<DisplayableProfileProps, "profile">;
+
+  const { onClose, match, profile }: MatchDrawerProps = $props();
 
   const score = $derived(match.score);
   const label = $derived(matchLabel(score));
@@ -50,6 +51,9 @@
 <Drawer {onClose} title={m.match_drawer_title()} size="auto">
   <div class="trakt-match-drawer">
     <div class="hero">
+      <p class="hero-subject bold">
+        {m.match_drawer_subject({ username: toDisplayableName(profile) })}
+      </p>
       <div class="gauge">
         <svg viewBox="0 0 36 36" aria-hidden="true">
           <path
@@ -68,6 +72,9 @@
         </div>
       </div>
       <p class="hero-label bold">{label}</p>
+      <p class="hero-caption secondary">
+        {m.match_drawer_overlap_caption()}
+      </p>
     </div>
 
     <section class="block">
@@ -226,10 +233,22 @@
     margin-left: 2px;
   }
 
+  .hero-subject {
+    margin: 0;
+    text-align: center;
+    font-size: var(--font-size-text);
+  }
+
   .hero-label {
     margin: 0;
     text-align: center;
     font-size: var(--font-size-separator);
+  }
+
+  .hero-caption {
+    margin: 0;
+    text-align: center;
+    font-size: var(--font-size-text-small);
   }
 
   .block {
@@ -307,7 +326,8 @@
     border-radius: var(--ni-12);
     background: color-mix(in srgb, var(--color-foreground) 6%, transparent);
     border: 1px solid transparent;
-    transition: background calc(var(--transition-increment) * 1) ease-out,
+    transition:
+      background calc(var(--transition-increment) * 1) ease-out,
       border-color calc(var(--transition-increment) * 1) ease-out,
       box-shadow calc(var(--transition-increment) * 1) ease-out,
       color calc(var(--transition-increment) * 1) ease-out;
@@ -329,8 +349,8 @@
       color-mix(in srgb, var(--color-foreground) 10%, transparent)
     );
     border-color: color-mix(in srgb, var(--color-foreground) 40%, transparent);
-    box-shadow: 0 0 0 1px
-        color-mix(in srgb, var(--color-foreground) 14%, transparent),
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--color-foreground) 14%, transparent),
       0 var(--ni-2) var(--ni-12)
         color-mix(in srgb, var(--color-foreground) 18%, transparent);
     font-weight: 600;
@@ -345,8 +365,8 @@
       color-mix(in srgb, var(--chip-unicorn) 14%, transparent)
     );
     border-color: color-mix(in srgb, var(--chip-unicorn) 60%, transparent);
-    box-shadow: 0 0 0 1px
-        color-mix(in srgb, var(--chip-unicorn) 28%, transparent),
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--chip-unicorn) 28%, transparent),
       0 var(--ni-2) var(--ni-14)
         color-mix(in srgb, var(--chip-unicorn) 40%, transparent);
     font-weight: 600;


### PR DESCRIPTION
## Why

Got friend feedback on the profile match UI. Two consistent reactions:

1. **Pill** reads `74% Crossover` with no anchor word. Visitors land on a profile, see a percentage next to a tonal label, and have no idea what's being measured or that it's even clickable.
2. **Drawer** opens with a ring and `Co-stars` headline, but never names who is being compared. People who do tap through still spend a moment parsing.

## What

### MatchPill

- Insert `match` anchor word between score and tonal label: `74% match · Crossover`. The plain-language hook anchors the percentage so first-time visitors can parse the pill at a glance.
- Add a right-side caret (`›`) with hover-slide. Standard drilldown affordance that matches the rest of the app (calendar controls, list titles, YIR header all use `CaretRightIcon` the same way).
- Pin pill height to `--ni-28` (matches `VipBadgeContent`) so MatchPill and the DIRECTOR/VIP badge share the row baseline next to the avatar.

### MatchDrawer

- New `You & @{username}` subject line above the gauge so the metric is framed as a comparison before the number is shown.
- `How your taste overlaps` caption under the tonal label, so the cinematic vocabulary (`Co-stars`, `Crossover`, `Spin-off`) has a plain-language explainer attached on first view.

### i18n

Three new keys (en defaults below, all auto-fallback for other locales until translations land):

| Key | Default |
|---|---|
| ``match_pill_anchor`` | `match` |
| ``match_drawer_subject`` | `You & @{username}` |
| ``match_drawer_overlap_caption`` | `How your taste overlaps` |

## Before / after

**Pill:**
- before: `74% Crossover`
- after: `74% match · Crossover ›`

**Drawer hero stack:**
- before: `[ring 76%] · Co-stars`
- after: `You & @klaus` / `[ring 76%]` / `Co-stars` / `How your taste overlaps`

## Test plan

- [ ] Open a public profile while logged in as another user. Pill renders the anchor word + caret; hover slides the caret 2px right.
- [ ] Pill height matches the DIRECTOR/VIP badge on VIP profiles.
- [ ] Tap pill → drawer opens with subject line + caption.
- [ ] Verify no regression in loading skeleton (placeholder dimensions unchanged).
- [ ] Verify aria-label on the pill still announces `{score}% match, {label}. Open match details.`