### PR TITLE
feat(lists): add rank reordering for user lists

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2763,6 +2763,19 @@
       "default": "Apply changes",
       "description": "Aria-label for the button that allows users to apply changes that are currently being edited."
     },
+    "button_text_reorder": {
+      "default": "Reorder",
+      "description": "Text for the button that opens a list reordering drawer."
+    },
+    "button_label_reorder_list": {
+      "default": "Reorder {name}",
+      "description": "Aria-label for the button that opens a list reordering drawer.",
+      "variables": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
     "button_text_continue": {
       "default": "Continue",
       "description": "Text for the button that allows users to continue to next screen etc."
@@ -6655,6 +6668,10 @@
     "drawer_title_sort": {
       "default": "Sort By",
       "description": "Title for the drawer containing sorting options for a user's list items. This should be as short and concise as possible."
+    },
+    "drawer_title_reorder_list": {
+      "default": "Drag to reorder",
+      "description": "Title for the drawer containing controls to reorder list items by dragging."
     },
     "header_sentiment_positive": {
       "default": "Positive",

--- a/projects/client/src/lib/components/drawer/Drawer.svelte
+++ b/projects/client/src/lib/components/drawer/Drawer.svelte
@@ -19,19 +19,21 @@
   const HEADER_OVERLAY_FADE_DISTANCE = 16;
 
   type DrawerProps = {
+    children: Snippet;
     onClose: () => void;
     title?: string;
     hasAutoClose?: boolean;
     trapSelector?: string;
     size?: "normal" | "large" | "auto";
     badge?: Snippet;
+    actions?: Snippet;
     metaInfo?: string | Snippet;
     onOpened?: () => void;
     classList?: string;
     variant?: "default" | "vip";
     drilldown?: ListDrilldownLinkProps;
     headerVariant?: "default" | "overlay";
-  } & ChildrenProps;
+  };
 
   const {
     children,
@@ -41,6 +43,7 @@
     trapSelector,
     size = "normal",
     badge,
+    actions,
     metaInfo,
     onOpened,
     classList = "",
@@ -148,19 +151,23 @@
       </div>
     {/if}
 
-    <RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>
-      <ActionButton
-        onclick={onClose}
-        label={m.button_label_close()}
-        style="ghost"
-        navigationType={DpadNavigationType.Item}
-        --color-foreground-default={headerVariant === "overlay"
-          ? "var(--color-text-primary)"
-          : "var(--color-text-secondary)"}
-      >
-        <CloseIcon />
-      </ActionButton>
-    </RenderFor>
+    <div class="trakt-drawer-actions">
+      {@render actions?.()}
+
+      <RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>
+        <ActionButton
+          onclick={onClose}
+          label={m.button_label_close()}
+          style="ghost"
+          navigationType={DpadNavigationType.Item}
+          --color-foreground-default={headerVariant === "overlay"
+            ? "var(--color-text-primary)"
+            : "var(--color-text-secondary)"}
+        >
+          <CloseIcon />
+        </ActionButton>
+      </RenderFor>
+    </div>
   </div>
 
   <div class="trakt-drawer-content" onscroll={updateHeaderOverlay}>
@@ -392,6 +399,13 @@
     &.has-title {
       justify-content: space-between;
     }
+  }
+
+  .trakt-drawer-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    flex-shrink: 0;
   }
 
   .trakt-drawer-content {

--- a/projects/client/src/lib/components/icons/ReorderIcon.svelte
+++ b/projects/client/src/lib/components/icons/ReorderIcon.svelte
@@ -1,0 +1,11 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 -960 960 960"
+  fill="currentColor"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M120-240v-80h720v80H120Zm0-200v-80h720v80H120Zm0-200v-80h720v80H120Z"
+  />
+</svg>

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.spec.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.spec.ts
@@ -23,4 +23,14 @@ describe('mapToConfirmation', () => {
     expect(result.operation).toBe('destructive');
     expect(result.message).toContain('harry');
   });
+
+  it('should build a destructive confirmation for DiscardChanges', () => {
+    const result = mapToConfirmation({
+      type: ConfirmationType.DiscardChanges,
+    });
+
+    expect(result.operation).toBe('destructive');
+    expect(result.buttonText).toBeTruthy();
+    expect(result.message).toBeTruthy();
+  });
 });

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
@@ -177,6 +177,12 @@ const CONFIRMATION_BUILDERS: ConfirmationBuilders = {
     message: m.confirmation_message_undo_sync(),
     operation: 'destructive',
   }),
+  [ConfirmationType.DiscardChanges]: () => ({
+    title: m.dialog_title_discard_changes(),
+    buttonText: m.button_text_discard(),
+    message: m.warning_prompt_discard_changes(),
+    operation: 'destructive',
+  }),
 };
 
 export function mapToConfirmation<T extends ConfirmationType>(

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
@@ -95,6 +95,9 @@ interface ConfirmationParamsMap {
   [ConfirmationType.UndoSync]: {
     type: ConfirmationType.UndoSync;
   };
+  [ConfirmationType.DiscardChanges]: {
+    type: ConfirmationType.DiscardChanges;
+  };
 }
 
 export type ConfirmationParams<T extends ConfirmationType> =

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
@@ -24,4 +24,5 @@ export enum ConfirmationType {
   HideRecommendation = 'hide-recommendation',
   UnlinkStreaming = 'unlink-streaming',
   UndoSync = 'undo-sync',
+  DiscardChanges = 'discard-changes',
 }

--- a/projects/client/src/lib/requests/queries/users/reorderListRequest.ts
+++ b/projects/client/src/lib/requests/queries/users/reorderListRequest.ts
@@ -1,0 +1,27 @@
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+
+type ReorderListParams = {
+  userId: string | number;
+  listId: string | number;
+  rank: number[];
+} & ApiParams;
+
+export async function reorderListRequest(
+  { fetch, userId, listId, rank }: ReorderListParams,
+): Promise<boolean> {
+  const response = await rawApiFetch({
+    fetch,
+    path: `/users/${encodeURIComponent(`${userId}`)}/lists/${
+      encodeURIComponent(`${listId}`)
+    }/items/reorder`,
+    init: {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ rank }),
+    },
+  });
+
+  return response.status === 200;
+}

--- a/projects/client/src/lib/sections/lists/user/ListActions.svelte
+++ b/projects/client/src/lib/sections/lists/user/ListActions.svelte
@@ -14,15 +14,18 @@
   import DeleteListButton from "./_internal/DeleteListButton.svelte";
   import EditListButton from "./_internal/EditListButton.svelte";
   import LikeListAction from "./_internal/LikeListAction.svelte";
+  import ListReorderDrawer from "./_internal/ListReorderDrawer.svelte";
   import SaveListDrawer from "./_internal/SaveListDrawer.svelte";
   import { useDeleteList } from "./_internal/useDeleteList";
   import { useLikeList } from "./_internal/useLikeList";
+  import ListReorderButton from "./ListReorderButton.svelte";
 
   const { list }: { list: MediaListSummary } = $props();
 
   const { deleteList, isDeleting, isDeleted } = $derived(useDeleteList(list));
 
   let showEditList = $state(false);
+  let showReorderList = $state(false);
 
   const { user } = useUser();
   const { likeList, unlikeList, isUpdating, isLiked } = $derived(
@@ -35,7 +38,12 @@
   );
 
   const handleLike = $derived(() => {
-    $isLiked ? unlikeList() : likeList();
+    if ($isLiked) {
+      unlikeList();
+      return;
+    }
+
+    likeList();
   });
 
   const isDisabled = $derived($isUpdating || isListOwner);
@@ -65,6 +73,11 @@
           textFactory={({ title: name }) => m.text_share_list({ name })}
           source={{ id: "user-list" }}
         />
+        <ListReorderButton
+          title={list.name}
+          disabled={$isDeleting}
+          onclick={() => (showReorderList = true)}
+        />
         <EditListButton
           {list}
           isDeleting={$isDeleting}
@@ -87,4 +100,12 @@
 
 {#if showEditList}
   <SaveListDrawer type="update" onClose={() => (showEditList = false)} {list} />
+{/if}
+
+{#if showReorderList}
+  <ListReorderDrawer
+    title={list.name}
+    source={{ type: "user-list", list }}
+    onClose={() => (showReorderList = false)}
+  />
 {/if}

--- a/projects/client/src/lib/sections/lists/user/ListReorderButton.svelte
+++ b/projects/client/src/lib/sections/lists/user/ListReorderButton.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import ReorderIcon from "$lib/components/icons/ReorderIcon.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+
+  const {
+    title,
+    disabled,
+    onclick,
+  }: {
+    title: string;
+    disabled?: boolean;
+    onclick: () => void;
+  } = $props();
+</script>
+
+<DropdownItem
+  label={m.button_label_reorder_list({ name: title })}
+  style="flat"
+  color="default"
+  variant="secondary"
+  {disabled}
+  {onclick}
+>
+  {m.button_text_reorder()}
+
+  {#snippet icon()}
+    <ReorderIcon />
+  {/snippet}
+</DropdownItem>

--- a/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
@@ -5,27 +5,24 @@
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType.ts";
   import { useConfirm } from "$lib/features/confirmation/useConfirm.ts";
-  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import { InvalidateAction } from "$lib/requests/models/InvalidateAction.ts";
   import { reorderListRequest } from "$lib/requests/queries/users/reorderListRequest.ts";
   import { useInvalidator } from "$lib/stores/useInvalidator.ts";
   import { assertDefined } from "$lib/utils/assert/assertDefined.ts";
   import { MEDIA_POSTER_PLACEHOLDER } from "$lib/utils/assets.ts";
-  import { onDestroy } from "svelte";
   import { flip } from "svelte/animate";
   import { cubicOut } from "svelte/easing";
   import type { ReorderListSource } from "../models/ReorderListSource.ts";
   import type { ReorderableListItem } from "./models/ReorderableListItem.ts";
+  import { type DragGhost, reorderDrag } from "./reorderDrag.ts";
   import {
     itemOrderSignature,
     listItemRankIds,
     sortReorderableItems,
   } from "./reorderListItems.ts";
   import { useReorderList } from "./useReorderList.ts";
-
-  const autoScrollEdgeSize = 88;
-  const autoScrollMaxFrameDistance = 14;
 
   const {
     source,
@@ -41,29 +38,23 @@
   const { invalidateAll } = useInvalidator();
   const { confirm } = useConfirm();
 
-  let orderedItems = $state<ReorderableListItem[]>([]);
-  let loadedSignature = $state("");
+  let localOrder = $state<{
+    signature: string;
+    items: ReorderableListItem[];
+  } | null>(null);
   let isApplying = $state(false);
   let draggedKey = $state<string | null>(null);
   let instantPosterKeys = $state<readonly string[]>([]);
   let placeholderIndex = $state<number | null>(null);
-  let dragPointerId = $state<number | null>(null);
-  let dragCaptureElement: HTMLElement | null = null;
-  let dragClientY = 0;
-  let autoScrollFrame: number | null = null;
-  let scrollContainer: HTMLElement | null = null;
-  let dragGhost = $state<{
-    top: number;
-    left: number;
-    width: number;
-    height: number;
-    offsetX: number;
-    offsetY: number;
-  } | null>(null);
-  let tableBody = $state<HTMLTableSectionElement | null>(null);
+  let dragGhost = $state<DragGhost | null>(null);
 
-  const rankOrderedItems = $derived(sortReorderableItems($list));
+  const rankOrderedItems = $derived(sortReorderableItems($list ?? []));
   const rankSignature = $derived(itemOrderSignature(rankOrderedItems));
+  const orderedItems = $derived(
+    localOrder?.signature === rankSignature
+      ? localOrder.items
+      : rankOrderedItems,
+  );
   const orderedSignature = $derived(itemOrderSignature(orderedItems));
   const isLoaded = $derived(!$isLoading);
   const hasChanges = $derived(isLoaded && orderedSignature !== rankSignature);
@@ -79,9 +70,8 @@
   const draggedItemRank = $derived(
     draggedKey == null
       ? null
-      : (placeholderIndex ?? orderedItems.findIndex((item) =>
-        item.key === draggedKey
-      )) + 1,
+      : (placeholderIndex ??
+          orderedItems.findIndex((item) => item.key === draggedKey)) + 1,
   );
   const dragGhostStyle = $derived(
     dragGhost == null
@@ -114,46 +104,6 @@
     return rows;
   });
 
-  $effect(() => {
-    if (!isLoaded || loadedSignature === rankSignature) {
-      return;
-    }
-
-    orderedItems = rankOrderedItems;
-    instantPosterKeys = [];
-    loadedSignature = rankSignature;
-  });
-
-  function draggedItemIndex() {
-    if (!draggedKey) {
-      return -1;
-    }
-
-    return orderedItems.findIndex((item) => item.key === draggedKey);
-  }
-
-  function getPointerDropIndex(clientY: number) {
-    if (draggedItemIndex() < 0) {
-      return null;
-    }
-
-    const rows = Array.from(
-      tableBody?.querySelectorAll<HTMLTableRowElement>("[data-reorder-key]") ??
-        [],
-    );
-
-    if (rows.length === 0) {
-      return 0;
-    }
-
-    const targetIndex = rows.findIndex((row) => {
-      const rect = row.getBoundingClientRect();
-      return clientY < rect.top + rect.height / 2;
-    });
-
-    return targetIndex < 0 ? rows.length : targetIndex;
-  }
-
   function itemRank(index: number) {
     if (placeholderIndex == null || index < placeholderIndex) {
       return index + 1;
@@ -162,230 +112,53 @@
     return index + 2;
   }
 
-  function commitDrag() {
-    if (!draggedItem || placeholderIndex == null) {
-      return;
-    }
-
-    orderedItems = [
-      ...visibleItems.slice(0, placeholderIndex),
-      draggedItem,
-      ...visibleItems.slice(placeholderIndex),
-    ];
-  }
-
-  function disablePosterAnimation(itemKey: string | null) {
-    if (itemKey == null || instantPosterKeys.includes(itemKey)) {
-      return;
-    }
-
-    instantPosterKeys = [...instantPosterKeys, itemKey];
-  }
-
   function shouldAnimatePoster(item: ReorderableListItem) {
     return !instantPosterKeys.includes(item.key);
   }
 
-  function endDrag() {
-    stopAutoScroll();
+  function onDragStart(key: string, ghost: DragGhost, fromIndex: number) {
+    draggedKey = key;
+    dragGhost = ghost;
+    placeholderIndex = fromIndex;
+  }
 
-    if (dragPointerId != null && dragCaptureElement != null) {
-      try {
-        if (dragCaptureElement.hasPointerCapture(dragPointerId)) {
-          dragCaptureElement.releasePointerCapture(dragPointerId);
-        }
-      } catch {
-        // The browser may already have released capture during pointercancel.
+  function onGhostMove(ghost: DragGhost) {
+    dragGhost = ghost;
+  }
+
+  function onPlaceholderMove(index: number) {
+    placeholderIndex = index;
+  }
+
+  function onDragEnd(
+    key: string | null,
+    finalIndex: number | null,
+    cancelled: boolean,
+  ) {
+    if (!cancelled && key != null && finalIndex != null) {
+      const item = orderedItems.find((i) => i.key === key);
+
+      if (item) {
+        const visible = orderedItems.filter((i) => i.key !== key);
+
+        localOrder = {
+          signature: rankSignature,
+          items: [
+            ...visible.slice(0, finalIndex),
+            item,
+            ...visible.slice(finalIndex),
+          ],
+        };
+      }
+
+      if (!instantPosterKeys.includes(key)) {
+        instantPosterKeys = [...instantPosterKeys, key];
       }
     }
 
     draggedKey = null;
     placeholderIndex = null;
-    dragPointerId = null;
-    dragCaptureElement = null;
-    scrollContainer = null;
     dragGhost = null;
-    window.removeEventListener("pointermove", handlePointerMove);
-    window.removeEventListener("pointerup", handlePointerEnd);
-    window.removeEventListener("pointercancel", handlePointerCancel);
-  }
-
-  function updateGhostPosition(clientX: number, clientY: number) {
-    if (!dragGhost) {
-      return;
-    }
-
-    dragGhost = {
-      ...dragGhost,
-      left: clientX - dragGhost.offsetX,
-      top: clientY - dragGhost.offsetY,
-    };
-  }
-
-  function updatePlaceholderIndex(clientY: number) {
-    const toIndex = getPointerDropIndex(clientY);
-
-    if (toIndex == null || toIndex === placeholderIndex) {
-      return;
-    }
-
-    placeholderIndex = toIndex;
-  }
-
-  function updateDragPointer(clientX: number, clientY: number) {
-    dragClientY = clientY;
-    updateGhostPosition(clientX, clientY);
-    updatePlaceholderIndex(clientY);
-  }
-
-  function getScrollContainer() {
-    const element = tableBody?.closest(".trakt-drawer-content");
-
-    return element instanceof HTMLElement ? element : null;
-  }
-
-  function getAutoScrollStep(distanceFromEdge: number) {
-    const distance = Math.max(distanceFromEdge, 0);
-    const intensity = Math.min(
-      (autoScrollEdgeSize - distance) / autoScrollEdgeSize,
-      1,
-    );
-
-    return Math.ceil(autoScrollMaxFrameDistance * intensity);
-  }
-
-  function getAutoScrollDistance() {
-    if (scrollContainer == null) {
-      return 0;
-    }
-
-    const containerRect = scrollContainer.getBoundingClientRect();
-    const distanceFromTop = dragClientY - containerRect.top;
-    const distanceFromBottom = containerRect.bottom - dragClientY;
-    const maxScrollTop = scrollContainer.scrollHeight -
-      scrollContainer.clientHeight;
-
-    if (distanceFromTop < autoScrollEdgeSize && scrollContainer.scrollTop > 0) {
-      return -getAutoScrollStep(distanceFromTop);
-    }
-
-    if (
-      distanceFromBottom < autoScrollEdgeSize &&
-      scrollContainer.scrollTop < maxScrollTop
-    ) {
-      return getAutoScrollStep(distanceFromBottom);
-    }
-
-    return 0;
-  }
-
-  function handleAutoScroll() {
-    autoScrollFrame = null;
-
-    if (dragPointerId == null || scrollContainer == null) {
-      return;
-    }
-
-    const scrollDistance = getAutoScrollDistance();
-    const previousScrollTop = scrollContainer.scrollTop;
-
-    scrollContainer.scrollTop += scrollDistance;
-
-    if (scrollContainer.scrollTop !== previousScrollTop) {
-      updatePlaceholderIndex(dragClientY);
-    }
-
-    startAutoScroll();
-  }
-
-  function startAutoScroll() {
-    if (autoScrollFrame != null) {
-      return;
-    }
-
-    autoScrollFrame = requestAnimationFrame(handleAutoScroll);
-  }
-
-  function stopAutoScroll() {
-    if (autoScrollFrame == null) {
-      return;
-    }
-
-    cancelAnimationFrame(autoScrollFrame);
-    autoScrollFrame = null;
-  }
-
-  function handlePointerMove(event: PointerEvent) {
-    if (dragPointerId !== event.pointerId) {
-      return;
-    }
-
-    event.preventDefault();
-    updateDragPointer(event.clientX, event.clientY);
-  }
-
-  function handlePointerEnd(event: PointerEvent) {
-    if (dragPointerId !== event.pointerId) {
-      return;
-    }
-
-    disablePosterAnimation(draggedKey);
-    commitDrag();
-    endDrag();
-  }
-
-  function handlePointerCancel(event: PointerEvent) {
-    if (dragPointerId !== event.pointerId) {
-      return;
-    }
-
-    disablePosterAnimation(draggedKey);
-    endDrag();
-  }
-
-  function handleDragStart(event: PointerEvent, item: ReorderableListItem) {
-    if (event.button !== 0) {
-      return;
-    }
-
-    event.preventDefault();
-    endDrag();
-
-    const row = event.currentTarget as HTMLTableRowElement;
-    const rowRect = row.getBoundingClientRect();
-    const fromIndex = orderedItems.findIndex((orderedItem) =>
-      orderedItem.key === item.key
-    );
-    if (fromIndex < 0) {
-      return;
-    }
-
-    dragCaptureElement = tableBody ?? row;
-    try {
-      dragCaptureElement.setPointerCapture(event.pointerId);
-    } catch {
-      dragCaptureElement = null;
-    }
-
-    draggedKey = item.key;
-    placeholderIndex = fromIndex;
-    dragPointerId = event.pointerId;
-    scrollContainer = getScrollContainer();
-    dragClientY = event.clientY;
-    dragGhost = {
-      top: rowRect.top,
-      left: rowRect.left,
-      width: rowRect.width,
-      height: rowRect.height,
-      offsetX: event.clientX - rowRect.left,
-      offsetY: event.clientY - rowRect.top,
-    };
-    window.addEventListener("pointermove", handlePointerMove, {
-      passive: false,
-    });
-    window.addEventListener("pointerup", handlePointerEnd);
-    window.addEventListener("pointercancel", handlePointerCancel);
-    startAutoScroll();
   }
 
   async function requestReorder() {
@@ -448,8 +221,6 @@
       },
     };
   }
-
-  onDestroy(endDrag);
 </script>
 
 {#snippet itemSummary(item: ReorderableListItem, animatePoster = true)}
@@ -512,7 +283,13 @@
     {:else}
       <table class="reorder-table">
         <tbody
-          bind:this={tableBody}
+          use:reorderDrag={{
+            getItems: () => orderedItems,
+            onDragStart,
+            onGhostMove,
+            onPlaceholderMove,
+            onDragEnd,
+          }}
           class:has-active-drag={draggedKey != null}
         >
           {#each renderRows as row (row.key)}
@@ -520,11 +297,6 @@
               data-reorder-key={row.type === "item" ? row.item.key : undefined}
               class:drag-placeholder={row.type === "placeholder"}
               animate:flip={{ duration: 220, easing: cubicOut }}
-              onpointerdown={(event) => {
-                if (row.type === "item") {
-                  handleDragStart(event, row.item);
-                }
-              }}
             >
               <td class="rank-cell">
                 {#if row.type === "item"}
@@ -611,7 +383,6 @@
   tbody {
     tr {
       cursor: grab;
-      touch-action: none;
       filter: drop-shadow(
         var(--ni-1) var(--ni-1) var(--ni-4)
           color-mix(in srgb, var(--color-shadow) 10%, transparent)
@@ -626,6 +397,9 @@
     }
 
     td {
+      touch-action: none;
+      user-select: none;
+      -webkit-user-select: none;
       background: var(--reorder-row-background);
 
       &:first-child {
@@ -708,6 +482,8 @@
     flex-shrink: 0;
     border-radius: var(--border-radius-s);
     background-color: var(--color-surface-button-disabled);
+    pointer-events: none;
+    -webkit-user-drag: none;
   }
 
   .item-title {

--- a/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
@@ -1,0 +1,777 @@
+<script lang="ts">
+  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import CheckIcon from "$lib/components/icons/CheckIcon.svelte";
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { InvalidateAction } from "$lib/requests/models/InvalidateAction.ts";
+  import { reorderListRequest } from "$lib/requests/queries/users/reorderListRequest.ts";
+  import { useInvalidator } from "$lib/stores/useInvalidator.ts";
+  import { assertDefined } from "$lib/utils/assert/assertDefined.ts";
+  import { MEDIA_POSTER_PLACEHOLDER } from "$lib/utils/assets.ts";
+  import { onDestroy } from "svelte";
+  import { flip } from "svelte/animate";
+  import { cubicOut } from "svelte/easing";
+  import type { ReorderListSource } from "../models/ReorderListSource.ts";
+  import type { ReorderableListItem } from "./models/ReorderableListItem.ts";
+  import {
+    itemOrderSignature,
+    listItemRankIds,
+    sortReorderableItems,
+  } from "./reorderListItems.ts";
+  import { useReorderList } from "./useReorderList.ts";
+
+  const autoScrollEdgeSize = 88;
+  const autoScrollMaxFrameDistance = 14;
+
+  const {
+    source,
+    title,
+    onClose,
+  }: {
+    source: ReorderListSource;
+    title: string;
+    onClose: () => void;
+  } = $props();
+
+  const { list, isLoading, hasNextPage, fetchNextPage } = $derived(
+    useReorderList(source),
+  );
+  const { invalidateAll } = useInvalidator();
+
+  let orderedItems = $state<ReorderableListItem[]>([]);
+  let loadedSignature = $state("");
+  let isFetchingNextPage = $state(false);
+  let isApplying = $state(false);
+  let draggedKey = $state<string | null>(null);
+  let instantPosterKeys = $state<readonly string[]>([]);
+  let placeholderIndex = $state<number | null>(null);
+  let dragPointerId = $state<number | null>(null);
+  let dragCaptureElement: HTMLElement | null = null;
+  let dragClientY = 0;
+  let autoScrollFrame: number | null = null;
+  let scrollContainer: HTMLElement | null = null;
+  let dragGhost = $state<{
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+    offsetX: number;
+    offsetY: number;
+  } | null>(null);
+  let tableBody = $state<HTMLTableSectionElement | null>(null);
+
+  const rankOrderedItems = $derived(sortReorderableItems($list));
+  const rankSignature = $derived(itemOrderSignature(rankOrderedItems));
+  const orderedSignature = $derived(itemOrderSignature(orderedItems));
+  const isLoaded = $derived(!$isLoading && !$hasNextPage);
+  const hasChanges = $derived(isLoaded && orderedSignature !== rankSignature);
+  const canApply = $derived(hasChanges && !isApplying);
+  const draggedItem = $derived(
+    orderedItems.find((item) => item.key === draggedKey),
+  );
+  const visibleItems = $derived(
+    draggedKey == null
+      ? orderedItems
+      : orderedItems.filter((item) => item.key !== draggedKey),
+  );
+  const draggedItemRank = $derived(
+    draggedKey == null
+      ? null
+      : (placeholderIndex ?? orderedItems.findIndex((item) =>
+        item.key === draggedKey
+      )) + 1,
+  );
+  const dragGhostStyle = $derived(
+    dragGhost == null
+      ? ""
+      : `top: ${dragGhost.top}px; left: ${dragGhost.left}px; width: ${dragGhost.width}px; height: ${dragGhost.height}px;`,
+  );
+  const renderRows = $derived.by(() => {
+    const rows: (
+      | { key: string; type: "placeholder" }
+      | { key: string; type: "item"; item: ReorderableListItem; rank: number }
+    )[] = [];
+
+    visibleItems.forEach((item, index) => {
+      if (placeholderIndex === index) {
+        rows.push({ key: "drag-placeholder", type: "placeholder" });
+      }
+
+      rows.push({
+        key: item.key,
+        type: "item",
+        item,
+        rank: itemRank(index),
+      });
+    });
+
+    if (placeholderIndex === visibleItems.length) {
+      rows.push({ key: "drag-placeholder", type: "placeholder" });
+    }
+
+    return rows;
+  });
+
+  $effect(() => {
+    if ($isLoading || !$hasNextPage || isFetchingNextPage) {
+      return;
+    }
+
+    isFetchingNextPage = true;
+    void fetchNextPage().finally(() => {
+      isFetchingNextPage = false;
+    });
+  });
+
+  $effect(() => {
+    if (!isLoaded || loadedSignature === rankSignature) {
+      return;
+    }
+
+    orderedItems = rankOrderedItems;
+    instantPosterKeys = [];
+    loadedSignature = rankSignature;
+  });
+
+  function draggedItemIndex() {
+    if (!draggedKey) {
+      return -1;
+    }
+
+    return orderedItems.findIndex((item) => item.key === draggedKey);
+  }
+
+  function getPointerDropIndex(clientY: number) {
+    if (draggedItemIndex() < 0) {
+      return null;
+    }
+
+    const rows = Array.from(
+      tableBody?.querySelectorAll<HTMLTableRowElement>("[data-reorder-key]") ??
+        [],
+    );
+
+    if (rows.length === 0) {
+      return 0;
+    }
+
+    const targetIndex = rows.findIndex((row) => {
+      const rect = row.getBoundingClientRect();
+      return clientY < rect.top + rect.height / 2;
+    });
+
+    return targetIndex < 0 ? rows.length : targetIndex;
+  }
+
+  function itemRank(index: number) {
+    if (placeholderIndex == null || index < placeholderIndex) {
+      return index + 1;
+    }
+
+    return index + 2;
+  }
+
+  function commitDrag() {
+    if (!draggedItem || placeholderIndex == null) {
+      return;
+    }
+
+    orderedItems = [
+      ...visibleItems.slice(0, placeholderIndex),
+      draggedItem,
+      ...visibleItems.slice(placeholderIndex),
+    ];
+  }
+
+  function disablePosterAnimation(itemKey: string | null) {
+    if (itemKey == null || instantPosterKeys.includes(itemKey)) {
+      return;
+    }
+
+    instantPosterKeys = [...instantPosterKeys, itemKey];
+  }
+
+  function shouldAnimatePoster(item: ReorderableListItem) {
+    return !instantPosterKeys.includes(item.key);
+  }
+
+  function endDrag() {
+    stopAutoScroll();
+
+    if (dragPointerId != null && dragCaptureElement != null) {
+      try {
+        if (dragCaptureElement.hasPointerCapture(dragPointerId)) {
+          dragCaptureElement.releasePointerCapture(dragPointerId);
+        }
+      } catch {
+        // The browser may already have released capture during pointercancel.
+      }
+    }
+
+    draggedKey = null;
+    placeholderIndex = null;
+    dragPointerId = null;
+    dragCaptureElement = null;
+    scrollContainer = null;
+    dragGhost = null;
+    window.removeEventListener("pointermove", handlePointerMove);
+    window.removeEventListener("pointerup", handlePointerEnd);
+    window.removeEventListener("pointercancel", handlePointerCancel);
+  }
+
+  function updateGhostPosition(clientX: number, clientY: number) {
+    if (!dragGhost) {
+      return;
+    }
+
+    dragGhost = {
+      ...dragGhost,
+      left: clientX - dragGhost.offsetX,
+      top: clientY - dragGhost.offsetY,
+    };
+  }
+
+  function updatePlaceholderIndex(clientY: number) {
+    const toIndex = getPointerDropIndex(clientY);
+
+    if (toIndex == null || toIndex === placeholderIndex) {
+      return;
+    }
+
+    placeholderIndex = toIndex;
+  }
+
+  function updateDragPointer(clientX: number, clientY: number) {
+    dragClientY = clientY;
+    updateGhostPosition(clientX, clientY);
+    updatePlaceholderIndex(clientY);
+  }
+
+  function getScrollContainer() {
+    const element = tableBody?.closest(".trakt-drawer-content");
+
+    return element instanceof HTMLElement ? element : null;
+  }
+
+  function getAutoScrollStep(distanceFromEdge: number) {
+    const distance = Math.max(distanceFromEdge, 0);
+    const intensity = Math.min(
+      (autoScrollEdgeSize - distance) / autoScrollEdgeSize,
+      1,
+    );
+
+    return Math.ceil(autoScrollMaxFrameDistance * intensity);
+  }
+
+  function getAutoScrollDistance() {
+    if (scrollContainer == null) {
+      return 0;
+    }
+
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const distanceFromTop = dragClientY - containerRect.top;
+    const distanceFromBottom = containerRect.bottom - dragClientY;
+    const maxScrollTop = scrollContainer.scrollHeight -
+      scrollContainer.clientHeight;
+
+    if (distanceFromTop < autoScrollEdgeSize && scrollContainer.scrollTop > 0) {
+      return -getAutoScrollStep(distanceFromTop);
+    }
+
+    if (
+      distanceFromBottom < autoScrollEdgeSize &&
+      scrollContainer.scrollTop < maxScrollTop
+    ) {
+      return getAutoScrollStep(distanceFromBottom);
+    }
+
+    return 0;
+  }
+
+  function handleAutoScroll() {
+    autoScrollFrame = null;
+
+    if (dragPointerId == null || scrollContainer == null) {
+      return;
+    }
+
+    const scrollDistance = getAutoScrollDistance();
+    const previousScrollTop = scrollContainer.scrollTop;
+
+    scrollContainer.scrollTop += scrollDistance;
+
+    if (scrollContainer.scrollTop !== previousScrollTop) {
+      updatePlaceholderIndex(dragClientY);
+    }
+
+    startAutoScroll();
+  }
+
+  function startAutoScroll() {
+    if (autoScrollFrame != null) {
+      return;
+    }
+
+    autoScrollFrame = requestAnimationFrame(handleAutoScroll);
+  }
+
+  function stopAutoScroll() {
+    if (autoScrollFrame == null) {
+      return;
+    }
+
+    cancelAnimationFrame(autoScrollFrame);
+    autoScrollFrame = null;
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (dragPointerId !== event.pointerId) {
+      return;
+    }
+
+    event.preventDefault();
+    updateDragPointer(event.clientX, event.clientY);
+  }
+
+  function handlePointerEnd(event: PointerEvent) {
+    if (dragPointerId !== event.pointerId) {
+      return;
+    }
+
+    disablePosterAnimation(draggedKey);
+    commitDrag();
+    endDrag();
+  }
+
+  function handlePointerCancel(event: PointerEvent) {
+    if (dragPointerId !== event.pointerId) {
+      return;
+    }
+
+    disablePosterAnimation(draggedKey);
+    endDrag();
+  }
+
+  function handleDragStart(event: PointerEvent, item: ReorderableListItem) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    event.preventDefault();
+    endDrag();
+
+    const row = event.currentTarget as HTMLTableRowElement;
+    const rowRect = row.getBoundingClientRect();
+    const fromIndex = orderedItems.findIndex((orderedItem) =>
+      orderedItem.key === item.key
+    );
+    if (fromIndex < 0) {
+      return;
+    }
+
+    dragCaptureElement = tableBody ?? row;
+    try {
+      dragCaptureElement.setPointerCapture(event.pointerId);
+    } catch {
+      dragCaptureElement = null;
+    }
+
+    draggedKey = item.key;
+    placeholderIndex = fromIndex;
+    dragPointerId = event.pointerId;
+    scrollContainer = getScrollContainer();
+    dragClientY = event.clientY;
+    dragGhost = {
+      top: rowRect.top,
+      left: rowRect.left,
+      width: rowRect.width,
+      height: rowRect.height,
+      offsetX: event.clientX - rowRect.left,
+      offsetY: event.clientY - rowRect.top,
+    };
+    window.addEventListener("pointermove", handlePointerMove, {
+      passive: false,
+    });
+    window.addEventListener("pointerup", handlePointerEnd);
+    window.addEventListener("pointercancel", handlePointerCancel);
+    startAutoScroll();
+  }
+
+  async function requestReorder() {
+    return reorderListRequest({
+      userId: assertDefined(
+        source.list.user.slug,
+        "Expected user list to have a user slug",
+      ),
+      listId: source.list.id,
+      rank: listItemRankIds(orderedItems),
+    });
+  }
+
+  async function refreshReorderedItems() {
+    await invalidateAll([
+      InvalidateAction.Listed("movie"),
+      InvalidateAction.Listed("show"),
+    ]);
+  }
+
+  async function handleApply() {
+    if (!canApply) {
+      return;
+    }
+
+    isApplying = true;
+
+    try {
+      const result = await requestReorder();
+
+      if (result) {
+        onClose();
+        await refreshReorderedItems();
+      }
+    } catch {
+      // drawer stays open for retry
+    } finally {
+      isApplying = false;
+    }
+  }
+
+  function dragGhostPortal(node: HTMLElement) {
+    document.body.appendChild(node);
+
+    return {
+      destroy() {
+        node.remove();
+      },
+    };
+  }
+
+  onDestroy(endDrag);
+</script>
+
+{#snippet itemSummary(item: ReorderableListItem, animatePoster = true)}
+  <div class="item-summary">
+    <CrossOriginImage
+      src={item.posterUrl ?? MEDIA_POSTER_PLACEHOLDER}
+      alt={m.image_alt_media_poster({ title: item.title })}
+      animate={animatePoster}
+      loading={animatePoster ? "lazy" : "eager"}
+      classList="reorder-item-poster"
+    />
+    <div class="item-title">
+      <span class="bold ellipsis">{item.title}</span>
+      {#if item.subtitle}
+        <span class="small secondary ellipsis">
+          {item.subtitle}
+        </span>
+      {/if}
+    </div>
+  </div>
+{/snippet}
+
+{#snippet dragHandle()}
+  <div class="drag-handle" aria-hidden="true">
+    <span></span>
+    <span></span>
+    <span></span>
+    <span></span>
+    <span></span>
+    <span></span>
+  </div>
+{/snippet}
+
+<Drawer
+  {onClose}
+  title={m.drawer_title_reorder_list()}
+  metaInfo={title}
+  size="large"
+  headerVariant="overlay"
+>
+  {#snippet actions()}
+    <ActionButton
+      label={m.button_label_apply()}
+      color="purple"
+      disabled={!canApply}
+      onclick={handleApply}
+    >
+      <CheckIcon />
+    </ActionButton>
+  {/snippet}
+
+  <div class="reorder-drawer">
+    {#if !isLoaded}
+      <div class="reorder-loading" role="status" aria-live="polite">
+        <LoadingIndicator />
+        <p class="secondary bold">{m.yir_state_loading()}</p>
+      </div>
+    {:else if orderedItems.length === 0}
+      <p class="secondary">{m.list_placeholder_empty()}</p>
+    {:else}
+      <table class="reorder-table">
+        <tbody
+          bind:this={tableBody}
+          class:has-active-drag={draggedKey != null}
+        >
+          {#each renderRows as row (row.key)}
+            <tr
+              data-reorder-key={row.type === "item" ? row.item.key : undefined}
+              class:drag-placeholder={row.type === "placeholder"}
+              animate:flip={{ duration: 220, easing: cubicOut }}
+              onpointerdown={(event) => {
+                if (row.type === "item") {
+                  handleDragStart(event, row.item);
+                }
+              }}
+            >
+              <td class="rank-cell">
+                {#if row.type === "item"}
+                  <span class="bold">#{row.rank}</span>
+                {/if}
+              </td>
+              <td>
+                {#if row.type === "item"}
+                  {@render itemSummary(row.item, shouldAnimatePoster(row.item))}
+                {:else}
+                  <div class="placeholder-space"></div>
+                {/if}
+              </td>
+              <td class="actions-cell">
+                {#if row.type === "item"}
+                  <div class="reorder-actions">
+                    {@render dragHandle()}
+                  </div>
+                {/if}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </div>
+
+  {#if draggedItem && dragGhost && draggedItemRank != null}
+    <div
+      class="drag-ghost"
+      style={dragGhostStyle}
+      aria-hidden="true"
+      use:dragGhostPortal
+    >
+      <div class="ghost-cell rank-cell">
+        <span class="bold">#{draggedItemRank}</span>
+      </div>
+      <div class="ghost-cell">
+        {@render itemSummary(draggedItem, false)}
+      </div>
+      <div class="ghost-cell actions-cell">
+        <div class="reorder-actions">
+          {@render dragHandle()}
+        </div>
+      </div>
+    </div>
+  {/if}
+</Drawer>
+
+<style lang="scss">
+  .reorder-drawer {
+    --reorder-row-background: var(--color-card-background);
+
+    min-height: 100%;
+    padding-bottom: var(--gap-m);
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+  }
+
+  .reorder-loading {
+    min-height: var(--ni-220);
+    display: grid;
+    align-content: center;
+    justify-items: center;
+    gap: var(--gap-xs);
+  }
+
+  .reorder-table {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: separate;
+    border-spacing: 0 calc((var(--gap-xs) + var(--gap-s)) / 2);
+  }
+
+  td {
+    box-sizing: border-box;
+    position: relative;
+    padding: var(--ni-8);
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  tbody {
+    tr {
+      cursor: grab;
+      touch-action: none;
+      filter: drop-shadow(
+        var(--ni-1) var(--ni-1) var(--ni-4)
+          color-mix(in srgb, var(--color-shadow) 10%, transparent)
+      );
+      transition: opacity var(--transition-increment) ease-in-out;
+    }
+
+    &.has-active-drag {
+      tr:not(.drag-placeholder) {
+        opacity: var(--de-emphasized-opacity);
+      }
+    }
+
+    td {
+      background: var(--reorder-row-background);
+
+      &:first-child {
+        border-top-left-radius: var(--border-radius-m);
+        border-bottom-left-radius: var(--border-radius-m);
+      }
+
+      &:last-child {
+        border-top-right-radius: var(--border-radius-m);
+        border-bottom-right-radius: var(--border-radius-m);
+      }
+    }
+  }
+
+  .drag-placeholder {
+    cursor: grabbing;
+    filter: none;
+    pointer-events: none;
+
+    td {
+      background: transparent;
+
+      &::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        box-sizing: border-box;
+        pointer-events: none;
+        border-top: var(--border-thickness-xxs) dashed
+          color-mix(in srgb, var(--color-background-purple) 48%, transparent);
+        border-bottom: var(--border-thickness-xxs) dashed
+          color-mix(in srgb, var(--color-background-purple) 48%, transparent);
+      }
+
+      &:first-child {
+        &::after {
+          border-left: var(--border-thickness-xxs) dashed
+            color-mix(in srgb, var(--color-background-purple) 48%, transparent);
+          border-top-left-radius: var(--border-radius-m);
+          border-bottom-left-radius: var(--border-radius-m);
+        }
+      }
+
+      &:last-child {
+        &::after {
+          border-right: var(--border-thickness-xxs) dashed
+            color-mix(in srgb, var(--color-background-purple) 48%, transparent);
+          border-top-right-radius: var(--border-radius-m);
+          border-bottom-right-radius: var(--border-radius-m);
+        }
+      }
+    }
+  }
+
+  .placeholder-space {
+    min-height: calc(var(--ni-40) * 1.5);
+  }
+
+  .rank-cell {
+    width: var(--ni-56);
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .actions-cell {
+    width: var(--ni-56);
+  }
+
+  .item-summary {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+  }
+
+  .item-summary :global(.reorder-item-poster) {
+    width: var(--ni-40);
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
+    flex-shrink: 0;
+    border-radius: var(--border-radius-s);
+    background-color: var(--color-surface-button-disabled);
+  }
+
+  .item-title {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-micro);
+  }
+
+  .reorder-actions {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .drag-handle {
+    all: unset;
+    width: var(--ni-32);
+    height: var(--ni-32);
+    flex-shrink: 0;
+    display: grid;
+    grid-template-columns: repeat(2, var(--ni-4));
+    grid-template-rows: repeat(3, var(--ni-4));
+    place-content: center;
+    gap: var(--ni-3);
+    border-radius: var(--border-radius-m);
+    color: var(--color-text-secondary);
+    pointer-events: none;
+    touch-action: none;
+
+    span {
+      width: var(--ni-4);
+      height: var(--ni-4);
+      border-radius: 50%;
+      background: currentColor;
+    }
+  }
+
+  .drag-ghost {
+    position: fixed;
+    z-index: calc(var(--layer-top) + 1);
+    pointer-events: none;
+
+    display: grid;
+    grid-template-columns: var(--ni-56) minmax(0, 1fr) var(--ni-56);
+    align-items: center;
+    box-sizing: border-box;
+
+    border-radius: var(--border-radius-m);
+    background: var(--color-card-background);
+    box-shadow: var(--shadow-menu);
+    color: var(--color-text-primary);
+    opacity: 1;
+    overflow: hidden;
+    transform: translate3d(0, 0, 0);
+    will-change: left, top;
+
+    .ghost-cell {
+      box-sizing: border-box;
+      min-width: 0;
+      padding: var(--ni-8);
+    }
+
+    .drag-handle {
+      color: var(--color-text-primary);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
@@ -3,6 +3,8 @@
   import Drawer from "$lib/components/drawer/Drawer.svelte";
   import CheckIcon from "$lib/components/icons/CheckIcon.svelte";
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
+  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType.ts";
+  import { useConfirm } from "$lib/features/confirmation/useConfirm.ts";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import { InvalidateAction } from "$lib/requests/models/InvalidateAction.ts";
@@ -37,6 +39,7 @@
 
   const { list, isLoading } = $derived(useReorderList(source));
   const { invalidateAll } = useInvalidator();
+  const { confirm } = useConfirm();
 
   let orderedItems = $state<ReorderableListItem[]>([]);
   let loadedSignature = $state("");
@@ -424,6 +427,18 @@
     }
   }
 
+  function handleClose() {
+    if (!hasChanges) {
+      onClose();
+      return;
+    }
+
+    confirm({
+      type: ConfirmationType.DiscardChanges,
+      onConfirm: onClose,
+    })();
+  }
+
   function dragGhostPortal(node: HTMLElement) {
     document.body.appendChild(node);
 
@@ -469,7 +484,7 @@
 {/snippet}
 
 <Drawer
-  {onClose}
+  onClose={handleClose}
   title={m.drawer_title_reorder_list()}
   metaInfo={title}
   size="large"

--- a/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
@@ -35,14 +35,11 @@
     onClose: () => void;
   } = $props();
 
-  const { list, isLoading, hasNextPage, fetchNextPage } = $derived(
-    useReorderList(source),
-  );
+  const { list, isLoading } = $derived(useReorderList(source));
   const { invalidateAll } = useInvalidator();
 
   let orderedItems = $state<ReorderableListItem[]>([]);
   let loadedSignature = $state("");
-  let isFetchingNextPage = $state(false);
   let isApplying = $state(false);
   let draggedKey = $state<string | null>(null);
   let instantPosterKeys = $state<readonly string[]>([]);
@@ -65,7 +62,7 @@
   const rankOrderedItems = $derived(sortReorderableItems($list));
   const rankSignature = $derived(itemOrderSignature(rankOrderedItems));
   const orderedSignature = $derived(itemOrderSignature(orderedItems));
-  const isLoaded = $derived(!$isLoading && !$hasNextPage);
+  const isLoaded = $derived(!$isLoading);
   const hasChanges = $derived(isLoaded && orderedSignature !== rankSignature);
   const canApply = $derived(hasChanges && !isApplying);
   const draggedItem = $derived(
@@ -112,17 +109,6 @@
     }
 
     return rows;
-  });
-
-  $effect(() => {
-    if ($isLoading || !$hasNextPage || isFetchingNextPage) {
-      return;
-    }
-
-    isFetchingNextPage = true;
-    void fetchNextPage().finally(() => {
-      isFetchingNextPage = false;
-    });
   });
 
   $effect(() => {

--- a/projects/client/src/lib/sections/lists/user/_internal/models/ReorderableListItem.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/models/ReorderableListItem.ts
@@ -1,0 +1,8 @@
+export type ReorderableListItem = {
+  key: string;
+  listItemId: number;
+  rank: number;
+  title: string;
+  subtitle?: string;
+  posterUrl?: HttpsUrl;
+};

--- a/projects/client/src/lib/sections/lists/user/_internal/reorderDrag.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/reorderDrag.spec.ts
@@ -1,0 +1,323 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from 'vitest';
+import type { ReorderableListItem } from './models/ReorderableListItem.ts';
+import { type DragGhost, reorderDrag } from './reorderDrag.ts';
+
+const items: readonly ReorderableListItem[] = [
+  { key: 'a', listItemId: 1, rank: 1, title: 'A' },
+  { key: 'b', listItemId: 2, rank: 2, title: 'B' },
+  { key: 'c', listItemId: 3, rank: 3, title: 'C' },
+];
+
+function makeRow(
+  key: string,
+  top: number,
+  height: number,
+): HTMLTableRowElement {
+  const row = document.createElement('tr');
+  row.setAttribute('data-reorder-key', key);
+  vi.spyOn(row, 'getBoundingClientRect').mockReturnValue({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 100,
+    width: 100,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect);
+  return row;
+}
+
+describe('action: reorderDrag', () => {
+  let node: HTMLTableSectionElement;
+  let rowA: HTMLTableRowElement;
+  let rowB: HTMLTableRowElement;
+  let rowC: HTMLTableRowElement;
+  let onDragStart: Mock<
+    (key: string, ghost: DragGhost, fromIndex: number) => void
+  >;
+  let onGhostMove: Mock<(ghost: DragGhost) => void>;
+  let onPlaceholderMove: Mock<(index: number) => void>;
+  let onDragEnd: Mock<
+    (
+      key: string | null,
+      placeholderIndex: number | null,
+      cancelled: boolean,
+    ) => void
+  >;
+
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', vi.fn().mockReturnValue(1));
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+    node = document.createElement('tbody') as HTMLTableSectionElement;
+    // jsdom does not implement pointer capture — assign stubs directly
+    (node as unknown as Record<string, unknown>).setPointerCapture = vi.fn();
+    (node as unknown as Record<string, unknown>).hasPointerCapture = vi
+      .fn()
+      .mockReturnValue(false);
+    (node as unknown as Record<string, unknown>).releasePointerCapture = vi
+      .fn();
+
+    rowA = makeRow('a', 0, 50);
+    rowB = makeRow('b', 50, 50);
+    rowC = makeRow('c', 100, 50);
+    node.appendChild(rowA);
+    node.appendChild(rowB);
+    node.appendChild(rowC);
+    document.body.appendChild(node);
+
+    onDragStart = vi.fn();
+    onGhostMove = vi.fn();
+    onPlaceholderMove = vi.fn();
+    onDragEnd = vi.fn();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(node);
+    vi.unstubAllGlobals();
+  });
+
+  function createAction(
+    overrides: Partial<Parameters<typeof reorderDrag>[1]> = {},
+  ) {
+    return reorderDrag(node, {
+      getItems: () => items,
+      onDragStart,
+      onGhostMove,
+      onPlaceholderMove,
+      onDragEnd,
+      ...overrides,
+    });
+  }
+
+  function pointerDown(
+    target: HTMLElement,
+    { button = 0, pointerId = 1, clientX = 50, clientY = 25 } = {},
+  ) {
+    target.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        button,
+        pointerId,
+        clientX,
+        clientY,
+      }),
+    );
+  }
+
+  function pointerMove({ pointerId = 1, clientX = 60, clientY = 40 } = {}) {
+    node.dispatchEvent(
+      new PointerEvent('pointermove', {
+        bubbles: true,
+        pointerId,
+        clientX,
+        clientY,
+      }),
+    );
+  }
+
+  function pointerUp({ pointerId = 1 } = {}) {
+    node.dispatchEvent(
+      new PointerEvent('pointerup', { bubbles: true, pointerId }),
+    );
+  }
+
+  function pointerCancel({ pointerId = 1 } = {}) {
+    node.dispatchEvent(
+      new PointerEvent('pointercancel', { bubbles: true, pointerId }),
+    );
+  }
+
+  describe('pointerdown', () => {
+    it('should ignore non-primary button', () => {
+      createAction();
+      pointerDown(rowA, { button: 2 });
+      expect(onDragStart).not.toHaveBeenCalled();
+    });
+
+    it('should ignore elements without the row attribute', () => {
+      const cell = document.createElement('td');
+      node.appendChild(cell);
+      createAction();
+      pointerDown(cell);
+      expect(onDragStart).not.toHaveBeenCalled();
+    });
+
+    it('should ignore keys not present in the items list', () => {
+      const unknownRow = makeRow('unknown', 150, 50);
+      node.appendChild(unknownRow);
+      createAction();
+      pointerDown(unknownRow);
+      expect(onDragStart).not.toHaveBeenCalled();
+    });
+
+    it('should call onDragStart with key, ghost geometry, and fromIndex', () => {
+      createAction();
+      pointerDown(rowA, { clientX: 50, clientY: 25 });
+      expect(onDragStart).toHaveBeenCalledWith(
+        'a',
+        { top: 0, left: 0, width: 100, height: 50, offsetX: 50, offsetY: 25 },
+        0,
+      );
+    });
+
+    it('should resolve fromIndex from item position in list', () => {
+      createAction();
+      pointerDown(rowB, { clientX: 20, clientY: 60 });
+      expect(onDragStart).toHaveBeenCalledWith(
+        'b',
+        expect.objectContaining({ top: 50 }),
+        1,
+      );
+    });
+
+    it('should start the auto-scroll loop', () => {
+      createAction();
+      pointerDown(rowA);
+      expect(requestAnimationFrame).toHaveBeenCalled();
+    });
+  });
+
+  describe('pointermove', () => {
+    it('should ignore events from a different pointer', () => {
+      createAction();
+      pointerDown(rowA);
+      pointerMove({ pointerId: 99 });
+      expect(onGhostMove).not.toHaveBeenCalled();
+    });
+
+    it('should call onGhostMove with updated position offset by initial grab point', () => {
+      createAction();
+      pointerDown(rowA, { clientX: 50, clientY: 25 }); // offsetX=50, offsetY=25
+      pointerMove({ clientX: 60, clientY: 40 }); // left=60-50=10, top=40-25=15
+      expect(onGhostMove).toHaveBeenCalledWith(
+        expect.objectContaining({ left: 10, top: 15 }),
+      );
+    });
+
+    it('should call onPlaceholderMove when the drop index changes', () => {
+      createAction();
+      pointerDown(rowA, { clientY: 25 }); // placeholderIndex = 0
+      // rowA mid = 25, rowB mid = 75: clientY=40 lands in rowB slot → index 1
+      pointerMove({ clientY: 40 });
+      expect(onPlaceholderMove).toHaveBeenCalledWith(1);
+    });
+
+    it('should not call onPlaceholderMove when the drop index is unchanged', () => {
+      createAction();
+      pointerDown(rowA, { clientY: 25 }); // placeholderIndex = 0
+      // clientY=10 < rowA mid=25 → index 0, same as current
+      pointerMove({ clientY: 10 });
+      expect(onPlaceholderMove).not.toHaveBeenCalled();
+    });
+
+    it('should return last-row index when pointer is below all rows', () => {
+      createAction();
+      pointerDown(rowA, { clientY: 25 }); // placeholderIndex = 0
+      // clientY=200 > all row midpoints → index = rows.length = 3
+      pointerMove({ clientY: 200 });
+      expect(onPlaceholderMove).toHaveBeenCalledWith(3);
+    });
+  });
+
+  describe('pointerup', () => {
+    it('should ignore events from a different pointer', () => {
+      createAction();
+      pointerDown(rowA);
+      pointerUp({ pointerId: 99 });
+      expect(onDragEnd).not.toHaveBeenCalled();
+    });
+
+    it('should call onDragEnd with cancelled=false at the initial index', () => {
+      createAction();
+      pointerDown(rowA, { clientY: 25 });
+      pointerUp();
+      expect(onDragEnd).toHaveBeenCalledWith('a', 0, false);
+    });
+
+    it('should call onDragEnd with the final placeholder index after moves', () => {
+      createAction();
+      pointerDown(rowA, { clientY: 25 });
+      pointerMove({ clientY: 40 }); // moves to index 1
+      pointerUp();
+      expect(onDragEnd).toHaveBeenCalledWith('a', 1, false);
+    });
+  });
+
+  describe('pointercancel', () => {
+    it('should ignore events from a different pointer', () => {
+      createAction();
+      pointerDown(rowA);
+      pointerCancel({ pointerId: 99 });
+      expect(onDragEnd).not.toHaveBeenCalled();
+    });
+
+    it('should call onDragEnd with cancelled=true', () => {
+      createAction();
+      pointerDown(rowA, { clientY: 25 });
+      pointerCancel();
+      expect(onDragEnd).toHaveBeenCalledWith('a', 0, true);
+    });
+  });
+
+  describe('update', () => {
+    it('should use the new params for subsequent drag events', () => {
+      const action = createAction();
+      const newOnDragStart = vi.fn<
+        (key: string, ghost: DragGhost, fromIndex: number) => void
+      >();
+      action.update({
+        getItems: () => items,
+        onDragStart: newOnDragStart,
+        onGhostMove,
+        onPlaceholderMove,
+        onDragEnd,
+      });
+      pointerDown(rowA);
+      expect(newOnDragStart).toHaveBeenCalled();
+      expect(onDragStart).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('destroy', () => {
+    it('should remove all four pointer event listeners', () => {
+      const action = createAction();
+      const spy = vi.spyOn(node, 'removeEventListener');
+      action.destroy();
+      expect(spy).toHaveBeenCalledTimes(4);
+    });
+
+    it('should stop the auto-scroll loop if a drag is in progress', () => {
+      const action = createAction();
+      pointerDown(rowA);
+      action.destroy();
+      expect(cancelAnimationFrame).toHaveBeenCalled();
+    });
+  });
+
+  describe('custom rowDataAttribute', () => {
+    it('should use the provided attribute name to identify draggable rows', () => {
+      const customRow = document.createElement('tr');
+      customRow.setAttribute('data-list-row', 'a');
+      vi.spyOn(customRow, 'getBoundingClientRect').mockReturnValue(
+        rowA.getBoundingClientRect(),
+      );
+      node.innerHTML = '';
+      node.appendChild(customRow);
+
+      createAction({ rowDataAttribute: 'data-list-row' });
+      pointerDown(customRow);
+      expect(onDragStart).toHaveBeenCalledWith('a', expect.any(Object), 0);
+    });
+  });
+});

--- a/projects/client/src/lib/sections/lists/user/_internal/reorderDrag.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/reorderDrag.ts
@@ -1,0 +1,256 @@
+import type { ReorderableListItem } from './models/ReorderableListItem.ts';
+
+export type DragGhost = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  offsetX: number;
+  offsetY: number;
+};
+
+type ReorderDragParams = {
+  getItems: () => readonly ReorderableListItem[];
+  onDragStart: (key: string, ghost: DragGhost, fromIndex: number) => void;
+  onGhostMove: (ghost: DragGhost) => void;
+  onPlaceholderMove: (index: number) => void;
+  onDragEnd: (
+    key: string | null,
+    placeholderIndex: number | null,
+    cancelled: boolean,
+  ) => void;
+  rowDataAttribute?: string;
+  scrollContainerClassName?: string;
+};
+
+const autoScrollEdgeSize = 88;
+const autoScrollMaxDistance = 14;
+
+export function reorderDrag(
+  node: HTMLTableSectionElement,
+  initialParams: ReorderDragParams,
+) {
+  let params = initialParams;
+
+  const rowAttr = params.rowDataAttribute ?? 'data-reorder-key';
+  const rowDatasetKey = rowAttr
+    .replace(/^data-/, '')
+    .replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  const scrollClass = params.scrollContainerClassName ?? 'trakt-drawer-content';
+
+  let draggedKey: string | null = null;
+  let dragGhost: DragGhost | null = null;
+  let placeholderIndex: number | null = null;
+  let dragPointerId: number | null = null;
+  let dragClientY = 0;
+  let autoScrollFrame: number | null = null;
+  let scrollContainer: HTMLElement | null = null;
+
+  function getPointerDropIndex(clientY: number): number | null {
+    if (draggedKey == null) return null;
+
+    const rows = Array.from(
+      node.querySelectorAll<HTMLTableRowElement>(`[${rowAttr}]`),
+    );
+
+    if (rows.length === 0) return 0;
+
+    const targetIndex = rows.findIndex((row) => {
+      const rect = row.getBoundingClientRect();
+      return clientY < rect.top + rect.height / 2;
+    });
+
+    return targetIndex < 0 ? rows.length : targetIndex;
+  }
+
+  function getScrollContainer(): HTMLElement | null {
+    const element = node.closest(`.${scrollClass}`);
+    return element instanceof HTMLElement ? element : null;
+  }
+
+  function scrollStep(distanceFromEdge: number): number {
+    const distance = Math.max(distanceFromEdge, 0);
+    const intensity = Math.min(
+      (autoScrollEdgeSize - distance) / autoScrollEdgeSize,
+      1,
+    );
+    return Math.ceil(autoScrollMaxDistance * intensity);
+  }
+
+  function scrollDistance(): number {
+    if (!scrollContainer) return 0;
+
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const distanceFromTop = dragClientY - containerRect.top;
+    const distanceFromBottom = containerRect.bottom - dragClientY;
+    const maxScrollTop = scrollContainer.scrollHeight -
+      scrollContainer.clientHeight;
+
+    if (distanceFromTop < autoScrollEdgeSize && scrollContainer.scrollTop > 0) {
+      return -scrollStep(distanceFromTop);
+    }
+
+    if (
+      distanceFromBottom < autoScrollEdgeSize &&
+      scrollContainer.scrollTop < maxScrollTop
+    ) {
+      return scrollStep(distanceFromBottom);
+    }
+
+    return 0;
+  }
+
+  function tickAutoScroll() {
+    autoScrollFrame = null;
+    if (dragPointerId == null || !scrollContainer) return;
+
+    const delta = scrollDistance();
+    const prevScrollTop = scrollContainer.scrollTop;
+    scrollContainer.scrollTop += delta;
+
+    if (scrollContainer.scrollTop !== prevScrollTop) {
+      const toIndex = getPointerDropIndex(dragClientY);
+      if (toIndex != null && toIndex !== placeholderIndex) {
+        placeholderIndex = toIndex;
+        params.onPlaceholderMove(toIndex);
+      }
+    }
+
+    startAutoScroll();
+  }
+
+  function startAutoScroll() {
+    if (autoScrollFrame != null) return;
+    autoScrollFrame = requestAnimationFrame(tickAutoScroll);
+  }
+
+  function stopAutoScroll() {
+    if (autoScrollFrame == null) return;
+    cancelAnimationFrame(autoScrollFrame);
+    autoScrollFrame = null;
+  }
+
+  function endDrag(cancelled: boolean) {
+    stopAutoScroll();
+
+    if (dragPointerId != null) {
+      try {
+        if (node.hasPointerCapture(dragPointerId)) {
+          node.releasePointerCapture(dragPointerId);
+        }
+      } catch {
+        // Browser may have already released capture during pointercancel.
+      }
+    }
+
+    const endedKey = draggedKey;
+    const endedIndex = placeholderIndex;
+
+    draggedKey = null;
+    dragGhost = null;
+    placeholderIndex = null;
+    dragPointerId = null;
+    scrollContainer = null;
+
+    params.onDragEnd(endedKey, endedIndex, cancelled);
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (event.pointerId !== dragPointerId) return;
+    event.preventDefault();
+
+    dragClientY = event.clientY;
+
+    if (dragGhost) {
+      dragGhost = {
+        ...dragGhost,
+        left: event.clientX - dragGhost.offsetX,
+        top: event.clientY - dragGhost.offsetY,
+      };
+      params.onGhostMove(dragGhost);
+    }
+
+    const toIndex = getPointerDropIndex(event.clientY);
+    if (toIndex != null && toIndex !== placeholderIndex) {
+      placeholderIndex = toIndex;
+      params.onPlaceholderMove(toIndex);
+    }
+  }
+
+  function handlePointerUp(event: PointerEvent) {
+    if (event.pointerId !== dragPointerId) return;
+    endDrag(false);
+  }
+
+  function handlePointerCancel(event: PointerEvent) {
+    if (event.pointerId !== dragPointerId) return;
+    endDrag(true);
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    if (event.button !== 0) return;
+
+    const row = (event.target as HTMLElement).closest<HTMLTableRowElement>(
+      `[${rowAttr}]`,
+    );
+    const key = row?.dataset[rowDatasetKey];
+    if (!key) return;
+
+    const fromIndex = params.getItems().findIndex((item) => item.key === key);
+    if (fromIndex < 0) return;
+
+    event.preventDefault();
+
+    try {
+      node.setPointerCapture(event.pointerId);
+    } catch {
+      return;
+    }
+
+    const rowRect = row.getBoundingClientRect();
+
+    draggedKey = key;
+    dragPointerId = event.pointerId;
+    placeholderIndex = fromIndex;
+    scrollContainer = getScrollContainer();
+    dragClientY = event.clientY;
+    dragGhost = {
+      top: rowRect.top,
+      left: rowRect.left,
+      width: rowRect.width,
+      height: rowRect.height,
+      offsetX: event.clientX - rowRect.left,
+      offsetY: event.clientY - rowRect.top,
+    };
+
+    params.onDragStart(key, dragGhost, fromIndex);
+    startAutoScroll();
+  }
+
+  node.addEventListener('pointerdown', handlePointerDown);
+  node.addEventListener('pointermove', handlePointerMove, { passive: false });
+  node.addEventListener('pointerup', handlePointerUp);
+  node.addEventListener('pointercancel', handlePointerCancel);
+
+  return {
+    update(newParams: ReorderDragParams) {
+      params = newParams;
+    },
+    destroy() {
+      stopAutoScroll();
+      if (dragPointerId != null) {
+        try {
+          if (node.hasPointerCapture(dragPointerId)) {
+            node.releasePointerCapture(dragPointerId);
+          }
+        } catch {
+          // Already released.
+        }
+      }
+      node.removeEventListener('pointerdown', handlePointerDown);
+      node.removeEventListener('pointermove', handlePointerMove);
+      node.removeEventListener('pointerup', handlePointerUp);
+      node.removeEventListener('pointercancel', handlePointerCancel);
+    },
+  };
+}

--- a/projects/client/src/lib/sections/lists/user/_internal/reorderListItems.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/reorderListItems.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { ReorderableListItem } from './models/ReorderableListItem.ts';
+import {
+  itemOrderSignature,
+  listItemRankIds,
+  sortReorderableItems,
+} from './reorderListItems.ts';
+
+const items: ReorderableListItem[] = [
+  {
+    key: 'show-2',
+    listItemId: 202,
+    rank: 2,
+    title: 'Second',
+  },
+  {
+    key: 'movie-1',
+    listItemId: 101,
+    rank: 1,
+    title: 'First',
+  },
+  {
+    key: 'episode-3',
+    listItemId: 303,
+    rank: 3,
+    title: 'Third',
+  },
+];
+
+describe('reorderListItems', () => {
+  it('should sort reorderable items by rank', () => {
+    const result = sortReorderableItems(items);
+
+    expect(itemOrderSignature(result)).toBe('movie-1|show-2|episode-3');
+  });
+
+  it('should build list item rank ids in the current order', () => {
+    const result = listItemRankIds(items);
+
+    expect(result).toEqual([202, 101, 303]);
+  });
+});

--- a/projects/client/src/lib/sections/lists/user/_internal/reorderListItems.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/reorderListItems.ts
@@ -1,0 +1,68 @@
+import type { ListItem } from '$lib/requests/models/ListItem.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { ReorderableListItem } from './models/ReorderableListItem.ts';
+import { episodeNumberLabel } from '$lib/utils/intl/episodeNumberLabel.ts';
+import { seasonLabel } from '$lib/utils/intl/seasonLabel.ts';
+
+function mediaSubtitle(media: MediaEntry): string | undefined {
+  return media.year?.toString();
+}
+
+function mediaPosterUrl(media: MediaEntry): HttpsUrl {
+  return media.poster.url.thumb;
+}
+
+export function mapListItemToReorderableItem(
+  item: ListItem,
+): ReorderableListItem {
+  if (item.type === 'movie' || item.type === 'show') {
+    return {
+      key: item.key,
+      listItemId: item.id,
+      rank: item.rank,
+      title: item.entry.title,
+      subtitle: mediaSubtitle(item.entry),
+      posterUrl: mediaPosterUrl(item.entry),
+    };
+  }
+
+  if (item.type === 'season') {
+    return {
+      key: item.key,
+      listItemId: item.id,
+      rank: item.rank,
+      title: item.entry.show.title,
+      subtitle: seasonLabel(item.entry.season.number),
+      posterUrl: item.entry.season.poster?.url.thumb ??
+        mediaPosterUrl(item.entry.show),
+    };
+  }
+
+  return {
+    key: item.key,
+    listItemId: item.id,
+    rank: item.rank,
+    title: item.entry.show.title,
+    subtitle: `${
+      episodeNumberLabel({
+        seasonNumber: item.entry.episode.season,
+        episodeNumber: item.entry.episode.number,
+      })
+    } - ${item.entry.episode.title}`,
+    posterUrl: mediaPosterUrl(item.entry.show),
+  };
+}
+
+export function sortReorderableItems(
+  items: ReorderableListItem[],
+): ReorderableListItem[] {
+  return [...items].sort((a, b) => a.rank - b.rank);
+}
+
+export function itemOrderSignature(items: ReorderableListItem[]): string {
+  return items.map((item) => item.key).join('|');
+}
+
+export function listItemRankIds(items: ReorderableListItem[]): number[] {
+  return items.map((item) => item.listItemId);
+}

--- a/projects/client/src/lib/sections/lists/user/_internal/useReorderList.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useReorderList.ts
@@ -1,20 +1,48 @@
-import type { ReorderListSource } from '../models/ReorderListSource.ts';
-import { useListItems } from '../useListItems.ts';
-import { mapListItemToReorderableItem } from './reorderListItems.ts';
+import { useAllPagesInfiniteQuery } from '$lib/features/query/useQuery.ts';
+import type { ListItem } from '$lib/requests/models/ListItem.ts';
+import { userListItemsQuery } from '$lib/requests/queries/users/userListItemsQuery.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { map } from 'rxjs';
+import type { ReorderListSource } from '../models/ReorderListSource.ts';
+import { mapListItemToReorderableItem } from './reorderListItems.ts';
 
-const REORDER_PAGE_SIZE = 100;
+const reorderPageSize = 100;
+
+function uniqueByKey(entries: ListItem[]): ListItem[] {
+  const seen = new Set<string>();
+  return entries.filter((item) => {
+    if (seen.has(item.key)) return false;
+    seen.add(item.key);
+    return true;
+  });
+}
 
 export function useReorderList(source: ReorderListSource) {
-  const { list, ...rest } = useListItems({
-    list: source.list,
-    limit: REORDER_PAGE_SIZE,
-  });
-
-  return {
-    list: list.pipe(
-      map((items) => items.map(mapListItemToReorderableItem)),
+  const query = useAllPagesInfiniteQuery(userListItemsQuery({
+    userId: assertDefined(
+      source.list.user.slug,
+      'Expected user list to have a user slug',
     ),
-    ...rest,
-  };
+    listId: source.list.slug,
+    limit: reorderPageSize,
+  }));
+
+  const isLoading = query.pipe(
+    map(($query) =>
+      $query.isPending || $query.isFetchingNextPage || $query.hasNextPage
+    ),
+  );
+
+  const list = query.pipe(
+    map(($query) => {
+      if ($query.isPending || $query.isFetchingNextPage || $query.hasNextPage) {
+        return [];
+      }
+
+      const entries = $query.data?.pages.flatMap((page) => page.entries) ?? [];
+      return uniqueByKey(entries).map(mapListItemToReorderableItem);
+    }),
+  );
+
+  return { isLoading, list };
 }

--- a/projects/client/src/lib/sections/lists/user/_internal/useReorderList.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useReorderList.ts
@@ -1,0 +1,20 @@
+import type { ReorderListSource } from '../models/ReorderListSource.ts';
+import { useListItems } from '../useListItems.ts';
+import { mapListItemToReorderableItem } from './reorderListItems.ts';
+import { map } from 'rxjs';
+
+const REORDER_PAGE_SIZE = 100;
+
+export function useReorderList(source: ReorderListSource) {
+  const { list, ...rest } = useListItems({
+    list: source.list,
+    limit: REORDER_PAGE_SIZE,
+  });
+
+  return {
+    list: list.pipe(
+      map((items) => items.map(mapListItemToReorderableItem)),
+    ),
+    ...rest,
+  };
+}

--- a/projects/client/src/lib/sections/lists/user/models/ReorderListSource.ts
+++ b/projects/client/src/lib/sections/lists/user/models/ReorderListSource.ts
@@ -1,0 +1,6 @@
+import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
+
+export type ReorderListSource = {
+  type: 'user-list';
+  list: MediaListSummary;
+};


### PR DESCRIPTION
## Summary

- RE https://github.com/trakt/trakt-web/issues/1702
- Add a Reorder action to owned custom list menus.
- Add a drag-and-drop drawer for changing list item rank order.
- POST custom list reorder changes to `/users/{user_id}/lists/{list_id}/items/reorder`.
- Close the drawer and refresh list items after a successful reorder.

## Notes

This focuses on custom Lists only. Watchlist and Favorites can use the same structure later once their reorder endpoints are available.

## Design

<img width="1601" height="1089" alt="Screenshot 2026-06-04 at 14 53 35" src="https://github.com/user-attachments/assets/1e039bbc-4b51-4668-aacb-43e12728c141" />

<img width="1601" height="1089" alt="Screenshot 2026-06-04 at 14 53 40" src="https://github.com/user-attachments/assets/459d0b58-3861-4de9-85ff-b47b937755d8" />

<img width="1601" height="1089" alt="Screenshot 2026-06-04 at 14 54 29" src="https://github.com/user-attachments/assets/3cae8e45-60f8-4e43-b323-313aa2cbf25d" />

## Interaction Flow


https://github.com/user-attachments/assets/ca79a10d-2a65-4e51-81b6-5a1112947357

