### PR TITLE
fix: see your private profile if you are logged in

### DIFF
--- a/projects/client/src/routes/profile/[slug]/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
+  import { useIsMe } from "$lib/features/auth/stores/useIsMe.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
@@ -14,6 +15,7 @@
   const { params }: PageProps = $props();
 
   const { user, isLoading } = $derived(useProfile(params.slug));
+  const { isMe } = $derived(useIsMe(params.slug));
 
   const title = $derived(
     $user?.username
@@ -38,7 +40,7 @@
 
   {#if !$isLoading && $user}
     <CoverImageSetter src={$user.cover?.url} type="main" />
-    {#if $user.private}
+    {#if $user.private && !$isMe}
       <PrivateProfile profile={$user} slug={$user.slug ?? ""} />
     {:else}
       <Profile profile={$user} slug={$user.slug ?? ""} />


### PR DESCRIPTION
fixes #1979 

If you're logged in and your profile is private, you should be able to see it.

with private profile:
<img width="2898" height="834" alt="image" src="https://github.com/user-attachments/assets/49194472-fbf4-42b9-8419-1abac0cb0b93" />
