### PR TITLE
fix(errors): ignore cross-origin object SecurityErrors

### DIFF
--- a/projects/client/src/lib/features/errors/ErrorProvider.svelte
+++ b/projects/client/src/lib/features/errors/ErrorProvider.svelte
@@ -69,9 +69,11 @@
       Filter out errors caused by blocked frames e.g.,
       due to popup blockers or browser privacy settings)
     */
+    const message = error.message.toLowerCase();
     if (
       error.name === "SecurityError" &&
-      error.message.toLowerCase().includes("blocked a frame")
+      (message.includes("blocked a frame") ||
+        message.includes("cross-origin object"))
     ) {
       return;
     }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2471
- Firefox now also filters out errors caused by blocked frames

## 👀 Example 👀

Before/after:
<img width="1075" height="713" alt="Screenshot 2026-06-04 at 18 22 53" src="https://github.com/user-attachments/assets/317d455f-2397-4f38-bd92-b8cf00437a73" />

<img width="1075" height="713" alt="Screenshot 2026-06-04 at 18 23 01" src="https://github.com/user-attachments/assets/b2aebb63-5792-4822-8c2f-a270ac225296" />
