### PR TITLE
fix: show private profile to approved user

### DIFF
--- a/projects/client/src/lib/features/auth/stores/useIsFollowing.spec.ts
+++ b/projects/client/src/lib/features/auth/stores/useIsFollowing.spec.ts
@@ -1,0 +1,48 @@
+import { UserProfileHarryMappedMock } from '$mocks/data/users/mapped/UserProfileHarryMappedMock.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { setAuthorization } from '$test/beds/store/renderStore.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useIsFollowing } from './useIsFollowing.ts';
+
+describe('store: useIsFollowing', () => {
+  describe('when authorized', () => {
+    beforeEach(() => {
+      setAuthorization(true);
+    });
+
+    it('should be true for an approved followed user', async () => {
+      const result = await runQuery({
+        factory: () =>
+          useIsFollowing(UserProfileHarryMappedMock.slug ?? '').isFollowing,
+        waitFor: (value) => value === true,
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should be false for a user that is not followed', async () => {
+      const result = await runQuery({
+        factory: () => useIsFollowing('not-a-followed-user').isFollowing,
+        waitFor: (value) => value === false,
+      });
+
+      expect(result).to.equal(false);
+    });
+  });
+
+  describe('when unauthorized', () => {
+    beforeEach(() => {
+      setAuthorization(false);
+    });
+
+    it('should be false', async () => {
+      const result = await runQuery({
+        factory: () =>
+          useIsFollowing(UserProfileHarryMappedMock.slug ?? '').isFollowing,
+        waitFor: (value) => value === false,
+      });
+
+      expect(result).to.equal(false);
+    });
+  });
+});

--- a/projects/client/src/lib/features/auth/stores/useIsFollowing.ts
+++ b/projects/client/src/lib/features/auth/stores/useIsFollowing.ts
@@ -1,0 +1,15 @@
+import { map } from 'rxjs';
+import { useUser } from './useUser.ts';
+
+export function useIsFollowing(slug: string) {
+  const { network } = useUser();
+
+  return {
+    isFollowing: network.pipe(
+      map(($network) => {
+        if (!$network) return undefined;
+        return $network.following.some((user) => user.slug === slug);
+      }),
+    ),
+  };
+}

--- a/projects/client/src/routes/profile/[slug]/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CoverImageSetter from "$lib/components/background/CoverImageSetter.svelte";
+  import { useIsFollowing } from "$lib/features/auth/stores/useIsFollowing.ts";
   import { useIsMe } from "$lib/features/auth/stores/useIsMe.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
@@ -16,6 +17,15 @@
 
   const { user, isLoading } = $derived(useProfile(params.slug));
   const { isMe } = $derived(useIsMe(params.slug));
+  const { isFollowing } = $derived(useIsFollowing(params.slug));
+
+  const isPrivateProfile = $derived(
+    $user?.private === true && !$isMe && $isFollowing === false,
+  );
+  const isProfileVisible = $derived(
+    $user != null &&
+      ($isMe === true || $isFollowing === true || !$user.private),
+  );
 
   const title = $derived(
     $user?.username
@@ -40,9 +50,9 @@
 
   {#if !$isLoading && $user}
     <CoverImageSetter src={$user.cover?.url} type="main" />
-    {#if $user.private && !$isMe}
+    {#if isPrivateProfile}
       <PrivateProfile profile={$user} slug={$user.slug ?? ""} />
-    {:else}
+    {:else if isProfileVisible}
       <Profile profile={$user} slug={$user.slug ?? ""} />
     {/if}
   {/if}


### PR DESCRIPTION
Fixes #1866

before, clicking on a private followed allowed profile would return "this profile is private". Now, it renders correctly.

<img width="892" height="1836" alt="image" src="https://github.com/user-attachments/assets/3551de51-8e95-47ce-af63-a7bba1f2aada" />

- [x] Unit tested
- [x] UI tested