### PR TITLE
fix: reorganize footer links under platform and community

### DIFF
--- a/projects/client/src/lib/sections/footer/components/PageLinks.svelte
+++ b/projects/client/src/lib/sections/footer/components/PageLinks.svelte
@@ -11,25 +11,15 @@
 <div class="trakt-page-links">
   <div class="trakt-link-group">
     <span class="secondary">{m.text_footer_category_platform()}</span>
+    <Link href={UrlBuilder.about()}>
+      <span class="bold">{m.link_text_about()}</span>
+    </Link>
     <Link href={UrlBuilder.vip()}>
       <span class="bold">VIP</span>
     </Link>
-    <RenderFor audience="vip">
-      <Link
-        href={UrlBuilder.feedback()}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <span class="bold">{m.link_text_feedback()}</span>
-      </Link>
-      <Link
-        href={UrlBuilder.og.support($user?.slug)}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <span class="bold">{m.link_text_support()}</span>
-      </Link>
-    </RenderFor>
+    <Link href={UrlBuilder.branding()}>
+      <span class="bold">{m.link_text_branding()}</span>
+    </Link>
   </div>
 
   <div class="trakt-link-group">
@@ -41,12 +31,22 @@
     >
       <span class="bold">{m.link_text_forums()}</span>
     </Link>
-    <Link href={UrlBuilder.about()}>
-      <span class="bold">{m.link_text_about()}</span>
-    </Link>
-    <Link href={UrlBuilder.branding()}>
-      <span class="bold">{m.link_text_branding()}</span>
-    </Link>
+    <RenderFor audience="vip">
+      <Link
+        href={UrlBuilder.og.support($user?.slug)}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span class="bold">{m.link_text_support()}</span>
+      </Link>
+      <Link
+        href={UrlBuilder.feedback()}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span class="bold">{m.link_text_feedback()}</span>
+      </Link>
+    </RenderFor>
   </div>
 
   <div class="trakt-link-group">


### PR DESCRIPTION
## Summary
This updates the footer information architecture so links appear under the intended categories. The goal is to make navigation labels match their section grouping.

- Platform now contains: About, VIP, Branding
- Community now contains: Forums, Support, Feedback
- Support and Feedback remain VIP-only links; only their grouping changed
- Legal links are unchanged

## Pull Request Checklist

Before you dim the lights and raise the curtain on your cinematic masterpiece,
make sure your pull request has passed these critical checks:

- [x] **Clear and Concise Title:** Does your title shine a spotlight on the
      essence of your changes?
- [x] **Detailed Description:** Have you set the stage with a compelling
      narrative that explains the "why" and "how" of your changes?
- [ ] **Screenshots/Videos:** Have you captured the magic with visual evidence
      that showcases your changes in action?
- [ ] **Tests:** Has your code undergone a rigorous dress rehearsal with unit
      tests to ensure it performs flawlessly under pressure?
- [x] **Coding Standards:** Does your code adhere to the project's style guide,
      ensuring it's as elegant as a film score?
- [x] **Commit Messages:** Are your commit messages clear and concise, guiding
      the audience through the evolution of your code?
- [ ] **Documentation:** If your changes impact the script, have you updated the
      documentation accordingly?
- [x] **Code Review:** Are you prepared to embrace feedback from the discerning
      eyes of the project maintainers and fellow contributors?