### PR TITLE
feat(profile): changes my stats to be fully about screen time

### DIFF
--- a/projects/client/i18n/messages/bg-BG.json
+++ b/projects/client/i18n/messages/bg-BG.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Дневно екранно време",
   "header_stats_graph_shows_movies": "Сериали срещу филми",
   "header_stats_monthly": "Месечна статистика",
-  "header_stats_my_stats": "Моите статистики",
   "header_status": "Статус",
   "header_stream_on": "Стриймвай на",
   "header_streaming": "Наличност",

--- a/projects/client/i18n/messages/ca-ES.json
+++ b/projects/client/i18n/messages/ca-ES.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Temps de pantalla diari",
   "header_stats_graph_shows_movies": "Sèries vs Pel·lícules",
   "header_stats_monthly": "Estadístiques mensuals",
-  "header_stats_my_stats": "Les meves estadístiques",
   "header_status": "Estat",
   "header_stream_on": "En streaming a",
   "header_streaming": "Disponibilitat",

--- a/projects/client/i18n/messages/da-DK.json
+++ b/projects/client/i18n/messages/da-DK.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Daglig Skærmtid",
   "header_stats_graph_shows_movies": "Serier vs. film",
   "header_stats_monthly": "Månedlig statistik",
-  "header_stats_my_stats": "Min Statistik",
   "header_status": "Status",
   "header_stream_on": "Stream på",
   "header_streaming": "Tilgængelighed",

--- a/projects/client/i18n/messages/de-DE.json
+++ b/projects/client/i18n/messages/de-DE.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Tägliche Bildschirmzeit",
   "header_stats_graph_shows_movies": "Serien vs. Filme",
   "header_stats_monthly": "Monatliche Statistiken",
-  "header_stats_my_stats": "Meine Statistiken",
   "header_status": "Status",
   "header_stream_on": "Streamen auf",
   "header_streaming": "Verfügbarkeit",

--- a/projects/client/i18n/messages/el-GR.json
+++ b/projects/client/i18n/messages/el-GR.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Καθημερινός Χρόνος Οθόνης",
   "header_stats_graph_shows_movies": "Σειρές εναντίον Ταινιών",
   "header_stats_monthly": "Μηνιαία Στατιστικά",
-  "header_stats_my_stats": "Τα Στατιστικά μου",
   "header_status": "Κατάσταση",
   "header_stream_on": "Ροή σε",
   "header_streaming": "Διαθεσιμότητα",

--- a/projects/client/i18n/messages/en-AU.json
+++ b/projects/client/i18n/messages/en-AU.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Daily Screen Time",
   "header_stats_graph_shows_movies": "Shows vs Movies",
   "header_stats_monthly": "Monthly Stats",
-  "header_stats_my_stats": "My Stats",
   "header_status": "Status",
   "header_stream_on": "Stream on",
   "header_streaming": "Availability",

--- a/projects/client/i18n/messages/es-ES.json
+++ b/projects/client/i18n/messages/es-ES.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Tiempo en pantalla diario",
   "header_stats_graph_shows_movies": "Series vs Películas",
   "header_stats_monthly": "Estadísticas mensuales",
-  "header_stats_my_stats": "Mis estadísticas",
   "header_status": "Estado",
   "header_stream_on": "Ver en",
   "header_streaming": "Disponibilidad",

--- a/projects/client/i18n/messages/es-MX.json
+++ b/projects/client/i18n/messages/es-MX.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Tiempo de pantalla diario",
   "header_stats_graph_shows_movies": "Series vs Películas",
   "header_stats_monthly": "Estadísticas Mensuales",
-  "header_stats_my_stats": "Mis estadísticas",
   "header_status": "Estado",
   "header_stream_on": "Transmitir en",
   "header_streaming": "Disponibilidad",

--- a/projects/client/i18n/messages/fa-IR.json
+++ b/projects/client/i18n/messages/fa-IR.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "زمان نمایش روزانه",
   "header_stats_graph_shows_movies": "سریال‌ها در مقابل فیلم‌ها",
   "header_stats_monthly": "آمار ماهانه",
-  "header_stats_my_stats": "آمار من",
   "header_status": "وضعیت",
   "header_stream_on": "پخش در",
   "header_streaming": "دسترسی",

--- a/projects/client/i18n/messages/fr-CA.json
+++ b/projects/client/i18n/messages/fr-CA.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Temps d'écran quotidien",
   "header_stats_graph_shows_movies": "Séries c. films",
   "header_stats_monthly": "Statistiques mensuelles",
-  "header_stats_my_stats": "Mes statistiques",
   "header_status": "Statut",
   "header_stream_on": "Regarder sur",
   "header_streaming": "Disponibilité",

--- a/projects/client/i18n/messages/fr-FR.json
+++ b/projects/client/i18n/messages/fr-FR.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Temps d'écran quotidien",
   "header_stats_graph_shows_movies": "Séries vs Films",
   "header_stats_monthly": "Statistiques mensuelles",
-  "header_stats_my_stats": "Mes statistiques",
   "header_status": "Statut",
   "header_stream_on": "Diffuser sur",
   "header_streaming": "Disponibilité",

--- a/projects/client/i18n/messages/hu-HU.json
+++ b/projects/client/i18n/messages/hu-HU.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Napi képernyőidő",
   "header_stats_graph_shows_movies": "Sorozatok vs Filmek",
   "header_stats_monthly": "Havi statisztikák",
-  "header_stats_my_stats": "Saját statisztikáim",
   "header_status": "Állapot",
   "header_stream_on": "Streameld itt:",
   "header_streaming": "Elérhetőség",

--- a/projects/client/i18n/messages/id-ID.json
+++ b/projects/client/i18n/messages/id-ID.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Waktu Layar Harian",
   "header_stats_graph_shows_movies": "Acara vs Film",
   "header_stats_monthly": "Statistik Bulanan",
-  "header_stats_my_stats": "Statistik Saya",
   "header_status": "Status",
   "header_stream_on": "Streaming di",
   "header_streaming": "Ketersediaan",

--- a/projects/client/i18n/messages/it-IT.json
+++ b/projects/client/i18n/messages/it-IT.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Tempo di Schermo Giornaliero",
   "header_stats_graph_shows_movies": "Serie vs Film",
   "header_stats_monthly": "Statistiche mensili",
-  "header_stats_my_stats": "Le mie Statistiche",
   "header_status": "Stato",
   "header_stream_on": "Guarda su",
   "header_streaming": "Disponibilità",

--- a/projects/client/i18n/messages/ja-JP.json
+++ b/projects/client/i18n/messages/ja-JP.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "日別視聴時間",
   "header_stats_graph_shows_movies": "番組 vs 映画",
   "header_stats_monthly": "月間統計",
-  "header_stats_my_stats": "マイ統計",
   "header_status": "ステータス",
   "header_stream_on": "で視聴",
   "header_streaming": "配信状況",

--- a/projects/client/i18n/messages/nb-NO.json
+++ b/projects/client/i18n/messages/nb-NO.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Daglig skjermtid",
   "header_stats_graph_shows_movies": "Serier vs. Filmer",
   "header_stats_monthly": "Månedlig statistikk",
-  "header_stats_my_stats": "Min statistikk",
   "header_status": "Status",
   "header_stream_on": "Strøm på",
   "header_streaming": "Tilgjengelighet",

--- a/projects/client/i18n/messages/nl-NL.json
+++ b/projects/client/i18n/messages/nl-NL.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Dagelijkse schermtijd",
   "header_stats_graph_shows_movies": "Series vs. Films",
   "header_stats_monthly": "Maandelijkse Statistieken",
-  "header_stats_my_stats": "Mijn statistieken",
   "header_status": "Status",
   "header_stream_on": "Streamen op",
   "header_streaming": "Beschikbaarheid",

--- a/projects/client/i18n/messages/pl-PL.json
+++ b/projects/client/i18n/messages/pl-PL.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Dzienny czas przed ekranem",
   "header_stats_graph_shows_movies": "Seriale kontra filmy",
   "header_stats_monthly": "Statystyki miesięczne",
-  "header_stats_my_stats": "Moje statystyki",
   "header_status": "Status",
   "header_stream_on": "Stream",
   "header_streaming": "Dostępność",

--- a/projects/client/i18n/messages/pt-BR.json
+++ b/projects/client/i18n/messages/pt-BR.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Tempo de Tela Diário",
   "header_stats_graph_shows_movies": "Séries vs Filmes",
   "header_stats_monthly": "Estatísticas Mensais",
-  "header_stats_my_stats": "Minhas Estatísticas",
   "header_status": "Status",
   "header_stream_on": "Assistir em",
   "header_streaming": "Disponibilidade",

--- a/projects/client/i18n/messages/pt-PT.json
+++ b/projects/client/i18n/messages/pt-PT.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Tempo de Tela Diário",
   "header_stats_graph_shows_movies": "Séries vs Filmes",
   "header_stats_monthly": "Estatísticas Mensais",
-  "header_stats_my_stats": "Minhas Estatísticas",
   "header_status": "Estado",
   "header_stream_on": "Transmitir em",
   "header_streaming": "Disponibilidade",

--- a/projects/client/i18n/messages/ro-RO.json
+++ b/projects/client/i18n/messages/ro-RO.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Timp zilnic petrecut în fața ecranului",
   "header_stats_graph_shows_movies": "Seriale vs Filme",
   "header_stats_monthly": "Statistici lunare",
-  "header_stats_my_stats": "Statisticile mele",
   "header_status": "Stare",
   "header_stream_on": "Disponibil pe",
   "header_streaming": "Disponibilitate",

--- a/projects/client/i18n/messages/ru-RU.json
+++ b/projects/client/i18n/messages/ru-RU.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Ежедневное экранное время",
   "header_stats_graph_shows_movies": "Сериалы против фильмов",
   "header_stats_monthly": "Ежемесячная статистика",
-  "header_stats_my_stats": "Моя статистика",
   "header_status": "Статус",
   "header_stream_on": "Смотреть на",
   "header_streaming": "Доступность",

--- a/projects/client/i18n/messages/sv-SE.json
+++ b/projects/client/i18n/messages/sv-SE.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Daglig skärmtid",
   "header_stats_graph_shows_movies": "Serier vs filmer",
   "header_stats_monthly": "Månatlig statistik",
-  "header_stats_my_stats": "Min statistik",
   "header_status": "Status",
   "header_stream_on": "Streama på",
   "header_streaming": "Tillgänglighet",

--- a/projects/client/i18n/messages/tr-TR.json
+++ b/projects/client/i18n/messages/tr-TR.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Günlük Ekran Süresi",
   "header_stats_graph_shows_movies": "Diziler ve Filmler",
   "header_stats_monthly": "Aylık İstatistikler",
-  "header_stats_my_stats": "İstatistiklerim",
   "header_status": "Durum",
   "header_stream_on": "Şurada yayınla",
   "header_streaming": "Mevcutluk",

--- a/projects/client/i18n/messages/uk-UA.json
+++ b/projects/client/i18n/messages/uk-UA.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "Щоденний час перед екраном",
   "header_stats_graph_shows_movies": "Серіали проти фільмів",
   "header_stats_monthly": "Місячна статистика",
-  "header_stats_my_stats": "Моя статистика",
   "header_status": "Статус",
   "header_stream_on": "Транслювати на",
   "header_streaming": "Доступність",

--- a/projects/client/i18n/messages/zh-CN.json
+++ b/projects/client/i18n/messages/zh-CN.json
@@ -496,7 +496,6 @@
   "header_stats_graph_screen_time_daily": "每日屏幕时间",
   "header_stats_graph_shows_movies": "节目 vs 电影",
   "header_stats_monthly": "月度统计",
-  "header_stats_my_stats": "我的统计",
   "header_status": "状态",
   "header_stream_on": "在...播放",
   "header_streaming": "可用性",

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6000,12 +6000,12 @@
       "description": "Tooltip for episodes stat icon in weekly pulse."
     },
     "tooltip_stats_movies": {
-      "default": "Movies watched this week",
-      "description": "Tooltip for movies stat icon in weekly pulse."
+      "default": "Time spent watching movies this week",
+      "description": "Tooltip for movies screen time stat icon in weekly pulse."
     },
     "tooltip_stats_shows": {
-      "default": "Unique shows watched",
-      "description": "Tooltip for unique shows stat icon in weekly pulse."
+      "default": "Time spent watching shows this week",
+      "description": "Tooltip for shows screen time stat icon in weekly pulse."
     },
     "tooltip_stats_active_days": {
       "default": "Days with at least one watch",
@@ -6221,20 +6221,20 @@
         }
       }
     },
-    "header_stats_my_stats": {
-      "default": "My Stats",
-      "description": "Title for the weekly pulse stats section and drawer."
+    "header_screen_time": {
+      "default": "Screen Time",
+      "description": "Title for the screen time stats section and drawer."
     },
     "header_stats_graph_peak": {
       "default": "Peak Hours",
       "description": "Title for the watch clock graph in weekly pulse."
     },
     "header_stats_graph_screen_time_daily": {
-      "default": "Daily Screen Time",
+      "default": "Daily Breakdown",
       "description": "Title for the daily screen time bar chart in weekly pulse, showing % of waking hours spent watching per day."
     },
     "label_stats_screen_time_total": {
-      "default": "Screen Time",
+      "default": "Total",
       "description": "Label for total screen time stat in weekly pulse."
     },
     "tooltip_stats_screen_time_total": {

--- a/projects/client/src/lib/sections/profile/Profile.svelte
+++ b/projects/client/src/lib/sections/profile/Profile.svelte
@@ -7,7 +7,7 @@
   import RecentlyWatchedList from "../lists/history/RecentlyWatchedList.svelte";
   import LibraryList from "../lists/library/LibraryList.svelte";
   import PersonalLists from "../lists/user/PersonalLists.svelte";
-  import MyStats from "../stats/MyStats.svelte";
+  import ScreenTime from "../stats/ScreenTime.svelte";
   import MyActivityList from "./components/MyActivityList.svelte";
   import ProfileContainer from "./components/ProfileContainer.svelte";
   import ProfileDetails from "./components/ProfileDetails.svelte";
@@ -28,7 +28,7 @@
 </ProfileContainer>
 
 {#if $isMe}
-  <MyStats />
+  <ScreenTime />
   <PersonalHistoryList mode={$mode} />
   <MyActivityList mode={$mode} />
   <ProgressList mode={$mode} />

--- a/projects/client/src/lib/sections/profile/ProfileDrawer.svelte
+++ b/projects/client/src/lib/sections/profile/ProfileDrawer.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import MyStatsDrawerHost from "../stats/MyStatsDrawerHost.svelte";
+  import ScreenTimeDrawerHost from "../stats/ScreenTimeDrawerHost.svelte";
+  import MatchDrawerHost from "./_internal/MatchDrawerHost.svelte";
   import {
     ProfileDrawers,
     profileDrawerNavigation,
   } from "./_internal/profileDrawerNavigation.ts";
   import ActivityDrawerHost from "./components/_internal/drawers/ActivityDrawerHost.svelte";
   import type { DisplayableProfileProps } from "./DisplayableProfileProps.ts";
-  import MatchDrawerHost from "./_internal/MatchDrawerHost.svelte";
 
   const { slug, profile }: DisplayableProfileProps = $props();
 
@@ -16,8 +16,8 @@
   );
 </script>
 
-{#if drawer === ProfileDrawers.MyStats}
-  <MyStatsDrawerHost onClose={close} />
+{#if drawer === ProfileDrawers.ScreenTime}
+  <ScreenTimeDrawerHost onClose={close} />
 {:else if drawer === ProfileDrawers.Activity}
   <ActivityDrawerHost {sourceCommentId} onClose={close} />
 {:else if drawer === ProfileDrawers.Match}

--- a/projects/client/src/lib/sections/profile/_internal/profileDrawerNavigation.ts
+++ b/projects/client/src/lib/sections/profile/_internal/profileDrawerNavigation.ts
@@ -5,7 +5,7 @@ const commentIdParam = 'comment_id';
 
 export enum ProfileDrawers {
   Activity = 'activity',
-  MyStats = 'my-stats',
+  ScreenTime = 'screen-time',
   Match = 'match',
 }
 
@@ -17,8 +17,8 @@ function mapToDrawer(value: string | Nil) {
   switch (value) {
     case ProfileDrawers.Activity:
       return ProfileDrawers.Activity;
-    case ProfileDrawers.MyStats:
-      return ProfileDrawers.MyStats;
+    case ProfileDrawers.ScreenTime:
+      return ProfileDrawers.ScreenTime;
     case ProfileDrawers.Match:
       return ProfileDrawers.Match;
     default:
@@ -41,7 +41,7 @@ export function profileDrawerNavigation(searchParams?: URLSearchParams) {
         ProfileDrawers.Activity,
         id != null ? { [commentIdParam]: String(id) } : undefined,
       ),
-    buildMyStatsDrawerLink: () => buildDrawerLink(ProfileDrawers.MyStats),
+    buildScreenTimeDrawerLink: () => buildDrawerLink(ProfileDrawers.ScreenTime),
     buildMatchDrawerLink: () => buildDrawerLink(ProfileDrawers.Match),
   };
 }

--- a/projects/client/src/lib/sections/stats/ScreenTime.svelte
+++ b/projects/client/src/lib/sections/stats/ScreenTime.svelte
@@ -9,7 +9,7 @@
   import { useWeeklyPulse } from "./_internal/useWeeklyPulse.ts";
   import { getDateRangeLabel } from "./_internal/utils/getDateRangeLabel.ts";
 
-  const { buildMyStatsDrawerLink } = profileDrawerNavigation();
+  const { buildScreenTimeDrawerLink } = profileDrawerNavigation();
 
   const { mode } = useDiscover();
 
@@ -23,19 +23,19 @@
 {#if hasItems || $isLoading}
   <SectionList
     id={{
-      scope: "weekly-pulse",
+      scope: "screen-time",
     }}
     items={$items}
-    title={m.header_stats_my_stats()}
+    title={m.header_screen_time()}
     drilldown={{
-      ...buildMyStatsDrawerLink(),
-      source: { id: "weekly-pulse" },
+      ...buildScreenTimeDrawerLink(),
+      source: { id: "screen-time" },
       label: m.button_text_view_all(),
     }}
     --height-list="var(--height-pulse-list)"
   >
     {#snippet metaInfo()}
-      <p class="trakt-weekly-pulse-range tag secondary">
+      <p class="tag secondary">
         {getDateRangeLabel(dateRange)}
       </p>
     {/snippet}
@@ -57,7 +57,7 @@
     {#snippet empty()}
       {#if $isLoading}
         <div class="trakt-pulse-skeleton-wrapper">
-          <SkeletonList id="weekly-pulse" variant="portrait" />
+          <SkeletonList id="screen-time" variant="portrait" />
         </div>
       {/if}
     {/snippet}

--- a/projects/client/src/lib/sections/stats/ScreenTimeDrawerHost.svelte
+++ b/projects/client/src/lib/sections/stats/ScreenTimeDrawerHost.svelte
@@ -26,15 +26,12 @@
 <Drawer
   {onClose}
   onOpened={() => (isOpen = true)}
-  title={m.header_stats_my_stats()}
+  title={m.header_screen_time()}
   size="large"
   {metaInfo}
 >
   {#if isOpen}
-    <div
-      class="weekly-pulse-drawer-content"
-      transition:fade={{ duration: 150 }}
-    >
+    <div class="screen-time-drawer-content" transition:fade={{ duration: 150 }}>
       <div class="pulse-graphs">
         {#each graphs as entry (entry.key)}
           <PulseGraph item={entry} />
@@ -56,8 +53,8 @@
   {/if}
 </Drawer>
 
-<style lang="scss">
-  .weekly-pulse-drawer-content {
+<style>
+  .screen-time-drawer-content {
     display: flex;
     flex-direction: column;
     gap: var(--gap-s);

--- a/projects/client/src/lib/sections/stats/_internal/getStatItems.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/getStatItems.spec.ts
@@ -11,6 +11,8 @@ const emptyWeek: WeekData = {
   uniqueShows: 0,
   ratings: [],
   totalMinutes: 0,
+  movieMinutes: 0,
+  showMinutes: 0,
   dailyMinutes: [],
 };
 
@@ -37,9 +39,8 @@ describe('getStatItems', () => {
       expect(keys).toContain('screenTimeTotal');
       expect(keys).toContain('screenTimeShare');
       expect(keys).toContain('avgPerDay');
-      expect(keys).toContain('movies');
-      expect(keys).toContain('episodes');
-      expect(keys).toContain('shows');
+      expect(keys).toContain('movieTime');
+      expect(keys).toContain('showTime');
     });
 
     it('returns common + movie stats only for movie mode', () => {
@@ -52,9 +53,8 @@ describe('getStatItems', () => {
       expect(keys).toContain('screenTimeTotal');
       expect(keys).toContain('screenTimeShare');
       expect(keys).toContain('avgPerDay');
-      expect(keys).toContain('movies');
-      expect(keys).not.toContain('episodes');
-      expect(keys).not.toContain('shows');
+      expect(keys).toContain('movieTime');
+      expect(keys).not.toContain('showTime');
     });
 
     it('returns common + show stats only for show mode', () => {
@@ -67,9 +67,8 @@ describe('getStatItems', () => {
       expect(keys).toContain('screenTimeTotal');
       expect(keys).toContain('screenTimeShare');
       expect(keys).toContain('avgPerDay');
-      expect(keys).not.toContain('movies');
-      expect(keys).toContain('episodes');
-      expect(keys).toContain('shows');
+      expect(keys).not.toContain('movieTime');
+      expect(keys).toContain('showTime');
     });
   });
 
@@ -94,9 +93,8 @@ describe('getStatItems', () => {
       expect(getKey(items, 'screenTimeTotal')?.deltaKind).toBe('time');
       expect(getKey(items, 'screenTimeShare')?.deltaKind).toBe('percentage');
       expect(getKey(items, 'avgPerDay')?.deltaKind).toBe('time');
-      expect(getKey(items, 'movies')?.deltaKind).toBe('count');
-      expect(getKey(items, 'episodes')?.deltaKind).toBe('count');
-      expect(getKey(items, 'shows')?.deltaKind).toBe('count');
+      expect(getKey(items, 'movieTime')?.deltaKind).toBe('time');
+      expect(getKey(items, 'showTime')?.deltaKind).toBe('time');
     });
   });
 
@@ -151,35 +149,22 @@ describe('getStatItems', () => {
       expect(getKey(items, 'avgPerDay')?.rawValue).toBe(0);
     });
 
-    it('movies rawValue equals movieDates length', () => {
+    it('movieTime rawValue equals movieMinutes', () => {
       const items = getStatItems({
-        thisWeek: makeWeek({
-          movieDates: [new Date(), new Date(), new Date()],
-        }),
+        thisWeek: makeWeek({ movieMinutes: 120 }),
         lastWeek: emptyWeek,
         mode: 'movie',
       });
-      expect(getKey(items, 'movies')?.rawValue).toBe(3);
+      expect(getKey(items, 'movieTime')?.rawValue).toBe(120);
     });
 
-    it('episodes rawValue equals showDates length', () => {
+    it('showTime rawValue equals showMinutes', () => {
       const items = getStatItems({
-        thisWeek: makeWeek({
-          showDates: [new Date(), new Date()],
-        }),
+        thisWeek: makeWeek({ showMinutes: 90 }),
         lastWeek: emptyWeek,
         mode: 'show',
       });
-      expect(getKey(items, 'episodes')?.rawValue).toBe(2);
-    });
-
-    it('shows rawValue equals uniqueShows', () => {
-      const items = getStatItems({
-        thisWeek: makeWeek({ uniqueShows: 5 }),
-        lastWeek: emptyWeek,
-        mode: 'show',
-      });
-      expect(getKey(items, 'shows')?.rawValue).toBe(5);
+      expect(getKey(items, 'showTime')?.rawValue).toBe(90);
     });
   });
 
@@ -204,31 +189,22 @@ describe('getStatItems', () => {
       expect(getKey(items, 'screenTimeShare')?.delta).toBe(25);
     });
 
-    it('movies delta is difference in movie count', () => {
+    it('movieTime delta is difference in movie minutes', () => {
       const items = getStatItems({
-        thisWeek: makeWeek({ movieDates: [new Date(), new Date()] }),
-        lastWeek: makeWeek({ movieDates: [new Date()] }),
+        thisWeek: makeWeek({ movieMinutes: 120 }),
+        lastWeek: makeWeek({ movieMinutes: 60 }),
         mode: 'movie',
       });
-      expect(getKey(items, 'movies')?.delta).toBe(1);
+      expect(getKey(items, 'movieTime')?.delta).toBe(60);
     });
 
-    it('episodes delta is difference in episode count', () => {
+    it('showTime delta is difference in show minutes', () => {
       const items = getStatItems({
-        thisWeek: makeWeek({ showDates: [new Date()] }),
-        lastWeek: makeWeek({ showDates: [new Date(), new Date(), new Date()] }),
+        thisWeek: makeWeek({ showMinutes: 30 }),
+        lastWeek: makeWeek({ showMinutes: 90 }),
         mode: 'show',
       });
-      expect(getKey(items, 'episodes')?.delta).toBe(-2);
-    });
-
-    it('shows delta is difference in unique show count', () => {
-      const items = getStatItems({
-        thisWeek: makeWeek({ uniqueShows: 4 }),
-        lastWeek: makeWeek({ uniqueShows: 4 }),
-        mode: 'show',
-      });
-      expect(getKey(items, 'shows')?.delta).toBe(0);
+      expect(getKey(items, 'showTime')?.delta).toBe(-60);
     });
   });
 });

--- a/projects/client/src/lib/sections/stats/_internal/getStatItems.ts
+++ b/projects/client/src/lib/sections/stats/_internal/getStatItems.ts
@@ -3,7 +3,6 @@ import { getLocale, languageTag } from '$lib/features/i18n/index.ts';
 import * as m from '$lib/features/i18n/messages.ts';
 import { WAKING_HOURS_PER_DAY } from '$lib/sections/stats/_internal/constants/index.ts';
 import { toHumanDuration } from '$lib/utils/formatting/date/toHumanDuration.ts';
-import { toHumanNumber } from '$lib/utils/formatting/number/toHumanNumber.ts';
 import { toPercentage } from '$lib/utils/formatting/number/toPercentage.ts';
 import type { PulseStat } from './models/PulseStat.ts';
 import type { PulseStatItem } from './models/PulseStatItem.ts';
@@ -81,37 +80,25 @@ export function getStatItems(
 
   const movieStats: PulseStat[] = [
     {
-      key: 'movies',
-      rawValue: thisWeek.movieDates.length,
-      value: toHumanNumber(thisWeek.movieDates.length, languageTag()),
+      key: 'movieTime',
+      rawValue: thisWeek.movieMinutes,
+      value: toHumanDuration({ minutes: thisWeek.movieMinutes }, languageTag()),
       label: m.label_stats_movies(),
       tooltip: m.tooltip_stats_movies(),
-      delta: computeDelta(
-        thisWeek.movieDates.length,
-        lastWeek.movieDates.length,
-      ),
-      deltaKind: 'count',
+      delta: computeDelta(thisWeek.movieMinutes, lastWeek.movieMinutes),
+      deltaKind: 'time',
     },
   ];
 
   const showStats: PulseStat[] = [
     {
-      key: 'episodes',
-      rawValue: thisWeek.showDates.length,
-      value: toHumanNumber(thisWeek.showDates.length, languageTag()),
-      label: m.label_stats_episodes(),
-      tooltip: m.tooltip_stats_episodes(),
-      delta: computeDelta(thisWeek.showDates.length, lastWeek.showDates.length),
-      deltaKind: 'count',
-    },
-    {
-      key: 'shows',
-      rawValue: thisWeek.uniqueShows,
-      value: toHumanNumber(thisWeek.uniqueShows, languageTag()),
+      key: 'showTime',
+      rawValue: thisWeek.showMinutes,
+      value: toHumanDuration({ minutes: thisWeek.showMinutes }, languageTag()),
       label: m.label_stats_shows(),
       tooltip: m.tooltip_stats_shows(),
-      delta: computeDelta(thisWeek.uniqueShows, lastWeek.uniqueShows),
-      deltaKind: 'count',
+      delta: computeDelta(thisWeek.showMinutes, lastWeek.showMinutes),
+      deltaKind: 'time',
     },
   ];
 

--- a/projects/client/src/lib/sections/stats/_internal/models/WeekData.ts
+++ b/projects/client/src/lib/sections/stats/_internal/models/WeekData.ts
@@ -4,5 +4,7 @@ export type WeekData = {
   readonly uniqueShows: number;
   readonly ratings: ReadonlyArray<{ readonly rating: number }>;
   readonly totalMinutes: number;
+  readonly movieMinutes: number;
+  readonly showMinutes: number;
   readonly dailyMinutes: ReadonlyArray<number>;
 };

--- a/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
@@ -63,6 +63,8 @@ function buildWeekData(
     uniqueShows: countUniqueShows(shows),
     ratings,
     totalMinutes: computeTotalMinutes(all),
+    movieMinutes: computeTotalMinutes(movies),
+    showMinutes: computeTotalMinutes(shows),
     dailyMinutes: computeDailyMinutes(all, now),
   };
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2507
- Changes `My Stats` to `Screen Time`
- Any non-time related stat is changed to show time related data (e.g. time spent watching movies vs movie count).

## 👀 Example 👀
<img width="1192" height="781" alt="Screenshot 2026-06-05 at 11 31 54" src="https://github.com/user-attachments/assets/9f5f1ad7-c3a7-4ff9-a488-9eed0ba75e94" />

<img width="1192" height="781" alt="Screenshot 2026-06-05 at 11 32 00" src="https://github.com/user-attachments/assets/946145ff-f217-46d2-b832-2a46767917b4" />
