### PR TITLE
feat: enable status global filter

### DIFF
--- a/projects/client/src/lib/features/filters/_internal/constants.ts
+++ b/projects/client/src/lib/features/filters/_internal/constants.ts
@@ -176,7 +176,39 @@ const COUNTRY_FILTER: Filter = {
   },
 };
 
+const STATUS_FILTER: Filter = {
+  label: m.header_status,
+  key: FilterKey.Status,
+  type: 'list',
+  options: [
+    { label: m.translated_value_status_released, value: 'returning series,continuing,released' },
+    { label: m.translated_value_status_upcoming, value: 'upcoming,in production,planned,post production' },
+    { label: m.translated_value_status_ended, value: 'ended' },
+    { label: m.translated_value_status_canceled, value: 'canceled' },
+    { label: m.translated_value_status_rumored, value: 'rumored' },
+  ],
+  advanced: {
+    type: 'multi-select',
+    options: [
+      {
+        label: m.translated_value_status_returning_series,
+        value: 'returning series',
+      },
+      { label: m.translated_value_status_released, value: 'released' },
+      { label: m.translated_value_status_continuing, value: 'continuing' },
+      { label: m.translated_value_status_upcoming, value: 'upcoming' },
+      { label: m.translated_value_status_in_production, value: 'in production' },
+      { label: m.translated_value_status_post_production, value: 'post production' },
+      { label: m.translated_value_status_planned, value: 'planned' },
+      { label: m.translated_value_status_ended, value: 'ended' },
+      { label: m.translated_value_status_canceled, value: 'canceled' },
+      { label: m.translated_value_status_rumored, value: 'rumored' },
+    ],
+  },
+};
+
 export const FILTERS = [
+  STATUS_FILTER,
   GENRE_FILTER,
   STREAMING_FILTER,
   DECADE_FILTER,

--- a/projects/client/src/lib/features/filters/models/Filter.ts
+++ b/projects/client/src/lib/features/filters/models/Filter.ts
@@ -19,6 +19,7 @@ export enum FilterKey {
   ImdbRatings = 'imdb_ratings',
   RtMeter = 'rt_meters',
   RtUserMeter = 'rt_user_meters',
+  Status = 'statuses',
 }
 
 type BaseFilter = {


### PR DESCRIPTION
Adds Status filter to navbar filters. Lets users narrow shows by airing status (returning, upcoming, ended, canceled, etc).

  Simple mode keeps things tidy: 4 grouped buckets that combine related statuses (e.g., "Returning Series" covers both returning series and continuing). Advanced mode exposes all 8 individual ShowStatus values for
  power users who want finer control.

  Status dropdown sits below Certification + Region in simple view. FilterGroup got a small grid tweak so any lone odd row item spans full width — keeps layout balanced no matter how many list filters exist.

  Summary

  - New Status filter (FilterKey.Status = 'statuses').
  - Simple view: 4 grouped options (returning, upcoming, ended, canceled).
  - Advanced view: 8 separate multi-select options, one per ShowStatus.
  - FilterGroup lays out a lone odd child across both columns.
  - New i18n strings: header_status, translated_value_status_*.

  Test plan

  - [ ] Open filter sidebar → Status visible below Certification/Region.
  - [ ] Status spans full width when alone in its row.
  - [ ] Simple Status pick → URL ?statuses=... matches grouped CSV.
  - [ ] Advanced Status → 8 separate multi-select entries.
  - [ ] Multi-select advanced → URL reflects combined CSV.
  - [ ] Reload with ?statuses= param → filter restores.
  - [ ] i18n labels render correctly.