### PR TITLE
feat(discover): add releases calendar

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -394,6 +394,10 @@
       "default": "Anticipated",
       "description": "Title for lists containing anticipated movies or shows. This title should be as short and concise as possible."
     },
+    "list_title_releases": {
+      "default": "Releases",
+      "description": "Title for a curated calendar list of upcoming movies and episodes from trending, recommended, or anticipated titles. This title should be short."
+    },
     "button_text_get_vip": {
       "default": "Get",
       "description": "Text for the button that takes users to the VIP subscription page."
@@ -1229,6 +1233,10 @@
     "button_label_view_all_anticipated_shows": {
       "default": "View all anticipated shows",
       "description": "Aria-label for the button that allows users to view all anticipated shows."
+    },
+    "button_label_view_releases": {
+      "default": "View releases",
+      "description": "Aria-label for the button that opens the Releases page."
     },
     "list_title_anticipated_movies": {
       "default": "Anticipated Movies",
@@ -3531,6 +3539,10 @@
       "default": "Discover",
       "description": "Title for the discover page."
     },
+    "page_description_releases": {
+      "default": "Upcoming movies and episodes from trending, recommended, or anticipated titles.",
+      "description": "Short description for the Releases page."
+    },
     "list_title_start_watching": {
       "default": "Start Watching",
       "description": "Title for lists containing shows or movies a user should start watching. This title should be as short and concise as possible."
@@ -3619,6 +3631,10 @@
     "page_title_trending_media": {
       "default": "Trending media",
       "description": "Title for the trending media page."
+    },
+    "page_title_releases": {
+      "default": "Releases",
+      "description": "Title for the Releases page."
     },
     "button_text_media": {
       "default": "Media",

--- a/projects/client/src/lib/features/calendar/CalendarItem.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarItem.svelte
@@ -10,53 +10,69 @@
   import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { hasAired } from "$lib/utils/media/hasAired";
+  import type { Snippet } from "svelte";
   import type { CalendarItem } from "./_internal/useCalendar";
   import CalendarMediaCard from "./CalendarMediaCard.svelte";
+
+  type CalendarItemProps = {
+    item: CalendarItem;
+    variant?: "default" | "summary";
+    source?: string;
+    popupActions?: Snippet;
+  };
 
   const {
     item,
     variant = "default",
-  }: { item: CalendarItem; variant?: "default" | "summary" } = $props();
+    source = "calendar",
+    popupActions: externalPopupActions,
+  }: CalendarItemProps = $props();
 
   const isDropped = $derived(
     "show" in item ? useIsDropped(item.show).isDropped : undefined,
   );
 
-  const hasActions = $derived(hasAired(item) || !$isDropped);
+  const hasEpisodeActions = $derived(
+    hasAired(item) || !$isDropped || externalPopupActions,
+  );
 </script>
 
 <trakt-calendar-item data-variant={variant}>
   {#if "show" in item}
     {#snippet popupActions()}
-      <RenderFor audience="authenticated">
-        {#if hasAired(item)}
-          <MarkAsWatchedAction
-            style="dropdown-item"
-            type="episode"
-            title={item.title}
-            show={item.show}
-            media={item}
-            mode="hybrid"
-          />
-        {/if}
+      {#if externalPopupActions}
+        {@render externalPopupActions()}
+      {:else}
+        <RenderFor audience="authenticated">
+          {#if hasAired(item)}
+            <MarkAsWatchedAction
+              style="dropdown-item"
+              type="episode"
+              title={item.title}
+              show={item.show}
+              media={item}
+              mode="hybrid"
+            />
+          {/if}
 
-        {#if !$isDropped}
-          <DropAction
-            style="dropdown-item"
-            type="show"
-            id={item.show.id}
-            title={item.show.title}
-          />
-        {/if}
-      </RenderFor>
+          {#if !$isDropped}
+            <DropAction
+              style="dropdown-item"
+              type="show"
+              id={item.show.id}
+              title={item.show.title}
+            />
+          {/if}
+        </RenderFor>
+      {/if}
     {/snippet}
 
     <EpisodeItem
       episode={item}
       media={item.show}
       variant={variant === "default" ? "upcoming" : "calendar"}
-      source="calendar"
-      popupActions={hasActions ? popupActions : undefined}
+      {source}
+      popupActions={hasEpisodeActions ? popupActions : undefined}
     >
       {#snippet tag()}
         {#if variant === "summary"}
@@ -78,7 +94,12 @@
   {/if}
 
   {#if item.type === "movie"}
-    <CalendarMediaCard media={item} type={item.type} />
+    <CalendarMediaCard
+      media={item}
+      type={item.type}
+      {source}
+      popupActions={externalPopupActions}
+    />
   {/if}
 </trakt-calendar-item>
 

--- a/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
@@ -15,10 +15,21 @@
   import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
   import { toTranslatedType } from "$lib/utils/formatting/string/toTranslatedType";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import type { Snippet } from "svelte";
   import { AnalyticsEvent } from "../analytics/events/AnalyticsEvent";
   import { useTrack } from "../analytics/useTrack";
 
-  const { type, media }: Pick<MediaCardProps, "type" | "media"> = $props();
+  type CalendarMediaCardProps = Pick<MediaCardProps, "type" | "media"> & {
+    popupActions?: Snippet;
+    source?: string;
+  };
+
+  const {
+    type,
+    media,
+    popupActions: externalPopupActions,
+    source = "calendar",
+  }: CalendarMediaCardProps = $props();
 
   const { track } = useTrack(AnalyticsEvent.SummaryDrilldown);
 
@@ -35,24 +46,32 @@
   </div>
 {/snippet}
 
+{#snippet popupActions()}
+  {#if externalPopupActions}
+    {@render externalPopupActions()}
+  {:else}
+    <WatchlistAction
+      style="dropdown-item"
+      title={media.title}
+      type={media.type}
+      {media}
+    />
+    <MarkAsWatchedAction
+      style="dropdown-item"
+      title={media.title}
+      type={media.type}
+      {media}
+    />
+  {/if}
+{/snippet}
+
 <LandscapeCard>
   <RenderFor audience="authenticated">
     <CardActionBar>
       {#snippet actions()}
         <PopupMenu label={m.button_label_popup_menu({ title: media.title })}>
           {#snippet items()}
-            <WatchlistAction
-              style="dropdown-item"
-              title={media.title}
-              type={media.type}
-              {media}
-            />
-            <MarkAsWatchedAction
-              style="dropdown-item"
-              title={media.title}
-              type={media.type}
-              {media}
-            />
+            {@render popupActions()}
           {/snippet}
         </PopupMenu>
       {/snippet}
@@ -62,7 +81,7 @@
   <Link
     focusable={false}
     href={UrlBuilder.media(type, media.slug)}
-    onclick={() => track({ source: "calendar", type })}
+    onclick={() => track({ source, type })}
   >
     <CardCover
       title={media.title}

--- a/projects/client/src/lib/features/calendar/ReleasesCalendar.svelte
+++ b/projects/client/src/lib/features/calendar/ReleasesCalendar.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import { useDiscover } from "$lib/features/discover/useDiscover";
+  import type { ReleasesCalendarEntry } from "$lib/requests/queries/calendars/releasesCalendarQuery";
+  import { getDaysDifference } from "$lib/utils/date/getDaysDifference";
+  import { useFilter } from "../filters/useFilter";
+  import { useReleasesCalendar } from "./_internal/useReleasesCalendar";
+  import CalendarLayout from "./CalendarLayout.svelte";
+  import { useCalendarPeriod } from "./context/useCalendarPeriod";
+  import type { CalendarPeriod } from "./models/CalendarLayoutProps";
+  import ReleasesCalendarItem from "./ReleasesCalendarItem.svelte";
+
+  const order = "chronological" as const;
+
+  const {
+    startDate,
+    endDate,
+    next,
+    previous,
+    reset,
+    loadMore,
+    accumulate,
+    activeDate,
+  } = useCalendarPeriod();
+  const { mode } = useDiscover();
+  const { filterMap } = useFilter();
+
+  const days = $derived(getDaysDifference($startDate, $endDate));
+
+  const { isLoading, calendar } = $derived(
+    useReleasesCalendar({
+      start: $startDate,
+      days,
+      type: $mode,
+      filter: $filterMap,
+    }),
+  );
+
+  const periods: CalendarPeriod<ReleasesCalendarEntry>[] = $derived(
+    accumulate({
+      calendar: $calendar,
+      fingerprint: `releases:${$mode}:${JSON.stringify($filterMap)}`,
+    }),
+  );
+
+  const navigation = $derived({
+    onNext: next,
+    onPrevious: previous,
+    onReset: reset,
+  });
+</script>
+
+<CalendarLayout
+  activeDate={$activeDate}
+  isLoading={$isLoading}
+  {navigation}
+  onLoadMore={loadMore}
+  {periods}
+  {order}
+>
+  {#snippet item(media)}
+    <ReleasesCalendarItem item={media} variant="summary" />
+  {/snippet}
+</CalendarLayout>

--- a/projects/client/src/lib/features/calendar/ReleasesCalendarItem.svelte
+++ b/projects/client/src/lib/features/calendar/ReleasesCalendarItem.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import type { ReleasesCalendarEntry } from "$lib/requests/queries/calendars/releasesCalendarQuery";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import ListsDrawer from "$lib/sections/components/lists-drawer/ListsDrawer.svelte";
+  import ListAction from "$lib/sections/components/lists-drawer/ListAction.svelte";
+  import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
+  import WatchlistAction from "$lib/sections/media-actions/watchlist/WatchlistAction.svelte";
+  import { hasAired } from "$lib/utils/media/hasAired";
+  import CalendarItem from "./CalendarItem.svelte";
+
+  type ReleasesCalendarItemProps = {
+    item: ReleasesCalendarEntry;
+    variant?: "default" | "summary";
+  };
+
+  const {
+    item,
+    variant = "default",
+  }: ReleasesCalendarItemProps = $props();
+
+  const listTarget = $derived("show" in item ? item.show : item);
+
+  let isListsDrawerOpen = $state(false);
+</script>
+
+{#snippet popupActions()}
+  <RenderFor audience="authenticated">
+    <WatchlistAction
+      style="dropdown-item"
+      title={listTarget.title}
+      type={listTarget.type}
+      media={listTarget}
+    />
+
+    {#if hasAired(item)}
+      {#if "show" in item}
+        <MarkAsWatchedAction
+          style="dropdown-item"
+          type="episode"
+          title={item.title}
+          show={item.show}
+          media={item}
+          mode="hybrid"
+        />
+      {:else}
+        <MarkAsWatchedAction
+          style="dropdown-item"
+          title={item.title}
+          type={item.type}
+          media={item}
+        />
+      {/if}
+    {/if}
+
+    <ListAction
+      style="dropdown-item"
+      media={listTarget}
+      title={listTarget.title}
+      onClick={() => (isListsDrawerOpen = true)}
+    />
+  </RenderFor>
+{/snippet}
+
+<CalendarItem
+  {item}
+  {variant}
+  source="releases"
+  {popupActions}
+/>
+
+{#if isListsDrawerOpen}
+  <ListsDrawer
+    media={listTarget}
+    onClose={() => (isListsDrawerOpen = false)}
+    metaInfo={listTarget.title}
+  />
+{/if}

--- a/projects/client/src/lib/features/calendar/_internal/useReleasesCalendar.ts
+++ b/projects/client/src/lib/features/calendar/_internal/useReleasesCalendar.ts
@@ -1,0 +1,69 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import {
+  type ReleasesCalendarEntry,
+  releasesCalendarQuery,
+} from '$lib/requests/queries/calendars/releasesCalendarQuery.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { isSameDay } from 'date-fns/isSameDay';
+import { map, type Observable } from 'rxjs';
+import type { FilterParams } from '../../../requests/models/FilterParams.ts';
+import type { DiscoverMode } from '../../discover/models/DiscoverMode.ts';
+import type { Calendar } from '../models/Calendar.ts';
+
+const releasesCalendarSourceLimit = 50;
+
+type UseReleasesCalendarParams = {
+  start: Date;
+  days: number;
+  type: DiscoverMode;
+} & FilterParams;
+
+type ReleasesCalendarResult = {
+  isLoading: Observable<boolean>;
+  calendar: Observable<Calendar<ReleasesCalendarEntry>>;
+};
+
+export function useReleasesCalendar(
+  props: UseReleasesCalendarParams,
+): ReleasesCalendarResult {
+  const [yyyyMmDd] = props.start.toISOString().split('T');
+  const startDate = assertDefined(
+    yyyyMmDd,
+    'Could not extract start date.',
+  );
+
+  const query = useQuery(
+    releasesCalendarQuery({
+      startDate,
+      days: props.days,
+      type: props.type,
+      filter: props.filter,
+      filterOverride: props.filterOverride,
+      sourceLimit: releasesCalendarSourceLimit,
+    }),
+  );
+
+  const isLoading = query.pipe(
+    map(toLoadingState),
+  );
+
+  return {
+    isLoading,
+    calendar: query.pipe(
+      map(($query) => $query.data ?? []),
+      map(($items) =>
+        Array.from({ length: props.days }, (_, i) => {
+          const date = new Date(props.start);
+          date.setDate(props.start.getDate() + i);
+
+          const items = $items.filter(
+            (item) => isSameDay(item.effectiveReleaseDate, date),
+          );
+
+          return { date, items };
+        })
+      ),
+    ),
+  };
+}

--- a/projects/client/src/lib/requests/_internal/mapToUpcomingEpisodeEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToUpcomingEpisodeEntry.ts
@@ -1,0 +1,13 @@
+import type { UpcomingEpisodeEntry } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
+import type { CalendarShowResponse } from '@trakt/api';
+import { mapToEpisodeEntry } from './mapToEpisodeEntry.ts';
+import { mapToShowEntry } from './mapToShowEntry.ts';
+
+export function mapToUpcomingEpisodeEntry(
+  item: CalendarShowResponse,
+): UpcomingEpisodeEntry {
+  return {
+    show: mapToShowEntry(item.show),
+    ...mapToEpisodeEntry(item.episode),
+  };
+}

--- a/projects/client/src/lib/requests/queries/calendars/releasesCalendarQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/calendars/releasesCalendarQuery.spec.ts
@@ -1,0 +1,29 @@
+import { time } from '$lib/utils/timing/time.ts';
+import { UpcomingEpisodesMappedMock } from '$mocks/data/calendars/mapped/UpcomingEpisodesMappedMock.ts';
+import { UpcomingMoviesMappedMock } from '$mocks/data/calendars/mapped/UpcomingMoviesMappedMock.ts';
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { describe, expect, it } from 'vitest';
+import { releasesCalendarQuery } from './releasesCalendarQuery.ts';
+
+describe('releasesCalendarQuery', () => {
+  it('should query all calendar entries that are in releases source lists', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createTestBedQuery(
+          releasesCalendarQuery({
+            startDate: new Date(Date.now() - time.days(1)).toISOString(),
+            days: 30,
+            type: 'media',
+            sourceLimit: 10,
+          }),
+        ),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal([
+      ...UpcomingEpisodesMappedMock,
+      ...UpcomingMoviesMappedMock,
+    ]);
+  });
+});

--- a/projects/client/src/lib/requests/queries/calendars/releasesCalendarQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/releasesCalendarQuery.ts
@@ -1,0 +1,351 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import type { DiscoverMode } from '$lib/features/discover/models/DiscoverMode.ts';
+import { coalesceEpisodes } from '$lib/requests/_internal/coalesceEpisodes.ts';
+import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
+import { mapToMovieEntry } from '$lib/requests/_internal/mapToMovieEntry.ts';
+import { mapToUpcomingEpisodeEntry } from '$lib/requests/_internal/mapToUpcomingEpisodeEntry.ts';
+import type { ApiParams } from '$lib/requests/api.ts';
+import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { MovieEntrySchema } from '$lib/requests/models/MovieEntry.ts';
+import { movieAnticipatedRequest } from '$lib/requests/queries/movies/movieAnticipatedQuery.ts';
+import { movieTrendingRequest } from '$lib/requests/queries/movies/movieTrendingQuery.ts';
+import { recommendedMoviesRequest } from '$lib/requests/queries/recommendations/recommendedMoviesQuery.ts';
+import { recommendedShowsRequest } from '$lib/requests/queries/recommendations/recommendedShowsQuery.ts';
+import { showAnticipatedRequest } from '$lib/requests/queries/shows/showAnticipatedQuery.ts';
+import { showTrendingRequest } from '$lib/requests/queries/shows/showTrendingQuery.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import type { CalendarMovieResponse, CalendarShowResponse } from '@trakt/api';
+import { z } from 'zod';
+import {
+  UpcomingEpisodeEntrySchema,
+  upcomingEpisodesRequest,
+} from './upcomingEpisodesQuery.ts';
+import { upcomingMoviesRequest } from './upcomingMoviesQuery.ts';
+
+type IdContainer = {
+  ids: {
+    trakt: number;
+  };
+};
+
+type MovieTopListItem = {
+  movie: IdContainer;
+};
+
+type ShowTopListItem = {
+  show: IdContainer;
+};
+
+type TopListResult<T> = {
+  lists: ReadonlyArray<ReadonlyArray<T> | Nil>;
+  responses: ReadonlyArray<{ status: number }>;
+};
+
+type ReleasesCalendarBody = {
+  movies: CalendarMovieResponse[];
+  episodes: CalendarShowResponse[];
+  movieTopLists: ReadonlyArray<ReadonlyArray<MovieTopListItem> | Nil>;
+  showTopLists: ReadonlyArray<ReadonlyArray<ShowTopListItem> | Nil>;
+};
+
+type ReleasesCalendarResponse = {
+  body: ReleasesCalendarBody;
+  status: number;
+};
+
+export type ReleasesCalendarParams =
+  & {
+    startDate: string;
+    days: number;
+    type: DiscoverMode;
+    sourceLimit: number;
+  }
+  & ApiParams
+  & FilterParams;
+
+const ReleasesCalendarEntrySchema = z.union([
+  UpcomingEpisodeEntrySchema,
+  MovieEntrySchema,
+]);
+
+export type ReleasesCalendarEntry = z.infer<typeof ReleasesCalendarEntrySchema>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function hasTraktId(value: unknown): value is IdContainer {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const ids = value.ids;
+  if (!isRecord(ids)) {
+    return false;
+  }
+
+  return typeof ids.trakt === 'number';
+}
+
+function isMovieTopListItem(item: unknown): item is MovieTopListItem {
+  return isRecord(item) && hasTraktId(item.movie);
+}
+
+function isShowTopListItem(item: unknown): item is ShowTopListItem {
+  return isRecord(item) && hasTraktId(item.show);
+}
+
+function isCalendarMovie(item: unknown): item is CalendarMovieResponse {
+  return isRecord(item) && isRecord(item.movie);
+}
+
+function isCalendarShow(item: unknown): item is CalendarShowResponse {
+  return isRecord(item) && isRecord(item.show) && isRecord(item.episode);
+}
+
+function toList<T>(
+  body: unknown,
+  isItem: (item: unknown) => item is T,
+): T[] {
+  if (!Array.isArray(body)) {
+    return [];
+  }
+
+  return body.filter(isItem);
+}
+
+function idsFromLists<T>(
+  lists: ReadonlyArray<ReadonlyArray<T> | Nil>,
+  getId: (item: T) => number,
+) {
+  return new Set(
+    lists.flatMap((list) => list?.map(getId) ?? []),
+  );
+}
+
+function findFailedResponse(
+  responses: ReadonlyArray<{ status: number } | Nil>,
+) {
+  return responses.find((response) =>
+    response != null && response.status !== 200
+  );
+}
+
+async function fetchMovieTopLists(
+  {
+    fetch,
+    filter,
+    filterOverride,
+    sourceLimit,
+  }: ReleasesCalendarParams,
+): Promise<TopListResult<MovieTopListItem>> {
+  const [trending, recommended, anticipated] = await Promise.all([
+    movieTrendingRequest({
+      fetch,
+      filter,
+      filterOverride,
+      limit: sourceLimit,
+      page: 1,
+    }),
+    recommendedMoviesRequest({
+      fetch,
+      filter,
+      filterOverride,
+      limit: sourceLimit,
+    }),
+    movieAnticipatedRequest({
+      fetch,
+      filter,
+      filterOverride,
+      limit: sourceLimit,
+      page: 1,
+    }),
+  ]);
+
+  return {
+    responses: [trending, recommended, anticipated],
+    lists: [
+      toList(trending.body, isMovieTopListItem),
+      toList(recommended.body, isMovieTopListItem),
+      toList(anticipated.body, isMovieTopListItem),
+    ],
+  };
+}
+
+async function fetchShowTopLists(
+  {
+    fetch,
+    filter,
+    filterOverride,
+    sourceLimit,
+  }: ReleasesCalendarParams,
+): Promise<TopListResult<ShowTopListItem>> {
+  const [trending, recommended, anticipated] = await Promise.all([
+    showTrendingRequest({
+      fetch,
+      filter,
+      filterOverride,
+      limit: sourceLimit,
+      page: 1,
+    }),
+    recommendedShowsRequest({
+      fetch,
+      filter,
+      filterOverride,
+      limit: sourceLimit,
+    }),
+    showAnticipatedRequest({
+      fetch,
+      filter,
+      filterOverride,
+      limit: sourceLimit,
+      page: 1,
+    }),
+  ]);
+
+  return {
+    responses: [trending, recommended, anticipated],
+    lists: [
+      toList(trending.body, isShowTopListItem),
+      toList(recommended.body, isShowTopListItem),
+      toList(anticipated.body, isShowTopListItem),
+    ],
+  };
+}
+
+const emptyTopListResult = <T>(): TopListResult<T> => ({
+  lists: [],
+  responses: [],
+});
+
+const emptyReleasesCalendarBody = (): ReleasesCalendarBody => ({
+  movies: [],
+  episodes: [],
+  movieTopLists: [],
+  showTopLists: [],
+});
+
+const releasesCalendarRequest = async (
+  params: ReleasesCalendarParams,
+): Promise<ReleasesCalendarResponse> => {
+  const { fetch, startDate, days, type, filter, filterOverride } = params;
+
+  const includeMovies = type !== 'show';
+  const includeShows = type !== 'movie';
+
+  const [
+    moviesResponse,
+    episodesResponse,
+    movieTopLists,
+    showTopLists,
+  ] = await Promise.all([
+    includeMovies
+      ? upcomingMoviesRequest({
+        fetch,
+        startDate,
+        days,
+        filter,
+        filterOverride,
+        target: 'all',
+      })
+      : undefined,
+    includeShows
+      ? upcomingEpisodesRequest({
+        fetch,
+        startDate,
+        days,
+        filter,
+        filterOverride,
+        target: 'all',
+      })
+      : undefined,
+    includeMovies
+      ? fetchMovieTopLists(params)
+      : emptyTopListResult<MovieTopListItem>(),
+    includeShows
+      ? fetchShowTopLists(params)
+      : emptyTopListResult<ShowTopListItem>(),
+  ]);
+
+  const failedResponse = findFailedResponse([
+    moviesResponse,
+    episodesResponse,
+    ...movieTopLists.responses,
+    ...showTopLists.responses,
+  ]);
+
+  if (failedResponse) {
+    return {
+      body: emptyReleasesCalendarBody(),
+      status: failedResponse.status,
+    };
+  }
+
+  return {
+    body: {
+      movies: toList(moviesResponse?.body, isCalendarMovie),
+      episodes: toList(episodesResponse?.body, isCalendarShow),
+      movieTopLists: movieTopLists.lists,
+      showTopLists: showTopLists.lists,
+    },
+    status: 200,
+  };
+};
+
+export const releasesCalendarQuery = defineQuery({
+  key: 'releasesCalendar',
+  invalidations: [
+    InvalidateAction.Watchlisted('show'),
+    InvalidateAction.MarkAsWatched('episode'),
+    InvalidateAction.MarkAsWatched('show'),
+    InvalidateAction.Drop('show'),
+    InvalidateAction.Watchlisted('movie'),
+    InvalidateAction.MarkAsWatched('movie'),
+    InvalidateAction.HideRecommended('show'),
+    InvalidateAction.HideRecommended('movie'),
+  ],
+  dependencies: (
+    params: ReleasesCalendarParams,
+  ) => [
+    params.type,
+    params.startDate,
+    params.days,
+    params.sourceLimit,
+    ...getGlobalFilterDependencies(
+      params.filterOverride?.movie ?? params.filter,
+    ),
+    ...getGlobalFilterDependencies(
+      params.filterOverride?.show ?? params.filter,
+    ),
+  ],
+  request: releasesCalendarRequest,
+  mapper: (response) => {
+    const movieIds = idsFromLists(
+      response.body.movieTopLists,
+      (item) => item.movie.ids.trakt,
+    );
+    const showIds = idsFromLists(
+      response.body.showTopLists,
+      (item) => item.show.ids.trakt,
+    );
+
+    const movies = response.body.movies
+      .filter((entry) => movieIds.has(entry.movie.ids.trakt))
+      .map((entry) => mapToMovieEntry(entry.movie));
+
+    const episodes = coalesceEpisodes(
+      response.body.episodes
+        .filter((entry) => showIds.has(entry.show.ids.trakt))
+        .map(mapToUpcomingEpisodeEntry),
+    );
+
+    return [...episodes, ...movies]
+      .toSorted((a, b) =>
+        a.effectiveReleaseDate.getTime() - b.effectiveReleaseDate.getTime()
+      );
+  },
+  schema: ReleasesCalendarEntrySchema.array(),
+  ttl: time.minutes(30),
+  refetchOnWindowFocus: true,
+});

--- a/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
@@ -1,7 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { coalesceEpisodes } from '$lib/requests/_internal/coalesceEpisodes.ts';
-import { mapToEpisodeEntry } from '$lib/requests/_internal/mapToEpisodeEntry.ts';
-import { mapToShowEntry } from '$lib/requests/_internal/mapToShowEntry.ts';
+import { mapToUpcomingEpisodeEntry } from '$lib/requests/_internal/mapToUpcomingEpisodeEntry.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
@@ -15,6 +14,7 @@ export type CalendarShowsParams =
   & {
     startDate: string;
     days: number;
+    target?: 'my' | 'all';
   }
   & ApiParams
   & FilterParams;
@@ -25,21 +25,25 @@ export const UpcomingEpisodeEntrySchema = EpisodeEntrySchema.merge(z.object({
 export type UpcomingEpisodeEntry = z.infer<typeof UpcomingEpisodeEntrySchema>;
 
 export const upcomingEpisodesRequest = (
-  { fetch, startDate, days, filter }: CalendarShowsParams,
-) =>
-  api({ fetch })
+  { fetch, startDate, days, filter, filterOverride, target = 'my' }:
+    CalendarShowsParams,
+) => {
+  const filterParams = filterOverride?.show ?? filter;
+
+  return api({ fetch })
     .calendars
     .shows({
       query: {
         extended: 'full,images',
-        ...filter,
+        ...filterParams,
       },
       params: {
-        target: 'my',
+        target,
         start_date: startDate,
         days,
       },
     });
+};
 
 export const upcomingEpisodesQuery = defineQuery({
   key: 'upcomingEpisodes',
@@ -52,19 +56,16 @@ export const upcomingEpisodesQuery = defineQuery({
   dependencies: (
     params,
   ) => [
+    params.target,
     params.startDate,
     params.days,
-    ...getGlobalFilterDependencies(params.filter),
+    ...getGlobalFilterDependencies(
+      params.filterOverride?.show ?? params.filter,
+    ),
   ],
   request: upcomingEpisodesRequest,
-  mapper: (response) => {
-    const episodes = response.body.map((item) => ({
-      show: mapToShowEntry(item.show),
-      ...mapToEpisodeEntry(item.episode),
-    }));
-
-    return coalesceEpisodes(episodes);
-  },
+  mapper: (response) =>
+    coalesceEpisodes(response.body.map(mapToUpcomingEpisodeEntry)),
   schema: UpcomingEpisodeEntrySchema.array(),
   ttl: time.minutes(30),
   refetchOnWindowFocus: true,

--- a/projects/client/src/lib/requests/queries/calendars/upcomingMediaQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingMediaQuery.ts
@@ -1,7 +1,6 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { coalesceEpisodes } from '$lib/requests/_internal/coalesceEpisodes.ts';
-import { mapToEpisodeEntry } from '$lib/requests/_internal/mapToEpisodeEntry.ts';
-import { mapToShowEntry } from '$lib/requests/_internal/mapToShowEntry.ts';
+import { mapToUpcomingEpisodeEntry } from '$lib/requests/_internal/mapToUpcomingEpisodeEntry.ts';
 import { type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { time } from '$lib/utils/timing/time.ts';
@@ -20,6 +19,7 @@ export type CalendarMediaParams =
   & {
     startDate: string;
     days: number;
+    target?: 'my' | 'all';
   }
   & ApiParams
   & FilterParams;
@@ -42,9 +42,15 @@ export const upcomingMediaQuery = defineQuery({
   dependencies: (
     params: CalendarMediaParams,
   ) => [
+    params.target,
     params.startDate,
     params.days,
-    ...getGlobalFilterDependencies(params.filter),
+    ...getGlobalFilterDependencies(
+      params.filterOverride?.movie ?? params.filter,
+    ),
+    ...getGlobalFilterDependencies(
+      params.filterOverride?.show ?? params.filter,
+    ),
   ],
   request: (params) =>
     Promise.all([
@@ -52,11 +58,9 @@ export const upcomingMediaQuery = defineQuery({
       upcomingMoviesRequest(params),
     ]),
   mapper: ([episodesResponse, moviesResponse]) => {
-    const allEpisodes = episodesResponse.body.map((item) => ({
-      show: mapToShowEntry(item.show),
-      ...mapToEpisodeEntry(item.episode),
-    }));
-    const episodes = coalesceEpisodes(allEpisodes);
+    const episodes = coalesceEpisodes(
+      episodesResponse.body.map(mapToUpcomingEpisodeEntry),
+    );
 
     const movies = moviesResponse.body.map((entry) =>
       mapToMovieEntry(entry.movie)

--- a/projects/client/src/lib/requests/queries/calendars/upcomingMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingMoviesQuery.ts
@@ -11,26 +11,31 @@ export type CalendarMoviesParams =
   & {
     startDate: string;
     days: number;
+    target?: 'my' | 'all';
   }
   & ApiParams
   & FilterParams;
 
 export const upcomingMoviesRequest = (
-  { fetch, startDate, days, filter }: CalendarMoviesParams,
-) =>
-  api({ fetch })
+  { fetch, startDate, days, filter, filterOverride, target = 'my' }:
+    CalendarMoviesParams,
+) => {
+  const filterParams = filterOverride?.movie ?? filter;
+
+  return api({ fetch })
     .calendars
     .movies({
       query: {
         extended: 'full,images',
-        ...filter,
+        ...filterParams,
       },
       params: {
-        target: 'my',
+        target,
         start_date: startDate,
         days,
       },
     });
+};
 
 export const upcomingMoviesQuery = defineQuery({
   key: 'upcomingMovies',
@@ -41,9 +46,12 @@ export const upcomingMoviesQuery = defineQuery({
   dependencies: (
     params,
   ) => [
+    params.target,
     params.startDate,
     params.days,
-    ...getGlobalFilterDependencies(params.filter),
+    ...getGlobalFilterDependencies(
+      params.filterOverride?.movie ?? params.filter,
+    ),
   ],
   request: upcomingMoviesRequest,
   mapper: (response) =>

--- a/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieAnticipatedQuery.ts
@@ -35,7 +35,7 @@ export function mapToAnticipatedMovie({
   };
 }
 
-const movieAnticipatedRequest = (
+export const movieAnticipatedRequest = (
   { fetch, limit, page, filter, filterOverride, search }:
     MovieAnticipatedParams,
 ) => {

--- a/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieTrendingQuery.ts
@@ -35,7 +35,7 @@ export function mapToTrendingMovie({
   };
 }
 
-const movieTrendingRequest = (
+export const movieTrendingRequest = (
   { fetch, limit, page, filter, filterOverride, search }: MovieTrendingParams,
 ) => {
   const filterParams = filterOverride?.movie ?? filter;

--- a/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showAnticipatedQuery.ts
@@ -42,7 +42,7 @@ export function mapToAnticipatedShow({
   };
 }
 
-const showAnticipatedRequest = (
+export const showAnticipatedRequest = (
   { fetch, limit, page, filter, filterOverride, search }: ShowAnticipatedParams,
 ) => {
   const filterParams = filterOverride?.show ?? filter;

--- a/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showTrendingQuery.ts
@@ -36,7 +36,7 @@ export function mapToTrendingShow({
   };
 }
 
-const showTrendingRequest = (
+export const showTrendingRequest = (
   { fetch, limit, page, filter, filterOverride, search }: ShowTrendingParams,
 ) => {
   const filterParams = filterOverride?.show ?? filter;

--- a/projects/client/src/lib/sections/lists/ReleasesList.svelte
+++ b/projects/client/src/lib/sections/lists/ReleasesList.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import ReleasesCalendarItem from "$lib/features/calendar/ReleasesCalendarItem.svelte";
+  import { useDiscover } from "$lib/features/discover/useDiscover";
+  import { useFilter } from "$lib/features/filters/useFilter";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import DrillableMediaList from "./drilldown/DrillableMediaList.svelte";
+  import { useReleasesItems } from "./stores/useReleasesItems";
+
+  const { mode } = useDiscover();
+  const { filterMap } = useFilter();
+</script>
+
+<DrillableMediaList
+  id={{
+    scope: "releases-list",
+    key: $mode,
+  }}
+  source={{ id: "releases", type: $mode }}
+  type={$mode}
+  variant="landscape"
+  filter={$filterMap}
+  useList={useReleasesItems}
+  urlBuilder={({ type }) => UrlBuilder.releases({ mode: type })}
+  drilldownLabel={m.button_label_view_releases()}
+  title={m.list_title_releases()}
+>
+  {#snippet item(entry)}
+    <ReleasesCalendarItem item={entry} />
+  {/snippet}
+</DrillableMediaList>

--- a/projects/client/src/lib/sections/lists/stores/_internal/filterReleasesItems.spec.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/filterReleasesItems.spec.ts
@@ -1,0 +1,76 @@
+import type { ReleasesCalendarEntry } from '$lib/requests/queries/calendars/releasesCalendarQuery.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { UpcomingEpisodesMappedMock } from '$mocks/data/calendars/mapped/UpcomingEpisodesMappedMock.ts';
+import { UpcomingMoviesMappedMock } from '$mocks/data/calendars/mapped/UpcomingMoviesMappedMock.ts';
+import { describe, expect, it } from 'vitest';
+import { filterReleasesItems } from './filterReleasesItems.ts';
+
+const baseEpisode = assertDefined(UpcomingEpisodesMappedMock.at(0));
+const baseMovie = assertDefined(UpcomingMoviesMappedMock.at(0));
+
+function releaseDate(day: number) {
+  return new Date(`2026-01-${day.toString().padStart(2, '0')}T00:00:00.000Z`);
+}
+
+function episodeOn(day: number, id: number): ReleasesCalendarEntry {
+  const date = releaseDate(day);
+
+  return {
+    ...baseEpisode,
+    airDate: date,
+    effectiveReleaseDate: date,
+    id,
+    key: `episode-${id}`,
+    number: id,
+    releaseDate: date,
+  };
+}
+
+function movieOn(day: number, id: number): ReleasesCalendarEntry {
+  const date = releaseDate(day);
+
+  return {
+    ...baseMovie,
+    airDate: date,
+    effectiveReleaseDate: date,
+    id,
+    key: `movie-${id}`,
+    releaseDate: date,
+    slug: `movie-${id}`,
+  };
+}
+
+describe('filterReleasesItems', () => {
+  it('should keep only future items and the next episode per show', () => {
+    const pastEpisode = episodeOn(1, 100);
+    const movie = movieOn(2, 200);
+    const firstShowEpisode = episodeOn(3, 101);
+    const secondShowEpisode = episodeOn(4, 102);
+
+    const result = filterReleasesItems({
+      entries: [
+        secondShowEpisode,
+        pastEpisode,
+        movie,
+        firstShowEpisode,
+      ],
+      limit: 10,
+      now: releaseDate(1),
+    });
+
+    expect(result).to.deep.equal([
+      movie,
+      firstShowEpisode,
+    ]);
+  });
+
+  it('should return no items when the limit is not positive', () => {
+    const result = filterReleasesItems({
+      entries: [movieOn(2, 200)],
+      limit: 0,
+      now: releaseDate(1),
+    });
+
+    expect(result).to.deep.equal([]);
+  });
+});

--- a/projects/client/src/lib/sections/lists/stores/_internal/filterReleasesItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/filterReleasesItems.ts
@@ -1,0 +1,48 @@
+import type { ReleasesCalendarEntry } from '$lib/requests/queries/calendars/releasesCalendarQuery.ts';
+import type { UpcomingEpisodeEntry } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
+
+type FilterReleasesItemsParams = {
+  entries: readonly ReleasesCalendarEntry[];
+  limit: number;
+  now: Date;
+};
+
+function isUpcomingEpisodeEntry(
+  entry: ReleasesCalendarEntry,
+): entry is UpcomingEpisodeEntry {
+  return 'show' in entry;
+}
+
+export function filterReleasesItems({
+  entries,
+  limit,
+  now,
+}: FilterReleasesItemsParams): ReleasesCalendarEntry[] {
+  if (limit <= 0) {
+    return [];
+  }
+
+  const seenShowIds = new Set<number>();
+  const nowTime = now.getTime();
+
+  return entries
+    .filter((entry) => entry.effectiveReleaseDate.getTime() > nowTime)
+    .toSorted((a, b) =>
+      a.effectiveReleaseDate.getTime() - b.effectiveReleaseDate.getTime()
+    )
+    .filter((entry) => {
+      if (!isUpcomingEpisodeEntry(entry)) {
+        return true;
+      }
+
+      const showId = entry.show.id;
+
+      if (seenShowIds.has(showId)) {
+        return false;
+      }
+
+      seenShowIds.add(showId);
+      return true;
+    })
+    .slice(0, limit);
+}

--- a/projects/client/src/lib/sections/lists/stores/useReleasesItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/useReleasesItems.ts
@@ -1,0 +1,50 @@
+import type { DiscoverMode } from '$lib/features/discover/models/DiscoverMode.ts';
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
+import {
+  releasesCalendarQuery,
+} from '$lib/requests/queries/calendars/releasesCalendarQuery.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { map } from 'rxjs';
+import { filterReleasesItems } from './_internal/filterReleasesItems.ts';
+
+type UseReleasesItemsProps = {
+  type: DiscoverMode;
+  limit: number;
+} & FilterParams;
+
+const daysToFetch = 30;
+const releasesSourceLimit = 20;
+
+export function useReleasesItems(props: UseReleasesItemsProps) {
+  const [yyyyMmDd] = new Date().toISOString().split('T');
+  const startDate = assertDefined(
+    yyyyMmDd,
+    'Could not extract current date.',
+  );
+
+  const query = useQuery(
+    releasesCalendarQuery({
+      startDate,
+      days: daysToFetch,
+      type: props.type,
+      filter: props.filter,
+      filterOverride: props.filterOverride,
+      sourceLimit: releasesSourceLimit,
+    }),
+  );
+
+  const isLoading = query.pipe(map(($query) => $query.isLoading));
+
+  const list = query.pipe(
+    map(($query) =>
+      filterReleasesItems({
+        entries: $query.data ?? [],
+        limit: props.limit,
+        now: new Date(),
+      })
+    ),
+  );
+
+  return { list, isLoading };
+}

--- a/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
@@ -9,6 +9,7 @@ import {
 import { upcomingMediaQuery } from '$lib/requests/queries/calendars/upcomingMediaQuery.ts';
 import { upcomingMoviesQuery } from '$lib/requests/queries/calendars/upcomingMoviesQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { type CreateQueryOptions } from '@tanstack/svelte-query';
 import { map } from 'rxjs';
 
@@ -19,11 +20,10 @@ type UseUpcomingItemsProps = {
 
 type UpcomingList = Array<MediaEntry | UpcomingEpisodeEntry>;
 
-const ONE_DAY = 1000 * 60 * 60 * 24;
-const DAYS_TO_FETCH = 14;
+const daysToFetch = 14;
 
 function daysAgo(days: number) {
-  return new Date(Date.now() - ONE_DAY * days);
+  return new Date(Date.now() - time.days(days));
 }
 
 function getUpcomingCalendarQuery(
@@ -32,7 +32,7 @@ function getUpcomingCalendarQuery(
 ) {
   const params = {
     startDate,
-    days: DAYS_TO_FETCH,
+    days: daysToFetch,
     filter: props.filter,
   };
 

--- a/projects/client/src/lib/sections/navbar/_internal/SideNavbarContent.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/SideNavbarContent.svelte
@@ -61,6 +61,7 @@
         UrlBuilder.anticipated(),
         m.list_title_most_anticipated(),
       )}
+      {@render navSubLink(UrlBuilder.releases(), m.list_title_releases())}
       {@render navSubLink(UrlBuilder.popular(), m.list_title_most_popular())}
     </NavGroup>
 

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -161,6 +161,9 @@ export const UrlBuilder = {
   popular(params?: DiscoverUrlParams) {
     return discoverDrilldownFactory('popular')(params);
   },
+  releases(params?: DiscoverUrlParams) {
+    return discoverDrilldownFactory('releases')(params);
+  },
   social: {
     activity: () => {
       return '/social/activity';

--- a/projects/client/src/mocks/handlers/calendars.ts
+++ b/projects/client/src/mocks/handlers/calendars.ts
@@ -11,7 +11,19 @@ export const calendars = [
     },
   ),
   http.get(
+    'http://localhost/calendars/all/shows/*',
+    () => {
+      return HttpResponse.json(UpcomingEpisodesResponseMock);
+    },
+  ),
+  http.get(
     'http://localhost/calendars/my/movies/*',
+    () => {
+      return HttpResponse.json(UpcomingMoviesResponseMock);
+    },
+  ),
+  http.get(
+    'http://localhost/calendars/all/movies/*',
     () => {
       return HttpResponse.json(UpcomingMoviesResponseMock);
     },

--- a/projects/client/src/routes/discover/+page.svelte
+++ b/projects/client/src/routes/discover/+page.svelte
@@ -9,6 +9,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import AnticipatedList from "$lib/sections/lists/anticipated/AnticipatedList.svelte";
   import PopularList from "$lib/sections/lists/popular/PopularList.svelte";
+  import ReleasesList from "$lib/sections/lists/ReleasesList.svelte";
   import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
   import TrendingList from "$lib/sections/lists/trending/TrendingList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
@@ -92,6 +93,9 @@
     type={$type}
     filterOverride={getThemeFilters("anticipated")}
   />
+  <RenderFor audience="authenticated">
+    <ReleasesList />
+  </RenderFor>
   <PopularList
     drilldownLabel={$type === "show"
       ? m.button_label_view_all_popular_shows()

--- a/projects/client/src/routes/discover/releases/+page.svelte
+++ b/projects/client/src/routes/discover/releases/+page.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import CalendarProvider from "$lib/features/calendar/CalendarProvider.svelte";
+  import ReleasesCalendar from "$lib/features/calendar/ReleasesCalendar.svelte";
+  import { useDiscover } from "$lib/features/discover/useDiscover";
+  import * as m from "$lib/features/i18n/messages";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
+
+  const { current } = useDiscover();
+</script>
+
+<TraktPage
+  audience="authenticated"
+  image={DEFAULT_SHARE_SHOW_COVER}
+  title={m.page_title_releases()}
+  info={{ overview: m.page_description_releases() }}
+>
+  <CalendarProvider>
+    <NavbarStateSetter
+      hasFilters
+      header={{
+        title: m.list_title_releases(),
+        metaInfo: $current.text(),
+      }}
+    />
+
+    <TraktPageCoverSetter />
+
+    <ReleasesCalendar />
+  </CalendarProvider>
+</TraktPage>


### PR DESCRIPTION
## Summary

Adds a new Discover Releases experience backed by the all-calendar endpoint. Releases gives users a broader view of what is coming out soon without requiring them to follow every show or movie first.

Today, `/calendar` is focused on “my” calendar: releases from shows and movies the user follows. That works well for personal tracking, but it does not help users discover upcoming releases.

The new Releases page solves that by showing upcoming movies and TV episodes from the all-calendar feed, filtered through high-signal Discover sources like trending, recommended, and anticipated titles. This helps users quickly answer: “What worthwhile releases are coming up?” without wading through the full global calendar.

Related: https://github.com/trakt/trakt-web/issues/1703

## Changes

- Add a Releases row to Discover and a `/discover/releases` calendar page.
- Swapped the Popular sub-entry in the sidebar for this Releases shortcut.
- Query the all-calendar target and filter results to trending, recommended, or anticipated movies/shows.
- Keep the row higher quality by using a smaller source window and showing only the next upcoming episode per show.
- Use Releases-specific dropdown actions without the personal-calendar Drop Show action.
- Add unit coverage for the Releases calendar query and row filtering.

## Design

<img width="1592" height="977" alt="Screenshot 2026-06-05 at 11 54 33" src="https://github.com/user-attachments/assets/4364ee84-a159-40d6-a592-6b39b0414518" />
<img width="1592" height="977" alt="Screenshot 2026-06-05 at 11 53 56" src="https://github.com/user-attachments/assets/996e2ad2-662d-4360-bcef-44a0f3717afe" />
