### PR TITLE
fix(watched): hide mark-as-watched on unreleased episodes in seasons drawer

### DIFF
--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -45,7 +45,9 @@
     useMarkAsWatched({ type: "episode", media: episode, show }),
   );
 
-  const isActionable = $derived(isWatchable || hasBulkMarkAsWatched);
+  const isActionable = $derived(
+    !isFuture && (isWatchable || hasBulkMarkAsWatched),
+  );
   const variant = $derived(isFuture ? "upcoming" : "default");
 
   const src = $derived(


### PR DESCRIPTION
## Summary

In the seasons drawer (`/shows/<slug>?view=seasons&mode=show`), unreleased episodes (e.g. `tna-impact` S23 E24-E26) were showing the per-episode mark-as-watched action in their popup menu.

Root cause: `SeasonEpisodeItem.isActionable` was `isWatchable || hasBulkMarkAsWatched`. `hasBulkMarkAsWatched` already excludes future episodes, but `isWatchable` does not, so the kebab menu rendered with the per-episode mark-as-watched item for unreleased entries.

Fix: gate `isActionable` on `!isFuture` so both the per-episode and bulk variants are hidden until the episode airs.

## Test plan

- [ ] Visit a show whose current season has both aired and upcoming episodes (e.g. https://app.trakt.tv/shows/tna-impact?season=23&view=seasons&mode=show)
- [ ] Aired episodes still have the kebab menu with the mark-as-watched options
- [ ] Future episodes have no popup menu at all (no kebab visible)
- [ ] `deno task check` passes
- [ ] `deno task test:unit` passes