### PR TITLE
List: keep drawer open to manage multiple lists

### DIFF
--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaActions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import ListsDrawer from "$lib/sections/components/lists-drawer/ListsDrawer.svelte";
   import TrackAction from "$lib/sections/media-actions/mark-as-watched/TrackAction.svelte";
   import SummaryActionsBar from "../../../_internal/SummaryActionsBar.svelte";
   import BookmarkAction from "./BookmarkAction.svelte";
@@ -7,6 +8,8 @@
   import TrailerButton from "./TrailerButton.svelte";
 
   const { media, title }: { media: MediaEntry; title: string } = $props();
+
+  let isListsDrawerOpen = $state(false);
 
   const targetProps = $derived({
     title: media.title,
@@ -16,7 +19,11 @@
 </script>
 
 {#snippet popupActions()}
-  <MediaPopupActions {media} {title} />
+  <MediaPopupActions
+    {media}
+    {title}
+    onListAction={() => (isListsDrawerOpen = true)}
+  />
 {/snippet}
 
 <SummaryActionsBar popup={{ actions: popupActions, title }}>
@@ -24,3 +31,7 @@
   <BookmarkAction {media} />
   <TrailerButton slug={media.slug} trailer={media.trailer} style="action" />
 </SummaryActionsBar>
+
+{#if isListsDrawerOpen}
+  <ListsDrawer onClose={() => (isListsDrawerOpen = false)} {media} {title} />
+{/if}

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
@@ -6,20 +6,24 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import ListAction from "$lib/sections/components/lists-drawer/ListAction.svelte";
-  import ListsDrawer from "$lib/sections/components/lists-drawer/ListsDrawer.svelte";
   import SetCoverImageAction from "$lib/sections/media-actions/cover-image/SetCoverImageAction.svelte";
   import DropAction from "$lib/sections/media-actions/drop/DropAction.svelte";
+  import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
-  import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import HistoryButton from "$lib/sections/summary/components/history/HistoryButton.svelte";
   import SideActions from "./SideActions.svelte";
 
-  const { media, title }: { media: MediaEntry; title: string } = $props();
+  type MediaPopupActionsProps = {
+    media: MediaEntry;
+    title: string;
+    onListAction: () => void;
+  };
+
+  const { media, title, onListAction }: MediaPopupActionsProps = $props();
 
   const { isWatched } = $derived(useIsWatched({ media, type: media.type }));
   const { isDropped } = $derived(useIsDropped(media));
-  let isListsDrawerOpen = $state(false);
 
   const reportParams = $derived<ReportParams>(
     media.type === "show"
@@ -42,7 +46,7 @@
   style="dropdown-item"
   {media}
   {title}
-  onClick={() => (isListsDrawerOpen = true)}
+  onClick={onListAction}
   variant="primary"
 />
 
@@ -81,11 +85,3 @@
     variant="primary"
   />
 </RenderFor>
-
-{#if isListsDrawerOpen}
-  <ListsDrawer
-    onClose={() => (isListsDrawerOpen = false)}
-    {media}
-    title={media.title}
-  />
-{/if}


### PR DESCRIPTION
# Summary
Fixes https://github.com/trakt/trakt-web/issues/2062

Opening **Manage Lists** from a media summary page now keeps the drawer open while you add/remove the item across lists. Previously the drawer closed after the first toggle, forcing you to reopen it for every list. You now toggle as many lists on/off as you want and dismiss the drawer yourself (X button, or swipe down on mobile).

# Problem
The lists drawer was rendered *inside* `MediaPopupActions`, which lives inside the summary actions popup. Each list row is portaled to `document.body` — physically outside the popup's DOM — so clicking one tripped the popup's `clickOutside` handler (`SummaryActionsSlider.svelte`), unmounting the popup *and the drawer along with it*. Nothing in the add/remove path itself was closing the drawer; it was collateral damage from the popup teardown.

# Fix
Host the drawer **outside** the popup, mirroring the pattern the lists section already uses in `DefaultMediaItem.svelte`:

- **`MediaActions.svelte`** — owns `isListsDrawerOpen` and renders `<ListsDrawer>` as a sibling of the actions bar; passes an `onListAction` callback into the popup.
- **`MediaPopupActions.svelte`** — drops the local drawer state/render and just forwards `onListAction` to `ListAction`.

The drawer's lifecycle is now independent of the popup, so toggling a list no longer tears it down.

# Behavior Notes
- **Desktop:** the actions dropdown still slides closed on the first toggle (expected — the drawer is now independent and stays open).
- **Mobile:** unaffected; the actions drawer and lists drawer stack as before.

# Testing
- `deno task check` → 0 errors, 0 warnings.
- Manual: open Manage Lists from a movie/show summary, toggle several lists on and off (including the remove-confirmation flow), confirm the drawer stays open and only closes via X / swipe.
