### PR TITLE
fix: move favorites above screen time

### DIFF
--- a/projects/client/src/lib/sections/profile/Profile.svelte
+++ b/projects/client/src/lib/sections/profile/Profile.svelte
@@ -27,6 +27,8 @@
   <ProfileDetails {slug} {profile} />
 </ProfileContainer>
 
+<FavoritesList {slug} title={m.list_title_favorites()} mode={$mode} />
+
 {#if $isMe}
   <ScreenTime />
   <PersonalHistoryList mode={$mode} />
@@ -35,8 +37,6 @@
 {:else}
   <RecentlyWatchedList title={m.list_title_history()} {slug} mode={$mode} />
 {/if}
-
-<FavoritesList {slug} title={m.list_title_favorites()} mode={$mode} />
 
 {#if !$isMe}
   <PersonalLists {slug} type="personal" mode={$mode} />


### PR DESCRIPTION
Moves Favorites above Screen Time in the Profile section.