### PR TITLE
ci(deps): dump probe log tail on bisect failure

### DIFF
--- a/.github/scripts/ncu-bisect.sh
+++ b/.github/scripts/ncu-bisect.sh
@@ -158,9 +158,7 @@ dump_probe_log() {
   if [ "$DUMPED_PROBES" -ge 5 ]; then return; fi
   DUMPED_PROBES=$((DUMPED_PROBES + 1))
   log "  ── tail of $log_file ──"
-  tail -n 40 "$log_file" 2>/dev/null | while IFS= read -r line; do
-    printf '       %s\n' "$line" >&2
-  done
+  tail -n 40 "$log_file" 2>/dev/null | sed 's/^/       /' >&2
   log "  ── end of $log_file ──"
 }
 

--- a/.github/scripts/ncu-bisect.sh
+++ b/.github/scripts/ncu-bisect.sh
@@ -119,6 +119,7 @@ verify() {
   if [ "$VERIFY_MODE" = "fast" ]; then
     if ! (cd "$CLIENT" && deno task check) >> "$log_file" 2>&1; then
       log "  ✗ check failed"
+      dump_probe_log "$log_file"
       return 1
     fi
     log "  ✓ verify passed (check)"
@@ -141,10 +142,26 @@ verify() {
 
   if [ "$check_ok" -ne 0 ] || [ "$test_ok" -ne 0 ]; then
     log "  ✗ verify failed (check_exit=$check_ok test_exit=$test_ok)"
+    dump_probe_log "$log_file"
     return 1
   fi
   log "  ✓ verify passed (check + tests)"
   return 0
+}
+
+# Dump last 40 lines of a probe log to stderr so the failure reason is
+# visible in the workflow log without artifact uploads. Capped to keep
+# the workflow log readable when many probes fail in a row.
+DUMPED_PROBES=0
+dump_probe_log() {
+  local log_file="$1"
+  if [ "$DUMPED_PROBES" -ge 5 ]; then return; fi
+  DUMPED_PROBES=$((DUMPED_PROBES + 1))
+  log "  ── tail of $log_file ──"
+  tail -n 40 "$log_file" 2>/dev/null | while IFS= read -r line; do
+    printf '       %s\n' "$line" >&2
+  done
+  log "  ── end of $log_file ──"
 }
 
 # Recursive bisection driven by side effects (no stdout capture).

--- a/.github/workflows/packages_major.yml
+++ b/.github/workflows/packages_major.yml
@@ -69,6 +69,10 @@ jobs:
         working-directory: projects/client
         run: deno task i18n:web
 
+      - name: Forge the Paraglide Runes aka Compile Paraglide
+        working-directory: projects/client
+        run: deno run -A npm:@inlang/paraglide-js compile --project ./i18n/project.inlang --outdir ./src/lib/paraglide
+
       - name: Enumerate Major-Only Candidates
         id: enumerate
         working-directory: projects/client

--- a/.github/workflows/packages_major.yml
+++ b/.github/workflows/packages_major.yml
@@ -67,11 +67,7 @@ jobs:
 
       - name: Forge i18n Artifacts Once
         working-directory: projects/client
-        run: deno task i18n:web
-
-      - name: Forge the Paraglide Runes aka Compile Paraglide
-        working-directory: projects/client
-        run: deno run -A npm:@inlang/paraglide-js compile --project ./i18n/project.inlang --outdir ./src/lib/paraglide
+        run: deno task i18n:prepare
 
       - name: Enumerate Major-Only Candidates
         id: enumerate

--- a/.github/workflows/packages_minor.yml
+++ b/.github/workflows/packages_minor.yml
@@ -43,6 +43,10 @@ jobs:
         working-directory: projects/client
         run: deno task i18n:web
 
+      - name: Forge the Paraglide Runes aka Compile Paraglide
+        working-directory: projects/client
+        run: deno run -A npm:@inlang/paraglide-js compile --project ./i18n/project.inlang --outdir ./src/lib/paraglide
+
       - name: Enumerate Minor Candidates
         id: enumerate
         working-directory: projects/client

--- a/.github/workflows/packages_minor.yml
+++ b/.github/workflows/packages_minor.yml
@@ -41,11 +41,7 @@ jobs:
 
       - name: Forge i18n Artifacts Once
         working-directory: projects/client
-        run: deno task i18n:web
-
-      - name: Forge the Paraglide Runes aka Compile Paraglide
-        working-directory: projects/client
-        run: deno run -A npm:@inlang/paraglide-js compile --project ./i18n/project.inlang --outdir ./src/lib/paraglide
+        run: deno task i18n:prepare
 
       - name: Enumerate Minor Candidates
         id: enumerate

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -26,6 +26,8 @@
     "test:e2e": "cucumber-js -c ./cucumber.mjs",
     "i18n:web": "deno task i18n:generate ./i18n --platforms web",
     "i18n:web:watch": "deno task i18n:generate:watch ./i18n --platforms web",
+    "i18n:compile": "deno run -A npm:@inlang/paraglide-js compile --project ./i18n/project.inlang --outdir ./src/lib/paraglide",
+    "i18n:prepare": "deno task i18n:web && deno task i18n:compile",
     "sync:immutable": "deno run --allow-net --allow-read --allow-env .scripts/sync-immutable-to-r2.ts",
     "prune:immutable": "deno run --allow-net --allow-env .scripts/prune-immutable-r2.ts",
     "i18n:resolve": "deno run --allow-read --allow-write .scripts/resolve-i18n.ts",


### PR DESCRIPTION
## Summary

- The 2026-06-07 dep-bumper run rejected all 30 minor candidates with `✗ check failed` and zero context. Each probe's full verify output was written only to `/tmp/bisect-logs/probe-NNN.log` on the runner; the runner is ephemeral and the workflow doesn't upload artifacts, so the underlying svelte-check error was invisible from the GitHub Actions log.
- This patches `ncu-bisect.sh` to dump up to the last 40 lines of each failing probe log to stderr, capped at 5 dumps per run to keep the workflow log readable when many probes fail in a row.

## Test plan

- [x] Merge, trigger `packages_minor.yml` manually, confirm the first failing probe's actual error (svelte-check / svelte-kit sync output) shows up in the run log.
- [x] Use that signal to file a follow-up fix for the underlying bisect failure.