### PR TITLE
feat(i18n): add placeholder consistency check

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -68,6 +68,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  i18n-check:
+    needs: files-changed
+    if: ${{
+      needs.files-changed.outputs.client_source == 'true' ||
+      needs.files-changed.outputs.i18n_source == 'true'
+      }}
+    name: The Babelfish Audit (i18n Placeholders)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Secure the Evidence aka Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Deno Environment
+        uses: ./.github/actions/setup-deno
+
+      - name: Audit Translation Placeholders
+        working-directory: projects/client
+        run: 'deno task i18n:check'
+
   test:
     needs: files-changed
     if: ${{

--- a/projects/client/.scripts/check-i18n-placeholders.spec.ts
+++ b/projects/client/.scripts/check-i18n-placeholders.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractPlaceholders,
+  findMismatches,
+} from './check-i18n-placeholders.ts';
+
+describe('check-i18n-placeholders', () => {
+  describe('extractPlaceholders', () => {
+    it('should extract single placeholder', () => {
+      expect(extractPlaceholders('Remove {title}'))
+        .toEqual(new Set(['title']));
+    });
+
+    it('should extract multiple placeholders', () => {
+      expect(extractPlaceholders('{count} of {total}'))
+        .toEqual(new Set(['count', 'total']));
+    });
+
+    it('should extract ICU plural placeholder name', () => {
+      expect(
+        extractPlaceholders('{count, plural, one {episode} other {episodes}}'),
+      )
+        .toEqual(new Set(['count']));
+    });
+
+    it('should extract ICU select placeholder name', () => {
+      expect(
+        extractPlaceholders(
+          '{gender, select, male {he} female {she} other {they}}',
+        ),
+      )
+        .toEqual(new Set(['gender']));
+    });
+
+    it('should extract nested placeholders inside ICU plural form content', () => {
+      expect(
+        extractPlaceholders(
+          '{count, plural, one {{name} has {count} episode} other {{name} has {count} episodes}}',
+        ),
+      ).toEqual(new Set(['count', 'name']));
+    });
+
+    it('should not treat plain form literals as placeholders', () => {
+      expect(
+        extractPlaceholders('{count, plural, one {episode} other {episodes}}'),
+      ).toEqual(new Set(['count']));
+    });
+
+    it('should ignore mangled placeholder with backslash', () => {
+      expect(extractPlaceholders('Remove "{\\s_title}"'))
+        .toEqual(new Set());
+    });
+
+    it('should return empty set for text without placeholders', () => {
+      expect(extractPlaceholders('plain text')).toEqual(new Set());
+    });
+  });
+
+  describe('findMismatches', () => {
+    it('should pass when target placeholders match source', () => {
+      const source = { greeting: 'Hello {name}' };
+      const target = { greeting: 'Hallo {name}' };
+      expect(findMismatches(source, target, 'de')).toEqual([]);
+    });
+
+    it('should flag mangled {\\s_X} as missing source placeholder', () => {
+      const source = { key: 'Remove "{title}"' };
+      const target = { key: 'Entferne "{\\s_title}"' };
+      const result = findMismatches(source, target, 'de');
+      expect(result).toHaveLength(1);
+      expect(result[0]?.reason).toContain('missing in target: title');
+    });
+
+    it('should flag extra placeholders not in source', () => {
+      const source = { greeting: 'Hello {name}' };
+      const target = { greeting: 'Hallo {name} {extra}' };
+      const result = findMismatches(source, target, 'de');
+      expect(result).toHaveLength(1);
+      expect(result[0]?.reason).toContain('extra in target: extra');
+    });
+
+    it('should flag missing placeholders in target', () => {
+      const source = { greeting: 'Reply to {user}' };
+      const target = { greeting: 'Responder...' };
+      const result = findMismatches(source, target, 'pt');
+      expect(result).toHaveLength(1);
+      expect(result[0]?.reason).toContain('missing in target: user');
+    });
+
+    it('should pass for matching ICU plurals', () => {
+      const source = {
+        units: '{count, plural, one {episode} other {episodes}}',
+      };
+      const target = {
+        units: '{count, plural, one {episodio} other {episodios}}',
+      };
+      expect(findMismatches(source, target, 'es')).toEqual([]);
+    });
+
+    it('should skip keys missing from source', () => {
+      const source = {};
+      const target = { greeting: 'Hallo {name}' };
+      expect(findMismatches(source, target, 'de')).toEqual([]);
+    });
+  });
+});

--- a/projects/client/.scripts/check-i18n-placeholders.ts
+++ b/projects/client/.scripts/check-i18n-placeholders.ts
@@ -1,0 +1,169 @@
+import { I18N_MESSAGES_DIR, I18N_META_DIR } from './_internal/constants.ts';
+
+const IDENTIFIER_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const ICU_KEYWORDS = new Set([
+  'plural',
+  'select',
+  'selectordinal',
+  'number',
+  'date',
+  'time',
+]);
+
+const RECURSIVE_ICU_KEYWORDS = new Set(['plural', 'select', 'selectordinal']);
+
+function scanForPlaceholders(text: string, names: Set<string>): void {
+  let depth = 0;
+  let start = -1;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+
+    if (ch === '{') {
+      if (depth === 0) start = i + 1;
+      depth++;
+      continue;
+    }
+
+    if (ch !== '}' || depth === 0) continue;
+
+    depth--;
+    if (depth !== 0) continue;
+
+    const inner = text.slice(start, i);
+    const commaIndex = inner.indexOf(',');
+
+    if (commaIndex === -1) {
+      const candidate = inner.trim();
+      if (IDENTIFIER_RE.test(candidate)) names.add(candidate);
+      continue;
+    }
+
+    const name = inner.slice(0, commaIndex).trim();
+    const remaining = inner.slice(commaIndex + 1);
+    const keyword = remaining.trim().split(/[,\s]/)[0] ?? '';
+
+    if (!IDENTIFIER_RE.test(name) || !ICU_KEYWORDS.has(keyword)) continue;
+    names.add(name);
+
+    if (RECURSIVE_ICU_KEYWORDS.has(keyword)) {
+      scanFormContents(remaining, names);
+    }
+  }
+}
+
+function scanFormContents(text: string, names: Set<string>): void {
+  let depth = 0;
+  let start = -1;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+
+    if (ch === '{') {
+      if (depth === 0) start = i + 1;
+      depth++;
+      continue;
+    }
+
+    if (ch !== '}' || depth === 0) continue;
+
+    depth--;
+    if (depth !== 0) continue;
+
+    scanForPlaceholders(text.slice(start, i), names);
+  }
+}
+
+export function extractPlaceholders(text: string): ReadonlySet<string> {
+  const names = new Set<string>();
+  scanForPlaceholders(text, names);
+  return names;
+}
+
+type Mismatch = {
+  locale: string;
+  key: string;
+  reason: string;
+  source: string;
+  target: string;
+};
+
+export function findMismatches(
+  source: Readonly<Record<string, string>>,
+  target: Readonly<Record<string, string>>,
+  locale: string,
+): ReadonlyArray<Mismatch> {
+  const mismatches: Array<Mismatch> = [];
+
+  for (const [key, translation] of Object.entries(target)) {
+    const sourceText = source[key];
+    if (typeof sourceText !== 'string' || typeof translation !== 'string') {
+      continue;
+    }
+
+    const sourceNames = extractPlaceholders(sourceText);
+    const targetNames = extractPlaceholders(translation);
+    const extra = [...targetNames].filter((n) => !sourceNames.has(n));
+    const missing = [...sourceNames].filter((n) => !targetNames.has(n));
+
+    if (extra.length === 0 && missing.length === 0) continue;
+
+    const parts: Array<string> = [];
+    if (extra.length > 0) parts.push(`extra in target: ${extra.join(', ')}`);
+    if (missing.length > 0) {
+      parts.push(`missing in target: ${missing.join(', ')}`);
+    }
+
+    mismatches.push({
+      locale,
+      key,
+      reason: parts.join('; '),
+      source: sourceText,
+      target: translation,
+    });
+  }
+
+  return mismatches;
+}
+
+async function readSource(): Promise<Record<string, string>> {
+  const raw = await Deno.readTextFile(`${I18N_META_DIR}/en.json`);
+  const parsed = JSON.parse(raw) as {
+    messages: Record<string, { default: string }>;
+  };
+  return Object.fromEntries(
+    Object.entries(parsed.messages).map(([k, v]) => [k, v.default]),
+  );
+}
+
+async function readLocale(file: string): Promise<Record<string, string>> {
+  const raw = await Deno.readTextFile(`${I18N_MESSAGES_DIR}/${file}`);
+  return JSON.parse(raw) as Record<string, string>;
+}
+
+if (import.meta.main) {
+  const source = await readSource();
+  const all: Array<Mismatch> = [];
+
+  for await (const entry of Deno.readDir(I18N_MESSAGES_DIR)) {
+    if (!entry.isFile || !entry.name.endsWith('.json')) continue;
+
+    const target = await readLocale(entry.name);
+    const locale = entry.name.replace(/\.json$/, '');
+    all.push(...findMismatches(source, target, locale));
+  }
+
+  if (all.length === 0) {
+    console.log('All i18n placeholders consistent with source.');
+    Deno.exit(0);
+  }
+
+  console.error(`Found ${all.length} placeholder mismatch(es):\n`);
+  for (const m of all) {
+    console.error(`  ${m.locale} :: ${m.key}`);
+    console.error(`    reason: ${m.reason}`);
+    console.error(`    source: ${m.source}`);
+    console.error(`    target: ${m.target}\n`);
+  }
+  Deno.exit(1);
+}

--- a/projects/client/i18n/messages/pt-PT.json
+++ b/projects/client/i18n/messages/pt-PT.json
@@ -48,7 +48,7 @@
   "button_label_close_reaction": "Fechar",
   "button_label_collapse_navbar": "Recolher",
   "button_label_comment_replies": "Respostas à Avaliação",
-  "button_label_comment_reply": "Responder...",
+  "button_label_comment_reply": "Responder a {user}",
   "button_label_cookie_accept": "Aceitar todos os cookies",
   "button_label_cookie_accept_functional_only": "Aceitar apenas cookies funcionais",
   "button_label_create_list": "Criar lista",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -31,6 +31,7 @@
     "sync:immutable": "deno run --allow-net --allow-read --allow-env .scripts/sync-immutable-to-r2.ts",
     "prune:immutable": "deno run --allow-net --allow-env .scripts/prune-immutable-r2.ts",
     "i18n:resolve": "deno run --allow-read --allow-write .scripts/resolve-i18n.ts",
+    "i18n:check": "deno run --allow-read .scripts/check-i18n-placeholders.ts",
     "i18n:generate": "deno run --allow-read --allow-write i18n/generator/cli.ts -i i18n/meta/ -o i18n/",
     "i18n:generate:watch": "deno run --allow-read --allow-write i18n/generator/cli.ts -i i18n/meta/ -o i18n/ --watch"
   },


### PR DESCRIPTION
## Summary

- New CI guard comparing placeholder names in `i18n/meta/en.json` source vs each `i18n/messages/<locale>.json` translation
- Catches Crowdin sync regressions: mangled placeholders (`{title}` -> `{\s_title}`), missing placeholders, extra placeholders
- ICU-aware balanced-brace parser correctly skips `{count, plural, one {episode} other {episodes}}` form text

## Background

PR #2525 introduced `{\s_title}` mangle in de-DE for 4 keys. Root cause: project setting `normalizePlaceholder: true` rewrites source `{title}` to internal `{s_title}`. Translator manually typed `{s_title}` literal in editor (vs clicking placeholder chip), so the placeholder ref tag was missing - Crowdin escaped it as `\s_title` on export. Crowdin QA `variables` check was set to ignorable, letting bad text slip through.

Crowdin-side fixes already applied:
- 4 de-DE strings re-entered with proper placeholder refs and approved
- pt-PT `button_label_comment_reply` was missing `{user}` entirely - fixed
- Project QA settings: `variables` and `icu` now non-ignorable (blocks save on mismatch)

This PR is the repo-side belt-and-suspenders.

## Test plan

- [x] Unit tests added (`.scripts/check-i18n-placeholders.spec.ts`, 12 cases covering simple placeholders, ICU plurals, ICU select, mangled `\s_`, missing/extra detection)
- [x] `deno task i18n:check` passes locally against current `main` after Crowdin fixes
- [x] Verified script catches the mangled `{\s_title}` pattern from PR #2525 via unit test
- [ ] Confirm new `i18n-check` GH Actions job runs on this PR

## Notes

Wires `deno task i18n:check` -> `projects/client/.scripts/check-i18n-placeholders.ts`. New `i18n-check` job in `ci_cd.yml` runs on `client_source` or `i18n_source` file changes.