### PR TITLE
fix(footer): prevents toast from overlapping footer

### DIFF
--- a/projects/client/src/lib/sections/footer/Footer.svelte
+++ b/projects/client/src/lib/sections/footer/Footer.svelte
@@ -26,10 +26,17 @@
     padding-left: var(--layout-distance-side);
     padding-right: var(--layout-distance-side);
 
+    &.has-toast {
+      margin-top: calc(var(--height-toast-card) + var(--gap-xxl));
+    }
+
     @include for-tablet-sm-and-below {
       &.has-toast {
-        margin-top: calc(var(--height-toast-card) + var(--gap-xxl));
+        margin-top: 0;
       }
+
+      margin-top: 0;
+      margin-bottom: var(--gap-l);
 
       height: fit-content;
       position: relative;

--- a/projects/client/src/lib/sections/footer/components/FooterContent.svelte
+++ b/projects/client/src/lib/sections/footer/components/FooterContent.svelte
@@ -35,7 +35,7 @@
     gap: var(--gap-xxl);
 
     box-sizing: border-box;
-    padding: var(--footer-bar-padding) 0;
+    padding-top: var(--footer-bar-padding);
 
     transition: gap var(--transition-increment) ease-in-out;
 

--- a/projects/client/src/lib/sections/toast/Toast.svelte
+++ b/projects/client/src/lib/sections/toast/Toast.svelte
@@ -27,8 +27,6 @@
     --toast-gap: var(--gap-m);
     --toast-bottom-distance: var(--ni-24);
     --toast-height: calc(var(--height-toast-card) + 2 * var(--toast-padding));
-    --toast-footer-top: var(--footer-height) - var(--footer-bar-padding);
-    --toast-footer-offset: var(--toast-footer-top) - var(--toast-height);
 
     position: fixed;
     z-index: var(--layer-overlay);
@@ -43,7 +41,7 @@
 
     bottom: max(
       var(--toast-bottom-distance),
-      var(--toast-footer-offset) - var(--distance-from-bottom)
+      var(--footer-height) - var(--distance-from-bottom)
     );
     left: 50%;
     transform: translateX(-50%);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2531
- Footer spacing is now fixed, e.g. less huge gaps.
- Toast no longer overlaps footer.

## 👀 Examples 👀
Before/after:

https://github.com/user-attachments/assets/cace47c7-34d8-48f7-8c12-745708cb5896


https://github.com/user-attachments/assets/2024fe0c-17ad-4c76-8f26-5f3ee1cc7b6a

Before/after:

https://github.com/user-attachments/assets/1dc2bc80-7b33-4235-9369-a49103fdeac3


https://github.com/user-attachments/assets/9f43ba3b-5c7e-44a3-b655-2671a48917e9

