### PR TITLE
fix(list): drilldown respects collapsed state

### DIFF
--- a/projects/client/src/lib/components/lists/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/SectionList.svelte
@@ -152,7 +152,7 @@
           {metaInfo}
           actions={isCollapsed ? undefined : actions}
           navigationType={headerNavigationType}
-          {drilldown}
+          drilldown={isCollapsed ? undefined : drilldown}
           disabled={items.length === 0 && drilldown?.mode !== "always"}
         />
       {/if}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2533
- Collapsed state now hide drilldown again.

## 👀 Example 👀
Before/after:
<img width="369" height="46" alt="Screenshot 2026-06-08 at 10 51 53" src="https://github.com/user-attachments/assets/917e9716-54d7-4f9d-89e7-f7e95d4811ed" />

<img width="369" height="46" alt="Screenshot 2026-06-08 at 10 52 58" src="https://github.com/user-attachments/assets/d6660dcd-7b65-45ee-970d-5d6b4b354332" />
