### PR TITLE
fix(summary): fixes episode card sizing in drawer

### DIFF
--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -91,7 +91,7 @@
   </RenderFor>
 {/snippet}
 
-<div use:scrollActiveItemIntoView={isCurrentEpisode}>
+{#snippet episodeItem()}
   <EpisodeItem
     {episode}
     media={show}
@@ -102,4 +102,15 @@
     {source}
     coverUrl={$src}
   />
-</div>
+{/snippet}
+
+{#if isCurrentEpisode}
+  <div
+    use:scrollActiveItemIntoView={isCurrentEpisode}
+    class="trakt-season-episode-item"
+  >
+    {@render episodeItem()}
+  </div>
+{:else}
+  {@render episodeItem()}
+{/if}

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawerHost.svelte
@@ -182,6 +182,10 @@
     :global(.trakt-list-item-container) {
       padding: 0;
     }
+
+    :global(.trakt-grid-list-container) {
+      overflow-x: visible;
+    }
   }
 
   .seasons-section {
@@ -212,6 +216,10 @@
   }
 
   .episodes-section {
+    :global(.trakt-season-episode-item) {
+      min-width: 0;
+    }
+
     :global(.trakt-list-items) {
       grid-template-columns: 1fr;
       grid-row-gap: var(--gap-s);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2538
- Episode cards in the drawer are now sized properly.

## 👀 Example 👀
Before/after:
<img width="465" height="578" alt="Screenshot 2026-06-08 at 14 50 10" src="https://github.com/user-attachments/assets/f14661e3-8ab1-452a-91b9-f09c9ba9e4d5" />

<img width="368" height="741" alt="Screenshot 2026-06-08 at 15 02 19" src="https://github.com/user-attachments/assets/0022496f-e1fa-4549-9208-7f3d97e12ce8" />
