### PR TITLE
fix(stats): makes screen time durations fit in card

### DIFF
--- a/projects/client/src/lib/sections/stats/_internal/PulseCell.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseCell.svelte
@@ -3,6 +3,7 @@
   import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
   import type { PulseDeltaKind } from "./models/PulseDeltaKind";
   import PulseDeltaTag from "./PulseDeltaTag.svelte";
+  import { splitDuration } from "./utils/splitDuration.ts";
 
   type PulseCellProps = {
     value: string;
@@ -12,11 +13,23 @@
     deltaKind: PulseDeltaKind;
   };
 
-  const { value, label, tooltip, delta, deltaKind }: PulseCellProps = $props();
+  const {
+    value: originalValue,
+    label,
+    tooltip,
+    delta,
+    deltaKind,
+  }: PulseCellProps = $props();
+
+  const value = $derived(
+    deltaKind === "time" ? splitDuration(originalValue) : [originalValue],
+  );
 </script>
 
 {#snippet valueText()}
-  <p class="trakt-pulse-cell-value bold ellipsis">{value}</p>
+  {#each value as part, index (index)}
+    <span class="trakt-pulse-cell-value bold ellipsis">{part}</span>
+  {/each}
 {/snippet}
 
 <Card
@@ -53,17 +66,19 @@
 
     overflow: hidden;
     height: 100%;
-  }
 
-  .trakt-pulse-cell-body {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-xxs);
-    flex: 1;
-    justify-content: center;
+    :global(.trakt-tooltip-trigger),
+    .trakt-pulse-cell-body {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--gap-xxs);
+      flex: 1;
+      justify-content: flex-start;
+      align-items: center;
+    }
   }
 
   .trakt-pulse-cell-value {
-    font-size: var(--ni-28);
+    font-size: var(--ni-24);
   }
 </style>

--- a/projects/client/src/lib/sections/stats/_internal/utils/splitDuration.test.ts
+++ b/projects/client/src/lib/sections/stats/_internal/utils/splitDuration.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { splitDuration } from './splitDuration.ts';
+
+describe('splitDuration', () => {
+  describe('compact format (no space between number and unit)', () => {
+    it('splits English duration', () => {
+      expect(splitDuration('7d 24h 59m')).toEqual(['7d', '24h', '59m']);
+    });
+
+    it('splits partial duration (days + hours)', () => {
+      expect(splitDuration('2d 4h')).toEqual(['2d', '4h']);
+    });
+
+    it('splits single unit', () => {
+      expect(splitDuration('45m')).toEqual(['45m']);
+    });
+  });
+
+  describe('spaced format (space between number and unit)', () => {
+    it('splits Dutch duration', () => {
+      expect(splitDuration('7 d 24 u 59 m')).toEqual([
+        '7 d',
+        '24 u',
+        '59 m',
+      ]);
+    });
+
+    it('splits German duration', () => {
+      expect(splitDuration('7 T 24 Std 59 Min')).toEqual([
+        '7 T',
+        '24 Std',
+        '59 Min',
+      ]);
+    });
+
+    it('splits French duration', () => {
+      expect(splitDuration('7 j 24 h 59 min')).toEqual([
+        '7 j',
+        '24 h',
+        '59 min',
+      ]);
+    });
+
+    it('splits Portuguese duration', () => {
+      expect(splitDuration('7 d 24 h 59 min')).toEqual([
+        '7 d',
+        '24 h',
+        '59 min',
+      ]);
+    });
+
+    it('splits Spanish duration', () => {
+      expect(splitDuration('7 d 24 h 59 min')).toEqual([
+        '7 d',
+        '24 h',
+        '59 min',
+      ]);
+    });
+  });
+
+  describe('non-Latin scripts', () => {
+    it('splits Japanese duration', () => {
+      expect(splitDuration('7日 24時間 59分')).toEqual([
+        '7日',
+        '24時間',
+        '59分',
+      ]);
+    });
+
+    it('splits Chinese duration', () => {
+      expect(splitDuration('7天 24小时 59分钟')).toEqual([
+        '7天',
+        '24小时',
+        '59分钟',
+      ]);
+    });
+  });
+
+  describe('fallback', () => {
+    it('returns original string in array when no match', () => {
+      expect(splitDuration('unknown')).toEqual(['unknown']);
+    });
+
+    it('returns original string when empty', () => {
+      expect(splitDuration('')).toEqual(['']);
+    });
+  });
+});

--- a/projects/client/src/lib/sections/stats/_internal/utils/splitDuration.ts
+++ b/projects/client/src/lib/sections/stats/_internal/utils/splitDuration.ts
@@ -1,0 +1,3 @@
+export function splitDuration(duration: string): string[] {
+  return duration.match(/\d+\s*\p{L}+/gu) ?? [duration];
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2540
- Allows screen time duration values (e.g., "1h 30m") to wrap onto multiple lines within stats cards by splitting them into individual components.
- Adjusts the layout of pulse cells to support flexible wrapping of these duration parts.
- Reduces the font size of pulse cell values to ensure better fit within the card's confines.

## 👀 Example 👀
Before/after:
<img width="368" height="660" alt="Screenshot 2026-06-08 at 15 24 56" src="https://github.com/user-attachments/assets/316b190b-a0a0-4a3a-ad50-b9161a68c0c3" />

<img width="368" height="660" alt="Screenshot 2026-06-08 at 15 23 10" src="https://github.com/user-attachments/assets/ccc561a3-73cb-4d68-adcf-845e111ab11d" />
