### PR TITLE
feat: adds 'Moderate' action for directors

### DIFF
--- a/projects/client/src/lib/sections/components/admin/ModerateAction.svelte
+++ b/projects/client/src/lib/sections/components/admin/ModerateAction.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import GearIcon from "$lib/components/icons/GearIcon.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+
+  const { variant }: { variant?: "primary" | "secondary" } = $props();
+</script>
+
+<RenderFor audience="director">
+  <DropdownItem
+    variant={variant ?? "primary"}
+    onclick={() => {
+      const { pathname } = page.url;
+      globalThis.window.open(
+        `${UrlBuilder.admin()}${pathname}`,
+        "_blank",
+        "noopener,noreferrer",
+      );
+    }}
+    style="flat"
+    color="default"
+    label="Moderate"
+  >
+    Moderate
+    {#snippet icon()}
+      <GearIcon />
+    {/snippet}
+  </DropdownItem>
+</RenderFor>

--- a/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
@@ -11,6 +11,7 @@
   import ReportButton from "$lib/features/report/ReportButton.svelte";
   import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import ModerateAction from "$lib/sections/components/admin/ModerateAction.svelte";
   import type { DisplayableProfileProps } from "$lib/sections/profile/DisplayableProfileProps";
   import { toDisplayableName } from "$lib/utils/profile/toDisplayableName";
   import { useBlockUser } from "./useBlockUser";
@@ -145,5 +146,7 @@
         label={m.button_label_report_user({ username: userDisplayName })}
       />
     </RenderFor>
+
+    <ModerateAction variant="secondary" />
   {/snippet}
 </PopupMenu>

--- a/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
@@ -5,6 +5,7 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
+  import ModerateAction from "$lib/sections/components/admin/ModerateAction.svelte";
   import SetCoverImageAction from "$lib/sections/media-actions/cover-image/SetCoverImageAction.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
@@ -64,3 +65,5 @@
     variant="primary"
   />
 </RenderFor>
+
+<ModerateAction />

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
@@ -5,6 +5,7 @@
   import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import ModerateAction from "$lib/sections/components/admin/ModerateAction.svelte";
   import ListAction from "$lib/sections/components/lists-drawer/ListAction.svelte";
   import SetCoverImageAction from "$lib/sections/media-actions/cover-image/SetCoverImageAction.svelte";
   import DropAction from "$lib/sections/media-actions/drop/DropAction.svelte";
@@ -85,3 +86,5 @@
     variant="primary"
   />
 </RenderFor>
+
+<ModerateAction />

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -340,6 +340,7 @@ export const UrlBuilder = {
     wikipedia: (id: string) => `https://en.wikipedia.org/wiki/${id}`,
   },
   feedback: () => 'https://roadmap.trakt.tv',
+  admin: () => 'https://admin.trakt.tv',
   api: {
     shareableImage: (type: 'movie' | 'show', slug: string) => {
       const basePath = `/api/shareable-image?type=${type}&slug=${slug}`;


### PR DESCRIPTION
## 🎶 Notes 🎶
- Introduces a new 'ModerateAction' component, available to users with director privileges.
- This action provides a quick link to open the current page's URL within the Trakt admin panel.
- Integrates the 'Moderate' action into key UI elements, including profile overflow menus and episode and media summary popup actions.
- Extends the `UrlBuilder` utility with a dedicated 'admin' URL for consistent and centralized routing to the administration interface.