### PR TITLE
YIR: 2024 highest rated

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4757,6 +4757,14 @@
       "default": "Time Watched",
       "description": "Stat label under the time-watched duration on the 2024 Year in Review most-watched cards."
     },
+    "yir_2024_highest_rated_shows": {
+      "default": "Highest Rated TV Shows",
+      "description": "Section heading above the highest-rated shows list on the 2024 Year in Review template."
+    },
+    "yir_2024_highest_rated_movies": {
+      "default": "Highest Rated Movies",
+      "description": "Section heading above the highest-rated movies list on the 2024 Year in Review template."
+    },
     "yir_2024_most_watched_networks": {
       "default": "Most watched networks",
       "description": "Section heading above the networks bubble chart on the 2024 Year in Review template."

--- a/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
+++ b/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
@@ -7,6 +7,7 @@
   import Yir2024MostPlayedSection from "./_internal/Yir2024MostPlayedSection.svelte";
   import Yir2024PageInner from "./_internal/Yir2024PageInner.svelte";
   import Yir2024PlayCard from "./_internal/Yir2024PlayCard.svelte";
+  import Yir2024RatedSection from "./_internal/Yir2024RatedSection.svelte";
   import Yir2024StatsSection from "./_internal/Yir2024StatsSection.svelte";
   import Yir2024TopSection from "./_internal/Yir2024TopSection.svelte";
 
@@ -74,6 +75,12 @@
       </Yir2024PageInner>
     {/if}
 
+    {#if detail.topRated.shows.length > 0}
+      <Yir2024PageInner>
+        <Yir2024RatedSection type="shows" items={detail.topRated.shows} />
+      </Yir2024PageInner>
+    {/if}
+
     {#if detail.stats.movies.playCounts.total > 0}
       <Yir2024PageInner>
         <Yir2024StatsSection type="movies" stats={detail.stats.movies} {year} />
@@ -101,6 +108,12 @@
     {#if detail.genres.movies.itemCount > 0}
       <Yir2024PageInner>
         <Yir2024GenresSection type="movies" genres={detail.genres.movies} />
+      </Yir2024PageInner>
+    {/if}
+
+    {#if detail.topRated.movies.length > 0}
+      <Yir2024PageInner>
+        <Yir2024RatedSection type="movies" items={detail.topRated.movies} />
       </Yir2024PageInner>
     {/if}
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedCard.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedCard.svelte
@@ -270,7 +270,9 @@
     width: var(--ni-300);
     aspect-ratio: 2 / 3;
     overflow: hidden;
-    border-radius: var(--border-radius-s);
+    // Matches the summary-page poster corner (SummaryPoster.svelte), shared
+    // with the highest-rated section poster.
+    border-radius: var(--border-radius-xxl);
     box-shadow: 0 var(--ni-16) var(--ni-48)
       color-mix(in srgb, var(--shade-1000) 50%, transparent);
     transition: transform 0.25s var(--transition-increment) ease-out;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024RatedSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024RatedSection.svelte
@@ -1,0 +1,317 @@
+<script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import type { YirTopRatedItem } from "$lib/requests/models/YirDetail.ts";
+  import UserRating from "$lib/sections/components/UserRating.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+
+  type Yir2024RatedSectionProps = {
+    type: "shows" | "movies";
+    items: YirTopRatedItem[];
+  };
+
+  const { type, items }: Yir2024RatedSectionProps = $props();
+
+  const heading = $derived(
+    type === "shows"
+      ? m.yir_2024_highest_rated_shows()
+      : m.yir_2024_highest_rated_movies(),
+  );
+
+  let activeIndex = $state(0);
+  const activeItem = $derived(items.at(activeIndex) ?? items.at(0));
+
+  function itemUrl(item: YirTopRatedItem | undefined): string {
+    if (!item) return "";
+    return UrlBuilder.media(item.entry.type, item.entry.slug);
+  }
+
+  function rankLabel(rank: number): string {
+    return rank.toString().padStart(2, "0");
+  }
+</script>
+
+<section class="yir-2024-rated" id="section-{type}-highest-rated">
+  <article class="yir-2024-rated-panel">
+    <div class="yir-2024-rated-covers" aria-hidden="true">
+      {#each items as item, index (item.entry.id)}
+        <div class="yir-2024-rated-cover" class:current={index === activeIndex}>
+          <CrossOriginImage src={item.entry.cover?.url?.medium} alt="" />
+        </div>
+      {/each}
+    </div>
+    <div class="yir-2024-rated-shade"></div>
+
+    <div class="yir-2024-rated-grid">
+      <div class="yir-2024-rated-main">
+        <h2 class="bold yir-2024-rated-heading">{heading}</h2>
+
+        <ol class="yir-2024-rated-list" role="list">
+          {#each items as item, index (item.entry.id)}
+            <li class="yir-2024-rated-row" role="listitem">
+              <Link
+                href={itemUrl(item)}
+                color="inherit"
+                onmouseenter={() => (activeIndex = index)}
+                onfocus={() => (activeIndex = index)}
+              >
+                <span class="bold yir-2024-rated-rank" aria-hidden="true">
+                  .{rankLabel(index + 1)}
+                </span>
+                <span class="yir-2024-rated-title">{item.entry.title}</span>
+                <span class="yir-2024-rated-score">
+                  <UserRating rating={item.rating} />
+                </span>
+              </Link>
+            </li>
+          {/each}
+        </ol>
+      </div>
+
+      <!-- Redundant link for pointer users, No tab stop, no label, kept out of screen-reader order. -->
+      <Link href={itemUrl(activeItem)} color="inherit" focusable={false}>
+        <div class="yir-2024-rated-poster">
+          {#each items as item, index (item.entry.id)}
+            <div
+              class="yir-2024-rated-poster-layer"
+              class:current={index === activeIndex}
+            >
+              <CrossOriginImage src={item.entry.poster?.url?.medium} alt="" />
+            </div>
+          {/each}
+        </div>
+      </Link>
+    </div>
+  </article>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-2024-rated {
+    width: 100%;
+  }
+
+  .yir-2024-rated-panel {
+    position: relative;
+    width: 100%;
+    min-height: var(--ni-560);
+    overflow: hidden;
+    border-radius: var(--border-radius-xxl);
+    color: var(--shade-10);
+
+    @include for-mobile {
+      min-height: 0;
+      border-radius: var(--border-radius-xl);
+    }
+  }
+
+  .yir-2024-rated-covers {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
+
+  .yir-2024-rated-cover {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    transition: opacity 0.5s ease;
+
+    &.current {
+      opacity: 1;
+    }
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+
+  .yir-2024-rated-shade {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    background:
+      linear-gradient(
+        to right,
+        color-mix(in srgb, var(--shade-1000) 85%, transparent) 0%,
+        color-mix(in srgb, var(--shade-1000) 40%, transparent) 55%,
+        transparent 100%
+      ),
+      linear-gradient(
+        to top,
+        color-mix(in srgb, var(--purple-700) 70%, var(--shade-1000)) 0%,
+        color-mix(in srgb, var(--purple-700) 30%, transparent) 65%,
+        color-mix(in srgb, var(--purple-700) 10%, transparent) 100%
+      );
+  }
+
+  .yir-2024-rated-grid {
+    position: relative;
+    z-index: 2;
+    height: 100%;
+    box-sizing: border-box;
+    padding: var(--ni-44) var(--ni-52);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas: "main poster";
+    column-gap: var(--ni-52);
+    align-items: start;
+
+    @include for-tablet-sm-and-below {
+      padding: var(--ni-32);
+      column-gap: var(--ni-32);
+    }
+
+    @include for-mobile {
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-areas: "main";
+      padding: var(--ni-20);
+    }
+  }
+
+  .yir-2024-rated-main {
+    grid-area: main;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-32);
+
+    @include for-mobile {
+      gap: var(--ni-20);
+    }
+  }
+
+  .yir-2024-rated-heading {
+    margin: 0;
+    font-size: clamp(var(--ni-28), 3.5vw, var(--ni-44));
+
+    @include for-mobile {
+      font-size: var(--ni-24);
+    }
+  }
+
+  .yir-2024-rated-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    &:hover .yir-2024-rated-row:not(:hover) {
+      opacity: 0.5;
+    }
+  }
+
+  .yir-2024-rated-row {
+    transition: opacity 0.25s var(--transition-increment) ease-out;
+
+    :global(.trakt-link) {
+      display: flex;
+      align-items: center;
+      gap: var(--ni-20);
+      padding-block: var(--ni-10);
+      border-bottom: 1px solid
+        color-mix(in srgb, var(--shade-10) 22%, transparent);
+      text-decoration: none;
+      color: inherit;
+
+      @include for-mobile {
+        gap: var(--ni-12);
+        padding-block: var(--ni-8);
+      }
+    }
+
+    &:last-child :global(.trakt-link) {
+      border-bottom: none;
+    }
+  }
+
+  .yir-2024-rated-rank {
+    flex: none;
+    width: var(--ni-32);
+    font-size: clamp(var(--ni-14), 1.2vw, var(--ni-18));
+    color: var(--shade-300);
+
+    @include for-mobile {
+      width: var(--ni-24);
+      font-size: var(--font-size-tag);
+    }
+  }
+
+  .yir-2024-rated-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: clamp(var(--ni-14), 1.2vw, var(--ni-18));
+
+    @include for-mobile {
+      font-size: var(--font-size-tag);
+    }
+  }
+
+  .yir-2024-rated-score {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    color: var(--shade-300);
+    font-size: clamp(var(--ni-14), 1.2vw, var(--ni-18));
+
+    @include for-mobile {
+      font-size: var(--font-size-tag);
+    }
+  }
+
+  :global(.yir-2024-rated-grid > .trakt-link) {
+    grid-area: poster;
+    align-self: start;
+    justify-self: end;
+    display: block;
+    text-decoration: none;
+
+    @include for-mobile {
+      display: none;
+    }
+  }
+
+  .yir-2024-rated-poster {
+    position: relative;
+    width: var(--ni-300);
+    aspect-ratio: 2 / 3;
+    overflow: hidden;
+    // Matches the summary-page poster corner (SummaryPoster.svelte).
+    border-radius: var(--border-radius-xxl);
+    box-shadow: 0 var(--ni-16) var(--ni-48)
+      color-mix(in srgb, var(--shade-1000) 50%, transparent);
+    transition: transform 0.25s var(--transition-increment) ease-out;
+
+    &:hover {
+      transform: scale(1.03);
+    }
+
+    @include for-tablet-sm-and-below {
+      width: var(--ni-220);
+    }
+  }
+
+  .yir-2024-rated-poster-layer {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    transition: opacity 0.5s ease;
+
+    &.current {
+      opacity: 1;
+    }
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TopSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TopSection.svelte
@@ -37,6 +37,10 @@
     overflow: hidden;
   }
 
+  // Centered soft glow. The vertical radius is sized so the gradient reaches
+  // full transparency right at the top and bottom edges — otherwise `overflow:
+  // hidden` clips it mid-fade and leaves a hard purple seam where the section
+  // meets the first-play card below.
   .yir-2024-top-gradient {
     position: absolute;
     inset: 0;
@@ -44,7 +48,7 @@
     pointer-events: none;
     opacity: 0.35;
     background: radial-gradient(
-      55% 55% at 50% 60%,
+      55% 50% at 50% 50%,
       var(--purple-700) 0%,
       color-mix(in srgb, var(--purple-700) 0%, transparent) 100%
     );

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WatchedStats.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WatchedStats.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
   import CommentIcon from "$lib/components/icons/CommentIcon.svelte";
-  import FavoriteIcon from "$lib/components/icons/FavoriteIcon.svelte";
   import PlayIcon from "$lib/components/icons/PlayIcon.svelte";
+  import StarIcon from "$lib/components/icons/StarIcon.svelte";
   import ListIcon from "$lib/components/icons/mobile/ListIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import type { YirStatsCategory } from "$lib/requests/models/YirDetail";
@@ -55,7 +55,7 @@
   </span>
 
   <span class="yir-2024-stat">
-    <span class="yir-2024-stat-icon"><FavoriteIcon state="filled" /></span>
+    <span class="yir-2024-stat-icon"><StarIcon fill="full" /></span>
     <span class="yir-2024-stat-display">
       <span class="bold yir-2024-stat-value">
         {formatNumber(stats.ratingsCounts.total)}

--- a/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
@@ -2,6 +2,7 @@
   import Link from "$lib/components/link/Link.svelte";
   import { m } from "$lib/paraglide/messages";
   import type { YirTopRatedItem } from "$lib/requests/models/YirDetail";
+  import UserRating from "$lib/sections/components/UserRating.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import YirPageInner from "./YirPageInner.svelte";
   import YirSectionHeader from "./YirSectionHeader.svelte";
@@ -56,14 +57,14 @@
               }}
             >
               <div class="yir-poster">
-                <div class="yir-corner-rating">
-                  <span>{item.rating}</span>
-                </div>
                 <img
                   class="yir-poster-img"
-                  src={item.entry.poster.url.thumb}
+                  src={item.entry.poster?.url?.thumb}
                   alt={item.entry.title}
                 />
+              </div>
+              <div class="yir-rating">
+                <UserRating rating={item.rating} />
               </div>
             </Link>
           </div>
@@ -111,7 +112,7 @@
 
     &:hover .yir-grid-item:not(:hover) {
       .yir-poster-img,
-      .yir-corner-rating {
+      .yir-rating {
         opacity: 0.3;
       }
     }
@@ -139,32 +140,8 @@
     box-shadow: 0 0 var(--ni-20) var(--shade-1000);
     position: relative;
 
-    .yir-poster-img,
-    .yir-corner-rating {
+    .yir-poster-img {
       transition: all 0.5s;
-    }
-  }
-
-  .yir-corner-rating {
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: 1;
-    width: 0;
-    height: 0;
-    border-style: solid;
-    border-width: 0 var(--ni-32) var(--ni-32) 0;
-    border-color: transparent var(--red-500) transparent transparent;
-    font-weight: bold;
-    color: var(--shade-10);
-
-    span {
-      position: absolute;
-      top: var(--ni-4);
-      right: var(--ni-neg-32);
-      width: var(--ni-18);
-      text-align: center;
-      font-size: var(--ni-11);
     }
   }
 
@@ -173,5 +150,15 @@
     display: block;
     aspect-ratio: 2 / 3;
     object-fit: cover;
+  }
+
+  // 5-point star rating (shared v3 UserRating), centered beneath the poster.
+  .yir-rating {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: var(--ni-8);
+    color: var(--shade-10);
+    transition: all 0.5s;
   }
 </style>


### PR DESCRIPTION
# Summary

Ports the v2 "Highest Rated" section into the 2024 YIR template — a fanart panel with a ranked top list on the left and a featured poster on the right. Also aligns rating display across **both** templates on the shared v3 star + 5-point scale, and folds in two small polish fixes (most-watched poster radius, top-section background seam).

# Screenshot

<img width="1255" height="657" alt="image" src="https://github.com/user-attachments/assets/5a8adb81-b33a-4cdc-94ca-1c5fb6baf61c" />

# What

- **`Yir2024RatedSection.svelte`** (new) — single fanart panel: each entry's cover is stacked as a crossfading layer behind a purple wash; heading + ranked list (`.01`–`.NN`, title, rating) on the left, featured poster on the right. Hovering/focusing a row crossfades both the background **and** the poster to that entry (defaults to #1). Gated in `Yir2024.svelte` for shows (after show genres) and movies (after movie genres) on `topRated.{shows,movies}.length > 0`.
- Rating renders via the shared **`UserRating`** (star + 5-point value through `toUserRating`) — no bespoke rating UI.

## Consistency / fixes

- **`default/_internal/YirRatedSection.svelte`** — replaced the red corner-triangle rating badge with the shared `UserRating` centered beneath each poster, so both templates show the same star + 5-point rating. Hover-dim now fades the rating alongside the poster.
- **`Yir2024WatchedStats.svelte`** — the top **RATINGS** stat now uses a star icon instead of the heart, matching the rating convention.
- **`Yir2024MostPlayedCard.svelte`** — poster corner radius bumped to the shared summary-page radius (`--border-radius-xxl`), matching the highest-rated poster.
- **`Yir2024TopSection.svelte`** — fixed a faint purple seam between the stats and first-play sections: the radial glow was clipped mid-fade by `overflow: hidden`, so it's re-centered (`55% 50% at 50% 50%`) to reach full transparency within the section bounds.

# i18n

- `yir_2024_highest_rated_shows`, `yir_2024_highest_rated_movies`.
- Locale message files left to the Crowdin sync (matches prior YIR feature commits).

# Conventions

- Named PascalCase props type; `.ts` import extensions; reuses `Link`, `CrossOriginImage`, `UserRating`, `UrlBuilder.media`.
- Semantic `<ol>` / `<li>` ranked list with reset list styles so screen readers announce position; rank is `aria-hidden`.
- The duplicate featured-poster link is `focusable={false}` + `alt=""` (kept out of the tab order and the a11y name) — same resolution as the most-watched card.
- Optional chaining on all image accessors (`cover?.url?.medium`, `poster?.url?.medium`).
- Parent-driven spacing (`Yir2024PageInner` + `--content-gap`); `.bold` utility class; no `line-height` / `letter-spacing`; all colors are semantic CSS vars.
- Featured poster hidden on mobile; the list spans full width.

# Test plan

- [ ] `/users/{user}/year/2024` renders **Highest Rated TV Shows** after show genres and **Highest Rated Movies** after movie genres; gated on `topRated.{type}.length > 0`.
- [ ] Hovering/focusing a row crossfades the background fanart and the featured poster to that entry; defaults to #1.
- [ ] Rating shows the 5-point value + star (a 10 → `5`); matches the rest of v3.
- [ ] Rank is zero-padded (`.01`, `.02`, …); rows divide cleanly with no divider under the last row.
- [ ] Default template: each poster shows the centered 5-point star rating (corner badge gone); hover dims non-hovered items.
- [ ] Top stats: **RATINGS** uses a star icon.
- [ ] No purple seam between the top stats and the first-play card.
- [ ] Most-watched poster corners match the highest-rated poster.
- [ ] Mobile: featured poster hidden, list full-width; tablet poster steps down.
- [ ] Theme switch doesn't affect colors (YIR is dark-only).
