### PR TITLE
fix(stats): uses available space for streak text

### DIFF
--- a/projects/client/src/lib/sections/stats/StreakCallout.svelte
+++ b/projects/client/src/lib/sections/stats/StreakCallout.svelte
@@ -155,7 +155,7 @@
 
     display: flex;
     align-items: center;
-    gap: var(--gap-l);
+    gap: var(--gap-s);
 
     border: var(--ni-1) solid var(--color-streak-border);
     border-radius: var(--border-radius-l);
@@ -164,9 +164,13 @@
   .trakt-streak-left {
     display: flex;
     align-items: center;
-    gap: var(--gap-m);
+    gap: var(--gap-l);
     min-width: 0;
     flex: 1;
+
+    @include for-tablet-sm-and-below {
+      gap: var(--gap-s);
+    }
   }
 
   .trakt-streak-right {
@@ -174,10 +178,13 @@
     flex-direction: row;
     align-items: center;
     gap: var(--gap-l);
+
+    max-width: var(--ni-160);
     flex: 1;
 
     @include for-tablet-sm-and-below {
       gap: var(--gap-s);
+      flex: none;
     }
   }
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2547
- Uses available space for streak text.

## 👀 Example 👀
Before/after:
<img width="368" height="660" alt="Screenshot 2026-06-09 at 08 52 19" src="https://github.com/user-attachments/assets/3e966c8b-af01-4529-991c-25ecab14b0f6" />

<img width="368" height="660" alt="Screenshot 2026-06-09 at 08 52 11" src="https://github.com/user-attachments/assets/a678e287-976f-4e15-b52c-daf4014eea1a" />
