### PR TITLE
Fix/more stable continue watching list

### DIFF
--- a/projects/client/src/lib/components/lists/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/SectionList.svelte
@@ -36,6 +36,7 @@
     variant?: ListVariant;
     titleAction?: Snippet;
     drilldown?: ListDrilldownLinkProps;
+    contentHash?: string;
   };
 
   const {
@@ -52,6 +53,7 @@
     subtitle,
     variant = "default",
     titleAction: externalTitleAction,
+    contentHash,
   }: SectionListProps<T> = $props();
 
   const { isEditMode, section } = useEditMode();
@@ -161,7 +163,7 @@
           {#snippet childrenA()}
             <div
               use:scrollHistory={listId}
-              use:resetScroll
+              use:resetScroll={contentHash}
               class="trakt-list-item-container section-list-horizontal-scroll"
               data-dpad-navigation={DpadNavigationType.List}
               data-navigation-type={$navigation}

--- a/projects/client/src/lib/components/lists/section-list/_internal/resetScroll.ts
+++ b/projects/client/src/lib/components/lists/section-list/_internal/resetScroll.ts
@@ -1,6 +1,20 @@
 import { tick } from 'svelte';
 
-export function resetScroll(node: HTMLElement) {
+export function resetScroll(node: HTMLElement, key?: unknown) {
+  if (key !== undefined) {
+    // Key-based mode: reset only when key changes, not on every DOM mutation.
+    // Used by lists with stable item arrays (e.g. UpNextList) so that in-place
+    // updates (marking as watched) don't scroll back to position 0.
+    return {
+      update() {
+        tick().then(() => {
+          node.scrollLeft = 0;
+        });
+      },
+      destroy() {},
+    };
+  }
+
   const observer = new MutationObserver(() => {
     tick().then(() => {
       node.scrollLeft = 0;
@@ -10,6 +24,7 @@ export function resetScroll(node: HTMLElement) {
   observer.observe(node, { childList: true });
 
   return {
+    update() {},
     destroy() {
       observer.disconnect();
     },

--- a/projects/client/src/lib/features/filters/useFilter.ts
+++ b/projects/client/src/lib/features/filters/useFilter.ts
@@ -1,6 +1,6 @@
 import type { FilterKey } from '$lib/features/filters/models/Filter.ts';
 import { useParameters } from '$lib/features/parameters/useParameters.ts';
-import { combineLatest, map } from 'rxjs';
+import { combineLatest, distinctUntilChanged, map } from 'rxjs';
 import { getAdditionalKeys } from '../../sections/navbar/components/filter/filters/_internal/getAdditionalKeys.ts';
 import { useNavbarState } from '../../sections/navbar/useNavbarState.ts';
 import { useUser } from '../auth/stores/useUser.ts';
@@ -74,6 +74,18 @@ export function useFilter() {
 
             return filterMap;
           }, {} as Record<string, string>);
+      }),
+      /*
+        combineLatest includes `user`, which can refresh after any action
+        that can update history/ratings/etc. Without distinctUntilChanged,
+        a new object reference would propagate to consumers and cause
+        list stores to recreate with empty previous state.
+       */
+      distinctUntilChanged((a, b) => {
+        const aKeys = Object.keys(a);
+        const bKeys = Object.keys(b);
+        return aKeys.length === bKeys.length &&
+          aKeys.every((k) => a[k] === b[k]);
       }),
     ),
   };

--- a/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
@@ -3,6 +3,7 @@
   import { useFilter } from "$lib/features/filters/useFilter";
   import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
   import { DEFAULT_PAGE_SIZE } from "$lib/utils/constants";
+  import { checksum } from "$lib/utils/string/checksum";
   import SkeletonList from "../../../components/lists/SkeletonList.svelte";
   import { mediaListHeightResolver } from "../utils/mediaListHeightResolver";
   import NoFilterResultsPlaceholder from "./_internal/NoFilterResultsPlaceholder.svelte";
@@ -34,6 +35,20 @@
     }),
   );
 
+  /*
+    The filter values are used as the content hash to ensure list
+    scroll position is reset when applying/changing filters.
+  */
+  const contentHash = $derived(
+    checksum(
+      JSON.stringify({
+        type,
+        filter: filter ?? {},
+        filterOverride: filterOverride ?? {},
+      }),
+    ),
+  );
+
   const defaultVariant = $derived(useDefaultCardVariant(type));
   const variant = $derived(externalVariant ?? $defaultVariant);
   const height = $derived(mediaListHeightResolver(variant));
@@ -56,6 +71,7 @@
   {drilldown}
   {titleAction}
   actions={externalActions ? actions : undefined}
+  {contentHash}
   --height-list={height}
 >
   {#snippet empty()}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2550, fixes #2551
- Certain actions could cause the filter map to get a new object reference. Which could cause the continue watching list to be remounted, losing the stable-ness.
- Also a small change to resetting scroll in the section list. E.g. scrolling in it, marking something as watched, would reset the scroll also. This is no only done when filters change.