### PR TITLE
YIR: 2024 trends

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4781,6 +4781,64 @@
       "default": "Highest Rated Movies",
       "description": "Section heading above the highest-rated movies list on the 2024 Year in Review template."
     },
+    "yir_2024_show_trends": {
+      "default": "Show Trends",
+      "description": "Heading for the section showing the most-watched shows that premiered each month, on the 2024 Year in Review template."
+    },
+    "yir_2024_movie_trends": {
+      "default": "Movie Trends",
+      "description": "Heading for the section showing the most-watched movies that premiered each month, on the 2024 Year in Review template."
+    },
+    "yir_2024_trends_subtitle_shows": {
+      "default": "The most watched shows that premiered in {year}.",
+      "description": "Subtitle under the Show Trends heading on the 2024 Year in Review template.",
+      "variables": {
+        "year": {
+          "type": "number"
+        }
+      }
+    },
+    "yir_2024_trends_subtitle_movies": {
+      "default": "The most watched movies that premiered in {year}.",
+      "description": "Subtitle under the Movie Trends heading on the 2024 Year in Review template.",
+      "variables": {
+        "year": {
+          "type": "number"
+        }
+      }
+    },
+    "yir_2024_trends_watched_shows": {
+      "default": "You watched {watched} of {total} shows.",
+      "description": "Summary of how many of the trending shows the user watched, on the 2024 Year in Review template.",
+      "variables": {
+        "watched": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        }
+      }
+    },
+    "yir_2024_trends_watched_movies": {
+      "default": "You watched {watched} of {total} movies.",
+      "description": "Summary of how many of the trending movies the user watched, on the 2024 Year in Review template.",
+      "variables": {
+        "watched": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        }
+      }
+    },
+    "yir_2024_trend_watchers": {
+      "default": "{count} watchers",
+      "description": "Watcher count shown beneath each trending title on the 2024 Year in Review template. `count` is a pre-formatted number string."
+    },
+    "yir_2024_trend_watched": {
+      "default": "Watched",
+      "description": "Label on the chip marking a trending title the user has watched, on the 2024 Year in Review template."
+    },
     "yir_2024_most_watched_networks": {
       "default": "Most watched networks",
       "description": "Section heading above the networks bubble chart on the 2024 Year in Review template."

--- a/projects/client/src/lib/requests/_internal/mapToYirDetail.ts
+++ b/projects/client/src/lib/requests/_internal/mapToYirDetail.ts
@@ -6,6 +6,7 @@ import type {
   YirMostWatchedItem,
   YirStatsCategory,
   YirTopRatedItem,
+  YirTrendItem,
   YirWatchedItem,
 } from '../models/YirDetail.ts';
 import { mapToMovieEntry } from './mapToMovieEntry.ts';
@@ -81,6 +82,20 @@ type RawTopRatedMovie = {
   movie: MovieResponse;
 };
 
+type RawTrendShow = {
+  month: number;
+  watchers: number;
+  watched: boolean;
+  show: ShowResponse;
+};
+
+type RawTrendMovie = {
+  month: number;
+  watchers: number;
+  watched: boolean;
+  movie: MovieResponse;
+};
+
 type RawYirResponse = {
   stats: {
     all: RawStatsCategory & { lists_counts: RawStats };
@@ -106,6 +121,10 @@ type RawYirResponse = {
   top_rated: {
     shows: RawTopRatedShow[];
     movies: RawTopRatedMovie[];
+  };
+  trends?: {
+    shows: RawTrendShow[];
+    movies: RawTrendMovie[];
   };
 };
 
@@ -198,6 +217,24 @@ function mapTopRatedMovies(raw: RawTopRatedMovie[]): YirTopRatedItem[] {
   }));
 }
 
+function mapTrendShows(raw: RawTrendShow[]): YirTrendItem[] {
+  return raw.map((item) => ({
+    month: item.month,
+    watchers: item.watchers,
+    watched: item.watched,
+    entry: mapToShowEntry(item.show),
+  }));
+}
+
+function mapTrendMovies(raw: RawTrendMovie[]): YirTrendItem[] {
+  return raw.map((item) => ({
+    month: item.month,
+    watchers: item.watchers,
+    watched: item.watched,
+    entry: mapToMovieEntry(item.movie),
+  }));
+}
+
 export function mapToYirDetail(response: RawYirResponse): YirDetail {
   const { stats, images } = response;
 
@@ -233,6 +270,10 @@ export function mapToYirDetail(response: RawYirResponse): YirDetail {
     topRated: {
       shows: mapTopRatedShows(response.top_rated?.shows ?? []),
       movies: mapTopRatedMovies(response.top_rated?.movies ?? []),
+    },
+    trends: {
+      shows: mapTrendShows(response.trends?.shows ?? []),
+      movies: mapTrendMovies(response.trends?.movies ?? []),
     },
   };
 }

--- a/projects/client/src/lib/requests/models/YirDetail.ts
+++ b/projects/client/src/lib/requests/models/YirDetail.ts
@@ -56,6 +56,14 @@ const YirTopRatedItemSchema = z.object({
   entry: MediaEntrySchema,
 });
 
+const YirTrendItemSchema = z.object({
+  /** Calendar month (1-12) the title premiered in. */
+  month: z.number(),
+  watchers: z.number(),
+  watched: z.boolean(),
+  entry: MediaEntrySchema,
+});
+
 const YirWatchedMovieSchema = z.object({
   type: z.literal('movie'),
   watchedAt: z.date(),
@@ -106,6 +114,10 @@ export const YirDetailSchema = z.object({
     shows: YirTopRatedItemSchema.array(),
     movies: YirTopRatedItemSchema.array(),
   }),
+  trends: z.object({
+    shows: YirTrendItemSchema.array(),
+    movies: YirTrendItemSchema.array(),
+  }).nullish(),
 });
 
 export type YirDetail = z.infer<typeof YirDetailSchema>;
@@ -117,6 +129,7 @@ export type YirGenresGroup = z.infer<typeof YirGenresGroupSchema>;
 export type YirCompany = z.infer<typeof YirCompanySchema>;
 export type YirMostWatchedItem = z.infer<typeof YirMostWatchedItemSchema>;
 export type YirTopRatedItem = z.infer<typeof YirTopRatedItemSchema>;
+export type YirTrendItem = z.infer<typeof YirTrendItemSchema>;
 export type YirWatchedItem = z.infer<typeof YirWatchedItemSchema>;
 export type YirWatchedMovie = z.infer<typeof YirWatchedMovieSchema>;
 export type YirWatchedEpisode = z.infer<typeof YirWatchedEpisodeSchema>;

--- a/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
+++ b/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
@@ -10,6 +10,7 @@
   import Yir2024RatedSection from "./_internal/Yir2024RatedSection.svelte";
   import Yir2024StatsSection from "./_internal/Yir2024StatsSection.svelte";
   import Yir2024TopSection from "./_internal/Yir2024TopSection.svelte";
+  import Yir2024TrendsSection from "./_internal/Yir2024TrendsSection.svelte";
 
   const {
     detail,
@@ -81,6 +82,16 @@
       </Yir2024PageInner>
     {/if}
 
+    {#if (detail.trends?.shows.length ?? 0) > 0}
+      <Yir2024PageInner>
+        <Yir2024TrendsSection
+          type="shows"
+          items={detail.trends?.shows ?? []}
+          {year}
+        />
+      </Yir2024PageInner>
+    {/if}
+
     {#if detail.stats.movies.playCounts.total > 0}
       <Yir2024PageInner>
         <Yir2024StatsSection type="movies" stats={detail.stats.movies} {year} />
@@ -98,10 +109,7 @@
 
     {#if detail.studios.length > 0}
       <Yir2024PageInner>
-        <Yir2024CompaniesSection
-          type="movies"
-          companies={detail.studios}
-        />
+        <Yir2024CompaniesSection type="movies" companies={detail.studios} />
       </Yir2024PageInner>
     {/if}
 
@@ -114,6 +122,16 @@
     {#if detail.topRated.movies.length > 0}
       <Yir2024PageInner>
         <Yir2024RatedSection type="movies" items={detail.topRated.movies} />
+      </Yir2024PageInner>
+    {/if}
+
+    {#if (detail.trends?.movies.length ?? 0) > 0}
+      <Yir2024PageInner>
+        <Yir2024TrendsSection
+          type="movies"
+          items={detail.trends?.movies ?? []}
+          {year}
+        />
       </Yir2024PageInner>
     {/if}
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TrendCard.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TrendCard.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import CheckIcon from "$lib/components/icons/CheckIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { m } from "$lib/paraglide/messages";
+  import type { YirTrendItem } from "$lib/requests/models/YirDetail.ts";
+  import { formatNumber } from "$lib/utils/format/formatNumber.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+
+  type Yir2024TrendCardProps = {
+    item: YirTrendItem;
+  };
+
+  const { item }: Yir2024TrendCardProps = $props();
+
+  const itemUrl = $derived(UrlBuilder.media(item.entry.type, item.entry.slug));
+
+  // Localized month name derived from the 1-12 index (year-agnostic).
+  const monthLabel = $derived(
+    new Intl.DateTimeFormat(languageTag(), { month: "long" }).format(
+      new Date(2024, item.month - 1, 1),
+    ),
+  );
+
+  const watchersLabel = $derived(
+    m.yir_2024_trend_watchers({ count: formatNumber(item.watchers) }),
+  );
+</script>
+
+<div class="yir-2024-trend-card">
+  <Link href={itemUrl} color="inherit">
+    <span class="uppercase yir-2024-trend-month">{monthLabel}</span>
+
+    <div class="yir-2024-trend-poster">
+      <CrossOriginImage
+        src={item.entry.poster?.url?.medium}
+        alt={item.entry.title}
+      />
+    </div>
+
+    <span class="yir-2024-trend-title">{item.entry.title}</span>
+    <span class="uppercase yir-2024-trend-watchers">{watchersLabel}</span>
+
+    {#if item.watched}
+      <span class="yir-2024-trend-watched">
+        <CheckIcon />
+        <span class="bold uppercase">{m.yir_2024_trend_watched()}</span>
+      </span>
+    {/if}
+  </Link>
+</div>
+
+<style>
+  /* The whole card is one Link laid out as a column; strip the link's
+     underline and inherit the card's white text. */
+  .yir-2024-trend-card :global(.trakt-link) {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-4);
+    text-decoration: none;
+    color: var(--shade-10);
+  }
+
+  .yir-2024-trend-month {
+    font-size: var(--font-size-text);
+    color: var(--shade-300);
+    letter-spacing: 1px;
+    /* A little breathing room above the poster. */
+    margin-bottom: var(--ni-4);
+  }
+
+  .yir-2024-trend-poster {
+    width: 100%;
+    aspect-ratio: 2 / 3;
+    overflow: hidden;
+    border-radius: var(--border-radius-m);
+    background-color: var(--shade-900);
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+  }
+
+  .yir-2024-trend-title {
+    font-size: var(--font-size-title);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding-top: var(--ni-4);
+  }
+
+  .yir-2024-trend-watchers {
+    font-size: var(--font-size-tag);
+    color: var(--shade-300);
+    letter-spacing: 1px;
+  }
+
+  /* Purple "✓ Watched" pill, sitting below the watcher count (matches v2). */
+  .yir-2024-trend-watched {
+    align-self: flex-start;
+    margin-top: var(--ni-4);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ni-4);
+    padding: var(--ni-4) var(--ni-12);
+    border-radius: var(--border-radius-xl);
+    background-color: var(--purple-500);
+    color: var(--shade-10);
+    font-size: var(--font-size-tag);
+    white-space: nowrap;
+
+    :global(svg) {
+      width: var(--ni-12);
+      height: var(--ni-12);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TrendsSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TrendsSection.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { YirTrendItem } from "$lib/requests/models/YirDetail.ts";
+  import Yir2024TrendCard from "./Yir2024TrendCard.svelte";
+
+  type Yir2024TrendsSectionProps = {
+    type: "shows" | "movies";
+    items: YirTrendItem[];
+    year: number;
+  };
+
+  const { type, items, year }: Yir2024TrendsSectionProps = $props();
+
+  // Render in calendar order regardless of how the API sorts the payload.
+  const ordered = $derived([...items].sort((a, b) => a.month - b.month));
+  const watchedCount = $derived(items.filter((item) => item.watched).length);
+
+  const heading = $derived(
+    type === "shows" ? m.yir_2024_show_trends() : m.yir_2024_movie_trends(),
+  );
+  const subtitle = $derived(
+    type === "shows"
+      ? m.yir_2024_trends_subtitle_shows({ year })
+      : m.yir_2024_trends_subtitle_movies({ year }),
+  );
+  const watchedSummary = $derived(
+    type === "shows"
+      ? m.yir_2024_trends_watched_shows({
+          watched: watchedCount,
+          total: items.length,
+        })
+      : m.yir_2024_trends_watched_movies({
+          watched: watchedCount,
+          total: items.length,
+        }),
+  );
+</script>
+
+<section class="yir-2024-trends" id="section-{type}-trends">
+  <header class="yir-2024-trends-header">
+    <h2 class="bold yir-2024-trends-title">{heading}</h2>
+    <p class="yir-2024-trends-subtitle">{subtitle}</p>
+    <p class="yir-2024-trends-subtitle">{watchedSummary}</p>
+  </header>
+
+  <ol class="yir-2024-trends-grid" role="list">
+    {#each ordered as item (item.month)}
+      <li role="listitem">
+        <Yir2024TrendCard {item} />
+      </li>
+    {/each}
+  </ol>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  // Purple gradient panel (matches v2's trends sections).
+  .yir-2024-trends {
+    // border-box so the panel's padding stays inside its 100% width (there's
+    // no global box-sizing reset) — otherwise it overflows the page wrapper.
+    box-sizing: border-box;
+    width: 100%;
+    color: var(--shade-10);
+    border-radius: var(--border-radius-xxl);
+    padding: var(--ni-44);
+    background: linear-gradient(
+      19.44deg,
+      var(--purple-900) 21.85%,
+      color-mix(in srgb, var(--purple-900) 80%, transparent) 59.01%,
+      color-mix(in srgb, var(--purple-700) 0%, transparent) 104.87%
+    );
+
+    @include for-mobile {
+      border-radius: var(--border-radius-xl);
+      padding: var(--ni-20);
+    }
+  }
+
+  .yir-2024-trends-header {
+    margin-bottom: var(--ni-32);
+
+    @include for-mobile {
+      margin-bottom: var(--ni-20);
+    }
+  }
+
+  .yir-2024-trends-title {
+    margin: 0;
+    font-size: clamp(var(--ni-32), 5vw, var(--ni-56));
+    line-height: 1;
+
+    @include for-mobile {
+      font-size: var(--ni-28);
+    }
+  }
+
+  .yir-2024-trends-subtitle {
+    margin: var(--ni-4) 0 0;
+    font-size: var(--ni-22);
+    line-height: 1.2;
+    color: var(--shade-10);
+
+    @include for-mobile {
+      font-size: var(--font-size-title);
+    }
+  }
+
+  // Six across (12 items → two rows) on desktop, stepping down with the
+  // viewport. List semantics preserved with reset styles.
+  .yir-2024-trends-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: var(--ni-24) var(--ni-20);
+
+    @include for-tablet-lg {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    @include for-tablet-sm {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    @include for-mobile {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--ni-20) var(--ni-12);
+    }
+  }
+</style>


### PR DESCRIPTION
# Summary

Ports the v2 "Show Trends" / "Movie Trends" sections into the 2024 YIR template — for each calendar month, the most-watched show/movie that premiered that year, shown as a poster grid with watcher counts and a "Watched" chip on titles you've seen. Consumes the `trends` field from the YIR response.

# Screenshot

<img width="1231" height="1029" alt="image" src="https://github.com/user-attachments/assets/46fb19a6-4e12-46f4-bd43-99723e7c2537" />

# What

- **`Yir2024TrendsSection.svelte`** — heading (`Show Trends` / `Movie Trends`) + subtitle (`The most watched … that premiered in {year}.`) + a watched summary (`You watched {n} of {total} …`), above a responsive poster grid (6 → 4 → 3 → 2 columns). Rendered as a purple gradient panel matching v2. Items are sorted into calendar order regardless of payload order.
- **`Yir2024TrendCard.svelte`** — one month: uppercase month label, poster, title, `{n} watchers`, and a purple `✓ Watched` pill (when watched) sitting beneath the watcher count. Month names are localized via `Intl.DateTimeFormat(languageTag())` rather than the API's English `month_name`.
- **Data layer** — `YirTrendItem { month, watchers, watched, entry }` + `trends: { shows, movies }` added to `YirDetail`; `mapTrendShows`/`mapTrendMovies` map the raw `{ month, watchers, watched, show/movie }` (via `mapToShowEntry`/`mapToMovieEntry`). Raw `trends` is optional with an empty-group fallback.
- **Registered** in `Yir2024.svelte` — Show Trends after the shows rated section, Movie Trends after the movies rated section, each gated on `detail.trends?.{type}.length > 0`.
- **i18n** — `yir_2024_show_trends`, `yir_2024_movie_trends`, `yir_2024_trends_subtitle_{shows,movies}`, `yir_2024_trends_watched_{shows,movies}`, `yir_2024_trend_watchers`, `yir_2024_trend_watched`.

# Conventions

- Named PascalCase props types; `.ts` import extensions; reuses `Link`, `CrossOriginImage`, `CheckIcon`.
- Semantic `<ol>`/`<li>` grid with `role="list"`/`role="listitem"` (so Safari/VoiceOver keeps list semantics), reset list styles.
- Locale-aware: `Intl` month names, `formatNumber` watcher counts.
- All colors are semantic palette vars; the section gradient is tokenized (`--purple-900`/`--purple-700`). The panel uses `box-sizing: border-box` (no global reset) so its padding stays within the page wrapper, matching the other sections.
- Defensive template gating (`detail.trends?.…`) so a stale cached `YirDetail` (mapped before `trends` existed) can't crash the page — it just hides the section until fresh data lands.
- Typography utility classes (`.bold` / `.uppercase`) with semantic font-size vars.
- The "Watched" chip is a small custom pill (no existing reusable watched-on-poster component); `"{count} watchers"` is a single key (counts are always large, matching v2's always-plural label).

# Test plan

> The `trends` data is auto cache-busted on deploy (the YIR query key hashes the schema, which changed). If a section looks stale locally, clear IndexedDB (`indexedDB.deleteDatabase('keyval-store')`) and reload.

- [ ] `/users/{user}/year/2024` renders **Show Trends** after the shows rated section and **Movie Trends** after the movies rated section; gated on `trends.{type}.length > 0`.
- [ ] 12 cards in calendar order (Jan→Dec); each shows month, poster, title, `{n} watchers`, and links to the title.
- [ ] Titles you've watched show the purple `✓ Watched` chip beneath the watcher count; the summary line counts them (`You watched {n} of 12 …`).
- [ ] Month names + counts localize with the active language.
- [ ] Grid steps 6 → 4 → 3 → 2 columns down to phones; the panel keeps the same inset/padding as the other sections at every width.
- [ ] With no `trends` data, the sections are absent — no layout gap, no crash.
- [ ] Theme switch doesn't affect colors (YIR is dark-only).
