### PR TITLE
feat(summary): add ratings breakdown drawer

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2241,6 +2241,31 @@
       "default": "Ratings",
       "description": "Header for the filter that allows users to select a rating."
     },
+    "header_ratings_trakt": {
+      "default": "Trakt Rating",
+      "description": "Section header in the ratings breakdown drawer above the Trakt rating distribution card."
+    },
+    "header_ratings_official": {
+      "default": "Official Ratings",
+      "description": "Section header in the ratings breakdown drawer for the row of official rating sources (IMDb, Rotten Tomatoes critics and audience)."
+    },
+    "text_ratings_votes": {
+      "default": "{count} votes",
+      "description": "Vote count text shown under the Trakt rating in the ratings breakdown drawer.",
+      "variables": {
+        "count": {
+          "type": "string"
+        }
+      }
+    },
+    "text_ratings_no_data": {
+      "default": "No ratings yet.",
+      "description": "Empty-state text shown in the ratings breakdown drawer when no rating data is available for the title."
+    },
+    "button_label_view_ratings_breakdown": {
+      "default": "View ratings breakdown",
+      "description": "Aria-label for the Trakt rating in the summary header that opens the ratings breakdown drawer."
+    },
     "button_label_view_all_items_in": {
       "default": "View all items in \"{title}\"",
       "description": "Aria-label for the button that allows users to view all items in a specific category or list.",

--- a/projects/client/src/lib/components/summary/RatingIntl.ts
+++ b/projects/client/src/lib/components/summary/RatingIntl.ts
@@ -1,3 +1,4 @@
 export type RatingIntl = {
   voteText: (count: number) => string;
+  viewBreakdownLabel: () => string;
 };

--- a/projects/client/src/lib/components/summary/RatingIntlProvider.ts
+++ b/projects/client/src/lib/components/summary/RatingIntlProvider.ts
@@ -1,7 +1,9 @@
 import type { RatingIntl } from '$lib/components/summary/RatingIntl.ts';
+import * as m from '$lib/features/i18n/messages.ts';
 import { languageTag } from '$lib/features/i18n/index.ts';
 import { toHumanNumber } from '$lib/utils/formatting/number/toHumanNumber.ts';
 
 export const RatingIntlProvider: RatingIntl = {
   voteText: (count) => toHumanNumber(count, languageTag()),
+  viewBreakdownLabel: () => m.button_label_view_ratings_breakdown(),
 };

--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
   import IMDBIcon from "$lib/components/icons/IMDBIcon.svelte";
   import { getLocale } from "$lib/features/i18n";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
@@ -11,6 +12,7 @@
   } from "$lib/utils/formatting/number/toRottenTomatoRating";
   import { toTraktRating } from "$lib/utils/formatting/number/toTraktRating";
   import { toVotesBasedRating } from "$lib/utils/formatting/number/toVotesBasedRating";
+  import ActionButton from "../buttons/ActionButton.svelte";
   import PopcornIcon from "../icons/PopcornIcon.svelte";
   import RatingIcon from "../icons/RatingIcon.svelte";
   import RottenIcon from "../icons/RottenIcon.svelte";
@@ -19,16 +21,26 @@
   import RatingItem from "./RatingItem.svelte";
   import { getDisplayableRatings } from "./_internal/getDisplayableRatings";
 
+  type TraktRatingDrilldown = {
+    href: string;
+    noscroll: boolean;
+    replacestate: boolean;
+  };
+
   type RatingListProps = {
     i18n?: RatingIntl;
     ratings: MediaRating;
     entry: MediaEntry | EpisodeEntry;
+    drilldown?: TraktRatingDrilldown;
+    variant?: "all" | "external";
   };
 
   const {
     i18n = RatingIntlProvider,
     ratings,
     entry,
+    drilldown,
+    variant = "all",
   }: RatingListProps = $props();
 
   const { trakt, imdb, rotten } = $derived(
@@ -40,7 +52,7 @@
   );
 </script>
 
-<div class="trakt-summary-ratings">
+{#snippet traktItem()}
   <RatingItem
     rating={trakt?.rating && toTraktRating(trakt.rating, getLocale())}
   >
@@ -49,6 +61,12 @@
       {i18n.voteText(trakt?.votes ?? 0)}
     {/snippet}
   </RatingItem>
+{/snippet}
+
+<div class="trakt-summary-ratings">
+  {#if variant === "all"}
+    {@render traktItem()}
+  {/if}
 
   <RatingItem rating={imdb?.rating} url={imdb?.url}>
     <IMDBIcon style={toVotesBasedRating(imdb?.votes)} />
@@ -72,6 +90,20 @@
       {/snippet}
     </RatingItem>
   {/if}
+
+  {#if drilldown}
+    <ActionButton
+      classList="trakt-ratings-drilldown-button"
+      href={drilldown.href}
+      noscroll={drilldown.noscroll}
+      replacestate={drilldown.replacestate}
+      label={i18n.viewBreakdownLabel()}
+      style="ghost"
+      size="small"
+    >
+      <CaretRightIcon />
+    </ActionButton>
+  {/if}
 </div>
 
 <style lang="scss">
@@ -81,6 +113,13 @@
     display: flex;
     align-items: center;
     gap: var(--gap-m);
+
+    :global(.trakt-ratings-drilldown-button) {
+      :global(svg) {
+        width: var(--ni-20);
+        height: var(--ni-20);
+      }
+    }
 
     @include for-mobile() {
       gap: var(--gap-s);

--- a/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
@@ -16,6 +16,7 @@
   import type { MediaDetailsProps } from "./components/details/MediaDetailsProps";
   import HistoryDrawerHost from "./components/history/HistoryDrawerHost.svelte";
   import NotesDrawerHost from "./components/notes/NotesDrawerHost.svelte";
+  import RatingsDrawer from "./components/rating/RatingsDrawer.svelte";
   import SeasonsDrawerHost from "./components/seasons/SeasonsDrawerHost.svelte";
   import SentimentDrawer from "./components/sentiment/SentimentDrawer.svelte";
   import TriviaDrawerHost from "./components/trivia/TriviaDrawerHost.svelte";
@@ -122,4 +123,8 @@
       : undefined}
     onClose={close}
   />
+{/if}
+
+{#if drawer === SummaryDrawers.Ratings}
+  <RatingsDrawer {...details} onClose={close} />
 {/if}

--- a/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
+++ b/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
@@ -12,6 +12,7 @@ export enum SummaryDrawers {
   Seasons = 'seasons',
   Notes = 'notes',
   Comments = 'comments',
+  Ratings = 'ratings',
 }
 
 const commentIdParam = 'comment_id';
@@ -42,6 +43,8 @@ function mapToDrawer(value: string | Nil) {
       return SummaryDrawers.Notes;
     case SummaryDrawers.Comments:
       return SummaryDrawers.Comments;
+    case SummaryDrawers.Ratings:
+      return SummaryDrawers.Ratings;
     default:
       return null;
   }

--- a/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
@@ -5,6 +5,10 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { useWatchCount } from "$lib/stores/useWatchCount";
   import type { Snippet } from "svelte";
+  import {
+    SummaryDrawers,
+    summaryDrawerNavigation,
+  } from "../../_internal/summaryDrawerNavigation";
   import EpisodeTitle from "../_internal/EpisodeTitle.svelte";
   import SummaryPosterTags from "../_internal/SummaryPosterTags.svelte";
   import SummaryTitle from "../_internal/SummaryTitle.svelte";
@@ -42,6 +46,9 @@
   const { ratings } = $derived(
     useMediaMetaInfo({ type, episode, media: show }),
   );
+
+  const { buildDrawerLink } = summaryDrawerNavigation();
+  const ratingsDrawerLink = $derived(buildDrawerLink(SummaryDrawers.Ratings));
 </script>
 
 {#snippet tags()}
@@ -66,7 +73,11 @@
   <SummaryHeader {title}>
     <EpisodeTitle {episode} {show} {showIntl} />
     <SummaryTitle {title} {crew} {type} {episode} media={show} />
-    <RatingList ratings={$ratings} entry={episode} />
+    <RatingList
+      ratings={$ratings}
+      entry={episode}
+      drilldown={ratingsDrawerLink}
+    />
   </SummaryHeader>
 
   <Spoiler media={episode} {show} {type}>

--- a/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
@@ -4,6 +4,10 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { useWatchCount } from "$lib/stores/useWatchCount";
+  import {
+    SummaryDrawers,
+    summaryDrawerNavigation,
+  } from "../../../_internal/summaryDrawerNavigation";
   import EpisodeTitle from "../../_internal/EpisodeTitle.svelte";
   import SpoilerSection from "../../_internal/SpoilerSection.svelte";
   import Summary from "../../_internal/Summary.svelte";
@@ -37,6 +41,9 @@
     useMediaMetaInfo({ type, episode, media: show }),
   );
 
+  const { buildDrawerLink } = summaryDrawerNavigation();
+  const ratingsDrawerLink = $derived(buildDrawerLink(SummaryDrawers.Ratings));
+
   const { isRateable } = $derived(
     useIsRateable({ type, media: episode, show }),
   );
@@ -64,7 +71,11 @@
   {/snippet}
 
   {#snippet meta()}
-    <RatingList ratings={$ratings} entry={episode} />
+    <RatingList
+      ratings={$ratings}
+      entry={episode}
+      drilldown={ratingsDrawerLink}
+    />
     <EpisodeTitle {episode} {show} {showIntl} />
     <SummaryTitle {title} {type} {crew} media={show} {episode} />
 

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -5,6 +5,10 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import { useWatchCount } from "$lib/stores/useWatchCount";
+  import {
+    SummaryDrawers,
+    summaryDrawerNavigation,
+  } from "../../_internal/summaryDrawerNavigation";
   import SummaryCover from "../_internal/SummaryCover.svelte";
   import SummaryPosterTags from "../_internal/SummaryPosterTags.svelte";
   import SummaryTitle from "../_internal/SummaryTitle.svelte";
@@ -38,6 +42,9 @@
   const { ratings } = $derived(useMediaMetaInfo(target));
   const { isDropped } = $derived(useIsDropped(media));
   const { isStarted } = $derived(useIsStarted(target));
+
+  const { buildDrawerLink } = summaryDrawerNavigation();
+  const ratingsDrawerLink = $derived(buildDrawerLink(SummaryDrawers.Ratings));
 
   const posterUrl = $derived(streamOn?.preferred?.link ?? media.trailer);
 </script>
@@ -74,7 +81,11 @@
   <div class="trakt-summary-main-content">
     <SummaryHeader {title}>
       <SummaryTitle {title} {crew} {...target} />
-      <RatingList ratings={$ratings} entry={media} />
+      <RatingList
+        ratings={$ratings}
+        entry={media}
+        drilldown={ratingsDrawerLink}
+      />
     </SummaryHeader>
 
     <Spoiler {media} {type}>

--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -9,6 +9,10 @@
   import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { useWatchCount } from "$lib/stores/useWatchCount";
+  import {
+    SummaryDrawers,
+    summaryDrawerNavigation,
+  } from "../../../_internal/summaryDrawerNavigation";
   import SpoilerSection from "../../_internal/SpoilerSection.svelte";
   import Summary from "../../_internal/Summary.svelte";
   import SummaryPosterTags from "../../_internal/SummaryPosterTags.svelte";
@@ -42,6 +46,9 @@
   const { isRateable } = $derived(useIsRateable(target));
   const { isDropped } = $derived(useIsDropped(media));
   const { isStarted } = $derived(useIsStarted(target));
+
+  const { buildDrawerLink } = summaryDrawerNavigation();
+  const ratingsDrawerLink = $derived(buildDrawerLink(SummaryDrawers.Ratings));
 </script>
 
 {#snippet tags()}
@@ -77,7 +84,11 @@
   {/snippet}
 
   {#snippet meta()}
-    <RatingList ratings={$ratings} entry={media} />
+    <RatingList
+      ratings={$ratings}
+      entry={media}
+      drilldown={ratingsDrawerLink}
+    />
     <SummaryTitle {title} {crew} {...target} />
 
     <RenderFor audience="authenticated">

--- a/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import { getDisplayableRatings } from "$lib/components/summary/_internal/getDisplayableRatings";
+  import RatingList from "$lib/components/summary/RatingList.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { fade } from "svelte/transition";
+  import { useMediaMetaInfo } from "../media/useMediaMetaInfo.ts";
+  import RatingsDistribution from "./_internal/RatingsDistribution.svelte";
+  import type { RatingsDrawerProps } from "./_internal/RatingsDrawerProps.ts";
+
+  const { onClose, ...props }: RatingsDrawerProps = $props();
+
+  const metaInfoTarget = $derived(
+    props.type === "episode"
+      ? {
+          type: "episode" as const,
+          media: props.show,
+          episode: props.episode,
+        }
+      : { type: props.type, media: props.media },
+  );
+
+  const entry = $derived(
+    props.type === "episode" ? props.episode : props.media,
+  );
+
+  const { ratings: rawRatings } = $derived(useMediaMetaInfo(metaInfoTarget));
+
+  const ratings = $derived(
+    getDisplayableRatings({ ratings: $rawRatings, entry }),
+  );
+
+  const hasAnyRating = $derived(
+    ratings.trakt != null || ratings.imdb != null || ratings.rotten != null,
+  );
+
+  let isOpen = $state(false);
+</script>
+
+<Drawer
+  {onClose}
+  onOpened={() => (isOpen = true)}
+  title={m.header_ratings()}
+  size="auto"
+>
+  {#if isOpen}
+    <div
+      class="trakt-ratings-drawer-content"
+      transition:fade={{ duration: 150 }}
+    >
+      {#if !hasAnyRating}
+        <p class="ratings-empty secondary">{m.text_ratings_no_data()}</p>
+      {:else}
+        {#if ratings.trakt}
+          <RatingsDistribution trakt={ratings.trakt} />
+        {/if}
+
+        <section class="ratings-card official-card">
+          <h3 class="card-title bold secondary">
+            {m.header_ratings_official()}
+          </h3>
+          <div class="official-row">
+            <RatingList {ratings} {entry} variant="external" />
+          </div>
+        </section>
+      {/if}
+    </div>
+  {/if}
+</Drawer>
+
+<style>
+  .trakt-ratings-drawer-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-m);
+  }
+
+  .ratings-empty {
+    color: var(--color-text-secondary);
+  }
+
+  .ratings-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+    padding: var(--ni-12) var(--ni-16);
+    border-radius: var(--border-radius-l);
+    background: var(--color-card-background);
+  }
+
+  .card-title {
+    color: var(--color-text-secondary);
+    margin: 0;
+    font-size: var(--font-size-text-small);
+  }
+
+  .official-card {
+    padding-block: var(--ni-16);
+  }
+
+  .official-row {
+    --color-link-active: var(--color-text-primary);
+
+    display: flex;
+    justify-content: center;
+
+    :global(.trakt-summary-ratings) {
+      width: 100%;
+      justify-content: space-between;
+      gap: 0;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { MediaRating } from "$lib/requests/models/MediaRating.ts";
+  import { getLocale } from "$lib/features/i18n";
+  import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber";
+  import { toTraktRating } from "$lib/utils/formatting/number/toTraktRating";
+  import { STAR_RATINGS } from "../constants/index.ts";
+
+  type RatingsDistributionProps = {
+    trakt: NonNullable<MediaRating["trakt"]>;
+  };
+
+  const { trakt }: RatingsDistributionProps = $props();
+
+  type DistributionKey =
+    & keyof NonNullable<typeof trakt.distribution>
+    & string;
+
+  const starBuckets = $derived(
+    STAR_RATINGS.map((star) => {
+      const low = String(star.range.min + 1) as DistributionKey;
+      const high = String(star.range.max) as DistributionKey;
+      const value = (trakt.distribution?.[low] ?? 0) +
+        (trakt.distribution?.[high] ?? 0);
+      return { star: star.index, value };
+    }),
+  );
+
+  const maxValue = $derived(
+    Math.max(...starBuckets.map((b) => b.value), 1),
+  );
+
+  function toIntensity(value: number, max: number): 0 | 1 | 2 | 3 | 4 {
+    if (value <= 0) return 0;
+    const ratio = value / max;
+    if (ratio <= 0.25) return 1;
+    if (ratio <= 0.5) return 2;
+    if (ratio <= 0.75) return 3;
+    return 4;
+  }
+
+  const traktPercent = $derived(toTraktRating(trakt.rating, getLocale()));
+  const voteCountText = $derived(toHumanNumber(trakt.votes, getLocale()));
+</script>
+
+<section class="trakt-ratings-distribution">
+  <h3 class="card-title bold secondary">{m.header_ratings_trakt()}</h3>
+
+  <div class="ratings-row">
+    <div class="trakt-display">
+      <p class="trakt-rating-value bold">{traktPercent}</p>
+      <p class="trakt-rating-votes secondary uppercase tag">
+        {m.text_ratings_votes({ count: voteCountText })}
+      </p>
+    </div>
+
+    <div class="trakt-histogram" aria-hidden="true">
+      <div class="histogram-bars">
+        {#each starBuckets as bucket (bucket.star)}
+          <div class="histogram-bar-slot">
+            <div
+              class="histogram-bar"
+              data-intensity={toIntensity(bucket.value, maxValue)}
+              style="--bar-height: {(bucket.value / maxValue) * 100}%"
+            ></div>
+            <span class="bar-tooltip tag bold">
+              {toHumanNumber(bucket.value, getLocale())}
+            </span>
+          </div>
+        {/each}
+      </div>
+      <div class="histogram-scale tag secondary">
+        {#each starBuckets as bucket (bucket.star)}
+          <span>{bucket.star}</span>
+        {/each}
+      </div>
+    </div>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-ratings-distribution {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+
+    padding: var(--ni-12) var(--ni-16);
+    border-radius: var(--border-radius-l);
+    background: var(--color-card-background);
+  }
+
+  .card-title {
+    color: var(--color-text-secondary);
+    margin: 0;
+    font-size: var(--font-size-text-small);
+  }
+
+  .ratings-row {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    gap: var(--gap-m);
+  }
+
+  .trakt-display {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    flex-shrink: 0;
+  }
+
+  .trakt-rating-value {
+    font-size: var(--ni-32);
+    line-height: 100%;
+  }
+
+  .trakt-rating-votes {
+    color: var(--color-text-secondary);
+  }
+
+  .trakt-histogram {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-2);
+  }
+
+  .histogram-bars {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: var(--ni-4);
+    height: var(--ni-48);
+  }
+
+  .histogram-bar-slot {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    height: 100%;
+    transform-origin: bottom;
+    transition: transform calc(0.5 * var(--transition-increment)) ease-in-out;
+
+    @include for-mouse {
+      &:hover {
+        transform: scale(1.1);
+
+        .histogram-bar {
+          background: var(--color-text-primary);
+        }
+
+        .bar-tooltip {
+          opacity: 1;
+          transform: translate(-50%, calc(-1 * var(--ni-6)));
+        }
+      }
+    }
+  }
+
+  .histogram-bar {
+    width: 70%;
+    height: var(--bar-height);
+    min-height: var(--ni-2);
+    border-radius: var(--border-radius-xs);
+    transform-origin: bottom;
+    animation: rating-bar-rise 650ms cubic-bezier(0.16, 1, 0.3, 1) 250ms both;
+    transition: background var(--transition-increment) ease-in-out;
+
+    &[data-intensity="0"] {
+      background: var(--color-heatmap-empty);
+    }
+    &[data-intensity="1"] {
+      background: var(--color-heatmap-l1);
+    }
+    &[data-intensity="2"] {
+      background: var(--color-heatmap-l2);
+    }
+    &[data-intensity="3"] {
+      background: var(--color-heatmap-l3);
+    }
+    &[data-intensity="4"] {
+      background: var(--color-heatmap-l4);
+    }
+  }
+
+  .bar-tooltip {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translate(-50%, 0);
+    padding: var(--ni-2) var(--ni-6);
+    border-radius: var(--border-radius-xs);
+    background: var(--color-tooltip-background);
+    color: var(--color-tooltip-text);
+    opacity: 0;
+    pointer-events: none;
+    white-space: nowrap;
+    transition: opacity var(--transition-increment) ease-in-out,
+      transform var(--transition-increment) ease-in-out;
+  }
+
+  .histogram-scale {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    color: var(--color-text-secondary);
+
+    span {
+      text-align: center;
+    }
+  }
+
+  @keyframes rating-bar-rise {
+    from {
+      transform: scaleY(0);
+    }
+    to {
+      transform: scaleY(1);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDrawerProps.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDrawerProps.ts
@@ -1,0 +1,7 @@
+import type { MediaDetailsProps } from '../../details/MediaDetailsProps.ts';
+
+export type RatingsDrawerProps =
+  & {
+    onClose: () => void;
+  }
+  & MediaDetailsProps;


### PR DESCRIPTION
<img width="408" height="627" alt="Screenshot 2026-06-10 at 10 28 25" src="https://github.com/user-attachments/assets/ad56f695-7c06-4d1c-b3fc-a9a2d92f9f7f" />

## Summary

Adds a Ratings breakdown drawer that opens when the user taps the Trakt rating chip on any movie / show / episode summary header. On desktop it slides in from the right as a side panel; on mobile it surfaces as a bottom sheet (existing `Drawer` primitive handles both).

The drawer shows:

- **Trakt Rating card** — the Trakt percentage and total vote count on the left, a 1–10 vote distribution histogram on the right. Bars are color-graded by intensity using the same purple palette as the activity heatmap (more votes → darker), with the votes line aligned to the histogram's 1–10 scale at the bottom. Hovering a bar reveals a tooltip with the formatted vote count and bumps the bar to a high-contrast color. The bars animate scaleY from the baseline after a 250 ms delay so they rise once the drawer settles.
- **Official Ratings card** — IMDb, Rotten Tomatoes critic and audience chips, spread edge-to-edge. The Trakt chip is suppressed here (`hideTrakt`) since it already heads the drawer. The chip underline is themed to the primary text color in this card to read better against the muted background.

### API touches

- `RatingList` (`lib/components/summary/RatingList.svelte`) gets two new optional props — `traktLink` (renders the Trakt chip as a SvelteKit `<a>` with `noscroll` / `replacestate` data attributes pointing at the drawer route) and `hideTrakt` (skips the Trakt chip entirely). Both are non-breaking — existing call sites are unaffected unless they opt in.
- `SummaryDrawers` enum gets a new `Ratings = 'ratings'` member, switched on inside `SummaryDrawer.svelte` to render `RatingsDrawer`.
- Four summary entry points wire the new drawer link: `media/MediaSummary.svelte` (+ `v2`) and `episode/EpisodeSummary.svelte` (+ `v2`).


### i18n

New keys in `i18n/meta/en.json` for the drawer copy and the trigger's aria-label. Generated `messages/en.json` + paraglide outputs follow.

## Test plan

- [ ] On `/movies/<slug>` and `/shows/<slug>`, tap the Trakt % chip in the summary header — drawer opens on desktop, bottom sheet on mobile.
- [ ] Same for `/shows/<slug>/seasons/<n>/episodes/<m>`.
- [ ] Histogram bars rise from the baseline after the drawer is open (no left-to-right slide).
- [ ] Hover each bar — tooltip with vote count appears above, bar pops to high-contrast color.
- [ ] Tallest bar uses the darkest purple, shorter ones step through lighter shades.
- [ ] Closing the drawer (X / backdrop / browser back) clears the `?view=ratings` URL param without polluting history.
- [ ] Light + dark theme: Trakt chip underline in the Official Ratings card reads as `text-primary` (white on dark, near-black on light), not purple.