### PR TITLE
feat(summary): prototype season ratings line chart

### DIFF
--- a/projects/client/src/lib/components/charts/LineChart.svelte
+++ b/projects/client/src/lib/components/charts/LineChart.svelte
@@ -19,6 +19,8 @@
   // Flip the tooltip below the point when it's near the plot top, so it isn't
   // clipped by the chart's container.
   const TOOLTIP_FLIP_THRESHOLD = 52;
+  // Vertical space reserved under the plot for x-axis tick labels.
+  const LABEL_BAND = 18;
 
   const {
     data,
@@ -26,6 +28,9 @@
     seriesIndex = 0,
     color,
     showArea = false,
+    baseline,
+    showDots = false,
+    tickLabels,
     fillColor,
     dotColor,
     dotHaloColor,
@@ -48,9 +53,12 @@
   const resolvedHalo = $derived(dotHaloColor ?? "var(--color-card-background)");
 
   const margin = $derived(Math.max($dotRadius + 3, 5));
+  const labelBand = $derived(tickLabels ? LABEL_BAND : 0);
   const width = $derived($observedWidth);
   const height$ = $derived($observedHeight);
   const innerWidth = $derived(Math.max(width - margin * 2, 0));
+  // Bottom of the plotting area, lifted above the tick-label band.
+  const plotBottom = $derived(height$ - margin - labelBand);
 
   const values = $derived(data.map((d) => d.value));
   const hasPlot = $derived(width > 0 && height$ > 0 && data.length > 0);
@@ -58,12 +66,20 @@
   const yScale = $derived.by(() => {
     const dataMin = Math.min(...values);
     const dataMax = Math.max(...values);
-    const min = Math.min(dataMin, 0);
+    const floor = baseline ?? Math.min(dataMin, 0);
+    const top = Math.max(dataMax, floor);
     // Flat-span guard: a zero-height domain divides by zero and amplifies
     // float jitter into a jumping baseline; pad it to a unit span.
-    const max = min === Math.max(dataMax, 0) ? min + 1 : Math.max(dataMax, 0);
-    return scaleLinear().domain([min, max]).range([height$ - margin, margin]);
+    const ceil = floor === top ? floor + 1 : top;
+    return scaleLinear().domain([floor, ceil]).range([plotBottom, margin]);
   });
+
+  const ticks = $derived(
+    (tickLabels ?? []).map((text, index) => ({
+      text,
+      x: points[index]?.x ?? margin,
+    })).filter((tick) => tick.text !== ""),
+  );
 
   const xScale = $derived(
     scalePoint<number>()
@@ -88,12 +104,14 @@
     }));
   });
 
-  const baseline = $derived(
-    Math.min(Math.max(yScale(0), margin), height$ - margin),
+  const areaBaseY = $derived(
+    Math.min(Math.max(yScale(baseline ?? 0), margin), plotBottom),
   );
   const linePath = $derived(hasPlot ? buildLinePath(smoothPoints) : "");
   const areaPath = $derived(
-    hasPlot ? buildAreaPath({ points: smoothPoints, baseline }) : "",
+    hasPlot
+      ? buildAreaPath({ points: smoothPoints, baseline: areaBaseY })
+      : "",
   );
 
   const interaction = createPlotInteraction({
@@ -176,13 +194,36 @@
         style="d: path('{linePath}');"
       />
 
+      {#if showDots}
+        {#each points as point, index (data[index].label)}
+          <circle
+            class="data-dot"
+            cx={point.x}
+            cy={point.y}
+            r={$dotRadius * 0.8}
+            style="fill: {resolvedDot}; stroke: {resolvedHalo};"
+          />
+        {/each}
+      {/if}
+
+      {#each ticks as tick (tick.text)}
+        <text
+          class="line-tick"
+          x={tick.x}
+          y={height$ - margin}
+          text-anchor="middle"
+        >
+          {tick.text}
+        </text>
+      {/each}
+
       {#if activePoint}
         <line
           class="active-guide"
           x1={activePoint.x}
           y1={margin}
           x2={activePoint.x}
-          y2={height$ - margin}
+          y2={plotBottom}
         />
         <circle
           class="active-dot"
@@ -286,6 +327,17 @@
       both;
   }
 
+  .data-dot {
+    stroke-width: var(--viz-line-width);
+    animation: viz-fade-in var(--viz-enter-duration) var(--viz-enter-ease) both;
+  }
+
+  .line-tick {
+    fill: var(--viz-label);
+    font-size: var(--font-size-tag);
+    text-anchor: middle;
+  }
+
   .line-chart-tooltip {
     position: absolute;
     pointer-events: none;
@@ -333,7 +385,8 @@
   @media (prefers-reduced-motion: reduce) {
     .line-path,
     .area-path,
-    .active-dot {
+    .active-dot,
+    .data-dot {
       animation: none;
     }
   }

--- a/projects/client/src/lib/components/charts/models/LineChartProps.ts
+++ b/projects/client/src/lib/components/charts/models/LineChartProps.ts
@@ -18,6 +18,16 @@ export type LineChartProps = {
   color?: string;
   /** Fill the area beneath the line (turns the primitive into an area chart). */
   showArea?: boolean;
+  /**
+   * Y-value the domain floors at and the area fills down to. Defaults to
+   * `min(0, dataMin)`. Set a non-zero floor (e.g. 60 for a 60-100 ratings
+   * range) to zoom the line into its meaningful band.
+   */
+  baseline?: number;
+  /** Render a static marker at every data point, not just the active one. */
+  showDots?: boolean;
+  /** Sparse labels rendered under the axis; index-aligned, empty strings skipped. */
+  tickLabels?: string[];
   /** CSS color for the area fill; defaults to a `color` vertical fade gradient. */
   fillColor?: string;
   /** CSS color for the hover/pin marker dot. Defaults to `color`. */

--- a/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
@@ -161,5 +161,5 @@
 {/if}
 
 {#if drawer === SummaryDrawers.Ratings}
-  <RatingsDrawer {...details} onClose={close} />
+  <RatingsDrawer {...details} {seasons} onClose={close} />
 {/if}

--- a/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
@@ -7,8 +7,9 @@
   import { useMediaMetaInfo } from "../media/useMediaMetaInfo.ts";
   import RatingsDistribution from "./_internal/RatingsDistribution.svelte";
   import type { RatingsDrawerProps } from "./_internal/RatingsDrawerProps.ts";
+  import SeasonRatingsChart from "./_internal/SeasonRatingsChart.svelte";
 
-  const { onClose, ...props }: RatingsDrawerProps = $props();
+  const { onClose, seasons, ...props }: RatingsDrawerProps = $props();
 
   const metaInfoTarget = $derived(
     props.type === "episode"
@@ -53,6 +54,10 @@
       {:else}
         {#if ratings.trakt}
           <RatingsDistribution trakt={ratings.trakt} />
+        {/if}
+
+        {#if props.type === "show" && seasons}
+          <SeasonRatingsChart {seasons} />
         {/if}
 
         <section class="ratings-card official-card">

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDrawerProps.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDrawerProps.ts
@@ -1,7 +1,9 @@
+import type { Season } from '$lib/requests/models/Season.ts';
 import type { MediaDetailsProps } from '../../details/MediaDetailsProps.ts';
 
 export type RatingsDrawerProps =
   & {
     onClose: () => void;
+    seasons?: Season[];
   }
   & MediaDetailsProps;

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/SeasonRatingsChart.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/SeasonRatingsChart.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import LineChart from "$lib/components/charts/LineChart.svelte";
+  import type { Season } from "$lib/requests/models/Season.ts";
+
+  type SeasonPoint = { season: number; rating: number };
+
+  type Props = {
+    seasons: Season[];
+  };
+
+  const { seasons }: Props = $props();
+
+  const points: SeasonPoint[] = $derived.by(() => {
+    const now = new Date();
+    return seasons
+      .filter((s) => s.number > 0 && s.rating != null && s.airDate <= now)
+      .map((s) => ({
+        season: s.number,
+        rating: Math.round((s.rating ?? 0) * 100),
+      }))
+      .sort((a, b) => a.season - b.season);
+  });
+
+  const data = $derived(
+    points.map((p) => ({ value: p.rating, label: `S${p.season}` })),
+  );
+  const tickLabels = $derived(points.map((p) => `S${p.season}`));
+
+  // Zoom the line into its meaningful band rather than anchoring at 0.
+  const baseline = $derived(Math.min(...points.map((p) => p.rating), 60));
+
+  const peak = $derived(
+    points.length > 0
+      ? points.reduce((acc, p) => (p.rating > acc.rating ? p : acc))
+      : null,
+  );
+  const trough = $derived(
+    points.length > 0
+      ? points.reduce((acc, p) => (p.rating < acc.rating ? p : acc))
+      : null,
+  );
+</script>
+
+{#if points.length >= 2}
+  <section class="trakt-season-ratings-chart">
+    <div class="header">
+      <h3 class="card-title bold secondary">Quality Over Time</h3>
+      {#if peak && trough}
+        <span class="meta tag secondary">
+          Peak S{peak.season} · {peak.rating}% &nbsp;·&nbsp; Low S{trough
+            .season} · {trough.rating}%
+        </span>
+      {/if}
+    </div>
+
+    <div class="chart">
+      <LineChart
+        {data}
+        {tickLabels}
+        {baseline}
+        showArea
+        showDots
+        label="Season ratings over time"
+        height="var(--ni-160)"
+      >
+        {#snippet tooltip({ label, value })}
+          <span class="season-tooltip">{label} · {value}%</span>
+        {/snippet}
+      </LineChart>
+    </div>
+  </section>
+{/if}
+
+<style>
+  .trakt-season-ratings-chart {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+    padding: var(--ni-12) var(--ni-16);
+    border-radius: var(--border-radius-l);
+    background: var(--color-card-background);
+  }
+
+  .header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--gap-s);
+    flex-wrap: wrap;
+  }
+
+  .card-title {
+    color: var(--color-text-secondary);
+    margin: 0;
+    font-size: var(--font-size-text-small);
+  }
+
+  .meta {
+    color: var(--color-text-secondary);
+  }
+
+  .chart {
+    width: 100%;
+  }
+
+  .season-tooltip {
+    display: block;
+    white-space: nowrap;
+    background-color: var(--color-tooltip-background);
+    color: var(--color-tooltip-text);
+    font-size: var(--ni-12);
+    line-height: 1;
+    font-weight: 500;
+    border-radius: var(--border-radius-xs);
+    padding: var(--ni-6) var(--ni-8);
+    box-shadow: var(--shadow-menu);
+  }
+</style>


### PR DESCRIPTION
## Summary

Prototype only - not for merge as-is. Throwaway exploration on top of #2568.

Adds a "Quality Over Time" line chart inside the Ratings drawer for shows. X-axis: season number. Y-axis: Trakt rating per season. Renders only when there are 2+ rated seasons.

## How it works

- Pulls real `Season[]` already available in `SummaryDrawer` and forwards it to `RatingsDrawer`.
- New `SeasonRatingsChart.svelte` (in `_internal/`) maps seasons → `{ season, rating }` points (rating mapped to percent), filters specials (S0) and null ratings, sorts ascending.
- Pure SVG: padded viewBox, area gradient (`--color-accent`), gridlines at 70/80/90, point dots with per-point labels, S{n} axis labels, header peak/low callout.

## Open questions

- Naming - "Quality Over Time" vs "Season Trends" vs something else.
- Whether to use `airDate` for chronological x-axis (handles uneven gaps between seasons better) vs raw season number.
- Tooltip on point hover (currently static labels above each dot).
- Empty/sparse states - currently silent skip when < 2 rated seasons; might want a "not enough data" hint.
- i18n - all strings hardcoded; needs Paraglide keys before any non-prototype use.

## Examples

<img width="1717" height="598" alt="image" src="https://github.com/user-attachments/assets/9073d551-b791-4fbd-914a-9222cc29c483" />
<img width="1717" height="592" alt="image" src="https://github.com/user-attachments/assets/844c98e3-4bea-4d24-b47f-7a31159fc4ca" />
<img width="1717" height="592" alt="image" src="https://github.com/user-attachments/assets/b51187ad-16f3-497b-a454-57cd5525415d" />
<img width="1717" height="592" alt="image" src="https://github.com/user-attachments/assets/4cd448d1-3f4a-44d5-a474-c1b0fe2bd855" />


## Test plan

- [ ] Open Ratings drawer on a multi-season show with ratings (e.g. FROM, Severance) - chart renders.
- [ ] Open on a single-season show or one missing season ratings - chart absent, rest of drawer unaffected.
- [ ] Open on a movie - chart absent.
- [ ] Drawer still works in light/dark themes.