### PR TITLE
feat(profile): add incoming follow requests under current user profile

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2486,6 +2486,32 @@
         }
       }
     },
+    "button_text_approve_follow_request": {
+      "default": "Approve Request",
+      "description": "Text for the button that approves an incoming follow request."
+    },
+    "button_label_approve_follow_request": {
+      "default": "Approve follow request from {username}",
+      "description": "Aria-label for the button that approves an incoming follow request.",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "button_text_reject_follow_request": {
+      "default": "Reject Request",
+      "description": "Text for the button that rejects an incoming follow request."
+    },
+    "button_label_reject_follow_request": {
+      "default": "Reject follow request from {username}",
+      "description": "Aria-label for the button that rejects an incoming follow request.",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
+    },
     "warning_prompt_unfollow_user": {
       "default": "Are you sure you want to unfollow {username}?",
       "description": "Warning prompt shown when a user tries to unfollow a profile.",
@@ -2574,6 +2600,10 @@
     "list_placeholder_following": {
       "default": "There is no one here (yet).",
       "description": "Placeholder text shown when there are no profiles followed by the user."
+    },
+    "list_placeholder_follow_requests": {
+      "default": "There are no follow requests.",
+      "description": "Placeholder text shown when there are no incoming follow requests."
     },
     "button_label_read_more": {
       "default": "Read more",
@@ -3625,6 +3655,14 @@
     "button_text_followers": {
       "default": "Followers",
       "description": "Aria-label for the button that allows users to toggle the social list to view who their followers are."
+    },
+    "button_label_follow_requests": {
+      "default": "Follow requests",
+      "description": "Aria-label for the button that allows users to toggle the social list to view incoming follow requests."
+    },
+    "button_text_follow_requests": {
+      "default": "Requests",
+      "description": "Text for the button that allows users to toggle the social list to view incoming follow requests."
     },
     "button_label_dismiss": {
       "default": "Dismiss",
@@ -5710,6 +5748,24 @@
     "text_info_follow_request": {
       "default": "Follow request has been sent.",
       "description": "Text shown when a follow request has been sent to another user."
+    },
+    "text_info_follow_request_approved": {
+      "default": "Approved follow request from {username}.",
+      "description": "Text shown when a user approves an incoming follow request.",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "text_info_follow_request_rejected": {
+      "default": "Rejected follow request from {username}.",
+      "description": "Text shown when a user rejects an incoming follow request.",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
     },
     "text_info_following": {
       "default": "You are now following {username}.",

--- a/projects/client/src/lib/components/toggles/_internal/ToggleIcon.svelte
+++ b/projects/client/src/lib/components/toggles/_internal/ToggleIcon.svelte
@@ -53,6 +53,10 @@
   <FollowersIcon />
 {/if}
 
+{#if option.value === "requests"}
+  <HourglassIcon />
+{/if}
+
 {#if option.value === "newest"}
   <RecentIcon />
 {/if}

--- a/projects/client/src/lib/components/toggles/_internal/constants.ts
+++ b/projects/client/src/lib/components/toggles/_internal/constants.ts
@@ -13,7 +13,7 @@ export type TogglerId =
   | 'library';
 
 type DiscoverToggleType = DiscoverMode;
-type SocialToggleType = 'following' | 'followers';
+type SocialToggleType = 'following' | 'followers' | 'requests';
 type CommentToggleType = CommentSortType;
 type TriviaToggleType = 'spoilers' | 'no-spoilers';
 type ProgressToggleType = 'in-progress' | 'dropped' | 'completed';
@@ -51,6 +51,11 @@ const social: ToggleDefinition<'social'> = {
       value: 'followers',
       text: m.button_text_followers,
       label: m.button_label_followers,
+    },
+    {
+      value: 'requests',
+      text: m.button_text_follow_requests,
+      label: m.button_label_follow_requests,
     },
   ],
 };

--- a/projects/client/src/lib/features/auth/queries/currentUserFollowRequestsQuery.spec.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserFollowRequestsQuery.spec.ts
@@ -1,0 +1,16 @@
+import { UserFollowRequestsMappedMock } from '$mocks/data/users/mapped/UserFollowRequestsMappedMock.ts';
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { describe, expect, it } from 'vitest';
+import { currentUserFollowRequestsQuery } from './currentUserFollowRequestsQuery.ts';
+
+describe('currentUserFollowRequestsQuery', () => {
+  it('should query for incoming follow requests', async () => {
+    const result = await runQuery({
+      factory: () => createTestBedQuery(currentUserFollowRequestsQuery()),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(UserFollowRequestsMappedMock);
+  });
+});

--- a/projects/client/src/lib/features/auth/queries/currentUserFollowRequestsQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserFollowRequestsQuery.ts
@@ -1,0 +1,45 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { mapToUserProfile } from '$lib/requests/_internal/mapToUserProfile.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { UserProfileSchema } from '$lib/requests/models/UserProfile.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { z } from 'zod';
+
+const UserFollowRequestSchema = z.object({
+  id: z.number(),
+  requestedAt: z.date(),
+  user: UserProfileSchema,
+});
+
+export type UserFollowRequest = z.infer<typeof UserFollowRequestSchema>;
+
+type CurrentUserFollowRequestsParams = {
+  enabled?: boolean;
+} & ApiParams;
+
+const currentUserFollowRequestsRequest = ({ fetch }: ApiParams) =>
+  api({ fetch })
+    .users
+    .requests
+    .follow({
+      query: {
+        extended: 'full',
+      },
+    });
+
+export const currentUserFollowRequestsQuery = defineQuery({
+  key: 'currentUserFollowRequests',
+  request: currentUserFollowRequestsRequest,
+  invalidations: [InvalidateAction.User.Follow],
+  dependencies: [],
+  mapper: (response) =>
+    response.body.map((request) => ({
+      id: request.id,
+      requestedAt: new Date(request.requested_at),
+      user: mapToUserProfile(request.user),
+    })),
+  schema: z.array(UserFollowRequestSchema),
+  ttl: time.minutes(15),
+  enabled: (params: CurrentUserFollowRequestsParams) => params.enabled ?? true,
+});

--- a/projects/client/src/lib/requests/queries/users/approveFollowRequest.ts
+++ b/projects/client/src/lib/requests/queries/users/approveFollowRequest.ts
@@ -1,0 +1,19 @@
+import { api, type ApiParams } from '$lib/requests/api.ts';
+
+type ApproveFollowRequestParams = {
+  requestId: number;
+} & ApiParams;
+
+export function approveFollowRequest(
+  { fetch, requestId }: ApproveFollowRequestParams,
+): Promise<boolean> {
+  return api({ fetch })
+    .users
+    .requests
+    .approve({
+      params: {
+        id: String(requestId),
+      },
+    })
+    .then(({ status }) => status === 200);
+}

--- a/projects/client/src/lib/requests/queries/users/denyFollowRequest.ts
+++ b/projects/client/src/lib/requests/queries/users/denyFollowRequest.ts
@@ -1,0 +1,19 @@
+import { api, type ApiParams } from '$lib/requests/api.ts';
+
+type DenyFollowRequestParams = {
+  requestId: number;
+} & ApiParams;
+
+export function denyFollowRequest(
+  { fetch, requestId }: DenyFollowRequestParams,
+): Promise<boolean> {
+  return api({ fetch })
+    .users
+    .requests
+    .deny({
+      params: {
+        id: String(requestId),
+      },
+    })
+    .then(({ status }) => status === 204);
+}

--- a/projects/client/src/lib/requests/queries/users/followersQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/followersQuery.spec.ts
@@ -1,4 +1,5 @@
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { UserFollowersMappedMock } from '$mocks/data/users/mapped/UserFollowersMappedMock.ts';
 import { UserProfileHarryMappedMock } from '$mocks/data/users/mapped/UserProfileHarryMappedMock.ts';
 import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
@@ -7,17 +8,25 @@ import { describe, expect, it } from 'vitest';
 import { followersQuery } from './followersQuery.ts';
 
 describe('followersQuery', () => {
+  const slug = assertDefined(UserProfileHarryMappedMock.slug);
+
   it('should query for followers', async () => {
     const result = await runQuery({
       factory: () =>
         createTestBedQuery(
           followersQuery({
-            slug: assertDefined(UserProfileHarryMappedMock.slug),
+            slug,
           }),
         ),
       mapper: (response) => response?.data,
     });
 
     expect(result).to.deep.equal(UserFollowersMappedMock);
+  });
+
+  it('should invalidate when the user follow state changes', () => {
+    const query = followersQuery({ slug });
+
+    expect(query.queryKey).toContain(InvalidateAction.User.Follow);
   });
 });

--- a/projects/client/src/lib/requests/queries/users/followersQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/followersQuery.ts
@@ -3,6 +3,7 @@ import { api, type ApiParams } from '$lib/requests/api.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { z } from 'zod';
 import { mapToUserProfile } from '../../_internal/mapToUserProfile.ts';
+import { InvalidateAction } from '../../models/InvalidateAction.ts';
 import { UserProfileSchema } from '../../models/UserProfile.ts';
 
 type FollowersParams = { slug: string } & ApiParams;
@@ -23,7 +24,7 @@ const followersRequest = (
 
 export const followersQuery = defineQuery({
   key: 'followers',
-  invalidations: [],
+  invalidations: [InvalidateAction.User.Follow],
   dependencies: (
     params: FollowersParams,
   ) => [params.slug],

--- a/projects/client/src/lib/requests/queries/users/followingQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/followingQuery.spec.ts
@@ -1,4 +1,5 @@
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { UserFollowingMappedMock } from '$mocks/data/users/mapped/UserFollowingMappedMock.ts';
 import { UserProfileHarryMappedMock } from '$mocks/data/users/mapped/UserProfileHarryMappedMock.ts';
 import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
@@ -7,17 +8,25 @@ import { describe, expect, it } from 'vitest';
 import { followingQuery } from './followingQuery.ts';
 
 describe('followingQuery', () => {
+  const slug = assertDefined(UserProfileHarryMappedMock.slug);
+
   it('should query for following', async () => {
     const result = await runQuery({
       factory: () =>
         createTestBedQuery(
           followingQuery({
-            slug: assertDefined(UserProfileHarryMappedMock.slug),
+            slug,
           }),
         ),
       mapper: (response) => response?.data,
     });
 
     expect(result).to.deep.equal(UserFollowingMappedMock);
+  });
+
+  it('should invalidate when the user follow state changes', () => {
+    const query = followingQuery({ slug });
+
+    expect(query.queryKey).toContain(InvalidateAction.User.Follow);
   });
 });

--- a/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
@@ -3,7 +3,10 @@
   import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import BlockIcon from "$lib/components/icons/BlockIcon.svelte";
+  import CheckIcon from "$lib/components/icons/CheckIcon.svelte";
+  import CloseIcon from "$lib/components/icons/CloseIcon.svelte";
   import FollowIcon from "$lib/components/icons/FollowIcon.svelte";
+  import Snackbar from "$lib/components/snackbar/Snackbar.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
@@ -19,6 +22,9 @@
 
   const { profile, slug }: DisplayableProfileProps = $props();
 
+  let snackbarOpen = $state(false);
+  let snackbarMessage = $state("");
+
   const { blocked } = useUser();
   const isBlocked = $derived($blocked.has(slug));
 
@@ -27,10 +33,13 @@
 
   const {
     isRequestingFollow,
+    incomingFollowRequest,
     followStatus,
     followUser,
     unfollowUser,
     cancelFollowRequest,
+    approveIncomingFollowRequest,
+    denyIncomingFollowRequest,
   } = $derived(useFollowUserRequest(slug));
 
   const userDisplayName = $derived(toDisplayableName(profile));
@@ -94,6 +103,40 @@
     disabled: $isRequestingBlock,
     ...events,
   });
+
+  const openSnackbar = (message: string) => {
+    snackbarMessage = message;
+    snackbarOpen = true;
+  };
+
+  const closeSnackbar = () => {
+    snackbarOpen = false;
+  };
+
+  const handleFollowRequest = async (
+    action: (requestId: number) => Promise<boolean>,
+    successMessage: (params: { username: string }) => string,
+  ) => {
+    const requestId = $incomingFollowRequest?.id;
+    if (requestId == null) return;
+
+    const succeeded = await action(requestId);
+    if (!succeeded) return;
+
+    openSnackbar(successMessage({ username: userDisplayName }));
+  };
+
+  const approveRequest = () =>
+    handleFollowRequest(
+      approveIncomingFollowRequest,
+      m.text_info_follow_request_approved,
+    );
+
+  const denyRequest = () =>
+    handleFollowRequest(
+      denyIncomingFollowRequest,
+      m.text_info_follow_request_rejected,
+    );
 </script>
 
 <PopupMenu
@@ -102,6 +145,39 @@
   size="normal"
 >
   {#snippet items()}
+    {#if $incomingFollowRequest}
+      <DropdownItem
+        style="flat"
+        color="default"
+        variant="secondary"
+        label={m.button_label_approve_follow_request({
+          username: userDisplayName,
+        })}
+        onclick={approveRequest}
+        disabled={$isRequestingFollow}
+      >
+        {m.button_text_approve_follow_request()}
+        {#snippet icon()}
+          <CheckIcon />
+        {/snippet}
+      </DropdownItem>
+      <DropdownItem
+        style="flat"
+        color="red"
+        variant="secondary"
+        label={m.button_label_reject_follow_request({
+          username: userDisplayName,
+        })}
+        onclick={denyRequest}
+        disabled={$isRequestingFollow}
+      >
+        {m.button_text_reject_follow_request()}
+        {#snippet icon()}
+          <CloseIcon />
+        {/snippet}
+      </DropdownItem>
+    {/if}
+
     {#if !isBlocked}
       <DropdownItem
         style="flat"
@@ -150,3 +226,10 @@
     <ModerateAction variant="secondary" />
   {/snippet}
 </PopupMenu>
+
+<Snackbar
+  open={snackbarOpen}
+  onDismiss={closeSnackbar}
+  title={m.button_label_follow_requests()}
+  message={snackbarMessage}
+/>

--- a/projects/client/src/lib/sections/profile-banner/_internal/useFollowUser.ts
+++ b/projects/client/src/lib/sections/profile-banner/_internal/useFollowUser.ts
@@ -1,11 +1,17 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import {
+  currentUserFollowRequestsQuery,
+  type UserFollowRequest,
+} from '$lib/features/auth/queries/currentUserFollowRequestsQuery.ts';
 import { currentUserPendingFollowsQuery } from '$lib/features/auth/queries/currentUserPendingFollowsQuery.ts';
 import { useAuth } from '$lib/features/auth/stores/useAuth.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { useQuery } from '$lib/features/query/useQuery.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { UserProfile } from '$lib/requests/models/UserProfile.ts';
+import { approveFollowRequest } from '$lib/requests/queries/users/approveFollowRequest.ts';
+import { denyFollowRequest } from '$lib/requests/queries/users/denyFollowRequest.ts';
 import { followUserRequest } from '$lib/requests/queries/users/followUserRequest.ts';
 import { unfollowUserRequest } from '$lib/requests/queries/users/unfollowUserRequest.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
@@ -19,6 +25,7 @@ export function useFollowUserRequest(slug: string) {
   const { isAuthorized } = useAuth();
   const { network } = useUser();
   const pendingFollowsQuerySignal = useQuery(currentUserPendingFollowsQuery());
+  const followRequestsQuerySignal = useQuery(currentUserFollowRequestsQuery());
   const isRequestingFollow = new BehaviorSubject(false);
 
   const pendingFollows = isAuthorized.pipe(
@@ -26,6 +33,20 @@ export function useFollowUserRequest(slug: string) {
       authorized
         ? pendingFollowsQuerySignal.pipe(map((query) => query.data))
         : of<UserProfile[]>([])
+    ),
+  );
+
+  const followRequests = isAuthorized.pipe(
+    switchMap((authorized) =>
+      authorized
+        ? followRequestsQuerySignal.pipe(map((query) => query.data ?? []))
+        : of<UserFollowRequest[]>([])
+    ),
+  );
+
+  const incomingFollowRequest = followRequests.pipe(
+    map((requests) =>
+      requests.find((request) => request.user.slug === slug) ?? null
     ),
   );
 
@@ -77,7 +98,34 @@ export function useFollowUserRequest(slug: string) {
     isRequestingFollow.next(false);
   };
 
+  const respondToFollowRequest = async (
+    action: (params: { requestId: number }) => Promise<boolean>,
+    requestId: number,
+  ): Promise<boolean> => {
+    isRequestingFollow.next(true);
+
+    try {
+      const succeeded = await action({ requestId });
+      if (succeeded) {
+        await invalidate(InvalidateAction.User.Follow);
+      }
+
+      return succeeded;
+    } finally {
+      isRequestingFollow.next(false);
+    }
+  };
+
+  const approveIncomingFollowRequest = (requestId: number) =>
+    respondToFollowRequest(approveFollowRequest, requestId);
+
+  const denyIncomingFollowRequest = (requestId: number) =>
+    respondToFollowRequest(denyFollowRequest, requestId);
+
   return {
+    approveIncomingFollowRequest,
+    denyIncomingFollowRequest,
+    incomingFollowRequest,
     isRequestingFollow,
     followStatus,
     followUser,

--- a/projects/client/src/lib/sections/profile/_internal/getProfileSocialPlaceholder.ts
+++ b/projects/client/src/lib/sections/profile/_internal/getProfileSocialPlaceholder.ts
@@ -1,0 +1,10 @@
+import * as m from '$lib/features/i18n/messages.ts';
+import type { ProfileSocialListType } from '../models/ProfileSocialListType.ts';
+
+export function getProfileSocialPlaceholder(
+  type: ProfileSocialListType,
+): string {
+  if (type === 'following') return m.list_placeholder_following();
+  if (type === 'followers') return m.list_placeholder_followers();
+  return m.list_placeholder_follow_requests();
+}

--- a/projects/client/src/lib/sections/profile/components/ProfileListPaginated.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileListPaginated.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
-  import * as m from "$lib/features/i18n/messages.ts";
+  import { getProfileSocialPlaceholder } from "../_internal/getProfileSocialPlaceholder";
+  import type { ProfileSocialListType } from "../models/ProfileSocialListType";
   import { useFollowing } from "../stores/useFollowing";
   import ProfileCard from "./ProfileCard.svelte";
 
@@ -10,16 +11,12 @@
     type,
   }: {
     slug: string;
-    type: "following" | "followers";
+    type: ProfileSocialListType;
   } = $props();
 
   const { profiles, isLoading } = $derived(useFollowing(slug, type));
 
-  const placeholder = $derived(
-    type === "following"
-      ? m.list_placeholder_following()
-      : m.list_placeholder_followers(),
-  );
+  const placeholder = $derived(getProfileSocialPlaceholder(type));
 </script>
 
 <GridList

--- a/projects/client/src/lib/sections/profile/components/ProfilesList.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfilesList.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import Toggler from "$lib/components/toggles/Toggler.svelte";
-  import { useToggler } from "$lib/components/toggles/useToggler";
   import { useIsMe } from "$lib/features/auth/stores/useIsMe";
   import * as m from "$lib/features/i18n/messages.ts";
   import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
   import CtaItem from "$lib/sections/lists/components/cta/CtaItem.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { getProfileSocialPlaceholder } from "../_internal/getProfileSocialPlaceholder";
   import { useFollowing } from "../stores/useFollowing";
+  import { useProfileSocialToggler } from "../stores/useProfileSocialToggler";
   import ProfileItem from "./ProfileItem.svelte";
 
   const {
@@ -16,14 +17,10 @@
     slug: string;
   } = $props();
 
-  const { current, set, options } = useToggler("social");
+  const { current, set, options } = $derived(useProfileSocialToggler(slug));
   const { profiles, isLoading } = $derived(useFollowing(slug, $current.value));
 
-  const placeholder = $derived(
-    $current.value === "following"
-      ? m.list_placeholder_following()
-      : m.list_placeholder_followers(),
-  );
+  const placeholder = $derived(getProfileSocialPlaceholder($current.value));
 
   const { isMe } = $derived(useIsMe(slug));
 </script>
@@ -63,7 +60,7 @@
     {/snippet}
 
     {#snippet actions()}
-      <Toggler value={$current.value} onChange={set} {options} />
+      <Toggler value={$current.value} onChange={set} options={$options} />
     {/snippet}
   </SectionList>
 </div>

--- a/projects/client/src/lib/sections/profile/models/ProfileSocialListType.ts
+++ b/projects/client/src/lib/sections/profile/models/ProfileSocialListType.ts
@@ -1,0 +1,1 @@
+export type ProfileSocialListType = 'following' | 'followers' | 'requests';

--- a/projects/client/src/lib/sections/profile/stores/useFollowing.ts
+++ b/projects/client/src/lib/sections/profile/stores/useFollowing.ts
@@ -1,10 +1,23 @@
 import { useQuery } from '$lib/features/query/useQuery.ts';
+import { currentUserFollowRequestsQuery } from '$lib/features/auth/queries/currentUserFollowRequestsQuery.ts';
 import { followingQuery } from '$lib/requests/queries/users/followingQuery.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { map } from 'rxjs';
 import { followersQuery } from '../../../requests/queries/users/followersQuery.ts';
+import type { ProfileSocialListType } from '../models/ProfileSocialListType.ts';
 
-export function useFollowing(slug: string, type: 'following' | 'followers') {
+export function useFollowing(slug: string, type: ProfileSocialListType) {
+  if (type === 'requests') {
+    const query = useQuery(currentUserFollowRequestsQuery());
+
+    return {
+      profiles: query.pipe(
+        map(($query) => $query.data?.map((request) => request.user) ?? []),
+      ),
+      isLoading: query.pipe(map(toLoadingState)),
+    };
+  }
+
   const query = type === 'following'
     ? useQuery(followingQuery({ slug }))
     : useQuery(followersQuery({ slug }));

--- a/projects/client/src/lib/sections/profile/stores/useProfileSocialToggler.ts
+++ b/projects/client/src/lib/sections/profile/stores/useProfileSocialToggler.ts
@@ -1,0 +1,62 @@
+import type { ToggleOption } from '$lib/components/toggles/ToggleOption.ts';
+import { useToggler } from '$lib/components/toggles/useToggler.ts';
+import { currentUserFollowRequestsQuery } from '$lib/features/auth/queries/currentUserFollowRequestsQuery.ts';
+import { useIsMe } from '$lib/features/auth/stores/useIsMe.ts';
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import { combineLatest, map } from 'rxjs';
+import type { ProfileSocialListType } from '../models/ProfileSocialListType.ts';
+
+function filterSocialOptions(
+  options: ToggleOption<ProfileSocialListType>[],
+  hasFollowRequests: boolean,
+): ToggleOption<ProfileSocialListType>[] {
+  return options.filter((option) =>
+    option.value !== 'requests' || hasFollowRequests
+  );
+}
+
+function findCurrentOption(
+  options: ToggleOption<ProfileSocialListType>[],
+  value: ProfileSocialListType,
+) {
+  return options.find((option) => option.value === value) ??
+    options.find((option) => option.value === 'following') ??
+    options.at(0);
+}
+
+export function useProfileSocialToggler(slug: string) {
+  const { current, options, set } = useToggler('social');
+  const { isMe } = useIsMe(slug);
+
+  const followRequestsQuery = useQuery(
+    isMe.pipe(
+      map(($isMe) => currentUserFollowRequestsQuery({ enabled: $isMe })),
+    ),
+  );
+
+  const followRequests = combineLatest([isMe, followRequestsQuery]).pipe(
+    map(([$isMe, $query]) => $isMe ? $query.data ?? [] : []),
+  );
+
+  const visibleOptions = followRequests.pipe(
+    map(($followRequests) =>
+      filterSocialOptions(
+        options as ToggleOption<ProfileSocialListType>[],
+        $followRequests.length > 0,
+      )
+    ),
+  );
+
+  const visibleCurrent = combineLatest([current, visibleOptions]).pipe(
+    map(([$current, $options]) =>
+      findCurrentOption($options, $current.value) ?? $current
+    ),
+  );
+
+  return {
+    current: visibleCurrent,
+    followRequests,
+    options: visibleOptions,
+    set,
+  };
+}

--- a/projects/client/src/mocks/data/users/mapped/UserFollowRequestsMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/UserFollowRequestsMappedMock.ts
@@ -1,0 +1,10 @@
+import type { UserFollowRequest } from '$lib/features/auth/queries/currentUserFollowRequestsQuery.ts';
+import { UserProfileHarryMappedMock } from './UserProfileHarryMappedMock.ts';
+
+export const UserFollowRequestsMappedMock: UserFollowRequest[] = [
+  {
+    id: 1,
+    requestedAt: new Date('2025-01-31T23:12:41.000Z'),
+    user: UserProfileHarryMappedMock,
+  },
+];

--- a/projects/client/src/mocks/data/users/response/UserFollowRequestsResponseMock.ts
+++ b/projects/client/src/mocks/data/users/response/UserFollowRequestsResponseMock.ts
@@ -1,0 +1,10 @@
+import type { RequestsResponse } from '@trakt/api';
+import { UserProfileHarryResponseMock } from './UserProfileHarryResponseMock.ts';
+
+export const UserFollowRequestsResponseMock: RequestsResponse[] = [
+  {
+    id: 1,
+    requested_at: '2025-01-31T23:12:41.000Z',
+    user: UserProfileHarryResponseMock,
+  },
+];

--- a/projects/client/src/mocks/handlers/users.ts
+++ b/projects/client/src/mocks/handlers/users.ts
@@ -26,6 +26,7 @@ import { ShowActivityHistoryResponseMock } from '../data/users/response/ShowActi
 import { SocialActivityResponseMock } from '../data/users/response/SocialActivityResponseMock.ts';
 import { UserBlockedResponseMock } from '../data/users/response/UserBlockedResponseMock.ts';
 import { UserFollowersResponseMock } from '../data/users/response/UserFollowersResponseMock.ts';
+import { UserFollowRequestsResponseMock } from '../data/users/response/UserFollowRequestsResponseMock.ts';
 import { UserFollowingResponseMock } from '../data/users/response/UserFollowingResponseMock.ts';
 import { UserMonthInReviewResponseMock } from '../data/users/response/UserMonthInReviewResponseMock.ts';
 import { UserPendingFollowsResponseMock } from '../data/users/response/UserPendingFollowsResponseMock.ts';
@@ -128,8 +129,17 @@ export const users = [
   http.get('http://localhost/users/me/following', () => {
     return HttpResponse.json(UserFollowingResponseMock);
   }),
+  http.get('http://localhost/users/requests', () => {
+    return HttpResponse.json(UserFollowRequestsResponseMock);
+  }),
   http.get('http://localhost/users/requests/following', () => {
     return HttpResponse.json(UserPendingFollowsResponseMock);
+  }),
+  http.post('http://localhost/users/requests/:id', () => {
+    return new HttpResponse(null, { status: 200 });
+  }),
+  http.delete('http://localhost/users/requests/:id', () => {
+    return new HttpResponse(null, { status: 204 });
   }),
   http.get(
     `http://localhost/users/${UserProfileHarryMappedMock.slug}/lists/${

--- a/projects/client/src/routes/profile/[slug]/social/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/social/+page.svelte
@@ -1,22 +1,24 @@
 <script lang="ts">
   import Toggler from "$lib/components/toggles/Toggler.svelte";
-  import { useToggler } from "$lib/components/toggles/useToggler";
   import { m } from "$lib/features/i18n/messages";
   import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import ProfileListPaginated from "$lib/sections/profile/components/ProfileListPaginated.svelte";
+  import { useProfileSocialToggler } from "$lib/sections/profile/stores/useProfileSocialToggler";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import type { PageProps } from "./$types";
 
   const { params }: PageProps = $props();
 
-  const { current, set, options } = useToggler("social");
+  const { current, set, options } = $derived(
+    useProfileSocialToggler(params.slug),
+  );
 </script>
 
 {#snippet actions()}
-  <Toggler value={$current.value} onChange={set} {options} />
+  <Toggler value={$current.value} onChange={set} options={$options} />
 {/snippet}
 
 {#snippet metaInfo()}


### PR DESCRIPTION
## Summary

Related to #2459.

Adds incoming follow request support to profile social lists for private users. When the signed-in user has at least one pending incoming follow request, the profile social toggler now shows a `Requests` state. Selecting it renders the requesting users in the same profile row/card UI used by followers and following, so the user can open the requester profile.

The requester profile overflow menu now exposes `Approve Request` and `Reject Request` actions, with confirmation snackbars after successful approval or rejection.

## Details

- Adds a `currentUserFollowRequestsQuery` for `GET /users/requests` with full user mapping and follow-state invalidation.
- Adds approve and deny request helpers for `POST /users/requests/:id` and `DELETE /users/requests/:id`.
- Shows the `Requests` social toggle only for the signed-in user’s own profile and only when incoming requests exist.
- Falls back to `following` if the current social toggle becomes hidden after requests are cleared.
- Busts follow caches after follow-state changes so following, followers, pending follows, and incoming requests refetch consistently.
- Adds approve/reject actions to profile overflow menus only when that profile has an incoming request.
- Shows success snackbars only after the API confirms the approve/reject action.
- Allows the shared `Snackbar` component to be used as a notification-only toast without an action button.
- Adds MSW mocks and focused tests for incoming requests and follow invalidation keys.

## Edge Cases

- Non-authenticated users and other users’ profiles do not fetch or show incoming follow requests in the social toggler.
- The `Requests` toggle is hidden when the incoming request list is empty.
- If an approve/reject API response does not match the expected success status, the snackbar is not shown and caches are not invalidated.
- Denying a request expects `204`; approving expects `200`.
- Existing follow/unfollow/request-cancel behavior continues to share the same follow invalidation path.

## Flow

Follow a private profile (B) with account A.
<img width="1074" height="1101" alt="Screenshot 2026-06-10 at 13 32 04" src="https://github.com/user-attachments/assets/1ad159ab-8ed0-4cce-8cfa-8a546a6f1459" />

Shows as Pending under A's account.
<img width="1074" height="1101" alt="Screenshot 2026-06-10 at 13 31 44" src="https://github.com/user-attachments/assets/0573ffa1-67c6-419e-bd83-0416ae383495" />

🆕 A's request is displayed under B's account.
<img width="1071" height="1101" alt="Screenshot 2026-06-10 at 13 32 33" src="https://github.com/user-attachments/assets/c1af5d4e-41c2-4d8d-b119-692647f81f7b" />

🆕 B can approve or reject the request.
<img width="1071" height="1101" alt="Screenshot 2026-06-10 at 13 32 45" src="https://github.com/user-attachments/assets/a906dbda-ce48-4027-b74e-7948a78061b8" />

Snackbar without action is displayed for action confirmation.
<img width="1071" height="1101" alt="Screenshot 2026-06-10 at 13 34 24" src="https://github.com/user-attachments/assets/efdf20b5-e383-423c-b3dd-6210b7aa98c2" />

A's profile appears in B's Followers list 🎉
<img width="1071" height="1101" alt="Screenshot 2026-06-10 at 13 34 45" src="https://github.com/user-attachments/assets/3a0c9f57-feda-4139-9738-617563d22659" />
