### PR TITLE
YIR: 2024 People

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5113,6 +5113,42 @@
       "default": "Most Watched Movies",
       "description": "Section header above the top-10 most-watched movies list on the 2024 Year in Review template."
     },
+    "yir_2024_people_label": {
+      "default": "Most watched",
+      "description": "Small uppercase label above each people column (Actors/Actresses/Directors/Writers) in the 2024 Year in Review people section."
+    },
+    "yir_2024_people_actors": {
+      "default": "Actors",
+      "description": "Title of the most-watched actors column on the 2024 Year in Review people section."
+    },
+    "yir_2024_people_actresses": {
+      "default": "Actresses",
+      "description": "Title of the most-watched actresses column on the 2024 Year in Review people section."
+    },
+    "yir_2024_people_directors": {
+      "default": "Directors",
+      "description": "Title of the most-watched directors column on the 2024 Year in Review people section."
+    },
+    "yir_2024_people_writers": {
+      "default": "Writers",
+      "description": "Title of the most-watched writers column on the 2024 Year in Review people section."
+    },
+    "yir_2024_people_seen_in": {
+      "default": "Seen in",
+      "description": "Label on the expandable button that reveals the shows/movies a person appeared in, on the 2024 Year in Review people section."
+    },
+    "yir_2024_people_show_count": {
+      "default": "{count} shows",
+      "description": "Show count shown beside a person's name on the 2024 Year in Review people section. Plural form is used for all counts for now."
+    },
+    "yir_2024_people_movie_count": {
+      "default": "{count} movies",
+      "description": "Movie count shown beside a person's name on the 2024 Year in Review people section. Plural form is used for all counts for now."
+    },
+    "yir_2024_people_episode_count": {
+      "default": "{count} episodes",
+      "description": "Episode count shown after a show in the expanded 'seen in' list on the 2024 Year in Review people section. Plural form is used for all counts for now."
+    },
     "yir_2024_plays_label": {
       "default": "Plays",
       "description": "Stat label under the play count on the 2024 Year in Review most-watched cards."

--- a/projects/client/src/lib/requests/_internal/mapToYirPerson.ts
+++ b/projects/client/src/lib/requests/_internal/mapToYirPerson.ts
@@ -7,6 +7,7 @@ type RawYirPersonTitle = {
   type: 'show' | 'movie';
   trakt_id: number;
   episode_count?: number;
+  year?: number | null;
 };
 
 type RawYirPerson = {
@@ -30,6 +31,7 @@ function mapPerson(raw: RawYirPerson): YirPerson {
       type: t.type,
       traktId: t.trakt_id,
       episodeCount: t.episode_count,
+      year: t.year,
     })),
   };
 }

--- a/projects/client/src/lib/requests/models/YirPerson.ts
+++ b/projects/client/src/lib/requests/models/YirPerson.ts
@@ -6,6 +6,7 @@ const YirPersonTitleSchema = z.object({
   type: z.enum(['show', 'movie']),
   traktId: z.number(),
   episodeCount: z.number().optional(),
+  year: z.number().nullish(),
 });
 
 export const YirPersonSchema = z.object({

--- a/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
+++ b/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
@@ -6,6 +6,7 @@
   import Yir2024GenresSection from "./_internal/Yir2024GenresSection.svelte";
   import Yir2024MostPlayedSection from "./_internal/Yir2024MostPlayedSection.svelte";
   import Yir2024PageInner from "./_internal/Yir2024PageInner.svelte";
+  import Yir2024PeopleSection from "./_internal/Yir2024PeopleSection.svelte";
   import Yir2024PlayCard from "./_internal/Yir2024PlayCard.svelte";
   import Yir2024RatedSection from "./_internal/Yir2024RatedSection.svelte";
   import Yir2024StatsSection from "./_internal/Yir2024StatsSection.svelte";
@@ -135,6 +136,10 @@
         />
       </Yir2024PageInner>
     {/if}
+
+    <Yir2024PageInner>
+      <Yir2024PeopleSection {slug} {year} />
+    </Yir2024PageInner>
 
     {#if detail.lastWatched}
       <Yir2024PageInner>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PeopleColumn.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PeopleColumn.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { YirPeopleType } from "$lib/requests/models/YirPerson.ts";
+  import { useYirPeople } from "../../_internal/useYirPeople.ts";
+  import Yir2024PersonRow from "./Yir2024PersonRow.svelte";
+
+  type Yir2024PeopleColumnProps = {
+    slug: string;
+    year: number;
+    type: YirPeopleType;
+    title: string;
+  };
+
+  const { slug, year, type, title }: Yir2024PeopleColumnProps = $props();
+
+  const { people, isLoading } = $derived(useYirPeople({ slug, year, type }));
+</script>
+
+{#if $isLoading || ($people?.length ?? 0) > 0}
+  <div class="trakt-yir-2024-people-column">
+    <header class="yir-2024-people-column-header">
+      <span class="uppercase yir-2024-people-column-label">
+        {m.yir_2024_people_label()}
+      </span>
+      <h2 class="bold yir-2024-people-column-title">{title}</h2>
+    </header>
+
+    {#if ($people?.length ?? 0) > 0}
+      <ol class="yir-2024-people-list" role="list">
+        {#each $people ?? [] as person, index (person.id)}
+          <Yir2024PersonRow {person} rank={index + 1} />
+        {/each}
+      </ol>
+    {:else}
+      <p class="yir-2024-people-column-loading">{m.yir_state_loading()}</p>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .trakt-yir-2024-people-column {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .yir-2024-people-column-header {
+    margin-bottom: var(--ni-12);
+  }
+
+  .yir-2024-people-column-label {
+    display: block;
+    font-size: var(--font-size-text);
+    letter-spacing: 2px;
+    color: var(--shade-10);
+  }
+
+  .yir-2024-people-column-title {
+    margin: var(--ni-2) 0 0;
+    font-size: var(--ni-32);
+    line-height: 1.1;
+    color: var(--shade-10);
+  }
+
+  /* Capped height with its own scroll, so each of the four columns scrolls
+     independently within the panel. */
+  .yir-2024-people-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    /* ~4 rows tall; the rest scrolls within the column. */
+    max-height: var(--ni-240);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .yir-2024-people-column-loading {
+    margin: 0;
+    padding: var(--ni-20) 0;
+    color: var(--shade-500);
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PeopleSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PeopleSection.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import Yir2024PeopleColumn from "./Yir2024PeopleColumn.svelte";
+
+  type Yir2024PeopleSectionProps = {
+    slug: string;
+    year: number;
+  };
+
+  const { slug, year }: Yir2024PeopleSectionProps = $props();
+</script>
+
+<section class="trakt-yir-2024-people" id="section-people">
+  <div class="yir-2024-people-grid">
+    <div class="yir-2024-people-cell">
+      <Yir2024PeopleColumn
+        {slug}
+        {year}
+        type="actors"
+        title={m.yir_2024_people_actors()}
+      />
+    </div>
+    <div class="yir-2024-people-cell">
+      <Yir2024PeopleColumn
+        {slug}
+        {year}
+        type="actresses"
+        title={m.yir_2024_people_actresses()}
+      />
+    </div>
+    <div class="yir-2024-people-cell">
+      <Yir2024PeopleColumn
+        {slug}
+        {year}
+        type="directors"
+        title={m.yir_2024_people_directors()}
+      />
+    </div>
+    <div class="yir-2024-people-cell">
+      <Yir2024PeopleColumn
+        {slug}
+        {year}
+        type="writers"
+        title={m.yir_2024_people_writers()}
+      />
+    </div>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  // Same radial-gradient wrapper as the stats graph panels.
+  .trakt-yir-2024-people {
+    --people-divider: var(--shade-1000);
+
+    box-sizing: border-box;
+    width: 100%;
+    overflow: hidden;
+    border-radius: var(--ni-64);
+    padding: var(--ni-44);
+    background: radial-gradient(
+      50% 39.27% at 50% 0%,
+      color-mix(in srgb, var(--shade-950) 90%, var(--blue-500) 10%) 0%,
+      color-mix(in srgb, var(--shade-950) 70%, var(--shade-900) 30%) 100%
+    );
+
+    @include for-mobile {
+      border-radius: var(--ni-32);
+      padding: var(--ni-20);
+    }
+  }
+
+  // Two columns × two rows on desktop; single column once stacked.
+  .yir-2024-people-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+
+    @include for-tablet-sm-and-below {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+
+  .yir-2024-people-cell {
+    min-width: 0;
+  }
+
+  // Vertical divider between the two columns (pad each side toward the line).
+  .yir-2024-people-cell:nth-child(odd) {
+    padding-right: var(--ni-48);
+    border-right: var(--border-thickness-xs) solid var(--people-divider);
+  }
+
+  .yir-2024-people-cell:nth-child(even) {
+    padding-left: var(--ni-48);
+  }
+
+  // Horizontal divider between the two rows.
+  .yir-2024-people-cell:nth-child(1),
+  .yir-2024-people-cell:nth-child(2) {
+    padding-bottom: var(--ni-44);
+    border-bottom: var(--border-thickness-xs) solid var(--people-divider);
+  }
+
+  .yir-2024-people-cell:nth-child(3),
+  .yir-2024-people-cell:nth-child(4) {
+    padding-top: var(--ni-44);
+  }
+
+  // Stacked: drop the vertical divider, keep horizontal dividers between all.
+  @include for-tablet-sm-and-below {
+    .yir-2024-people-cell:nth-child(odd) {
+      padding-right: 0;
+      border-right: none;
+    }
+
+    .yir-2024-people-cell:nth-child(even) {
+      padding-left: 0;
+    }
+
+    .yir-2024-people-cell:nth-child(1) {
+      padding-bottom: var(--ni-32);
+    }
+
+    .yir-2024-people-cell:nth-child(2) {
+      padding-top: var(--ni-32);
+      padding-bottom: var(--ni-32);
+    }
+
+    .yir-2024-people-cell:nth-child(3) {
+      padding-top: var(--ni-32);
+      padding-bottom: var(--ni-32);
+      border-bottom: var(--border-thickness-xs) solid var(--people-divider);
+    }
+
+    .yir-2024-people-cell:nth-child(4) {
+      padding-top: var(--ni-32);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PersonRow.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PersonRow.svelte
@@ -1,0 +1,309 @@
+<script lang="ts">
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
+  import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
+  import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import { m } from "$lib/paraglide/messages";
+  import type {
+    YirPerson,
+    YirPersonTitle,
+  } from "$lib/requests/models/YirPerson.ts";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import { PLACEHOLDERS } from "$lib/utils/assets";
+  import { DEFAULT_AVATAR } from "$lib/utils/constants";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+
+  type Yir2024PersonRowProps = {
+    person: YirPerson;
+    rank: number;
+  };
+
+  const { person, rank }: Yir2024PersonRowProps = $props();
+
+  let expanded = $state(false);
+
+  const rankLabel = $derived(String(rank).padStart(2, "0"));
+  const personUrl = $derived(UrlBuilder.people(person.slug));
+  const avatarSrc = $derived.by(() => {
+    const isMissingHeadshot = !person.headshot.url.thumb;
+    const isPlaceHolder = PLACEHOLDERS.includes(person.headshot.url.thumb);
+
+    return isMissingHeadshot || isPlaceHolder
+      ? DEFAULT_AVATAR
+      : person.headshot.url.thumb;
+  });
+  const hasTitles = $derived(person.titles.length > 0);
+
+  // Trailing detail for an expanded title: episode count for shows, release
+  // year for movies.
+  function titleMeta(title: YirPersonTitle): string {
+    if (title.type === "show" && title.episodeCount) {
+      return `— ${m.yir_2024_people_episode_count({ count: title.episodeCount })}`;
+    }
+    return title.year ? `(${title.year})` : "";
+  }
+</script>
+
+{#snippet countsContent()}
+  {#if person.count.shows > 0}
+    <span>{m.yir_2024_people_show_count({ count: person.count.shows })}</span>
+  {/if}
+  {#if person.count.movies > 0}
+    <span>{m.yir_2024_people_movie_count({ count: person.count.movies })}</span>
+  {/if}
+{/snippet}
+
+<li class="yir-2024-person" class:is-expanded={expanded} role="listitem">
+  <div class="yir-2024-person-main">
+    <span class="yir-2024-person-rank">{rankLabel}</span>
+
+    <CrossOriginImage
+      classList="yir-2024-person-avatar"
+      src={avatarSrc}
+      alt={person.name}
+      loading="lazy"
+      animate={false}
+    />
+
+    <div class="yir-2024-person-text">
+      <Link href={personUrl} color="inherit">
+        <span class="yir-2024-person-name">{person.name}</span>
+      </Link>
+
+      {#if hasTitles}
+        <button
+          type="button"
+          class="yir-2024-person-counts"
+          aria-expanded={expanded}
+          aria-controls="titles-{person.id}"
+          onclick={() => (expanded = !expanded)}
+        >
+          {@render countsContent()}
+        </button>
+      {:else}
+        <span class="yir-2024-person-counts">
+          {@render countsContent()}
+        </span>
+      {/if}
+    </div>
+
+    {#if hasTitles}
+      <button
+        type="button"
+        class="yir-2024-person-seen-in"
+        aria-expanded={expanded}
+        aria-controls="titles-{person.id}"
+        aria-label={m.yir_2024_people_seen_in()}
+        onclick={() => (expanded = !expanded)}
+      >
+        <span class="yir-2024-person-caret"><CaretRightIcon /></span>
+      </button>
+    {/if}
+  </div>
+
+  {#if expanded}
+    <ul id="titles-{person.id}" class="yir-2024-person-titles" role="list">
+      {#each person.titles as title (title.traktId)}
+        {@const meta = titleMeta(title)}
+        <li class="yir-2024-person-title" role="listitem">
+          <Link
+            href={UrlBuilder.media(title.type, String(title.traktId))}
+            color="inherit"
+          >
+            <span class="yir-2024-person-title-icon">
+              {#if title.type === "movie"}
+                <MovieIcon />
+              {:else}
+                <ShowIcon />
+              {/if}
+            </span>
+            <span class="yir-2024-person-title-text">
+              {title.title}{#if meta}&nbsp;{meta}{/if}
+            </span>
+          </Link>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</li>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .yir-2024-person {
+    border-bottom: var(--border-thickness-xxs) solid
+      color-mix(in srgb, var(--shade-700) 60%, transparent);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .yir-2024-person-main {
+    display: flex;
+    align-items: center;
+    gap: var(--ni-12);
+    padding: var(--ni-10) 0;
+  }
+
+  .yir-2024-person-rank {
+    flex: none;
+    min-width: var(--ni-24);
+    font-size: var(--ni-16);
+    color: var(--shade-500);
+  }
+
+  // Name on line 1, watched counts stacked beneath it on line 2. Flexes to
+  // fill the row so the chevron stays pinned right.
+  .yir-2024-person-text {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-2);
+  }
+
+  // Only the name links to the person; make it block so it truncates to the
+  // column width.
+  .yir-2024-person-text :global(.trakt-link) {
+    display: block;
+    min-width: 0;
+    text-decoration: none;
+  }
+
+  :global(.yir-2024-person-avatar) {
+    flex: none;
+    width: var(--ni-40);
+    height: var(--ni-40);
+    border-radius: 50%;
+    object-fit: cover;
+    background-color: var(--shade-800);
+  }
+
+  .yir-2024-person-name {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--ni-18);
+    transition: color 0.2s;
+  }
+
+  @include for-mouse {
+    // `.yir-2024-person-name` is scoped to this component, so the global
+    // `.trakt-link` hover only matches names rendered here.
+    :global(.trakt-link:hover) .yir-2024-person-name {
+      color: var(--purple-300);
+    }
+  }
+
+  // Clicking the counts toggles the expansion like the chevron, so it's a
+  // button — reset the chrome to a plain gray label that lightens on hover.
+  // `.uppercase` only targets p/span/h1-6/code, so uppercase is set here.
+  .yir-2024-person-counts {
+    align-self: flex-start;
+    display: inline-flex;
+    padding: 0;
+    border: none;
+    background: none;
+    font-family: inherit;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--shade-500);
+    white-space: nowrap;
+    cursor: pointer;
+    transition: color 0.2s;
+  }
+
+  // Override the global `span { font-size }` so the count text is actually
+  // small; a bullet separates the show + movie counts when both are present.
+  .yir-2024-person-counts span {
+    font-size: var(--font-size-tag);
+  }
+
+  .yir-2024-person-counts span + span::before {
+    content: "•";
+    margin: 0 var(--ni-4);
+  }
+
+  .yir-2024-person-counts:hover {
+    color: var(--shade-300);
+  }
+
+  // Text dropped — a purple circle around the chevron keeps the button
+  // affordance for the expand toggle.
+  .yir-2024-person-seen-in {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--ni-28);
+    height: var(--ni-28);
+    border: none;
+    border-radius: 50%;
+    background-color: var(--purple-500);
+    cursor: pointer;
+    color: var(--shade-10);
+    transition: background-color 0.2s;
+
+    &:hover {
+      background-color: var(--purple-400);
+    }
+  }
+
+  .yir-2024-person-caret {
+    display: inline-flex;
+    transition: transform 0.2s;
+    // CaretRightIcon points right; rotate it down while collapsed.
+    transform: rotate(90deg);
+
+    :global(svg) {
+      width: var(--ni-12);
+      height: var(--ni-12);
+    }
+  }
+
+  .yir-2024-person.is-expanded .yir-2024-person-caret {
+    transform: rotate(-90deg);
+  }
+
+  .yir-2024-person-titles {
+    list-style: none;
+    margin: 0;
+    // Left-aligned to the row edge (under the rank), not indented under the name.
+    padding: 0 0 var(--ni-16);
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-8);
+  }
+
+  .yir-2024-person-title {
+    font-size: var(--font-size-text);
+  }
+
+  .yir-2024-person-title :global(.trakt-link) {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ni-8);
+    text-decoration: none;
+    color: var(--shade-100);
+    transition: color 0.2s;
+  }
+
+  @include for-mouse {
+    .yir-2024-person-title :global(.trakt-link):hover {
+      color: var(--purple-300);
+    }
+  }
+
+  .yir-2024-person-title-icon {
+    flex: none;
+    display: inline-flex;
+    color: var(--shade-400);
+
+    :global(svg) {
+      width: var(--ni-16);
+      height: var(--ni-16);
+    }
+  }
+</style>


### PR DESCRIPTION
# Overview

Adds the **Most Watched People** section to the 2024 Year in Review template: a 2×2 grid of Actors, Actresses, Directors, and Writers in a single gradient panel, matching the v2 design.

# Screenshot

<img width="1232" height="883" alt="image" src="https://github.com/user-attachments/assets/4ae2b794-ff94-41b6-b092-fd930dd6cbf7" />

# What's new

- **`Yir2024PeopleSection`** — the panel (same radial gradient as the stats graph wrappers), with the four quadrants laid out 2×2 and separated by black divider lines (vertical between columns, horizontal between rows). Collapses to one column on mobile.
- **`Yir2024PeopleColumn`** — a "MOST WATCHED" label + title (`Actors`, etc.) and a height-capped (~4 rows) list that scrolls independently within each quadrant. One `useYirPeople` query per type.
- **`Yir2024PersonRow`** — rank, circular avatar + name (linked to the person page), show/movie counts, and a purple **"Seen in"** pill that expands inline to the titles. Each expanded title links to its show/movie detail page, with episode counts for shows ("— N episodes") and release year for movies ("(year)").

# Data

Built entirely on the existing native people layer — `useYirPeople` → `yirPeopleQuery` → `mapToYirPeople` → the `YirPerson` model, the same one the default YIR template uses. No new query, mapper, or hook.

The only data change: an optional `year` field added to `YirPersonTitle` (model + mapper) so the expanded "seen in" list can show release years. It's `.nullish()` and ignored by the default template, so it's backward compatible.

# Conventions

- List semantics (`role="list"` / `role="listitem"`) on every list, `<h2>` column titles, design tokens for all sizing (incl. the divider via `--border-thickness-xs`), `lang="scss"` where SCSS features are used.
- `deno fmt`, eslint, and `svelte-check` all pass.

# Notes

- The section renders unconditionally (people data lives in separate per-type queries, not the main `detail` payload), mirroring the default `YirPeopleSection`. A user missing an entire category would see an empty quadrant.
- Title links resolve by trakt id (`/shows/{id}`), since the title model carries no slug.

# Follow-ups

- [ ] **Proper pluralization for the people counts.** This project's Paraglide setup does not compile ICU plural syntax (`{count, plural, one {…} other {…}}`) — even the existing `yir_unit_*` messages are broken by it. As an interim measure the count strings (`yir_2024_people_{show,movie,episode}_count`) use the plural form only (`"{count} shows"`), so a count of 1 renders "1 SHOWS" / "1 MOVIES" / "1 episodes". Once plural support is sorted (fix the Paraglide pipeline, or add a pluralization helper), switch these to proper singular/plural handling.
