### PR TITLE
fix/Actor-page-font-increase

### DIFF
--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -155,10 +155,14 @@
     {@render content(media.poster.url.thumb)}
     <CardFooter {action}>
       <div class="trakt-card-credit-footer">
-        {@render tag?.()}
-        <p class="trakt-card-subtitle ellipsis">
+        <p class="trakt-card-title ellipsis">
           {rest.role}
         </p>
+        {#if tag}
+          <div class="trakt-card-subtitle">
+            {@render tag()}
+          </div>
+        {/if}
       </div>
     </CardFooter>
   </PortraitCard>
@@ -174,14 +178,12 @@
     }
   }
 
-  .trakt-card-credit-footer {
-    transform: scale(0.85);
-    transform-origin: bottom left;
-
-    transition: transform var(--transition-increment) ease-in-out;
-
-    @include for-mobile {
-      transform: scale(0.9);
+  .trakt-card-credit-footer .trakt-card-subtitle {
+    :global(p),
+    :global(.trakt-text-tag),
+    :global(.trakt-media-icon-tag) {
+      color: var(--color-text-secondary);
+      font-size: var(--font-size-text-small);
     }
   }
 </style>


### PR DESCRIPTION
Fixes #2574
<img width="1456" height="1260" alt="Screenshot 2026-06-10 at 23 10 07" src="https://github.com/user-attachments/assets/f873e98d-aba6-4efb-8d74-b4048396f9e3" />


## Changes

- Reorders credit card footer: character/job name now displays on top, release year on bottom
- Role text uses `trakt-card-title` class (14px)
- Release year wrapped in `trakt-card-subtitle` (12px, `--color-text-secondary` / `#9EA6AC`)
- Overrides `trakt-text-tag` font size within credit footer to `--font-size-text-small` (12px), correcting the previous 10px from `--font-size-tag`

## Test plan

- [ ] Open Actor page and verify credit cards show character/job name on top (14px)
- [ ] Verify release year displays below in `#9EA6AC` at 12px
- [ ] Check movie credits (DurationTag) and show credits (EpisodeCountTag) render correctly