### PR TITLE
feat/Actor-Page-relocating-details

### DIFF
--- a/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
@@ -9,6 +9,8 @@
   import SummaryContainer from "./../summary/SummaryContainer.svelte";
   import SummaryHeader from "./../summary/SummaryHeader.svelte";
   import SummaryOverview from "./../summary/SummaryOverview.svelte";
+  import DetailSeparator from "./v2/_internal/DetailSeparator.svelte";
+  import { hasSocialMediaLinks } from "./v2/_internal/hasSocialMediaLinks";
   import ImdbLink from "./v2/_internal/ImdbLink.svelte";
   import PersonDetails from "./v2/_internal/PersonDetails.svelte";
   import SocialMediaLinks from "./v2/_internal/SocialMediaLinks.svelte";
@@ -55,16 +57,19 @@
   </div>
 
   <div class="person-meta-info">
-    <div class="person-social-media-links">
-      <SocialMediaLinks {person} />
-    </div>
-
     <PersonDetails
       height={person.height}
       birthday={person.birthday}
       deathDate={person.deathDate}
       variant="compact"
     />
+
+    {#if hasSocialMediaLinks(person)}
+      <DetailSeparator />
+      <div class="person-social-media-links">
+        <SocialMediaLinks {person} />
+      </div>
+    {/if}
   </div>
 </SummaryContainer>
 
@@ -72,8 +77,8 @@
   .person-meta-info {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: var(--gap-l);
+    justify-content: flex-start;
+    gap: var(--gap-m);
   }
 
   .trakt-summary-main-content {

--- a/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
@@ -13,6 +13,7 @@
   import ImdbLink from "./_internal/ImdbLink.svelte";
   import PersonDetails from "./_internal/PersonDetails.svelte";
   import SocialMediaLinks from "./_internal/SocialMediaLinks.svelte";
+  import { hasSocialMediaLinks } from "./_internal/hasSocialMediaLinks";
 
   const { person }: { person: PersonSummary } = $props();
 </script>
@@ -34,7 +35,9 @@
       textFactory={({ title: name }) => m.text_share_person({ name })}
       source={{ id: "person" }}
     />
-    <SocialMediaLinks {person} />
+    {#if hasSocialMediaLinks(person)}
+      <SocialMediaLinks {person} />
+    {/if}
     <RenderFor audience="authenticated">
       <PopupMenu
         label={m.button_label_popup_menu({ title: person.name })}

--- a/projects/client/src/lib/sections/summary/components/people/v2/_internal/DetailSeparator.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/_internal/DetailSeparator.svelte
@@ -1,0 +1,11 @@
+<div class="trakt-detail-separator"></div>
+
+<style lang="scss">
+  .trakt-detail-separator {
+    width: var(--ni-1);
+    align-self: stretch;
+
+    background-color: var(--color-text-secondary);
+    opacity: 0.25;
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/people/v2/_internal/PersonDetails.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/_internal/PersonDetails.svelte
@@ -7,6 +7,7 @@
   import { toHumanDay } from "$lib/utils/formatting/date/toHumanDay";
   import { toMeasurement } from "$lib/utils/formatting/number/toMeasurement";
   import Celebration from "./Celebration.svelte";
+  import DetailSeparator from "./DetailSeparator.svelte";
 
   const {
     birthday,
@@ -35,7 +36,7 @@
       <p>{toMeasurement(height / 100, getLocale())}</p>
     </div>
     {#if birthday}
-      <div class="trakt-detail-separator"></div>
+      <DetailSeparator />
     {/if}
   {/if}
   {#if birthday}
@@ -44,9 +45,11 @@
         <Celebration />
       {/if}
       <span class="bold secondary">{m.header_birthday()}</span>
-      <p>{toHumanDay({ date: birthday, locale: getLocale(), format: "short" })}</p>
+      <p>
+        {toHumanDay({ date: birthday, locale: getLocale(), format: "short" })}
+      </p>
     </div>
-    <div class="trakt-detail-separator"></div>
+    <DetailSeparator />
     <div class="trakt-person-detail">
       <span class="bold secondary">{detailHeader}</span>
       {#if deathDate}
@@ -59,7 +62,9 @@
   {/if}
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .trakt-person-details {
     --details-width: var(--ni-320);
     --details-gap: var(--gap-m);
@@ -75,15 +80,21 @@
 
       .trakt-person-detail {
         width: fit-content;
-        align-items: flex-end;
+        align-items: flex-start;
       }
     }
   }
 
-  .trakt-detail-separator {
-    width: var(--ni-1);
-    background-color: var(--color-text-secondary);
-    opacity: 0.25;
+  @include for-tablet-lg {
+    .trakt-person-detail span.bold {
+      font-weight: normal;
+    }
+  }
+
+  @include for-desktop {
+    .trakt-person-detail span.bold {
+      font-weight: normal;
+    }
   }
 
   .trakt-person-detail {

--- a/projects/client/src/lib/sections/summary/components/people/v2/_internal/SocialMediaLinks.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/_internal/SocialMediaLinks.svelte
@@ -8,23 +8,17 @@
   const xUsername = $derived(person.socialMedia?.x);
   const instagramUsername = $derived(person.socialMedia?.instagram);
 
-  const hasSocialMediaLinks = $derived(
-    facebookUsername || xUsername || instagramUsername,
-  );
-
   const source = "person-summary";
 </script>
 
-{#if hasSocialMediaLinks}
-  {#if facebookUsername}
-    <ExternalLinkAction id={facebookUsername} type="facebook" {source} />
-  {/if}
+{#if facebookUsername}
+  <ExternalLinkAction id={facebookUsername} type="facebook" {source} />
+{/if}
 
-  {#if xUsername}
-    <ExternalLinkAction id={xUsername} type="x" {source} />
-  {/if}
+{#if xUsername}
+  <ExternalLinkAction id={xUsername} type="x" {source} />
+{/if}
 
-  {#if instagramUsername}
-    <ExternalLinkAction id={instagramUsername} type="instagram" {source} />
-  {/if}
+{#if instagramUsername}
+  <ExternalLinkAction id={instagramUsername} type="instagram" {source} />
 {/if}

--- a/projects/client/src/lib/sections/summary/components/people/v2/_internal/hasSocialMediaLinks.ts
+++ b/projects/client/src/lib/sections/summary/components/people/v2/_internal/hasSocialMediaLinks.ts
@@ -1,0 +1,6 @@
+import type { PersonSummary } from '$lib/requests/models/PersonSummary.ts';
+
+export function hasSocialMediaLinks(person: PersonSummary): boolean {
+  const { facebook, x, instagram } = person.socialMedia ?? {};
+  return Boolean(facebook || x || instagram);
+}


### PR DESCRIPTION
## Description

On the desktop Actor/Person page summary, the physical details row (Birthday, Age, Height) and Social Media links were visually misaligned — social icons were pushed to the far right via `justify-content: space-between`, leaving awkward empty space between the two groups.

This PR restructures that row so:
- **PersonDetails** (Birthday, Age, Height) anchors to the left
- A trailing separator follows the last detail item inline
- **SocialMediaLinks** sits immediately after the separator, part of the same inline row
- All spacing uses a consistent `gap-m` token throughout
- Detail labels (birthday, height, age) are rendered at normal weight on tablet-lg and desktop — bold is preserved on mobile

Mobile layout (`v2/PeopleSummary`) is **not touched**.

## Changes

- `PeopleSummary.svelte` — swapped DOM order of `PersonDetails` / `SocialMediaLinks`, switched `.person-meta-info` from `space-between` to `flex-start` with `gap-m`, passed `trailingSeparator={true}` to `PersonDetails`
- `PersonDetails.svelte` — added `trailingSeparator` prop that renders a trailing separator after the age block; overrides `.bold` label weight to `normal` at `tablet-lg` and `desktop` breakpoints

## Screenshots/Videos
<img width="1100" height="1266" alt="Screenshot 2026-06-11 at 11 29 19" src="https://github.com/user-attachments/assets/2cc1035e-cd74-4797-8700-4b1a1f7297f6" />
<img width="1763" height="922" alt="Screenshot 2026-06-11 at 08 21 07" src="https://github.com/user-attachments/assets/275a434c-2a73-4072-aac8-3c3004205acd" />

<!-- Add before/after screenshots of the desktop Actor page -->

## Pull Request Checklist

- [x] **Clear and Concise Title:** Does your title shine a spotlight on the essence of your changes?
- [x] **Detailed Description:** Have you set the stage with a compelling narrative that explains the "why" and "how" of your changes?
- [x] **Screenshots/Videos:** Have you captured the magic with visual evidence that showcases your changes in action?
- [x] **Tests:** No logic changes — purely layout/style, no unit tests required
- [x] **Coding Standards:** Follows project conventions (CSS vars, SCSS mixins, Svelte 5 runes, `$props()`)
- [x] **Commit Messages:** Conventional Commits format (`refactor(actor): ...`)
- [x] **Documentation:** No documentation impact
- [x] **Code Review:** Ready for review