### PR TITLE
fix(share): makes content more readable

### DIFF
--- a/projects/client/src/lib/features/share/_internal/FeedContent.svelte
+++ b/projects/client/src/lib/features/share/_internal/FeedContent.svelte
@@ -36,6 +36,7 @@
 
     flex: 1;
     height: 100%;
+    margin-top: 16px;
 
     color: #efefef;
   }

--- a/projects/client/src/lib/features/share/_internal/MainCredit.svelte
+++ b/projects/client/src/lib/features/share/_internal/MainCredit.svelte
@@ -44,12 +44,14 @@
   .trakt-main-credit {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 8px;
 
-    font-size: 26px;
+    font-size: 36px;
 
     span {
       font-size: 26px;
+      flex-shrink: 0;
     }
   }
 </style>

--- a/projects/client/src/lib/features/share/_internal/OpenGraphContent.svelte
+++ b/projects/client/src/lib/features/share/_internal/OpenGraphContent.svelte
@@ -4,7 +4,6 @@
   import type { MediaCrew } from "$lib/requests/models/MediaCrew.ts";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import type { MediaRating } from "$lib/requests/models/MediaRating.ts";
-  import { SHARE_TYPE_DIMENSIONS } from "../models/ShareType.ts";
   import MainCredit from "./MainCredit.svelte";
   import RatingsList from "./RatingsList.svelte";
   import Title from "./Title.svelte";
@@ -16,14 +15,9 @@
   };
 
   const { media, crew, ratings }: OpenGraphContentProps = $props();
-
-  const { padding } = $derived(SHARE_TYPE_DIMENSIONS["open-graph"]);
 </script>
 
-<div
-  class="trakt-open-graph-content"
-  style="padding-right: {padding}px; padding-left: {padding * 2}px;"
->
+<div class="trakt-open-graph-content">
   <Title title={media.title} />
   <MainCredit type={media.type} {crew} />
   <RatingsList {ratings} />
@@ -31,6 +25,8 @@
 
 <style>
   .trakt-open-graph-content {
+    padding-left: 48px;
+
     box-sizing: border-box;
 
     display: flex;

--- a/projects/client/src/lib/features/share/_internal/Poster.svelte
+++ b/projects/client/src/lib/features/share/_internal/Poster.svelte
@@ -16,7 +16,7 @@
   const posterHeight = $derived.by(() => {
     switch (variant) {
       case "feed":
-        return height / 1.5;
+        return height / 1.25;
       case "story":
         return height / 1.75;
       case "open-graph":

--- a/projects/client/src/lib/features/share/_internal/RatingsList.svelte
+++ b/projects/client/src/lib/features/share/_internal/RatingsList.svelte
@@ -74,17 +74,17 @@
     gap: 6px;
 
     color: #efefef;
-    font-size: 26px;
+    font-size: 32px;
     font-weight: bold;
 
     span {
-      font-size: 26px;
+      font-size: 32px;
       font-weight: bold;
     }
 
     :global(svg) {
-      width: 26px;
-      height: 26px;
+      width: 32px;
+      height: 32px;
     }
   }
 
@@ -96,7 +96,7 @@
 
   .imdb-rating {
     :global(svg) {
-      width: 52px;
+      width: 64px;
     }
   }
 </style>

--- a/projects/client/src/lib/features/share/_internal/Title.svelte
+++ b/projects/client/src/lib/features/share/_internal/Title.svelte
@@ -10,7 +10,7 @@
   .trakt-share-title {
     margin: 0;
 
-    font-size: 48px;
-    line-height: 52px;
+    font-size: 56px;
+    line-height: 60px;
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2586
- Makes text in images more readable

## 👀 Examples 👀
Before/after:
<img width="984" height="340" alt="Screenshot 2026-06-11 at 14 54 20" src="https://github.com/user-attachments/assets/277a95c5-2da7-4d07-baf3-caaf87a0641e" />

<img width="984" height="343" alt="Screenshot 2026-06-11 at 14 53 30" src="https://github.com/user-attachments/assets/3ed0c8a8-b656-4d44-b925-84791ceeeff2" />

Before/after:
<img width="984" height="571" alt="Screenshot 2026-06-11 at 14 54 33" src="https://github.com/user-attachments/assets/64791768-8227-4117-9e49-7eec3a3eaeb2" />

<img width="984" height="565" alt="Screenshot 2026-06-11 at 14 53 38" src="https://github.com/user-attachments/assets/aa630166-fa83-489c-a1fd-c1bd2c1a2325" />

Before/after:
<img width="984" height="898" alt="Screenshot 2026-06-11 at 14 54 49" src="https://github.com/user-attachments/assets/bbccf09d-275d-4d6a-8480-1701b2d2445f" />

<img width="984" height="897" alt="Screenshot 2026-06-11 at 14 53 53" src="https://github.com/user-attachments/assets/f0d24a3e-6496-44a4-9ada-d0f83b85870f" />
