### PR TITLE
feat: favorites updates

### DIFF
--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -2,4 +2,5 @@ export enum FeatureFlag {
   YearInReview = 'year-in-review',
   EditMode = 'edit-mode',
   StreamingSync = 'streaming-sync',
+  ScopedFavorites = 'scoped-favorites',
 }

--- a/projects/client/src/lib/sections/lists/favorites/FavoritesList.svelte
+++ b/projects/client/src/lib/sections/lists/favorites/FavoritesList.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
   import { useIsMe } from "$lib/features/auth/stores/useIsMe";
   import type { DiscoverMode } from "$lib/features/discover/models/DiscoverMode";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
   import * as m from "$lib/features/i18n/messages";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import CtaItem from "$lib/sections/lists/components/cta/CtaItem.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { map } from "rxjs";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
-  import { useFavoritesList } from "../stores/useFavoritesList";
+  import {
+    useFavoritesList,
+    type UseFavoritesProps,
+  } from "../stores/useFavoritesList";
   import FavoriteMediaItem from "./_internal/FavoriteMediaItem.svelte";
 
   const {
@@ -30,6 +37,29 @@
     type: "favorites" as const,
     mediaType: mode === "media" ? undefined : mode,
   });
+
+  const currentYear = new Date().getFullYear();
+
+  const { isEnabled } = useFeatureFlag();
+  const isFlagEnabled = $derived(isEnabled(FeatureFlag.ScopedFavorites));
+
+  function useFavoritesListForYear(params: UseFavoritesProps) {
+    const result = useFavoritesList(params);
+    return {
+      ...result,
+      list: result.list.pipe(
+        map((entries) =>
+          entries.filter(
+            (entry) => entry.favoritedAt.getFullYear() === currentYear,
+          ),
+        ),
+      ),
+    };
+  }
+
+  const useFavorites = $derived(
+    $isFlagEnabled ? useFavoritesListForYear : useFavoritesList,
+  );
 </script>
 
 <DrillableMediaList
@@ -39,11 +69,21 @@
     key: `${mode}-${slug}`,
   }}
   type={mode}
-  useList={(params) => useFavoritesList({ ...params, slug })}
+  useList={(params) => useFavorites({ ...params, slug })}
   drilldownLabel={m.button_label_view_all_favorites()}
   source={{ id: "favorites", type: mode }}
   urlBuilder={() => UrlBuilder.profile.favorites(slug)}
 >
+  {#snippet metaInfo()}
+    <RenderForFeature flag={FeatureFlag.ScopedFavorites}>
+      {#snippet enabled()}
+        <p class="tag secondary">
+          {currentYear}
+        </p>
+      {/snippet}
+    </RenderForFeature>
+  {/snippet}
+
   {#snippet item(media)}
     <FavoriteMediaItem {media} {mode} isActionable={$isMe} />
   {/snippet}

--- a/projects/client/src/lib/sections/lists/stores/useFavoritesList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useFavoritesList.ts
@@ -8,7 +8,7 @@ import type { SortDirection } from '$lib/sections/lists/user/models/SortDirectio
 import { DEFAULT_PAGE_SIZE } from '$lib/utils/constants.ts';
 import { usePaginatedListQuery } from './usePaginatedListQuery.ts';
 
-type UseFavoritesProps = {
+export type UseFavoritesProps = {
   type?: DiscoverMode;
   slug: string;
   limit?: number;

--- a/projects/client/src/lib/sections/lists/user/_internal/useListSorting.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useListSorting.ts
@@ -47,6 +47,13 @@ type UseListSortingProps = {
   slug: string;
 };
 
+function getDefaultSortBy(props: UseListSortingProps): SortBy | undefined {
+  if (props.type === 'favorites') {
+    return 'added';
+  }
+  return undefined;
+}
+
 function getDefaultDirection(props: UseListSortingProps): SortDirection {
   if (
     props.type === 'watchlist' ||
@@ -74,11 +81,13 @@ export function useListSorting(
 
   return {
     update,
-    options: LIST_SORT_OPTIONS,
+    options: props.type === 'favorites'
+      ? LIST_SORT_OPTIONS.filter((option) => option.value !== undefined)
+      : LIST_SORT_OPTIONS,
     current: params.pipe(
       map(($params) => {
         const defaultDirection = getDefaultDirection(props);
-        const sortBy = mapToSortBy($params.sort_by);
+        const sortBy = mapToSortBy($params.sort_by) ?? getDefaultSortBy(props);
         const sortHow = mapToDirection($params.sort_how) ?? defaultDirection;
 
         const sorting = LIST_SORT_OPTIONS.find(


### PR DESCRIPTION
Resolves #2549 

## Summary
  - Favorites list now defaults to "Date Added" sort on page load (previously showed API default order)
  - "Default" sort option removed from favorites — not meaningful since `added` is the canonical baseline
  - Other lists (watchlist, user lists) are unaffected

  ## How it works
  - `getDefaultSortBy` returns `'added'` when type is `'favorites'`; applied via `??` fallback when no `sort_by` URL param is present
  - Favorites sort options exclude the `undefined`-value "Default" entry to avoid a state where selecting "Default" silently resolves to "Date Added"
  
  
<img width="2112" height="481" alt="image" src="https://github.com/user-attachments/assets/82c0bf03-9fea-4d8a-9b1d-b1c01c8202df" />

<img width="2135" height="706" alt="image" src="https://github.com/user-attachments/assets/1d3524b1-e39e-4936-88f5-9e38a39c2e36" />

