### PR TITLE
Fix/sentiment design consistency

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/InfoCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/InfoCard.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import Card from "$lib/components/card/Card.svelte";
+
+  const { children }: ChildrenProps = $props();
+</script>
+
+<Card variant="transparent" --width-card="100%" --height-card="fit-content">
+  <div class="trakt-info-container">
+    {@render children()}
+  </div>
+</Card>
+
+<style>
+  .trakt-info-container {
+    position: relative;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+
+    box-sizing: border-box;
+    padding: var(--ni-20) var(--ni-24);
+
+    background: color-mix(in srgb, var(--color-text-primary) 4%, transparent);
+    border: var(--border-thickness-xxs) solid
+      color-mix(in srgb, var(--color-text-primary) 24%, transparent);
+    border-radius: var(--border-radius-m);
+
+    :global(.trakt-spoiler) {
+      cursor: pointer;
+    }
+
+    :global(li) {
+      font-size: var(--font-size-text);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/_internal/InfoCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/InfoCard.svelte
@@ -1,17 +1,23 @@
 <script lang="ts">
   import Card from "$lib/components/card/Card.svelte";
 
-  const { children }: ChildrenProps = $props();
+  type InfoCardProps = {
+    variant?: "default" | "highlight";
+  } & ChildrenProps;
+
+  const { children, variant = "default" }: InfoCardProps = $props();
 </script>
 
 <Card variant="transparent" --width-card="100%" --height-card="fit-content">
-  <div class="trakt-info-container">
+  <div class="trakt-info-container" data-variant={variant}>
     {@render children()}
   </div>
 </Card>
 
 <style>
   .trakt-info-container {
+    --border-opacity-info: 10%;
+
     position: relative;
 
     display: flex;
@@ -22,8 +28,6 @@
     padding: var(--ni-20) var(--ni-24);
 
     background: color-mix(in srgb, var(--color-text-primary) 4%, transparent);
-    border: var(--border-thickness-xxs) solid
-      color-mix(in srgb, var(--color-text-primary) 24%, transparent);
     border-radius: var(--border-radius-m);
 
     :global(.trakt-spoiler) {
@@ -32,6 +36,32 @@
 
     :global(li) {
       font-size: var(--font-size-text);
+    }
+
+    &[data-variant="highlight"] {
+      --border-opacity-info: 25%;
+
+      overflow: hidden;
+
+      &::before {
+        content: "";
+
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+
+        background: linear-gradient(
+          90deg,
+          transparent 0%,
+          var(--color-sentiment-highlight-border) 50%,
+          transparent 100%
+        );
+
+        transform: translateX(-100%);
+        animation: slide calc(5 * var(--transition-increment)) ease-in-out;
+      }
     }
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentContent.svelte
+++ b/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentContent.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import * as m from "$lib/features/i18n/messages.ts";
   import type { SentimentAnalysis } from "$lib/requests/models/SentimentAnalysis";
+  import InfoCard from "../../_internal/InfoCard.svelte";
   import SentimentAspects from "./SentimentAspects.svelte";
 
   const { sentiment }: { sentiment: SentimentAnalysis } = $props();
@@ -8,18 +9,21 @@
 
 <div class="trakt-sentiment-content">
   <p>{sentiment.analysis}</p>
-  <div class="trakt-sentiment-highlight">
+
+  <InfoCard variant="highlight">
     <p class="bold">{m.header_sentiment_highlight()}</p>
     <p>{sentiment.highlight}</p>
-  </div>
+  </InfoCard>
 
-  <div class="trakt-sentiment-aspects">
-    <p class="bold">{m.header_sentiment_aspects()}</p>
-    <SentimentAspects
-      pros={sentiment.aspect.pros}
-      cons={sentiment.aspect.cons}
-    />
-  </div>
+  <InfoCard>
+    <div class="trakt-sentiment-aspects">
+      <p class="bold">{m.header_sentiment_aspects()}</p>
+      <SentimentAspects
+        pros={sentiment.aspect.pros}
+        cons={sentiment.aspect.cons}
+      />
+    </div>
+  </InfoCard>
 </div>
 
 <style>
@@ -29,53 +33,9 @@
     gap: var(--gap-xl);
   }
 
-  .trakt-sentiment-highlight {
-    position: relative;
-
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-xs);
-
-    padding: var(--ni-16);
-
-    overflow: hidden;
-    background: var(--background-sentiment-highlight);
-
-    border-radius: var(--border-radius-m);
-    border: var(--ni-1) solid var(--color-sentiment-highlight-border);
-  }
-
-  .trakt-sentiment-highlight::before {
-    content: "";
-
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-
-    background: linear-gradient(
-      90deg,
-      transparent 0%,
-      var(--color-sentiment-highlight-border) 50%,
-      transparent 100%
-    );
-
-    transform: translateX(-100%);
-    animation: slide calc(5 * var(--transition-increment)) ease-in-out;
-  }
-
   .trakt-sentiment-aspects {
     display: flex;
     flex-direction: column;
     gap: var(--gap-xs);
-
-    :global(.trakt-sentiment-body) {
-      border-radius: var(--border-radius-m);
-      background: var(--background-sentiment-highlight);
-
-      box-sizing: border-box;
-      padding: var(--ni-16);
-    }
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaCard.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import Card from "$lib/components/card/Card.svelte";
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import type { MediaTrivia } from "$lib/requests/models/MediaTrivia";
   import { Marked } from "marked";
+  import InfoCard from "../../_internal/InfoCard.svelte";
 
   const {
     trivia,
@@ -20,40 +20,12 @@
   {@html marked.parse(trivia.text)}
 {/snippet}
 
-<Card variant="transparent" --width-card="100%" --height-card="fit-content">
-  <div class="trakt-trivia-container">
-    {#if !trivia.isSpoiler}
+<InfoCard>
+  {#if !trivia.isSpoiler}
+    {@render parsedContent()}
+  {:else}
+    <Spoiler {media} type={media.type}>
       {@render parsedContent()}
-    {:else}
-      <Spoiler {media} type={media.type}>
-        {@render parsedContent()}
-      </Spoiler>
-    {/if}
-  </div>
-</Card>
-
-<style>
-  .trakt-trivia-container {
-    position: relative;
-
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-s);
-
-    box-sizing: border-box;
-    padding: var(--ni-20) var(--ni-24);
-
-    background: color-mix(in srgb, var(--color-text-primary) 4%, transparent);
-    border: var(--border-thickness-xxs) solid
-      color-mix(in srgb, var(--color-text-primary) 24%, transparent);
-    border-radius: var(--border-radius-m);
-
-    :global(.trakt-spoiler) {
-      cursor: pointer;
-    }
-
-    :global(li) {
-      font-size: var(--font-size-text);
-    }
-  }
-</style>
+    </Spoiler>
+  {/if}
+</InfoCard>

--- a/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/trivia/_internal/TriviaSummaryCard.svelte
@@ -87,8 +87,6 @@
     padding: var(--ni-20);
 
     background: var(--background-vip-drawer);
-    border: var(--border-thickness-xxs) solid
-      color-mix(in srgb, var(--color-text-primary) 17%, transparent);
     border-radius: var(--border-radius-xl);
   }
 

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -188,11 +188,6 @@
     var(--shade-800) 10%,
     transparent
   );
-  --background-sentiment-highlight: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--shade-800) 5%, transparent) 0%,
-    color-mix(in srgb, var(--shade-800) 2.5%, transparent) 100%
-  );
 
   /*
    * VIP page
@@ -496,11 +491,6 @@
     in srgb,
     var(--shade-10) 10%,
     transparent
-  );
-  --background-sentiment-highlight: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--shade-10) 5%, transparent) 0%,
-    color-mix(in srgb, var(--shade-10) 2.5%, transparent) 100%
   );
 
   /*


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2595
- Small refactor to extract an `InfoCard`
- Makes the content in the sentiment drawer more consistent with the trivia.
- Also removes the border from the trivia summary card to keep it more consistent with other cards.

## 👀 Examples 👀
Before/after:
<img width="520" height="284" alt="Screenshot 2026-06-12 at 09 42 56" src="https://github.com/user-attachments/assets/9d84fbc9-75af-4659-b78e-58efa8dde5ca" />

<img width="520" height="284" alt="Screenshot 2026-06-12 at 09 42 34" src="https://github.com/user-attachments/assets/9630539e-c08f-43cc-843f-a613aaecc246" />

Before/after:
<img width="413" height="896" alt="Screenshot 2026-06-12 at 09 43 08" src="https://github.com/user-attachments/assets/5ddbda0f-3bd2-4f65-a121-ed61d9291ac5" />

<img width="423" height="894" alt="Screenshot 2026-06-12 at 09 42 12" src="https://github.com/user-attachments/assets/d6edf00e-c817-45ae-a528-1957ea992b2d" />


## Update
Small tweaks: no more borders, and aligns highlight & pros/cons (e.g. title in the card). Main sentiment is no longer in a card:
<img width="413" height="896" alt="Screenshot 2026-06-12 at 11 51 49" src="https://github.com/user-attachments/assets/dc9c3ba2-843c-4eb3-a373-061247644e3a" />
