### PR TITLE
Settings: make all section titles bold

### DIFF
--- a/projects/client/src/lib/sections/settings/StreamingSyncDetail.svelte
+++ b/projects/client/src/lib/sections/settings/StreamingSyncDetail.svelte
@@ -35,7 +35,6 @@
   <SettingsBlock
     title={m.header_sync_detail({ id: syncId })}
     description={m.description_sync_detail()}
-    boldTitle
   >
     {#snippet titlePrefix()}
       <span class="title-prefix">

--- a/projects/client/src/lib/sections/settings/_internal/SettingsBlock.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsBlock.svelte
@@ -5,12 +5,10 @@
     title,
     description,
     children,
-    boldTitle = false,
     titlePrefix,
   }: ChildrenProps & {
     title: string;
     description: string;
-    boldTitle?: boolean;
     titlePrefix?: Snippet;
   } = $props();
 </script>
@@ -18,8 +16,7 @@
 <div class="trakt-settings-block">
   <div class="trakt-settings-block-header">
     <p
-      class="settings-title"
-      class:bold={boldTitle}
+      class="settings-title bold"
       class:has-prefix={Boolean(titlePrefix)}
     >
       {#if titlePrefix}{@render titlePrefix()}{/if}{title}

--- a/projects/client/src/lib/sections/settings/_internal/streaming-sync/DataSyncs.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-sync/DataSyncs.svelte
@@ -47,7 +47,6 @@
 <SettingsBlock
   title={m.header_data_syncs()}
   description={m.description_data_syncs()}
-  boldTitle
 >
   {#if $summary && $summary.count > 0 && $summary.latest}
     <div class="trakt-data-syncs-banner">

--- a/projects/client/src/lib/sections/settings/_internal/streaming-sync/SyncItemsSection.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-sync/SyncItemsSection.svelte
@@ -76,7 +76,7 @@
   );
 </script>
 
-<SettingsBlock {title} {description} boldTitle>
+<SettingsBlock {title} {description}>
   {#if $isError}
     <SyncLoadError onRetry={retry} />
   {:else if !$isLoading && $items.length === 0}


### PR DESCRIPTION
# Make all settings section titles bold

Previously only the streaming-sync sections rendered their titles bold, via an opt-in `boldTitle` prop on `SettingsBlock`. This makes bold the default for **every** settings section so titles are consistent across the page.

# Changes
- `SettingsBlock` now always applies the `bold` class to its title and the `boldTitle` prop is removed (default + type).
- Dropped the redundant `boldTitle` attribute from the three callers that set it: `StreamingSyncDetail`, `DataSyncs`, `SyncItemsSection`.

# Result
Appearance, Behavior, Profile, Genres, Blocked Users, Clear Data, Raw Export/Import, and Preview Features now match the streaming-sync look with bold section titles.
