### PR TITLE
fix(list): only drag when interacting with drag handle

### DIFF
--- a/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
@@ -382,7 +382,7 @@
 
   tbody {
     tr {
-      cursor: grab;
+      cursor: default;
       filter: drop-shadow(
         var(--ni-1) var(--ni-1) var(--ni-4)
           color-mix(in srgb, var(--color-shadow) 10%, transparent)
@@ -397,7 +397,6 @@
     }
 
     td {
-      touch-action: none;
       user-select: none;
       -webkit-user-select: none;
       background: var(--reorder-row-background);
@@ -511,7 +510,7 @@
     gap: var(--ni-3);
     border-radius: var(--border-radius-m);
     color: var(--color-text-secondary);
-    pointer-events: none;
+    cursor: grab;
     touch-action: none;
 
     span {

--- a/projects/client/src/lib/sections/lists/user/_internal/reorderDrag.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/reorderDrag.spec.ts
@@ -23,6 +23,9 @@ function makeRow(
 ): HTMLTableRowElement {
   const row = document.createElement('tr');
   row.setAttribute('data-reorder-key', key);
+  const handle = document.createElement('div');
+  handle.className = 'drag-handle';
+  row.appendChild(handle);
   vi.spyOn(row, 'getBoundingClientRect').mockReturnValue({
     top,
     bottom: top + height,
@@ -104,7 +107,8 @@ describe('action: reorderDrag', () => {
     target: HTMLElement,
     { button = 0, pointerId = 1, clientX = 50, clientY = 25 } = {},
   ) {
-    target.dispatchEvent(
+    const dispatchTarget = target.querySelector('.drag-handle') ?? target;
+    dispatchTarget.dispatchEvent(
       new PointerEvent('pointerdown', {
         bubbles: true,
         button,
@@ -309,6 +313,9 @@ describe('action: reorderDrag', () => {
     it('should use the provided attribute name to identify draggable rows', () => {
       const customRow = document.createElement('tr');
       customRow.setAttribute('data-list-row', 'a');
+      const customHandle = document.createElement('div');
+      customHandle.className = 'drag-handle';
+      customRow.appendChild(customHandle);
       vi.spyOn(customRow, 'getBoundingClientRect').mockReturnValue(
         rowA.getBoundingClientRect(),
       );

--- a/projects/client/src/lib/sections/lists/user/_internal/reorderDrag.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/reorderDrag.ts
@@ -21,6 +21,7 @@ type ReorderDragParams = {
   ) => void;
   rowDataAttribute?: string;
   scrollContainerClassName?: string;
+  dragHandleSelector?: string;
 };
 
 const autoScrollEdgeSize = 88;
@@ -37,6 +38,7 @@ export function reorderDrag(
     .replace(/^data-/, '')
     .replace(/-([a-z])/g, (_, c) => c.toUpperCase());
   const scrollClass = params.scrollContainerClassName ?? 'trakt-drawer-content';
+  const handleSelector = params.dragHandleSelector ?? '.drag-handle';
 
   let draggedKey: string | null = null;
   let dragGhost: DragGhost | null = null;
@@ -190,7 +192,10 @@ export function reorderDrag(
   function handlePointerDown(event: PointerEvent) {
     if (event.button !== 0) return;
 
-    const row = (event.target as HTMLElement).closest<HTMLTableRowElement>(
+    const target = event.target as HTMLElement;
+    if (!target.closest(handleSelector)) return;
+
+    const row = target.closest<HTMLTableRowElement>(
       `[${rowAttr}]`,
     );
     const key = row?.dataset[rowDatasetKey];


### PR DESCRIPTION
## 🎶 Notes 🎶

-  Fixes #2616
- Dragging list items is now only via the drag handle, making it possible to scroll again on mobile devices 😅

## 👀 Example 👀

Before:

https://github.com/user-attachments/assets/d6650118-e566-4e61-bc7f-d5c75eabbba1

After:

https://github.com/user-attachments/assets/20378a55-19c8-4366-91e0-57e62dc92e3b

