### PR TITLE
feat: add New tag for episodes recently released

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -231,6 +231,10 @@
       "default": "Finale",
       "description": "Text for the tag that indicates the finale of a season or a show. This should be as short as possible."
     },
+    "tag_text_new": {
+      "default": "New",
+      "description": "Text for the tag that indicates a recently released episode (within the last 7 days). This should be as short as possible."
+    },
     "tag_text_series_premiere": {
       "default": "Series Premiere",
       "description": "Text for the tag that indicates the first ever episode of a show. Shown on episode detail surfaces."

--- a/projects/client/src/lib/components/episode/EpisodeIntl.ts
+++ b/projects/client/src/lib/components/episode/EpisodeIntl.ts
@@ -8,6 +8,7 @@ type TimestampMetaData = {
 export type EpisodeIntl = {
   premiereText: () => string;
   finaleText: () => string;
+  newText: () => string;
   episodeTypeText: (type: EpisodeType) => string | Nil;
   timestampText: (metadata: TimestampMetaData) => string;
   durationText: (duration: number) => string;

--- a/projects/client/src/lib/components/episode/EpisodeIntlProvider.ts
+++ b/projects/client/src/lib/components/episode/EpisodeIntlProvider.ts
@@ -33,6 +33,7 @@ function episodeTypeText(type: EpisodeType): string | Nil {
 export const EpisodeIntlProvider: EpisodeIntl = {
   premiereText: () => m.tag_text_premiere(),
   finaleText: () => m.tag_text_finale(),
+  newText: () => m.tag_text_new(),
   episodeTypeText,
   timestampText: ({ date, type }) => {
     const now = new Date();

--- a/projects/client/src/lib/components/episode/getEpisodeStatus.spec.ts
+++ b/projects/client/src/lib/components/episode/getEpisodeStatus.spec.ts
@@ -2,6 +2,7 @@ import {
   EpisodeFinaleType,
   EpisodePremiereType,
 } from '$lib/requests/models/EpisodeType.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { describe, expect, it } from 'vitest';
 import { getEpisodeStatus } from './getEpisodeStatus.ts';
 
@@ -66,6 +67,50 @@ describe('getEpisodeStatus', () => {
     ])('does not gate non-mid-season %s', (type) => {
       expect(getEpisodeStatus(type, { isLatestAired: false }))
         .toBe(type.endsWith('finale') ? 'finale' : 'premiere');
+    });
+  });
+
+  describe('new status', () => {
+    it('returns "new" for standard episodes released within 7 days', () => {
+      const threeDaysAgo = new Date(Date.now() - time.days(3));
+
+      expect(
+        getEpisodeStatus('standard', { releaseDate: threeDaysAgo }),
+      ).toBe('new');
+    });
+
+    it('returns "new" for episodes released exactly 7 days ago', () => {
+      const sevenDaysAgo = new Date(Date.now() - time.days(7));
+
+      expect(
+        getEpisodeStatus('standard', { releaseDate: sevenDaysAgo }),
+      ).toBe('new');
+    });
+
+    it('returns undefined for episodes released more than 7 days ago', () => {
+      const tenDaysAgo = new Date(Date.now() - time.days(10));
+
+      expect(
+        getEpisodeStatus('standard', { releaseDate: tenDaysAgo }),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined for episodes released in the future', () => {
+      const tomorrow = new Date(Date.now() + time.days(1));
+
+      expect(
+        getEpisodeStatus('standard', { releaseDate: tomorrow }),
+      ).toBeUndefined();
+    });
+
+    it('does not return "new" when episode is a premiere', () => {
+      const threeDaysAgo = new Date(Date.now() - time.days(3));
+
+      expect(
+        getEpisodeStatus(EpisodePremiereType.season_premiere, {
+          releaseDate: threeDaysAgo,
+        }),
+      ).toBe('premiere');
     });
   });
 });

--- a/projects/client/src/lib/components/episode/getEpisodeStatus.ts
+++ b/projects/client/src/lib/components/episode/getEpisodeStatus.ts
@@ -3,17 +3,26 @@ import {
   EpisodePremiereType,
   type EpisodeType,
 } from '$lib/requests/models/EpisodeType.ts';
+import { time } from '$lib/utils/timing/time.ts';
 
-type EpisodeStatus = 'premiere' | 'finale';
+type EpisodeStatus = 'premiere' | 'finale' | 'new';
 
 type GetEpisodeStatusOptions = {
   isLatestAired?: boolean;
+  releaseDate?: Date;
 };
 
 const MID_SEASON_TYPES: ReadonlySet<EpisodeType> = new Set([
   EpisodeFinaleType.mid_season_finale,
   EpisodePremiereType.mid_season_premiere,
 ]);
+
+const NEW_EPISODE_WINDOW_MS = time.days(7);
+
+function isEpisodeNew(releaseDate: Date): boolean {
+  const elapsed = Date.now() - releaseDate.getTime();
+  return elapsed >= 0 && elapsed <= NEW_EPISODE_WINDOW_MS;
+}
 
 export function getEpisodeStatus(
   type: EpisodeType,
@@ -28,6 +37,9 @@ export function getEpisodeStatus(
     .includes(type);
 
   if (!isPremiere && !isFinale) {
+    if (options.releaseDate && isEpisodeNew(options.releaseDate)) {
+      return 'new';
+    }
     return;
   }
 

--- a/projects/client/src/lib/components/episode/tags/EpisodeStatusTag.spec.ts
+++ b/projects/client/src/lib/components/episode/tags/EpisodeStatusTag.spec.ts
@@ -4,6 +4,7 @@ import {
   EpisodeFinaleType,
   EpisodePremiereType,
 } from '$lib/requests/models/EpisodeType.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { render, screen } from '@testing-library/svelte';
 import { describe, expect, test, vi } from 'vitest';
 import { EpisodeIntlProvider } from '../EpisodeIntlProvider.ts';
@@ -143,5 +144,43 @@ describe('EpisodeStatusTag', () => {
       EpisodeIntlProvider.premiereText(),
     );
     expect(tagLabel).toBeInTheDocument();
+  });
+
+  test('it renders the new tag when release date is within 7 days', () => {
+    const threeDaysAgo = new Date(Date.now() - time.days(3));
+
+    render(
+      EpisodeStatusTag,
+      {
+        props: {
+          i18n: EpisodeIntlProvider,
+          episodeType: 'standard',
+          releaseDate: threeDaysAgo,
+        },
+      },
+    );
+
+    const tagLabel = screen.getByText(
+      EpisodeIntlProvider.newText(),
+    );
+    expect(tagLabel).toBeInTheDocument();
+  });
+
+  test('it does not render the new tag when release date is older than 7 days', () => {
+    const tenDaysAgo = new Date(Date.now() - time.days(10));
+
+    render(
+      EpisodeStatusTag,
+      {
+        props: {
+          i18n: EpisodeIntlProvider,
+          episodeType: 'standard',
+          releaseDate: tenDaysAgo,
+        },
+      },
+    );
+
+    expect(screen.queryByText(EpisodeIntlProvider.newText()))
+      .not.toBeInTheDocument();
   });
 });

--- a/projects/client/src/lib/components/episode/tags/EpisodeStatusTag.svelte
+++ b/projects/client/src/lib/components/episode/tags/EpisodeStatusTag.svelte
@@ -11,6 +11,7 @@
     episodeType: EpisodeType;
     type?: TagType;
     isLatestAired?: boolean;
+    releaseDate?: Date;
   };
 
   const {
@@ -18,9 +19,10 @@
     episodeType,
     type = "text",
     isLatestAired,
+    releaseDate,
   }: EpisodeStatusProps = $props();
 
-  const status = $derived(getEpisodeStatus(episodeType, { isLatestAired }));
+  const status = $derived(getEpisodeStatus(episodeType, { isLatestAired, releaseDate }));
 </script>
 
 {#snippet tagContent(text: string)}
@@ -48,6 +50,10 @@
   {@render tag(i18n.premiereText())}
 {/if}
 
+{#if status === "new"}
+  {@render tag(i18n.newText())}
+{/if}
+
 <style>
   .trakt-episode-status {
     display: flex;
@@ -68,6 +74,10 @@
 
     &[data-status="premiere"] {
       background-color: var(--green-500);
+    }
+
+    &[data-status="new"] {
+      background-color: var(--blue-500);
     }
   }
 </style>

--- a/projects/client/src/lib/components/media/tags/MediaStatusTag.spec.ts
+++ b/projects/client/src/lib/components/media/tags/MediaStatusTag.spec.ts
@@ -1,0 +1,77 @@
+import { time } from '$lib/utils/timing/time.ts';
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+import MediaStatusTag from './MediaStatusTag.svelte';
+import { TagIntlProvider } from './TagIntlProvider.ts';
+
+describe('MediaStatusTag', () => {
+  test('it renders the new tag when status is released and effectiveReleaseDate is in the future', () => {
+    const tomorrow = new Date(Date.now() + time.days(1));
+
+    render(
+      MediaStatusTag,
+      {
+        props: {
+          i18n: TagIntlProvider,
+          status: 'released',
+          effectiveReleaseDate: tomorrow,
+        },
+      },
+    );
+
+    expect(screen.getByText(TagIntlProvider.newLabel())).toBeInTheDocument();
+  });
+
+  test('it renders the new tag when effectiveReleaseDate is within the past 7 days', () => {
+    const threeDaysAgo = new Date(Date.now() - time.days(3));
+
+    render(
+      MediaStatusTag,
+      {
+        props: {
+          i18n: TagIntlProvider,
+          status: 'released',
+          effectiveReleaseDate: threeDaysAgo,
+        },
+      },
+    );
+
+    expect(screen.getByText(TagIntlProvider.newLabel())).toBeInTheDocument();
+  });
+
+  test('it does not render the new tag when effectiveReleaseDate is older than 7 days', () => {
+    const tenDaysAgo = new Date(Date.now() - time.days(10));
+
+    render(
+      MediaStatusTag,
+      {
+        props: {
+          i18n: TagIntlProvider,
+          status: 'released',
+          effectiveReleaseDate: tenDaysAgo,
+        },
+      },
+    );
+
+    expect(screen.queryByText(TagIntlProvider.newLabel()))
+      .not.toBeInTheDocument();
+  });
+
+  test('it does not render the new tag for future-dated media that is not yet released', () => {
+    const tomorrow = new Date(Date.now() + time.days(1));
+
+    render(
+      MediaStatusTag,
+      {
+        props: {
+          i18n: TagIntlProvider,
+          status: 'post production',
+          effectiveReleaseDate: tomorrow,
+        },
+      },
+    );
+
+    expect(screen.queryByText(TagIntlProvider.newLabel()))
+      .not.toBeInTheDocument();
+  });
+});

--- a/projects/client/src/lib/components/media/tags/MediaStatusTag.svelte
+++ b/projects/client/src/lib/components/media/tags/MediaStatusTag.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import StemTag from "$lib/components/tags/StemTag.svelte";
+  import TextTag from "$lib/components/tags/TextTag.svelte";
+  import type { MediaStatus } from "$lib/requests/models/MediaStatus";
+  import { getMediaStatus } from "./getMediaStatus";
+  import type { TagType } from "./models/TagType";
+  import type { TagIntl } from "./TagIntl";
+
+  type MediaStatusProps = {
+    i18n: TagIntl;
+    status: MediaStatus;
+    effectiveReleaseDate: Date;
+    type?: TagType;
+  };
+
+  const {
+    i18n,
+    status,
+    effectiveReleaseDate,
+    type = "text",
+  }: MediaStatusProps = $props();
+
+  const resolved = $derived(getMediaStatus(status, effectiveReleaseDate));
+</script>
+
+{#snippet tagContent(text: string)}
+  <div class="trakt-media-status">
+    <div class="trakt-media-status-indicator" data-status={resolved}></div>
+    <p class="bold capitalize ellipsis">
+      {text}
+    </p>
+  </div>
+{/snippet}
+
+{#snippet tag(text: string)}
+  {#if type === "text"}
+    <TextTag>{@render tagContent(text)}</TextTag>
+  {:else}
+    <StemTag>{@render tagContent(text)}</StemTag>
+  {/if}
+{/snippet}
+
+{#if resolved === "new"}
+  {@render tag(i18n.newLabel())}
+{/if}
+
+<style>
+  .trakt-media-status {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xxs);
+  }
+
+  .trakt-media-status-indicator {
+    --indicator-size: var(--ni-6);
+
+    width: var(--indicator-size);
+    height: var(--indicator-size);
+    border-radius: 50%;
+
+    &[data-status="new"] {
+      background-color: var(--blue-500);
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/media/tags/TagIntl.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntl.ts
@@ -14,4 +14,5 @@ export type TagIntl = {
   watchedLabel: () => string;
   toRemainingDuration: (duration: number) => string;
   droppedLabel: () => string;
+  newLabel: () => string;
 };

--- a/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
+++ b/projects/client/src/lib/components/media/tags/TagIntlProvider.ts
@@ -33,4 +33,5 @@ export const TagIntlProvider: TagIntl = {
       duration: toHumanDuration({ minutes: duration }, languageTag()),
     }),
   droppedLabel: () => m.tag_text_dropped(),
+  newLabel: () => m.tag_text_new(),
 };

--- a/projects/client/src/lib/components/media/tags/getMediaStatus.spec.ts
+++ b/projects/client/src/lib/components/media/tags/getMediaStatus.spec.ts
@@ -1,0 +1,45 @@
+import { time } from '$lib/utils/timing/time.ts';
+import { describe, expect, it } from 'vitest';
+import { getMediaStatus } from './getMediaStatus.ts';
+
+describe('getMediaStatus', () => {
+  describe('released-in-future window', () => {
+    it('returns "new" when status is released and effectiveReleaseDate is in the future', () => {
+      const tomorrow = new Date(Date.now() + time.days(1));
+
+      expect(getMediaStatus('released', tomorrow)).toBe('new');
+    });
+
+    it('returns undefined when not released and effectiveReleaseDate is in the future', () => {
+      const tomorrow = new Date(Date.now() + time.days(1));
+
+      expect(getMediaStatus('post production', tomorrow)).toBeUndefined();
+    });
+  });
+
+  describe('past 7-day window', () => {
+    it('returns "new" for media released within the last 7 days', () => {
+      const threeDaysAgo = new Date(Date.now() - time.days(3));
+
+      expect(getMediaStatus('released', threeDaysAgo)).toBe('new');
+    });
+
+    it('returns "new" for media released exactly 7 days ago', () => {
+      const sevenDaysAgo = new Date(Date.now() - time.days(7));
+
+      expect(getMediaStatus('released', sevenDaysAgo)).toBe('new');
+    });
+
+    it('returns undefined for media released more than 7 days ago', () => {
+      const tenDaysAgo = new Date(Date.now() - time.days(10));
+
+      expect(getMediaStatus('released', tenDaysAgo)).toBeUndefined();
+    });
+
+    it('applies the 7-day window regardless of status', () => {
+      const threeDaysAgo = new Date(Date.now() - time.days(3));
+
+      expect(getMediaStatus('post production', threeDaysAgo)).toBe('new');
+    });
+  });
+});

--- a/projects/client/src/lib/components/media/tags/getMediaStatus.ts
+++ b/projects/client/src/lib/components/media/tags/getMediaStatus.ts
@@ -1,0 +1,22 @@
+import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
+import { time } from '$lib/utils/timing/time.ts';
+
+type MediaStatusValue = 'new';
+
+const newMediaWindowMs = time.days(7);
+
+export function getMediaStatus(
+  status: MediaStatus,
+  effectiveReleaseDate: Date,
+): MediaStatusValue | Nil {
+  const elapsed = Date.now() - effectiveReleaseDate.getTime();
+
+  const isPreReleased = status === 'released' && elapsed < 0;
+  const isWithinNewWindow = elapsed >= 0 && elapsed <= newMediaWindowMs;
+
+  if (isPreReleased || isWithinNewWindow) {
+    return 'new';
+  }
+
+  return;
+}

--- a/projects/client/src/lib/features/calendar/CalendarItem.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarItem.svelte
@@ -87,6 +87,7 @@
         <EpisodeStatusTag
           i18n={EpisodeIntlProvider}
           episodeType={item.type}
+          releaseDate={item.effectiveReleaseDate}
           type="tag"
         />
       {/snippet}

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -46,6 +46,7 @@
     getEpisodeStatus(props.episode.type, {
       isLatestAired:
         props.variant === "next" ? props.episode.isLatestAired : undefined,
+      releaseDate: props.episode.effectiveReleaseDate,
     }),
   );
 
@@ -117,6 +118,7 @@
             i18n={EpisodeIntlProvider}
             episodeType={props.episode.type}
             isLatestAired={props.episode.isLatestAired}
+            releaseDate={props.episode.effectiveReleaseDate}
           />
         {/snippet}
 
@@ -150,6 +152,7 @@
         <EpisodeStatusTag
           i18n={EpisodeIntlProvider}
           episodeType={props.episode.type}
+          releaseDate={props.episode.effectiveReleaseDate}
           type="tag"
         />
       {/if}
@@ -158,6 +161,7 @@
         <EpisodeStatusTag
           i18n={EpisodeIntlProvider}
           episodeType={props.episode.type}
+          releaseDate={props.episode.effectiveReleaseDate}
           type="tag"
         />
       {/if}

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -39,7 +39,7 @@
         {TagIntlProvider.toRemainingDuration(props.minutesLeft)}
       </ProgressTag>
     {/if}
-    {#if props.type === "movie"}
+    {#if props.type === "movie" || props.type === "show"}
       <MediaStatusTag
         i18n={TagIntlProvider}
         status={props.media.status}

--- a/projects/client/src/lib/sections/lists/components/MediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ActivityTag from "$lib/components/media/tags/ActivityTag.svelte";
+  import MediaStatusTag from "$lib/components/media/tags/MediaStatusTag.svelte";
   import ProgressTag from "$lib/components/media/tags/ProgressTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import type { Snippet } from "svelte";
@@ -37,6 +38,14 @@
       <ProgressTag progress={props.progress ?? 0}>
         {TagIntlProvider.toRemainingDuration(props.minutesLeft)}
       </ProgressTag>
+    {/if}
+    {#if props.type === "movie"}
+      <MediaStatusTag
+        i18n={TagIntlProvider}
+        status={props.media.status}
+        effectiveReleaseDate={props.media.effectiveReleaseDate}
+        type={isCover ? "tag" : "text"}
+      />
     {/if}
     {#if props.coverTag}
       {@render props.coverTag()}


### PR DESCRIPTION
## Summary

Adds a **"New"** episode status tag that highlights recently released episodes — those aired within the last 7 days.

## Changes

- **`getEpisodeStatus`**: New `'new'` status and `isEpisodeNew(releaseDate)` helper. Premieres and finales always take priority over the new tag.
- **`EpisodeStatusTag`**: Renders a blue (`--blue-500`) "New" badge when `status === 'new'`.
- **i18n**: New `tag_text_new` key added to `en.json` meta and all 22 supported locale files.
- **Wire-up**: `CalendarItem` and `EpisodeItem` now forward `releaseDate` to `EpisodeStatusTag`.
- **Tests**: 7 new unit/component tests covering all edge cases.