### PR TITLE
feat: implement clearing library data

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7294,6 +7294,10 @@
       "default": "History",
       "description": "Text for the source option that allows users to clear their watch history."
     },
+    "text_clear_source_library": {
+      "default": "Library",
+      "description": "Text for the source option that allows users to clear their library (collection)."
+    },
     "button_text_clear_now": {
       "default": "Clear now",
       "description": "Text for the button that clears the user's chosen source, e.g. watchlist, ratings, etc.."

--- a/projects/client/src/lib/features/auth/queries/_internal/toCollectionTraktIds.ts
+++ b/projects/client/src/lib/features/auth/queries/_internal/toCollectionTraktIds.ts
@@ -1,0 +1,10 @@
+import type {
+  CollectionMinimalResponse,
+  CollectionMinimalShowResponse,
+} from '@trakt/api';
+
+export function toCollectionTraktIds(
+  response: CollectionMinimalResponse | CollectionMinimalShowResponse | Nil,
+): number[] {
+  return Object.keys(response ?? {}).map((key) => parseInt(key, 10));
+}

--- a/projects/client/src/lib/features/auth/queries/currentUserCollectionQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserCollectionQuery.ts
@@ -1,0 +1,44 @@
+import z from 'zod';
+import { api, type ApiParams } from '../../../requests/api.ts';
+import { InvalidateAction } from '../../../requests/models/InvalidateAction.ts';
+import { time } from '../../../utils/timing/time.ts';
+import { defineQuery } from '../../query/defineQuery.ts';
+import { toCollectionTraktIds } from './_internal/toCollectionTraktIds.ts';
+
+const UserCollectionSchema = z.object({
+  movies: z.set(z.number()),
+  episodes: z.set(z.number()),
+});
+
+export type UserCollection = z.infer<typeof UserCollectionSchema>;
+
+const currentUserCollectionRequest = (
+  { fetch }: ApiParams,
+  type: 'movies' | 'episodes',
+) =>
+  api({ fetch })
+    .sync
+    .collection
+    .minimal[type]({
+      query: {},
+    });
+
+export const currentUserCollectionQuery = defineQuery({
+  key: 'currentUserCollection',
+  request: (params) =>
+    Promise.all([
+      currentUserCollectionRequest(params, 'movies'),
+      currentUserCollectionRequest(params, 'episodes'),
+    ]),
+  invalidations: [
+    InvalidateAction.Collected('movie'),
+    InvalidateAction.Collected('episode'),
+  ],
+  dependencies: [],
+  mapper: ([moviesResponse, episodesResponse]) => ({
+    movies: new Set(toCollectionTraktIds(moviesResponse.body)),
+    episodes: new Set(toCollectionTraktIds(episodesResponse.body)),
+  }),
+  schema: UserCollectionSchema,
+  ttl: time.hours(3),
+});

--- a/projects/client/src/lib/features/auth/queries/currentUserPlexLibraryQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserPlexLibraryQuery.ts
@@ -1,11 +1,9 @@
-import {
-  type CollectionMinimalResponse,
-  type CollectionMinimalShowResponse,
-} from '@trakt/api';
 import z from 'zod';
 import { api, type ApiParams } from '../../../requests/api.ts';
+import { InvalidateAction } from '../../../requests/models/InvalidateAction.ts';
 import { time } from '../../../utils/timing/time.ts';
 import { defineQuery } from '../../query/defineQuery.ts';
+import { toCollectionTraktIds } from './_internal/toCollectionTraktIds.ts';
 
 const UserPlexLibrarySchema = z.object({
   movieIds: z.array(z.number()),
@@ -28,12 +26,6 @@ const currentUserPlexLibraryRequest = (
       },
     });
 
-function toTraktIds(
-  libraryResponse: CollectionMinimalResponse | CollectionMinimalShowResponse,
-): number[] {
-  return Object.keys(libraryResponse).map((key) => parseInt(key, 10));
-}
-
 export const currentUserPlexLibraryQuery = defineQuery({
   key: 'currentUserPlexLibrary',
   request: (params) =>
@@ -42,12 +34,15 @@ export const currentUserPlexLibraryQuery = defineQuery({
       currentUserPlexLibraryRequest(params, 'shows'),
       currentUserPlexLibraryRequest(params, 'episodes'),
     ]),
-  invalidations: [],
+  invalidations: [
+    InvalidateAction.Collected('movie'),
+    InvalidateAction.Collected('episode'),
+  ],
   dependencies: [],
   mapper: ([moviesResponse, showsResponse, episodesResponse]) => ({
-    movieIds: toTraktIds(moviesResponse.body),
-    showIds: toTraktIds(showsResponse.body),
-    episodeIds: toTraktIds(episodesResponse.body),
+    movieIds: toCollectionTraktIds(moviesResponse.body),
+    showIds: toCollectionTraktIds(showsResponse.body),
+    episodeIds: toCollectionTraktIds(episodesResponse.body),
   }),
   schema: UserPlexLibrarySchema,
   ttl: time.hours(3),

--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -14,6 +14,10 @@ import {
 } from 'rxjs';
 import { getContext, setContext } from 'svelte';
 import {
+  currentUserCollectionQuery,
+  type UserCollection,
+} from '../queries/currentUserCollectionQuery.ts';
+import {
   currentUserCommentReactionsQuery,
   type UserReactions,
 } from '../queries/currentUserCommentReactionsQuery.ts';
@@ -142,6 +146,7 @@ function createUseUserInstance() {
   const userQuerySignal = useQuery(currentUserSettingsQuery());
   const { history: historySignal } = useCurrentUserHistory();
   const watchlistQuerySignal = useQuery(currentUserWatchlistQuery());
+  const collectionQuerySignal = useQuery(currentUserCollectionQuery());
   const ratingsQuerySignal = useQuery(currentUserRatingsQuery());
   const commentReactionsQuerySignal = useQuery(
     currentUserCommentReactionsQuery(),
@@ -170,6 +175,10 @@ function createUseUserInstance() {
           watchlist: of<UserWatchlist>({
             movies: new Set(),
             shows: new Set(),
+          }),
+          collection: of<UserCollection>({
+            movies: new Set(),
+            episodes: new Set(),
           }),
           ratings: of<UserRatings>({
             episodes: new Map(),
@@ -211,6 +220,9 @@ function createUseUserInstance() {
         history: historySignal,
         watchlist: watchlistQuerySignal.pipe(
           map((watchlist) => watchlist.data),
+        ),
+        collection: collectionQuerySignal.pipe(
+          map((collection) => collection.data),
         ),
         ratings: ratingsQuerySignal.pipe(
           map((ratings) => ratings.data),
@@ -258,6 +270,9 @@ function createUseUserInstance() {
     history: share(sharedUserContext$.pipe(switchMap((ctx) => ctx.history))),
     watchlist: share(
       sharedUserContext$.pipe(switchMap((ctx) => ctx.watchlist)),
+    ),
+    collection: share(
+      sharedUserContext$.pipe(switchMap((ctx) => ctx.collection)),
     ),
     ratings: share(sharedUserContext$.pipe(switchMap((ctx) => ctx.ratings))),
     reactions: share(

--- a/projects/client/src/lib/requests/models/InvalidateAction.ts
+++ b/projects/client/src/lib/requests/models/InvalidateAction.ts
@@ -11,6 +11,7 @@ export type InvalidateActionOptions =
   | `${typeof INVALIDATION_ID}:auth`
   | `${typeof INVALIDATION_ID}:rated:${ExtendedMediaType}`
   | `${typeof INVALIDATION_ID}:mark_as_watched:${ExtendedMediaType}`
+  | `${typeof INVALIDATION_ID}:collected:${ExtendedMediaType}`
   | `${typeof INVALIDATION_ID}:watchlisted:${MediaType}`
   | `${typeof INVALIDATION_ID}:dropped::${MediaType}`
   | `${typeof INVALIDATION_ID}:restored:show`
@@ -33,6 +34,7 @@ type TypeDataMap = {
   'auth': null;
   'rated': ExtendedMediaType;
   'mark_as_watched': ExtendedMediaType;
+  'collected': ExtendedMediaType;
   'watchlisted': MediaType;
   'dropped': MediaType;
   'restored': 'show';
@@ -77,6 +79,9 @@ export const InvalidateAction = {
 
   MarkAsWatched: (type: ExtendedMediaType) =>
     buildInvalidationKey('mark_as_watched', type),
+
+  Collected: (type: ExtendedMediaType) =>
+    buildInvalidationKey('collected', type),
 
   Watchlisted: (type: MediaType) => buildInvalidationKey('watchlisted', type),
   Listed: (type: MediaType) => buildInvalidationKey('listed', type),

--- a/projects/client/src/lib/requests/queries/sync/libraryEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/libraryEpisodesQuery.ts
@@ -1,4 +1,5 @@
 import { api } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { defineInfiniteQuery } from '../../../features/query/defineQuery.ts';
 import { time } from '../../../utils/timing/time.ts';
 import { extractPageMeta } from '../../_internal/extractPageMeta.ts';
@@ -24,7 +25,7 @@ export const episodeLibraryRequest = (
 
 export const libraryEpisodesQuery = defineInfiniteQuery({
   key: 'libraryEpisodesQuery',
-  invalidations: [],
+  invalidations: [InvalidateAction.Collected('episode')],
   dependencies: (params) => [params.page, params.limit, params.availableOn],
   request: episodeLibraryRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/sync/libraryMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/libraryMoviesQuery.ts
@@ -1,4 +1,5 @@
 import { api } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { defineInfiniteQuery } from '../../../features/query/defineQuery.ts';
 import { time } from '../../../utils/timing/time.ts';
 import { extractPageMeta } from '../../_internal/extractPageMeta.ts';
@@ -24,7 +25,7 @@ export const movieLibraryRequest = (
 
 export const libraryMoviesQuery = defineInfiniteQuery({
   key: 'libraryMoviesQuery',
-  invalidations: [],
+  invalidations: [InvalidateAction.Collected('movie')],
   dependencies: (params) => [params.page, params.limit, params.availableOn],
   request: movieLibraryRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/sync/libraryQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/libraryQuery.ts
@@ -1,6 +1,7 @@
 import type { DiscoverMode } from '$lib/features/discover/models/DiscoverMode.ts';
 import { defineInfiniteQuery } from '$lib/features/query/defineQuery.ts';
 import { api } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { extractPageMeta } from '../../_internal/extractPageMeta.ts';
 import { LibraryItemSchema } from '../../models/LibraryItem.ts';
@@ -38,7 +39,10 @@ const mediaLibraryRequest = (
 
 export const libraryQuery = defineInfiniteQuery({
   key: 'libraryQuery',
-  invalidations: [],
+  invalidations: [
+    InvalidateAction.Collected('movie'),
+    InvalidateAction.Collected('episode'),
+  ],
   dependencies: (
     params,
   ) => [params.page, params.limit, params.availableOn, params.type],

--- a/projects/client/src/lib/sections/settings/_internal/ClearData.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/ClearData.svelte
@@ -24,7 +24,7 @@
   import SettingsBlock from "./SettingsBlock.svelte";
   import SettingsRow from "./SettingsRow.svelte";
 
-  const { watchlist, ratings, history } = useUser();
+  const { watchlist, ratings, history, collection } = useUser();
   const { invalidateAll } = useInvalidator();
   const { clearInProgress } = useClearInProgress();
   const { confirm } = useConfirm();
@@ -42,6 +42,8 @@
         return { type: activeSourceType, input: $ratings };
       case "history":
         return { type: activeSourceType, input: $history ?? undefined };
+      case "library":
+        return { type: activeSourceType, input: $collection };
     }
   });
 

--- a/projects/client/src/lib/sections/settings/_internal/clear/clearData.ts
+++ b/projects/client/src/lib/sections/settings/_internal/clear/clearData.ts
@@ -1,4 +1,5 @@
 import { clearHistory } from '$lib/sections/settings/sync/clearHistory.ts';
+import { clearLibrary } from '$lib/sections/settings/sync/clearLibrary.ts';
 import { clearRatings } from '$lib/sections/settings/sync/clearRatings.ts';
 import { clearWatchlist } from '$lib/sections/settings/sync/clearWatchlist.ts';
 import type { SyncEngineCallbacks } from '../../sync/models/SyncEngineCallbacks.ts';
@@ -18,5 +19,9 @@ export async function clearData(
 
   if (data.type === 'history') {
     await clearHistory(data.input, callbacks);
+  }
+
+  if (data.type === 'library') {
+    await clearLibrary(data.input, callbacks);
   }
 }

--- a/projects/client/src/lib/sections/settings/_internal/clear/constants/index.ts
+++ b/projects/client/src/lib/sections/settings/_internal/clear/constants/index.ts
@@ -19,4 +19,8 @@ export const CLEAR_DATA_SOURCES: readonly ClearSource[] = [
     type: 'history',
     label: m.text_clear_source_history,
   },
+  {
+    type: 'library',
+    label: m.text_clear_source_library,
+  },
 ];

--- a/projects/client/src/lib/sections/settings/_internal/clear/getClearProperties.ts
+++ b/projects/client/src/lib/sections/settings/_internal/clear/getClearProperties.ts
@@ -17,6 +17,8 @@ function getTotalCount(source: ClearSource) {
       );
     case 'history':
       return source.input.movies.size + source.input.shows.size;
+    case 'library':
+      return source.input.movies.size + source.input.episodes.size;
   }
 }
 
@@ -38,6 +40,11 @@ function getInvalidations(source: ClearSource) {
         InvalidateAction.MarkAsWatched('movie'),
         InvalidateAction.MarkAsWatched('show'),
         InvalidateAction.MarkAsWatched('episode'),
+      ];
+    case 'library':
+      return [
+        InvalidateAction.Collected('movie'),
+        InvalidateAction.Collected('episode'),
       ];
   }
 }

--- a/projects/client/src/lib/sections/settings/_internal/clear/models/ClearDataInputMap.ts
+++ b/projects/client/src/lib/sections/settings/_internal/clear/models/ClearDataInputMap.ts
@@ -1,3 +1,4 @@
+import type { UserCollection } from '$lib/features/auth/queries/currentUserCollectionQuery.ts';
 import type { UserRatings } from '$lib/features/auth/queries/currentUserRatingsQuery.ts';
 import type { UserWatchlist } from '$lib/features/auth/queries/currentUserWatchlistQuery.ts';
 import type { UserHistory } from '$lib/features/auth/stores/useCurrentUserHistory.ts';
@@ -6,4 +7,5 @@ export type ClearDataInputMap = {
   watchlist: UserWatchlist;
   ratings: UserRatings;
   history: UserHistory;
+  library: UserCollection;
 };

--- a/projects/client/src/lib/sections/settings/sync/clearLibrary.ts
+++ b/projects/client/src/lib/sections/settings/sync/clearLibrary.ts
@@ -1,0 +1,68 @@
+import type { UserCollection } from '$lib/features/auth/queries/currentUserCollectionQuery.ts';
+import { rawApiFetch } from '$lib/requests/api.ts';
+import { SYNC_CHUNK_SIZE } from '$lib/sections/settings/sync/constants/index.ts';
+import { chunk } from '$lib/utils/array/chunk.ts';
+import { createSyncRunner } from './createSyncRunner.ts';
+import type { SyncEngineCallbacks } from './models/SyncEngineCallbacks.ts';
+
+type CollectionId = { ids: { trakt: number } };
+
+function removeFromCollection(
+  body: { movies: CollectionId[] } | { episodes: CollectionId[] },
+  signal?: AbortSignal,
+) {
+  return rawApiFetch({
+    path: '/sync/collection/remove',
+    init: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal,
+    },
+  }).then((response) => {
+    if (!response.ok) {
+      throw response;
+    }
+
+    return response;
+  });
+}
+
+export async function clearLibrary(
+  collection: UserCollection,
+  { onProgress, onError, onStart, onComplete, signal }: SyncEngineCallbacks,
+): Promise<void> {
+  onStart?.();
+
+  try {
+    const movies = Array.from(collection.movies).map((id) => ({
+      ids: { trakt: id },
+    }));
+    const episodes = Array.from(collection.episodes).map((id) => ({
+      ids: { trakt: id },
+    }));
+
+    const { run } = createSyncRunner({ onProgress, onError, signal });
+
+    if (movies.length > 0) {
+      await run(
+        chunk(movies, SYNC_CHUNK_SIZE),
+        (batch) => batch,
+        (batch) => removeFromCollection({ movies: [...batch] }, signal),
+      );
+    }
+
+    if (episodes.length > 0) {
+      await run(
+        chunk(episodes, SYNC_CHUNK_SIZE),
+        (batch) => batch,
+        (batch) => removeFromCollection({ episodes: [...batch] }, signal),
+      );
+    }
+
+    onComplete?.(!signal?.aborted);
+  } catch (err) {
+    onComplete?.(false);
+    throw err;
+  }
+}

--- a/projects/client/src/lib/sections/settings/sync/processChunks.ts
+++ b/projects/client/src/lib/sections/settings/sync/processChunks.ts
@@ -21,7 +21,7 @@ export async function processChunks<TItem, TPayload, TResponse>(
 
     try {
       const payload = buildPayload(batch);
-      await retryWithRateLimit(() => sendRequest(payload));
+      await retryWithRateLimit(() => sendRequest(payload), signal);
     } catch (err) {
       errors += batch.length;
       onError(err instanceof Error ? err.message : String(err));

--- a/projects/client/src/lib/sections/settings/sync/retryWithRateLimit.ts
+++ b/projects/client/src/lib/sections/settings/sync/retryWithRateLimit.ts
@@ -1,6 +1,9 @@
 import { retry } from '$lib/utils/retry/retry.ts';
 
-export function retryWithRateLimit<T>(fn: () => Promise<T>): Promise<T> {
+export function retryWithRateLimit<T>(
+  fn: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
   return retry(async () => {
     try {
       return await fn();
@@ -13,5 +16,5 @@ export function retryWithRateLimit<T>(fn: () => Promise<T>): Promise<T> {
       }
       throw err;
     }
-  });
+  }, signal);
 }

--- a/projects/client/src/lib/utils/retry/retry.ts
+++ b/projects/client/src/lib/utils/retry/retry.ts
@@ -3,12 +3,16 @@ import { retryDelay } from './retryDelay.ts';
 
 const MAX_RETRIES = 3;
 
-export function retry<T>(fn: () => Promise<T>): Promise<T> {
+export function retry<T>(
+  fn: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
   return tsRetry<T>(
     fn,
     {
       maxTry: MAX_RETRIES,
-      delay: ({ currentTry }) => retryDelay(currentTry - 1),
+      delay: ({ currentTry }) =>
+        signal?.aborted ? 0 : retryDelay(currentTry - 1),
     },
   );
 }

--- a/projects/client/src/mocks/handlers/sync.ts
+++ b/projects/client/src/mocks/handlers/sync.ts
@@ -71,6 +71,14 @@ export const sync = [
       });
     },
   ),
+  http.post(
+    'http://localhost/sync/collection/remove',
+    () => {
+      return new HttpResponse(null, {
+        status: 200,
+      });
+    },
+  ),
   http.get(
     'http://localhost/sync/progress/up_next*',
     () => {


### PR DESCRIPTION
Fixes #2313 
* invalidates the query after clear
* clears custom and plex library
* uses already existing clear patterns

**Working example**


https://github.com/user-attachments/assets/4954375b-1435-4e93-b2a8-119a40d2c1d3





