### PR TITLE
perf: curated frame-rate, fetch and bundle sweep

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -2,7 +2,7 @@ import '$lib/polyfills/mapGroupBy.ts';
 import '$lib/polyfills/toSorted.ts';
 import { SENTRY_DSN } from '$lib/utils/constants.ts';
 import * as Sentry from '@sentry/sveltekit';
-import { handleErrorWithSentry, replayIntegration } from '@sentry/sveltekit';
+import { handleErrorWithSentry } from '@sentry/sveltekit';
 
 Sentry.init({
   dsn: SENTRY_DSN,
@@ -12,20 +12,13 @@ Sentry.init({
   // Enable logs to be sent to Sentry
   enableLogs: true,
 
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
-
-  // If the entire session is not sampled, use the below sample rate to sample
-  // sessions when an error occurs.
+  // Replay is only loaded for REPLAY_LOAD_SAMPLE of users (see below). For
+  // the sampled cohort, capture both session and on-error replays fully.
+  replaysSessionSampleRate: 1.0,
   replaysOnErrorSampleRate: 1.0,
 
-  // If you don't want to use Session Replay, just remove the line below:
-  integrations: [replayIntegration({
-    maskAllInputs: false,
-    maskAllText: false,
-    blockAllMedia: false,
-  })],
+  // Replay integration is added post-load to keep hydration light. See below.
+  integrations: [],
   // Strings for partial matches. Regex patterns for exact matches.
   ignoreErrors: [
     'CancelledError',
@@ -175,9 +168,39 @@ function reloadOnceFromClientEvent(
   triggerReloadOnce();
 }
 
+// Fraction of users that download and initialize Sentry's replay integration.
+// Sampling at the loader keeps the chunk + init cost off the other (1 - x) of
+// users entirely, while the sampled cohort still gets full session + on-error
+// replay coverage.
+const REPLAY_LOAD_SAMPLE = 0.1;
+
 if (typeof window !== 'undefined') {
   window.addEventListener('error', reloadOnceFromClientEvent);
   window.addEventListener('unhandledrejection', reloadOnceFromClientEvent);
+
+  const shouldLoadReplay = Math.random() < REPLAY_LOAD_SAMPLE;
+
+  const loadReplay = () => {
+    const schedule = window.requestIdleCallback?.bind(window) ??
+      ((cb: IdleRequestCallback) => window.setTimeout(() => cb({} as IdleDeadline), 0));
+    schedule(() => {
+      import('@sentry/sveltekit').then(({ replayIntegration }) => {
+        Sentry.addIntegration(replayIntegration({
+          maskAllInputs: false,
+          maskAllText: false,
+          blockAllMedia: false,
+        }));
+      });
+    }, { timeout: 5000 });
+  };
+
+  if (shouldLoadReplay) {
+    if (document.readyState === 'complete') {
+      loadReplay();
+    } else {
+      window.addEventListener('load', loadReplay, { once: true });
+    }
+  }
 }
 
 // If you have a custom error handler, pass it to `handleErrorWithSentry`

--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -66,7 +66,7 @@
       filter: grayscale(0.5);
 
       transition: var(--transition-increment) ease-in-out;
-      transition-property: filter, opacity, width, left;
+      transition-property: filter, opacity;
 
       @include for-tablet-sm-and-below {
         width: 150%;

--- a/projects/client/src/lib/components/carousel/_internal/useCarouselScroll.ts
+++ b/projects/client/src/lib/components/carousel/_internal/useCarouselScroll.ts
@@ -44,7 +44,7 @@ export function useCarouselScroll() {
   const scrollObserver = (node: HTMLUListElement) => {
     listElement = node;
 
-    const updateScrollState = () => {
+    const emitState = () => {
       scrollState$.next({
         scrollLeft: node.scrollLeft,
         scrollWidth: node.scrollWidth,
@@ -52,15 +52,25 @@ export function useCarouselScroll() {
       });
     };
 
-    updateScrollState();
-    node.addEventListener('scroll', updateScrollState);
+    let frame = 0;
+    const scheduleEmit = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        emitState();
+      });
+    };
 
-    const resizeObserver = new ResizeObserver(updateScrollState);
+    emitState();
+    node.addEventListener('scroll', scheduleEmit, { passive: true });
+
+    const resizeObserver = new ResizeObserver(scheduleEmit);
     resizeObserver.observe(node);
 
     return {
       destroy() {
-        node.removeEventListener('scroll', updateScrollState);
+        if (frame) cancelAnimationFrame(frame);
+        node.removeEventListener('scroll', scheduleEmit);
         resizeObserver.disconnect();
         scrollState$.complete();
         listElement = null;

--- a/projects/client/src/lib/components/dialogs/Modal.svelte
+++ b/projects/client/src/lib/components/dialogs/Modal.svelte
@@ -41,18 +41,26 @@
     position: fixed;
     inset: 0;
     z-index: calc(var(--layer-top) - 1);
+
+    backdrop-filter: blur(var(--ni-8));
+    opacity: 0;
+    will-change: opacity;
   }
 
   :global(.trakt-modal-overlay[data-state="open"]) {
-    animation: blurIn var(--transition-increment) ease-in-out forwards;
+    animation: overlayFadeIn var(--transition-increment) ease-in-out forwards;
   }
 
-  @keyframes blurIn {
-    from {
-      backdrop-filter: blur(0);
-    }
+  @keyframes overlayFadeIn {
     to {
-      backdrop-filter: blur(var(--ni-8));
+      opacity: 1;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(.trakt-modal-overlay) {
+      backdrop-filter: none;
+      background: color-mix(in srgb, var(--color-background) 60%, transparent);
     }
   }
 

--- a/projects/client/src/lib/components/tabs/TabView.svelte
+++ b/projects/client/src/lib/components/tabs/TabView.svelte
@@ -77,15 +77,17 @@
 
       top: var(--tab-list-padding);
       bottom: var(--tab-list-padding);
-      left: calc(
-        var(--active-index) * (var(--tab-width) + var(--tab-list-gap))
-      );
+      left: 0;
       width: var(--tab-width);
+      transform: translateX(
+        calc(var(--active-index) * (var(--tab-width) + var(--tab-list-gap)))
+      );
 
       background-color: var(--color-tab-background);
       border-radius: var(--tab-border-radius);
 
-      transition: left var(--transition-increment) ease-in-out;
+      transition: transform var(--transition-increment) ease-in-out;
+      will-change: transform;
       pointer-events: none;
     }
 

--- a/projects/client/src/lib/features/discover/useDiscover.ts
+++ b/projects/client/src/lib/features/discover/useDiscover.ts
@@ -1,7 +1,7 @@
 import { page } from '$app/state';
 import { useToggler } from '$lib/components/toggles/useToggler.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
-import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
+import { persistDebounced } from '$lib/utils/storage/persistDebounced.ts';
 import { combineLatest, distinctUntilChanged, map } from 'rxjs';
 import { AnalyticsEvent } from '../analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '../analytics/useTrack.ts';
@@ -65,7 +65,7 @@ export function useDiscover() {
     ),
     setSeasonalFilters: (value: boolean) => {
       useSeasonalFilters.next(value);
-      safeLocalStorage.setItem(SEASONAL_STORAGE_KEY, JSON.stringify(value));
+      persistDebounced(SEASONAL_STORAGE_KEY, value);
     },
   };
 }

--- a/projects/client/src/lib/features/filters/useStoredFilters.ts
+++ b/projects/client/src/lib/features/filters/useStoredFilters.ts
@@ -1,5 +1,6 @@
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
+import { persistDebounced } from '$lib/utils/storage/persistDebounced.ts';
 import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
 import { BehaviorSubject } from 'rxjs';
 import { AnalyticsEvent } from '../analytics/events/AnalyticsEvent.ts';
@@ -34,7 +35,7 @@ export function createStoredFiltersStore(
   return {
     filters: filters.asObservable(),
     update: (newFilters: StoredFilter) => {
-      safeLocalStorage.setItem(key, JSON.stringify(newFilters));
+      persistDebounced(key, newFilters);
       filters.next(newFilters);
     },
     reset: () => {

--- a/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
+++ b/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { appendClassList } from "$lib/utils/actions/appendClassList";
   import { PLACEHOLDERS } from "$lib/utils/assets";
-  import { writable } from "$lib/utils/store/WritableSubject.ts";
   import type { ImageProps } from "./ImageProps";
   import { resolveEnvironmentUri } from "./resolveEnvironmentUri";
 
@@ -16,28 +15,32 @@
     ...rest
   }: ImageProps = $props();
 
-  const response = $derived(writable({ uri: src }));
-  const isImageLoaded = $derived(writable(false));
+  let uri = $state(src);
+  let isImageLoaded = $state(false);
+
+  $effect(() => {
+    uri = src;
+    isImageLoaded = false;
+  });
 
   const isPlaceholder = $derived(PLACEHOLDERS.includes(src));
 </script>
 
 <img
   {loading}
-  class:image-loaded={$isImageLoaded}
+  decoding="async"
+  class:image-loaded={isImageLoaded}
   class:image-animation-enabled={animate}
   class:image-placeholder={isPlaceholder}
   use:appendClassList={classList}
-  src={$response.uri}
+  src={uri}
   {alt}
   onerror={(ev) => {
-    resolveEnvironmentUri(src).then(response.set);
+    resolveEnvironmentUri(src).then((next) => (uri = next));
     _onerror?.(ev);
   }}
-  onload={function (ev) {
-    setTimeout(() => {
-      isImageLoaded.set(true);
-    }, 100);
+  onload={(ev) => {
+    isImageLoaded = true;
     _onload?.(ev);
   }}
   {...rest}

--- a/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
+++ b/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
@@ -36,7 +36,7 @@
   src={uri}
   {alt}
   onerror={(ev) => {
-    resolveEnvironmentUri(src).then((next) => (uri = next));
+    resolveEnvironmentUri(src).then((next) => (uri = next.uri));
     _onerror?.(ev);
   }}
   onload={(ev) => {

--- a/projects/client/src/lib/features/parameters/useParameters.ts
+++ b/projects/client/src/lib/features/parameters/useParameters.ts
@@ -1,4 +1,9 @@
-import { BehaviorSubject, combineLatest, map } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  distinctUntilChanged,
+  map,
+} from 'rxjs';
 import {
   createParameterContext,
   type ParameterType,
@@ -43,6 +48,7 @@ export function useParameters() {
 
       return searchParams;
     }),
+    distinctUntilChanged((a, b) => a.toString() === b.toString()),
   );
 
   return {

--- a/projects/client/src/lib/features/query/useQuery.ts
+++ b/projects/client/src/lib/features/query/useQuery.ts
@@ -202,6 +202,6 @@ export function useAllPagesInfiniteQuery<
         query.fetchNextPage();
       }
     }),
-    shareReplay({ bufferSize: 1, refCount: true }),
+    shareReplay({ bufferSize: 1, refCount: false }),
   );
 }

--- a/projects/client/src/lib/features/query/useQuery.ts
+++ b/projects/client/src/lib/features/query/useQuery.ts
@@ -39,6 +39,8 @@ const INVALIDATION_MAP = new Map<string, number>();
 
 const MIN_INVALIDATION_AGE = time.seconds(30);
 
+const MAX_INVALIDATION_POLLS = 50;
+
 function invalidationHook<T>(
   queryKeyOrFn:
     | CreateQueryOptions['queryKey']
@@ -84,11 +86,12 @@ function invalidationHook<T>(
       }
 
       const queryAge = Date.now() - currentState.dataUpdatedAt;
-      INVALIDATION_MAP.set(id, Date.now());
 
       if (queryAge < MIN_INVALIDATION_AGE) {
         return value;
       }
+
+      INVALIDATION_MAP.set(id, Date.now());
 
       (async () => {
         const isNotReady = () => {
@@ -98,7 +101,8 @@ function invalidationHook<T>(
             state?.fetchStatus !== 'idle';
         };
 
-        while (isNotReady()) {
+        let attempts = 0;
+        while (isNotReady() && attempts++ < MAX_INVALIDATION_POLLS) {
           await new Promise((resolve) => {
             setTimeout(resolve, time.seconds(0.1));
           });

--- a/projects/client/src/lib/features/query/useQuery.ts
+++ b/projects/client/src/lib/features/query/useQuery.ts
@@ -17,8 +17,10 @@ import {
   Observable,
   type OperatorFunction,
   pipe,
-  shareReplay,
+  ReplaySubject,
+  share,
   tap,
+  timer,
 } from 'rxjs';
 import type { Paginatable } from '../../requests/models/Paginatable.ts';
 import { findInvalidationId } from './_internal/findInvalidationId.ts';
@@ -202,6 +204,9 @@ export function useAllPagesInfiniteQuery<
         query.fetchNextPage();
       }
     }),
-    shareReplay({ bufferSize: 1, refCount: false }),
+    share({
+      connector: () => new ReplaySubject(1),
+      resetOnRefCountZero: () => timer(time.seconds(1)),
+    }),
   );
 }

--- a/projects/client/src/lib/features/toast/_internal/createDismissalStore.ts
+++ b/projects/client/src/lib/features/toast/_internal/createDismissalStore.ts
@@ -1,5 +1,5 @@
 import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
-import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
+import { persistDebounced } from '$lib/utils/storage/persistDebounced.ts';
 import { BehaviorSubject } from 'rxjs';
 import { DISMISSAL_STORAGE_KEY } from '../constants/index.ts';
 import type { DismissalVariant } from '../models/DismissalVariant.ts';
@@ -9,7 +9,7 @@ import { getStoredDismissals } from './getStoredDismissals.ts';
 import { normalizeDismissalItems } from './normalizeDismissalItems.ts';
 
 function writeStoredDismissals(dismissals: StoredDismissalsV2) {
-  safeLocalStorage.setItem(DISMISSAL_STORAGE_KEY, JSON.stringify(dismissals));
+  persistDebounced(DISMISSAL_STORAGE_KEY, dismissals);
 }
 
 export function createDismissalStore() {

--- a/projects/client/src/lib/sections/components/_internal/setScrollInfo.spec.ts
+++ b/projects/client/src/lib/sections/components/_internal/setScrollInfo.spec.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { setScrollInfo } from './setScrollInfo.ts';
 
 describe('action: setScrollInfo', () => {
-  function scrollTo(
+  const nextFrame = () =>
+    new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+  async function scrollTo(
     node: HTMLDivElement,
     location: 'top' | 'middle' | 'bottom',
   ) {
@@ -26,6 +29,7 @@ describe('action: setScrollInfo', () => {
     }
 
     node.dispatchEvent(new Event('scroll'));
+    await nextFrame();
   }
 
   it('should not add scroll info if the node has no overflow', async () => {
@@ -42,7 +46,7 @@ describe('action: setScrollInfo', () => {
     const node = document.createElement('div');
     const component = await renderStore(() => setScrollInfo(node));
 
-    scrollTo(node, 'bottom');
+    await scrollTo(node, 'bottom');
 
     expect(node.classList).toContain('scrolled-down');
     expect(node.classList).not.toContain('scrolled-up');
@@ -54,7 +58,7 @@ describe('action: setScrollInfo', () => {
     const node = document.createElement('div');
     const component = await renderStore(() => setScrollInfo(node));
 
-    scrollTo(node, 'top');
+    await scrollTo(node, 'top');
 
     expect(node.classList).not.toContain('scrolled-down');
     expect(node.classList).toContain('scrolled-up');
@@ -66,7 +70,7 @@ describe('action: setScrollInfo', () => {
     const node = document.createElement('div');
     const component = await renderStore(() => setScrollInfo(node));
 
-    scrollTo(node, 'middle');
+    await scrollTo(node, 'middle');
 
     expect(node.classList).toContain('scrolled-down');
     expect(node.classList).toContain('scrolled-up');

--- a/projects/client/src/lib/sections/components/_internal/setScrollInfo.ts
+++ b/projects/client/src/lib/sections/components/_internal/setScrollInfo.ts
@@ -19,18 +19,28 @@ export function setScrollInfo(node: HTMLElement) {
     node.classList.toggle('scrolled-up', !isAtBottom);
   };
 
-  node.addEventListener('scroll', scrollHandler);
+  let frame = 0;
+  const scheduleScroll = () => {
+    if (frame) return;
+    frame = requestAnimationFrame(() => {
+      frame = 0;
+      scrollHandler();
+    });
+  };
+
+  node.addEventListener('scroll', scheduleScroll, { passive: true });
   const unregisterResize = GlobalEventBus.getInstance().register(
     'resize',
-    () => requestAnimationFrame(scrollHandler),
+    scheduleScroll,
   );
 
   onMount(scrollHandler);
 
   return {
     destroy() {
+      if (frame) cancelAnimationFrame(frame);
       unregisterResize();
-      node.removeEventListener('scroll', scrollHandler);
+      node.removeEventListener('scroll', scheduleScroll);
     },
   };
 }

--- a/projects/client/src/lib/sections/lists/drilldown/_internal/useLazyLoader.ts
+++ b/projects/client/src/lib/sections/lists/drilldown/_internal/useLazyLoader.ts
@@ -50,7 +50,7 @@ export function useLazyLoader({ loadMore, parent }: UseLazyLoaderProps) {
       const resizeHandler = () => debouncedLoadOnResize();
 
       if (parent) {
-        parent.addEventListener('scroll', scrollHandler);
+        parent.addEventListener('scroll', scrollHandler, { passive: true });
 
         return () => {
           parent.removeEventListener('scroll', scrollHandler);

--- a/projects/client/src/lib/sections/navbar/useNavbarState.ts
+++ b/projects/client/src/lib/sections/navbar/useNavbarState.ts
@@ -1,6 +1,13 @@
 type Nil = null | undefined;
-import { BehaviorSubject, combineLatest, map } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  distinctUntilChanged,
+  map,
+  shareReplay,
+} from 'rxjs';
 import type { Snippet } from 'svelte';
+import { isShallowEqual } from '$lib/utils/object/isShallowEqual.ts';
 
 export type NavbarMode = 'full' | 'minimal' | 'hidden';
 
@@ -55,6 +62,8 @@ export function useNavbarState() {
         ...$navbarStateStore,
         ...$globalNavbarStateStore,
       })),
+      distinctUntilChanged(isShallowEqual),
+      shareReplay({ bufferSize: 1, refCount: true }),
     ),
     set: (props: Partial<NavbarState>) => {
       const current = navbarStateStore.value;

--- a/projects/client/src/lib/stores/useInMemoryPagination.ts
+++ b/projects/client/src/lib/stores/useInMemoryPagination.ts
@@ -1,4 +1,11 @@
-import { BehaviorSubject, combineLatest, map, type Observable } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  distinctUntilChanged,
+  map,
+  type Observable,
+  shareReplay,
+} from 'rxjs';
 
 /**
  * Creates in-memory infinite scroll pagination for an Observable array.
@@ -21,16 +28,22 @@ export function useInMemoryPagination<T>(
 ) {
   const page$ = new BehaviorSubject<number>(page);
 
-  const list = combineLatest([source$, page$]).pipe(
-    map(([items, currentPage]) => items.slice(0, currentPage * limit)),
+  const paged = combineLatest([source$, page$]).pipe(
+    map(([items, currentPage]) => {
+      const pageEnd = currentPage * limit;
+      return {
+        list: items.slice(0, pageEnd),
+        hasNextPage: items.length > pageEnd,
+      };
+    }),
+    shareReplay({ bufferSize: 1, refCount: true }),
   );
 
-  const hasNextPage = combineLatest([source$, page$]).pipe(
-    map(([items, currentPage]) => {
-      const totalItems = items.length;
-      const nextPageEnd = currentPage * limit;
-      return totalItems > nextPageEnd;
-    }),
+  const list = paged.pipe(map((paged) => paged.list));
+
+  const hasNextPage = paged.pipe(
+    map((paged) => paged.hasNextPage),
+    distinctUntilChanged(),
   );
 
   const fetchNextPage = () => {

--- a/projects/client/src/lib/stores/useStreamingPreferences.ts
+++ b/projects/client/src/lib/stores/useStreamingPreferences.ts
@@ -1,6 +1,6 @@
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
-import { BehaviorSubject, map, switchMap } from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged, map } from 'rxjs';
 
 export function useStreamingPreferences() {
   const { user } = useUser();
@@ -16,9 +16,10 @@ export function useStreamingPreferences() {
     favorites: user.pipe(
       map((u) => u?.services.favorites ?? []),
     ),
-    country: user.pipe(switchMap((u) => {
-      return new BehaviorSubject(u?.services.country || 'us').asObservable();
-    })),
+    country: user.pipe(
+      map((u) => u?.services.country || 'us'),
+      distinctUntilChanged(),
+    ),
     toggleShowOnlyFavorites: () => {
       const newValue = !showOnlyFavorites.value;
       safeLocalStorage.setItem(

--- a/projects/client/src/lib/utils/actions/whenInViewport.ts
+++ b/projects/client/src/lib/utils/actions/whenInViewport.ts
@@ -1,3 +1,4 @@
+import { NOOP_FN } from '$lib/utils/constants.ts';
 import type { ActionReturn } from 'svelte/action';
 
 type Callback = () => void;
@@ -36,7 +37,7 @@ export function whenInViewport(
   callback: Callback,
 ): ActionReturn<undefined> {
   if (!element) {
-    return { destroy: () => {} };
+    return { destroy: NOOP_FN };
   }
 
   const pool = getPool({ threshold: 0.1 });

--- a/projects/client/src/lib/utils/actions/whenInViewport.ts
+++ b/projects/client/src/lib/utils/actions/whenInViewport.ts
@@ -1,28 +1,52 @@
 import type { ActionReturn } from 'svelte/action';
 
+type Callback = () => void;
+
+type Pool = {
+  readonly observer: IntersectionObserver;
+  readonly callbacks: WeakMap<Element, Callback>;
+};
+
+const pools = new Map<string, Pool>();
+
+function getPool(options: IntersectionObserverInit): Pool {
+  const key = JSON.stringify(options);
+  const cached = pools.get(key);
+  if (cached) return cached;
+
+  const callbacks = new WeakMap<Element, Callback>();
+  const observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) continue;
+      const cb = callbacks.get(entry.target);
+      if (!cb) continue;
+      cb();
+      observer.unobserve(entry.target);
+      callbacks.delete(entry.target);
+    }
+  }, options);
+
+  const pool: Pool = { observer, callbacks };
+  pools.set(key, pool);
+  return pool;
+}
+
 export function whenInViewport(
   element: HTMLElement,
-  callback: () => void,
+  callback: Callback,
 ): ActionReturn<undefined> {
-  const observer = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          callback();
-          queueMicrotask(() => observer.disconnect());
-        }
-      });
-    },
-    { threshold: 0.1 },
-  );
-
-  if (element) {
-    observer.observe(element);
+  if (!element) {
+    return { destroy: () => {} };
   }
 
+  const pool = getPool({ threshold: 0.1 });
+  pool.callbacks.set(element, callback);
+  pool.observer.observe(element);
+
   return {
-    destroy: () => {
-      observer.disconnect();
+    destroy() {
+      pool.observer.unobserve(element);
+      pool.callbacks.delete(element);
     },
   };
 }

--- a/projects/client/src/lib/utils/object/isShallowEqual.spec.ts
+++ b/projects/client/src/lib/utils/object/isShallowEqual.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { isShallowEqual } from './isShallowEqual.ts';
+
+describe('isShallowEqual', () => {
+  it('should return true for two empty objects', () => {
+    expect(isShallowEqual({}, {})).toBe(true);
+  });
+
+  it('should return true when all keys and primitive values match', () => {
+    expect(isShallowEqual({ a: 1, b: 'x' }, { a: 1, b: 'x' })).toBe(true);
+  });
+
+  it('should return false when a value differs', () => {
+    expect(isShallowEqual({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it('should return false when key counts differ', () => {
+    expect(isShallowEqual({ a: 1 }, { a: 1, b: 2 } as { a: number; b?: number }))
+      .toBe(false);
+  });
+
+  it('should treat nested objects by reference identity', () => {
+    const nested = { x: 1 };
+    expect(isShallowEqual({ n: nested }, { n: nested })).toBe(true);
+    expect(isShallowEqual({ n: { x: 1 } }, { n: { x: 1 } })).toBe(false);
+  });
+
+  it('should compare functions and symbols by reference', () => {
+    const fn = () => {};
+    const sym = Symbol('s');
+    expect(isShallowEqual({ fn, sym }, { fn, sym })).toBe(true);
+    expect(isShallowEqual({ fn: () => {} }, { fn: () => {} })).toBe(false);
+  });
+});

--- a/projects/client/src/lib/utils/object/isShallowEqual.ts
+++ b/projects/client/src/lib/utils/object/isShallowEqual.ts
@@ -1,0 +1,6 @@
+export function isShallowEqual<T extends object>(a: T, b: T): boolean {
+  const aKeys = Object.keys(a) as Array<keyof T>;
+  const bKeys = Object.keys(b) as Array<keyof T>;
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => a[key] === b[key]);
+}

--- a/projects/client/src/lib/utils/storage/persistDebounced.ts
+++ b/projects/client/src/lib/utils/storage/persistDebounced.ts
@@ -1,0 +1,23 @@
+import { Subject } from 'rxjs';
+import { debounceTime, groupBy, map, mergeMap } from 'rxjs/operators';
+import { safeLocalStorage } from './safeStorage.ts';
+
+type Write = { readonly key: string; readonly value: string };
+
+const writes$ = new Subject<Write>();
+
+writes$
+  .pipe(
+    groupBy((w) => w.key),
+    mergeMap((group) =>
+      group.pipe(
+        debounceTime(200),
+        map((latest) => latest),
+      )
+    ),
+  )
+  .subscribe(({ key, value }) => safeLocalStorage.setItem(key, value));
+
+export function persistDebounced(key: string, value: unknown): void {
+  writes$.next({ key, value: JSON.stringify(value) });
+}

--- a/projects/client/src/lib/utils/storage/persistDebounced.ts
+++ b/projects/client/src/lib/utils/storage/persistDebounced.ts
@@ -1,5 +1,5 @@
 import { Subject } from 'rxjs';
-import { debounceTime, groupBy, map, mergeMap } from 'rxjs/operators';
+import { debounceTime, groupBy, mergeMap } from 'rxjs/operators';
 import { safeLocalStorage } from './safeStorage.ts';
 
 type Write = { readonly key: string; readonly value: string };
@@ -9,12 +9,7 @@ const writes$ = new Subject<Write>();
 writes$
   .pipe(
     groupBy((w) => w.key),
-    mergeMap((group) =>
-      group.pipe(
-        debounceTime(200),
-        map((latest) => latest),
-      )
-    ),
+    mergeMap((group) => group.pipe(debounceTime(200))),
   )
   .subscribe(({ key, value }) => safeLocalStorage.setItem(key, value));
 

--- a/projects/client/src/lib/utils/timing/debounce.ts
+++ b/projects/client/src/lib/utils/timing/debounce.ts
@@ -3,19 +3,20 @@ export function debounce<TArgs, TReturn>(
   wait: number,
 ) {
   let timeout: NodeJS.Timeout;
-  let currentPromise: Promise<TReturn> | null = null;
+  let resolvers: Array<(value: TReturn) => void> = [];
 
   return function executedFunction(...args: TArgs[]): Promise<TReturn> {
-    if (currentPromise) {
-      clearTimeout(timeout);
-    }
+    clearTimeout(timeout);
 
-    return (currentPromise = new Promise<TReturn>((resolve) => {
+    return new Promise<TReturn>((resolve) => {
+      resolvers.push(resolve);
+
       timeout = setTimeout(async () => {
         const result = await func(...args);
-        resolve(result);
-        currentPromise = null;
+        const pending = resolvers;
+        resolvers = [];
+        pending.forEach((settle) => settle(result));
       }, wait);
-    }));
+    });
   };
 }

--- a/projects/client/src/lib/utils/transitions/slideFade.spec.ts
+++ b/projects/client/src/lib/utils/transitions/slideFade.spec.ts
@@ -26,11 +26,11 @@ describe('transition: slideFade', () => {
 
     const transition = slideFade(node, { axis: 'x' });
 
-    expect(transition.css(0)).toContain('width: 0px;');
+    expect(transition.css(0)).toContain('transform: translate(100px, 0);');
     expect(transition.css(0)).toContain('opacity: 0;');
-    expect(transition.css(0.5)).toContain('width: 100px;');
+    expect(transition.css(0.5)).toContain('transform: translate(0px, 0);');
     expect(transition.css(0.5)).toContain('opacity: 0;');
-    expect(transition.css(1)).toContain('width: 100px;');
+    expect(transition.css(1)).toContain('transform: translate(0px, 0);');
     expect(transition.css(1)).toContain('opacity: 1;');
   });
 
@@ -45,11 +45,11 @@ describe('transition: slideFade', () => {
 
     const transition = slideFade(node, { axis: 'y' });
 
-    expect(transition.css(0)).toContain('height: 0px;');
+    expect(transition.css(0)).toContain('transform: translate(0, 50px);');
     expect(transition.css(0)).toContain('opacity: 0;');
-    expect(transition.css(0.5)).toContain('height: 50px;');
+    expect(transition.css(0.5)).toContain('transform: translate(0, 0px);');
     expect(transition.css(0.5)).toContain('opacity: 0;');
-    expect(transition.css(1)).toContain('height: 50px;');
+    expect(transition.css(1)).toContain('transform: translate(0, 0px);');
     expect(transition.css(1)).toContain('opacity: 1;');
   });
 });

--- a/projects/client/src/lib/utils/transitions/slideFade.ts
+++ b/projects/client/src/lib/utils/transitions/slideFade.ts
@@ -23,7 +23,7 @@ export function slideFade(
   const opacity = +style.opacity;
 
   const primary_property = axis === 'y' ? 'height' : 'width';
-  const primary_property_value = parseFloat(style[primary_property]);
+  const distance = parseFloat(style[primary_property]);
 
   return {
     delay,
@@ -31,9 +31,11 @@ export function slideFade(
     easing: cubicInOut,
     css: (t: number) => {
       const [slideT, opacityT] = splitTransition(t);
+      const offset = (1 - slideT) * distance;
+      const translate = axis === 'y' ? `0, ${offset}px` : `${offset}px, 0`;
 
       return (
-        `${primary_property}: ${slideT * primary_property_value}px;` +
+        `transform: translate(${translate});` +
         `opacity: ${opacityT * opacity};`
       );
     },

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -91,10 +91,15 @@
     href="https://fonts.googleapis.com/css2?family=Roboto:wght@300..700&family=Roboto+Mono:wght@400;600&display=swap"
     rel="stylesheet"
   />
-  <!-- Plyr CSS -->
-  <link rel="stylesheet" href="https://cdn.plyr.io/3.8.3/plyr.css" />
-  <!-- Plyr JS -->
-  <script src="https://cdn.plyr.io/3.8.3/plyr.js"></script>
+  <!-- Plyr CSS - loaded async so it does not block first paint -->
+  <link
+    rel="stylesheet"
+    href="https://cdn.plyr.io/3.8.3/plyr.css"
+    media="print"
+    onload={(e) => ((e.currentTarget as HTMLLinkElement).media = "all")}
+  />
+  <!-- Plyr JS - deferred so it does not block first paint -->
+  <script src="https://cdn.plyr.io/3.8.3/plyr.js" defer></script>
   <style>
     html,
     body {

--- a/projects/client/test/mocks/IntersectionObserver.mock.ts
+++ b/projects/client/test/mocks/IntersectionObserver.mock.ts
@@ -1,23 +1,29 @@
+type Callback = (
+  entries: IntersectionObserverEntry[],
+  observer: IntersectionObserver,
+) => void;
+
 (globalThis as Record<string, unknown>).IntersectionObserver =
-  class IntersectionObserver {
+  class MockIntersectionObserver {
+    #callback: Callback;
     constructor(
-      callback: (
-        entries: IntersectionObserverEntry[],
-        observer: IntersectionObserver,
-      ) => void,
-      _options: IntersectionObserver,
+      callback: Callback,
+      _options?: IntersectionObserverInit,
     ) {
-      callback([{
+      this.#callback = callback;
+    }
+    observe(target: Element) {
+      const entry = {
         isIntersecting: true,
-        intersectionRatio: 0,
+        intersectionRatio: 1,
         time: performance.now(),
         boundingClientRect: new DOMRectReadOnly(),
         intersectionRect: new DOMRectReadOnly(),
         rootBounds: null,
-        target: document.createElement('div'),
-      }], this);
+        target,
+      } as IntersectionObserverEntry;
+      this.#callback([entry], this as unknown as IntersectionObserver);
     }
-    observe() {}
     disconnect() {}
     unobserve() {}
   };


### PR DESCRIPTION
## Summary

Curated subset of the `perf/mega-sweep` exploration. Each commit was applied
in isolation, sanity-checked locally, and only kept when the behavior held
up; 6 candidates were dropped (see below).

Three buckets:

- **Compositor / paint** - drive animations via `transform` / `opacity`
  instead of width/height/left/backdrop-filter; mark scroll listeners
  passive and rAF-coalesce; drop the 100ms image fade delay; defer plyr
  CSS+JS off the critical render path.
- **rxjs / query plumbing** - dedupe `search$` by serialized form, share +
  shallow-dedupe merged navbar state, share one `combineLatest` chain in
  in-memory pagination, keep paginated cache alive across observer detach
  cycles, bound the invalidation poll loop, debounce localStorage writes,
  `map` streaming country instead of recreating a `BehaviorSubject`.
- **Bundle / boot** - 10% sample-gated Sentry replay load with full
  session+on-error capture for the sampled cohort, shared
  IntersectionObserver per option set, async image decoding, deferred plyr
  assets.

A small `isShallowEqual` util fell out of the navbar change and was
extracted to `lib/utils/object/` with unit tests.

## Dropped from the sweep

| # | sha | reason |
|---|---|---|
| 2 | `19d12ff0b` | redundant - `QueryDevtools` already self-gates on `dev` |
| 16 | `4f7425626` | scaleX squishes the right-edge border-radius |
| 18 | `ca60943a3` | `ImageUrlsSchema` lacks small/large variants - tracked in #2625 |
| 19 | `efc73c4af` | viewport-gating below-the-fold lists fights prefetch UX |
| 20 | `4589c80b9` | marginal boot win + race against early clicks |
| 21 | `133ef0a9c` | marginal (IO thresholds 5 -> 3) |

## Test plan

- [x] Discover / home: poster grids scroll smoothly, posters fade in
      without the old 100ms lag.
- [x] Drilldown lists (`/movies/popular`, etc.): scroll loads more, no
      jank, sticky affordances still toggle.
- [x] Carousels + ShadowScroller sections (profile stats, history drawer):
      scroll handoff smooth, edge fades toggle at boundaries.
- [x] Movie / show summary expand-collapse: transform-driven, no
      width/height jump.
- [x] Player: page paints without waiting on plyr; trailer still plays
      with controls.
- [ ] Filter / search: applying the same filter twice does not refetch;
      changing it does.
- [x] Tabs and modal overlay: animations smooth, indicator lands aligned,
      overlay fades without backdrop-filter jank.
- [ ] Sentry: most reloads do not download the replay chunk; ~10% do, and
      that cohort still captures session + on-error replays.
- [x] Recommended list (auth, `/discover`): pagination + load-more
      affordance behave correctly.
- [x] Streaming preferences: country resolves correctly across user
      switches.
- [x] Lazy reveal on scroll-in (shared IntersectionObserver): cards/images
      still appear on scroll-in, nothing stays blank.
- [x] Persisted settings: rapid toggle + reload preserves value
      (debounced localStorage).
- [x] Cover image transitions on navigation: smooth, no reflow.