### PR TITLE
docs(client): rewrite performance rule as framework-agnostic principles

### DIFF
--- a/.agents/rules/performance.md
+++ b/.agents/rules/performance.md
@@ -112,9 +112,9 @@ the rule against current authoritative docs rather than trust folklore.
 - **Pick the multicast variant that matches your replay needs.** Use
   `shareReplay({ bufferSize: 1, refCount: true })` for "BehaviorSubject
   semantics with auto-teardown when nothing is listening." Use
-  `share({ connector: () => new ReplaySubject(1), resetOnRefCountZero:
-  () => timer(N) })` when the source must survive a brief unsubscribe
-  (a navigation round-trip, say) but still tear down when truly idle.
+  `share({ connector: () => new ReplaySubject(1), resetOnRefCountZero: () => timer(N) })`
+  when the source must survive a brief unsubscribe (a navigation
+  round-trip, say) but still tear down when truly idle.
   [rxjs.dev: `shareReplay`](https://rxjs.dev/api/operators/shareReplay),
   [rxjs.dev: `share`](https://rxjs.dev/api/operators/share).
 - **Avoid `shareReplay({ refCount: false })` (and the equivalent
@@ -124,10 +124,11 @@ the rule against current authoritative docs rather than trust folklore.
   listeners.
   [RxJS issue 5034 / discussion 6731](https://github.com/ReactiveX/rxjs/issues/5034).
 - **Use `distinctUntilChanged` whenever the upstream may emit new
-  *identities* with identical *values*.** A `combineLatest(...).pipe(
-  map(spread))` builds a fresh object each tick; provide a key/equality
-  function (value-based for primitives, structural for objects) so
-  downstream consumers do not re-render on no-op upstream churn.
+  *identities* with identical *values*.** A
+  `combineLatest(...).pipe(map(spread))` builds a fresh object each
+  tick; provide a key/equality function (value-based for primitives,
+  structural for objects) so downstream consumers do not re-render on
+  no-op upstream churn.
   [rxjs.dev: `distinctUntilChanged`](https://rxjs.dev/api/operators/distinctUntilChanged).
 - **Map, don't reconstruct.** If a derived stream is a pure function of
   an upstream, use `map` or `combineLatest` + `map`; don't tear down and
@@ -164,7 +165,7 @@ the rule against current authoritative docs rather than trust folklore.
   are usually ready before the user scrolls, avoiding a spinner.
   Reserve viewport-gating for data the user is *unlikely* to reach, or
   for fetches expensive enough to demonstrably hurt initial paint.
-  [TanStack: prefetching](https://tanstack.com/query/v4/docs/framework/react/guides/prefetching).
+  [TanStack: prefetching](https://tanstack.com/query/v5/docs/framework/react/guides/prefetching).
 - **Invalidate from the mutation, not on a poll.** Use
   `queryClient.invalidateQueries({ predicate })` from the write site
   rather than polling timers on the read site. Polling is a last
@@ -175,11 +176,11 @@ the rule against current authoritative docs rather than trust folklore.
   a ceiling becomes a runaway tab when the source fails for a
   structural reason. Cap retries and back off; cap polls at a
   session-scoped count.
-  [TanStack: window-focus refetching](https://tanstack.com/query/v4/docs/framework/react/guides/window-focus-refetching).
+  [TanStack: window-focus refetching](https://tanstack.com/query/v5/docs/framework/react/guides/window-focus-refetching).
 - **Seed lists from a parent query's data with `initialData` when the
   shape allows it.** Avoids a second network round-trip for a detail
   view that the list already rendered.
-  [TanStack: initial query data](https://tanstack.com/query/v4/docs/react/guides/initial-query-data).
+  [TanStack: initial query data](https://tanstack.com/query/v5/docs/framework/react/guides/initial-query-data).
 
 ---
 

--- a/.agents/rules/performance.md
+++ b/.agents/rules/performance.md
@@ -1,343 +1,316 @@
 # Performance Guidelines
 
-Distilled from the `perf/curated` sweep. Read when the work touches
-animations, scroll handlers, IntersectionObservers, rxjs query plumbing,
-critical-render path, or any change whose stated goal is "make this faster".
+Framework-agnostic perf principles for client-side work. Read when the work
+touches animations, scroll/resize handlers, observers, reactive streams,
+async data, bundle/critical render path, images, or tests that interact
+with any of the above. Sources are linked inline so the reader can verify
+the rule against current authoritative docs rather than trust folklore.
 
 ---
 
-## Animations & transitions
+## Animation & compositing
 
-### Prefer compositor properties
-
-Animate **`transform`** and **`opacity`** only. Avoid the
-layout-triggering properties: `width`, `height`, `top`, `left`, `right`,
-`bottom`, `margin`, `padding`, `backdrop-filter`.
-
-```scss
-/* Bad - reflows every frame */
-.tab-indicator {
-  left: calc(var(--active-index) * (var(--tab-width) + var(--tab-list-gap)));
-  transition: left var(--transition-increment) ease-in-out;
-}
-
-/* Good - composited */
-.tab-indicator {
-  left: 0;
-  transform: translateX(
-    calc(var(--active-index) * (var(--tab-width) + var(--tab-list-gap)))
-  );
-  transition: transform var(--transition-increment) ease-in-out;
-  will-change: transform;
-}
-```
-
-Same pattern applies to:
-
-- Tab indicators (`translateX`, not `left`)
-- Slide-in/out transitions (`translate`, not `width`/`height`)
-- Cover image swap (`opacity`/`transform`, not `width`/`left`)
-- Modal overlays (fade `opacity`, not animate `backdrop-filter`)
-
-### Progress-bar trap
-
-`transform: scaleX(ratio)` on a full-width fill **squishes its
-border-radius on the right edge** (scaled corners pinch). Two paths:
-
-1. Keep `width: var(--progress)%` - layout cost on a small bar is
-   negligible.
-2. Use `clip-path: inset(0 calc((1 - var(--ratio)) * 100%) 0 0 round X)` -
-   composited and preserves rounded corners.
-
-Don't ship a scaleX progress bar without confirming the rounded-edge case.
-
-### Image fade-in
-
-`CrossOriginImage` already animates `opacity` via the `image-loaded` class
-on `onload`. **Do not add artificial setTimeout delays** before flipping
-the class - the natural decode delay is the fade. Add `decoding="async"`
-on the `<img>` so the decode happens off the main thread.
+- **Animate only `transform` and `opacity`.** Other properties (`top`,
+  `left`, `width`, `height`, `margin`, `backdrop-filter`) trigger layout
+  or paint every frame; `transform` and `opacity` run on the compositor.
+  [web.dev: Animations guide](https://web.dev/articles/animations-guide).
+- **Use translate/scale/rotate, not their geometric equivalents.**
+  `translate()` replaces top/left; `scale()` replaces width/height;
+  `rotate()` replaces angular layout changes.
+  [web.dev: Compositor-only properties](https://web.dev/articles/stick-to-compositor-only-properties-and-manage-layer-count).
+- **Don't preemptively promote elements to their own layer** with
+  `will-change` or `translateZ(0)` on the off-chance they animate. Each
+  promoted layer costs GPU memory and management overhead;
+  over-promotion is a measurable regression.
+  [web.dev: Compositor-only properties](https://web.dev/articles/stick-to-compositor-only-properties-and-manage-layer-count).
+- **Treat `will-change` as a last-resort diagnostic.** Apply it
+  surgically via JS just before a change and reset to `auto` when the
+  animation ends; never blanket-declare it in stylesheets.
+  [MDN: `will-change`](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change).
+- **Scaling rounded shapes via `transform: scale(...)` re-rasters in
+  Chromium (since Chrome 53) unless `will-change: transform` is set on
+  the element.** CSS animations and the Web Animations API are exempt;
+  imperative script-driven scale is not. With `will-change: transform`
+  the element is locked to a fixed bitmap and scaled cheaply, at the
+  cost of crispness during the scale.
+  [Chrome Blog: Re-rastering on composite](https://developer.chrome.com/blog/re-rastering-composite).
+- **For progress / fill bars, prefer `width` or `clip-path: inset(...)`
+  over `scaleX`.** ScaleX uniformly stretches the element's
+  `border-radius`, so the right edge of a 30%-filled bar gets a pinched,
+  scaled corner. `width` keeps corners shaped; `clip-path: inset(0 X 0 0
+  round Y)` is composited and keeps corners crisp.
+  [MDN: `clip-path`](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path).
 
 ---
 
-## Scroll listeners
+## Event listeners
 
-### Always passive, always rAF-coalesced
-
-Unless the handler calls `preventDefault()`, attach with
-`{ passive: true }` so the compositor keeps scrolling smooth while JS
-runs. Coalesce frequent emissions with `requestAnimationFrame` so the
-handler runs at most once per frame.
-
-```ts
-let frame = 0;
-const schedule = () => {
-  if (frame) return;
-  frame = requestAnimationFrame(() => {
-    frame = 0;
-    handler();
-  });
-};
-
-node.addEventListener('scroll', schedule, { passive: true });
-
-return {
-  destroy() {
-    if (frame) cancelAnimationFrame(frame);
-    node.removeEventListener('scroll', schedule);
-  },
-};
-```
-
-### Spec consequence
-
-When tests dispatch synthetic `scroll` events against a rAF-coalesced
-handler, **flush a frame** before asserting:
-
-```ts
-const nextFrame = () =>
-  new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-
-node.dispatchEvent(new Event('scroll'));
-await nextFrame();
-expect(node.classList).toContain('scrolled-down');
-```
+- **Declare touch and wheel listeners `{ passive: true }`** unless the
+  handler calls `preventDefault()`. Without `passive`, the browser must
+  wait for JS to finish before scrolling because it cannot statically
+  predict `preventDefault()`. Chrome data: 80% of touch handlers that
+  blocked scrolling never called `preventDefault()`; 10% added more than
+  100 ms of delay.
+  [Chrome / Lighthouse: passive listeners](https://developer.chrome.com/docs/lighthouse/best-practices/uses-passive-event-listeners),
+  [MDN: `addEventListener` passive](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).
+- **Coalesce high-frequency handlers (scroll, resize, animation-frame
+  updates) with `requestAnimationFrame`.** Schedule at most one rAF per
+  frame; cancel pending frames on teardown. Run only paint-affecting
+  work in the rAF callback.
+  [MDN: `requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame).
+- **Don't rAF-throttle `pointermove`** to reduce event rate; user agents
+  already coalesce pointermove updates into single events. Use
+  `PointerEvent.getCoalescedEvents()` only when sub-frame fidelity
+  matters (drawing tools, fine-grained gesture trails).
+  [MDN: `PointerEvent.getCoalescedEvents()`](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/getCoalescedEvents).
+- **Always remove listeners (and cancel pending rAFs) on teardown.**
+  Lingering listeners hold their closures and the elements they
+  captured in memory.
+  [MDN: `removeEventListener`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener).
 
 ---
 
-## IntersectionObserver
+## IntersectionObserver, ResizeObserver, lazy work
 
-### Pool by options
-
-Don't construct a fresh `IntersectionObserver` per node. Pool by
-serialized options so all callers with the same threshold/root share one
-observer.
-
-```ts
-const pools = new Map<string, Pool>();
-function getPool(options: IntersectionObserverInit): Pool {
-  const key = JSON.stringify(options);
-  return pools.get(key) ?? /* create + cache */ ...;
-}
-```
-
-The shared `whenInViewport` action in `$lib/utils/actions/whenInViewport`
-already implements this. Use it.
-
-### Test mock must match real semantics
-
-The pool looks callbacks up by `entry.target`. Make sure
-`test/mocks/IntersectionObserver.mock.ts` fires its synthetic entry with
-the actual element passed to `observe()` (not a freshly-created `<div>`).
-Otherwise pool-based lookups silently swallow every hit in tests.
-
----
-
-## rxjs plumbing
-
-### `combineLatest` re-emits fresh identity
-
-`combineLatest(...).pipe(map(spread))` emits a new object every upstream
-tick, even when values are identical. Multi-subscriber chains should:
-
-1. Multicast with `shareReplay({ bufferSize: 1, refCount: true })` so
-   downstream consumers reuse one chain.
-2. Add `distinctUntilChanged(shallowEqual)` so identical-by-value
-   emissions short-circuit before the cascade.
-
-Use `isShallowEqual` from `$lib/utils/object/isShallowEqual.ts`. Don't
-re-implement.
-
-### Survive transient detach with `share` + delayed reset
-
-`shareReplay({ refCount: true })` tears down the source observable when
-the last subscriber leaves - costly on navigation (list -> detail ->
-list) because the chain restarts from scratch.
-
-`shareReplay({ refCount: false })` keeps the chain alive forever -
-**permanent subscription, memory leak** when the source is a TanStack
-QueryObserver or any long-lived listener.
-
-The right pattern is `share` with a delayed reset:
-
-```ts
-import { ReplaySubject, share, timer } from 'rxjs';
-import { time } from '$lib/utils/timing/time.ts';
-
-source$.pipe(
-  share({
-    connector: () => new ReplaySubject(1),
-    resetOnRefCountZero: () => timer(time.seconds(1)),
-  }),
-);
-```
-
-The 1s grace period covers transient detach (nav round-trip) while still
-tearing down for real unmounts.
-
-### Don't recreate Subjects when `map` will do
-
-```ts
-// Bad - new BehaviorSubject every upstream emission
-country$ = user$.pipe(
-  switchMap((u) => new BehaviorSubject(toCountry(u))),
-);
-
-// Good - just map
-country$ = user$.pipe(map(toCountry));
-```
-
-### Dedupe URL/param chains by serialized form
-
-`URLSearchParams` instances are not value-equal even when serialized
-strings match. Add `distinctUntilChanged((a, b) => a.toString() === b.toString())`
-on `search$`-style chains so identical query strings short-circuit
-downstream refetches and re-renders.
-
-### Coalesce localStorage writes
-
-Frequent settings toggles synchronously hit localStorage and block the
-main thread. Use a debounced Subject grouped by key:
-
-```ts
-writes$
-  .pipe(
-    groupBy((w) => w.key),
-    mergeMap((group) => group.pipe(debounceTime(200))),
-  )
-  .subscribe(({ key, value }) => safeLocalStorage.setItem(key, value));
-```
-
-`persistDebounced` in `$lib/utils/storage/persistDebounced.ts` already
-does this.
+- **One observer can watch many targets, so share rather than
+  multiply.** Construct a single `IntersectionObserver` per
+  `(root, threshold)` config and call `observe()` for every target that
+  needs that config.
+  [MDN: Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API),
+  [W3C: Intersection Observer](https://www.w3.org/TR/intersection-observer/).
+- **Keep threshold lists small.** Each threshold can fire the callback
+  once per target per crossing, so `[0, 0.25, 0.5, 0.75, 1.0]` is 5x
+  the work of `[0]` for the same observation.
+  [MDN: Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+- **Reach for `content-visibility: auto` before reaching for a custom
+  observer.** It lets the browser skip layout, paint, and hit-testing
+  for off-screen subtrees while keeping find-in-page, tab order, and
+  focus working. Pair it with a `contain-intrinsic-size` hint so
+  off-screen content does not collapse and cause layout shift.
+  [web.dev: `content-visibility`](https://web.dev/articles/content-visibility),
+  [MDN: `content-visibility`](https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility).
+- **Prefer native `loading="lazy"` over a custom IntersectionObserver
+  for image deferral.** It is connection-aware (1250 px below the
+  viewport on 4G, 2500 px on slower) and free of JS cost.
+  [web.dev: Browser-level lazy loading](https://web.dev/articles/browser-level-image-lazy-loading).
+- **Never lazy-load above-the-fold or LCP-relevant images.** Lazy
+  loading them adds an unnecessary network round-trip into the LCP
+  critical path. Always set explicit `width`/`height`; without them the
+  browser may treat the image as 0x0 and eagerly load everything to be
+  safe.
+  [web.dev: Browser-level lazy loading](https://web.dev/articles/browser-level-image-lazy-loading).
 
 ---
 
-## Bundle & critical-render path
+## Reactive streams (RxJS)
 
-### Sample at the loader, not just the SDK
-
-SDK-level sample rates (`replaysSessionSampleRate: 0.1`) still **download
-and initialize the integration for 100% of users**; only recording is
-skipped. To save the chunk for the unsampled cohort, gate the dynamic
-import itself:
-
-```ts
-const REPLAY_LOAD_SAMPLE = 0.1;
-const shouldLoadReplay = Math.random() < REPLAY_LOAD_SAMPLE;
-
-if (shouldLoadReplay) {
-  import('@sentry/sveltekit').then(({ replayIntegration }) => {
-    Sentry.addIntegration(replayIntegration(...));
-  });
-}
-```
-
-Tradeoff: on-error replays drop to the sample rate too. Set internal
-rates to `1.0` so the sampled cohort still gets full coverage.
-
-### Defer third-party scripts off critical render
-
-CSS: load asynchronously by setting `media="print"` then swapping to
-`"all"` on load. **Svelte 5 requires an expression handler** - the
-HTML-string `onload="this.media='all'"` does not compile:
-
-```svelte
-<link
-  rel="stylesheet"
-  href="https://cdn.plyr.io/3.8.3/plyr.css"
-  media="print"
-  onload={(e) => ((e.currentTarget as HTMLLinkElement).media = "all")}
-/>
-```
-
-JS: add `defer` attribute. The script executes after parsing without
-blocking.
-
-### Image rendering hints
-
-On every `<img>`:
-
-- `loading="lazy"` (unless above the fold)
-- `decoding="async"` (always)
-
-For responsive `srcset`, the underlying schema must expose multiple
-variants. `ImageUrlsSchema` currently only exposes `medium` and `thumb`;
-extending it (or per-domain schemas like YIR fanart) is a prerequisite
-before adding `srcset` to those call sites.
+- **Multicast cold sources that have more than one subscriber.** Without
+  a multicast operator (`share`, `shareReplay`), each subscription
+  re-runs the entire pipeline, including any side-effecting source
+  (HTTP, observer setup).
+  [rxjs.dev: `share`](https://rxjs.dev/api/operators/share).
+- **Pick the multicast variant that matches your replay needs.** Use
+  `shareReplay({ bufferSize: 1, refCount: true })` for "BehaviorSubject
+  semantics with auto-teardown when nothing is listening." Use
+  `share({ connector: () => new ReplaySubject(1), resetOnRefCountZero:
+  () => timer(N) })` when the source must survive a brief unsubscribe
+  (a navigation round-trip, say) but still tear down when truly idle.
+  [rxjs.dev: `shareReplay`](https://rxjs.dev/api/operators/shareReplay),
+  [rxjs.dev: `share`](https://rxjs.dev/api/operators/share).
+- **Avoid `shareReplay({ refCount: false })` (and the equivalent
+  `share({ resetOnRefCountZero: false })`) on long-lived sources.** The
+  underlying subscription is never torn down; that is fine for true
+  app-scope singletons, a memory leak for query observers or DOM
+  listeners.
+  [RxJS issue 5034 / discussion 6731](https://github.com/ReactiveX/rxjs/issues/5034).
+- **Use `distinctUntilChanged` whenever the upstream may emit new
+  *identities* with identical *values*.** A `combineLatest(...).pipe(
+  map(spread))` builds a fresh object each tick; provide a key/equality
+  function (value-based for primitives, structural for objects) so
+  downstream consumers do not re-render on no-op upstream churn.
+  [rxjs.dev: `distinctUntilChanged`](https://rxjs.dev/api/operators/distinctUntilChanged).
+- **Map, don't reconstruct.** If a derived stream is a pure function of
+  an upstream, use `map` or `combineLatest` + `map`; don't tear down and
+  recreate a Subject on every change. Recreated subjects break identity
+  for downstream consumers and replay nothing on resubscribe.
+  [rxjs.dev: `BehaviorSubject`](https://rxjs.dev/api/index/class/BehaviorSubject).
+- **Group-debounce writes to side-effect sinks.** For coalescing bursty
+  events that target many keys (localStorage writes, telemetry pings),
+  partition the stream via `groupBy(keyFn)` and then
+  `mergeMap(group => group.pipe(debounceTime(N)))`. Per-key debounce,
+  single subscription.
+  [rxjs.dev: `groupBy`](https://rxjs.dev/api/operators/groupBy).
 
 ---
 
-## Viewport-gating: prefetch usually wins
+## Async data caching
 
-Don't viewport-gate a list's data fetch just because it's below the fold.
-Browsers handle a handful of parallel queries fine, and a small upfront
-spend primes the cache so the list renders instantly when the user
-scrolls. Reserve viewport-gating for cases where the fetch is heavy
-enough to demonstrably hurt initial paint of the visible content.
-
-DOM render-gating is a different layer - SectionList already
-viewport-gates its own children's *rendering*. The fetch lives one layer
-up (in the `*List` wrapper that calls `useQuery`), so gating only the
-SectionList doesn't reduce network cost.
-
----
-
-## Provider mount deferral
-
-Don't defer mounting providers (drawer, dialog, etc.) behind
-`requestIdleCallback` or `onMount(setTimeout(...))` for "boot speed". The
-mount cost is negligible compared to the race risk: early user
-interactions (e.g. clicking a button within the first 500ms) hit a
-not-yet-mounted provider and silently no-op.
-
----
-
-## Empty methods
-
-Use `NOOP_FN` from `$lib/utils/constants.ts`, not inline `() => {}`.
-DeepSource flags inline empties as `JS-0321`.
-
-```ts
-import { NOOP_FN } from '$lib/utils/constants.ts';
-
-if (!element) {
-  return { destroy: NOOP_FN };
-}
-```
-
----
-
-## Sanity checks before claiming a perf win
-
-- **Is the work the change skips actually expensive?** A `combineLatest`
-  chain that emits 20 times per session does not justify a `shareReplay`
-  in isolation. The chain has to either be hot or feed expensive
-  downstream work.
-- **Does an SDK / library already self-gate?** Check before wrapping.
-  `QueryDevtools` already gates on `dev` internally; wrapping it in
-  `{#if dev}` is dead weight.
-- **Does the perf optimization fight UX?** Lazy-mount of below-fold
-  fetches stops prefetch and forces a spinner on scroll. Mount-defer
-  drops early clicks. ScaleX on progress bars breaks border-radius.
-  Honest tradeoff comes first.
+- **Pick a TTL per query class, not per call site.** TanStack Query's
+  `staleTime` controls how long cached data is considered fresh;
+  `gcTime` controls how long inactive cached data lives before garbage
+  collection. The defaults (`staleTime: 0`, `gcTime: 5 min`) favor
+  freshness over network savings; override for stable data.
+  [TanStack: important defaults](https://tanstack.com/query/v5/docs/framework/react/guides/important-defaults),
+  [TanStack: QueryClient](https://tanstack.com/query/latest/docs/reference/QueryClient).
+- **Survive transient unsubscribe.** When a query observer briefly
+  drops to zero subscribers (route change, conditional render flip) and
+  then reattaches, you do not want a full restart. `gcTime` keeps the
+  cached data alive; on the rxjs side, `share` with a delayed
+  `resetOnRefCountZero` keeps the upstream pipeline warm for the same
+  window.
+  [TanStack: important defaults](https://tanstack.com/query/v5/docs/framework/react/guides/important-defaults).
+- **Prefer prefetch over viewport-gated fetch for below-the-fold data
+  the user is *likely* to reach.** Below-the-fold lists fetched eagerly
+  are usually ready before the user scrolls, avoiding a spinner.
+  Reserve viewport-gating for data the user is *unlikely* to reach, or
+  for fetches expensive enough to demonstrably hurt initial paint.
+  [TanStack: prefetching](https://tanstack.com/query/v4/docs/framework/react/guides/prefetching).
+- **Invalidate from the mutation, not on a poll.** Use
+  `queryClient.invalidateQueries({ predicate })` from the write site
+  rather than polling timers on the read site. Polling is a last
+  resort for data without a write hook (push notifications, external
+  sync).
+  [TanStack: query invalidation](https://tanstack.com/query/v5/docs/framework/react/guides/query-invalidation).
+- **Bound any retry or poll loop.** A retry-until-success loop without
+  a ceiling becomes a runaway tab when the source fails for a
+  structural reason. Cap retries and back off; cap polls at a
+  session-scoped count.
+  [TanStack: window-focus refetching](https://tanstack.com/query/v4/docs/framework/react/guides/window-focus-refetching).
+- **Seed lists from a parent query's data with `initialData` when the
+  shape allows it.** Avoids a second network round-trip for a detail
+  view that the list already rendered.
+  [TanStack: initial query data](https://tanstack.com/query/v4/docs/react/guides/initial-query-data).
 
 ---
 
-## Commit scopes
+## Bundle & critical render path
 
-`commitlint.config.js` enforces `scope-enum` strictly. Before committing
-perf work, pick a scope from the enum. Common mismatches:
+- **Defer third-party JS that isn't needed for first paint.** Use the
+  `defer` attribute (executes after parse, in document order) or
+  dynamic `import()` from inside an idle callback / `load` event. Avoid
+  `async` for code that depends on document state.
+  [MDN: `<script>` `defer` / `async`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script).
+- **Defer non-critical CSS** by attaching it with `media="print"` and
+  swapping to `"all"` on load. In Svelte 5 the handler must be an
+  expression (`onload={(e) => ...}`); the legacy HTML-string form
+  doesn't compile.
+  [web.dev: Defer non-critical CSS](https://web.dev/articles/defer-non-critical-css).
+- **Code-split at route boundaries.** SvelteKit and Vite already split
+  per route; resist adding manual `import()` calls that fragment a
+  route's main chunk further. Those generally cost more in HTTP
+  round-trips than they save in initial bytes.
+  [Vite: build features](https://vite.dev/guide/build).
+- **For sampled third-party SDKs, sample at the loader, not just in the
+  SDK config.** A `sessionSampleRate: 0.1` setting inside an SDK still
+  downloads and initializes the SDK for 100% of users; only the
+  recording is skipped. Gate the dynamic `import()` itself with a
+  `Math.random() < N` check so the unsampled cohort never pays the
+  bundle cost.
+  [web.dev: Reduce JavaScript payloads with code splitting](https://web.dev/articles/reduce-javascript-payloads-with-code-splitting).
+- **Self-host or preconnect to font sources** and prefer
+  `font-display: swap` (or `optional` for non-critical fonts) so text
+  is rendered with a fallback while the web font loads.
+  [web.dev: Avoid invisible text during font loading](https://web.dev/articles/avoid-invisible-text).
 
-| Tempting scope | Use instead |
-|----------------|-------------|
-| `scroll`       | `list` (or matching feature) |
-| `pagination`   | `list`                       |
-| `modal`        | `dialog`                     |
-| `tabs`         | `transition`                 |
-| `sentry`       | `errors`                     |
-| `storage`      | `settings`                   |
-| `viewport`     | `card`                       |
-| `parameters`   | `parameter`                  |
-| `timing`       | `transition`                 |
-| `image`        | `transition` or `cover`      |
+---
+
+## Images
+
+- **Always set explicit `width` and `height` on `<img>`** so the
+  browser can reserve the correct aspect-ratio box before the image
+  loads. Eliminates CLS and makes native lazy loading viable.
+  [web.dev: Optimize CLS - images without dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions).
+- **Pair `loading="lazy"` with `decoding="async"`** on every non-LCP
+  image. Async decode keeps long decodes off the main thread; lazy
+  defers below-the-fold fetches.
+  [MDN: `img` loading](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading),
+  [MDN: `img` decoding](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#decoding).
+- **Serve responsive variants with `srcset` + `sizes`.** Let the
+  browser pick the right resolution per viewport / DPR; do not ship a
+  1600 px cover to a 320 px mobile viewport.
+  [MDN: Responsive images](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images).
+- **Use `<picture>` for art direction or format fallbacks** (different
+  crops by viewport, AVIF/WebP fallback to JPEG). Order sources from
+  most-preferred to least: `<source type="image/avif">`, then
+  `<source type="image/webp">`, then the JPEG/PNG `<img>` baseline.
+  [MDN: `<picture>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture).
+- **Don't render content images with `background-image`.** Background
+  images lack `alt`, `srcset`, native lazy loading, and decode hints,
+  and they aren't visible to screen readers or LCP detection. Reserve
+  CSS backgrounds for decorative patterns.
+  [web.dev: Optimize LCP](https://web.dev/articles/optimize-lcp).
+
+---
+
+## Test-side discipline
+
+- **Flush a frame after dispatching synthetic events that trigger
+  rAF-coalesced handlers.** Pattern:
+  `await new Promise(r => requestAnimationFrame(() => r()))`. Otherwise
+  the assertion runs before the queued callback fires and the test
+  flickers.
+  [MDN: `requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame).
+- **An `IntersectionObserver` test mock must fire its callback with the
+  actual `target` passed to `observe()`,** not a freshly-created
+  element. Production code that uses a shared observer pool looks
+  callbacks up by `entry.target`; mocks that synthesise a new `<div>`
+  per construction silently swallow every hit.
+  [W3C: Intersection Observer](https://www.w3.org/TR/intersection-observer/).
+- **Don't simulate observer behavior with `setTimeout`.** Time-based
+  fakes drift under vitest's fake timers and hide ordering bugs. Mock
+  the observer's surface (`observe`, `unobserve`, `disconnect`) and
+  invoke its callback synchronously from the mock; vitest will await
+  microtasks naturally.
+  [Vitest: Mocking](https://vitest.dev/guide/mocking).
+- **When the production change adds a delay (rAF, debounce, idle
+  callback), update the spec in the same commit.** A spec that passed
+  on synchronous behavior and silently fails on async is a worse signal
+  than a spec that explicitly waits for the new boundary.
+
+---
+
+## Honest tradeoffs
+
+The category most likely to introduce regressions in the name of
+performance. Apply skeptically.
+
+- **Don't viewport-gate a list's *fetch* just because it's below the
+  fold.** Browsers handle a handful of parallel queries fine, and a
+  modest upfront fetch primes the cache so the list renders instantly
+  when the user scrolls. Render-gating (`content-visibility: auto`) is
+  the cheaper, safer optimization for the same goal.
+  [web.dev: `content-visibility`](https://web.dev/articles/content-visibility).
+- **Don't defer mounting context providers behind `requestIdleCallback`
+  for boot speed.** Mount cost is small; the race against an early
+  user interaction (first 500 ms) that hits a not-yet-mounted provider
+  and silently no-ops is a real regression.
+- **`scaleX` on a progress bar breaks the right-edge corner radius.**
+  See the animation section for the proper alternatives.
+- **Don't micro-optimize cold paths.** A `shareReplay` on a stream with
+  one subscriber emitting ten times per session saves nothing
+  measurable. Optimize hot paths (per-frame, per-keystroke, per-scroll)
+  and surfaces that show up in profiling, not branches that "feel
+  expensive" by inspection.
+- **Verify before declaring a win.** Local feel is not a measurement.
+  Compare in DevTools Performance / Lighthouse / Core Web Vitals real
+  user monitoring before and after, on the affected interaction. If
+  you can't show the delta, the optimization may not exist.
+  [web.dev: User-centric performance metrics](https://web.dev/articles/user-centric-performance-metrics).
+- **Check whether the library already handles the optimization.**
+  Wrapping a debug-only component in a `dev` gate is dead weight if
+  the component already self-gates on `dev` internally. Read the
+  library code before adding a hand-rolled gate around it.
+
+---
+
+## When in doubt
+
+1. Profile first. Chrome DevTools Performance panel + Core Web Vitals
+   RUM beat intuition.
+   [web.dev: Core Web Vitals](https://web.dev/articles/vitals).
+2. Move the heavy work off the main thread (worker, idle callback,
+   compositor) instead of trying to make it faster on it.
+3. Defer below-the-fold *rendering* before deferring below-the-fold
+   *data*.
+4. When two optimizations contradict, pick the one easier to reverse
+   if measurements disagree later.


### PR DESCRIPTION
## Summary

The `performance.md` rule that landed on main alongside the perf sweep
read more like a patch log of that specific PR (\"scopes to use in
commitlint\", \"NOOP_FN from constants\", \"existing whenInViewport pool\")
than like reusable guidance.

This rewrites it as framework-agnostic perf principles, each citing an
authoritative primary source so future readers can verify the rule
against current docs rather than trust folklore. Sources are web.dev,
MDN, W3C, rxjs.dev, TanStack docs, Chrome blog - no random Medium
posts.

Coverage matches the previous file (animations, listeners, observers,
rxjs, async data, bundle / critical render path, images, tests, honest
tradeoffs) but the rules are decoupled from any particular file or
commit in this repo.

## Test plan

- [ ] Skim the new file end-to-end - does any rule still feel
      project-coupled?
- [ ] Spot-check three citation links and make sure they still resolve
      to the relevant section.
- [ ] If you disagree with any principle, push back here before this
      becomes the loaded house rule.