### PR TITLE
feat(summary): add media Social Activity indicator and drawer

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7733,6 +7733,48 @@
     "text_streaming_tmdb_pill": {
       "default": "TMDB {id}",
       "description": "Pill label showing the TMDB id of a synced item."
+    },
+    "text_social_activities_placeholder": {
+      "default": "No one you follow has watched, rated, reviewed, or watchlisted this yet.",
+      "description": "Placeholder text shown when there are no social activities to show for a movie, show, or episode."
+    },
+    "link_label_open_review": {
+      "default": "Open review by {user}",
+      "description": "Text for the link that opens a review of a specific user.",
+      "variables": {
+        "user": {
+          "type": "string"
+        }
+      }
+    },
+    "tag_text_watchlisted": {
+      "default": "Watchlisted",
+      "description": "Text for the tag that indicates if a movie or show is watchlisted. This should be as short and concise as possible."
+    },
+    "tag_text_reviewed": {
+      "default": "Reviewed",
+      "description": "Text for the tag that indicates if a movie, show, or episode is reviewed. This should be as short and concise as possible."
+    },
+    "link_label_view_social_activities": {
+      "default": "View social activities for {title}",
+      "description": "Text for the link that opens social activities for a specific movie, show, or episode.",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "text_no_activity": {
+      "default": "No activity",
+      "description": "Placeholder text shown when there are no social activities for a movie, show, or episode. This should be as short and concise as possible."
+    },
+    "text_social_activity": {
+      "default": "Activity",
+      "description": "Text for singular social activity label."
+    },
+    "text_social_activities": {
+      "default": "Activities",
+      "description": "Text for plural social activities label."
     }
   }
 }

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -3,4 +3,5 @@ export enum FeatureFlag {
   EditMode = 'edit-mode',
   StreamingSync = 'streaming-sync',
   ScopedFavorites = 'scoped-favorites',
+  SocialActivities = 'social-activities',
 }

--- a/projects/client/src/lib/requests/models/MediaSocial.ts
+++ b/projects/client/src/lib/requests/models/MediaSocial.ts
@@ -1,0 +1,39 @@
+import { UserProfileSchema } from '$lib/requests/models/UserProfile.ts';
+import { z } from 'zod';
+
+const MediaSocialRatingSchema = z.object({
+  rating: z.number(),
+  ratedAt: z.date().nullish(),
+});
+
+const MediaSocialCommentSchema = z.object({
+  id: z.number(),
+  key: z.string(),
+  comment: z.string(),
+  isSpoiler: z.boolean(),
+  isReview: z.boolean(),
+  createdAt: z.date().nullish(),
+  updatedAt: z.date().nullish(),
+});
+
+const MediaSocialWatchedSchema = z.object({
+  plays: z.number(),
+  lastWatchedAt: z.date().nullish(),
+  lastUpdatedAt: z.date().nullish(),
+  rating: MediaSocialRatingSchema.optional(),
+  comment: MediaSocialCommentSchema.optional(),
+});
+
+const MediaSocialWatchlistedSchema = z.object({
+  listedAt: z.date(),
+});
+
+export const MediaSocialSchema = z.object({
+  key: z.string(),
+  followedAt: z.date(),
+  user: UserProfileSchema,
+  watched: MediaSocialWatchedSchema.optional(),
+  watchlisted: MediaSocialWatchlistedSchema.optional(),
+});
+
+export type MediaSocial = z.infer<typeof MediaSocialSchema>;

--- a/projects/client/src/lib/requests/queries/comments/commentQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/comments/commentQuery.spec.ts
@@ -1,0 +1,22 @@
+import { mapToMediaComment } from '$lib/requests/_internal/mapToMediaComment.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { MovieHereticCommentsResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticCommentsResponseMock.ts';
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { describe, expect, it } from 'vitest';
+import { commentQuery } from './commentQuery.ts';
+
+describe('commentQuery', () => {
+  it('should query for a comment by id', async () => {
+    const commentResponse = assertDefined(
+      MovieHereticCommentsResponseMock.at(0),
+    );
+    const result = await runQuery({
+      factory: () =>
+        createTestBedQuery(commentQuery({ id: commentResponse.id })),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(mapToMediaComment(commentResponse));
+  });
+});

--- a/projects/client/src/lib/requests/queries/comments/commentQuery.ts
+++ b/projects/client/src/lib/requests/queries/comments/commentQuery.ts
@@ -1,0 +1,58 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { mapToMediaComment } from '$lib/requests/_internal/mapToMediaComment.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { MediaCommentSchema } from '$lib/requests/models/MediaComment.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { type CommentResponse, commentResponseSchema } from '@trakt/api';
+
+type CommentParams =
+  & {
+    id: number;
+  }
+  & ApiParams;
+
+const commentRequest = async ({ fetch, id }: CommentParams) => {
+  const response = await rawApiFetch({
+    fetch,
+    path: `/comments/${id}?extended=images`,
+  });
+
+  if (!response.ok) {
+    return {
+      body: null,
+      status: response.status,
+    };
+  }
+
+  return {
+    body: commentResponseSchema.parse(await response.json()),
+    status: response.status,
+  };
+};
+
+function mapToComment(response: CommentResponse | null) {
+  if (response == null) {
+    throw new Error('Comment response body is missing');
+  }
+
+  return mapToMediaComment(response);
+}
+
+export const commentQuery = defineQuery({
+  key: 'comment',
+  invalidations: [
+    InvalidateAction.React,
+    InvalidateAction.Comment.Post('movie'),
+    InvalidateAction.Comment.Post('show'),
+    InvalidateAction.Comment.Post('episode'),
+    InvalidateAction.Comment.Reply('movie'),
+    InvalidateAction.Comment.Reply('show'),
+    InvalidateAction.Comment.Reply('episode'),
+  ],
+  dependencies: (params) => [params.id],
+  request: commentRequest,
+  mapper: (response) => mapToComment(response.body),
+  schema: MediaCommentSchema,
+  ttl: time.minutes(30),
+});

--- a/projects/client/src/lib/requests/queries/media/mediaSocialQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/media/mediaSocialQuery.spec.ts
@@ -1,0 +1,75 @@
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { mediaSocialQuery } from '$lib/requests/queries/media/mediaSocialQuery.ts';
+import { EpisodeSiloResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloResponseMock.ts';
+import { MediaSocialMappedMock } from '$mocks/data/summary/common/mapped/MediaSocialMappedMock.ts';
+import { MovieHereticResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticResponseMock.ts';
+import { ShowSiloResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloResponseMock.ts';
+import { createTestBedInfiniteQuery } from '$test/beds/query/createTestBedInfiniteQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { mapToEntries } from '$test/utils/mapToEntries.ts';
+import { describe, expect, it } from 'vitest';
+
+describe('mediaSocialQuery', () => {
+  it('should query movie social users', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createTestBedInfiniteQuery(
+          mediaSocialQuery({
+            type: 'movie',
+            slug: MovieHereticResponseMock.ids.slug,
+            limit: 5,
+          }),
+        ),
+      mapper: mapToEntries,
+    });
+
+    expect(result).to.deep.equal(MediaSocialMappedMock);
+  });
+
+  it('should query show social users', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createTestBedInfiniteQuery(
+          mediaSocialQuery({
+            type: 'show',
+            slug: ShowSiloResponseMock.ids.slug,
+            limit: 5,
+          }),
+        ),
+      mapper: mapToEntries,
+    });
+
+    expect(result).to.deep.equal(MediaSocialMappedMock);
+  });
+
+  it('should query episode social users', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createTestBedInfiniteQuery(
+          mediaSocialQuery({
+            type: 'episode',
+            slug: ShowSiloResponseMock.ids.slug,
+            season: EpisodeSiloResponseMock.season,
+            episode: EpisodeSiloResponseMock.number,
+            limit: 5,
+          }),
+        ),
+      mapper: mapToEntries,
+    });
+
+    expect(result).to.deep.equal(MediaSocialMappedMock);
+  });
+
+  it('should invalidate when social inputs can change', () => {
+    const query = mediaSocialQuery({
+      type: 'movie',
+      slug: MovieHereticResponseMock.ids.slug,
+      limit: 5,
+    });
+
+    expect(query.queryKey).toContain(InvalidateAction.User.Follow);
+    expect(query.queryKey).toContain(InvalidateAction.MarkAsWatched('movie'));
+    expect(query.queryKey).toContain(InvalidateAction.Rated('episode'));
+    expect(query.queryKey).toContain(InvalidateAction.Watchlisted('show'));
+  });
+});

--- a/projects/client/src/lib/requests/queries/media/mediaSocialQuery.ts
+++ b/projects/client/src/lib/requests/queries/media/mediaSocialQuery.ts
@@ -1,0 +1,277 @@
+import { defineInfiniteQuery } from '$lib/features/query/defineQuery.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
+import { mapToUserProfile } from '$lib/requests/_internal/mapToUserProfile.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import {
+  type MediaSocial,
+  MediaSocialSchema,
+} from '$lib/requests/models/MediaSocial.ts';
+import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import type { ProfileResponse } from '@trakt/api';
+import { z } from 'zod';
+
+type MediaSocialMovieTarget = {
+  type: 'movie';
+  slug: string;
+};
+
+type MediaSocialShowTarget = {
+  type: 'show';
+  slug: string;
+};
+
+type MediaSocialEpisodeTarget = {
+  type: 'episode';
+  slug: string;
+  season: number;
+  episode: number;
+};
+
+export type MediaSocialQueryTarget =
+  | MediaSocialMovieTarget
+  | MediaSocialShowTarget
+  | MediaSocialEpisodeTarget;
+
+type MediaSocialParams =
+  & MediaSocialQueryTarget
+  & PaginationParams
+  & ApiParams;
+
+const MediaSocialUserResponseSchema = z.object({
+  username: z.string(),
+  private: z.boolean().default(false),
+  deleted: z.boolean().default(false),
+  name: z.string().nullish().default(null),
+  vip: z.boolean().nullish(),
+  vip_ep: z.boolean().nullish(),
+  director: z.boolean().nullish(),
+  ids: z.object({
+    slug: z.string().nullish(),
+    trakt: z.number(),
+  }),
+  images: z.object({
+    avatar: z.object({
+      full: z.string().nullish(),
+    }).default({ full: null }),
+  }).default({ avatar: { full: null } }),
+  location: z.string().nullish().default(null),
+  about: z.string().nullish().default(null),
+  vip_cover_image: z.string().nullish().default(null),
+  joined_at: z.string().nullish().default(null),
+}).passthrough();
+
+const MediaSocialRatingResponseSchema = z.object({
+  rating: z.number(),
+  rated_at: z.string().nullish(),
+});
+
+const MediaSocialCommentResponseSchema = z.object({
+  ids: z.object({ trakt: z.number() }),
+  comment: z.string().nullish(),
+  spoiler: z.boolean(),
+  review: z.boolean(),
+  created_at: z.string().nullish(),
+  updated_at: z.string().nullish(),
+});
+
+const MediaSocialWatchedResponseSchema = z.object({
+  plays: z.number(),
+  last_watched_at: z.string().nullish(),
+  last_updated_at: z.string().nullish(),
+  rating: MediaSocialRatingResponseSchema.optional(),
+  comment: MediaSocialCommentResponseSchema.optional(),
+});
+
+const MediaSocialWatchlistedResponseSchema = z.object({
+  listed_at: z.string(),
+});
+
+export const MediaSocialResponseSchema = z.array(
+  z.object({
+    followed_at: z.string(),
+    user: MediaSocialUserResponseSchema,
+    watched: MediaSocialWatchedResponseSchema.optional(),
+    watchlisted: MediaSocialWatchlistedResponseSchema.optional(),
+  }),
+);
+
+export type MediaSocialResponse = z.infer<typeof MediaSocialResponseSchema>;
+export type MediaSocialResponseInput = z.input<
+  typeof MediaSocialResponseSchema
+>;
+type MediaSocialEntryResponse = MediaSocialResponse[number];
+type MediaSocialWatchedResponse = NonNullable<
+  MediaSocialEntryResponse['watched']
+>;
+type MediaSocialWatched = NonNullable<MediaSocial['watched']>;
+
+function toDate(value: string | null | undefined): Date | null {
+  if (value == null) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function toSocialPath(params: MediaSocialQueryTarget): string {
+  const slug = encodeURIComponent(params.slug);
+
+  switch (params.type) {
+    case 'movie':
+      return `/movies/${slug}/social`;
+    case 'show':
+      return `/shows/${slug}/social`;
+    case 'episode':
+      return `/shows/${slug}/seasons/${params.season}/episodes/${params.episode}/social`;
+  }
+}
+
+function toSocialSearchParams(params: PaginationParams): string {
+  const searchParams = new URLSearchParams();
+
+  if (params.page != null) {
+    searchParams.set('page', String(params.page));
+  }
+
+  if (params.limit != null) {
+    searchParams.set('limit', String(params.limit));
+  }
+
+  const search = searchParams.toString();
+  return search.length > 0 ? `?${search}` : '';
+}
+
+function getTargetDependencies(params: MediaSocialQueryTarget) {
+  return params.type === 'episode'
+    ? [params.type, params.slug, params.season, params.episode]
+    : [params.type, params.slug];
+}
+
+function getInvalidations(): ReturnType<typeof InvalidateAction.Rated>[] {
+  const types: ExtendedMediaType[] = ['movie', 'show', 'episode'];
+
+  return types.flatMap((type) => [
+    InvalidateAction.Rated(type),
+    InvalidateAction.MarkAsWatched(type),
+    InvalidateAction.Comment.Post(type),
+  ]);
+}
+
+function mapToSocialComment(
+  comment: MediaSocialWatchedResponse['comment'] | undefined,
+): MediaSocialWatched['comment'] | undefined {
+  if (comment == null) return undefined;
+
+  const id = comment.ids.trakt;
+
+  return {
+    id,
+    key: `comment-${id}`,
+    comment: comment.comment ?? '',
+    isSpoiler: comment.spoiler,
+    isReview: comment.review,
+    createdAt: toDate(comment.created_at),
+    updatedAt: toDate(comment.updated_at),
+  };
+}
+
+function mapToSocialRating(
+  rating: MediaSocialWatchedResponse['rating'] | undefined,
+): MediaSocialWatched['rating'] | undefined {
+  if (rating == null) return undefined;
+
+  return {
+    rating: rating.rating,
+    ratedAt: toDate(rating.rated_at),
+  };
+}
+
+function mapToSocialWatched(
+  watched: MediaSocialEntryResponse['watched'] | undefined,
+): MediaSocialWatched | undefined {
+  if (watched == null) return undefined;
+
+  const rating = mapToSocialRating(watched.rating);
+  const comment = mapToSocialComment(watched.comment);
+
+  return {
+    plays: watched.plays,
+    lastWatchedAt: toDate(watched.last_watched_at),
+    lastUpdatedAt: toDate(watched.last_updated_at),
+    ...(rating && { rating }),
+    ...(comment && { comment }),
+  };
+}
+
+function mapToMediaSocial(entry: MediaSocialEntryResponse): MediaSocial {
+  const user = mapToUserProfile(entry.user as ProfileResponse);
+  const watched = mapToSocialWatched(entry.watched);
+  const watchlisted = entry.watchlisted == null
+    ? undefined
+    : { listedAt: new Date(entry.watchlisted.listed_at) };
+
+  return {
+    key: `media-social-${user.id}`,
+    followedAt: new Date(entry.followed_at),
+    user,
+    ...(watched && { watched }),
+    ...(watchlisted && { watchlisted }),
+  };
+}
+
+const mediaSocialRequest = async (
+  { fetch, ...params }: MediaSocialParams,
+) => {
+  const response = await rawApiFetch({
+    fetch,
+    path: `${toSocialPath(params)}${toSocialSearchParams(params)}`,
+  });
+
+  if (response.status === 204) {
+    return {
+      body: [],
+      headers: response.headers,
+      status: 204,
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      body: [],
+      headers: response.headers,
+      status: response.status,
+    };
+  }
+
+  return {
+    body: MediaSocialResponseSchema.parse(await response.json()),
+    headers: response.headers,
+    status: 200,
+  };
+};
+
+export const mediaSocialQuery = defineInfiniteQuery({
+  key: 'mediaSocial',
+  invalidations: [
+    InvalidateAction.User.Follow,
+    InvalidateAction.Watchlisted('movie'),
+    InvalidateAction.Watchlisted('show'),
+    ...getInvalidations(),
+  ],
+  dependencies: (
+    params: MediaSocialParams,
+  ) => [
+    ...getTargetDependencies(params),
+    params.page,
+    params.limit,
+  ],
+  request: mediaSocialRequest,
+  mapper: (response, params) => ({
+    entries: response.body.map(mapToMediaSocial),
+    page: extractPageMeta(response.headers, params.page),
+  }),
+  schema: PaginatableSchemaFactory(MediaSocialSchema),
+  ttl: time.minutes(5),
+});

--- a/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
@@ -4,7 +4,9 @@
   import type { Season } from "$lib/requests/models/Season";
   import type { SentimentAnalysis } from "$lib/requests/models/SentimentAnalysis";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
+  import type { MediaSocialQueryTarget } from "$lib/requests/queries/media/mediaSocialQuery.ts";
   import WhereToWatchDrawerHost from "$lib/sections/lists/where-to-watch/_internal/WhereToWatchDrawerHost.svelte";
+  import { episodeActivityTitle } from "$lib/utils/intl/episodeActivityTitle.ts";
   import {
     SummaryDrawers,
     summaryDrawerNavigation,
@@ -12,6 +14,7 @@
   import CastDrawerHost from "./components/cast/CastDrawerHost.svelte";
   import type { CommentsProps } from "./components/comments/CommentsProps";
   import CommentsDrawerHost from "./components/comments/drawers/CommentsDrawerHost.svelte";
+  import ReviewDrawerHost from "./components/comments/drawers/ReviewDrawerHost.svelte";
   import DetailsDrawer from "./components/details/DetailsDrawer.svelte";
   import type { MediaDetailsProps } from "./components/details/MediaDetailsProps";
   import HistoryDrawerHost from "./components/history/HistoryDrawerHost.svelte";
@@ -19,6 +22,7 @@
   import RatingsDrawer from "./components/rating/RatingsDrawer.svelte";
   import SeasonsDrawerHost from "./components/seasons/SeasonsDrawerHost.svelte";
   import SentimentDrawer from "./components/sentiment/SentimentDrawer.svelte";
+  import SocialDrawerHost from "./components/social/SocialDrawerHost.svelte";
   import TriviaDrawerHost from "./components/trivia/TriviaDrawerHost.svelte";
   import VideoDrawerHost from "./components/videos/VideoDrawerHost.svelte";
 
@@ -29,7 +33,7 @@
     currentSeason,
     ...details
   }: {
-    sentiment?: SentimentAnalysis | Nil;
+    sentiment?: SentimentAnalysis | null | undefined;
     videos?: MediaVideo[];
     seasons?: Season[];
     currentSeason?: number;
@@ -72,6 +76,25 @@
         }
       : { type: details.type, media: details.media },
   );
+
+  const socialTarget = $derived.by((): MediaSocialQueryTarget => {
+    if (details.type === "episode") {
+      return {
+        type: "episode",
+        slug: details.show.slug,
+        season: details.episode.season,
+        episode: details.episode.number,
+      };
+    }
+
+    return { type: details.type, slug: details.media.slug };
+  });
+
+  const socialTitle = $derived.by(() =>
+    details.type === "episode"
+      ? episodeActivityTitle(details.episode, details.show)
+      : details.media.title,
+  );
 </script>
 
 {#if drawer === SummaryDrawers.Sentiment && sentiment}
@@ -98,6 +121,10 @@
   <HistoryDrawerHost {...details} onClose={close} />
 {/if}
 
+{#if drawer === SummaryDrawers.Social}
+  <SocialDrawerHost target={socialTarget} title={socialTitle} onClose={close} />
+{/if}
+
 {#if drawer === SummaryDrawers.Notes && media}
   <NotesDrawerHost {media} onClose={close} />
 {/if}
@@ -121,6 +148,14 @@
     source={sourceCommentId != null
       ? { id: sourceCommentId, isReplying: false }
       : undefined}
+    onClose={close}
+  />
+{/if}
+
+{#if drawer === SummaryDrawers.Review && sourceCommentId != null}
+  <ReviewDrawerHost
+    {...commentsProps}
+    commentId={sourceCommentId}
     onClose={close}
   />
 {/if}

--- a/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
+++ b/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
@@ -8,10 +8,12 @@ export enum SummaryDrawers {
   Videos = 'videos',
   Trivia = 'trivia',
   History = 'history',
+  Social = 'social',
   WhereToWatch = 'where-to-watch',
   Seasons = 'seasons',
   Notes = 'notes',
   Comments = 'comments',
+  Review = 'review',
   Ratings = 'ratings',
 }
 
@@ -19,6 +21,7 @@ const commentIdParam = 'comment_id';
 
 const summaryDrawerParams = {
   [SummaryDrawers.Comments]: { [commentIdParam]: '' },
+  [SummaryDrawers.Review]: { [commentIdParam]: '' },
 } satisfies Partial<Record<SummaryDrawers, Record<string, string>>>;
 
 function mapToDrawer(value: string | Nil) {
@@ -35,6 +38,8 @@ function mapToDrawer(value: string | Nil) {
       return SummaryDrawers.Trivia;
     case SummaryDrawers.History:
       return SummaryDrawers.History;
+    case SummaryDrawers.Social:
+      return SummaryDrawers.Social;
     case SummaryDrawers.WhereToWatch:
       return SummaryDrawers.WhereToWatch;
     case SummaryDrawers.Seasons:
@@ -43,6 +48,8 @@ function mapToDrawer(value: string | Nil) {
       return SummaryDrawers.Notes;
     case SummaryDrawers.Comments:
       return SummaryDrawers.Comments;
+    case SummaryDrawers.Review:
+      return SummaryDrawers.Review;
     case SummaryDrawers.Ratings:
       return SummaryDrawers.Ratings;
     default:
@@ -65,6 +72,11 @@ export function summaryDrawerNavigation(searchParams?: URLSearchParams) {
       buildDrawerLink(
         SummaryDrawers.Comments,
         id != null ? { [commentIdParam]: String(id) } : undefined,
+      ),
+    buildReviewDrawerLink: (id: number) =>
+      buildDrawerLink(
+        SummaryDrawers.Review,
+        { [commentIdParam]: String(id) },
       ),
   };
 }

--- a/projects/client/src/lib/sections/summary/components/_internal/SocialActivitiesButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SocialActivitiesButton.svelte
@@ -1,0 +1,262 @@
+<script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag.ts";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
+  import type { MediaSocialQueryTarget } from "$lib/requests/queries/media/mediaSocialQuery.ts";
+  import UserAvatar from "$lib/sections/lists/components/UserAvatar.svelte";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte.ts";
+  import {
+    SummaryDrawers,
+    summaryDrawerNavigation,
+  } from "../../_internal/summaryDrawerNavigation.ts";
+  import { useSocialActivities } from "./useSocialActivities.ts";
+
+  const avatarDisplayLimit = 5;
+
+  type SocialActivitiesButtonProps = {
+    target: MediaSocialQueryTarget;
+    title: string;
+  };
+
+  const { target, title }: SocialActivitiesButtonProps = $props();
+
+  const target$ = fromRune(() => target);
+  const {
+    entries: socialEntries,
+    isLoading,
+    hasNextPage,
+  } = useSocialActivities(target$);
+
+  const activityCount = $derived($socialEntries.length);
+  const isInitialLoading = $derived($isLoading && activityCount === 0);
+
+  const watchers = $derived($socialEntries.slice(0, avatarDisplayLimit));
+  const activityCountLabel = $derived(
+    `${activityCount}${$hasNextPage ? "+" : ""}`,
+  );
+
+  const hasWatchers = $derived(watchers.length > 0);
+  const avatarStackCount = $derived(watchers.length);
+
+  const { buildDrawerLink } = summaryDrawerNavigation();
+  const drawerLink = $derived(buildDrawerLink(SummaryDrawers.Social));
+</script>
+
+<RenderForFeature flag={FeatureFlag.SocialActivities}>
+  {#snippet enabled()}
+    <div class="trakt-social-activities-button-link-wrapper">
+      {#if isInitialLoading}
+        <div class="social-activities-skeleton" role="status" aria-busy="true">
+          <span class="skeleton-count"></span>
+          <span class="skeleton-label"></span>
+        </div>
+      {:else}
+        <Link
+          {...drawerLink}
+          color="inherit"
+          label={m.link_label_view_social_activities({ title })}
+        >
+          <span class="social-activities-content">
+            {#if hasWatchers}
+              <span
+                class="trakt-social-activities-avatar-stack"
+                aria-hidden="true"
+              >
+                {#each watchers as watcher, index (watcher.key)}
+                  <span
+                    class="trakt-social-activities-avatar"
+                    style:z-index={avatarStackCount - index}
+                  >
+                    <UserAvatar user={watcher.user} size="small" />
+                  </span>
+                {/each}
+              </span>
+            {/if}
+
+            <span
+              class="trakt-social-activities-label"
+              class:is-text-only={activityCount === 0}
+            >
+              {#if activityCount > 0}
+                <span class="trakt-social-activities-count bold">
+                  {activityCountLabel}
+                </span>
+                <span class="trakt-social-activities-text">
+                  {activityCount === 1
+                    ? m.text_social_activity()
+                    : m.text_social_activities()}
+                </span>
+              {:else}
+                <span class="trakt-social-activities-text">
+                  {m.text_no_activity()}
+                </span>
+              {/if}
+            </span>
+          </span>
+        </Link>
+      {/if}
+    </div>
+  {/snippet}
+</RenderForFeature>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-social-activities-button-link-wrapper {
+    align-self: flex-start;
+    margin-top: var(--gap-xxs);
+
+    :global(.trakt-link) {
+      text-decoration: none;
+    }
+
+    @include for-tablet-sm-and-below {
+      align-self: center;
+    }
+  }
+
+  .social-activities-skeleton,
+  .social-activities-content {
+    --pill-accent: var(--color-foreground);
+    --height-watched-by-label: calc(var(--font-size-text) + var(--ni-2));
+
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ni-4);
+    height: var(--ni-36);
+    padding: 0 var(--ni-8);
+    box-sizing: border-box;
+    border-radius: var(--border-radius-xxl);
+
+    background: linear-gradient(
+      to right,
+      color-mix(in srgb, var(--pill-accent) 22%, transparent) 0%,
+      color-mix(in srgb, var(--pill-accent) 22%, transparent) 0%,
+      color-mix(in srgb, var(--color-foreground) 5%, transparent) 0%,
+      color-mix(in srgb, var(--color-foreground) 5%, transparent) 100%
+    );
+
+    border: var(--ni-1) solid
+      color-mix(in srgb, var(--color-border) 40%, transparent);
+    color: inherit;
+
+    cursor: pointer;
+
+    font-family: inherit;
+    white-space: nowrap;
+
+    transition:
+      transform var(--transition-increment) ease-out,
+      border-color var(--transition-increment) ease-out;
+
+    &:active {
+      transform: scale(0.97);
+    }
+  }
+
+  .trakt-social-activities-avatar-stack {
+    display: inline-flex;
+    align-items: center;
+    pointer-events: none;
+  }
+
+  .trakt-social-activities-avatar {
+    --watched-by-avatar-size: var(--ni-28);
+
+    position: relative;
+
+    width: var(--watched-by-avatar-size);
+    height: var(--watched-by-avatar-size);
+    flex: 0 0 var(--watched-by-avatar-size);
+
+    margin-left: calc(var(--watched-by-avatar-size) * -0.5);
+
+    border-radius: 50%;
+    overflow: hidden;
+    box-sizing: border-box;
+
+    &:first-child {
+      margin-left: 0;
+    }
+
+    :global(.trakt-user-avatar) {
+      width: var(--watched-by-avatar-size);
+      height: var(--watched-by-avatar-size);
+
+      :global(img) {
+        border-width: var(--ni-1);
+      }
+    }
+  }
+
+  .trakt-social-activities-label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ni-4);
+    height: var(--height-watched-by-label);
+    padding-right: var(--ni-4);
+
+    &.is-text-only {
+      padding-inline: var(--ni-8);
+    }
+  }
+
+  .trakt-social-activities-text {
+    opacity: 0.85;
+  }
+
+  .trakt-social-activities-count {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .social-activities-skeleton {
+    cursor: default;
+    background: color-mix(in srgb, var(--color-foreground) 5%, transparent);
+
+    &:active {
+      transform: none;
+    }
+
+    .skeleton-count {
+      width: 3.5ch;
+    }
+
+    .skeleton-label {
+      width: 8.5ch;
+    }
+
+    span {
+      display: inline-block;
+      height: var(--height-watched-by-label);
+      border-radius: var(--border-radius-xs, var(--ni-4));
+      background: color-mix(in srgb, var(--color-foreground) 12%, transparent);
+
+      position: relative;
+      overflow: hidden;
+
+      &::after {
+        content: "";
+
+        position: absolute;
+        top: 0;
+
+        width: 300%;
+        height: 100%;
+
+        transform: translateX(100%);
+
+        animation: slide calc(8 * var(--transition-increment)) infinite;
+
+        background: linear-gradient(
+          110deg,
+          transparent 0%,
+          transparent 30%,
+          color-mix(in srgb, var(--color-foreground) 25%, transparent) 50%,
+          transparent 70%,
+          transparent 100%
+        );
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/_internal/sortMediaSocialEntries.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/sortMediaSocialEntries.spec.ts
@@ -1,0 +1,77 @@
+import type { MediaSocial } from '$lib/requests/models/MediaSocial.ts';
+import { UserProfileHarryMappedMock } from '$mocks/data/users/mapped/UserProfileHarryMappedMock.ts';
+import { describe, expect, it } from 'vitest';
+import { sortMediaSocialEntries } from './sortMediaSocialEntries.ts';
+
+function socialEntry(
+  key: string,
+  overrides: Omit<Partial<MediaSocial>, 'key' | 'user'>,
+): MediaSocial {
+  return {
+    key,
+    followedAt: new Date('2026-01-01T00:00:00.000Z'),
+    user: {
+      ...UserProfileHarryMappedMock,
+      id: Number(key.replace(/\D/g, '')),
+      key: `user-${key}`,
+      username: key,
+      slug: key,
+    },
+    ...overrides,
+  };
+}
+
+describe('sortMediaSocialEntries', () => {
+  it('sorts by rating, play count, watchlist, and latest activity date', () => {
+    const ratedLowPlays = socialEntry('rated-low-plays', {
+      watched: {
+        plays: 1,
+        rating: {
+          rating: 8,
+          ratedAt: new Date('2026-01-01T00:00:00.000Z'),
+        },
+      },
+    });
+    const watchedHighPlays = socialEntry('watched-high-plays', {
+      watched: {
+        plays: 9,
+        lastWatchedAt: new Date('2026-05-01T00:00:00.000Z'),
+      },
+    });
+    const watchedLowPlays = socialEntry('watched-low-plays', {
+      watched: {
+        plays: 2,
+        lastWatchedAt: new Date('2026-06-01T00:00:00.000Z'),
+      },
+    });
+    const watchlistedRecent = socialEntry('watchlisted-recent', {
+      watchlisted: {
+        listedAt: new Date('2026-06-01T00:00:00.000Z'),
+      },
+    });
+    const watchlistedOld = socialEntry('watchlisted-old', {
+      watchlisted: {
+        listedAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    });
+
+    const entries = [
+      watchlistedOld,
+      watchedLowPlays,
+      watchlistedRecent,
+      watchedHighPlays,
+      ratedLowPlays,
+    ];
+
+    const sorted = sortMediaSocialEntries(entries);
+
+    expect(sorted.map((entry) => entry.key)).toEqual([
+      'rated-low-plays',
+      'watched-high-plays',
+      'watched-low-plays',
+      'watchlisted-recent',
+      'watchlisted-old',
+    ]);
+    expect(entries.at(0)?.key).toBe('watchlisted-old');
+  });
+});

--- a/projects/client/src/lib/sections/summary/components/_internal/sortMediaSocialEntries.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/sortMediaSocialEntries.ts
@@ -1,0 +1,46 @@
+import type { MediaSocial } from '$lib/requests/models/MediaSocial.ts';
+
+function hasRating(entry: MediaSocial) {
+  return entry.watched?.rating != null;
+}
+
+function watchlistedValue(entry: MediaSocial) {
+  return entry.watchlisted == null ? 0 : 1;
+}
+
+function watchedPlays(entry: MediaSocial) {
+  return entry.watched?.plays ?? 0;
+}
+
+function dateValue(date: Date | null | undefined) {
+  return date?.getTime() ?? 0;
+}
+
+function lastActivityDate(entry: MediaSocial) {
+  return Math.max(
+    dateValue(entry.watched?.rating?.ratedAt),
+    dateValue(entry.watched?.comment?.updatedAt),
+    dateValue(entry.watched?.comment?.createdAt),
+    dateValue(entry.watched?.lastUpdatedAt),
+    dateValue(entry.watched?.lastWatchedAt),
+    dateValue(entry.watchlisted?.listedAt),
+  );
+}
+
+function compareDescending(a: number, b: number) {
+  return b - a;
+}
+
+function compareSocialEntry(a: MediaSocial, b: MediaSocial) {
+  return (
+    compareDescending(Number(hasRating(a)), Number(hasRating(b))) ||
+    compareDescending(watchedPlays(a), watchedPlays(b)) ||
+    compareDescending(watchlistedValue(a), watchlistedValue(b)) ||
+    compareDescending(lastActivityDate(a), lastActivityDate(b)) ||
+    a.user.username.localeCompare(b.user.username)
+  );
+}
+
+export function sortMediaSocialEntries(entries: MediaSocial[]) {
+  return [...entries].sort(compareSocialEntry);
+}

--- a/projects/client/src/lib/sections/summary/components/_internal/useSocialActivities.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/useSocialActivities.ts
@@ -1,0 +1,47 @@
+import {
+  useAllPagesInfiniteQuery,
+  useInfiniteQuery,
+} from '$lib/features/query/useQuery.ts';
+import {
+  mediaSocialQuery,
+  type MediaSocialQueryTarget,
+} from '$lib/requests/queries/media/mediaSocialQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { map, type Observable, switchMap } from 'rxjs';
+import { sortMediaSocialEntries } from './sortMediaSocialEntries.ts';
+
+const socialActivitiesLimit = 100;
+
+type UseSocialActivitiesOptions = {
+  mode?: 'default' | 'all';
+};
+
+export function useSocialActivities(
+  target$: Observable<MediaSocialQueryTarget>,
+  { mode = 'default' }: UseSocialActivitiesOptions = {},
+) {
+  const query = target$.pipe(
+    switchMap((target) => {
+      const queryDef = mediaSocialQuery({
+        ...target,
+        limit: socialActivitiesLimit,
+      });
+      return mode === 'all'
+        ? useAllPagesInfiniteQuery(queryDef)
+        : useInfiniteQuery(queryDef);
+    }),
+  );
+
+  const entries = query.pipe(
+    map(($query) =>
+      sortMediaSocialEntries(
+        $query.data?.pages.flatMap((page) => page.entries) ?? [],
+      )
+    ),
+  );
+
+  const isLoading = query.pipe(map(toLoadingState));
+  const hasNextPage = query.pipe(map(($query) => $query.hasNextPage));
+
+  return { entries, isLoading, hasNextPage };
+}

--- a/projects/client/src/lib/sections/summary/components/comments/drawers/CommentReplies.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/drawers/CommentReplies.svelte
@@ -50,7 +50,7 @@
     class="trakt-comment-replies"
     transition:slide={{ duration: 150, axis: "y" }}
   >
-    {#each $list as reply}
+    {#each $list as reply (reply.id)}
       <div class="trakt-comment-container">
         <CommentReply comment={reply} {media} {...typeProps} />
       </div>

--- a/projects/client/src/lib/sections/summary/components/comments/drawers/CommentsDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/drawers/CommentsDrawerHost.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import Drawer from "$lib/components/drawer/Drawer.svelte";
-  import PaginatedList from "$lib/components/lists/PaginatedList.svelte";
   import Toggler from "$lib/components/toggles/Toggler.svelte";
   import { useToggler } from "$lib/components/toggles/useToggler";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -9,9 +8,7 @@
   import type { CommentsProps } from "../CommentsProps";
   import type { ActiveComment } from "../_internal/models/ActiveComment";
   import { useComments } from "../_internal/useComments";
-  import CommentThreadCard from "./CommentThreadCard.svelte";
-  import { THREAD_LIST_CLASS } from "./constants";
-  import { useActiveComment } from "./useActiveComment";
+  import ReviewsDrawerShell from "./_internal/ReviewsDrawerShell.svelte";
 
   type CommentsDrawerProps = {
     source?: ActiveComment;
@@ -21,12 +18,6 @@
   const { onClose, source, media, ...props }: CommentsDrawerProps = $props();
 
   const { current: sortType, set, options } = useToggler("comment");
-
-  const { reset, setReplying, activeComment } = $derived(
-    useActiveComment(source),
-  );
-  const isReplying = (id: number) =>
-    $activeComment?.id === id && $activeComment?.isReplying;
 
   const isOpened = writable(false);
 </script>
@@ -39,52 +30,21 @@
   onOpened={() => isOpened.set(true)}
 >
   {#if $isOpened}
-    <div class={THREAD_LIST_CLASS}>
-      <PaginatedList
-        type={`comments-${$sortType.value}`}
-        target="parent"
-        useList={() =>
-          useComments({
-            slug: media.slug,
-            limit: COMMENTS_DRILL_SIZE,
-            sort: $sortType.value,
-            ...props,
-          })}
-      >
-        {#snippet items(items)}
-          {#each items as comment (comment.id)}
-            <CommentThreadCard
-              {comment}
-              {media}
-              {reset}
-              {setReplying}
-              {...props}
-              isReplying={isReplying(comment.id)}
-              shouldScrollIntoView={comment.id === source?.id}
-            />
-          {/each}
-        {/snippet}
-      </PaginatedList>
-    </div>
+    <ReviewsDrawerShell
+      {source}
+      useList={() =>
+        useComments({
+          slug: media.slug,
+          limit: COMMENTS_DRILL_SIZE,
+          sort: $sortType.value,
+          ...props,
+        })}
+      {media}
+      {...props}
+    />
   {/if}
 
   {#snippet badge()}
     <Toggler value={$sortType.value} onChange={set} {options} />
   {/snippet}
 </Drawer>
-
-<style>
-  .trakt-comment-threads-list {
-    overflow-y: auto;
-    overscroll-behavior: contain;
-    position: relative;
-
-    padding: var(--ni-4);
-
-    :global(.trakt-paginated-list) {
-      display: flex;
-      flex-direction: column;
-      gap: var(--gap-s);
-    }
-  }
-</style>

--- a/projects/client/src/lib/sections/summary/components/comments/drawers/ReviewDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/drawers/ReviewDrawerHost.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { CommentsProps } from "../CommentsProps.ts";
+  import ReviewsDrawerShell from "./_internal/ReviewsDrawerShell.svelte";
+  import { useSingleReview } from "./useSingleReview.ts";
+
+  type ReviewDrawerProps = {
+    commentId: number;
+    onClose: () => void;
+  } & CommentsProps;
+
+  const { commentId, onClose, media, ...props }: ReviewDrawerProps = $props();
+
+  const useList = $derived(useSingleReview({ commentId }));
+
+  let isOpened = $state(false);
+</script>
+
+<Drawer
+  {onClose}
+  title={m.dialog_title_comment()}
+  size="large"
+  metaInfo={media.title}
+  onOpened={() => (isOpened = true)}
+>
+  {#if isOpened}
+    <ReviewsDrawerShell {useList} {media} {...props} />
+  {/if}
+</Drawer>

--- a/projects/client/src/lib/sections/summary/components/comments/drawers/_internal/ReviewsDrawerShell.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/drawers/_internal/ReviewsDrawerShell.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import PaginatedList from "$lib/components/lists/PaginatedList.svelte";
+  import type { MediaComment } from "$lib/requests/models/MediaComment";
+  import type { PaginatableStore } from "$lib/sections/lists/drilldown/PaginatableStore";
+  import type { ActiveComment } from "../../_internal/models/ActiveComment";
+  import type { CommentsProps } from "../../CommentsProps";
+  import CommentThreadCard from "../CommentThreadCard.svelte";
+  import { THREAD_LIST_CLASS } from "../constants";
+  import { useActiveComment } from "../useActiveComment";
+
+  type ReviewsDrawerShellProps = {
+    source?: ActiveComment;
+    useList: PaginatableStore<MediaComment, string>;
+  } & CommentsProps;
+
+  const { source, useList, media, ...props }: ReviewsDrawerShellProps =
+    $props();
+
+  const { reset, setReplying, activeComment } = $derived(
+    useActiveComment(source),
+  );
+
+  const isReplying = (id: number) =>
+    $activeComment?.id === id && $activeComment?.isReplying;
+</script>
+
+<div class={THREAD_LIST_CLASS}>
+  <PaginatedList type="reviews" target="parent" {useList}>
+    {#snippet items(items)}
+      {#each items as comment (comment.id)}
+        <CommentThreadCard
+          {comment}
+          {media}
+          {reset}
+          {setReplying}
+          {...props}
+          isReplying={isReplying(comment.id)}
+          shouldScrollIntoView={comment.id === source?.id}
+        />
+      {/each}
+    {/snippet}
+  </PaginatedList>
+</div>
+
+<style>
+  .trakt-comment-threads-list {
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    position: relative;
+
+    padding: var(--ni-4);
+
+    :global(.trakt-paginated-list) {
+      display: flex;
+      flex-direction: column;
+      gap: var(--gap-s);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/comments/drawers/useSingleReview.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/drawers/useSingleReview.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { MediaComment } from '$lib/requests/models/MediaComment.ts';
+import { commentQuery } from '$lib/requests/queries/comments/commentQuery.ts';
+import type { PaginatableStore } from '$lib/sections/lists/drilldown/PaginatableStore.ts';
+
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { map, of } from 'rxjs';
+
+type UseSingleReviewParams = {
+  commentId: number;
+};
+
+export function useSingleReview(
+  { commentId }: UseSingleReviewParams,
+): PaginatableStore<MediaComment, string> {
+  return () => {
+    const query = useQuery(commentQuery({ id: commentId }));
+
+    const list = query.pipe(
+      map(($query) => ($query.data != null ? [$query.data] : [])),
+    );
+
+    const isLoading = query.pipe(map(toLoadingState));
+
+    return {
+      list,
+      isLoading,
+      hasNextPage: of(false),
+      fetchNextPage: () => Promise.resolve(),
+    };
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
@@ -10,6 +10,7 @@
     summaryDrawerNavigation,
   } from "../../_internal/summaryDrawerNavigation";
   import EpisodeTitle from "../_internal/EpisodeTitle.svelte";
+  import SocialActivitiesButton from "../_internal/SocialActivitiesButton.svelte";
   import SummaryPosterTags from "../_internal/SummaryPosterTags.svelte";
   import SummaryTitle from "../_internal/SummaryTitle.svelte";
   import { useMediaMetaInfo } from "../media/useMediaMetaInfo";
@@ -35,13 +36,19 @@
     posterSrc: string;
     contextualContent?: Snippet;
   } = $props();
-  const type = "episode";
+  const type = "episode" as const;
 
   const title = $derived(episodeIntl.title ?? episode.title);
   const overview = $derived(episodeIntl.overview ?? episode.overview);
   const showTitle = $derived(showIntl.title ?? show.title);
   const { watchCount } = $derived(useWatchCount({ show, episode, type }));
   const postCreditsCount = $derived(episode.postCredits?.length ?? 0);
+  const socialTarget = $derived({
+    type,
+    slug: show.slug,
+    season: episode.season,
+    episode: episode.number,
+  });
 
   const { ratings } = $derived(
     useMediaMetaInfo({ type, episode, media: show }),
@@ -78,6 +85,10 @@
       entry={episode}
       drilldown={ratingsDrawerLink}
     />
+
+    <RenderFor audience="authenticated">
+      <SocialActivitiesButton target={socialTarget} {title} />
+    </RenderFor>
   </SummaryHeader>
 
   <Spoiler media={episode} {show} {type}>

--- a/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
@@ -9,6 +9,7 @@
     summaryDrawerNavigation,
   } from "../../../_internal/summaryDrawerNavigation";
   import EpisodeTitle from "../../_internal/EpisodeTitle.svelte";
+  import SocialActivitiesButton from "../../_internal/SocialActivitiesButton.svelte";
   import SpoilerSection from "../../_internal/SpoilerSection.svelte";
   import Summary from "../../_internal/Summary.svelte";
   import SummaryPosterTags from "../../_internal/SummaryPosterTags.svelte";
@@ -29,13 +30,19 @@
     posterSrc,
   }: Omit<EpisodeSummaryProps, "seasons" | "streamon"> & { posterSrc: string } =
     $props();
-  const type = "episode";
+  const type = "episode" as const;
 
   const title = $derived(episodeIntl.title ?? episode.title);
   const overview = $derived(episodeIntl.overview ?? episode.overview);
   const showTitle = $derived(showIntl.title ?? show.title);
   const { watchCount } = $derived(useWatchCount({ show, episode, type }));
   const postCreditsCount = $derived(episode.postCredits?.length ?? 0);
+  const socialTarget = $derived({
+    type,
+    slug: show.slug,
+    season: episode.season,
+    episode: episode.number,
+  });
 
   const { ratings } = $derived(
     useMediaMetaInfo({ type, episode, media: show }),
@@ -71,15 +78,16 @@
   {/snippet}
 
   {#snippet meta()}
+    <EpisodeTitle {episode} {show} {showIntl} />
+    <SummaryTitle {title} {type} {crew} media={show} {episode} />
     <RatingList
       ratings={$ratings}
       entry={episode}
       drilldown={ratingsDrawerLink}
     />
-    <EpisodeTitle {episode} {show} {showIntl} />
-    <SummaryTitle {title} {type} {crew} media={show} {episode} />
 
     <RenderFor audience="authenticated">
+      <SocialActivitiesButton target={socialTarget} {title} />
       <EpisodeActions {episode} {show} {title} {showTitle} />
     </RenderFor>
   {/snippet}

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -9,6 +9,7 @@
     SummaryDrawers,
     summaryDrawerNavigation,
   } from "../../_internal/summaryDrawerNavigation";
+  import SocialActivitiesButton from "../_internal/SocialActivitiesButton.svelte";
   import SummaryCover from "../_internal/SummaryCover.svelte";
   import SummaryPosterTags from "../_internal/SummaryPosterTags.svelte";
   import SummaryTitle from "../_internal/SummaryTitle.svelte";
@@ -38,6 +39,10 @@
   const title = $derived(intl?.title ?? media?.title ?? "");
   const { watchCount } = $derived(useWatchCount(target));
   const postCreditsCount = $derived(media.postCredits?.length ?? 0);
+  const socialTarget = $derived({
+    type: target.type,
+    slug: media.slug,
+  });
 
   const { ratings } = $derived(useMediaMetaInfo(target));
   const { isDropped } = $derived(useIsDropped(media));
@@ -86,6 +91,10 @@
         entry={media}
         drilldown={ratingsDrawerLink}
       />
+
+      <RenderFor audience="authenticated">
+        <SocialActivitiesButton target={socialTarget} {title} />
+      </RenderFor>
     </SummaryHeader>
 
     <Spoiler {media} {type}>

--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -13,6 +13,7 @@
     SummaryDrawers,
     summaryDrawerNavigation,
   } from "../../../_internal/summaryDrawerNavigation";
+  import SocialActivitiesButton from "../../_internal/SocialActivitiesButton.svelte";
   import SpoilerSection from "../../_internal/SpoilerSection.svelte";
   import Summary from "../../_internal/Summary.svelte";
   import SummaryPosterTags from "../../_internal/SummaryPosterTags.svelte";
@@ -42,6 +43,10 @@
   const title = $derived(intl?.title ?? media?.title ?? "");
   const { watchCount } = $derived(useWatchCount(target));
   const postCreditsCount = $derived(media.postCredits?.length ?? 0);
+  const socialTarget = $derived({
+    type: target.type,
+    slug: media.slug,
+  });
 
   const { isRateable } = $derived(useIsRateable(target));
   const { isDropped } = $derived(useIsDropped(media));
@@ -84,14 +89,15 @@
   {/snippet}
 
   {#snippet meta()}
+    <SummaryTitle {title} {crew} {...target} />
     <RatingList
       ratings={$ratings}
       entry={media}
       drilldown={ratingsDrawerLink}
     />
-    <SummaryTitle {title} {crew} {...target} />
 
     <RenderFor audience="authenticated">
+      <SocialActivitiesButton target={socialTarget} {title} />
       <MediaActions {media} {title} />
     </RenderFor>
   {/snippet}

--- a/projects/client/src/lib/sections/summary/components/social/SocialDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/social/SocialDrawerHost.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { MediaSocialQueryTarget } from "$lib/requests/queries/media/mediaSocialQuery.ts";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte.ts";
+  import { fade } from "svelte/transition";
+  import { useSocialActivities } from "../_internal/useSocialActivities.ts";
+  import SocialActivityRow from "./_internal/SocialActivityRow.svelte";
+  import SocialActivitySummaryHeader from "./_internal/SocialActivitySummaryHeader.svelte";
+
+  type SocialDrawerHostProps = {
+    target: MediaSocialQueryTarget;
+    title: string;
+    onClose: () => void;
+  };
+
+  const { target, title, onClose }: SocialDrawerHostProps = $props();
+
+  const target$ = fromRune(() => target);
+  const { entries: socialEntries, isLoading } = useSocialActivities(target$, {
+    mode: "all",
+  });
+
+  const hasEntries = $derived($socialEntries.length > 0);
+  const activityCount = $derived($socialEntries.length);
+  const ratings = $derived.by(() => {
+    return $socialEntries
+      .map((entry) => entry.watched?.rating?.rating)
+      .filter((rating): rating is number => rating != null);
+  });
+
+  let isOpen = $state(false);
+</script>
+
+<Drawer
+  {onClose}
+  onOpened={() => (isOpen = true)}
+  title={m.list_title_social_activity()}
+  metaInfo={title}
+  size="auto"
+>
+  {#if isOpen}
+    <div transition:fade={{ duration: 150 }}>
+      <RenderFor audience="authenticated">
+        <div class="trakt-social-activity-drawer">
+          {#if $isLoading && !hasEntries}
+            <LoadingIndicator />
+          {/if}
+
+          {#if !$isLoading && !hasEntries}
+            <p class="social-activity-placeholder">
+              {m.text_social_activities_placeholder()}
+            </p>
+          {/if}
+
+          {#if hasEntries}
+            <div class="trakt-social-activity-section">
+              <SocialActivitySummaryHeader {activityCount} {ratings} />
+
+              <ul class="trakt-social-activity-list">
+                {#each $socialEntries as entry (entry.key)}
+                  <SocialActivityRow {entry} />
+                {/each}
+              </ul>
+            </div>
+          {/if}
+        </div>
+      </RenderFor>
+    </div>
+  {/if}
+</Drawer>
+
+<style>
+  .trakt-social-activity-drawer {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-m);
+  }
+
+  .social-activity-placeholder {
+    color: var(--color-text-secondary);
+    padding-block: var(--gap-s);
+  }
+
+  .trakt-social-activity-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+
+  .trakt-social-activity-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/social/_internal/SocialActivityRow.svelte
+++ b/projects/client/src/lib/sections/summary/components/social/_internal/SocialActivityRow.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import Link from "$lib/components/link/Link.svelte";
+  import type { MediaSocial } from "$lib/requests/models/MediaSocial.ts";
+  import UserAvatar from "$lib/sections/lists/components/UserAvatar.svelte";
+  import { toDisplayableName } from "$lib/utils/profile/toDisplayableName.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+  import SocialActivityTag from "./SocialActivityTag.svelte";
+  import { mapToSocialActivityEntries } from "./mapToSocialActivityEntries.ts";
+
+  const { entry }: { entry: MediaSocial } = $props();
+
+  const displayName = $derived(toDisplayableName(entry.user));
+
+  const profileHref = $derived(
+    entry.user.slug == null
+      ? undefined
+      : UrlBuilder.profile.user(entry.user.slug),
+  );
+
+  const activities = $derived(mapToSocialActivityEntries(entry));
+</script>
+
+<li class="trakt-social-activity-row">
+  <div class="trakt-social-activity-card-grid">
+    <UserAvatar user={entry.user} />
+
+    <div class="trakt-social-activity-user-copy">
+      <Link href={profileHref} color="inherit">
+        <span class="trakt-social-activity-profile-copy">
+          <p class="trakt-card-title ellipsis bold">
+            {displayName}
+          </p>
+        </span>
+      </Link>
+
+      <div class="trakt-social-activity-pills">
+        {#each activities as activity (activity.key)}
+          <SocialActivityTag {activity} />
+        {/each}
+      </div>
+    </div>
+  </div>
+</li>
+
+<style>
+  .trakt-social-activity-row {
+    padding: var(--gap-xs) var(--gap-s);
+    border-radius: var(--border-radius-m);
+
+    background: color-mix(in srgb, var(--color-foreground) 5%, transparent);
+
+    :global(.trakt-link) {
+      text-decoration: none;
+      min-width: 0;
+    }
+  }
+
+  .trakt-social-activity-card-grid {
+    display: grid;
+    grid-template-columns: var(--ni-44) minmax(0, 1fr);
+    align-items: center;
+    gap: var(--gap-s);
+    min-width: 0;
+  }
+
+  .trakt-social-activity-user-copy {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-4);
+
+    min-width: 0;
+  }
+
+  .trakt-social-activity-profile-copy {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-2);
+    min-width: 0;
+  }
+
+  .trakt-social-activity-pills {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: var(--ni-4);
+    flex-wrap: wrap;
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/social/_internal/SocialActivitySummaryHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/social/_internal/SocialActivitySummaryHeader.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import StarIcon from "$lib/components/icons/StarIcon.svelte";
+  import { getLocale } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { toUserRating } from "$lib/utils/formatting/number/toUserRating";
+
+  type SocialActivitySummaryHeaderProps = {
+    activityCount: number;
+    ratings: number[];
+  };
+
+  const { activityCount, ratings }: SocialActivitySummaryHeaderProps = $props();
+
+  const activityCountLabel = $derived(
+    `${activityCount} ${activityCount === 1 ? m.text_social_activity() : m.text_social_activities()}`,
+  );
+
+  const averageRating = $derived.by(() => {
+    if (ratings.length === 0) return null;
+
+    const totalRating = ratings.reduce((total, rating) => total + rating, 0);
+    return totalRating / ratings.length;
+  });
+</script>
+
+<header class="trakt-social-activity-summary-header">
+  <p class="secondary small bold">
+    {activityCountLabel}
+  </p>
+
+  {#if averageRating}
+    <div class="social-activity-summary-rating">
+      <span class="secondary small bold">
+        {toUserRating(averageRating, getLocale())}
+      </span>
+      <span class="social-activity-summary-rating-icon secondary">
+        <StarIcon fill="full" />
+      </span>
+    </div>
+  {/if}
+</header>
+
+<style>
+  .trakt-social-activity-summary-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gap-s);
+    padding: 0 var(--gap-s) var(--ni-2);
+    min-width: 0;
+  }
+
+  .social-activity-summary-rating {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--ni-4);
+    flex: 0 0 auto;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .social-activity-summary-rating-icon {
+    display: inline-flex;
+    width: var(--ni-14);
+    height: var(--ni-14);
+
+    :global(svg) {
+      width: 100%;
+      height: 100%;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/social/_internal/SocialActivityTag.svelte
+++ b/projects/client/src/lib/sections/summary/components/social/_internal/SocialActivityTag.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import StarIcon from "$lib/components/icons/StarIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import StemTag from "$lib/components/tags/StemTag.svelte";
+  import { getLocale } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { toUserRating } from "$lib/utils/formatting/number/toUserRating";
+  import { summaryDrawerNavigation } from "../../../_internal/summaryDrawerNavigation";
+  import type { SocialActivityEntry } from "../models/SocialActivityEntry";
+
+  const { activity }: { activity: SocialActivityEntry } = $props();
+
+  const { buildReviewDrawerLink } = summaryDrawerNavigation();
+
+  const tagText = $derived.by(() => {
+    switch (activity.type) {
+      case "review":
+        return m.tag_text_reviewed();
+      case "rating":
+        return toUserRating(activity.rating, getLocale());
+      case "watchlist":
+        return m.tag_text_watchlisted();
+      case "watch":
+        return activity.playCount === 1
+          ? m.tag_text_watched()
+          : m.tag_text_plays({ number: activity.playCount });
+    }
+  });
+</script>
+
+{#snippet tag()}
+  <StemTag>
+    <p class="bold capitalize no-wrap">{tagText}</p>
+
+    {#if activity.type === "rating"}
+      <span class="trakt-social-activity-icon">
+        <StarIcon fill="full" />
+      </span>
+    {/if}
+  </StemTag>
+{/snippet}
+
+{#if activity.type === "review"}
+  <span class="trakt-social-activity-link">
+    <Link
+      {...buildReviewDrawerLink(activity.reviewId)}
+      color="inherit"
+      label={m.link_label_open_review({ user: activity.author })}
+    >
+      {@render tag()}
+    </Link>
+  </span>
+{:else}
+  {@render tag()}
+{/if}
+
+<style>
+  .trakt-social-activity-link {
+    display: inline-flex;
+
+    :global(.trakt-link) {
+      text-decoration: none;
+    }
+  }
+
+  .trakt-social-activity-icon {
+    display: inline-flex;
+    width: var(--ni-12);
+    height: var(--ni-12);
+
+    :global(svg) {
+      width: 100%;
+      height: 100%;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/social/_internal/mapToSocialActivityEntries.ts
+++ b/projects/client/src/lib/sections/summary/components/social/_internal/mapToSocialActivityEntries.ts
@@ -1,0 +1,43 @@
+import type { MediaSocial } from '$lib/requests/models/MediaSocial.ts';
+import type { SocialActivityEntry } from '$lib/sections/summary/components/social/models/SocialActivityEntry.ts';
+import { toDisplayableName } from '$lib/utils/profile/toDisplayableName.ts';
+
+export function mapToSocialActivityEntries(
+  mediaSocial: MediaSocial,
+): SocialActivityEntry[] {
+  const activities: SocialActivityEntry[] = [];
+
+  if (mediaSocial.watched) {
+    activities.push({
+      key: `${mediaSocial.key}-watched`,
+      type: 'watch',
+      playCount: mediaSocial.watched.plays,
+    });
+  }
+
+  if (mediaSocial.watched?.rating) {
+    activities.push({
+      key: `${mediaSocial.key}-rated`,
+      type: 'rating',
+      rating: mediaSocial.watched.rating.rating,
+    });
+  }
+
+  if (mediaSocial.watched?.comment) {
+    activities.push({
+      key: `${mediaSocial.key}-reviewed`,
+      type: 'review',
+      reviewId: mediaSocial.watched.comment.id,
+      author: toDisplayableName(mediaSocial.user),
+    });
+  }
+
+  if (mediaSocial.watchlisted) {
+    activities.push({
+      key: `${mediaSocial.key}-watchlisted`,
+      type: 'watchlist',
+    });
+  }
+
+  return activities;
+}

--- a/projects/client/src/lib/sections/summary/components/social/models/SocialActivityEntry.ts
+++ b/projects/client/src/lib/sections/summary/components/social/models/SocialActivityEntry.ts
@@ -1,0 +1,29 @@
+type CommonSocialActivityEntry = {
+  key: string;
+};
+
+type ReviewSocialActivityEntry = CommonSocialActivityEntry & {
+  type: 'review';
+  author: string;
+  reviewId: number;
+};
+
+type RatingSocialActivityEntry = CommonSocialActivityEntry & {
+  type: 'rating';
+  rating: number;
+};
+
+type WatchSocialActivityEntry = CommonSocialActivityEntry & {
+  type: 'watch';
+  playCount: number;
+};
+
+type WatchlistSocialActivityEntry = CommonSocialActivityEntry & {
+  type: 'watchlist';
+};
+
+export type SocialActivityEntry =
+  | ReviewSocialActivityEntry
+  | RatingSocialActivityEntry
+  | WatchSocialActivityEntry
+  | WatchlistSocialActivityEntry;

--- a/projects/client/src/mocks/data/summary/common/mapped/MediaSocialMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/common/mapped/MediaSocialMappedMock.ts
@@ -1,0 +1,62 @@
+import type { MediaSocial } from '$lib/requests/models/MediaSocial.ts';
+import { UserProfileHarryMappedMock } from '$mocks/data/users/mapped/UserProfileHarryMappedMock.ts';
+
+const KimKitsuragiMappedMock = {
+  ...UserProfileHarryMappedMock,
+  id: 57,
+  key: 'user-57',
+  username: 'kim_kitsuragi',
+  name: {
+    first: 'Kim',
+    last: 'Kitsuragi',
+    full: 'Kim Kitsuragi',
+  },
+  slug: 'kim_kitsuragi',
+  avatar: {
+    url: 'https://avatar.test/kim.jpg',
+  },
+  isVip: false,
+};
+
+export const MediaSocialMappedMock: MediaSocial[] = [
+  {
+    key: 'media-social-41152',
+    followedAt: new Date('2025-01-04T18:22:10.000Z'),
+    user: {
+      ...UserProfileHarryMappedMock,
+      about: null,
+      location: null,
+    },
+    watched: {
+      plays: 2,
+      lastWatchedAt: new Date('2026-06-01T20:15:00.000Z'),
+      lastUpdatedAt: new Date('2026-06-01T20:16:00.000Z'),
+      rating: {
+        rating: 8,
+        ratedAt: new Date('2026-06-01T20:20:00.000Z'),
+      },
+      comment: {
+        id: 1337,
+        key: 'comment-1337',
+        comment:
+          'This all could have been avoided if he just started a podcast like a normal dude',
+        isSpoiler: false,
+        isReview: false,
+        createdAt: new Date('2026-06-01T20:25:00.000Z'),
+        updatedAt: new Date('2026-06-01T20:25:00.000Z'),
+      },
+    },
+  },
+  {
+    key: 'media-social-57',
+    followedAt: new Date('2025-01-05T19:22:10.000Z'),
+    user: {
+      ...KimKitsuragiMappedMock,
+      about: null,
+      location: null,
+    },
+    watchlisted: {
+      listedAt: new Date('2026-05-20T12:00:00.000Z'),
+    },
+  },
+];

--- a/projects/client/src/mocks/data/summary/common/response/MediaSocialResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/common/response/MediaSocialResponseMock.ts
@@ -1,0 +1,68 @@
+import {
+  type MediaSocialResponseInput,
+} from '$lib/requests/queries/media/mediaSocialQuery.ts';
+import { UserProfileHarryResponseMock } from '$mocks/data/users/response/UserProfileHarryResponseMock.ts';
+
+const HarryDuBoisResponseMock = {
+  username: UserProfileHarryResponseMock.username,
+  private: UserProfileHarryResponseMock.private,
+  deleted: UserProfileHarryResponseMock.deleted,
+  name: UserProfileHarryResponseMock.name,
+  vip: UserProfileHarryResponseMock.vip,
+  vip_ep: UserProfileHarryResponseMock.vip_ep,
+  director: UserProfileHarryResponseMock.director,
+  ids: UserProfileHarryResponseMock.ids,
+  images: {
+    avatar: {
+      full: UserProfileHarryResponseMock.images?.avatar.full,
+    },
+  },
+};
+
+const KimKitsuragiResponseMock = {
+  ...HarryDuBoisResponseMock,
+  username: 'kim_kitsuragi',
+  name: 'Kim Kitsuragi',
+  vip: false,
+  ids: {
+    slug: 'kim_kitsuragi',
+    trakt: 57,
+  },
+  images: {
+    avatar: {
+      full: 'https://avatar.test/kim.jpg',
+    },
+  },
+};
+
+export const MediaSocialResponseMock: MediaSocialResponseInput = [
+  {
+    followed_at: '2025-01-04T18:22:10.000Z',
+    user: HarryDuBoisResponseMock,
+    watched: {
+      plays: 2,
+      last_watched_at: '2026-06-01T20:15:00.000Z',
+      last_updated_at: '2026-06-01T20:16:00.000Z',
+      rating: {
+        rating: 8,
+        rated_at: '2026-06-01T20:20:00.000Z',
+      },
+      comment: {
+        ids: { trakt: 1337 },
+        comment:
+          'This all could have been avoided if he just started a podcast like a normal dude',
+        spoiler: false,
+        review: false,
+        created_at: '2026-06-01T20:25:00.000Z',
+        updated_at: '2026-06-01T20:25:00.000Z',
+      },
+    },
+  },
+  {
+    followed_at: '2025-01-05T19:22:10.000Z',
+    user: KimKitsuragiResponseMock,
+    watchlisted: {
+      listed_at: '2026-05-20T12:00:00.000Z',
+    },
+  },
+];

--- a/projects/client/src/mocks/handlers/comments.ts
+++ b/projects/client/src/mocks/handlers/comments.ts
@@ -3,10 +3,29 @@ import { http, HttpResponse } from 'msw';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { EpisodeSiloCommentsMappedMock } from '$mocks/data/summary/episodes/silo/mapped/EpisodeSiloCommentsMappedMock.ts';
 import { EpisodeSiloCommentReplyResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloCommentReplyResponseMock.ts';
+import { EpisodeSiloCommentsResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloCommentsResponseMock.ts';
+import { MovieHereticCommentsResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticCommentsResponseMock.ts';
 import { EpisodeSiloCommentReactionsResponseMock } from '../data/summary/episodes/silo/response/EpisodeSiloCommentReactionsResponseMock.ts';
 
-//http://localhost/comments/420/replies?page=1&limit=10
+const commentResponseMocks = [
+  ...EpisodeSiloCommentsResponseMock,
+  ...MovieHereticCommentsResponseMock,
+];
+
 export const comments = [
+  http.get(
+    'http://localhost/comments/:id',
+    ({ params }) => {
+      const id = Number(params.id);
+      const comment = commentResponseMocks.find((comment) => comment.id === id);
+
+      if (comment == null) {
+        return HttpResponse.json(null, { status: 404 });
+      }
+
+      return HttpResponse.json(comment);
+    },
+  ),
   http.get(
     `http://localhost/comments/${
       assertDefined(EpisodeSiloCommentsMappedMock.at(0)).id

--- a/projects/client/src/mocks/handlers/movies.ts
+++ b/projects/client/src/mocks/handlers/movies.ts
@@ -7,6 +7,7 @@ import { MoviesAnticipatedResponseMock } from '../data/movies/response/MoviesAnt
 import { MoviesPopularResponseMock } from '../data/movies/response/MoviesPopularResponseMock.ts';
 import { MoviesTrendingResponseMock } from '../data/movies/response/MoviesTrendingResponseMock.ts';
 import { MediaWatchingResponseMock } from '../data/summary/common/response/MediaWatchingResponseMock.ts';
+import { MediaSocialResponseMock } from '../data/summary/common/response/MediaSocialResponseMock.ts';
 import { HereticListsResponseMock } from '../data/summary/movies/heretic/response/HereticListsResponseMock.ts';
 import { MovieHereticPeopleResponseMock } from '../data/summary/movies/heretic/response/MovieHereticPeopleResponseMock.ts';
 import { MovieHereticRatingsResponseMock } from '../data/summary/movies/heretic/response/MovieHereticRatingsResponseMock.ts';
@@ -17,6 +18,20 @@ import { MovieHereticTranslationsResponseMock } from '../data/summary/movies/her
 import { MovieHereticVideoResponseMock } from '../data/summary/movies/heretic/response/MovieHereticVideoResponseMock.ts';
 import { MovieHereticWatchNowResponseMock } from '../data/summary/movies/heretic/response/MovieHereticWatchNowResponseMock.ts';
 import { MovieStudiosResponseMock } from '../data/summary/movies/heretic/response/MovieStudiosResponseMock.ts';
+
+function paginatedSocial(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const page = Number(searchParams.get('page') ?? 1);
+  const items = page > 1 ? [] : MediaSocialResponseMock;
+
+  return HttpResponse.json(items, {
+    headers: {
+      'x-pagination-page': `${page}`,
+      'x-pagination-page-count': '1',
+      'x-pagination-item-count': `${MediaSocialResponseMock.length}`,
+    },
+  });
+}
 
 export const movies = [
   http.get(
@@ -59,6 +74,12 @@ export const movies = [
     `http://localhost/movies/${MovieHereticResponseMock.ids.slug}/watching`,
     () => {
       return HttpResponse.json(MediaWatchingResponseMock);
+    },
+  ),
+  http.get(
+    `http://localhost/movies/${MovieHereticResponseMock.ids.slug}/social*`,
+    ({ request }) => {
+      return paginatedSocial(request);
     },
   ),
   http.get(

--- a/projects/client/src/mocks/handlers/shows.ts
+++ b/projects/client/src/mocks/handlers/shows.ts
@@ -11,6 +11,7 @@ import { ShowsAnticipatedResponseMock } from '../data/shows/response/ShowsAntici
 import { ShowsPopularResponseMock } from '../data/shows/response/ShowsPopularResponseMock.ts';
 import { ShowsTrendingResponseMock } from '../data/shows/response/ShowsTrendingResponseMock.ts';
 import { MediaWatchingResponseMock } from '../data/summary/common/response/MediaWatchingResponseMock.ts';
+import { MediaSocialResponseMock } from '../data/summary/common/response/MediaSocialResponseMock.ts';
 import { EpisodeSiloRatingsResponseMock } from '../data/summary/episodes/silo/response/EpisodeSiloRatingsResponseMock.ts';
 import { EpisodeSiloResponseMock } from '../data/summary/episodes/silo/response/EpisodeSiloResponseMock.ts';
 import { EpisodeSiloStatsResponseMock } from '../data/summary/episodes/silo/response/EpisodeSiloStatsResponseMock.ts';
@@ -30,6 +31,20 @@ import { ShowSiloVideoSeason1ResponseMock } from '../data/summary/shows/silo/res
 import { ShowSiloVideoSeason2ResponseMock } from '../data/summary/shows/silo/response/ShowSiloVideoSeason2ResponseMock.ts';
 import { ShowSiloWatchNowResponseMock } from '../data/summary/shows/silo/response/ShowSiloWatchNowResponseMock.ts';
 import { SiloListsResponseMock } from '../data/summary/shows/silo/response/SiloListsResponseMock.ts';
+
+function paginatedSocial(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const page = Number(searchParams.get('page') ?? 1);
+  const items = page > 1 ? [] : MediaSocialResponseMock;
+
+  return HttpResponse.json(items, {
+    headers: {
+      'x-pagination-page': `${page}`,
+      'x-pagination-page-count': '1',
+      'x-pagination-item-count': `${MediaSocialResponseMock.length}`,
+    },
+  });
+}
 
 export const shows = [
   http.get(
@@ -81,6 +96,12 @@ export const shows = [
     },
   ),
   http.get(
+    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/social*`,
+    ({ request }) => {
+      return paginatedSocial(request);
+    },
+  ),
+  http.get(
     `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/studios`,
     () => {
       return HttpResponse.json(ShowSiloStudiosResponseMock);
@@ -114,6 +135,12 @@ export const shows = [
     `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/seasons/${EpisodeSiloResponseMock.season}/episodes/${EpisodeSiloResponseMock.number}/watching`,
     () => {
       return HttpResponse.json(MediaWatchingResponseMock);
+    },
+  ),
+  http.get(
+    `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/seasons/${EpisodeSiloResponseMock.season}/episodes/${EpisodeSiloResponseMock.number}/social*`,
+    ({ request }) => {
+      return paginatedSocial(request);
     },
   ),
   http.get(


### PR DESCRIPTION
## Scene Setting

Adds social activity to movie, show, and episode summary pages using the new /social endpoints.

This surface real API-backed data showing who you follow and what they did for the current media item: watched, rated, reviewed, or watchlisted. The social button opens a drawer with a fuller list of users and activity pills.

AI assisted with Codex 5.5.

## What Changed

- Added a `mediaSocialQuery` backed by:
  - `GET /movies/:slug/social`
  - `GET /shows/:slug/social`
  - `GET /shows/:slug/seasons/:season/episodes/:episode/social`
- Added mapped `MediaSocial` models and mock fixtures for movies, shows, and episodes.
- Added the social activity button to movie, show, and episode summary headers.
  - The button is styled to match the existing "profile match" button under user profiles to give a consistent "social" feature look and feel.
- Added a social activity drawer with:
  - user avatar and display name
  - activity pills for plays, rating, review/comment, and watchlist state
  - activity count (header)
  - average rating from followed users who rated the media (header)
  - empty state when no followed users have activity
- Added deterministic social sorting:
  1. users with ratings
  2. watched users by play count
  3. watchlisted users
  4. latest activity date as tie breaker
  5. username as final stable tie breaker
- Disabled image fade animation for social avatars to avoid avatar blinking during remounts.
- Kept the existing drawer URL-state pattern by adding `social` and `review` summary drawers.
- Reused existing comment/reply UI where possible instead of creating a parallel review display.

- Added a focused review drawer for the `Reviewed` pill:
  - fetches the selected comment directly with `GET /comments/:id`
  - opens replies by default
  - avoids depending on the existing but paginated "all reviews drawer" to find the selected comment
→ This focused review drawer exists because opening the full reviews drawer cannot reliably scroll to a selected review when that review is not on the currently loaded page.

## Edge Cases Covered

- No social data: button displays `No Activity`; drawer shows “No one you follow has watched, rated, reviewed, or watchlisted this yet.”
- Loading state: button uses the existing skeleton-style loading treatment rather than text.
- More than one page of drawer results: drawer uses `useAllPagesInfiniteQuery`.
- Button count can indicate more data with `+` when the first page is not exhaustive.
- Ratings header is hidden when none of the displayed social users rated the media.
- Any social comment is surfaced as `Reviewed`, regardless of the API `review` flag.
- VIP avatars use the red border; non-VIP avatars use the neutral border.
- Social UI is wired consistently for movies, shows, and episodes.
- Timestamps are used only for sorting and are not shown.

## Design Decisions

- The social activity button is styled to match the existing profile match button under user profiles, giving social features a consistent look and feel across the app.
- A dedicated row/lane was considered, but discoverability was weaker because it pushed the feature further below the fold.
- The row/lane approach also used more vertical space than the compact button, which mattered on dense media summary pages and mobile.
- The drawer follows the existing summary drawer pattern so social activity feels like a drill-down from the summary header, similar to cast, ratings, reviews, and other contextual media details.
- Activity details are shown as compact pills to keep each user row scannable and to align visually with existing small metadata pills like actor episode counts.
- Timestamps are intentionally not displayed. They are useful for sorting, but showing them would make the drawer feel too invasive for social activity.

## Screenshots

Show with activity button and drawer:
<img width="1351" height="1014" alt="Screenshot 2026-06-16 at 09 35 19" src="https://github.com/user-attachments/assets/c04ac6a6-3582-471b-bc3e-99a0a05a16e9" />
Movie with activity button and drawer (with a "Reviewed" pill):
<img width="1351" height="1014" alt="Screenshot 2026-06-16 at 09 35 38" src="https://github.com/user-attachments/assets/b7dcf355-09a6-41b7-b351-4d625ded4124" />
New review drawer opened after clicking the "Reviewed" pill:
<img width="1351" height="1014" alt="Screenshot 2026-06-16 at 09 35 43" src="https://github.com/user-attachments/assets/a0c4fdef-dfa0-482d-8842-47120b37cca3" />
Empty state:
<img width="1351" height="1014" alt="Screenshot 2026-06-16 at 09 36 33" src="https://github.com/user-attachments/assets/4782b7db-0eaf-4aaa-8b23-97ac348c505f" />
An Episode with activity button:
<img width="1351" height="1014" alt="Screenshot 2026-06-16 at 09 39 12" src="https://github.com/user-attachments/assets/23ccfbb1-a68b-452b-bc33-47ad881c4125" />
