### PR TITLE
refactor(components): namespace component root classes with trakt-* prefix

### DIFF
--- a/projects/client/src/lib/components/Crossfade.svelte
+++ b/projects/client/src/lib/components/Crossfade.svelte
@@ -16,7 +16,7 @@
   } = $props();
 </script>
 
-<div class="crossfade-container">
+<div class="trakt-crossfade">
   {#if showA}
     <div
       class="crossfade-content"
@@ -39,7 +39,7 @@
   we need to ensure they are still rendered on top of each other.
 -->
 <style>
-  .crossfade-container {
+  .trakt-crossfade {
     position: relative;
     width: 100%;
     height: 100%;

--- a/projects/client/src/lib/components/NavigationGuard.svelte
+++ b/projects/client/src/lib/components/NavigationGuard.svelte
@@ -41,12 +41,12 @@
   });
 </script>
 
-<div class="navigation-guard" use:preventUnload={isActive}>
+<div class="trakt-navigation-guard" use:preventUnload={isActive}>
   {@render children()}
 </div>
 
 <style>
-  .navigation-guard {
+  .trakt-navigation-guard {
     display: contents;
   }
 </style>

--- a/projects/client/src/lib/components/charts/BubbleChart.svelte
+++ b/projects/client/src/lib/components/charts/BubbleChart.svelte
@@ -107,7 +107,7 @@
 </script>
 
 <div
-  class="bubble-chart"
+  class="trakt-bubble-chart"
   use:observeWidth
   use:observeHeight
   onpointermove={handlePointerMove}
@@ -188,7 +188,7 @@
 </div>
 
 <style lang="scss">
-  .bubble-chart {
+  .trakt-bubble-chart {
     position: relative;
     width: 100%;
     height: 100%;

--- a/projects/client/src/lib/components/legal/LegalPage.svelte
+++ b/projects/client/src/lib/components/legal/LegalPage.svelte
@@ -3,7 +3,7 @@
   export let lastUpdated: string;
 </script>
 
-<div class="legal-page">
+<div class="trakt-legal-page">
   <header class="legal-header">
     <h1>{title}</h1>
     <p class="last-updated">
@@ -27,7 +27,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .legal-page {
+  .trakt-legal-page {
     --width-max-page: var(--ni-920);
     --number-width: var(--ni-32);
 

--- a/projects/client/src/lib/components/lists/LetterGroupHeader.svelte
+++ b/projects/client/src/lib/components/lists/LetterGroupHeader.svelte
@@ -2,10 +2,10 @@
   const { letter }: { letter: string } = $props();
 </script>
 
-<span class="letter-header">{letter}</span>
+<span class="trakt-letter-group-header">{letter}</span>
 
 <style lang="scss">
-  .letter-header {
+  .trakt-letter-group-header {
     font-size: var(--ni-20);
     font-weight: bold;
     color: var(--color-text-primary);

--- a/projects/client/src/lib/components/media/tags/ProgressTag.svelte
+++ b/projects/client/src/lib/components/media/tags/ProgressTag.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div
-  class="progress-tag"
+  class="trakt-progress-tag"
   style:--progress-width={`${progress}%`}
   role="progressbar"
   aria-valuenow={progress}
@@ -51,7 +51,7 @@
     gap: var(--gap-xs);
   }
 
-  .progress-tag {
+  .trakt-progress-tag {
     width: 100%;
     min-width: 0;
 

--- a/projects/client/src/lib/components/select/NativeSelect.svelte
+++ b/projects/client/src/lib/components/select/NativeSelect.svelte
@@ -29,7 +29,7 @@
   );
 </script>
 
-<div class="native-select-container">
+<div class="trakt-native-select">
   {#if icon}
     <div class="native-select-icon">
       {@render icon()}
@@ -57,7 +57,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .native-select-container {
+  .trakt-native-select {
     --icon-size: var(--ni-16);
 
     position: relative;

--- a/projects/client/src/lib/components/text/ClampedText.svelte
+++ b/projects/client/src/lib/components/text/ClampedText.svelte
@@ -30,7 +30,7 @@
   const isExpanded = $derived($lines === 1337);
 </script>
 
-<div class="line-clamp-container">
+<div class="trakt-clamped-text">
   <p
     use:lineClamp={{ lines: $lines, isClamped }}
     use:appendClassList={classList}
@@ -53,7 +53,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .line-clamp-container {
+  .trakt-clamped-text {
     display: flex;
     align-items: flex-end;
 

--- a/projects/client/src/lib/features/calendar/CalendarLayout.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarLayout.svelte
@@ -80,7 +80,7 @@
   const isInitialLoad = $derived(isInitialPeriod && isLoading);
 </script>
 
-<div class="calendar-layout-container" use:observeDimension>
+<div class="trakt-calendar-layout" use:observeDimension>
   {#if navigation || !isInitialLoad}
     <div
       class="calendar-navigation"
@@ -131,7 +131,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .calendar-layout-container {
+  .trakt-calendar-layout {
     display: flex;
     flex-direction: column;
 
@@ -175,14 +175,14 @@
     @include for-mobile {
       --sticky-top: calc(env(safe-area-inset-top, 0) + var(--ni-4));
 
-      :global(.calendar-header) {
+      :global(.trakt-calendar-header) {
         transition: height var(--transition-increment) ease-in-out;
       }
 
       &:global(.is-scrolled) {
         gap: var(--ni-0);
 
-        :global(.calendar-header) {
+        :global(.trakt-calendar-header) {
           height: var(--ni-0);
         }
       }

--- a/projects/client/src/lib/features/calendar/_internal/CalendarControls.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarControls.svelte
@@ -20,7 +20,7 @@
   );
 </script>
 
-<div class="calendar-controls">
+<div class="trakt-calendar-controls">
   <ActionButton
     label={m.button_label_previous_calendar_period()}
     onclick={navigation.onPrevious}
@@ -50,7 +50,7 @@
 </div>
 
 <style>
-  .calendar-controls {
+  .trakt-calendar-controls {
     display: flex;
     align-items: center;
 

--- a/projects/client/src/lib/features/calendar/_internal/CalendarHeader.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarHeader.svelte
@@ -6,12 +6,12 @@
     $props();
 </script>
 
-<div class="calendar-header">
+<div class="trakt-calendar-header">
   <CalendarControls {...navigationProps} />
 </div>
 
 <style>
-  .calendar-header {
+  .trakt-calendar-header {
     height: var(--ni-40);
     overflow: hidden;
 

--- a/projects/client/src/lib/features/calendar/_internal/ContentIndicator.svelte
+++ b/projects/client/src/lib/features/calendar/_internal/ContentIndicator.svelte
@@ -8,7 +8,7 @@
   const hasMoreThanMax = $derived(itemCount > maxPreviewItems);
 </script>
 
-<div class="content-indicator">
+<div class="trakt-content-indicator">
   {#each indicators as _, i (i)}
     <span class="circle"></span>
   {/each}
@@ -19,7 +19,7 @@
 </div>
 
 <style>
-  .content-indicator {
+  .trakt-content-indicator {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/projects/client/src/lib/features/search/SearchModeToggles.svelte
+++ b/projects/client/src/lib/features/search/SearchModeToggles.svelte
@@ -55,14 +55,14 @@
   ];
 </script>
 
-<div class="search-mode-toggles" role="group">
+<div class="trakt-search-mode-toggles" role="group">
   <Toggler value={$selectedType} variant="text" {onChange} {options} />
 </div>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .search-mode-toggles {
+  .trakt-search-mode-toggles {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/projects/client/src/lib/features/search/SearchResultsGrid.svelte
+++ b/projects/client/src/lib/features/search/SearchResultsGrid.svelte
@@ -27,7 +27,7 @@
   });
 </script>
 
-<div class="search-results-grid" data-variant={type}>
+<div class="trakt-search-results-grid" data-variant={type}>
   <GridList
     id={`search-grid-list-${type}`}
     {items}
@@ -63,7 +63,7 @@
     }
   }
 
-  .search-results-grid:not([data-variant="lists"]) {
+  .trakt-search-results-grid:not([data-variant="lists"]) {
     @include for-mobile {
       @include responsive-layout(3, var(--gap-xxs));
       --footer-height: var(--height-card-footer-sm);
@@ -84,7 +84,7 @@
     }
   }
 
-  .search-results-grid[data-variant="lists"] {
+  .trakt-search-results-grid[data-variant="lists"] {
     @include responsive-layout(3, var(--list-gap));
 
     @include for-tablet-lg {

--- a/projects/client/src/lib/pages/errors/ErrorPage.svelte
+++ b/projects/client/src/lib/pages/errors/ErrorPage.svelte
@@ -19,7 +19,7 @@
   <title>{title}</title>
 </svelte:head>
 
-<main class="error-page">
+<main class="trakt-error-page">
   <h1>{title}</h1>
   {#if rest.children}
     {@render rest.children()}
@@ -31,7 +31,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .error-page {
+  .trakt-error-page {
     height: 100%;
 
     display: flex;

--- a/projects/client/src/lib/sections/branding/components/BrandingLogos.svelte
+++ b/projects/client/src/lib/sections/branding/components/BrandingLogos.svelte
@@ -40,7 +40,7 @@
   </button>
 {/snippet}
 
-<div class="branding-logo-sections">
+<div class="trakt-branding-logos">
   <section class="branding-logo-section">
     <div class="branding-section-header">
       <h2 class="branding-section-heading">
@@ -192,7 +192,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .branding-logo-sections {
+  .trakt-branding-logos {
     display: flex;
     flex-direction: column;
     gap: var(--gap-xxl);

--- a/projects/client/src/lib/sections/branding/components/BrandingQuestions.svelte
+++ b/projects/client/src/lib/sections/branding/components/BrandingQuestions.svelte
@@ -3,7 +3,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
 </script>
 
-<section class="branding-questions">
+<section class="trakt-branding-questions">
   <div class="branding-questions-inner">
     <div class="branding-questions-content">
       <h2 class="branding-section-heading">
@@ -29,7 +29,7 @@
 </section>
 
 <style lang="scss">
-  .branding-questions {
+  .trakt-branding-questions {
     width: 100%;
   }
 

--- a/projects/client/src/lib/sections/branding/components/BrandingRequirements.svelte
+++ b/projects/client/src/lib/sections/branding/components/BrandingRequirements.svelte
@@ -11,7 +11,7 @@
   ] as const;
 </script>
 
-<section class="branding-requirements">
+<section class="trakt-branding-requirements">
   <h2 class="branding-section-heading">{m.heading_branding_requirements()}</h2>
   <ul class="branding-requirements-list">
     {#each requirements as req, i (i)}
@@ -23,7 +23,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .branding-requirements {
+  .trakt-branding-requirements {
     display: flex;
     flex-direction: column;
     width: 100%;

--- a/projects/client/src/lib/sections/components/ToggleTag.svelte
+++ b/projects/client/src/lib/sections/components/ToggleTag.svelte
@@ -22,7 +22,7 @@
   const pressedState = $derived(isPressed ? "true" : "false");
 </script>
 
-<div class="toggle-tag" class:is-checked={isPressed}>
+<div class="trakt-toggle-tag" class:is-checked={isPressed}>
   <Button
     {disabled}
     {label}
@@ -47,7 +47,7 @@
 </div>
 
 <style>
-  .toggle-tag {
+  .trakt-toggle-tag {
     :global(.trakt-button) {
       flex-direction: row-reverse;
 

--- a/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CastMemberItem.svelte
@@ -35,7 +35,7 @@
   {/if}
 {/snippet}
 
-<div class="cast-member-item">
+<div class="trakt-cast-member-item">
   <PersonCard>
     <Link focusable={false} href={UrlBuilder.people(castMember.key, params)}>
       <CardCover
@@ -60,7 +60,7 @@
 </div>
 
 <style lang="scss">
-  .cast-member-item {
+  .trakt-cast-member-item {
     display: contents;
   }
 

--- a/projects/client/src/lib/sections/lists/components/CreditMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditMemberItem.svelte
@@ -118,7 +118,7 @@
   </div>
 {/snippet}
 
-<div class="credit-member-item" role="listitem">
+<div class="trakt-credit-member-item" role="listitem">
   <Card
     classList="trakt-credit-member-card"
     --height-card={cardHeight}
@@ -159,7 +159,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .credit-member-item {
+  .trakt-credit-member-item {
     width: 100%;
   }
 

--- a/projects/client/src/lib/sections/lists/watchlist/_internal/ReleasedTag.svelte
+++ b/projects/client/src/lib/sections/lists/watchlist/_internal/ReleasedTag.svelte
@@ -4,7 +4,7 @@
   import InfoTag from "$lib/components/media/tags/InfoTag.svelte";
 </script>
 
-<div class="watchlist-tag">
+<div class="trakt-released-tag">
   <InfoTag>
     {m.tag_text_movies()}
   </InfoTag>
@@ -14,7 +14,7 @@
 </div>
 
 <style>
-  .watchlist-tag {
+  .trakt-released-tag {
     display: flex;
     align-items: center;
     gap: var(--ni-4);

--- a/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchItem.svelte
+++ b/projects/client/src/lib/sections/lists/where-to-watch/_internal/WhereToWatchItem.svelte
@@ -65,7 +65,7 @@
   const nameLines = $derived(text ? 1 : 2);
 </script>
 
-<div class="where-to-watch-item">
+<div class="trakt-where-to-watch-item">
   <Link
     href={service.link}
     target="_blank"
@@ -94,7 +94,7 @@
 </div>
 
 <style>
-  .where-to-watch-item {
+  .trakt-where-to-watch-item {
     :global(.trakt-link) {
       text-decoration: none;
       color: var(--color-text-secondary);

--- a/projects/client/src/lib/sections/navbar/_internal/NavGroup.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/NavGroup.svelte
@@ -23,7 +23,7 @@
   } = $props();
 </script>
 
-<div class="nav-group">
+<div class="trakt-nav-group">
   <div class="nav-main-link" class:is-expanded={!isCollapsed}>
     <Tooltip
       content={title}
@@ -52,7 +52,7 @@
 </div>
 
 <style>
-  .nav-group {
+  .trakt-nav-group {
     display: flex;
     flex-direction: column;
     gap: var(--gap-xxs);

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/SliderFilter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/SliderFilter.svelte
@@ -63,7 +63,7 @@
   };
 </script>
 
-<div class="slider-container">
+<div class="trakt-slider-filter">
   <p>{sliderOptions.formatLabel(labelValue)}</p>
   <Slider
     range={sliderOptions.range}
@@ -76,7 +76,7 @@
 </div>
 
 <style>
-  .slider-container {
+  .trakt-slider-filter {
     width: 100%;
     height: var(--ni-64);
 

--- a/projects/client/src/lib/sections/profile-banner/ProfileImage.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfileImage.svelte
@@ -93,7 +93,7 @@
   }
 </script>
 
-<div class="profile-image-container" class:is-vip={isVip}>
+<div class="trakt-profile-image" class:is-vip={isVip}>
   <figure class="profile-image" data-sentry-block>
     <!-- This should be the first element, else: HierarchyRequestError -->
     <figcaption class="visually-hidden">
@@ -185,7 +185,7 @@
     border: 0;
   }
 
-  .profile-image-container {
+  .trakt-profile-image {
     position: relative;
 
     &.is-vip {
@@ -268,8 +268,8 @@
     }
   }
 
-  .profile-image-container:has(.editable-image-wrapper:hover) .edit-badge,
-  .profile-image-container:has(.editable-image-wrapper:focus-visible)
+  .trakt-profile-image:has(.editable-image-wrapper:hover) .edit-badge,
+  .trakt-profile-image:has(.editable-image-wrapper:focus-visible)
     .edit-badge {
     opacity: 1;
     transform: translate(15%, 15%) scale(1.1);

--- a/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfilePageBanner.svelte
@@ -38,7 +38,7 @@
   const isPublic = $derived(variant === "public");
 </script>
 
-<div class="profile-page-banner-container">
+<div class="trakt-profile-page-banner">
   <div class="profile-identity">
     <ProfileImage
       isEditable={$isMe}
@@ -105,7 +105,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .profile-page-banner-container {
+  .trakt-profile-page-banner {
     display: flex;
     flex-direction: column;
     gap: var(--gap-m);
@@ -125,7 +125,7 @@
         flex: initial;
       }
 
-      :global(.trakt-profile-about .line-clamp-container) {
+      :global(.trakt-profile-about .trakt-clamped-text) {
         align-items: flex-start;
       }
     }
@@ -137,7 +137,7 @@
     align-items: center;
     gap: var(--gap-s);
 
-    :global(.profile-image-container) {
+    :global(.trakt-profile-image) {
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -158,7 +158,7 @@
         white-space: normal;
       }
 
-      :global(.profile-image-container) {
+      :global(.trakt-profile-image) {
         --width: var(--ni-40);
         --height: var(--ni-40);
         --border-width: var(--border-thickness-xs);

--- a/projects/client/src/lib/sections/profile/components/ProfileItem.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileItem.svelte
@@ -68,7 +68,7 @@
   }
 
   .trakt-profile-item {
-    :global(.profile-image-container.is-vip)::before {
+    :global(.trakt-profile-image.is-vip)::before {
       --offset: calc(-1 * var(--border-thickness-s));
 
       content: "";
@@ -91,7 +91,7 @@
       z-index: var(--layer-background);
     }
 
-    :global(.profile-image-container) {
+    :global(.trakt-profile-image) {
       background-color: var(--color-card-background);
       border-radius: 50%;
 

--- a/projects/client/src/lib/sections/profile/components/SwipeCarousel.svelte
+++ b/projects/client/src/lib/sections/profile/components/SwipeCarousel.svelte
@@ -26,7 +26,7 @@
   }
 </script>
 
-<div class="swipe-carousel-root" use:carousel.setupSwipe={enabled}>
+<div class="trakt-swipe-carousel" use:carousel.setupSwipe={enabled}>
   <button
     class="swipe-carousel-nav"
     onclick={carousel.goToPrev}
@@ -65,7 +65,7 @@
 </div>
 
 <style lang="scss">
-  .swipe-carousel-root {
+  .trakt-swipe-carousel {
     touch-action: pan-y;
     display: flex;
     align-items: center;

--- a/projects/client/src/lib/sections/settings/_internal/SettingsGroupCard.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsGroupCard.svelte
@@ -2,14 +2,14 @@
   const { children }: ChildrenProps = $props();
 </script>
 
-<div class="settings-group-card">
+<div class="trakt-settings-group-card">
   {@render children()}
 </div>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .settings-group-card {
+  .trakt-settings-group-card {
     border-radius: var(--border-radius-l);
     background: var(--color-card-background);
     overflow: hidden;

--- a/projects/client/src/lib/sections/settings/_internal/SettingsGroupRow.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsGroupRow.svelte
@@ -57,12 +57,12 @@
 {/snippet}
 
 {#if rest.variant === "link"}
-  <a class="settings-group-row" href={rest.href}>
+  <a class="trakt-settings-group-row" href={rest.href}>
     {@render rowContent()}
   </a>
 {:else if rest.variant === "button"}
   <button
-    class="settings-group-row"
+    class="trakt-settings-group-row"
     onclick={rest.onclick}
     disabled={rest.disabled}
     aria-label={rest.label}
@@ -71,7 +71,7 @@
     {@render rowContent()}
   </button>
 {:else}
-  <div class="settings-group-row">
+  <div class="trakt-settings-group-row">
     {@render rowContent()}
   </div>
 {/if}
@@ -79,7 +79,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .settings-group-row {
+  .trakt-settings-group-row {
     display: flex;
     align-items: center;
     gap: var(--gap-m);

--- a/projects/client/src/lib/sections/settings/_internal/SettingsSectionLabel.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsSectionLabel.svelte
@@ -2,12 +2,12 @@
   const { title }: { title: string } = $props();
 </script>
 
-<p class="settings-section-label bold">{title}</p>
+<p class="trakt-settings-section-label bold">{title}</p>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .settings-section-label {
+  .trakt-settings-section-label {
     max-width: var(--ni-640);
     padding: var(--gap-m) var(--gap-m) var(--gap-xs);
     font-size: var(--font-size-title);

--- a/projects/client/src/lib/sections/settings/_internal/components/SyncProgress.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/components/SyncProgress.svelte
@@ -14,7 +14,7 @@
   );
 </script>
 
-<div class="sync-progress" transition:slide={{ duration: 150, axis: "y" }}>
+<div class="trakt-sync-progress" transition:slide={{ duration: 150, axis: "y" }}>
   <p class="secondary">
     {label}
   </p>
@@ -31,7 +31,7 @@
 </div>
 
 <style>
-  .sync-progress {
+  .trakt-sync-progress {
     display: flex;
     flex-direction: column;
     gap: var(--gap-s);

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
@@ -14,7 +14,7 @@
   const successCount = $derived(processedCount - errorCount);
 </script>
 
-<div class="import-complete" transition:slide={{ duration: 150, axis: "y" }}>
+<div class="trakt-import-complete" transition:slide={{ duration: 150, axis: "y" }}>
   <div class="import-complete-summary">
     <p class="secondary">
       {m.import_complete_synced({ count: successCount })}
@@ -38,7 +38,7 @@
 </div>
 
 <style>
-  .import-complete {
+  .trakt-import-complete {
     display: flex;
     flex-direction: column;
     gap: var(--gap-m);

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportDropzone.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportDropzone.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <div
-  class="import-dropzone"
+  class="trakt-import-dropzone"
   transition:slide={{ duration: 150, axis: "y" }}
   use:dropzone={{ accept, multiple: maxFiles > 1 }}
   onfiles={handleFiles}
@@ -31,7 +31,7 @@
 </div>
 
 <style>
-  .import-dropzone {
+  .trakt-import-dropzone {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportError.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportError.svelte
@@ -11,7 +11,7 @@
   const { error, onreset }: ImportErrorProps = $props();
 </script>
 
-<div class="import-error" transition:slide={{ duration: 150, axis: "y" }}>
+<div class="trakt-import-error" transition:slide={{ duration: 150, axis: "y" }}>
   <p class="secondary">
     {m.import_status_error({ message: error })}
   </p>
@@ -28,7 +28,7 @@
 </div>
 
 <style>
-  .import-error {
+  .trakt-import-error {
     display: flex;
     flex-direction: column;
     gap: var(--gap-xs);

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
@@ -35,7 +35,7 @@
   {/if}
 {/snippet}
 
-<div class="import-guide">
+<div class="trakt-import-guide">
   <p class="import-guide-title bold">{config.guide.title}</p>
 
   {#if config.guide.description != null}
@@ -73,7 +73,7 @@
 </div>
 
 <style lang="scss">
-  .import-guide {
+  .trakt-import-guide {
     display: flex;
     flex-direction: column;
     gap: var(--gap-s);

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportSummary.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportSummary.svelte
@@ -30,7 +30,7 @@
   });
 </script>
 
-<div class="import-summary" transition:slide={{ duration: 150, axis: "y" }}>
+<div class="trakt-import-summary" transition:slide={{ duration: 150, axis: "y" }}>
   <div class="import-summary-counts">
     {#if counts.history > 0}
       <p class="secondary">
@@ -77,7 +77,7 @@
 </div>
 
 <style>
-  .import-summary {
+  .trakt-import-summary {
     display: flex;
     flex-direction: column;
     gap: var(--gap-m);

--- a/projects/client/src/lib/sections/smart-lists/_internal/MediaTypeToggler.svelte
+++ b/projects/client/src/lib/sections/smart-lists/_internal/MediaTypeToggler.svelte
@@ -23,12 +23,12 @@
   ];
 </script>
 
-<div class="media-type-toggler">
+<div class="trakt-media-type-toggler">
   <Toggler value={type} variant="text" {onChange} {options} />
 </div>
 
 <style>
-  .media-type-toggler {
+  .trakt-media-type-toggler {
     display: flex;
   }
 </style>

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraphPeakHours.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraphPeakHours.svelte
@@ -6,7 +6,7 @@
   const max = $derived(Math.max(...data.buckets.map((b) => b.count), 1));
 </script>
 
-<div class="graph-peak-hours">
+<div class="trakt-pulse-graph-peak-hours">
   {#each data.buckets as bucket (bucket.key)}
     <div class="peak-row">
       <span class="peak-label tag">{bucket.label}</span>
@@ -22,7 +22,7 @@
 </div>
 
 <style lang="scss">
-  .graph-peak-hours {
+  .trakt-pulse-graph-peak-hours {
     display: flex;
     flex-direction: column;
     gap: var(--ni-8);

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
@@ -26,7 +26,7 @@
   }
 </script>
 
-<div class="graph-screen-time-daily">
+<div class="trakt-pulse-graph-screen-time-daily">
   {#each data.labels as label, i (i)}
     {@const pct = data.percentages[i] ?? 0}
     {@const minutes = data.minutesPerDay[i] ?? 0}
@@ -56,7 +56,7 @@
 </div>
 
 <style lang="scss">
-  .graph-screen-time-daily {
+  .trakt-pulse-graph-screen-time-daily {
     display: flex;
     gap: var(--ni-8);
 

--- a/projects/client/src/lib/sections/summary/components/people/v2/_internal/Celebration.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/_internal/Celebration.svelte
@@ -3,7 +3,7 @@
   import { Confetti } from "svelte-confetti";
 </script>
 
-<div class="confetti-container">
+<div class="trakt-celebration">
   <Confetti
     y={[0, 0.5]}
     x={[-1, 2]}
@@ -15,7 +15,7 @@
 </div>
 
 <style>
-  .confetti-container {
+  .trakt-celebration {
     position: absolute;
     left: 50%;
     top: 50%;

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/StarsConfetti.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/StarsConfetti.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <div
-  class="confetti-container"
+  class="trakt-stars-confetti"
   style="left: {position.x}px; top: {position.y}px;"
 >
   <Confetti
@@ -21,7 +21,7 @@
 </div>
 
 <style>
-  .confetti-container {
+  .trakt-stars-confetti {
     position: absolute;
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonProgressCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonProgressCard.svelte
@@ -53,7 +53,7 @@
   {/if}
 {/snippet}
 
-<div class="season-progress-card" class:is-complete={isComplete}>
+<div class="trakt-season-progress-card" class:is-complete={isComplete}>
   <div class="progress-header">
     <p class="bold capitalize">
       {seasonNumber === 0
@@ -91,7 +91,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .season-progress-card {
+  .trakt-season-progress-card {
     display: flex;
     flex-direction: column;
     gap: var(--gap-s);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CompaniesSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CompaniesSection.svelte
@@ -38,7 +38,7 @@
   }
 </script>
 
-<section class="yir-2024-companies" id="section-{type}-companies">
+<section class="trakt-yir-2024-companies-section" id="section-{type}-companies">
   <div class="yir-2024-companies-panel">
     <div class="yir-2024-companies-text">
       <h2 class="bold yir-2024-companies-heading">{heading}</h2>
@@ -68,7 +68,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-companies {
+  .trakt-yir-2024-companies-section {
     width: 100%;
   }
 
@@ -111,7 +111,7 @@
 
       // Stat list is rendered by Yir2024StatSummary (its own scope), so it
       // has to be reached with :global to take the remaining row width.
-      :global(.yir-2024-stat-summary) {
+      :global(.trakt-yir-2024-stat-summary) {
         flex: 1;
         min-width: 0;
       }

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024GenresSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024GenresSection.svelte
@@ -39,7 +39,7 @@
   }
 </script>
 
-<section class="yir-2024-genres" id="section-{type}-genres">
+<section class="trakt-yir-2024-genres-section" id="section-{type}-genres">
   <div class="yir-2024-genres-panel">
     <span class="bold yir-2024-genres-watermark" aria-hidden="true">
       {watermark}
@@ -66,7 +66,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-genres {
+  .trakt-yir-2024-genres-section {
     width: 100%;
   }
 
@@ -147,7 +147,7 @@
 
   // Stat list rendered by Yir2024StatSummary (its own scope), reached with
   // :global to constrain its column width on desktop.
-  .yir-2024-genres-top :global(.yir-2024-stat-summary) {
+  .yir-2024-genres-top :global(.trakt-yir-2024-stat-summary) {
     flex: 0 1 var(--ni-360);
     min-width: 0;
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte
@@ -53,7 +53,7 @@
   const joinYear = $derived($profile?.joinedAt?.getFullYear() ?? null);
 </script>
 
-<header class="yir-2024-hero">
+<header class="trakt-yir-2024-hero">
   <div class="yir-2024-year-row">
     <Yir2024Stars />
     <span class="bold yir-2024-current-year">{year}</span>
@@ -104,7 +104,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-hero {
+  .trakt-yir-2024-hero {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024LineChart.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024LineChart.svelte
@@ -5,7 +5,7 @@
   const { data, tooltip }: AreaChartProps = $props();
 </script>
 
-<div class="yir-2024-line-chart">
+<div class="trakt-yir-2024-line-chart">
   <!--
     2024 palette: white line, dark fill (~v2's #222 → shade-920), and a
     purple-500 hover pin with a faint white halo. Colors are passed as props
@@ -24,7 +24,7 @@
 </div>
 
 <style lang="scss">
-  .yir-2024-line-chart {
+  .trakt-yir-2024-line-chart {
     width: 100%;
     height: 100%;
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MediaCard.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MediaCard.svelte
@@ -32,7 +32,7 @@
   );
 </script>
 
-<article class="yir-2024-media-card">
+<article class="trakt-yir-2024-media-card">
   <div class="yir-2024-media-cover">
     <CrossOriginImage src={item.entry.cover.url.medium} alt="" />
   </div>
@@ -75,7 +75,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-media-card {
+  .trakt-yir-2024-media-card {
     position: relative;
     width: 100%;
     aspect-ratio: 16 / 9;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Membership.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Membership.svelte
@@ -9,7 +9,7 @@
   } = $props();
 </script>
 
-<div class="yir-2024-membership">
+<div class="trakt-yir-2024-membership">
   <div class="yir-2024-trakt-worldwide">
     <span class="bold yir-2024-membership-label">
       {m.yir_2024_trakt_worldwide()}
@@ -32,7 +32,7 @@
   // 6-column grid that mirrors the 6-poster wave above. Placing the label
   // blocks in columns 2 and 5 (centered within them) lines them up exactly
   // under poster 2 and poster 5.
-  .yir-2024-membership {
+  .trakt-yir-2024-membership {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     align-items: center;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedCard.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedCard.svelte
@@ -25,7 +25,7 @@
 </script>
 
 <li
-  class="yir-2024-most-played-card"
+  class="trakt-yir-2024-most-played-card"
   role="article"
   data-rank-position={(rank - 1) % 4}
 >
@@ -83,7 +83,7 @@
   // rotation: center / end / center / start). Alignment is driven by
   // `align-self` on the flex-column parent so spacing between cards still
   // comes from the parent's `gap` — no per-card margin.
-  .yir-2024-most-played-card {
+  .trakt-yir-2024-most-played-card {
     position: relative;
     width: 90%;
     height: var(--ni-640);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedSection.svelte
@@ -18,7 +18,7 @@
   );
 </script>
 
-<section class="yir-2024-most-played" id="section-{type}-most-watched">
+<section class="trakt-yir-2024-most-played-section" id="section-{type}-most-watched">
   <header class="yir-2024-most-played-header">
     <h2 class="bold yir-2024-most-played-heading">{heading}</h2>
   </header>
@@ -33,7 +33,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-most-played {
+  .trakt-yir-2024-most-played-section {
     position: relative;
     width: 100%;
     display: flex;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PageInner.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PageInner.svelte
@@ -8,7 +8,7 @@
   } = $props();
 </script>
 
-<div class="yir-2024-page-inner">
+<div class="trakt-yir-2024-page-inner">
   {@render children()}
 </div>
 
@@ -21,7 +21,7 @@
   // set on .yir-page) and mirrors it on the right so the content sits
   // centered between the two safe-areas. Tablet-sm-and-below loses the side
   // navbar so the YIR-specific minimum bumps to var(--ni-40).
-  .yir-2024-page-inner {
+  .trakt-yir-2024-page-inner {
     width: 100%;
     max-width: var(--ni-1280);
     margin: 0 auto;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PlayCard.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PlayCard.svelte
@@ -11,12 +11,12 @@
   const { item, playLabel, year }: Yir2024PlayCardProps = $props();
 </script>
 
-<section class="yir-2024-play-card">
+<section class="trakt-yir-2024-play-card">
   <Yir2024MediaCard {item} {playLabel} {year} />
 </section>
 
 <style lang="scss">
-  .yir-2024-play-card {
+  .trakt-yir-2024-play-card {
     width: 100%;
   }
 </style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PostersRow.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PostersRow.svelte
@@ -11,7 +11,7 @@
 </script>
 
 {#if entries.length > 0}
-  <div class="yir-2024-posters-row">
+  <div class="trakt-yir-2024-posters-row">
     {#each entries as entry (entry.key)}
       <a
         href={UrlBuilder.media(entry.type, entry.slug)}
@@ -27,7 +27,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-posters-row {
+  .trakt-yir-2024-posters-row {
     display: flex;
     align-items: flex-end;
     justify-content: center;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024RatedSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024RatedSection.svelte
@@ -32,7 +32,7 @@
   }
 </script>
 
-<section class="yir-2024-rated" id="section-{type}-highest-rated">
+<section class="trakt-yir-2024-rated-section" id="section-{type}-highest-rated">
   <article class="yir-2024-rated-panel">
     <div class="yir-2024-rated-covers" aria-hidden="true">
       {#each items as item, index (item.entry.id)}
@@ -89,7 +89,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-rated {
+  .trakt-yir-2024-rated-section {
     width: 100%;
   }
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024SectionHeader.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024SectionHeader.svelte
@@ -11,7 +11,7 @@
   } = $props();
 </script>
 
-<header class="yir-2024-section-header">
+<header class="trakt-yir-2024-section-header">
   <p class="bold yir-2024-section-header-intro">{intro}</p>
   <h2 class="bold yir-2024-section-header-title">{title}</h2>
 </header>
@@ -19,7 +19,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-section-header {
+  .trakt-yir-2024-section-header {
     display: flex;
     flex-direction: column;
     gap: var(--gap-xs);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Stars.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Stars.svelte
@@ -2,7 +2,7 @@
   import StarIcon from "$lib/components/icons/StarIcon.svelte";
 </script>
 
-<span class="yir-2024-stars" aria-hidden="true">
+<span class="trakt-yir-2024-stars" aria-hidden="true">
   <StarIcon fill="none" />
   <StarIcon fill="none" />
   <StarIcon fill="none" />
@@ -11,7 +11,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-stars {
+  .trakt-yir-2024-stars {
     display: inline-flex;
     align-items: center;
     gap: var(--gap-xs);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatSummary.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatSummary.svelte
@@ -12,7 +12,7 @@
   }: Yir2024StatSummaryProps = $props();
 </script>
 
-<dl class="yir-2024-stat-summary">
+<dl class="trakt-yir-2024-stat-summary">
   {#if mostWatched}
     <div class="yir-2024-stat-row">
       <dt>{m.yir_2024_stat_most_watched()}</dt>
@@ -48,7 +48,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-stat-summary {
+  .trakt-yir-2024-stat-summary {
     display: flex;
     flex-direction: column;
   }

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
@@ -118,7 +118,7 @@
   });
 </script>
 
-<section class="yir-2024-stats" id="section-{type}-stats">
+<section class="trakt-yir-2024-stats-section" id="section-{type}-stats">
   <div class="yir-2024-stats-stack">
     <article class="yir-2024-stats-panel yir-2024-stats-summary">
       <div class="yir-2024-stats-summary-text">
@@ -244,7 +244,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-stats {
+  .trakt-yir-2024-stats-section {
     width: 100%;
   }
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024ThanksSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024ThanksSection.svelte
@@ -17,7 +17,7 @@
   const nextYear = $derived(year + 1);
 </script>
 
-<section class="yir-2024-thanks" id="section-thanks">
+<section class="trakt-yir-2024-thanks-section" id="section-thanks">
   <div class="yir-2024-thanks-grid">
     <h2 class="bold yir-2024-thanks-intro">{m.yir_2024_thanks_intro()}</h2>
     <p class="bold yir-2024-thanks-title">{m.yir_2024_thanks_title()}</p>
@@ -38,7 +38,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-thanks {
+  .trakt-yir-2024-thanks-section {
     width: 100%;
     color: var(--shade-10);
     // Last section on the page — keep a gap below the posters so they don't

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TopSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TopSection.svelte
@@ -16,7 +16,7 @@
   } = $props();
 </script>
 
-<section class="yir-2024-top" id="section-totals">
+<section class="trakt-yir-2024-top-section" id="section-totals">
   <div class="yir-2024-top-gradient" aria-hidden="true"></div>
 
   <Yir2024PageInner>
@@ -31,7 +31,7 @@
 </section>
 
 <style lang="scss">
-  .yir-2024-top {
+  .trakt-yir-2024-top-section {
     position: relative;
     padding: var(--ni-104) 0 0 0;
     overflow: hidden;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TrendCard.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TrendCard.svelte
@@ -28,7 +28,7 @@
   );
 </script>
 
-<div class="yir-2024-trend-card">
+<div class="trakt-yir-2024-trend-card">
   <Link href={itemUrl} color="inherit">
     <span class="uppercase yir-2024-trend-month">{monthLabel}</span>
 
@@ -54,7 +54,7 @@
 <style>
   /* The whole card is one Link laid out as a column; strip the link's
      underline and inherit the card's white text. */
-  .yir-2024-trend-card :global(.trakt-link) {
+  .trakt-yir-2024-trend-card :global(.trakt-link) {
     display: flex;
     flex-direction: column;
     gap: var(--ni-4);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TrendsSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TrendsSection.svelte
@@ -36,7 +36,7 @@
   );
 </script>
 
-<section class="yir-2024-trends" id="section-{type}-trends">
+<section class="trakt-yir-2024-trends-section" id="section-{type}-trends">
   <header class="yir-2024-trends-header">
     <h2 class="bold yir-2024-trends-title">{heading}</h2>
     <p class="yir-2024-trends-subtitle">{subtitle}</p>
@@ -56,7 +56,7 @@
   @use "$style/scss/mixins/index" as *;
 
   // Purple gradient panel (matches v2's trends sections).
-  .yir-2024-trends {
+  .trakt-yir-2024-trends-section {
     // border-box so the panel's padding stays inside its 100% width (there's
     // no global box-sizing reset) — otherwise it overflows the page wrapper.
     box-sizing: border-box;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WatchedStats.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WatchedStats.svelte
@@ -25,7 +25,7 @@
   const historyUrl = $derived(UrlBuilder.profile.history(slug));
 </script>
 
-<div class="yir-2024-watched-stats">
+<div class="trakt-yir-2024-watched-stats">
   <span class="yir-2024-stat yir-2024-stat-link">
     <Link href={historyUrl} color="inherit">
       <span class="yir-2024-stat-row">
@@ -94,7 +94,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-2024-watched-stats {
+  .trakt-yir-2024-watched-stats {
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WeeklyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WeeklyPlaysChart.svelte
@@ -13,7 +13,7 @@
   } = $props();
 </script>
 
-<div class="yir-2024-weekly-chart">
+<div class="trakt-yir-2024-weekly-plays-chart">
   <YirWeeklyPlaysChart {data} {year} barSpacing={1}>
     {#snippet tooltip({ value, week, dateRange })}
       <YirTooltip
@@ -29,7 +29,7 @@
   // 2024 palette: bars use the lightest cool gray (shade-100, exactly
   // matches v2's #d2d6d9); peak week pops in the lighter purple-300, and
   // hover lands on purple-500 (#9f42c6, exactly matches v2's hover).
-  .yir-2024-weekly-chart {
+  .trakt-yir-2024-weekly-plays-chart {
     --color-bar-custom-default: var(--shade-100);
     --color-bar-custom-highlight: var(--purple-300);
     --color-bar-custom-hover: var(--purple-500);

--- a/projects/client/src/lib/sections/yir/YirPage.svelte
+++ b/projects/client/src/lib/sections/yir/YirPage.svelte
@@ -9,7 +9,7 @@
   const Template = $derived(getYirTemplate(year));
 </script>
 
-<div class="yir-page" id="year-in-review">
+<div class="trakt-yir-page" id="year-in-review">
   <YirHeader {slug} {year} />
   <!-- Always mount the template so its scaffold (header text, hero shell)
        paints immediately; detail-dependent sections inside the template
@@ -25,7 +25,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-page {
+  .trakt-yir-page {
     display: flex;
     flex-direction: column;
     background-color: var(--shade-950);

--- a/projects/client/src/lib/sections/yir/_internal/YirGenreBars.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirGenreBars.svelte
@@ -50,7 +50,7 @@
     */
 </script>
 
-<div class="yir-genre-bars" data-variant={variant}>
+<div class="trakt-yir-genre-bars" data-variant={variant}>
   {#each genres.genres as genre, index (genre.name)}
     {@const percentage = (genre.count / genres.itemCount) * 100}
     {@const relativePercentage = (genre.count / maxCount) * 100}
@@ -87,7 +87,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-genre-bars {
+  .trakt-yir-genre-bars {
     display: flex;
     padding: var(--ni-40) var(--ni-16) var(--ni-60) var(--ni-16);
     overflow-x: auto;
@@ -233,7 +233,7 @@
   // the bar's color and uppercase text, instead of the transparent
   // left-border style. ~31% matches v2's `#RRGGBB50` (0x50 alpha) tint so
   // the panel reads through the label.
-  .yir-genre-bars[data-variant="filled"] {
+  .trakt-yir-genre-bars[data-variant="filled"] {
     .yir-genre-label {
       width: max-content;
       max-width: 200%;

--- a/projects/client/src/lib/sections/yir/_internal/YirTooltip.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirTooltip.svelte
@@ -10,7 +10,7 @@
   } = $props();
 </script>
 
-<div class="yir-tooltip">
+<div class="trakt-yir-tooltip">
   <div class="yir-tooltip-main">{main}</div>
   {#if sub}
     <div class="yir-tooltip-sub">{sub}</div>
@@ -24,7 +24,7 @@
   // Styles are :global so the same classes can be reused by Carbon's
   // tooltip customHTML callback (see yirTooltipHTML.ts), which renders
   // outside this component's DOM.
-  :global(.yir-tooltip) {
+  :global(.trakt-yir-tooltip) {
     background: color-mix(in srgb, var(--shade-1000) 92%, transparent);
     border: var(--border-thickness-xxs) solid var(--shade-800);
     border-radius: var(--border-radius-xs);

--- a/projects/client/src/lib/sections/yir/_internal/yirTooltipHTML.ts
+++ b/projects/client/src/lib/sections/yir/_internal/yirTooltipHTML.ts
@@ -22,7 +22,7 @@ const line = (className: string, text: string | undefined): string =>
 export const yirTooltipHTML = (
   { main, sub, extra }: YirTooltipContent,
 ): string => `
-  <div class="yir-tooltip">
+  <div class="trakt-yir-tooltip">
     ${line('yir-tooltip-main', main)}
     ${line('yir-tooltip-sub', sub)}
     ${line('yir-tooltip-extra', extra)}

--- a/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
@@ -38,7 +38,7 @@
   );
 </script>
 
-<section class="yir-calendar-section" id="section-{how}-play">
+<section class="trakt-yir-calendar-section" id="section-{how}-play">
   <div
     class="yir-calendar-bg"
     style:background-image="url({item.entry.cover.url.medium})"
@@ -81,7 +81,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-calendar-section {
+  .trakt-yir-calendar-section {
     position: relative;
     text-align: center;
     background-color: var(--shade-950);

--- a/projects/client/src/lib/sections/yir/default/_internal/YirGenresSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirGenresSection.svelte
@@ -19,7 +19,7 @@
   );
 </script>
 
-<section class="yir-genres-section" id="section-{type}-genres">
+<section class="trakt-yir-genres-section" id="section-{type}-genres">
   <YirPageInner>
     <YirSectionHeader>
       {sectionTitle}
@@ -32,7 +32,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-genres-section {
+  .trakt-yir-genres-section {
     background-color: var(--shade-1000);
     padding-bottom: var(--ni-72);
 

--- a/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
@@ -32,7 +32,7 @@
   }
 </script>
 
-<section class="yir-most-watched-section" id="section-{type}-most-watched">
+<section class="trakt-yir-most-watched-section" id="section-{type}-most-watched">
   <!-- Featured card area with fanart backgrounds -->
   <div class="yir-most-watched-page">
     {#each items as item, index (item.entry.id)}
@@ -105,7 +105,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-most-watched-section {
+  .trakt-yir-most-watched-section {
     background-color: var(--shade-950);
     text-align: center;
     position: relative;

--- a/projects/client/src/lib/sections/yir/default/_internal/YirNetworksChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirNetworksChart.svelte
@@ -16,7 +16,7 @@
   }
 </script>
 
-<div class="yir-networks-chart">
+<div class="trakt-yir-networks-chart">
   <YirCompaniesBubbleChart {companies}>
     {#snippet tooltip({ company })}
       <YirTooltip
@@ -28,7 +28,7 @@
 </div>
 
 <style lang="scss">
-  .yir-networks-chart {
+  .trakt-yir-networks-chart {
     width: 100%;
     height: var(--height-bubble-chart);
   }

--- a/projects/client/src/lib/sections/yir/default/_internal/YirNetworksSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirNetworksSection.svelte
@@ -12,7 +12,7 @@
   } = $props();
 </script>
 
-<section class="yir-networks-section" id="section-shows-networks">
+<section class="trakt-yir-networks-section" id="section-shows-networks">
   <YirPageInner>
     <YirSectionHeader>
       {m.yir_section_title_networks()}
@@ -27,7 +27,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-networks-section {
+  .trakt-yir-networks-section {
     background-color: var(--shade-950);
   }
 

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPageInner.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPageInner.svelte
@@ -8,14 +8,14 @@
   } = $props();
 </script>
 
-<div class="yir-page-inner">
+<div class="trakt-yir-page-inner">
   {@render children()}
 </div>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-page-inner {
+  .trakt-yir-page-inner {
     position: relative;
     width: 100%;
     max-width: var(--ni-1280);

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
@@ -81,14 +81,14 @@
 </script>
 
 {#if $isLoading}
-  <div class="yir-people-group">
+  <div class="trakt-yir-people-group">
     <YirSectionHeader compact>
       {label}
     </YirSectionHeader>
     <p class="yir-people-loading">{m.yir_state_loading()}</p>
   </div>
 {:else if $people && $people.length > 0}
-  <div class="yir-people-group">
+  <div class="trakt-yir-people-group">
     <YirSectionHeader compact noTopPadding={type === "actresses"}>
       {label}
     </YirSectionHeader>
@@ -189,7 +189,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-people-group {
+  .trakt-yir-people-group {
     overflow: hidden;
     padding-bottom: var(--ni-30);
   }

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPeopleSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPeopleSection.svelte
@@ -12,7 +12,7 @@
   } = $props();
 </script>
 
-<section class="yir-people-section" id="section-people">
+<section class="trakt-yir-people-section" id="section-people">
   <YirPageInner>
     <YirPeopleGroup {slug} {year} type="actors" label={m.yir_section_title_top_actors()} />
     <YirPeopleGroup {slug} {year} type="actresses" label={m.yir_section_title_top_actresses()} />
@@ -22,7 +22,7 @@
 </section>
 
 <style lang="scss">
-  .yir-people-section {
+  .trakt-yir-people-section {
     background-color: var(--shade-1000);
   }
 </style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
@@ -31,7 +31,7 @@
   }
 </script>
 
-<section class="yir-rated-section" id="section-{type}-ratings">
+<section class="trakt-yir-rated-section" id="section-{type}-ratings">
   {#each items as item, index (item.entry.id)}
     <div
       class="yir-fanart-bg"
@@ -77,7 +77,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-rated-section {
+  .trakt-yir-rated-section {
     text-align: center;
     position: relative;
     background-color: var(--shade-950);

--- a/projects/client/src/lib/sections/yir/default/_internal/YirSectionHeader.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirSectionHeader.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <div
-  class="yir-section-header"
+  class="trakt-yir-section-header"
   class:compact
   class:no-top-padding={noTopPadding}
   class:flat
@@ -37,7 +37,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-section-header {
+  .trakt-yir-section-header {
     text-align: center;
     padding: var(--ni-72) 0;
 

--- a/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
@@ -37,7 +37,7 @@
   const hoursDaily = $derived(stats.minutes.daily / 60);
 </script>
 
-<section class="yir-stats-section" id="section-{type}-stats">
+<section class="trakt-yir-stats-section" id="section-{type}-stats">
   <YirPageInner>
     <YirSectionHeader>
       <strong>{formatNumber(stats.itemsCount ?? 0)}</strong>
@@ -141,7 +141,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-stats-section {
+  .trakt-yir-stats-section {
     background-color: var(--shade-950);
     padding-bottom: var(--ni-72);
 

--- a/projects/client/src/lib/sections/yir/default/_internal/YirStudiosSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirStudiosSection.svelte
@@ -12,7 +12,7 @@
   } = $props();
 </script>
 
-<section class="yir-studios-section" id="section-movies-networks">
+<section class="trakt-yir-studios-section" id="section-movies-networks">
   <YirPageInner>
     <YirSectionHeader>
       {m.yir_section_title_studios()}
@@ -27,7 +27,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-studios-section {
+  .trakt-yir-studios-section {
     background-color: var(--shade-950);
   }
 

--- a/projects/client/src/lib/sections/yir/default/_internal/YirTitleSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirTitleSection.svelte
@@ -32,7 +32,7 @@
   );
 </script>
 
-<section class="yir-title-page">
+<section class="trakt-yir-title-section">
   <div class="yir-cover-bg">
     <CrossOriginImage src={coverSrc} alt="" />
   </div>
@@ -68,7 +68,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-title-page {
+  .trakt-yir-title-section {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
@@ -26,7 +26,7 @@
   const hoursWatched = $derived(Math.round(stats.minutes.total / 60));
 </script>
 
-<section class="yir-totals-section" id="section-totals">
+<section class="trakt-yir-totals-section" id="section-totals">
   <YirPageInner>
     <YirSectionHeader>
       {m.yir_section_title_totals({ year })}
@@ -101,7 +101,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .yir-totals-section {
+  .trakt-yir-totals-section {
     background-color: var(--shade-1000);
     padding-bottom: var(--ni-72);
   }


### PR DESCRIPTION
## Summary

Mechanical follow-up to #2632. Brings 83 components into compliance with
the CSS class naming convention codified in `.agents/rules/components.md`:
every component's root markup element now wears a single namespaced
`trakt-{file-name-kebab}` class.

The audit that produced this PR was the same scan referenced in #2632:
116 candidate files, of which 81 were real deviations (35 were false
positives where the audit script captured a child element's class). 83
were ultimately renamed once the agents identified the actual root
element in each file.

## What changed

For each renamed component:

- Root `class="<old>"` -> `class="trakt-<file-name-kebab>"`
- Matching SCSS selectors (`.<old>`, `&.<old>`, `:global(.<old>)`)
  updated in the same file
- External `:global()` references in sibling/parent components updated
  to track the new name (e.g. `ProfilePageBanner.scss` now references
  `:global(.trakt-profile-image)` instead of `:global(.profile-image-container)`)

No behavior changes. No prop renames. No markup restructuring. No
style-value changes. Child element classes inside each component are
left as-is, per the rule: children stay kebab-case with no `trakt-`
prefix.

## Intentionally skipped

- `CommentReplies.svelte` and `FeatureFlagItems.svelte`: fragments with
  multiple top-level elements; no single root to rename.
- `DateWithAnniversary.svelte`: pure utility wrapper with no `<style>`
  block, exempt per rule section 1 ("Icon components and pure utility
  wrappers without their own styles are exempt").
- `Terms.svelte` / `Privacy.svelte` and similar: share the
  `legal-section` contract class consumed by `LegalPage`'s slot CSS;
  proper fix requires restructuring (out of scope for a rename-only PR).
- `QueryDevtools.svelte`: third-party React Query Devtools wrapper
  (root `tsqd-*`), exempt per rule section 8.

## Verification

- Re-ran the deviation scanner against `projects/client/src/lib/**/*.svelte`
  after the refactor: 2 entries remain, both the intentionally-skipped
  fragment components above.
- `deno task test:unit run` from `projects/client`: **1918 passed, 7
  skipped, 0 failed**.
- `deno fmt`: clean.

## Test plan

- [ ] CI green
- [ ] No visual regressions on the YIR sections (largest cluster of renames)
- [ ] No visual regressions on settings/import, calendar, profile banner,
      branding pages (other clusters)
- [ ] `deno task test:unit run` still green on CI