### PR TITLE
feat(card): desktop poster hover selector

### DIFF
--- a/projects/client/src/lib/components/card/CardCover.svelte
+++ b/projects/client/src/lib/components/card/CardCover.svelte
@@ -69,7 +69,9 @@
   </div>
 </div>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .trakt-card-cover {
     --padding-card-tag: var(--ni-8);
 
@@ -130,6 +132,17 @@
       :global(img.trakt-card-cover-image) {
         object-position: top;
       }
+    }
+  }
+
+  .trakt-card-cover {
+    outline: var(--border-thickness-xs) solid transparent;
+    transition: outline-color var(--transition-increment) ease-in-out;
+  }
+
+  @include for-mouse() {
+    :global(.trakt-card-content:hover) .trakt-card-cover {
+      outline-color: var(--color-card-border-hover);
     }
   }
 

--- a/projects/client/src/lib/sections/lists/components/list-summary/ListSummaryItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/ListSummaryItem.svelte
@@ -35,7 +35,9 @@
   </div>
 </Card>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .trakt-list-summary {
     height: var(--height-list-card);
     box-sizing: border-box;
@@ -45,6 +47,9 @@
     gap: var(--gap-xs);
 
     padding: var(--ni-12);
+
+    outline: var(--border-thickness-xs) solid transparent;
+    transition: outline-color var(--transition-increment) ease-in-out;
 
     background-color: color-mix(
       in srgb,
@@ -59,6 +64,12 @@
         var(--color-official-list-background) 40%,
         var(--color-background)
       );
+    }
+  }
+
+  @include for-mouse() {
+    :global(.trakt-card-content:hover) .trakt-list-summary {
+      outline-color: var(--color-card-border-hover);
     }
   }
 </style>

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -105,4 +105,9 @@
    */
   --color-input-focus: var(--purple-500);
   --color-input-error: var(--red-600);
+
+  /**
+   * Card
+   */
+  --color-card-border-hover: var(--purple-500);
 }


### PR DESCRIPTION
## Summary

- On hover-capable devices (desktop/mouse), poster cards and list summary cards show a **2px `purple-500` outline ring** on hover
- Uses `@media (hover: hover)` — touch devices are completely unaffected, no stuck states on mobile
- `outline-color` transitions smoothly from transparent → `var(--purple-500)` using the existing `--transition-increment` token
- Applied in two places: `CardCover.svelte` (all poster cards globally) and `ListSummaryItem.svelte` (list summary cards)

Closes #2637

## Screenshots

### Releases & Popular
<img width="916" height="539" alt="Screenshot 2026-06-16 at 15 50 58" src="https://github.com/user-attachments/assets/d372b178-df9b-4ba6-82c2-bfb373489d8d" />


### Trending & Recommended
<img width="935" height="899" alt="Screenshot 2026-06-16 at 15 50 44" src="https://github.com/user-attachments/assets/f1b27ceb-9ff2-4db5-8b07-c21cc2ac9b34" />


### Lists (My Lists / Liked / Collaborations)
<img width="911" height="984" alt="Screenshot 2026-06-16 at 15 50 15" src="https://github.com/user-attachments/assets/4942580a-2d87-4da7-ace8-d0452fce08f0" />


> **Note:** Drag the actual screenshots into the comments above to replace placeholders.

## Test plan

- [ ] Hover a poster card on desktop — 2px purple ring appears with smooth transition
- [ ] Hover a list summary card — same ring appears
- [ ] Test on touch device / mobile emulation — no ring, no stuck state
- [ ] Verify `prefers-reduced-motion` — transition duration collapses to 0ms via existing token
- [ ] Check dpad/keyboard navigation — existing focus outline unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)