### PR TITLE
feat(discover): Browse by Genre section and genre drill-down

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -1240,6 +1240,10 @@
       "default": "Seasons",
       "description": "Title for lists containing seasons of a show. This title should be as short and concise as possible."
     },
+    "section_title_browse_by_genre": {
+      "default": "Genres",
+      "description": "Title for the genres carousel section on the Discover page."
+    },
     "section_title_season_progress": {
       "default": "Season {number} progress",
       "description": "Title for the season progress card shown in the seasons drawer. Shows the season number.",

--- a/projects/client/src/lib/components/card/GenreCard.svelte
+++ b/projects/client/src/lib/components/card/GenreCard.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import type { Genre } from "@trakt/api";
+  import { whenInViewport } from "$lib/utils/actions/whenInViewport.ts";
+  import { writable } from "$lib/utils/store/WritableSubject.ts";
+  import { toTranslatedGenre } from "$lib/utils/formatting/string/toTranslatedGenre.ts";
+
+  type GenreCardProps = {
+    genre: Genre;
+    href: string;
+  };
+
+  const { genre, href }: GenreCardProps = $props();
+
+  const label = $derived(toTranslatedGenre(genre));
+  const isVisible = writable(false);
+</script>
+
+<div class="trakt-genre-card" use:whenInViewport={() => isVisible.set(true)}>
+  {#if $isVisible}
+    <a {href} class="trakt-link genre-link">
+      <span class="genre-label">{label}</span>
+    </a>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  @mixin light-card {
+    .trakt-genre-card {
+      background-color: var(--shade-80);
+      border-color: var(--shade-200);
+
+      @include for-mouse {
+        &:hover {
+          box-shadow: inset 0 0 0 2px var(--shade-700);
+        }
+      }
+    }
+  }
+
+  .trakt-genre-card {
+    flex-shrink: 0;
+    width: var(--width-genre-card, var(--width-portrait-card));
+    height: var(--height-genre-card, calc(var(--width-portrait-card) / 1.5));
+    border-radius: var(--border-radius-m);
+    overflow: hidden;
+    background-color: var(--shade-940);
+    box-shadow: var(--shadow-base);
+    border: 1px solid var(--shade-800);
+    box-sizing: border-box;
+    transition: box-shadow var(--transition-increment) ease-in-out;
+
+    @include for-mouse {
+      &:hover {
+        box-shadow: inset 0 0 0 2px var(--shade-50);
+      }
+    }
+  }
+
+  :global([data-theme='light']) {
+    @include light-card;
+  }
+
+  :global([data-theme='system']) {
+    @media (prefers-color-scheme: light) {
+      @include light-card;
+    }
+  }
+
+  .genre-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    text-decoration: none;
+  }
+
+  .genre-label {
+    color: var(--color-text-primary);
+    font-weight: bold;
+    font-size: calc(var(--font-size-tag) * 1.5);
+    text-align: center;
+    letter-spacing: 0.05em;
+    padding: var(--ni-8);
+  }
+</style>

--- a/projects/client/src/lib/sections/discover/GenreCarousel.svelte
+++ b/projects/client/src/lib/sections/discover/GenreCarousel.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
+  import GenreCard from "$lib/components/card/GenreCard.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { GENRES } from "$lib/features/filters/_internal/genres.ts";
+</script>
+
+<section class="trakt-genre-carousel">
+  <div class="section-header">
+    <a href="/discover/genre/action" class="trakt-link section-title-link">
+      <span class="section-title">{m.section_title_browse_by_genre()}</span>
+      <CaretRightIcon />
+    </a>
+  </div>
+
+  <div class="genre-track">
+    {#each GENRES as genre (genre)}
+      <GenreCard {genre} href="/discover/genre/{genre}" />
+    {/each}
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-genre-carousel {
+    --width-genre-card: var(--width-portrait-card);
+    --height-genre-card: calc(var(--width-portrait-card) / 1.5);
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--list-header-gap);
+  }
+
+  .section-header {
+    margin: 0 var(--layout-distance-side);
+    height: var(--ni-40);
+    display: flex;
+    align-items: center;
+  }
+
+  .section-title-link {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    text-decoration: none;
+    color: var(--color-text-primary);
+
+    :global(svg) {
+      flex-shrink: 0;
+      width: calc(var(--font-size-title) * 0.9);
+      height: calc(var(--font-size-title) * 0.9);
+    }
+
+    @include for-mouse {
+      &:hover {
+        color: var(--color-link-active);
+      }
+    }
+  }
+
+  .section-title {
+    font-size: var(--font-size-title);
+    font-weight: bold;
+    line-height: var(--ni-22);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .genre-track {
+    display: flex;
+    gap: var(--list-gap);
+    overflow-x: hidden;
+    mask-image: linear-gradient(
+      to right,
+      black calc(100% - var(--layout-distance-side)),
+      transparent calc(100% - var(--layout-distance-side))
+    );
+    scrollbar-width: none;
+    padding: 0 var(--layout-distance-side);
+    padding-bottom: var(--ni-4);
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    @supports (-moz-appearance: none) {
+      overflow-x: auto;
+      mask-image: none;
+    }
+
+    @include for-tablet-sm-and-below {
+      overflow-x: auto;
+      mask-image: none;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/discover/GenrePillCarousel.svelte
+++ b/projects/client/src/lib/sections/discover/GenrePillCarousel.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+  import type { Genre } from "@trakt/api";
+  import CaretLeftIcon from "$lib/components/icons/CaretLeftIcon.svelte";
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
+  import { GENRES } from "$lib/features/filters/_internal/genres.ts";
+  import { toTranslatedGenre } from "$lib/utils/formatting/string/toTranslatedGenre.ts";
+
+  type Props = {
+    activeGenre: Genre | null;
+  };
+
+  const { activeGenre }: Props = $props();
+
+  let trackEl = $state<HTMLDivElement | undefined>();
+  let canScrollLeft = $state(false);
+  let canScrollRight = $state(true);
+
+  const updateScrollState = () => {
+    if (!trackEl) return;
+    canScrollLeft = trackEl.scrollLeft > 0;
+    canScrollRight =
+      trackEl.scrollLeft < trackEl.scrollWidth - trackEl.clientWidth - 1;
+  };
+
+  const scroll = (direction: "left" | "right") => {
+    if (!trackEl?.firstElementChild) return;
+    const pillWidth = trackEl.firstElementChild.getBoundingClientRect().width;
+    const gap = parseFloat(getComputedStyle(trackEl).columnGap) || 0;
+    const amount = 3 * (pillWidth + gap);
+    trackEl.scrollBy({
+      left: direction === "left" ? -amount : amount,
+      behavior: "smooth",
+    });
+  };
+</script>
+
+<div class="genre-pill-carousel">
+  <button
+    class="scroll-btn"
+    onclick={() => scroll("left")}
+    disabled={!canScrollLeft}
+    aria-label="Scroll genres left"
+  >
+    <CaretLeftIcon />
+  </button>
+
+  <div class="pill-track" bind:this={trackEl} onscroll={updateScrollState}>
+    {#each GENRES as g (g)}
+      <a
+        href="/discover/genre/{g}"
+        class="genre-pill"
+        class:active={g === activeGenre}
+      >
+        {toTranslatedGenre(g)}
+      </a>
+    {/each}
+  </div>
+
+  <button
+    class="scroll-btn"
+    onclick={() => scroll("right")}
+    disabled={!canScrollRight}
+    aria-label="Scroll genres right"
+  >
+    <CaretRightIcon />
+  </button>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .genre-pill-carousel {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    max-width: calc(
+      10 * var(--width-portrait-card) * 0.765 + 9 * var(--list-gap) +
+      2 * var(--ni-16) + 2 * var(--gap-xs)
+    );
+    width: 100%;
+    margin: 0 auto;
+
+    @include for-tablet-sm-and-below {
+      max-width: none;
+      margin: 0;
+      padding: 0 var(--layout-distance-side);
+      box-sizing: border-box;
+    }
+  }
+
+  .scroll-btn {
+    all: unset;
+    cursor: pointer;
+    color: var(--color-text-primary);
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    transition: opacity var(--transition-increment) ease-in-out;
+
+    :global(svg) {
+      width: var(--ni-16);
+      height: var(--ni-16);
+    }
+
+    &:disabled {
+      opacity: 0.2;
+      cursor: default;
+    }
+  }
+
+  .pill-track {
+    display: flex;
+    gap: var(--list-gap);
+    overflow-x: hidden;
+    scrollbar-width: none;
+    flex: 1;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .genre-pill {
+    flex: 0 0 calc(var(--width-portrait-card) * 0.765);
+    width: calc(var(--width-portrait-card) * 0.765);
+
+    @include for-tablet-sm-and-below {
+      flex: 0 0 calc((100% - 2 * var(--list-gap)) / 3);
+      width: calc((100% - 2 * var(--list-gap)) / 3);
+    }
+    height: var(--ni-28);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    border-radius: var(--border-radius-xxl);
+    background-color: var(--color-card-background);
+    color: var(--color-text-primary);
+    text-decoration: none;
+    font-size: var(--font-size-text-small);
+    font-weight: bold;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    box-sizing: border-box;
+    padding: 0 var(--ni-4);
+
+    transition:
+      background-color var(--transition-increment) ease-in-out,
+      color var(--transition-increment) ease-in-out;
+
+    &.active {
+      background-color: var(--purple-500);
+      color: var(--color-overlay-foreground);
+    }
+
+    @include for-mouse {
+      &:not(.active):hover {
+        background-color: var(--color-calendar-background-hover);
+      }
+    }
+  }
+
+  @mixin light-pills {
+    .genre-pill:not(.active) {
+      background-color: var(--shade-80);
+    }
+
+    @include for-mouse {
+      .genre-pill:not(.active):hover {
+        background-color: var(--shade-300);
+      }
+    }
+  }
+
+  :global([data-theme='light']) {
+    @include light-pills;
+  }
+
+  :global([data-theme='system']) {
+    @media (prefers-color-scheme: light) {
+      @include light-pills;
+    }
+  }
+</style>

--- a/projects/client/src/routes/discover/+page.svelte
+++ b/projects/client/src/routes/discover/+page.svelte
@@ -5,6 +5,7 @@
   import { useSeasonalTheme } from "$lib/features/theme/useSeasonalTheme";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
+  import GenreCarousel from "$lib/sections/discover/GenreCarousel.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import AnticipatedList from "$lib/sections/lists/anticipated/AnticipatedList.svelte";
@@ -93,6 +94,8 @@
     type={$type}
     filterOverride={getThemeFilters("anticipated")}
   />
+  <GenreCarousel />
+
   <RenderFor audience="authenticated">
     <ReleasesList />
   </RenderFor>

--- a/projects/client/src/routes/discover/genre/[genre]/+page.svelte
+++ b/projects/client/src/routes/discover/genre/[genre]/+page.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import type { Genre } from "@trakt/api";
+  import { useDiscover } from "$lib/features/discover/useDiscover.ts";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import GenrePillCarousel from "$lib/sections/discover/GenrePillCarousel.svelte";
+  import type { FilterOverrideParams } from "$lib/requests/models/FilterParams.ts";
+  import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import AnticipatedList from "$lib/sections/lists/anticipated/AnticipatedList.svelte";
+  import PopularList from "$lib/sections/lists/popular/PopularList.svelte";
+  import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
+  import TrendingList from "$lib/sections/lists/trending/TrendingList.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets.ts";
+  import { toTranslatedGenre } from "$lib/utils/formatting/string/toTranslatedGenre.ts";
+
+  const { mode: type } = useDiscover();
+
+  const genre = $derived(page.params.genre as Genre);
+  const genreLabel = $derived(toTranslatedGenre(genre));
+
+  const genreFilter = $derived<FilterOverrideParams>({
+    movie: { genres: genre },
+    show: { genres: genre },
+  });
+</script>
+
+<TraktPage audience="all" image={DEFAULT_SHARE_SHOW_COVER} title={genreLabel}>
+  <NavbarStateSetter hasFilters={false}>
+    {#snippet actions()}
+      <DiscoverToggles />
+    {/snippet}
+  </NavbarStateSetter>
+
+  <TraktPageCoverSetter />
+
+  <GenrePillCarousel activeGenre={genre} />
+
+  <TrendingList
+    title={m.list_title_trending()}
+    drilldownLabel={$type === "show"
+      ? m.button_label_view_all_trending_shows()
+      : m.button_label_view_all_trending_movies()}
+    type={$type}
+    filterOverride={genreFilter}
+  />
+
+  <RenderFor audience="authenticated">
+    <RecommendedList
+      title={m.list_title_recommended()}
+      drilldownLabel={$type === "show"
+        ? m.button_label_view_all_recommended_shows()
+        : m.button_label_view_all_recommended_movies()}
+      type={$type}
+      filterOverride={genreFilter}
+    />
+  </RenderFor>
+
+  <PopularList
+    title={m.list_title_most_popular()}
+    drilldownLabel={$type === "show"
+      ? m.button_label_view_all_popular_shows()
+      : m.button_label_view_all_popular_movies()}
+    type={$type}
+    filterOverride={genreFilter}
+  />
+
+  <AnticipatedList
+    title={m.list_title_most_anticipated()}
+    drilldownLabel={$type === "show"
+      ? m.button_label_view_all_anticipated_shows()
+      : m.button_label_view_all_anticipated_movies()}
+    type={$type}
+    filterOverride={genreFilter}
+  />
+</TraktPage>


### PR DESCRIPTION
##Screenshots
<img width="1862" height="1134" alt="Screenshot 2026-06-17 at 14 30 43" src="https://github.com/user-attachments/assets/3f88faf4-7585-46e1-a307-d92f58f2fa22" />
<img width="1354" height="1093" alt="Screenshot 2026-06-17 at 14 36 18" src="https://github.com/user-attachments/assets/20c2d052-6f22-4a3c-9f89-212b3256dd7e" />


## Summary

- Adds a horizontal **genre card carousel** to the main Discover page between Anticipated and Releases, linking to genre drill-down routes
- Adds `/discover/genre/[genre]` drill-down page with Trending, Recommended (auth-gated), Popular, and Anticipated lists filtered by the selected genre
- Genre cards: `--shade-940` background, `1px solid --shade-800` border, hover inset glow, full light-theme support
- **Genre pill carousel** at the top of the drill-down page: chevron navigation (jump 3), active pill in `--purple-500`, 10 visible on desktop / 3 on mobile with chevrons aligned to page margins
- Light-theme overrides for both the genre cards and pill carousel

## Test plan

- [ ] Verify genre cards render on main Discover page in dark and light theme
- [ ] Tap/click a genre card → navigates to `/discover/genre/[genre]`
- [ ] Drill-down page shows correct genre label, pill highlighted, and all four lists filtered to that genre
- [ ] Authenticated: Recommended list appears; unauthenticated: only Trending, Popular, Anticipated
- [ ] Chevrons jump 3 pills at a time; left disabled at start, right disabled at end
- [ ] Mobile: 3 pills visible, chevrons flush with page margins
- [ ] Light theme: genre cards are visibly distinct from page background; inactive pills are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)