### PR TITLE
fix(i18n): isolate SSR locale per request to stop cross-request bleed

### DIFF
--- a/projects/client/src/lib/features/i18n/handle.spec.ts
+++ b/projects/client/src/lib/features/i18n/handle.spec.ts
@@ -3,6 +3,7 @@ import { interceptHandleResolveOptions } from '$test/resolve/interceptHandleReso
 import { describe, expect, it, vi } from 'vitest';
 import { LOCALE_COOKIE_NAME } from './constants.ts';
 import { DIR_PLACEHOLDER, handle, LANG_PLACEHOLDER } from './handle.ts';
+import { getLocale } from './index.ts';
 
 describe('handle: i18n', () => {
   it('should replace lang and text direction placeholders', async () => {
@@ -89,5 +90,44 @@ describe('handle: i18n', () => {
     const transformed = transformPageChunk?.({ html, done: true });
 
     expect(transformed).toContain(`lang="${cookieLocale}"`);
+  });
+
+  it('should not leak locale across concurrent requests', async () => {
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const observed: Array<string> = [];
+
+    // German request pauses mid-render to let an English request complete
+    // and mutate paraglide's shared global locale.
+    const germanRequest = handle({
+      event: mockRequestEvent({
+        url: 'http://localhost',
+        request: new Request('http://localhost', {
+          headers: new Headers({ 'Accept-Language': 'de-de' }),
+        }),
+      }),
+      resolve: async () => {
+        observed.push(getLocale());
+        await gate;
+        observed.push(getLocale());
+        return new Response('');
+      },
+    });
+
+    await handle({
+      event: mockRequestEvent({
+        url: 'http://localhost',
+        request: new Request('http://localhost', {
+          headers: new Headers({ 'Accept-Language': 'en-us' }),
+        }),
+      }),
+      resolve: () => Promise.resolve(new Response('')),
+    });
+
+    release?.();
+    await germanRequest;
+
+    // Both reads stay German despite the interleaved English request.
+    expect(observed).toEqual(['de-DE', 'de-DE']);
   });
 });

--- a/projects/client/src/lib/features/i18n/handle.ts
+++ b/projects/client/src/lib/features/i18n/handle.ts
@@ -18,7 +18,11 @@ export const DIR_PLACEHOLDER = '"%paraglide.textDirection%"';
 // `globalVariable` strategy leaks one request's locale into another's SSR
 // render. Per-request AsyncLocalStorage isolates the locale; `getLocale()`
 // reads the store before falling back to the shared global.
-const localeStorage = new AsyncLocalStorage<{ locale: AvailableLocale }>();
+const localeStorage = new AsyncLocalStorage<{
+  locale?: AvailableLocale;
+  origin?: string;
+  messageCalls?: Set<string>;
+}>();
 overwriteServerAsyncLocalStorage(localeStorage);
 
 export const handle: Handle = async ({ event, resolve }) => {

--- a/projects/client/src/lib/features/i18n/handle.ts
+++ b/projects/client/src/lib/features/i18n/handle.ts
@@ -6,11 +6,20 @@ import {
   setLocale,
 } from '$lib/features/i18n/index.ts';
 import { LocaleEndpoint } from '$lib/features/i18n/LocaleEndpoint.ts';
+import { overwriteServerAsyncLocalStorage } from '$lib/paraglide/runtime.js';
 import { time } from '$lib/utils/timing/time.ts';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Handle } from '@sveltejs/kit';
 
 export const LANG_PLACEHOLDER = '"%paraglide.lang%"';
 export const DIR_PLACEHOLDER = '"%paraglide.textDirection%"';
+
+// Cloudflare reuses one isolate across concurrent requests, so paraglide's
+// `globalVariable` strategy leaks one request's locale into another's SSR
+// render. Per-request AsyncLocalStorage isolates the locale; `getLocale()`
+// reads the store before falling back to the shared global.
+const localeStorage = new AsyncLocalStorage<{ locale: AvailableLocale }>();
+overwriteServerAsyncLocalStorage(localeStorage);
 
 export const handle: Handle = async ({ event, resolve }) => {
   if (event.url.pathname.startsWith(LocaleEndpoint.Set)) {
@@ -42,12 +51,13 @@ export const handle: Handle = async ({ event, resolve }) => {
   );
   const direction = getTextDirection(locale);
 
-  return resolve(event, {
-    transformPageChunk({ html, done }) {
-      if (!done) return html;
-      return html
-        .replace(LANG_PLACEHOLDER, locale)
-        .replace(DIR_PLACEHOLDER, direction);
-    },
-  });
+  return localeStorage.run({ locale }, () =>
+    resolve(event, {
+      transformPageChunk({ html, done }) {
+        if (!done) return html;
+        return html
+          .replace(LANG_PLACEHOLDER, locale)
+          .replace(DIR_PLACEHOLDER, direction);
+      },
+    }));
 };


### PR DESCRIPTION
## Problem

Fixes #2590
Logged-in and anonymous users intermittently got pages rendered in the wrong language (e.g. German served to an English user); a refresh usually fixed it.

## Root cause

SSR locale bleed across concurrent requests on a shared Cloudflare isolate.

- Paraglide's `globalVariable` strategy writes the resolved locale to a module-global `_locale` (`src/lib/paraglide/runtime.js`), with no `isServer` guard.
- The app's custom `i18n/handle.ts` calls `setLocale(...)` per request but never wired paraglide's server-side `AsyncLocalStorage`, so `serverAsyncLocalStorage` stayed `undefined`.
- Cloudflare reuses one isolate for many concurrent requests. Between a request's `setLocale('en')` and its actual component render (after auth + data awaits), a concurrent `de` request could overwrite the shared global. `getLocale()` then read the poisoned global and rendered the wrong language.
- Login/refresh just triggers a fresh SSR load that re-enters the race, which is why it looked intermittent. The user's own browser `Accept-Language` was never the trigger.

## Fix

Register a per-request `AsyncLocalStorage` via `overwriteServerAsyncLocalStorage` and wrap `resolve` in `localeStorage.run({ locale }, ...)`. `getLocale()` reads the request-scoped store first (`runtime.js` ALS branch) and never consults the shared global on the server. Relies on `nodejs_compat`, already enabled.

## Test

Added a regression test in `handle.spec.ts` that interleaves a `de` and `en` request. It is discriminating: without the wrap it fails with `['de-DE', 'en']`; with the fix it passes `['de-DE', 'de-DE']`. All 5 i18n handle tests green, `deno fmt` clean.