### PR TITLE
fix(i18n): render default locale for bots to prevent cached locale poisoning

### DIFF
--- a/projects/client/src/lib/features/i18n/handle.spec.ts
+++ b/projects/client/src/lib/features/i18n/handle.spec.ts
@@ -1,9 +1,10 @@
 import { mockRequestEvent } from '$test/request/mockRequestEvent.ts';
 import { interceptHandleResolveOptions } from '$test/resolve/interceptHandleResolveOptions.ts';
+import type { ResolveOptions } from '@sveltejs/kit';
 import { describe, expect, it, vi } from 'vitest';
 import { LOCALE_COOKIE_NAME } from './constants.ts';
 import { DIR_PLACEHOLDER, handle, LANG_PLACEHOLDER } from './handle.ts';
-import { getLocale } from './index.ts';
+import { defaultLocale, getLocale } from './index.ts';
 
 describe('handle: i18n', () => {
   it('should replace lang and text direction placeholders', async () => {
@@ -129,5 +130,52 @@ describe('handle: i18n', () => {
 
     // Both reads stay German despite the interleaved English request.
     expect(observed).toEqual(['de-DE', 'de-DE']);
+  });
+
+  it('should pin a bot user-agent to the default locale', async () => {
+    const html = `<html lang="${LANG_PLACEHOLDER}" dir="${DIR_PLACEHOLDER}">`;
+
+    // Bot prefers German via both cookie and header, but its response is
+    // publicly cached, so it must render the locale-neutral default.
+    const { transformPageChunk } = await interceptHandleResolveOptions(
+      handle,
+      new Request('http://localhost', {
+        headers: new Headers({
+          'Accept-Language': 'de-de',
+          'User-Agent':
+            'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+        }),
+      }),
+      (key) => (key === LOCALE_COOKIE_NAME ? 'de-DE' : null),
+    );
+
+    const transformed = transformPageChunk?.({ html, done: true });
+
+    expect(transformed).toContain(`lang="${defaultLocale}"`);
+  });
+
+  it('should pin a verified search crawler to the default locale', async () => {
+    const html = `<html lang="${LANG_PLACEHOLDER}" dir="${DIR_PLACEHOLDER}">`;
+
+    const event = mockRequestEvent({
+      url: 'http://localhost',
+      request: new Request('http://localhost', {
+        headers: new Headers({ 'Accept-Language': 'de-de' }),
+      }),
+    });
+    event.locals.isLegitimateBot = true;
+
+    let options: ResolveOptions | undefined;
+    await handle({
+      event,
+      resolve: (_, opts) => {
+        options = opts;
+        return Promise.resolve(new Response());
+      },
+    });
+
+    const transformed = options?.transformPageChunk?.({ html, done: true });
+
+    expect(transformed).toContain(`lang="${defaultLocale}"`);
   });
 });

--- a/projects/client/src/lib/features/i18n/handle.ts
+++ b/projects/client/src/lib/features/i18n/handle.ts
@@ -1,12 +1,14 @@
 import { LOCALE_COOKIE_NAME } from '$lib/features/i18n/constants.ts';
 import {
   type AvailableLocale,
+  defaultLocale,
   getPreferredLocale,
   getTextDirection,
   setLocale,
 } from '$lib/features/i18n/index.ts';
 import { LocaleEndpoint } from '$lib/features/i18n/LocaleEndpoint.ts';
 import { overwriteServerAsyncLocalStorage } from '$lib/paraglide/runtime.js';
+import { isBotAgent } from '$lib/utils/devices/isBotAgent.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Handle } from '@sveltejs/kit';
@@ -49,10 +51,16 @@ export const handle: Handle = async ({ event, resolve }) => {
     });
   }
 
-  const preferredLocale = getPreferredLocale(event.request.headers);
-  const locale = setLocale(
-    event.cookies.get(LOCALE_COOKIE_NAME) ?? preferredLocale,
-  );
+  // Bot responses are publicly cached (see handleCacheControl) under a
+  // locale-blind cache key, so a localized render would be served to every
+  // subsequent visitor on that URL. Pin bots to the default locale to keep
+  // cached HTML neutral.
+  const isCacheableBot = event.locals.isLegitimateBot ||
+    isBotAgent(event.request.headers.get('user-agent'));
+
+  const requestedLocale = event.cookies.get(LOCALE_COOKIE_NAME) ??
+    getPreferredLocale(event.request.headers);
+  const locale = setLocale(isCacheableBot ? defaultLocale : requestedLocale);
   const direction = getTextDirection(locale);
 
   return localeStorage.run({ locale }, () =>


### PR DESCRIPTION
## Problem

Logged-out users intermittently got pages rendered in the wrong language (German, Ukrainian) despite English browsers. A refresh usually fixed it. Captured a HAR: the offending document came back `cf-cache-status: HIT` with `cache-control: public, max-age=86400, s-maxage=120` and `vary: accept-encoding` - i.e. served from the CDN cache, not freshly rendered.

## Root cause

Two bugs stacked:

1. A localized render gets **publicly cached**. `handleCacheControl` (`hooks.server.ts`) returns `public` for bot user-agents and verified crawlers. The cache key is URL + accept-encoding only - it does **not** vary on locale or cookie.
2. So one localized bot render is stored and served to **every** subsequent visitor on that URL (humans included - CF does not re-run the worker on a HIT, so the human's `private, no-store` branch never fires). The language frozen into the cache is whatever that bot render produced: a crawler sending `Accept-Language: uk`, or - before #2643 - a concurrent-request locale bleed.

`?ref=trakt-og-autoredirect-non-vip-public` (OG/social share links) is exactly the kind of URL bots crawl, populating the public cache that humans then hit.

## Fix

Pin bots (verified search crawlers via `event.locals.isLegitimateBot`, plus known bot user-agents via `isBotAgent`) to the **default locale**, so any publicly-cached HTML is locale-neutral. Humans are unaffected: their responses are `private, no-store` and keep their cookie/`Accept-Language` locale.

This builds on the per-request `AsyncLocalStorage` isolation from #2643 - the forced default only sticks during render because the locale is request-scoped. Without that, a concurrent request could still overwrite the shared global mid-render.

## Tests

`handle.spec.ts`:
- bot user-agent with `de` cookie **and** `de` Accept-Language renders the default locale.
- verified search crawler (`locals.isLegitimateBot`) renders the default locale.

All i18n handle tests green, `svelte-check` 0 errors, eslint clean, `deno fmt` clean.

## Follow-ups (Cloudflare-side, not in this repo)

- The `max-age=86400` browser TTL on HTML is a CF Cache Rule (repo only sets `max-age=120`). One day is aggressive for a page that can go stale; worth lowering.
- **Purge the CDN cache after deploy** to evict already-poisoned entries (edge holds up to `s-maxage=120`; browsers up to a day).