### PR TITLE
fix(pwa): key service worker navigation cache by locale

### DIFF
--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -13,12 +13,17 @@ import {
   NetworkFirst,
   StaleWhileRevalidate,
 } from 'workbox-strategies';
+import { LOCALE_COOKIE_NAME } from './lib/features/i18n/constants.ts';
 import { time } from './lib/utils/timing/time.ts';
 import { CacheKey } from './worker/CacheKey.ts';
 
 declare global {
   interface ServiceWorkerGlobalScope {
     __WB_DISABLE_DEV_LOGS: boolean;
+    // Cookie Store API: present on Chromium, absent on Safari/Firefox.
+    cookieStore?: {
+      get(name: string): Promise<{ value: string } | null>;
+    };
   }
 }
 
@@ -77,9 +82,13 @@ self.addEventListener('install', () => {
   self.skipWaiting();
 });
 
-// Claim clients without deleting all caches to avoid churn and race conditions.
+// Claim clients and purge the navigation cache so stale locale-specific HTML
+// (e.g. a poisoned ru-RU document) is evicted on update.
 self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(Promise.all([
+    removeNavigationCache(),
+    self.clients.claim(),
+  ]));
 });
 
 addEventListener('message', (event) => {
@@ -91,10 +100,33 @@ addEventListener('message', (event) => {
 // Precache static assets
 precacheAndRoute(self.__WB_MANIFEST);
 
-// Navigation routes
+// Vary the navigation cache key by locale so a document rendered for one
+// locale is never served to a request for another (the SSR HTML is
+// locale-specific). Falls back to the plain key where the Cookie Store API is
+// unavailable (Safari/Firefox), which stay covered by the CacheBust message
+// and the activate-time purge.
+const localeAwareCacheKey = {
+  cacheKeyWillBeUsed: async ({ request }: { request: Request }) => {
+    const cookie = await self.cookieStore?.get(LOCALE_COOKIE_NAME).catch(
+      () => null,
+    );
+
+    if (!cookie?.value) {
+      return request;
+    }
+
+    const url = new URL(request.url);
+    url.searchParams.set('__locale', cookie.value);
+    return url.href;
+  },
+};
+
+// Navigation routes: StaleWhileRevalidate for fast cold loads, keyed per locale
+// to avoid cross-locale poisoning.
 const navigationHandler = new StaleWhileRevalidate({
   cacheName: CacheKey.navigation,
   plugins: [
+    localeAwareCacheKey,
     new ExpirationPlugin({
       maxAgeSeconds: time.hours(12) / time.seconds(1),
     }),

--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -73,6 +73,14 @@ setCatchHandler(async ({ event, request, url }) => {
   }
 });
 
+const toSeconds = (milliseconds: number) => milliseconds / time.seconds(1);
+
+const expiration = (maxAgeMs: number, maxEntries?: number) =>
+  new ExpirationPlugin({
+    maxAgeSeconds: toSeconds(maxAgeMs),
+    ...(maxEntries === undefined ? {} : { maxEntries }),
+  });
+
 function removeNavigationCache() {
   return caches.delete(CacheKey.navigation);
 }
@@ -91,7 +99,7 @@ self.addEventListener('activate', (event) => {
   ]));
 });
 
-addEventListener('message', (event) => {
+self.addEventListener('message', (event) => {
   if (event.data?.type === WorkerMessage.CacheBust) {
     event.waitUntil(removeNavigationCache());
   }
@@ -127,9 +135,7 @@ const navigationHandler = new StaleWhileRevalidate({
   cacheName: CacheKey.navigation,
   plugins: [
     localeAwareCacheKey,
-    new ExpirationPlugin({
-      maxAgeSeconds: time.hours(12) / time.seconds(1),
-    }),
+    expiration(time.hours(12)),
   ],
 });
 
@@ -156,15 +162,11 @@ registerRoute(
   ({ url }) => url.pathname.endsWith('manifest.webmanifest'),
   new NetworkFirst({
     cacheName: CacheKey.manifest,
-    plugins: [
-      new ExpirationPlugin({
-        maxAgeSeconds: time.hours(1) / time.seconds(1),
-      }),
-    ],
+    plugins: [expiration(time.hours(1))],
   }),
 );
 
-// Static assets with auth-aware cache
+// Same-origin static assets, media and documents (CacheFirst)
 registerRoute(
   ({ url }) => {
     // Skip caching for localhost
@@ -182,23 +184,14 @@ registerRoute(
   },
   new CacheFirst({
     cacheName: CacheKey.static,
-    plugins: [
-      new ExpirationPlugin({
-        maxAgeSeconds: time.days(30) / time.seconds(1),
-      }),
-    ],
+    plugins: [expiration(time.days(30))],
   }),
 );
 
 // External resources
 const externalRouteHandler = new StaleWhileRevalidate({
   cacheName: CacheKey.external,
-  plugins: [
-    new ExpirationPlugin({
-      maxEntries: 50,
-      maxAgeSeconds: time.days(7) / time.seconds(1),
-    }),
-  ],
+  plugins: [expiration(time.days(7), 50)],
 });
 
 // Fonts
@@ -218,12 +211,7 @@ registerRoute(
   ({ url }) => Domain.images.includes(url.hostname),
   new CacheFirst({
     cacheName: CacheKey.images,
-    plugins: [
-      new ExpirationPlugin({
-        maxEntries: 666,
-        maxAgeSeconds: time.days(30) / time.seconds(1),
-      }),
-    ],
+    plugins: [expiration(time.days(30), 666)],
     fetchOptions: {
       mode: 'no-cors',
     },


### PR DESCRIPTION
## Problem

Users were served the wrong locale (e.g. a Russian `<html lang=ru-RU>` document to an English user) and it persisted even after the edge cache was purged and the SSR fixes (#2643, #2645) shipped.

Root cause was the service worker, not the edge: the navigation route cached the full SSR HTML under a **locale-agnostic** key with `StaleWhileRevalidate`. So once a client cached a wrong-locale document, the SW served it from `trakt-web-navigation` on every navigation, intercepting before the network. Edge purge and HTTP cache headers are irrelevant once the SW owns the response.

`StaleWhileRevalidate` also serves the cached copy first and revalidates in the background, so for locale-varying HTML it is wrong-first by design.

## Fix

- **Locale-aware cache key**: a `cacheKeyWillBeUsed` plugin varies the navigation cache key by the `trakt-locale` cookie (`...?__locale=en`). A document rendered for one locale can no longer be served to a request for another. The `__locale` param only exists as the internal Cache Storage key - it never hits the address bar or the network request. Keeps `StaleWhileRevalidate`'s fast cold-load serve.
- **Graceful fallback**: where the Cookie Store API is unavailable (Safari/Firefox), the plugin returns the plain key. Those browsers stay covered by the `CacheBust` message and the activate-time purge.
- **Purge on activate**: `activate` now clears the navigation cache so already-poisoned documents are evicted for existing clients on the next SW update.

## Second commit - cleanup (no behavioral change)

- Extract a `toSeconds` helper and an `expiration()` plugin factory to remove the repeated `ExpirationPlugin`/`maxAgeSeconds` boilerplate across every route.
- Correct the misleading "auth-aware cache" comment (the static route has no auth awareness).
- Use `self.addEventListener` for the message listener to match the other lifecycle listeners.

Cache strategies, names, TTLs and entry limits are identical.

## Testing

Couldn't run `check`/`lint` in my working copy (deps not installed locally); relying on CI. To verify manually:

1. `deno task build && deno task preview` (faithful SW; dev SW has an empty precache manifest).
2. Set locale to `ru`, load a page - SW caches under `?__locale=ru`.
3. Switch to `en` - served under `?__locale=en`, never the `ru` entry.
4. Bump `service-worker.ts`, reload - `activate` wipes `trakt-web-navigation`.

## Follow-ups (out of scope, not addressed here)

- `setCatchHandler` returns a bare 503 on navigation failure - no offline shell.
- `.html` documents are cached `CacheFirst` for 30 days via the static route, overlapping the navigation handler.
- Image cache `maxEntries: 666` left as-is (changing it alters eviction behavior).