### PR TITLE
fix(rating): reveal vote count tooltip on tap for touch devices

### DIFF
--- a/projects/client/src/lib/components/tooltip/Tooltip.svelte
+++ b/projects/client/src/lib/components/tooltip/Tooltip.svelte
@@ -20,10 +20,6 @@
   const tooltipClass = $derived(
     variant === "compact" ? "trakt-tooltip-compact" : "trakt-tooltip",
   );
-
-  const arrowClass = $derived(
-    variant === "compact" ? "trakt-tooltip-compact-arrow" : undefined,
-  );
 </script>
 
 <Tooltip.Provider>
@@ -41,9 +37,6 @@
     </Tooltip.Trigger>
     <Tooltip.Portal>
       <Tooltip.Content class={tooltipClass} {side} {sideOffset}>
-        {#if arrowClass}
-          <Tooltip.Arrow class={arrowClass} />
-        {/if}
         {#if typeof content === "function"}
           {@render content()}
         {:else if variant === "default"}
@@ -88,12 +81,7 @@
 
     border-radius: var(--border-radius-xs);
     padding: var(--ni-6) var(--ni-8);
-    margin-left: var(--ni-neg-7);
 
     box-shadow: var(--shadow-menu);
-  }
-
-  :global(.trakt-tooltip-compact-arrow) {
-    color: var(--color-tooltip-background);
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte
@@ -4,6 +4,7 @@
   import { getLocale } from "$lib/features/i18n";
   import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber";
   import { toTraktRating } from "$lib/utils/formatting/number/toTraktRating";
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
   import { STAR_RATINGS } from "../constants/index.ts";
 
   type RatingsDistributionProps = {
@@ -54,26 +55,23 @@
       </p>
     </div>
 
-    <div class="trakt-histogram" aria-hidden="true">
-      <div class="histogram-bars">
-        {#each starBuckets as bucket (bucket.star)}
-          <div class="histogram-bar-slot">
+    <div class="trakt-histogram">
+      {#each starBuckets as bucket (bucket.star)}
+        <Tooltip
+          content={toHumanNumber(bucket.value, getLocale())}
+          variant="compact"
+          sideOffset={4}
+        >
+          <div class="histogram-column">
             <div
               class="histogram-bar"
               data-intensity={toIntensity(bucket.value, maxValue)}
-              style="--bar-height: {(bucket.value / maxValue) * 100}%"
+              style="--bar-fraction: {bucket.value / maxValue}"
             ></div>
-            <span class="bar-tooltip tag bold">
-              {toHumanNumber(bucket.value, getLocale())}
-            </span>
+            <span class="histogram-label tag secondary">{bucket.star}</span>
           </div>
-        {/each}
-      </div>
-      <div class="histogram-scale tag secondary">
-        {#each starBuckets as bucket (bucket.star)}
-          <span>{bucket.star}</span>
-        {/each}
-      </div>
+        </Tooltip>
+      {/each}
     </div>
   </div>
 </section>
@@ -123,46 +121,40 @@
   .trakt-histogram {
     flex: 1;
     min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: var(--ni-2);
-  }
-
-  .histogram-bars {
     display: grid;
     grid-template-columns: repeat(5, 1fr);
+    align-items: end;
     gap: var(--ni-4);
-    height: var(--ni-48);
-  }
 
-  .histogram-bar-slot {
-    position: relative;
-    display: flex;
-    justify-content: center;
-    align-items: flex-end;
-    height: 100%;
-    transform-origin: bottom;
-    transition: transform calc(0.5 * var(--transition-increment)) ease-in-out;
+    :global(.trakt-tooltip-trigger) {
+      transform-origin: bottom;
+      transition: transform calc(0.5 * var(--transition-increment)) ease-in-out;
 
-    @include for-mouse {
-      &:hover {
-        transform: scale(1.1);
-
-        .histogram-bar {
-          background: var(--color-text-primary);
-        }
-
-        .bar-tooltip {
-          opacity: 1;
-          transform: translate(-50%, calc(-1 * var(--ni-6)));
+      @include for-mouse {
+        &:hover {
+          transform: scale(1.1);
         }
       }
     }
   }
 
+  .histogram-column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--ni-2);
+    width: 100%;
+  }
+
+  @include for-mouse {
+    :global(.trakt-tooltip-trigger:hover) .histogram-bar {
+      background: var(--color-text-primary);
+    }
+  }
+
   .histogram-bar {
     width: 70%;
-    height: var(--bar-height);
+    height: calc(var(--bar-fraction, 0) * var(--ni-48));
     min-height: var(--ni-2);
     border-radius: var(--border-radius-xs);
     transform-origin: bottom;
@@ -186,30 +178,8 @@
     }
   }
 
-  .bar-tooltip {
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translate(-50%, 0);
-    padding: var(--ni-2) var(--ni-6);
-    border-radius: var(--border-radius-xs);
-    background: var(--color-tooltip-background);
-    color: var(--color-tooltip-text);
-    opacity: 0;
-    pointer-events: none;
-    white-space: nowrap;
-    transition: opacity var(--transition-increment) ease-in-out,
-      transform var(--transition-increment) ease-in-out;
-  }
-
-  .histogram-scale {
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
+  .histogram-label {
     color: var(--color-text-secondary);
-
-    span {
-      text-align: center;
-    }
   }
 
   @keyframes rating-bar-rise {


### PR DESCRIPTION
## Problem

Tapping a bar in the rating breakdown does nothing on mobile/touch devices. The per-star vote count tooltip (e.g. `1.3K`) was revealed only through a CSS `:hover` rule scoped to `@include for-mouse`, which never fires on `(hover: none) and (pointer: coarse)` devices.

## Fix

- Wrap each rating column (bar + its `1-5` label) in the shared `Tooltip` component (`variant="compact"`) instead of a hand-rolled `.bar-tooltip` span driven by CSS hover. `Tooltip` already handles hover (mouse), tap (touch), and outside-tap/escape dismissal via the same `useMedia` detection used elsewhere. Hovering or tapping anywhere in a column - bar or number - reveals that bar's count.
- Merged the former separate bars grid and scale grid into a single grid of columns. Each bar carries an explicit `fraction * track` height and columns are bottom-aligned, so the tooltip anchors to the bar's actual top (previously the trigger filled the full track height and the tooltip floated above empty space). `sideOffset` is 4.
- Dropped the now-redundant `aria-hidden` on the histogram so the per-star counts are reachable by keyboard and screen readers.

## Shared change

Removed the `trakt-tooltip-compact-arrow` and its coupled `margin-left: -7px` nudge from `Tooltip.svelte`. The arrow was misaligned against the bubble (floating-ui arrow vs. the manual margin offset), and the offset only existed to compensate for the arrow. This affects all `variant="compact"` tooltips (navbar, people summary) - they now render as a clean centered bubble with no arrow. The `default` variant never had an arrow and is unchanged.

## Verification

- Desktop (mouse): hovering a column lifts it and shows the count.
- Touch: tapping a bar or its number shows the count; tapping elsewhere dismisses it.
- Keyboard: columns are focusable and announce their count via the tooltip.

<img width="400" height="325" alt="image" src="https://github.com/user-attachments/assets/4b52a6e0-4635-472c-9f5c-1c6d3b4a660f" />
