### PR TITLE
fix(auth): make entire logout action button clickable

### DIFF
--- a/projects/client/src/lib/components/buttons/logout/LogoutButton.svelte
+++ b/projects/client/src/lib/components/buttons/logout/LogoutButton.svelte
@@ -7,7 +7,6 @@
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import * as m from "$lib/features/i18n/messages.ts";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
-  import ActionButton from "../ActionButton.svelte";
 
   const {
     style = "normal",
@@ -43,12 +42,18 @@
 {/if}
 
 {#if style === "action"}
-  <div class="trakt-logout-action-button">
-    <ActionButton {...commonProps} style="ghost" color="red">
+  <Button
+    style="ghost"
+    variant="secondary"
+    color="red"
+    navigationType={DpadNavigationType.Item}
+    {...commonProps}
+  >
+    {m.button_text_logout()}
+    {#snippet icon()}
       <LogoutIcon />
-    </ActionButton>
-    <span class="logout-label">{m.button_text_logout()}</span>
-  </div>
+    {/snippet}
+  </Button>
 {/if}
 
 {#if style === "dropdown-item"}
@@ -59,44 +64,3 @@
     {/snippet}
   </DropdownItem>
 {/if}
-
-<style lang="scss">
-  @use "$style/scss/mixins/index" as *;
-
-  .logout-label {
-    user-select: none;
-    pointer-events: none;
-  }
-
-  .trakt-logout-action-button {
-    display: flex;
-    align-items: center;
-    gap: var(--gap-xs);
-    padding: 0 var(--gap-s);
-    border-radius: var(--border-radius-m);
-    cursor: pointer;
-    --color-logout-button: var(--color-background-red);
-
-    :global(
-      .trakt-action-button[data-style="ghost"][data-variant="primary"][data-color="red"]
-    ) {
-      --color-foreground-action-button: var(--color-logout-button);
-
-      @include for-mouse {
-        &:hover {
-          background-color: transparent;
-        }
-      }
-    }
-
-    @include for-mouse {
-      &:hover {
-        background-color: color-mix(
-          in srgb,
-          var(--color-logout-button) 10%,
-          transparent
-        );
-      }
-    }
-  }
-</style>


### PR DESCRIPTION
## Problem

In the settings header, clicking the "Log out" text does nothing - only the icon triggers logout. The action style rendered the icon as an `ActionButton` (the only element with the `onclick`) and a sibling label with `pointer-events: none`, so clicks on the text never reached a handler.

## Fix

Render the action style through the shared `Button` component (`style="ghost"`, `variant="secondary"`, `color="red"`, icon snippet) instead of an `ActionButton` + sibling label. The whole control is now one clickable element, and it inherits the component's `:focus-visible` outline, native keyboard activation, and d-pad navigation (`navigationType={DpadNavigationType.Item}`). Dropped the bespoke `<style>` block.

## Verification

- Clicking either the icon or the "Log out" text triggers the logout confirmation.
- Keyboard: button is focusable with a visible focus ring; Enter/Space trigger logout.
- Ghost/secondary/red keeps the red icon and subtle hover tint.