### PR TITLE
docs: fix stale references in agent rule files

### DIFF
--- a/.agents/rules/performance.md
+++ b/.agents/rules/performance.md
@@ -1,3 +1,10 @@
+---
+trigger: glob
+globs: 'projects/client/src/**'
+description: 'Performance principles for animations, scroll/resize handlers, IntersectionObservers, rxjs plumbing, bundle/boot, and viewport gating.'
+applyTo: 'projects/client/src/**'
+---
+
 # Performance Guidelines
 
 Framework-agnostic perf principles for client-side work. Read when the work

--- a/.agents/rules/project.md
+++ b/.agents/rules/project.md
@@ -9,7 +9,7 @@ applyTo: '**'
 
 ## Tech Stack
 
-SvelteKit + TypeScript app (Svelte 5, runes mode) deployed to Cloudflare Pages. Monorepo using Deno workspaces with app at `projects/client/`.
+SvelteKit + TypeScript app (Svelte 5, runes mode) deployed to Cloudflare Workers. Monorepo using Deno workspaces with app at `projects/client/`.
 
 ## Project Structure
 
@@ -20,7 +20,7 @@ projects/client/src/
     components/    # Reusable UI components (buttons, forms, dialogs, media, etc.)
     features/      # Feature modules - self-contained domains (auth, calendar, theme, i18n, etc.)
     sections/      # Page composition - navbar, lists, profile, layout shells
-    guards/        # Conditional rendering (RenderFor, RenderForFeature, RenderForAudience)
+    guards/        # Conditional rendering (RenderFor, RenderForFeature)
     requests/      # API request mappers and query definitions
     stores/        # Reactive state (RxJS BehaviorSubject + localStorage)
     models/        # TypeScript type definitions
@@ -61,7 +61,7 @@ Use Svelte 5 `{#snippet}` for reusable template fragments and component slot alt
 
 ### Guards for conditional rendering
 
-Use `RenderFor`, `RenderForFeature`, `RenderForAudience` components instead of inline `{#if}` blocks for auth/feature/audience gating.
+Use `RenderFor`, `RenderForFeature` components instead of inline `{#if}` blocks for auth/feature/audience gating.
 
 ### Stores use RxJS + localStorage
 

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -21,8 +21,8 @@ Vitest + `@testing-library/svelte` in jsdom environment.
 ## Running Tests
 
 ```bash
-deno task client:test    # from project root
-vitest                   # from projects/client/
+deno task test:unit    # from projects/client/
+vitest                 # from projects/client/
 ```
 
 ## Testing Philosophy
@@ -82,6 +82,7 @@ src/mocks/
       mapped/{Entity}MappedMock.ts       # post-mapper domain model shape
 ```
 
+- `{domain}` may be a multi-segment path (e.g. `summary/episodes/silo`), not just a single folder; resulting in paths like `data/summary/episodes/silo/response/...`.
 - **`response/`** mocks mirror raw API payload - used by MSW handlers.
 - **`mapped/`** mocks mirror output of the corresponding `mapTo*` function - used as expected value in assertions.
 - Handler URLs use `http://localhost/...` origin and match the SDK path.


### PR DESCRIPTION
Audit of the agent instruction files (`CLAUDE.md`, `AGENTS.md`, `.agents/rules/*`) surfaced a few spots that drifted from the actual code. Every change verified against the current repo.

- **`testing.md`** - `deno task client:test` is not a real task; running it fails. Fixed to `deno task test:unit` from `projects/client`. Also noted the MSW `data/{domain}/...` path can be multi-segment (e.g. `summary/movies/heretic/...`).
- **`project.md`** - we deploy to Cloudflare **Workers** (static-assets), not Pages - `wrangler.jsonc` has no `pages_build_output_dir`. Also dropped `RenderForAudience` from the public-guard mentions; it lives in `guards/_internal/` and is never imported outside `guards/`. Public guards are `RenderFor` + `RenderForFeature`.
- **`performance.md`** - had no frontmatter at all, which breaks our own rule ("always keep `applyTo`"). Added single-quoted `globs`/`applyTo`/`description` matching the other rule files.

Docs only, no code touched.