### PR TITLE
fix(summary): ensures summary children container stretches vertically

### DIFF
--- a/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
@@ -76,6 +76,7 @@
 
   .trakt-summary-children {
     flex-grow: 1;
+    align-self: stretch;
 
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2652
- Empty summaries are no longer small and centered

## 👀 Example 👀
Before/after:
<img width="1328" height="546" alt="Screenshot 2026-06-17 at 21 31 02" src="https://github.com/user-attachments/assets/65b05324-8162-4ed6-b1ad-49981cd1f642" />

<img width="1328" height="546" alt="Screenshot 2026-06-17 at 21 31 06" src="https://github.com/user-attachments/assets/5e39db7b-b3c7-42a8-8c36-21348499fc4e" />
