### PR TITLE
fix: suppresses drop note prompt when completing an in progress movie

### DIFF
--- a/projects/client/src/lib/sections/lists/progress/_internal/MarkAsCompletedAction.svelte
+++ b/projects/client/src/lib/sections/lists/progress/_internal/MarkAsCompletedAction.svelte
@@ -30,6 +30,7 @@
       id: media.id,
       type: "movie",
       title: media.title,
+      context: "complete",
     }),
   );
 

--- a/projects/client/src/lib/sections/media-actions/drop/useDrop.ts
+++ b/projects/client/src/lib/sections/media-actions/drop/useDrop.ts
@@ -19,6 +19,7 @@ type DropProps = {
 
 export type DropStoreProps = DropProps & {
   title: string;
+  context?: 'drop' | 'complete';
 };
 
 function requestDrop(props: DropProps) {
@@ -41,7 +42,7 @@ function requestDrop(props: DropProps) {
 export function useDrop(
   props: DropStoreProps,
 ) {
-  const { title, ...target } = props;
+  const { title, context = 'drop', ...target } = props;
   const isDropping = new BehaviorSubject(false);
   const { user } = useUser();
   const { invalidate } = useInvalidator();
@@ -61,7 +62,9 @@ export function useDrop(
 
     await requestDrop(target);
 
-    dropNote?.show({ title, type: target.type, id: target.id });
+    if (context === 'drop') {
+      dropNote?.show({ title, type: target.type, id: target.id });
+    }
 
     await invalidate(InvalidateAction.Drop(target.type));
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2655
- When marking a movie that's in progress as watched/completed, users are no longer shown the note prompt that's shown when dropping.