### PR TITLE
fix(stats): adjusts streak attribution for early morning watches

### DIFF
--- a/projects/client/src/lib/sections/stats/_internal/constants/index.ts
+++ b/projects/client/src/lib/sections/stats/_internal/constants/index.ts
@@ -1,2 +1,5 @@
+import { time } from '$lib/utils/timing/time.ts';
+
 export const WAKING_HOURS_PER_DAY = 16;
 export const HEATMAP_MAX_INTENSITY_COUNT = 7;
+export const STREAK_DAY_BUFFER = time.minutes(30);

--- a/projects/client/src/lib/sections/stats/_internal/useStreak.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useStreak.spec.ts
@@ -62,6 +62,39 @@ describe('computeStreak', () => {
     expect(computeStreak(dates, now)).toEqual({ count: 2 });
   });
 
+  it('attributes a buffer-window watch only to the previous day', () => {
+    // A watch at 00:25 on Jan 15 is attributed to Jan 14 only — Jan 15 gets no credit.
+    const now = new Date('2024-01-15T12:00:00Z');
+    const dates = [
+      new Date('2024-01-15T00:25:00Z'), // 25 min past midnight → counts for Jan 14 only
+      new Date('2024-01-14T10:00:00Z'),
+    ];
+    // Only Jan 14 has activity; streak = 1 (ending yesterday)
+    expect(computeStreak(dates, now)).toEqual({ count: 1 });
+  });
+
+  it('breaks a streak when a day has only an early-morning watch', () => {
+    // Jan 13 has only a 00:15 watch — attributed to Jan 12, leaving Jan 13 empty.
+    // The streak from Jan 15 back stops at Jan 13.
+    const now = new Date('2024-01-15T12:00:00Z');
+    const dates = [
+      new Date('2024-01-15T10:00:00Z'), // normal watch
+      new Date('2024-01-14T10:00:00Z'), // normal watch
+      new Date('2024-01-13T00:15:00Z'), // only watch on Jan 13 — attributed to Jan 12
+      new Date('2024-01-12T10:00:00Z'), // normal watch
+    ];
+    expect(computeStreak(dates, now)).toEqual({ count: 2 });
+  });
+
+  it('does not apply buffer to watches at exactly 30 minutes past midnight', () => {
+    const now = new Date('2024-01-15T12:00:00Z');
+    const dates = [
+      new Date('2024-01-15T00:30:00Z'), // exactly at the buffer boundary → stays Jan 15
+      new Date('2024-01-14T10:00:00Z'),
+    ];
+    expect(computeStreak(dates, now)).toEqual({ count: 2 });
+  });
+
   it('uses local time for day boundaries, not UTC', () => {
     // getDayKey uses getFullYear/getMonth/getDate (local time).
     // In UTC (test env), these match UTC — confirming the function
@@ -79,25 +112,26 @@ describe('computeStreak', () => {
     // getDayKey returns unpadded strings like "2026-3-19".
     // String sort places "2026-3-19" before "2026-3-3" ("1" < "3" at pos 7),
     // which breaks streak detection — the sort must be numeric, not lexicographic.
-    const now = new Date('2026-03-30T12:00:00');
+    // Dates use T10:00:00Z (daytime) to avoid triggering the midnight buffer.
+    const now = new Date('2026-03-30T12:00:00Z');
     const dates = [
       // Continuous streak: March 22–30 (9 days)
-      new Date('2026-03-30'),
-      new Date('2026-03-29'),
-      new Date('2026-03-28'),
-      new Date('2026-03-27'),
-      new Date('2026-03-26'),
-      new Date('2026-03-25'),
-      new Date('2026-03-24'),
-      new Date('2026-03-23'),
-      new Date('2026-03-22'),
+      new Date('2026-03-30T10:00:00Z'),
+      new Date('2026-03-29T10:00:00Z'),
+      new Date('2026-03-28T10:00:00Z'),
+      new Date('2026-03-27T10:00:00Z'),
+      new Date('2026-03-26T10:00:00Z'),
+      new Date('2026-03-25T10:00:00Z'),
+      new Date('2026-03-24T10:00:00Z'),
+      new Date('2026-03-23T10:00:00Z'),
+      new Date('2026-03-22T10:00:00Z'),
       // Gap on March 21
-      new Date('2026-03-20'),
-      new Date('2026-03-19'),
-      new Date('2026-03-18'),
-      new Date('2026-03-16'),
+      new Date('2026-03-20T10:00:00Z'),
+      new Date('2026-03-19T10:00:00Z'),
+      new Date('2026-03-18T10:00:00Z'),
+      new Date('2026-03-16T10:00:00Z'),
       // Older entries that trigger the string-sort bug (single-digit day "3")
-      new Date('2026-03-03'),
+      new Date('2026-03-03T10:00:00Z'),
     ];
     expect(computeStreak(dates, now)).toEqual({ count: 9 });
   });

--- a/projects/client/src/lib/sections/stats/_internal/useStreak.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useStreak.ts
@@ -4,6 +4,7 @@ import { getDayKey } from '$lib/utils/date/getDayKey.ts';
 import { multicast } from '$lib/utils/store/multicast.ts';
 import { map } from 'rxjs';
 import { filterWatchedDates } from './filterWatchedDates.ts';
+import { getAttributedStreakDay } from './utils/getAttributedStreakDay.ts';
 
 type StreakResult = {
   readonly count: number;
@@ -24,7 +25,7 @@ export function computeStreak(
   const daysWithActivity = new Set(
     watchedDates
       .toSorted((a, b) => b.getTime() - a.getTime())
-      .map(getDayKey),
+      .map((date) => getDayKey(getAttributedStreakDay(date))),
   );
 
   const today = new Date(

--- a/projects/client/src/lib/sections/stats/_internal/utils/computeMonthlyStats.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/utils/computeMonthlyStats.spec.ts
@@ -162,6 +162,29 @@ describe('computeMonthlyStats', () => {
     });
   });
 
+  describe('streak buffer (30-minute window after midnight)', () => {
+    it('attributes a watch within the buffer window only to the previous day', () => {
+      // Apr 16 at 00:25 → attributed to Apr 15 only (not Apr 16)
+      // Apr 14 (normal) + Apr 15 (buffered) = streak of 2, ending yesterday
+      const dates = [
+        getDate(2026, 4, 14),
+        new Date(2026, 3, 16, 0, 25),
+      ];
+      const { currentStreak } = computeMonthlyStats(dates, NOW);
+      expect(currentStreak).toBe(2);
+    });
+
+    it('does not apply buffer at exactly 30 minutes past midnight', () => {
+      // Apr 16 at 00:30 → 00:30 − 30 min = 00:00 same day → no credit for Apr 15
+      const dates = [
+        getDate(2026, 4, 14),
+        new Date(2026, 3, 16, 0, 30),
+      ];
+      const { currentStreak } = computeMonthlyStats(dates, NOW);
+      expect(currentStreak).toBe(1);
+    });
+  });
+
   describe('activeDaysThisYear', () => {
     it('counts only days in the current year', () => {
       const dates = [

--- a/projects/client/src/lib/sections/stats/_internal/utils/computeMonthlyStats.ts
+++ b/projects/client/src/lib/sections/stats/_internal/utils/computeMonthlyStats.ts
@@ -1,4 +1,5 @@
 import { getDayKey } from '$lib/utils/date/getDayKey.ts';
+import { getAttributedStreakDay } from './getAttributedStreakDay.ts';
 
 export type MonthlyStats = {
   readonly currentStreak: number;
@@ -30,10 +31,10 @@ function areConsecutiveDays(dateA: Date, dateB: Date): boolean {
 function deduplicateAndSort(
   dates: ReadonlyArray<Date>,
 ): ReadonlyArray<Date> {
-  const uniqueByDay = new Map(
+  const uniqueByDay = new Map<string, Date>(
     dates.map((date) => {
-      const normalized = toMidnight(date);
-      return [getDayKey(normalized), normalized];
+      const day = getAttributedStreakDay(date);
+      return [getDayKey(day), day];
     }),
   );
   return [...uniqueByDay.values()].sort(

--- a/projects/client/src/lib/sections/stats/_internal/utils/getAttributedStreakDay.ts
+++ b/projects/client/src/lib/sections/stats/_internal/utils/getAttributedStreakDay.ts
@@ -1,0 +1,6 @@
+import { STREAK_DAY_BUFFER } from '$lib/sections/stats/_internal/constants/index.ts';
+
+export function getAttributedStreakDay(date: Date): Date {
+  const shifted = new Date(date.getTime() - STREAK_DAY_BUFFER);
+  return new Date(shifted.getFullYear(), shifted.getMonth(), shifted.getDate());
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2657
- Introduces a 30-minute buffer after midnight for streak calculations.
- Watch activity occurring within this buffer on a given day will now be attributed to the previous day for streak counting purposes.
- Prevents streaks from being broken when activity occurs shortly after midnight, ensuring more accurate and forgiving streak tracking.
- Adds dedicated unit tests to verify the new streak attribution logic across relevant statistical computations.