### PR TITLE
fix: ensures tab indicator matches tab width

### DIFF
--- a/projects/client/src/lib/components/tabs/TabView.svelte
+++ b/projects/client/src/lib/components/tabs/TabView.svelte
@@ -80,7 +80,7 @@
       left: 0;
       width: var(--tab-width);
       transform: translateX(
-        calc(var(--active-index) * (var(--tab-width) + var(--tab-list-gap)))
+        calc(var(--active-index) * (100% + var(--tab-list-gap)))
       );
 
       background-color: var(--color-tab-background);


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2659
- The position of the tab indicator is correct now; inside `translateX` the 100% is the width of the element itself.

## 👀 Example 👀
Before/after:

https://github.com/user-attachments/assets/8c3f1cf6-e48f-4a9f-b4c0-61b3dc5f7a52


https://github.com/user-attachments/assets/0ba1dedc-0e65-4190-bbce-be1696840a83

