### PR TITLE
fix(auth): bust navigation cache on auth transition to stop landing flicker

### DIFF
--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.spec.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.spec.ts
@@ -1,24 +1,57 @@
 import { time } from '$lib/utils/timing/time.ts';
 import { OidcUserMock } from '$mocks/data/auth/OidcUserMock.ts';
 import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
-import { describe, expect, it } from 'vitest';
+import { WorkerMessage } from '$worker/WorkerMessage.ts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getToken } from '../token/index.ts';
 import { getAuthContext } from './getAuthContext.ts';
 import { initializeUserManager } from './initializeUserManager.ts';
 import { useAuth } from './useAuth.ts';
 
+// Drive the real `workerRequest` against a stubbed service worker so the
+// navigation-cache bust is observable end to end.
+const postMessage = vi.fn();
+
+function stubServiceWorker() {
+  Object.defineProperty(globalThis.navigator, 'serviceWorker', {
+    configurable: true,
+    value: {
+      controller: {},
+      ready: Promise.resolve({ active: { postMessage } }),
+    },
+  });
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const bustedNavigationCache = () =>
+  postMessage.mock.calls.some(([message]) =>
+    message?.type === WorkerMessage.CacheBust
+  );
+
 describe('initializeUserManager', () => {
+  beforeEach(() => {
+    stubServiceWorker();
+    postMessage.mockClear();
+  });
+
+  afterEach(() => {
+    setAuthorization(false);
+  });
+
   it('should initialize unauthorized users', async () => {
     await renderStore(() => {
       const ctx = getAuthContext();
       return initializeUserManager({ ctx });
     });
     const { isAuthorized } = await renderStore(() => useAuth());
+    await flush();
 
     const token = getToken();
     expect(token.expiresAt).toBeNull();
     expect(token.value).toBeNull();
     expect(isAuthorized.value).toBe(false);
+    expect(bustedNavigationCache()).toBe(false);
   });
 
   it('should initialize authorized users', async () => {
@@ -31,10 +64,30 @@ describe('initializeUserManager', () => {
       });
     });
     const { isAuthorized } = await renderStore(() => useAuth());
+    await flush();
 
     const token = getToken();
     expect(token.expiresAt).toEqual(time.seconds(OidcUserMock.expires_at));
     expect(token.value).toEqual(OidcUserMock.access_token);
     expect(isAuthorized.value).toBe(true);
+    expect(bustedNavigationCache()).toBe(false);
+  });
+
+  it('should bust the navigation cache when an unauthorized context resolves to authorized', async () => {
+    setAuthorization(true);
+    await renderStore(() => {
+      const ctx = getAuthContext();
+      // A stale, SSR-unauthorized navigation document is hydrated while the
+      // client actually holds a valid session - the flicker scenario.
+      ctx.isAuthorized.next(false);
+      return initializeUserManager({
+        ctx,
+        tokenFromServer: OidcUserMock.access_token,
+      });
+    });
+    await renderStore(() => useAuth());
+    await flush();
+
+    expect(bustedNavigationCache()).toBe(true);
   });
 });

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -1,6 +1,8 @@
 import { browser } from '$app/environment';
 import { FETCH_ERROR_EVENT } from '$lib/features/errors/constants.ts';
 import { time } from '$lib/utils/timing/time.ts';
+import { WorkerMessage } from '$worker/WorkerMessage.ts';
+import { workerRequest } from '$worker/workerRequest.ts';
 import { type User, UserManager } from 'oidc-client-ts';
 import { BehaviorSubject, of } from 'rxjs';
 import { onMount } from 'svelte';
@@ -53,8 +55,22 @@ export function initializeUserManager(
       setToken(token);
       ctx.token.next(token);
 
-      ctx.isAuthorized.next(!isExpired);
+      const nextIsAuthorized = !isExpired;
+      // Client auth resolved differently than the SSR-seeded value the cached
+      // navigation document was rendered with. Evict it so the next load isn't
+      // served a stale unauthorized shell that flickers into the dashboard.
+      // Mirrors the logout-time bust in useAuth.
+      const didAuthorizationChange =
+        ctx.isAuthorized.value !== nextIsAuthorized;
+
+      ctx.isAuthorized.next(nextIsAuthorized);
       isInitializing.next(false);
+
+      if (didAuthorizationChange) {
+        // Best-effort: the SW may be unavailable (private mode, blocked).
+        // Swallow so a failed bust never surfaces as an unhandled rejection.
+        void workerRequest(WorkerMessage.CacheBust).catch(() => {});
+      }
     };
 
     const handleUserEvent = (user: User | null) => {


### PR DESCRIPTION
## Problem

On load, authenticated users briefly see the unauthorized homepage (the Landing "Join Trakt" page) before it flickers into the dashboard.

## Root cause

The service worker caches navigation HTML with `StaleWhileRevalidate`, keyed only by URL + locale (`service-worker.ts`) - there is no authentication dimension to the cache key. After login, the SW keeps serving a previously cached logged-out homepage document, which contains the `Landing` markup and an embedded server data payload with `isAuthorized=false`.

That stale document paints first. Then the client boots `initializeUserManager`, reads the live OIDC session from `localStorage` (oidc-client-ts store), flips `isAuthorized` to `true`, and re-renders into the authenticated dashboard. That swap is the flicker.

`logout()` in `useAuth` already busts the navigation cache. The login / token-acquisition direction did not - the asymmetry is the bug.

## Fix

Bust the navigation cache on the `isAuthorized` transition in `setAuthState`, mirroring the logout-time bust. The bust is gated on `didAuthorizationChange`, so silent token renewals (where the state stays `true`) do not churn the cache - only real login/logout transitions evict it.

### Why not an auth-aware cache key?

Keying the SW navigation cache by auth state would prevent even the first-load stale paint. It is not feasible here: the `trakt-oidc-auth` cookie is `httpOnly`, so the SW Cookie Store API cannot read it (unlike the locale cookie, which the existing `localeAwareCacheKey` reads). Busting respects that constraint.

### Convergence

The current load still paints the stale document once, then busts. The next navigation fetches fresh, auth-correct HTML and caches it, so subsequent loads are clean. The 1-year cookie lifetime keeps it stable thereafter. A follow-up could add a readable non-httpOnly auth-marker cookie + SW cache key to eliminate the single first-load paint entirely; tracked separately if we want it.

## Tests

`initializeUserManager.spec.ts`:
- unauthorized init -> no bust
- authorized-steady init -> no bust
- unauthorized context resolving to authorized (the flicker scenario) -> bust fires

Tests drive the real `workerRequest` against a stubbed service worker rather than mocking the `$worker`-aliased module (a `vi.mock` did not intercept the component-graph instance), so they also exercise the real SW message wiring.