### PR TITLE
MIR: native template

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5083,6 +5083,19 @@
         }
       }
     },
+    "mir_title_month_in_review": {
+      "default": "Month in Review",
+      "description": "Period label in the Month in Review header, shown beneath the month and year (the MIR equivalent of 'Year in Review')."
+    },
+    "mir_share_text": {
+      "default": "Check out my {month} Month in Review on Trakt",
+      "description": "Share text used when sharing a Month in Review page. {month} is the formatted month and year, e.g. 'May 2025'.",
+      "variables": {
+        "month": {
+          "type": "string"
+        }
+      }
+    },
     "yir_button_see_more": {
       "default": "See More",
       "description": "Button text for see more."
@@ -5343,6 +5356,18 @@
       "default": "movie genres",
       "description": "Faint background watermark text behind the movie-genres section heading on the 2024 Year in Review template."
     },
+    "yir_2024_streaming_intro": {
+      "default": "Availability on",
+      "description": "Lead-in line above the 'Streaming Services' heading on the Month in Review streaming section."
+    },
+    "yir_2024_streaming_title": {
+      "default": "Streaming Services",
+      "description": "Heading for the Month in Review streaming-services section, listing the subscription services the month's plays were available on."
+    },
+    "yir_2024_streaming_service_count": {
+      "default": "Service Count",
+      "description": "Label for the total number of distinct streaming services row in the Month in Review streaming section."
+    },
     "yir_2024_stats_intro_shows": {
       "default": "In {year}, you watched",
       "description": "Lead-in line above the big '{hours} hours of {count} Shows' headline on the 2024 Year in Review TV stats section.",
@@ -5358,6 +5383,24 @@
       "variables": {
         "year": {
           "type": "number"
+        }
+      }
+    },
+    "yir_2024_stats_intro_shows_monthly": {
+      "default": "In {month}, you watched",
+      "description": "Lead-in line above the big '{hours} hours of {count} Shows' headline on the Month in Review TV stats section. {month} is the month name, e.g. 'May'.",
+      "variables": {
+        "month": {
+          "type": "string"
+        }
+      }
+    },
+    "yir_2024_stats_intro_movies_monthly": {
+      "default": "In {month}, you watched",
+      "description": "Lead-in line above the big '{hours} hours of {count} Movies' headline on the Month in Review movie stats section. {month} is the month name, e.g. 'May'.",
+      "variables": {
+        "month": {
+          "type": "string"
         }
       }
     },
@@ -5393,6 +5436,18 @@
           "type": "string"
         },
         "end": {
+          "type": "string"
+        },
+        "count": {
+          "type": "string"
+        }
+      }
+    },
+    "yir_2024_stats_most_active_day": {
+      "default": "Your most active day was <b>{date}</b> with <b>{count} plays</b>.",
+      "description": "Info line on the Month in Review stats section reporting the user's busiest watching day within the month. The <b> tags wrap dynamic values that render as bold purple highlights — keep them around the same content when translating.",
+      "variables": {
+        "date": {
           "type": "string"
         },
         "count": {

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -1,5 +1,6 @@
 export enum FeatureFlag {
   YearInReview = 'year-in-review',
+  MonthInReview = 'month-in-review',
   EditMode = 'edit-mode',
   StreamingSync = 'streaming-sync',
   ScopedFavorites = 'scoped-favorites',

--- a/projects/client/src/lib/requests/_internal/mapToYirDetail.ts
+++ b/projects/client/src/lib/requests/_internal/mapToYirDetail.ts
@@ -6,6 +6,7 @@ import type {
   YirGenresGroup,
   YirMostWatchedItem,
   YirStatsCategory,
+  YirStreamingServices,
   YirTopRatedItem,
   YirTrendItem,
   YirWatchedItem,
@@ -29,6 +30,7 @@ type RawDistributions = {
   monthly: number[];
   days: number[];
   hourly?: number[];
+  daily?: number[] | null;
 };
 
 type RawStatsCategory = {
@@ -108,7 +110,18 @@ type RawThanks = {
   movies?: Array<{ movie: MovieResponse }>;
 };
 
-type RawYirResponse = {
+type RawStreamingServices = {
+  country: string;
+  services: Array<{
+    source: string;
+    name: string;
+    shows: number;
+    movies: number;
+    all: number;
+  }>;
+};
+
+export type RawYirResponse = {
   stats: {
     all: RawStatsCategory & { lists_counts: RawStats };
     shows: RawStatsCategory;
@@ -143,6 +156,7 @@ type RawYirResponse = {
     movies: RawTrendMovie[];
   };
   thanks?: RawThanks;
+  streaming_services?: RawStreamingServices | null;
 };
 
 function mapStatsCategory(raw: RawStatsCategory): YirStatsCategory {
@@ -271,6 +285,23 @@ function mapThanks(
   };
 }
 
+function mapStreamingServices(
+  raw: RawStreamingServices | null | undefined,
+): YirStreamingServices | undefined {
+  if (!raw) return undefined;
+
+  return {
+    country: raw.country,
+    services: raw.services.map((service) => ({
+      source: service.source,
+      name: service.name,
+      shows: service.shows,
+      movies: service.movies,
+      all: service.all,
+    })),
+  };
+}
+
 export function mapToYirDetail(response: RawYirResponse): YirDetail {
   const { stats, images } = response;
 
@@ -320,5 +351,6 @@ export function mapToYirDetail(response: RawYirResponse): YirDetail {
       movies: mapTrendMovies(response.trends?.movies ?? []),
     },
     thanks: mapThanks(response.thanks ?? {}),
+    streamingServices: mapStreamingServices(response.streaming_services),
   };
 }

--- a/projects/client/src/lib/requests/models/YirDetail.ts
+++ b/projects/client/src/lib/requests/models/YirDetail.ts
@@ -14,6 +14,27 @@ const YirDistributionsSchema = z.object({
   monthly: z.number().array(),
   days: z.number().array(),
   hourly: z.number().array().optional(),
+  // Per-day-of-month buckets (index 0 = 1st). Month in Review only; the
+  // monthly stats variant charts plays across the days of the chosen month.
+  // Nullish because the API emits it via `&.values` (can be null) and omits it
+  // entirely for Year in Review.
+  daily: z.number().array().nullish(),
+});
+
+// Subscription streaming services the user watched on during the period, with
+// per-type play counts. Month in Review only.
+const YirStreamingServiceSchema = z.object({
+  source: z.string(),
+  name: z.string(),
+  shows: z.number(),
+  movies: z.number(),
+  all: z.number(),
+});
+
+const YirStreamingServicesSchema = z.object({
+  /** ISO 3166-1 alpha-2 code resolved from the user's watchnow country. */
+  country: z.string(),
+  services: YirStreamingServiceSchema.array(),
 });
 
 const YirStatsCategorySchema = z.object({
@@ -139,6 +160,9 @@ export const YirDetailSchema = z.object({
     shows: MediaEntrySchema.array(),
     movies: MediaEntrySchema.array(),
   }).nullish(),
+  // Month in Review only: subscription services the period's plays were
+  // available on.
+  streamingServices: YirStreamingServicesSchema.nullish(),
 });
 
 export type YirDetail = z.infer<typeof YirDetailSchema>;
@@ -156,3 +180,5 @@ export type YirTrendItem = z.infer<typeof YirTrendItemSchema>;
 export type YirWatchedItem = z.infer<typeof YirWatchedItemSchema>;
 export type YirWatchedMovie = z.infer<typeof YirWatchedMovieSchema>;
 export type YirWatchedEpisode = z.infer<typeof YirWatchedEpisodeSchema>;
+export type YirStreamingService = z.infer<typeof YirStreamingServiceSchema>;
+export type YirStreamingServices = z.infer<typeof YirStreamingServicesSchema>;

--- a/projects/client/src/lib/requests/queries/users/mirDetailQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/mirDetailQuery.spec.ts
@@ -1,0 +1,38 @@
+import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { map } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { mirDetailQuery } from './mirDetailQuery.ts';
+
+describe('mirDetailQuery', () => {
+  // Map to the query's `data` so the resolved value is the YirDetail itself
+  // (runQuery's return type follows the factory's emission); the default
+  // waitFor gates until the loaded detail is present.
+  const detail = () =>
+    runQuery({
+      factory: () =>
+        createTestBedQuery(
+          mirDetailQuery({ slug: 'me', month: 5, year: 2025 }),
+        ).pipe(map((query) => query.data)),
+    });
+
+  it('should map the streaming services (Month in Review only)', async () => {
+    const result = await detail();
+
+    expect(result?.streamingServices).to.deep.equal({
+      country: 'us',
+      services: [
+        { source: 'netflix', name: 'Netflix', shows: 1, movies: 2, all: 3 },
+        { source: 'hulu', name: 'Hulu', shows: 0, movies: 1, all: 1 },
+      ],
+    });
+  });
+
+  it('should map the first play to a media entry', async () => {
+    const result = await detail();
+
+    expect(result?.firstWatched?.type).to.equal('movie');
+    expect(result?.firstWatched?.entry).to.deep.equal(MovieHereticMappedMock);
+  });
+});

--- a/projects/client/src/lib/requests/queries/users/mirDetailQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/mirDetailQuery.ts
@@ -1,0 +1,41 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import {
+  mapToYirDetail,
+  type RawYirResponse,
+} from '$lib/requests/_internal/mapToYirDetail.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { YirDetailSchema } from '../../models/YirDetail.ts';
+
+export type MirDetailParams = {
+  slug: string;
+  year: number;
+  month: number;
+} & ApiParams;
+
+const mirDetailRequest = (
+  { fetch, slug, year, month }: MirDetailParams,
+) =>
+  api({ fetch })
+    .users
+    .month_in_review({
+      params: { id: slug, year, month },
+      query: { extended: 'images' },
+    });
+
+export const mirDetailQuery = defineQuery({
+  key: 'mirDetail',
+  invalidations: [],
+  dependencies: (params) => [params.slug, params.year, params.month],
+  request: mirDetailRequest,
+  // The @trakt/api contract types month_in_review's body to a narrow subset,
+  // but the ts-rest client does not strip response fields - the full rich
+  // payload (most_watched, genres, distributions, ...) is present at runtime,
+  // so we reuse the YIR mapper by casting to its raw input shape.
+  mapper: (response) =>
+    response.body
+      ? mapToYirDetail(response.body as unknown as RawYirResponse)
+      : null,
+  schema: YirDetailSchema.nullable(),
+  ttl: time.hours(1),
+});

--- a/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
+++ b/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
@@ -2,6 +2,7 @@
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import { m } from "$lib/paraglide/messages";
   import type { YirDetail } from "$lib/requests/models/YirDetail";
+  import type { ReviewMode } from "../ReviewMode";
   import Yir2024CompaniesSection from "./_internal/Yir2024CompaniesSection.svelte";
   import Yir2024CountriesSection from "./_internal/Yir2024CountriesSection.svelte";
   import Yir2024GenresSection from "./_internal/Yir2024GenresSection.svelte";
@@ -10,7 +11,9 @@
   import Yir2024PeopleSection from "./_internal/Yir2024PeopleSection.svelte";
   import Yir2024PlayCard from "./_internal/Yir2024PlayCard.svelte";
   import Yir2024RatedSection from "./_internal/Yir2024RatedSection.svelte";
+  import Yir2024StatsMonthlySection from "./_internal/Yir2024StatsMonthlySection.svelte";
   import Yir2024StatsSection from "./_internal/Yir2024StatsSection.svelte";
+  import Yir2024StreamingSection from "./_internal/Yir2024StreamingSection.svelte";
   import Yir2024ThanksSection from "./_internal/Yir2024ThanksSection.svelte";
   import Yir2024TopSection from "./_internal/Yir2024TopSection.svelte";
   import Yir2024TrendsSection from "./_internal/Yir2024TrendsSection.svelte";
@@ -20,12 +23,23 @@
     isLoading,
     slug,
     year,
+    month = 1,
+    mode = "yir",
   }: {
     detail: YirDetail | null;
     isLoading: boolean;
     slug: string;
     year: number;
+    /** 1-12. Only meaningful in MIR mode; ignored for YIR. */
+    month?: number;
+    mode?: ReviewMode;
   } = $props();
+
+  // Year in Review surfaces the full top-10; Month in Review trims to a
+  // compact top-3 (matches v2's monthly_mode limit).
+  const isMir = $derived(mode === "mir");
+  const isYir = $derived(!isMir);
+  const mostPlayedLimit = $derived(isMir ? 3 : 10);
 </script>
 
 <svelte:head>
@@ -39,7 +53,7 @@
   <!-- Top section paints immediately; the Hero core (year, name, label,
        membership) renders without the detail query, while the posters /
        watched-stats / first-play parts gate on `detail` being present. -->
-  <Yir2024TopSection {detail} {slug} {year} />
+  <Yir2024TopSection {detail} {slug} {year} {month} {mode} />
 
   {#if detail}
     {#if detail.firstWatched}
@@ -52,9 +66,29 @@
       </Yir2024PageInner>
     {/if}
 
+    <!-- MIR-only: streaming availability, rendered right after the first play
+         (mirrors v2's monthly_mode placement). -->
+    {#if isMir && (detail.streamingServices?.services.length ?? 0) > 0}
+      <Yir2024PageInner>
+        <Yir2024StreamingSection
+          services={detail.streamingServices?.services ?? []}
+          country={detail.streamingServices?.country ?? ""}
+        />
+      </Yir2024PageInner>
+    {/if}
+
     {#if detail.stats.shows.playCounts.total > 0}
       <Yir2024PageInner>
-        <Yir2024StatsSection type="shows" stats={detail.stats.shows} {year} />
+        {#if isMir}
+          <Yir2024StatsMonthlySection
+            type="shows"
+            stats={detail.stats.shows}
+            {month}
+            {year}
+          />
+        {:else}
+          <Yir2024StatsSection type="shows" stats={detail.stats.shows} {year} />
+        {/if}
       </Yir2024PageInner>
     {/if}
 
@@ -62,12 +96,12 @@
       <Yir2024PageInner>
         <Yir2024MostPlayedSection
           type="shows"
-          items={detail.mostWatched.shows}
+          items={detail.mostWatched.shows.slice(0, mostPlayedLimit)}
         />
       </Yir2024PageInner>
     {/if}
 
-    {#if detail.networks.length > 0}
+    {#if isYir && detail.networks.length > 0}
       <Yir2024PageInner>
         <Yir2024CompaniesSection type="shows" companies={detail.networks} />
       </Yir2024PageInner>
@@ -79,19 +113,19 @@
       </Yir2024PageInner>
     {/if}
 
-    {#if detail.topRated.shows.length > 0}
+    {#if isYir && detail.topRated.shows.length > 0}
       <Yir2024PageInner>
         <Yir2024RatedSection type="shows" items={detail.topRated.shows} />
       </Yir2024PageInner>
     {/if}
 
-    {#if detail.countries.shows.countryCount > 0}
+    {#if isYir && detail.countries.shows.countryCount > 0}
       <Yir2024PageInner>
         <Yir2024CountriesSection type="shows" group={detail.countries.shows} />
       </Yir2024PageInner>
     {/if}
 
-    {#if (detail.trends?.shows.length ?? 0) > 0}
+    {#if isYir && (detail.trends?.shows.length ?? 0) > 0}
       <Yir2024PageInner>
         <Yir2024TrendsSection
           type="shows"
@@ -103,7 +137,20 @@
 
     {#if detail.stats.movies.playCounts.total > 0}
       <Yir2024PageInner>
-        <Yir2024StatsSection type="movies" stats={detail.stats.movies} {year} />
+        {#if isMir}
+          <Yir2024StatsMonthlySection
+            type="movies"
+            stats={detail.stats.movies}
+            {month}
+            {year}
+          />
+        {:else}
+          <Yir2024StatsSection
+            type="movies"
+            stats={detail.stats.movies}
+            {year}
+          />
+        {/if}
       </Yir2024PageInner>
     {/if}
 
@@ -111,12 +158,12 @@
       <Yir2024PageInner>
         <Yir2024MostPlayedSection
           type="movies"
-          items={detail.mostWatched.movies}
+          items={detail.mostWatched.movies.slice(0, mostPlayedLimit)}
         />
       </Yir2024PageInner>
     {/if}
 
-    {#if detail.studios.length > 0}
+    {#if isYir && detail.studios.length > 0}
       <Yir2024PageInner>
         <Yir2024CompaniesSection type="movies" companies={detail.studios} />
       </Yir2024PageInner>
@@ -128,19 +175,19 @@
       </Yir2024PageInner>
     {/if}
 
-    {#if detail.topRated.movies.length > 0}
+    {#if isYir && detail.topRated.movies.length > 0}
       <Yir2024PageInner>
         <Yir2024RatedSection type="movies" items={detail.topRated.movies} />
       </Yir2024PageInner>
     {/if}
 
-    {#if detail.countries.movies.countryCount > 0}
+    {#if isYir && detail.countries.movies.countryCount > 0}
       <Yir2024PageInner>
         <Yir2024CountriesSection type="movies" group={detail.countries.movies} />
       </Yir2024PageInner>
     {/if}
 
-    {#if (detail.trends?.movies.length ?? 0) > 0}
+    {#if isYir && (detail.trends?.movies.length ?? 0) > 0}
       <Yir2024PageInner>
         <Yir2024TrendsSection
           type="movies"
@@ -150,9 +197,11 @@
       </Yir2024PageInner>
     {/if}
 
-    <Yir2024PageInner>
-      <Yir2024PeopleSection {slug} {year} />
-    </Yir2024PageInner>
+    {#if isYir}
+      <Yir2024PageInner>
+        <Yir2024PeopleSection {slug} {year} />
+      </Yir2024PageInner>
+    {/if}
 
     {#if detail.lastWatched}
       <Yir2024PageInner>
@@ -164,8 +213,8 @@
       </Yir2024PageInner>
     {/if}
 
-    {#if (detail.thanks?.shows.length ?? 0) > 0 || (detail.thanks?.movies
-      .length ?? 0) > 0}
+    {#if isYir && ((detail.thanks?.shows.length ?? 0) > 0 || (detail.thanks
+      ?.movies.length ?? 0) > 0)}
       <Yir2024PageInner>
         <Yir2024ThanksSection
           shows={detail.thanks?.shows ?? []}

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024DailyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024DailyPlaysChart.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { m } from "$lib/paraglide/messages";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
+  import { formatNumber } from "$lib/utils/format/formatNumber";
+  import { toHumanShortDate } from "$lib/utils/formatting/date/toHumanShortDate";
+  import YirTooltip from "../../_internal/YirTooltip.svelte";
+
+  const {
+    data,
+    month,
+    year,
+  }: {
+    /** Plays per day-of-month (index 0 = the 1st). */
+    data: number[];
+    /** 1-12. */
+    month: number;
+    year: number;
+  } = $props();
+
+  const chartData = $derived(
+    data.map((value, index) => ({ value, label: `${index + 1}` })),
+  );
+
+  const isDesktop = useMedia(WellKnownMediaQuery.desktop);
+  const isTabletSmall = useMedia(WellKnownMediaQuery.tabletSmall);
+
+  // Tick density steps down with viewport so 28-31 day labels never collide.
+  // Desktop shows every day (matches the reference design); smaller screens
+  // thin the labels out.
+  const tickStep = $derived.by(() => {
+    if ($isDesktop) return 1;
+    if ($isTabletSmall) return 3;
+    return 5;
+  });
+
+  const tickLabels = $derived(
+    chartData.map((d, i) => (i % tickStep === 0 ? d.label : "")),
+  );
+
+  function dateLabel(day: number): string {
+    return toHumanShortDate(new Date(year, month - 1, day), languageTag());
+  }
+</script>
+
+<div class="trakt-yir-2024-daily-plays-chart">
+  <BarChart data={chartData} {tickLabels} barSpacing={1}>
+    {#snippet tooltip({ value, label })}
+      {@const day = parseInt(label, 10)}
+      <YirTooltip
+        main={m.yir_2024_stats_tooltip_plays({ count: formatNumber(value) })}
+        sub={dateLabel(day)}
+      />
+    {/snippet}
+  </BarChart>
+</div>
+
+<style lang="scss">
+  // Matches Yir2024WeeklyPlaysChart's 2024 palette: light gray bars, peak day
+  // in purple-300, hover purple-500.
+  .trakt-yir-2024-daily-plays-chart {
+    --color-bar-custom-default: var(--shade-100);
+    --color-bar-custom-highlight: var(--purple-300);
+    --color-bar-custom-hover: var(--purple-500);
+    --height-bar-chart: var(--ni-300);
+    width: 100%;
+
+    :global(.cds--chart-holder) {
+      --cds-charts-font-family: "Spline Sans", Helvetica, Arial, sans-serif;
+      --cds-charts-font-family-condensed:
+        "Spline Sans", Helvetica, Arial, sans-serif;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte
@@ -4,10 +4,13 @@
   import VipBadge from "$lib/components/badge/VipBadge.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import { languageTag } from "$lib/features/i18n";
   import { useQuery } from "$lib/features/query/useQuery";
   import { m } from "$lib/paraglide/messages";
   import type { YirDetail } from "$lib/requests/models/YirDetail";
+  import type { ReviewMode } from "../../ReviewMode";
   import { userProfileQuery } from "$lib/requests/queries/users/userProfileQuery";
+  import { toHumanMonth } from "$lib/utils/formatting/date/toHumanMonth";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
 
   import Yir2024Membership from "./Yir2024Membership.svelte";
@@ -18,10 +21,15 @@
     slug,
     year,
     detail,
+    month = 1,
+    mode = "yir",
   }: {
     slug: string;
     year: number;
     detail: YirDetail | null;
+    /** 1-12. Only meaningful in MIR mode. */
+    month?: number;
+    mode?: ReviewMode;
   } = $props();
 
   const profileQuery = $derived(useQuery(userProfileQuery({ slug })));
@@ -29,8 +37,12 @@
 
   const now = new Date();
   const isCurrentYear = $derived(year === now.getFullYear());
+  // MIR shows the month name as the huge label (lowercased by CSS); YIR keeps
+  // the "year in review" / "year to date" wording.
   const hugeLabel = $derived(
-    isCurrentYear
+    mode === "mir"
+      ? toHumanMonth(new Date(year, month - 1, 1), languageTag())
+      : isCurrentYear
       ? m.yir_2024_huge_label_year_to_date()
       : m.yir_2024_huge_label_year_in_review(),
   );

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsMonthlySection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsMonthlySection.svelte
@@ -1,30 +1,31 @@
 <script lang="ts">
   import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
   import PlayIcon from "$lib/components/icons/PlayIcon.svelte";
+  import MessageWithBold from "$lib/components/text/MessageWithBold.svelte";
   import { languageTag } from "$lib/features/i18n";
   import { m } from "$lib/paraglide/messages";
   import type { YirStatsCategory } from "$lib/requests/models/YirDetail";
   import { formatNumber } from "$lib/utils/format/formatNumber";
+  import { toHumanClockHour } from "$lib/utils/formatting/date/toHumanClockHour";
   import { toHumanClockTime } from "$lib/utils/formatting/date/toHumanClockTime";
   import { toHumanMonth } from "$lib/utils/formatting/date/toHumanMonth";
   import { toHumanShortDate } from "$lib/utils/formatting/date/toHumanShortDate";
-  import { addDays } from "date-fns/addDays";
-  import { setMonth } from "date-fns/setMonth";
-  import { startOfYear } from "date-fns/startOfYear";
 
-  import MessageWithBold from "$lib/components/text/MessageWithBold.svelte";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
+  import Yir2024DailyPlaysChart from "./Yir2024DailyPlaysChart.svelte";
   import Yir2024LineChart from "./Yir2024LineChart.svelte";
   import Yir2024SectionHeader from "./Yir2024SectionHeader.svelte";
-  import Yir2024WeeklyPlaysChart from "./Yir2024WeeklyPlaysChart.svelte";
 
   const {
     type,
     stats,
+    month,
     year,
   }: {
     type: "shows" | "movies";
     stats: YirStatsCategory;
+    /** 1-12. */
+    month: number;
     year: number;
   } = $props();
 
@@ -34,22 +35,27 @@
   const hoursTotal = $derived(Math.round(stats.minutes.total / 60));
   const playsTotal = $derived(stats.playCounts.total);
 
-  const hoursMonthly = $derived(stats.minutes.monthly / 60);
+  // Month in Review surfaces per-week / per-day averages (no per-month row, as
+  // the whole period is a single month).
   const hoursWeekly = $derived(stats.minutes.weekly / 60);
   const hoursDaily = $derived(stats.minutes.daily / 60);
 
-  const peakWeek = $derived.by(() => {
-    const weekly = stats.distributions?.weekly ?? [];
-    if (weekly.length === 0) return null;
-    const maxValue = Math.max(...weekly);
-    const maxIndex = weekly.indexOf(maxValue);
-    const start = addDays(startOfYear(new Date(year, 0, 1)), maxIndex * 7);
-    const end = addDays(start, 6);
-    const locale = languageTag();
+  const monthName = $derived(
+    toHumanMonth(new Date(year, month - 1, 1), languageTag()),
+  );
+
+  // Most active day within the month, from the per-day-of-month distribution.
+  const peakDay = $derived.by(() => {
+    const daily = stats.distributions?.daily ?? [];
+    if (daily.length === 0) return null;
+    const maxValue = Math.max(...daily);
+    const maxIndex = daily.indexOf(maxValue);
     return {
       count: maxValue,
-      start: toHumanShortDate(start, locale),
-      end: toHumanShortDate(end, locale),
+      date: toHumanShortDate(
+        new Date(year, month - 1, maxIndex + 1),
+        languageTag(),
+      ),
     };
   });
 
@@ -63,8 +69,8 @@
 
   const introMessage = $derived(
     type === "shows"
-      ? m.yir_2024_stats_intro_shows({ year })
-      : m.yir_2024_stats_intro_movies({ year }),
+      ? m.yir_2024_stats_intro_shows_monthly({ month: monthName })
+      : m.yir_2024_stats_intro_movies_monthly({ month: monthName }),
   );
   const summaryMessage = $derived(
     type === "shows"
@@ -85,22 +91,22 @@
     m.yir_2024_stats_card_plays({ count: formatNumber(playsTotal) }),
   );
 
-  // Hours chart data — 12 monthly buckets in user's locale.
-  const monthlyHoursData = $derived.by(() => {
+  // Daily-within-month plays power the summary's tall bar chart.
+  const dailyPlaysData = $derived(stats.distributions?.daily ?? []);
+
+  // Hours card line chart — plays distributed across the 24 hours of the day,
+  // in the user's locale clock format.
+  const hourlyHoursData = $derived.by(() => {
     const locale = languageTag();
-    const monthly = stats.distributions?.monthly ?? [];
-    return monthly.map((value, index) => ({
-      // The distribution stores minutes per bucket; the card frames hours so
-      // we convert before rendering.
-      value: Math.round(value / 60),
-      label: toHumanMonth(setMonth(new Date(0), index), locale, "short"),
+    const hourly = stats.distributions?.hourly ?? [];
+    return hourly.map((value, index) => ({
+      value: Math.round(value),
+      label: toHumanClockHour(new Date(2000, 0, 1, index), locale),
     }));
   });
 
-  // Plays chart data — 7 day-of-week buckets, with day names rendered in
-  // the user's locale via Intl. Reference dates pinned to a known week
-  // starting on Sunday (Jan 4, 2026 was a Sunday) so index 0 = Sun, …,
-  // 6 = Sat regardless of the current date.
+  // Plays card line chart — 7 day-of-week buckets. Reference dates pinned to a
+  // known week starting on Sunday (Jan 4, 2026) so index 0 = Sun … 6 = Sat.
   const weekdayLabels = $derived.by(() => {
     const formatter = new Intl.DateTimeFormat(languageTag(), {
       weekday: "short",
@@ -109,7 +115,7 @@
       formatter.format(new Date(2026, 0, 4 + i)),
     );
   });
-  const dailyPlaysData = $derived.by(() => {
+  const dayOfWeekData = $derived.by(() => {
     const days = stats.distributions?.days ?? [];
     return days.map((value, index) => ({
       value: Math.round(value),
@@ -118,20 +124,19 @@
   });
 </script>
 
-<section class="trakt-yir-2024-stats-section" id="section-{type}-stats">
+<section class="trakt-yir-2024-stats-monthly-section" id="section-{type}-stats">
   <div class="yir-2024-stats-stack">
     <article class="yir-2024-stats-panel yir-2024-stats-summary">
       <div class="yir-2024-stats-summary-text">
         <Yir2024SectionHeader intro={introMessage} title={summaryMessage} />
 
         <div class="yir-2024-stats-info">
-          {#if peakWeek}
+          {#if peakDay}
             <p>
               <MessageWithBold
-                message={m.yir_2024_stats_most_active_week({
-                  start: peakWeek.start,
-                  end: peakWeek.end,
-                  count: formatNumber(peakWeek.count),
+                message={m.yir_2024_stats_most_active_day({
+                  date: peakDay.date,
+                  count: formatNumber(peakDay.count),
                 })}
               />
             </p>
@@ -146,9 +151,9 @@
         </div>
       </div>
 
-      {#if stats.distributions?.weekly}
+      {#if dailyPlaysData.length > 0}
         <div class="yir-2024-stats-summary-chart">
-          <Yir2024WeeklyPlaysChart data={stats.distributions.weekly} {year} />
+          <Yir2024DailyPlaysChart data={dailyPlaysData} {month} {year} />
         </div>
       {/if}
 
@@ -168,10 +173,10 @@
       </header>
 
       <div class="yir-2024-stats-card-chart">
-        <Yir2024LineChart data={monthlyHoursData}>
+        <Yir2024LineChart data={hourlyHoursData}>
           {#snippet tooltip({ value, label })}
             <YirTooltip
-              main={m.yir_2024_stats_tooltip_hours({
+              main={m.yir_2024_stats_tooltip_plays({
                 count: formatNumber(value),
               })}
               sub={label}
@@ -181,10 +186,6 @@
       </div>
 
       <dl class="yir-2024-stats-averages">
-        <div class="yir-2024-stats-average-row">
-          <dt>{m.yir_2024_stats_per_month()}</dt>
-          <dd class="bold">{formatDecimal(hoursMonthly)}</dd>
-        </div>
         <div class="yir-2024-stats-average-row">
           <dt>{m.yir_2024_stats_per_week()}</dt>
           <dd class="bold">{formatDecimal(hoursWeekly)}</dd>
@@ -211,7 +212,7 @@
       </header>
 
       <div class="yir-2024-stats-card-chart">
-        <Yir2024LineChart data={dailyPlaysData}>
+        <Yir2024LineChart data={dayOfWeekData}>
           {#snippet tooltip({ value, label })}
             <YirTooltip
               main={m.yir_2024_stats_tooltip_plays({
@@ -224,10 +225,6 @@
       </div>
 
       <dl class="yir-2024-stats-averages">
-        <div class="yir-2024-stats-average-row">
-          <dt>{m.yir_2024_stats_per_month()}</dt>
-          <dd class="bold">{formatDecimal(stats.playCounts.monthly)}</dd>
-        </div>
         <div class="yir-2024-stats-average-row">
           <dt>{m.yir_2024_stats_per_week()}</dt>
           <dd class="bold">{formatDecimal(stats.playCounts.weekly)}</dd>
@@ -250,7 +247,9 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .trakt-yir-2024-stats-section {
+  // Layout mirrors Yir2024StatsSection exactly (full-width summary on top, two
+  // chart cards beneath) so the monthly and yearly stats read identically.
+  .trakt-yir-2024-stats-monthly-section {
     width: 100%;
   }
 
@@ -258,15 +257,11 @@
   // its own overflow:hidden — on the short line cards the tooltip gets cut
   // off. Let tooltips overflow the chart wrapper into the (taller) panel so
   // the full box shows.
-  .trakt-yir-2024-stats-section :global(.trakt-area-chart),
-  .trakt-yir-2024-stats-section :global(.trakt-bar-chart) {
+  .trakt-yir-2024-stats-monthly-section :global(.trakt-area-chart),
+  .trakt-yir-2024-stats-monthly-section :global(.trakt-bar-chart) {
     overflow: visible;
   }
 
-  // Summary panel sits at full width on its own row; the two chart cards
-  // share the row beneath in a 2-column grid that collapses to a single
-  // column at tablet-sm-and-below. Tight 10px gap so the three panels
-  // read as one continuous unit.
   .yir-2024-stats-stack {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
@@ -283,12 +278,6 @@
     }
   }
 
-  // Shared panel chrome: rounded card. --panel-padding-x exposes the
-  // horizontal padding so children can bleed (negative margin) to the
-  // panel edges and the watermark can match the inset.
-  // The three panels (summary on top, hours + plays beneath) only round
-  // their outer corners so they read as one continuous unit. Each panel
-  // exposes --panel-radius so the size can step down on smaller screens.
   .yir-2024-stats-panel {
     --panel-padding-x: var(--ni-44);
     --panel-padding-top: var(--ni-44);
@@ -301,8 +290,6 @@
     overflow: visible;
     padding: var(--panel-padding-top) var(--panel-padding-x)
       var(--panel-padding-bottom);
-    // Approximates v2's #112836 → #191C1E radial: a faint blue-tinged
-    // center at the top fading out to a darker charcoal everywhere else.
     background: radial-gradient(
       50% 39.27% at 50% 0%,
       color-mix(in srgb, var(--shade-950) 90%, var(--blue-500) 10%) 0%,
@@ -317,26 +304,19 @@
     }
   }
 
-  // Summary panel sits on top of the row pair: pill-rounded only on top.
   .yir-2024-stats-summary {
     border-top-left-radius: var(--panel-radius);
     border-top-right-radius: var(--panel-radius);
   }
 
-  // Hours card is the bottom-left of the desktop row.
   .yir-2024-stats-card-hours {
     border-bottom-left-radius: var(--panel-radius);
   }
 
-  // Plays card is the bottom-right of the desktop row.
   .yir-2024-stats-card-plays {
     border-bottom-right-radius: var(--panel-radius);
   }
 
-  // Once the cards stack vertically (tablet-sm-and-below), the hours card
-  // becomes the *middle* panel of the stack — drop its bottom corners — and
-  // the plays card becomes the bottom of the stack, so both its bottom
-  // corners pick up --panel-radius.
   @include for-tablet-sm-and-below {
     .yir-2024-stats-card-hours {
       border-bottom-left-radius: 0;
@@ -349,8 +329,6 @@
     }
   }
 
-  // Summary panel: heading + info on the left, weekly bar chart on the right.
-  // Stacks to a single column at tablet-sm-and-below.
   .yir-2024-stats-summary {
     display: grid;
     grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
@@ -381,17 +359,12 @@
       line-height: 1.3;
     }
 
-    // The i18n strings embed <b> around dynamic values; render those as
-    // bold purple inline highlights.
     :global(b) {
       color: var(--purple-300);
       font-weight: 700;
     }
   }
 
-  // The chart bleeds to the panel edges (negative horizontal margin) so the
-  // bar grid spans the full width of its column rather than sitting inside
-  // the panel's content padding.
   .yir-2024-stats-summary-chart {
     min-width: 0;
     width: auto;
@@ -403,10 +376,6 @@
     }
   }
 
-  // Each chart card stretches to the full inner width — line chart inside
-  // gets the entire row to render across. The card overrides the panel's
-  // bottom padding to a tighter value so the watermark sits closer to the
-  // averages list above it (no big empty gap between the two).
   .yir-2024-stats-card {
     --height-area-chart: var(--ni-104);
     --panel-padding-bottom: var(--ni-64);
@@ -447,17 +416,11 @@
     }
   }
 
-  // Same bleed treatment as the summary chart — let the line fill the
-  // entire card width.
   .yir-2024-stats-card-chart {
     margin: var(--ni-16) calc(-1 * var(--panel-padding-x)) 0;
     min-width: 0;
   }
 
-  // Averages list: each row's separator stretches edge-to-edge of the
-  // panel. The list itself bleeds outward; rows pull the inset back in
-  // via their own horizontal padding so the labels and values line up
-  // with the rest of the panel content.
   .yir-2024-stats-averages {
     margin: var(--ni-16) calc(-1 * var(--panel-padding-x)) 0;
     padding: 0;
@@ -495,9 +458,6 @@
     }
   }
 
-  // Faint repeated title at the bottom of each panel, partially clipped by
-  // overflow:hidden. Plain font-size that steps down at smaller viewports
-  // — no clamp / cqw cleverness so the size is predictable at every break.
   // Clips the watermark to the panel box (and its rounded corners) so the
   // panel itself can stay overflow:visible for chart tooltips.
   .yir-2024-stats-watermark-clip {

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StreamingSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StreamingSection.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { YirStreamingService } from "$lib/requests/models/YirDetail.ts";
+  import { formatNumber } from "$lib/utils/format/formatNumber.ts";
+  import YirStreamingBubbleChart from "../../_internal/YirStreamingBubbleChart.svelte";
+  import YirTooltip from "../../_internal/YirTooltip.svelte";
+
+  type Yir2024StreamingSectionProps = {
+    services: YirStreamingService[];
+    country: string;
+  };
+
+  const { services, country }: Yir2024StreamingSectionProps = $props();
+
+  // Highest-coverage services lead the stat list (the bubble chart shows the
+  // full set); mirrors v2's top-3 service summary.
+  const topServices = $derived(
+    [...services].sort((a, b) => b.all - a.all).slice(0, 3),
+  );
+
+  // FIXME(i18n): hardcoded English plurals match the existing convention
+  // across the YIR module (see Yir2024CompaniesSection). Migrate holistically
+  // when i18n keys are added across all YIR sections.
+  function showsUnit(count: number): string {
+    return count === 1 ? "show" : "shows";
+  }
+  function moviesUnit(count: number): string {
+    return count === 1 ? "movie" : "movies";
+  }
+
+  // Per-service count lines, each on its own row in the tooltip. Zero counts
+  // are omitted so a movies-only (or shows-only) service shows a single line.
+  function countLines(service: YirStreamingService): string[] {
+    return [
+      service.shows > 0
+        ? `${formatNumber(service.shows)} ${showsUnit(service.shows)}`
+        : null,
+      service.movies > 0
+        ? `${formatNumber(service.movies)} ${moviesUnit(service.movies)}`
+        : null,
+    ].filter((line): line is string => line !== null);
+  }
+</script>
+
+<section
+  class="trakt-yir-2024-streaming-section"
+  id="section-streaming-services"
+>
+  <div class="yir-2024-streaming-panel">
+    <div class="yir-2024-streaming-text">
+      <header class="yir-2024-streaming-heading-group">
+        <p class="bold yir-2024-streaming-intro">
+          {m.yir_2024_streaming_intro()}
+        </p>
+        <h2 class="bold yir-2024-streaming-heading">
+          {m.yir_2024_streaming_title()}
+        </h2>
+      </header>
+
+      <dl class="yir-2024-streaming-list">
+        {#each topServices as service (service.source)}
+          <div class="yir-2024-streaming-row">
+            <dt class="ellipsis yir-2024-streaming-name">{service.name}</dt>
+            <dd class="yir-2024-streaming-counts">
+              {#if service.shows > 0}
+                <span class="bold uppercase tag yir-2024-streaming-count-pill">
+                  {formatNumber(service.shows)} {showsUnit(service.shows)}
+                </span>
+              {/if}
+              {#if service.movies > 0}
+                <span class="bold uppercase tag yir-2024-streaming-count-pill">
+                  {formatNumber(service.movies)} {moviesUnit(service.movies)}
+                </span>
+              {/if}
+            </dd>
+          </div>
+        {/each}
+
+        <div class="yir-2024-streaming-row">
+          <dt>{m.yir_2024_streaming_service_count()}</dt>
+          <dd class="yir-2024-streaming-total">{formatNumber(services.length)}</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="yir-2024-streaming-chart">
+      <YirStreamingBubbleChart {services} {country}>
+        {#snippet tooltip({ service })}
+          {@const lines = countLines(service)}
+          <YirTooltip main={service.name} sub={lines.at(0)} extra={lines.at(1)} />
+        {/snippet}
+      </YirStreamingBubbleChart>
+    </div>
+  </div>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-yir-2024-streaming-section {
+    width: 100%;
+  }
+
+  // Two-column layout: text + stat list on the left, bubble chart on the
+  // right. Collapses to a single column on smaller viewports. Mirrors
+  // Yir2024CompaniesSection so streaming reads as a sibling section.
+  .yir-2024-streaming-panel {
+    --panel-padding-x: var(--ni-44);
+    --panel-padding-y: var(--ni-44);
+
+    padding: var(--panel-padding-y) var(--panel-padding-x);
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    gap: var(--ni-32);
+    align-items: center;
+
+    @include for-tablet-lg-and-below {
+      grid-template-columns: minmax(0, 1fr);
+      gap: var(--ni-24);
+    }
+
+    @include for-mobile {
+      --panel-padding-x: var(--ni-20);
+      --panel-padding-y: var(--ni-20);
+    }
+  }
+
+  .yir-2024-streaming-text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-32);
+  }
+
+  .yir-2024-streaming-heading-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+
+  .yir-2024-streaming-intro {
+    margin: 0;
+    font-size: var(--ni-24);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--shade-10);
+
+    @include for-mobile {
+      font-size: var(--ni-12);
+    }
+  }
+
+  .yir-2024-streaming-heading {
+    margin: 0;
+    font-size: clamp(var(--ni-32), 5vw, var(--ni-56));
+    line-height: 1.05;
+    color: var(--shade-10);
+
+    @include for-mobile {
+      font-size: var(--ni-28);
+    }
+  }
+
+  .yir-2024-streaming-list {
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+  }
+
+  // Divider under each row (matching the stat-summary list) so the rows read
+  // as a list; last row drops the divider.
+  .yir-2024-streaming-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--ni-32);
+    padding: var(--ni-16) 0;
+    border-bottom: var(--border-thickness-xxs) solid var(--shade-800);
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    @include for-tablet-sm-and-below {
+      gap: var(--ni-16);
+    }
+
+    dt {
+      font-size: var(--font-size-title);
+      color: var(--shade-10);
+      min-width: 0;
+    }
+
+    dd {
+      display: flex;
+      align-items: center;
+      font-size: var(--font-size-title);
+      color: var(--shade-10);
+      white-space: nowrap;
+    }
+  }
+
+  .yir-2024-streaming-name {
+    color: var(--purple-300);
+  }
+
+  // Shows and movies each get their own pill, laid out side by side.
+  .yir-2024-streaming-counts {
+    gap: var(--gap-xs);
+  }
+
+  // Pill-shaped count badge matching Yir2024StatSummary's stat-count pill so
+  // the streaming rows read like the genres / networks stat lists.
+  .yir-2024-streaming-count-pill {
+    background: var(--shade-10);
+    color: var(--shade-900);
+    border-radius: var(--border-radius-xxl);
+    padding: var(--ni-4) var(--ni-10);
+    white-space: nowrap;
+  }
+
+  .yir-2024-streaming-chart {
+    width: 100%;
+    min-width: 0;
+    height: var(--ni-480);
+
+    @include for-mobile {
+      height: var(--ni-380);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TopSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024TopSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { YirDetail } from "$lib/requests/models/YirDetail";
+  import type { ReviewMode } from "../../ReviewMode";
 
   import Yir2024Hero from "./Yir2024Hero.svelte";
   import Yir2024PageInner from "./Yir2024PageInner.svelte";
@@ -9,10 +10,15 @@
     detail,
     slug,
     year,
+    month = 1,
+    mode = "yir",
   }: {
     detail: YirDetail | null;
     slug: string;
     year: number;
+    /** 1-12. Only meaningful in MIR mode. */
+    month?: number;
+    mode?: ReviewMode;
   } = $props();
 </script>
 
@@ -21,7 +27,7 @@
 
   <Yir2024PageInner>
     <div class="yir-2024-top-stack">
-      <Yir2024Hero {slug} {year} {detail} />
+      <Yir2024Hero {slug} {year} {detail} {month} {mode} />
 
       {#if detail}
         <Yir2024WatchedStats stats={detail.stats.all} {slug} />

--- a/projects/client/src/lib/sections/yir/MirPage.svelte
+++ b/projects/client/src/lib/sections/yir/MirPage.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import Yir2024 from "./2024/Yir2024.svelte";
+  import MirHeader from "./_internal/MirHeader.svelte";
+  import { useMirDetail } from "./_internal/useMirDetail";
+
+  const {
+    slug,
+    year,
+    month,
+  }: {
+    slug: string;
+    year: number;
+    /** 1-12. */
+    month: number;
+  } = $props();
+
+  const { detail, isLoading } = $derived(useMirDetail({ slug, year, month }));
+</script>
+
+<div class="trakt-mir-page" id="month-in-review">
+  <MirHeader {slug} {year} {month} />
+  <!-- Month in Review reuses the 2024 template in MIR mode: the same scaffold
+       paints immediately and detail-dependent sections fill in once the query
+       lands. -->
+  <Yir2024
+    detail={$detail ?? null}
+    isLoading={$isLoading}
+    {slug}
+    {year}
+    {month}
+    mode="mir"
+  />
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-mir-page {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--shade-950);
+    color: var(--shade-10);
+    overflow-x: hidden;
+
+    // Breathing room below the final section so the last card doesn't sit
+    // flush against the bottom of the page.
+    padding-bottom: var(--ni-104);
+
+    @include for-mobile {
+      padding-bottom: var(--ni-72);
+    }
+
+    // MIR is rendered with a dark backdrop regardless of user theme.
+    // These overrides force chart colors to stay legible.
+    --color-bar-custom-default: var(--shade-300);
+    --color-bar-custom-highlight: var(--shade-10);
+    --color-bar-custom-hover: var(--red-700);
+    --color-bar-chart-text-primary: var(--shade-10);
+    --color-bar-chart-text-secondary: var(--shade-500);
+
+    // Account for the side navbar's outer margin (gap-s on each side) so the
+    // visible gap on the right of the navbar matches the gap on the left.
+    --layout-sidebar-distance: calc(
+      var(--side-navbar-width) + 2 * var(--gap-s)
+    );
+
+    @include for-tablet-sm-and-below {
+      --layout-sidebar-distance: 0;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/ReviewMode.ts
+++ b/projects/client/src/lib/sections/yir/ReviewMode.ts
@@ -1,0 +1,6 @@
+/**
+ * Which review the 2024 template is rendering. `yir` (Year in Review) is the
+ * default; `mir` (Month in Review) reuses the same template but hides some
+ * sections, limits others, and adds the streaming-services section.
+ */
+export type ReviewMode = 'yir' | 'mir';

--- a/projects/client/src/lib/sections/yir/_internal/MirHeader.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/MirHeader.svelte
@@ -1,0 +1,344 @@
+<script lang="ts">
+  import { browser } from "$app/environment";
+  import { goto } from "$app/navigation";
+  import { page } from "$app/state";
+  import { shortcut } from "@svelte-put/shortcut";
+  import { map } from "rxjs";
+
+  import { useShare } from "$lib/components/buttons/share/useShare";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { useQuery } from "$lib/features/query/useQuery";
+  import { m } from "$lib/paraglide/messages";
+  import { userProfileQuery } from "$lib/requests/queries/users/userProfileQuery";
+  import { toHumanMonth } from "$lib/utils/formatting/date/toHumanMonth";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+
+  import VipBadge from "$lib/components/badge/VipBadge.svelte";
+  import CaretLeftIcon from "$lib/components/icons/CaretLeftIcon.svelte";
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
+  import ShareIcon from "$lib/components/icons/ShareIcon.svelte";
+  import { trackWindowScroll } from "$lib/utils/actions/trackWindowScroll";
+
+  const {
+    slug,
+    year,
+    month,
+  }: {
+    slug: string;
+    year: number;
+    /** 1-12. */
+    month: number;
+  } = $props();
+
+  const profileQuery = $derived(useQuery(userProfileQuery({ slug })));
+  const profile = $derived(profileQuery.pipe(map(($q) => $q.data)));
+
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth() + 1;
+
+  // Step one month in either direction, rolling the year over at the bounds.
+  const previous = $derived(
+    month === 1 ? { year: year - 1, month: 12 } : { year, month: month - 1 },
+  );
+  const next = $derived(
+    month === 12 ? { year: year + 1, month: 1 } : { year, month: month + 1 },
+  );
+
+  // Allow forward navigation up to (and including) the current month.
+  const canGoNext = $derived(
+    next.year < currentYear ||
+      (next.year === currentYear && next.month <= currentMonth),
+  );
+
+  const monthName = $derived(
+    toHumanMonth(new Date(year, month - 1, 1), languageTag()),
+  );
+  const periodLabel = $derived(`${monthName} ${year}`);
+  const shareLabel = $derived(periodLabel);
+
+  const prevUrl = $derived(
+    UrlBuilder.users(slug).monthInReview(previous.year, previous.month),
+  );
+  const nextUrl = $derived(
+    UrlBuilder.users(slug).monthInReview(next.year, next.month),
+  );
+
+  function isTextInputTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false;
+    const tag = target.tagName;
+    return (
+      tag === "INPUT" ||
+      tag === "TEXTAREA" ||
+      tag === "SELECT" ||
+      target.isContentEditable
+    );
+  }
+
+  const { share } = $derived(useShare({ id: "mir" }));
+
+  const shareData = $derived({
+    title: m.mir_share_text({ month: shareLabel }),
+    text: m.mir_share_text({ month: shareLabel }),
+    url: browser ? page.url.toString() : "",
+  });
+
+  const canShare = $derived(
+    browser && !!navigator.canShare && navigator.canShare(shareData),
+  );
+</script>
+
+<svelte:window
+  use:shortcut={{
+    trigger: [
+      {
+        key: "ArrowLeft",
+        modifier: false,
+        // preventDefault is handled inside the callback so we don't hijack
+        // cursor navigation while the user is typing in a text input.
+        callback: ({ originalEvent }) => {
+          if (isTextInputTarget(originalEvent.target)) return;
+          originalEvent.preventDefault();
+          goto(prevUrl);
+        },
+      },
+      {
+        key: "ArrowRight",
+        modifier: false,
+        enabled: canGoNext,
+        callback: ({ originalEvent }) => {
+          if (isTextInputTarget(originalEvent.target)) return;
+          originalEvent.preventDefault();
+          goto(nextUrl);
+        },
+      },
+    ],
+  }}
+/>
+
+<header class="trakt-mir-header" use:trackWindowScroll={"scrolled"}>
+  <nav class="mir-header-section mir-header-center">
+    <a
+      href={prevUrl}
+      class="mir-header-nav-btn"
+      aria-label={m.yir_button_previous()}
+    >
+      <CaretLeftIcon />
+    </a>
+    <span class="mir-header-period-label">
+      <strong>{periodLabel}</strong>
+      <span class="mir-header-period">{m.mir_title_month_in_review()}</span>
+    </span>
+    {#if canGoNext}
+      <a
+        href={nextUrl}
+        class="mir-header-nav-btn"
+        aria-label={m.yir_button_next()}
+      >
+        <CaretRightIcon />
+      </a>
+    {:else}
+      <span class="mir-header-nav-btn disabled" aria-hidden="true">
+        <CaretRightIcon />
+      </span>
+    {/if}
+  </nav>
+
+  {#if $profile && ($profile.isVip || $profile.isDirector)}
+    <div class="mir-header-vip">
+      <VipBadge isDirector={$profile.isDirector} />
+    </div>
+  {/if}
+  {#if $profile}
+    <a href={UrlBuilder.profile.user(slug)} class="mir-header-user">
+      <div class="mir-header-avatar">
+        <CrossOriginImage src={$profile.avatar.url} alt="" />
+      </div>
+      <span class="mir-header-username">{$profile.username}</span>
+    </a>
+  {/if}
+  {#if canShare}
+    <button
+      class="mir-header-share"
+      onclick={() => share(shareData)}
+      aria-label={m.button_label_share({ title: m.mir_share_text({
+        month: shareLabel,
+      }) })}
+    >
+      <ShareIcon />
+    </button>
+  {/if}
+</header>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-mir-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
+
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--gap-m);
+
+    padding: var(--ni-20) var(--ni-10);
+
+    background: transparent;
+    color: var(--shade-10);
+
+    transition:
+      background-color 0.2s,
+      backdrop-filter 0.2s;
+
+    &:hover,
+    &:global(.scrolled) {
+      background: var(--color-background-mobile-navbar);
+      box-shadow: var(--shadow-navbar);
+      backdrop-filter: blur(var(--ni-8));
+
+      color: var(--color-text-primary);
+
+      :global(.mir-header-nav-btn),
+      :global(.mir-header-user),
+      :global(.mir-header-share) {
+        color: var(--color-text-primary);
+      }
+    }
+  }
+
+  .mir-header-section {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-s);
+    min-width: 0;
+  }
+
+  .mir-header-center {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    gap: var(--gap-s);
+  }
+
+  .mir-header-nav-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--ni-8);
+    background: none;
+    border: none;
+    color: var(--shade-10);
+    cursor: pointer;
+    text-decoration: none;
+    transition: color 0.2s;
+
+    &:hover:not(.disabled) {
+      color: var(--purple-300);
+    }
+
+    &.disabled {
+      opacity: 0.3;
+      cursor: default;
+    }
+
+    :global(svg) {
+      width: var(--ni-14);
+      height: var(--ni-14);
+    }
+  }
+
+  .mir-header-period-label {
+    font-size: var(--font-size-text);
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    white-space: nowrap;
+
+    strong {
+      font-weight: 700;
+    }
+  }
+
+  .mir-header-user {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+    color: var(--shade-10);
+    text-decoration: none;
+    min-width: 0;
+  }
+
+  .mir-header-avatar {
+    width: var(--ni-28);
+    height: var(--ni-28);
+    border-radius: 50%;
+    overflow: hidden;
+    background: var(--shade-800);
+    flex-shrink: 0;
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+
+  .mir-header-username {
+    font-size: var(--font-size-text);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .mir-header-share {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--ni-8);
+    background: none;
+    border: none;
+    color: var(--shade-10);
+    cursor: pointer;
+    transition: color 0.2s;
+
+    &:hover {
+      color: var(--purple-300);
+    }
+
+    :global(svg) {
+      width: var(--ni-20);
+      height: var(--ni-20);
+    }
+  }
+
+  @include for-tablet-sm-and-below {
+    .mir-header-period {
+      display: none;
+    }
+
+    .mir-header-username {
+      display: none;
+    }
+  }
+
+  @include for-mobile {
+    .trakt-mir-header {
+      padding: var(--ni-8) var(--ni-12);
+      gap: var(--gap-xs);
+    }
+
+    .mir-header-vip {
+      display: none;
+    }
+
+    .mir-header-user {
+      margin-right: auto;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/yir/_internal/YirStreamingBubbleChart.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirStreamingBubbleChart.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import BubbleChart from "$lib/components/charts/BubbleChart.svelte";
+  import { useQuery } from "$lib/features/query/useQuery";
+  import type { YirStreamingService } from "$lib/requests/models/YirDetail.ts";
+  import { streamingSourcesQuery } from "$lib/requests/queries/services/streamingSourcesQuery.ts";
+  import { map } from "rxjs";
+  import type { Snippet } from "svelte";
+
+  type ServiceTooltipArgs = {
+    service: YirStreamingService;
+  };
+
+  type YirStreamingBubbleChartProps = {
+    services: YirStreamingService[];
+    /** ISO 3166-1 alpha-2 country whose source catalog provides the logos. */
+    country: string;
+    tooltip: Snippet<[ServiceTooltipArgs]>;
+  };
+
+  const {
+    services,
+    country,
+    tooltip: tooltipSnippet,
+  }: YirStreamingBubbleChartProps = $props();
+
+  // Services without a brand color fall back to a neutral semantic gray so the
+  // bubble still reads against the dark panel.
+  const fallbackColor = "var(--shade-800)";
+
+  const sourcesQuery = useQuery(streamingSourcesQuery({}));
+  const sources = sourcesQuery.pipe(map(($query) => $query.data));
+
+  // Resolve each service's brand logo + color from the watchnow source catalog
+  // (keyed by country, with an all-country fallback) so bubbles render real
+  // logos rather than bare labels. `id` is the index, used to map back to the
+  // service in the tooltip.
+  const items = $derived.by(() => {
+    const byCountry = $sources;
+    const inCountry = byCountry?.get(country) ?? [];
+    const everywhere = byCountry ? Array.from(byCountry.values()).flat() : [];
+
+    return services.map((service, index) => {
+      const match = inCountry.find((source) => source.source === service.source) ??
+        everywhere.find((source) => source.source === service.source);
+
+      return {
+        id: index,
+        label: service.name,
+        value: service.all,
+        imageUrl: match?.logoUrl,
+        color: match?.color ?? fallbackColor,
+      };
+    });
+  });
+
+  const serviceByIndex = $derived(
+    new Map(services.map((service, index) => [index, service] as const)),
+  );
+</script>
+
+<BubbleChart {items}>
+  {#snippet tooltip({ item })}
+    {@const service = serviceByIndex.get(item.id)}
+    {#if service}
+      {@render tooltipSnippet({ service })}
+    {/if}
+  {/snippet}
+</BubbleChart>

--- a/projects/client/src/lib/sections/yir/_internal/useMirDetail.ts
+++ b/projects/client/src/lib/sections/yir/_internal/useMirDetail.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import { mirDetailQuery } from '$lib/requests/queries/users/mirDetailQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { map } from 'rxjs';
+
+type UseMirDetailProps = {
+  slug: string;
+  year: number;
+  month: number;
+};
+
+export function useMirDetail(props: UseMirDetailProps) {
+  const query = useQuery(mirDetailQuery(props));
+
+  return {
+    detail: query.pipe(map(($query) => $query.data)),
+    isLoading: query.pipe(map(toLoadingState)),
+  };
+}

--- a/projects/client/src/lib/utils/formatting/date/toHumanClockHour.ts
+++ b/projects/client/src/lib/utils/formatting/date/toHumanClockHour.ts
@@ -1,0 +1,16 @@
+import type { AvailableLanguage } from '$lib/features/i18n/index.ts';
+
+/**
+ * Compact hour-of-day label without minutes, e.g. "12am" / "1pm" (12-hour
+ * locales) or "13" (24-hour locales). Used for hourly chart axes where the
+ * ":00" from {@link toHumanClockTime} is redundant noise.
+ */
+export function toHumanClockHour(
+  date: Date,
+  locale: AvailableLanguage = 'en',
+): string {
+  return date
+    .toLocaleTimeString(locale, { hour: 'numeric' })
+    .replace(/\s+/g, '')
+    .toLowerCase();
+}

--- a/projects/client/src/mocks/data/users/response/UserMonthInReviewResponseMock.ts
+++ b/projects/client/src/mocks/data/users/response/UserMonthInReviewResponseMock.ts
@@ -179,6 +179,15 @@ export const UserMonthInReviewResponseMock: MonthInReviewResponse = {
   },
   'streaming_services': {
     'country': 'us',
-    'services': [],
+    'services': [
+      {
+        'source': 'netflix',
+        'name': 'Netflix',
+        'shows': 1,
+        'movies': 2,
+        'all': 3,
+      },
+      { 'source': 'hulu', 'name': 'Hulu', 'shows': 0, 'movies': 1, 'all': 1 },
+    ],
   },
 };

--- a/projects/client/src/routes/users/[user]/mir/+page.ts
+++ b/projects/client/src/routes/users/[user]/mir/+page.ts
@@ -1,0 +1,16 @@
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
+import { redirect } from '@sveltejs/kit';
+import { subMonths } from 'date-fns/subMonths';
+import type { PageLoad } from './$types';
+
+// Short URL: /users/:user/mir (no year/month) redirects to the previous month's review.
+// Query params (e.g. ?embedded_mode&slurm=1) are preserved across the redirect.
+export const load: PageLoad = ({ params, url }) => {
+  const previousMonth = subMonths(new Date(), 1);
+  const target = UrlBuilder.users(params.user).monthInReview(
+    previousMonth.getFullYear(),
+    previousMonth.getMonth() + 1,
+  );
+
+  return redirect(307, `${target}${url.search}`);
+};

--- a/projects/client/src/routes/users/[user]/mir/[year]/[month]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/mir/[year]/[month]/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import Frame from "$lib/components/frame/Frame.svelte";
+  import { useIsMe } from "$lib/features/auth/stores/useIsMe";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import * as m from "$lib/features/i18n/messages.ts";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import MirPage from "$lib/sections/yir/MirPage.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
@@ -10,7 +14,11 @@
 
   const { params }: PageProps = $props();
 
-  const audience = $derived(params.user === "me" ? "authenticated" : "all");
+  const { isMe } = $derived(useIsMe(params.user));
+  const audience = $derived($isMe ? "authenticated" : "all");
+
+  const year = $derived(Number(params.year));
+  const month = $derived(Number(params.month));
 </script>
 
 <TraktPage
@@ -19,22 +27,27 @@
   title={m.page_title_month_in_review()}
   mode="content-only"
 >
-  <NavbarStateSetter mode="minimal" />
+  <NavbarStateSetter mode="minimal" sidebar={{ mode: "fixed" }} />
 
   <TraktPageCoverSetter />
 
-  <Frame
-    slug={params.user}
-    urlBuilder={(slug: string, token: string | Nil) => {
-      return UrlBuilder.og.frame.monthInReview(
-        slug,
-        params.year,
-        params.month,
-        token,
-      );
-    }}
-    title={m.page_title_month_in_review()}
-    mode="cover"
-    source="mir"
-  />
+  <RenderForFeature flag={FeatureFlag.MonthInReview}>
+    {#snippet enabled()}
+      <MirPage slug={params.user} {year} {month} />
+    {/snippet}
+
+    <Frame
+      slug={params.user}
+      urlBuilder={(slug, token) =>
+        UrlBuilder.og.frame.monthInReview(
+          slug,
+          params.year,
+          params.month,
+          token,
+        )}
+      title={m.page_title_month_in_review()}
+      mode="cover"
+      source="mir"
+    />
+  </RenderForFeature>
 </TraktPage>


### PR DESCRIPTION
Adds a native v3 **Month in Review (MIR)** page that reuses the existing 2024 Year in Review template in "MIR mode" — mirroring how v2 reuses the same 2024 template via `monthly_mode?`. Previously `/users/:user/mir/:year/:month` only rendered the legacy v2 iframe.

# Screenshots

<img width="1788" height="1144" alt="image" src="https://github.com/user-attachments/assets/7d8d9248-0f68-4524-a8f2-b84af164f167" />

<img width="1788" height="1144" alt="image" src="https://github.com/user-attachments/assets/0e45b758-dca2-4928-a15b-de660b0f7e71" />


# Behaviour

- **Route:** `/users/:user/mir/:year/:month` renders the native page when   `FeatureFlag.MonthInReview` is enabled, and falls back to the v2 iframe (`Frame`) otherwise — exactly how the `/year` route gates YIR.
- **Short URL:** `/users/:user/mir` (no year/month) `307`-redirects to the previous month, preserving query params (e.g. `?embedded_mode&slurm=1`).
- **MIR mode** (vs YIR) on the shared 2024 template:
  - **Adds** a Streaming Services section (rendered right after the first-play card): a per-service stat list (shows/movies counts as pills + total service count) plus a bubble-pack chart with real service logos.
  - **Hides** people, thanks, networks, studios, countries, highest-rated, and trends.
  - **Limits** most-played to the top 3 (YIR keeps 10).
  - **Swaps** the per-type Stats section to a monthly variant: "In {Month}" framing, a per-day-of-month bar chart, most-active-day, and hourly / day-of-week cards.
  - Hero shows the lowercase **month name** instead of "year in review".
  - Month-aware header with prev/next **month** navigation + share.

# Architecture

The 2024 template (`Yir2024.svelte`) gains a `mode: 'yir' | 'mir'` prop (default `'yir'`, so YIR is unchanged) and a `month`. Both `YirPage` (year) and `MirPage` (month) render the same template, which switches on `mode` to drive its section components. `MirPage` + `MirHeader` are thin shells; everything else (sections, data model, mapper) is reused.

# Data

- New `mirDetailQuery` calls the typed `@trakt/api` `month_in_review` SDK method and reuses `mapToYirDetail` (the ts-rest client doesn't strip response fields, so the rich payload is available at runtime).
- `YirDetail` extended with `streamingServices` and a per-day-of-month `daily` distribution (both nullish — YIR is unaffected).

# Companion API change (trakt-website)

The shared `year_in_review.json.jbuilder` serializer now also emits `distributions.daily` (plays per day-of-month, from `monthly_distributions`) for MIR — the v3 monthly stats chart and "most active day" depend on it.

**Already deployed.**

# Tooltip clipping fix (YIR + MIR)

Carbon tooltips were clipped by `overflow: hidden` on the chart wrapper and the stats panel. Fixed in both `Yir2024StatsSection` (YIR) and `Yir2024StatsMonthlySection` (MIR): chart wrappers go `overflow: visible` and
the watermark moves into its own clip wrapper so the panel can stay visible.

# i18n

Adds `mir_title_month_in_review`, `mir_share_text`, `yir_2024_streaming_*`, and `yir_2024_stats_*_monthly` / `yir_2024_stats_most_active_day` keys to `i18n/meta/en.json` (generated output is rebuilt by the prebuild step).

# Testing

- `mirDetailQuery.spec.ts` covers the streaming + first-play mapping.
- `deno task check` → 0 errors / 0 warnings; `deno fmt` + ESLint clean (`MirHeader` carries the same pre-existing `no-navigation-without-resolve` findings as `YirHeader` — the module-wide `UrlBuilder` + `goto`/`href` pattern).

# Notes

- Streaming stat counts aren't deep-linked to history (v3 YIR sections don't link to history either); easy to add later.
- The monthly stats section is a deliberate sibling of the yearly one (the two diverge enough — daily vs weekly summary, hourly vs monthly card, most-active day vs week).
