### PR TITLE
feat(i18n): add generic empty state placeholder text

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2890,6 +2890,10 @@
       "default": "Edit List",
       "description": "Title for a screen that allows users to edit an existing list."
     },
+    "text_placeholder_generic": {
+      "default": "Nothing to see here.",
+      "description": "Generic placeholder text shown when a section or list has no content to display."
+    },
     "list_placeholder_personal_list_empty": {
       "default": "There is nothing in this list yet.",
       "description": "Placeholder text shown when there are no shows or movies in a user's personal list."


### PR DESCRIPTION
We currently have list_placeholder_empty, but its description dictates that it should be used specifically for "movies or shows in the user's watchlist".

We need a truly context-agnostic empty state (eg. "Nothing to see here.") for a few reasons:
- Misleading Context: We don't want to confuse translators by using watchlist-specific strings in unrelated areas of the app.
- Non-List UI: We need a generic placeholder for areas that lack content but aren't actually "lists" in the traditional sense, such as empty user ratings or empty social activity feeds.

I'm open to adjustments to the actual placeholder message