### PR TITLE
feat(shows): add rewatching sessions

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -421,6 +421,45 @@
       "default": "Watch again",
       "description": "Text for the button that allows users to mark a movie, episode, or show as re-watched."
     },
+    "button_text_start_rewatching": {
+      "default": "Start rewatching",
+      "description": "Text for the button that opens the rewatching drawer for a show."
+    },
+    "button_label_start_rewatching": {
+      "default": "Start rewatching \"{title}\"",
+      "description": "Aria-label for the button that opens the rewatching drawer for a show.",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "button_text_stop_rewatching": {
+      "default": "Stop rewatching",
+      "description": "Text for the button that stops an active rewatching session for a show."
+    },
+    "button_label_stop_rewatching": {
+      "default": "Stop rewatching \"{title}\"",
+      "description": "Aria-label for the button that stops an active rewatching session for a show.",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "confirmation_title_rewatching_prompt": {
+      "default": "Are you rewatching \"{title}\"?",
+      "description": "Title for a confirmation dialog that asks whether the user is currently rewatching the show after rewatching an episode.",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "confirmation_message_rewatching_prompt": {
+      "default": "Starting a rewatching session will update your Continue Watching.",
+      "description": "Message for a confirmation dialog explaining that starting a rewatching session will update the user's Up Next."
+    },
     "button_label_add_to_watchlist": {
       "default": "Add \"{title}\" to your Watchlist",
       "description": "Aria-label for the button that adds a movie or show to the user's watchlist.",
@@ -1352,6 +1391,18 @@
     "list_title_episodes": {
       "default": "Episodes",
       "description": "Title for lists containing episodes of a season. This title should be as short and concise as possible."
+    },
+    "drawer_title_rewatching": {
+      "default": "Rewatching",
+      "description": "Title for the drawer that lets users pick the next episode for a show rewatching session. This should be short and concise."
+    },
+    "text_rewatching_next_episode_prompt": {
+      "default": "What's the next episode you want to rewatch?",
+      "description": "Prompt shown above the episode list in the rewatching drawer."
+    },
+    "text_rewatching_no_episodes": {
+      "default": "There are no aired episodes to rewatch yet.",
+      "description": "Empty-state text shown in the rewatching drawer when no aired episodes are available."
     },
     "list_title_seasons": {
       "default": "Seasons",
@@ -4263,6 +4314,10 @@
     "tag_text_started": {
       "default": "Started",
       "description": "Text for the tag that is shown to indicate a show is started but not completed. This should be as short as possible."
+    },
+    "tag_text_rewatching": {
+      "default": "Rewatching",
+      "description": "Text for the tag that is shown to indicate a show has an active rewatching session. This should be as short as possible."
     },
     "header_height": {
       "default": "Height",
@@ -7370,6 +7425,14 @@
     "preview_feature_description_smart_related": {
       "default": "Use our next-gen engine to surface related movies and shows beyond the obvious.",
       "description": "Description for the Smart Related preview feature."
+    },
+    "preview_feature_title_rewatch": {
+      "default": "Rewatch",
+      "description": "Title for the Rewatch preview feature."
+    },
+    "preview_feature_description_rewatch": {
+      "default": "Start rewatching sessions for shows you've already seen, check in or mark watched episodes directly from the session drawer.",
+      "description": "Description for the Rewatch preview feature."
     },
     "header_official_links": {
       "default": "Official Links",

--- a/projects/client/src/lib/components/icons/FastRewindIcon.svelte
+++ b/projects/client/src/lib/components/icons/FastRewindIcon.svelte
@@ -1,0 +1,9 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="currentColor"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path d="M11 18V6L2.5 12L11 18ZM11.5 12L20 18V6L11.5 12Z" />
+</svg>

--- a/projects/client/src/lib/features/auth/queries/currentUserRewatchingQuery.spec.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserRewatchingQuery.spec.ts
@@ -1,0 +1,18 @@
+import { ShowSiloMinimalResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloMinimalResponseMock.ts';
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { describe, expect, it } from 'vitest';
+import { currentUserRewatchingQuery } from './currentUserRewatchingQuery.ts';
+
+describe('currentUserRewatchingQuery', () => {
+  it('should query rewatching shows', async () => {
+    const result = await runQuery({
+      factory: () => createTestBedQuery(currentUserRewatchingQuery()),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).toEqual({
+      shows: new Set([ShowSiloMinimalResponseMock.ids.trakt]),
+    });
+  });
+});

--- a/projects/client/src/lib/features/auth/queries/currentUserRewatchingQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserRewatchingQuery.ts
@@ -1,0 +1,55 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { z } from 'zod';
+
+const RewatchingShowResponseSchema = z.object({
+  hidden_at: z.string().datetime().nullish(),
+  type: z.literal('show'),
+  show: z.object({
+    ids: z.object({
+      trakt: z.number(),
+    }),
+  }),
+});
+
+const CurrentUserRewatchingResponseSchema = z.array(
+  RewatchingShowResponseSchema,
+);
+
+export const UserRewatchingSchema = z.object({
+  shows: z.set(z.number()),
+});
+
+export type UserRewatching = z.infer<typeof UserRewatchingSchema>;
+
+const currentUserRewatchingRequest = async ({ fetch }: ApiParams) => {
+  const response = await rawApiFetch({
+    fetch,
+    path: '/users/hidden/progress_watched_reset?type=show&limit=1000',
+  });
+
+  if (!response.ok) {
+    return { body: [], status: 200 };
+  }
+
+  return {
+    body: CurrentUserRewatchingResponseSchema.parse(await response.json()),
+    status: 200,
+  };
+};
+
+export const currentUserRewatchingQuery = defineQuery({
+  key: 'currentUserRewatching',
+  invalidations: [
+    InvalidateAction.Rewatching('show'),
+  ],
+  dependencies: [],
+  request: currentUserRewatchingRequest,
+  mapper: (response) => ({
+    shows: new Set(response.body.map((entry) => entry.show.ids.trakt)),
+  }),
+  schema: UserRewatchingSchema,
+  ttl: time.minutes(5),
+});

--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -40,6 +40,10 @@ import {
   type UserRatings,
 } from '../queries/currentUserRatingsQuery.ts';
 import {
+  currentUserRewatchingQuery,
+  type UserRewatching,
+} from '../queries/currentUserRewatchingQuery.ts';
+import {
   currentUserSettingsQuery,
   type UserSettings,
 } from '../queries/currentUserSettingsQuery.ts';
@@ -134,6 +138,7 @@ function createUseUserInstance() {
   const limitsQuerySignal = useQuery(userLimitsQuery());
   const notesQuerySignal = useQuery(currentUserNotesQuery());
   const droppedQuerySignal = useQuery(currentUserDroppedQuery());
+  const rewatchingQuerySignal = useQuery(currentUserRewatchingQuery());
   const blockedQuerySignal = useQuery(blockedUsersQuery());
 
   // Create a stream that switches between authorized and anonymous state
@@ -183,6 +188,9 @@ function createUseUserInstance() {
           dropped: of<UserDroppedHistory>({
             shows: new Set(),
           }),
+          rewatching: of<UserRewatching>({
+            shows: new Set(),
+          }),
           blocked: of<Set<string>>(new Set()),
         });
       }
@@ -225,6 +233,9 @@ function createUseUserInstance() {
         dropped: droppedQuerySignal.pipe(
           map((dropped) => dropped.data),
         ),
+        rewatching: rewatchingQuerySignal.pipe(
+          map((rewatching) => rewatching.data),
+        ),
         blocked: blockedQuerySignal.pipe(
           map((blocked) =>
             new Set(
@@ -256,6 +267,7 @@ function createUseUserInstance() {
     limits: sharedUserContext$.pipe(switchMap((ctx) => ctx.limits)),
     notes: sharedUserContext$.pipe(switchMap((ctx) => ctx.notes)),
     dropped: sharedUserContext$.pipe(switchMap((ctx) => ctx.dropped)),
+    rewatching: sharedUserContext$.pipe(switchMap((ctx) => ctx.rewatching)),
     blocked: sharedUserContext$.pipe(switchMap((ctx) => ctx.blocked)),
   };
 }

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
@@ -58,6 +58,12 @@ const CONFIRMATION_BUILDERS: ConfirmationBuilders = {
     message: m.warning_prompt_restore_show({ title: props.title }),
     operation: 'affirmative',
   }),
+  [ConfirmationType.StartRewatching]: (props) => ({
+    title: m.confirmation_title_rewatching_prompt({ title: props.title }),
+    buttonText: m.button_text_start_rewatching(),
+    message: m.confirmation_message_rewatching_prompt(),
+    operation: 'affirmative',
+  }),
   [ConfirmationType.DeleteList]: (props) => ({
     title: m.confirmation_title_delete_list(),
     buttonText: m.button_text_delete_list(),

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
@@ -44,6 +44,10 @@ interface ConfirmationParamsMap {
     type: ConfirmationType.RestoreShow;
     title: string;
   };
+  [ConfirmationType.StartRewatching]: {
+    type: ConfirmationType.StartRewatching;
+    title: string;
+  };
   [ConfirmationType.RemoveFavorite]: {
     type: ConfirmationType.RemoveFavorite;
     title: string;

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
@@ -5,6 +5,7 @@ export enum ConfirmationType {
   DropShow = 'drop-show',
   DropMovie = 'drop-movie',
   RestoreShow = 'restore-show',
+  StartRewatching = 'start-rewatching',
   DeleteList = 'delete-list',
   RemoveFavorite = 'remove-favorite',
   RemoveFromWatchList = 'remove-from-watchlist',

--- a/projects/client/src/lib/features/feature-flag/FeatureFlagTool.svelte
+++ b/projects/client/src/lib/features/feature-flag/FeatureFlagTool.svelte
@@ -29,7 +29,15 @@
       hasAutoClose={false}
       size="auto"
     >
-      <FeatureFlagItems />
+      <div class="trakt-feature-flag-items">
+        <FeatureFlagItems />
+      </div>
     </Drawer>
   {/if}
 </RenderFor>
+
+<style>
+  .trakt-feature-flag-items {
+    overflow-y: auto;
+  }
+</style>

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -7,4 +7,5 @@ export enum FeatureFlag {
   SocialActivities = 'social-activities',
   PlexSync = 'plex-sync',
   SmartRelated = 'smart-related',
+  Rewatching = 'rewatching',
 }

--- a/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
+++ b/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
@@ -1,6 +1,7 @@
 import BrainIcon from '$lib/components/icons/BrainIcon.svelte';
 import CalendarIcon from '$lib/components/icons/CalendarIcon.svelte';
 import EditModeIcon from '$lib/components/icons/EditModeIcon.svelte';
+import FastRewindIcon from '$lib/components/icons/FastRewindIcon.svelte';
 import FavoriteIcon from '$lib/components/icons/FavoriteIcon.svelte';
 import PlexLibraryIcon from '$lib/components/icons/PlexLibraryIcon.svelte';
 import SocialIcon from '$lib/components/icons/SocialIcon.svelte';
@@ -104,5 +105,10 @@ export const featureFlagDefinitions: FeatureFlagDefinitions = {
     title: () => m.preview_feature_title_smart_related(),
     description: () => m.preview_feature_description_smart_related(),
     audience: 'director',
+  },
+  [FeatureFlag.Rewatching]: {
+    icon: FastRewindIcon,
+    title: () => m.preview_feature_title_rewatch(),
+    description: () => m.preview_feature_description_rewatch(),
   },
 };

--- a/projects/client/src/lib/requests/_internal/mapToEpisodeEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToEpisodeEntry.ts
@@ -3,7 +3,11 @@ import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { MAX_DATE } from '$lib/utils/constants.ts';
 import { findDefined } from '$lib/utils/string/findDefined.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
-import type { CalendarShowResponse, UpNextResponse } from '@trakt/api';
+import type {
+  CalendarShowResponse,
+  EpisodeResponse as TraktEpisodeResponse,
+  UpNextResponse,
+} from '@trakt/api';
 import type { EpisodeEntry } from '../models/EpisodeEntry.ts';
 import { type EpisodeType, EpisodeUnknownType } from '../models/EpisodeType.ts';
 import { mapToPostCredits } from './mapToPostCredits.ts';
@@ -11,7 +15,8 @@ import { mapToTraktRating } from './mapToTraktRating.ts';
 
 type EpisodeResponse =
   | UpNextResponse['progress']['next_episode']
-  | CalendarShowResponse['episode'];
+  | CalendarShowResponse['episode']
+  | TraktEpisodeResponse;
 
 export function mapToEpisodeEntry(
   episodeResponse: EpisodeResponse,

--- a/projects/client/src/lib/requests/models/InvalidateAction.ts
+++ b/projects/client/src/lib/requests/models/InvalidateAction.ts
@@ -5,6 +5,7 @@ type UserType = 'avatar' | 'settings' | 'follow' | 'cover' | 'block';
 type ListType = 'edited' | 'deleted' | 'created' | 'like';
 type VipType = 'canceled' | 'updated';
 type PlexType = 'settings' | 'syncs';
+type RewatchingType = 'show';
 
 const INVALIDATION_ID = 'invalidate' as const;
 
@@ -27,6 +28,7 @@ export type InvalidateActionOptions =
   | `${typeof INVALIDATION_ID}:notes_edit:${MediaType}`
   | `${typeof INVALIDATION_ID}:notes_delete:${MediaType}`
   | `${typeof INVALIDATION_ID}:vip:${VipType}`
+  | `${typeof INVALIDATION_ID}:rewatching:${RewatchingType}`
   | `${typeof INVALIDATION_ID}:hide_recommended:${MediaType}`
   | `${typeof INVALIDATION_ID}:streaming_connection`
   | `${typeof INVALIDATION_ID}:data_sync`
@@ -53,6 +55,7 @@ type TypeDataMap = {
   'notes_edit': MediaType;
   'notes_delete': MediaType;
   'vip': VipType;
+  'rewatching': RewatchingType;
   'hide_recommended': MediaType;
   'streaming_connection': null;
   'data_sync': null;
@@ -135,6 +138,9 @@ export const InvalidateAction = {
     Canceled: buildInvalidationKey('vip', 'canceled'),
     Updated: buildInvalidationKey('vip', 'updated'),
   },
+
+  Rewatching: (type: RewatchingType) =>
+    buildInvalidationKey('rewatching', type),
 
   HideRecommended: (type: MediaType) =>
     buildInvalidationKey('hide_recommended', type),

--- a/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showProgressQuery.ts
@@ -85,6 +85,7 @@ export const showProgressQuery = defineQuery({
   invalidations: [
     InvalidateAction.MarkAsWatched('show'),
     InvalidateAction.MarkAsWatched('episode'),
+    InvalidateAction.Rewatching('show'),
   ],
   dependencies: (params) => [params.slug],
   request: showProgressRequest,

--- a/projects/client/src/lib/requests/queries/shows/showRewatchingRequest.spec.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRewatchingRequest.spec.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { startShowRewatchingRequest } from './startShowRewatchingRequest.ts';
+import { stopShowRewatchingRequest } from './stopShowRewatchingRequest.ts';
+
+describe('show rewatching requests', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should start a rewatch session one minute before now', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T12:00:00.000Z'));
+
+    const fetch = vi.fn(() =>
+      Promise.resolve(new Response(null, { status: 204 }))
+    ) as unknown as typeof globalThis.fetch;
+
+    const result = await startShowRewatchingRequest({
+      fetch,
+      id: 123,
+    });
+
+    expect(result).to.equal(true);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost/shows/123/progress/watched/reset',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ reset_at: '2026-06-18T11:59:00.000Z' }),
+      }),
+    );
+  });
+
+  it('should stop a rewatch session', async () => {
+    const fetch = vi.fn(() =>
+      Promise.resolve(new Response(null, { status: 204 }))
+    ) as unknown as typeof globalThis.fetch;
+
+    const result = await stopShowRewatchingRequest({
+      fetch,
+      id: 123,
+    });
+
+    expect(result).to.equal(true);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost/shows/123/progress/watched/reset',
+      expect.objectContaining({
+        method: 'DELETE',
+      }),
+    );
+  });
+});

--- a/projects/client/src/lib/requests/queries/shows/showRewatchingRequest.spec.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRewatchingRequest.spec.ts
@@ -7,7 +7,7 @@ describe('show rewatching requests', () => {
     vi.useRealTimers();
   });
 
-  it('should start a rewatch session one minute before now', async () => {
+  it('should start a rewatch session three minutes before now', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-18T12:00:00.000Z'));
 
@@ -25,7 +25,7 @@ describe('show rewatching requests', () => {
       'http://localhost/shows/123/progress/watched/reset',
       expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({ reset_at: '2026-06-18T11:59:00.000Z' }),
+        body: JSON.stringify({ reset_at: '2026-06-18T11:57:00.000Z' }),
       }),
     );
   });

--- a/projects/client/src/lib/requests/queries/shows/startShowRewatchingRequest.ts
+++ b/projects/client/src/lib/requests/queries/shows/startShowRewatchingRequest.ts
@@ -9,7 +9,7 @@ type StartShowRewatchingParams = {
 export async function startShowRewatchingRequest(
   { fetch, id }: StartShowRewatchingParams,
 ): Promise<boolean> {
-  const resetAt = new Date(Date.now() - time.minutes(1)).toISOString();
+  const resetAt = new Date(Date.now() - time.minutes(3)).toISOString();
 
   const response = await rawApiFetch({
     fetch,

--- a/projects/client/src/lib/requests/queries/shows/startShowRewatchingRequest.ts
+++ b/projects/client/src/lib/requests/queries/shows/startShowRewatchingRequest.ts
@@ -1,0 +1,28 @@
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { isValidResponse } from '$lib/features/query/_internal/isValidResponse.ts';
+import { time } from '$lib/utils/timing/time.ts';
+
+type StartShowRewatchingParams = {
+  id: number | string;
+} & ApiParams;
+
+export async function startShowRewatchingRequest(
+  { fetch, id }: StartShowRewatchingParams,
+): Promise<boolean> {
+  const resetAt = new Date(Date.now() - time.minutes(1)).toISOString();
+
+  const response = await rawApiFetch({
+    fetch,
+    path: `/shows/${encodeURIComponent(`${id}`)}/progress/watched/reset`,
+    init: {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ reset_at: resetAt }),
+    },
+  });
+
+  isValidResponse(response, 'startShowRewatchingRequest');
+  return response.ok;
+}

--- a/projects/client/src/lib/requests/queries/shows/stopShowRewatchingRequest.ts
+++ b/projects/client/src/lib/requests/queries/shows/stopShowRewatchingRequest.ts
@@ -1,0 +1,21 @@
+import { isValidResponse } from '$lib/features/query/_internal/isValidResponse.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+
+type StopShowRewatchingParams = {
+  id: number | string;
+} & ApiParams;
+
+export async function stopShowRewatchingRequest(
+  { fetch, id }: StopShowRewatchingParams,
+): Promise<boolean> {
+  const response = await rawApiFetch({
+    fetch,
+    path: `/shows/${encodeURIComponent(`${id}`)}/progress/watched/reset`,
+    init: {
+      method: 'DELETE',
+    },
+  });
+
+  isValidResponse(response, 'stopShowRewatchingRequest');
+  return response.ok;
+}

--- a/projects/client/src/lib/requests/queries/sync/progressWatchedQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/progressWatchedQuery.ts
@@ -74,6 +74,7 @@ export const progressWatchedQuery = defineInfiniteQuery({
     InvalidateAction.MarkAsWatched('episode'),
     InvalidateAction.Drop('show'),
     InvalidateAction.Restore,
+    InvalidateAction.Rewatching('show'),
   ],
   dependencies: (params: ProgressWatchedParams) => [
     params.page,

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -10,6 +10,7 @@
   import type { MediaInputDefault } from "$lib/models/MediaInput";
   import ListsDrawer from "$lib/sections/components/lists-drawer/ListsDrawer.svelte";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
+  import { useIsRewatching } from "$lib/sections/media-actions/rewatching/useIsRewatching";
   import { useIsWatchlisted } from "$lib/stores/useIsWatchlisted";
   import type { Snippet } from "svelte";
   import type { MediaCardProps } from "../components/models/MediaCardProps";
@@ -24,6 +25,7 @@
     style,
     mode,
     tag: externalTag,
+    coverTag: externalCoverTag,
     canDeemphasize,
     ...rest
   }: MediaCardProps<MediaInputDefault> & {
@@ -34,6 +36,7 @@
   const { isWatched, isPartiallyWatched } = $derived(
     useIsWatched({ type, media }),
   );
+  const { isRewatching } = $derived(useIsRewatching({ type, media }));
   const { isWatchlisted } = $derived(useIsWatchlisted({ type, media }));
 
   const isDeemphasized = $derived(canDeemphasize && $isWatched);
@@ -67,6 +70,7 @@
 
 {#snippet indicatorTags()}
   <StatusIndicators
+    isRewatching={$isRewatching}
     isWatched={$isWatched}
     isPartiallyWatched={$isPartiallyWatched}
     isWatchlisted={$isWatchlisted}
@@ -116,6 +120,7 @@
       {media}
       {style}
       tag={rest.variant !== "next" ? tag : undefined}
+      coverTag={externalCoverTag}
       contextualTag={mode === "mixed" ? contextualTag : undefined}
       indicators={indicatorTags}
       {...rest}

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -142,7 +142,108 @@
       ? UrlBuilder.episode(media.slug, rest.episode.season, rest.episode.number)
       : UrlBuilder.media(media.type, media.slug),
   );
+
+  const popupMenuTitle = $derived(
+    rest.type === "episode" ? rest.episode.title : media.title,
+  );
 </script>
+
+{#snippet cardContent()}
+  <div class="trakt-summary-poster">
+    <CardCover
+      title={coverData.title}
+      alt={`Poster for ${coverData.title}`}
+      src={coverData.poster}
+    />
+    {#if indicators}
+      <IndicatorTags>
+        {@render indicators()}
+      </IndicatorTags>
+    {/if}
+  </div>
+
+  <SummaryCardDetails
+    classList={hasMultiLineTitles ? "multi-line-titles" : ""}
+    {tag}
+    {layout}
+  >
+    {#if rest.type === "season"}
+      <p class="trakt-card-title ellipsis">
+        {media.title}
+      </p>
+      <p class="trakt-card-subtitle small secondary ellipsis">
+        {seasonLabel(rest.season.number)}
+      </p>
+    {:else if rest.variant === "activity"}
+      {#if rest.type === "episode"}
+        <p class="trakt-card-title ellipsis">
+          {episodeSubtitle(rest.episode)}
+          {#if !["multiple_episodes", "full_season"].includes(rest.episode.type)}
+            <Spoiler media={rest.episode} show={media} type="episode">
+              - {rest.episode.title}
+            </Spoiler>
+          {/if}
+        </p>
+      {:else}
+        <p class="trakt-card-title ellipsis">
+          {media.title}
+        </p>
+      {/if}
+      <p class="trakt-card-subtitle small secondary ellipsis capitalize">
+        {#if rest.activityType === "social"}
+          {toRelativeHumanDay(new Date(), rest.date, getLocale())}
+        {:else}
+          {toHumanDate(new Date(), rest.date, getLocale())}
+        {/if}
+      </p>
+    {:else if isShowContext && rest.type === "episode"}
+      <p class="trakt-card-title ellipsis">
+        <Spoiler media={rest.episode} show={media} type="episode">
+          {rest.episode.title}
+        </Spoiler>
+      </p>
+      <p class="trakt-card-subtitle small secondary ellipsis">
+        {episodeSubtitle(rest.episode)}
+      </p>
+    {:else if rest.type === "episode" || (rest.variant === "start" && "episode" in rest)}
+      <p class="trakt-card-title ellipsis">
+        {media.title}
+      </p>
+      <p class="trakt-card-subtitle small secondary ellipsis">
+        {episodeNumberLabel({
+          seasonNumber: rest.episode.season,
+          episodeNumber: rest.episode.number,
+        })}
+        {#if rest.variant !== "start"}
+          <Spoiler media={rest.episode} show={media} type="episode">
+            - {rest.episode.title}
+          </Spoiler>
+        {/if}
+      </p>
+    {:else if rest.variant === "credit"}
+      <p class="trakt-card-title ellipsis">
+        {media.title}
+      </p>
+      <p class="trakt-card-subtitle small secondary ellipsis">
+        {rest.role}
+      </p>
+    {:else}
+      <p class="trakt-card-title ellipsis">
+        {media.title}
+      </p>
+      {#if hasDistinctOriginalTitle}
+        <p class="secondary ellipsis">
+          ({media.originalTitle})
+        </p>
+      {/if}
+      <GenreList
+        classList="trakt-card-subtitle small ellipsis secondary"
+        separator=", "
+        genres={media.genres}
+      />
+    {/if}
+  </SummaryCardDetails>
+{/snippet}
 
 <Card
   classList="trakt-summary-card trakt-summary-card-{layout}"
@@ -155,7 +256,7 @@
     <CardActionBar variant={isCompact || isMinimal ? "standalone" : "default"}>
       {#snippet actions()}
         <PopupMenu
-          label={m.button_label_popup_menu({ title: media.title })}
+          label={m.button_label_popup_menu({ title: popupMenuTitle })}
           mode="standalone"
           title={media.title}
         >
@@ -179,100 +280,7 @@
     onclick={() => source && track({ source, type: rest.type })}
     color="inherit"
   >
-    <div class="trakt-summary-poster">
-      <CardCover
-        title={coverData.title}
-        alt={`Poster for ${coverData.title}`}
-        src={coverData.poster}
-      />
-      {#if indicators}
-        <IndicatorTags>
-          {@render indicators()}
-        </IndicatorTags>
-      {/if}
-    </div>
-
-    <SummaryCardDetails
-      classList={hasMultiLineTitles ? "multi-line-titles" : ""}
-      {tag}
-      {layout}
-    >
-      {#if rest.type === "season"}
-        <p class="trakt-card-title ellipsis">
-          {media.title}
-        </p>
-        <p class="trakt-card-subtitle small secondary ellipsis">
-          {seasonLabel(rest.season.number)}
-        </p>
-      {:else if rest.variant === "activity"}
-        {#if rest.type === "episode"}
-          <p class="trakt-card-title ellipsis">
-            {episodeSubtitle(rest.episode)}
-            {#if !["multiple_episodes", "full_season"].includes(rest.episode.type)}
-              <Spoiler media={rest.episode} show={media} type="episode">
-                - {rest.episode.title}
-              </Spoiler>
-            {/if}
-          </p>
-        {:else}
-          <p class="trakt-card-title ellipsis">
-            {media.title}
-          </p>
-        {/if}
-        <p class="trakt-card-subtitle small secondary ellipsis capitalize">
-          {#if rest.activityType === "social"}
-            {toRelativeHumanDay(new Date(), rest.date, getLocale())}
-          {:else}
-            {toHumanDate(new Date(), rest.date, getLocale())}
-          {/if}
-        </p>
-      {:else if isShowContext && rest.type === "episode"}
-        <p class="trakt-card-title ellipsis">
-          <Spoiler media={rest.episode} show={media} type="episode">
-            {rest.episode.title}
-          </Spoiler>
-        </p>
-        <p class="trakt-card-subtitle small secondary ellipsis">
-          {episodeSubtitle(rest.episode)}
-        </p>
-      {:else if rest.type === "episode" || (rest.variant === "start" && "episode" in rest)}
-        <p class="trakt-card-title ellipsis">
-          {media.title}
-        </p>
-        <p class="trakt-card-subtitle small secondary ellipsis">
-          {episodeNumberLabel({
-            seasonNumber: rest.episode.season,
-            episodeNumber: rest.episode.number,
-          })}
-          {#if rest.variant !== "start"}
-            <Spoiler media={rest.episode} show={media} type="episode">
-              - {rest.episode.title}
-            </Spoiler>
-          {/if}
-        </p>
-      {:else if rest.variant === "credit"}
-        <p class="trakt-card-title ellipsis">
-          {media.title}
-        </p>
-        <p class="trakt-card-subtitle small secondary ellipsis">
-          {rest.role}
-        </p>
-      {:else}
-        <p class="trakt-card-title ellipsis">
-          {media.title}
-        </p>
-        {#if hasDistinctOriginalTitle}
-          <p class="secondary ellipsis">
-            ({media.originalTitle})
-          </p>
-        {/if}
-        <GenreList
-          classList="trakt-card-subtitle small ellipsis secondary"
-          separator=", "
-          genres={media.genres}
-        />
-      {/if}
-    </SummaryCardDetails>
+    {@render cardContent()}
   </Link>
 
   <SummaryCardBottomBar {contextualTag} {tag} {layout}>

--- a/projects/client/src/lib/sections/lists/components/StatusIndicators.svelte
+++ b/projects/client/src/lib/sections/lists/components/StatusIndicators.svelte
@@ -1,22 +1,37 @@
 <script lang="ts">
   import BookmarkIcon from "$lib/components/icons/BookmarkIcon.svelte";
+  import FastRewindIcon from "$lib/components/icons/FastRewindIcon.svelte";
   import TrackIcon from "$lib/components/icons/TrackIcon.svelte";
   import IndicatorTag from "$lib/components/media/tags/IndicatorTag.svelte";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
 
   type StatusIndicatorsProps = {
+    isRewatching?: boolean;
     isWatched: boolean;
     isPartiallyWatched?: boolean;
     isWatchlisted: boolean;
   };
 
   const {
+    isRewatching = false,
     isWatched,
     isPartiallyWatched,
     isWatchlisted,
   }: StatusIndicatorsProps = $props();
+
+  const { isEnabled } = useFeatureFlag();
+  const isRewatchingFeatureEnabled = $derived(
+    isEnabled(FeatureFlag.Rewatching),
+  );
+  const showRewatching = $derived(isRewatching && $isRewatchingFeatureEnabled);
 </script>
 
-{#if isWatched || isPartiallyWatched}
+{#if showRewatching}
+  <IndicatorTag>
+    <FastRewindIcon />
+  </IndicatorTag>
+{:else if isWatched || isPartiallyWatched}
   <IndicatorTag variant={isPartiallyWatched ? "partial" : "full"}>
     <TrackIcon />
   </IndicatorTag>

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/MarkAsWatchedDrawerHost.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/_internal/MarkAsWatchedDrawerHost.svelte
@@ -8,11 +8,15 @@
   import TrackIcon from "$lib/components/icons/TrackIcon.svelte";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MarkAsWatchedAt } from "$lib/models/MarkAsWatchedAt";
   import { writable } from "$lib/utils/store/WritableSubject.ts";
+  import { combineLatest, firstValueFrom, map } from "rxjs";
   import { onDestroy } from "svelte";
   import CheckInAction from "../../check-in/CheckInAction.svelte";
+  import { useRewatching } from "../../rewatching/useRewatching.ts";
   import {
     useMarkAsWatched,
     type MarkAsWatchedStoreProps,
@@ -30,8 +34,19 @@
   } & MarkAsWatchedStoreProps = $props();
 
   const { confirm } = useConfirm();
+  const { isEnabled } = useFeatureFlag();
   const { isMarkingAsWatched, markAsWatched, isWatched } = $derived(
     useMarkAsWatched(target),
+  );
+
+  // The rewatching session only applies to a single show episode.
+  const rewatchingShow = $derived(
+    target.type === "episode" && !Array.isArray(target.media)
+      ? target.show
+      : null,
+  );
+  const rewatching = $derived(
+    rewatchingShow ? useRewatching({ show: rewatchingShow }) : null,
   );
 
   const confirmedAction = writable<MarkAsWatchedAt | null>(null);
@@ -47,7 +62,44 @@
     }
   };
 
+  const isRewatchingPromptCandidate = () => Boolean(rewatching) && $isWatched;
+
+  const promptForRewatching = async (
+    session: NonNullable<typeof rewatching>,
+    show: NonNullable<typeof rewatchingShow>,
+  ) => {
+    const canPrompt = await firstValueFrom(
+      combineLatest([
+        isEnabled(FeatureFlag.Rewatching),
+        session.isRewatching,
+      ]).pipe(map(([isFeatureEnabled, isAlreadyRewatching]) =>
+        isFeatureEnabled && !isAlreadyRewatching
+      )),
+    );
+
+    if (!canPrompt) {
+      return;
+    }
+
+    confirm({
+      type: ConfirmationType.StartRewatching,
+      title: show.title,
+      onConfirm: () => session.startRewatching(),
+    })();
+  };
+
+  const promptRewatchingAfterClose = (shouldPrompt: boolean) => {
+    autoClose();
+
+    if (shouldPrompt && rewatching && rewatchingShow) {
+      promptForRewatching(rewatching, rewatchingShow);
+    }
+  };
+
   const handler = async (watchedAt: MarkAsWatchedAt) => {
+    const shouldPromptRewatching =
+      watchedAt === "now" && isRewatchingPromptCandidate();
+
     const confirmMarkAsWatched = confirm({
       type: ConfirmationType.MarkAsWatched,
       title,
@@ -55,7 +107,7 @@
       onConfirm: async () => {
         confirmedAction.set(watchedAt);
         await markAsWatched(watchedAt);
-        autoClose();
+        promptRewatchingAfterClose(shouldPromptRewatching);
       },
     });
 
@@ -90,7 +142,8 @@
         style="dropdown-item"
         variant="primary"
         disabled={commonProps.disabled}
-        onCheckIn={autoClose}
+        onCheckIn={() =>
+          promptRewatchingAfterClose(isRewatchingPromptCandidate())}
       />
     {/if}
 

--- a/projects/client/src/lib/sections/media-actions/rewatching/RewatchingAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/rewatching/RewatchingAction.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import FastRewindIcon from "$lib/components/icons/FastRewindIcon.svelte";
+  import IconWrapper from "$lib/components/icons/IconWrapper.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry";
+  import { useHasWatchedShowEpisodes } from "./useHasWatchedShowEpisodes";
+  import { useRewatching } from "./useRewatching";
+
+  type RewatchingActionProps = {
+    show: ShowEntry;
+    title: string;
+    variant?: "primary" | "secondary";
+    startLink: {
+      href: string;
+      noscroll: boolean;
+      replacestate: boolean;
+    };
+  };
+
+  const {
+    show,
+    title,
+    variant = "primary",
+    startLink,
+  }: RewatchingActionProps = $props();
+
+  const { hasWatchedShowEpisodes } = $derived(
+    useHasWatchedShowEpisodes({ type: "show", media: show }),
+  );
+  const { isRewatching, stopRewatching, isUpdatingRewatching } = $derived(
+    useRewatching({ show }),
+  );
+
+  const isVisible = $derived($isRewatching || $hasWatchedShowEpisodes);
+
+  const onStopRewatching = () => stopRewatching();
+</script>
+
+{#snippet rewindIcon()}
+  <IconWrapper isLoading={$isUpdatingRewatching}>
+    <FastRewindIcon />
+  </IconWrapper>
+{/snippet}
+
+{#if isVisible}
+  {#if $isRewatching}
+    <DropdownItem
+      onclick={onStopRewatching}
+      label={m.button_label_stop_rewatching({ title })}
+      style="flat"
+      color="default"
+      disabled={$isUpdatingRewatching}
+      icon={rewindIcon}
+      {variant}
+    >
+      {m.button_text_stop_rewatching()}
+    </DropdownItem>
+  {:else}
+    <DropdownItem
+      {...startLink}
+      label={m.button_label_start_rewatching({ title })}
+      style="flat"
+      color="default"
+      disabled={$isUpdatingRewatching}
+      icon={rewindIcon}
+      {variant}
+    >
+      {m.button_text_start_rewatching()}
+    </DropdownItem>
+  {/if}
+{/if}

--- a/projects/client/src/lib/sections/media-actions/rewatching/RewatchingDrawerHost.svelte
+++ b/projects/client/src/lib/sections/media-actions/rewatching/RewatchingDrawerHost.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
+  import GridList from "$lib/components/lists/grid-list/GridList.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { useAllPagesInfiniteQuery } from "$lib/features/query/useQuery.ts";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry";
+  import { showActivityHistoryQuery } from "$lib/requests/queries/users/showActivityHistoryQuery.ts";
+  import { map } from "rxjs";
+  import { fade } from "svelte/transition";
+  import RewatchingEpisodeItem from "./_internal/RewatchingEpisodeItem.svelte";
+
+  type RewatchingDrawerProps = {
+    show: ShowEntry;
+    onClose: () => void;
+  };
+
+  const { show, onClose }: RewatchingDrawerProps = $props();
+
+  let isOpen = $state(false);
+  let isActionPending = $state(false);
+
+  const query = $derived(
+    useAllPagesInfiniteQuery(
+      showActivityHistoryQuery({ slug: "me", id: show.id, limit: 100 }),
+    ),
+  );
+
+  const watchedEpisodes = $derived(
+    query.pipe(
+      map(($query) => {
+        const entries =
+          $query.data?.pages.flatMap((page) => page.entries) ?? [];
+        const episodes = entries
+          .map((entry) => entry.episode)
+          .filter((episode, index, allEpisodes) =>
+            episode.season !== 0 &&
+            allEpisodes.findIndex((candidate) => candidate.id === episode.id) ===
+              index
+          );
+
+        return episodes.toSorted((episodeA, episodeB) => {
+          const seasonDiff = episodeA.season - episodeB.season;
+          return seasonDiff === 0
+            ? episodeA.number - episodeB.number
+            : seasonDiff;
+        });
+      }),
+    ),
+  );
+
+  const isLoading = $derived(
+    query.pipe(
+      map(($query) => $query.isPending || $query.isFetching),
+    ),
+  );
+
+  const isDrawerLoading = $derived($isLoading || isActionPending);
+
+  const drawerTitle = $derived(`${m.drawer_title_rewatching()} ${show.title}`);
+</script>
+
+<Drawer
+  {onClose}
+  onOpened={() => (isOpen = true)}
+  title={drawerTitle}
+  metaInfo={m.text_rewatching_next_episode_prompt()}
+  size="large"
+>
+  {#if isOpen}
+    <div
+      class="rewatching-drawer-content"
+      aria-busy={isDrawerLoading}
+      transition:fade={{ duration: 150 }}
+    >
+      {#snippet empty()}
+        <p class="secondary">
+          {m.text_rewatching_no_episodes()}
+        </p>
+      {/snippet}
+
+      {#if isDrawerLoading}
+        <LoadingIndicator />
+      {:else}
+        <GridList
+          id={`rewatching-episodes-${show.slug}`}
+          items={$watchedEpisodes}
+          {empty}
+          --width-item="var(--width-summary-card)"
+        >
+          {#snippet item(episode: EpisodeEntry)}
+            <RewatchingEpisodeItem
+              {episode}
+              {show}
+              onAction={onClose}
+              onPendingChange={(isPending) => (isActionPending = isPending)}
+            />
+          {/snippet}
+        </GridList>
+      {/if}
+    </div>
+  {/if}
+</Drawer>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .rewatching-drawer-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-m);
+
+    padding-bottom: var(--ni-8);
+
+    :global(.trakt-list-item-container) {
+      padding: 0;
+    }
+
+    :global(.trakt-list-items) {
+      grid-template-columns: 1fr;
+      grid-row-gap: var(--gap-s);
+    }
+
+    :global(.trakt-summary-card-minimal) {
+      --poster-aspect-ratio: 1.778;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/media-actions/rewatching/_internal/RewatchingEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/media-actions/rewatching/_internal/RewatchingEpisodeItem.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import CheckInIcon from "$lib/components/icons/CheckInIcon.svelte";
+  import IconWrapper from "$lib/components/icons/IconWrapper.svelte";
+  import TrackIcon from "$lib/components/icons/TrackIcon.svelte";
+  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
+  import { useConfirm } from "$lib/features/confirmation/useConfirm";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage.ts";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry";
+  import EpisodeItem from "$lib/sections/lists/components/EpisodeItem.svelte";
+  import { useCheckIn } from "../../check-in/useCheckIn";
+  import { useMarkAsWatched } from "../../mark-as-watched/useMarkAsWatched";
+  import { useRewatching } from "../useRewatching";
+
+  type RewatchingEpisodeAction = "watched" | "checkin";
+
+  type RewatchingEpisodeItemProps = {
+    show: ShowEntry;
+    episode: EpisodeEntry;
+    onAction: () => void;
+    onPendingChange: (isPending: boolean) => void;
+  };
+
+  const {
+    show,
+    episode,
+    onAction,
+    onPendingChange,
+  }: RewatchingEpisodeItemProps = $props();
+
+  let activeAction = $state<RewatchingEpisodeAction | null>(null);
+
+  const target = $derived({
+    type: "episode" as const,
+    media: episode,
+    show,
+  });
+
+  const { startRewatching, isUpdatingRewatching } = $derived(
+    useRewatching({ show }),
+  );
+  const { markAsWatched, isMarkingAsWatched, isWatchable: isMarkWatchable } =
+    $derived(
+      useMarkAsWatched(target),
+    );
+  const { checkin, isCheckingIn, isCheckedIn, isWatchable: isCheckinWatchable } =
+    $derived(
+      useCheckIn(target),
+    );
+  const { confirm } = useConfirm();
+
+  const src = $derived(
+    useEpisodeSpoilerImage({ episode, show, variant: "default" }),
+  );
+
+  const isBusy = $derived(
+    $isUpdatingRewatching || $isMarkingAsWatched || $isCheckingIn ||
+      activeAction != null,
+  );
+  const isCheckinDisabled = $derived(
+    isBusy || !isCheckinWatchable || $isCheckedIn,
+  );
+  const isWatchedDisabled = $derived(isBusy || !isMarkWatchable);
+
+  const runRewatchingAction = async (
+    action: RewatchingEpisodeAction,
+    handler: () => Promise<unknown>,
+  ) => {
+    activeAction = action;
+    onPendingChange(true);
+
+    try {
+      const didStart = await startRewatching();
+      if (!didStart) return;
+
+      await handler();
+      onAction();
+    } finally {
+      activeAction = null;
+      onPendingChange(false);
+    }
+  };
+
+  const markAsWatchedNow = () =>
+    runRewatchingAction("watched", () => markAsWatched("now"));
+
+  const checkinNow = () => runRewatchingAction("checkin", checkin);
+
+  const selectCheckin = () => {
+    if (isCheckinDisabled) return;
+    checkinNow();
+  };
+
+  const selectWatched = () => {
+    if (isWatchedDisabled) return;
+    confirmMarkAsWatched();
+  };
+
+  const confirmMarkAsWatched = $derived(
+    confirm({
+      type: ConfirmationType.MarkAsWatched,
+      title: episode.title,
+      target,
+      onConfirm: markAsWatchedNow,
+    }),
+  );
+</script>
+
+{#snippet checkinIcon()}
+  <IconWrapper isLoading={activeAction === "checkin"}>
+    <CheckInIcon />
+  </IconWrapper>
+{/snippet}
+
+{#snippet watchedIcon()}
+  <IconWrapper isLoading={activeAction === "watched"}>
+    <TrackIcon state="unwatched" />
+  </IconWrapper>
+{/snippet}
+
+{#snippet popupActions()}
+  <DropdownItem
+    onclick={selectCheckin}
+    label={m.button_label_checkin({ title: episode.title })}
+    style="flat"
+    color="default"
+    disabled={isCheckinDisabled}
+    variant="primary"
+  >
+    {m.button_text_checkin()}
+    {#snippet icon()}
+      {@render checkinIcon()}
+    {/snippet}
+  </DropdownItem>
+
+  <DropdownItem
+    onclick={selectWatched}
+    label={m.button_label_mark_as_watched_now()}
+    style="flat"
+    color="default"
+    disabled={isWatchedDisabled}
+    variant="primary"
+  >
+    {m.button_text_mark_as_watched_now()}
+    {#snippet icon()}
+      {@render watchedIcon()}
+    {/snippet}
+  </DropdownItem>
+{/snippet}
+
+{#snippet action()}
+  <ActionButton
+    onclick={confirmMarkAsWatched}
+    label={m.button_label_mark_as_watched({ title: episode.title })}
+    color="purple"
+    variant="secondary"
+    style="ghost"
+    disabled={isBusy || !isMarkWatchable}
+  >
+    {@render watchedIcon()}
+  </ActionButton>
+{/snippet}
+
+<EpisodeItem
+  {episode}
+  media={show}
+  variant="default"
+  style="minimal"
+  context="show"
+  source="rewatching-drawer"
+  coverUrl={$src}
+  {popupActions}
+  {action}
+/>

--- a/projects/client/src/lib/sections/media-actions/rewatching/useHasWatchedShowEpisodes.ts
+++ b/projects/client/src/lib/sections/media-actions/rewatching/useHasWatchedShowEpisodes.ts
@@ -1,0 +1,32 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import { map, of } from 'rxjs';
+
+type HasWatchedShowEpisodesProps = MediaStoreProps;
+
+export function useHasWatchedShowEpisodes(
+  props: HasWatchedShowEpisodesProps,
+) {
+  const { type } = props;
+  const media = Array.isArray(props.media) ? props.media : [props.media];
+  const { history } = useUser();
+
+  if (type !== 'show') {
+    return { hasWatchedShowEpisodes: of(false) };
+  }
+
+  return {
+    hasWatchedShowEpisodes: history.pipe(
+      map(($history) => {
+        if (!$history) {
+          return false;
+        }
+
+        return media.every((m) => {
+          const show = $history.shows.get(m.id);
+          return show?.episodes.some((e) => e.season !== 0) ?? false;
+        });
+      }),
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/media-actions/rewatching/useIsRewatching.ts
+++ b/projects/client/src/lib/sections/media-actions/rewatching/useIsRewatching.ts
@@ -1,0 +1,27 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import { map, of } from 'rxjs';
+
+type IsRewatchingProps = MediaStoreProps;
+
+export function useIsRewatching(props: IsRewatchingProps) {
+  const { type } = props;
+  const media = Array.isArray(props.media) ? props.media : [props.media];
+  const { rewatching } = useUser();
+
+  if (type !== 'show') {
+    return { isRewatching: of(false) };
+  }
+
+  return {
+    isRewatching: rewatching.pipe(
+      map(($rewatching) => {
+        if (!$rewatching) {
+          return false;
+        }
+
+        return media.every((m) => $rewatching.shows.has(m.id));
+      }),
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/media-actions/rewatching/useRewatching.ts
+++ b/projects/client/src/lib/sections/media-actions/rewatching/useRewatching.ts
@@ -1,0 +1,76 @@
+import { FeatureFlag } from '$lib/features/feature-flag/models/FeatureFlag.ts';
+import { useFeatureFlag } from '$lib/features/feature-flag/useFeatureFlag.ts';
+import { startShowRewatchingRequest } from '$lib/requests/queries/shows/startShowRewatchingRequest.ts';
+import { stopShowRewatchingRequest } from '$lib/requests/queries/shows/stopShowRewatchingRequest.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { useInvalidator } from '$lib/stores/useInvalidator.ts';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { useIsRewatching } from './useIsRewatching.ts';
+
+type UseRewatchingProps = {
+  show: {
+    id: number;
+  };
+};
+
+export function useRewatching({ show }: UseRewatchingProps) {
+  const isUpdatingRewatching = new BehaviorSubject(false);
+  const { invalidateAll } = useInvalidator();
+  const { isEnabled } = useFeatureFlag();
+  const isRewatchingFeatureEnabled = isEnabled(FeatureFlag.Rewatching);
+  const { isRewatching } = useIsRewatching({
+    type: 'show',
+    media: show,
+  });
+
+  const invalidateRewatching = () =>
+    invalidateAll([
+      InvalidateAction.Rewatching('show'),
+      InvalidateAction.MarkAsWatched('show'),
+    ]);
+
+  const startRewatching = async () => {
+    if (!(await firstValueFrom(isRewatchingFeatureEnabled))) {
+      return false;
+    }
+
+    isUpdatingRewatching.next(true);
+
+    try {
+      const didStart = await startShowRewatchingRequest({ id: show.id });
+      if (didStart) {
+        await invalidateRewatching();
+      }
+
+      return didStart;
+    } finally {
+      isUpdatingRewatching.next(false);
+    }
+  };
+
+  const stopRewatching = async () => {
+    if (!(await firstValueFrom(isRewatchingFeatureEnabled))) {
+      return false;
+    }
+
+    isUpdatingRewatching.next(true);
+
+    try {
+      const didStop = await stopShowRewatchingRequest({ id: show.id });
+      if (didStop) {
+        await invalidateRewatching();
+      }
+
+      return didStop;
+    } finally {
+      isUpdatingRewatching.next(false);
+    }
+  };
+
+  return {
+    isRewatching,
+    isUpdatingRewatching,
+    startRewatching,
+    stopRewatching,
+  };
+}

--- a/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import type { MediaVideo } from "$lib/requests/models/MediaVideo";
   import type { Season } from "$lib/requests/models/Season";
   import type { SentimentAnalysis } from "$lib/requests/models/SentimentAnalysis";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
   import type { MediaSocialQueryTarget } from "$lib/requests/queries/media/mediaSocialQuery.ts";
+  import RewatchingDrawerHost from "$lib/sections/media-actions/rewatching/RewatchingDrawerHost.svelte";
   import WhereToWatchDrawerHost from "$lib/sections/lists/where-to-watch/_internal/WhereToWatchDrawerHost.svelte";
   import { episodeActivityTitle } from "$lib/utils/intl/episodeActivityTitle.ts";
   import {
@@ -162,4 +165,12 @@
 
 {#if drawer === SummaryDrawers.Ratings}
   <RatingsDrawer {...details} {seasons} onClose={close} />
+{/if}
+
+{#if drawer === SummaryDrawers.Rewatching && showEntry}
+  <RenderForFeature flag={FeatureFlag.Rewatching}>
+    {#snippet enabled()}
+      <RewatchingDrawerHost show={showEntry} onClose={close} />
+    {/snippet}
+  </RenderForFeature>
 {/if}

--- a/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
+++ b/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
@@ -15,6 +15,7 @@ export enum SummaryDrawers {
   Comments = 'comments',
   Review = 'review',
   Ratings = 'ratings',
+  Rewatching = 'rewatching',
 }
 
 const commentIdParam = 'comment_id';
@@ -52,6 +53,8 @@ function mapToDrawer(value: string | Nil) {
       return SummaryDrawers.Review;
     case SummaryDrawers.Ratings:
       return SummaryDrawers.Ratings;
+    case SummaryDrawers.Rewatching:
+      return SummaryDrawers.Rewatching;
     default:
       return null;
   }

--- a/projects/client/src/lib/sections/summary/components/_internal/RewatchingTag.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/RewatchingTag.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import FastRewindIcon from "$lib/components/icons/FastRewindIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import StemTag from "$lib/components/tags/StemTag.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import {
+    SummaryDrawers,
+    summaryDrawerNavigation,
+  } from "../../_internal/summaryDrawerNavigation.ts";
+
+  const { buildDrawerLink } = summaryDrawerNavigation();
+</script>
+
+<rewatching-tag>
+  <Link {...buildDrawerLink(SummaryDrawers.Seasons)}>
+    <StemTag
+      --color-background-stem-tag="var(--color-background-indicator-tag)"
+      --color-foreground-stem-tag="var(--color-text-indicator-tag)"
+    >
+      <FastRewindIcon />
+
+      <p class="bold uppercase no-wrap">{m.tag_text_rewatching()}</p>
+    </StemTag>
+  </Link>
+</rewatching-tag>
+
+<style>
+  rewatching-tag {
+    :global(.trakt-tag) {
+      position: relative;
+
+      :global(svg) {
+        width: var(--ni-12);
+        height: var(--ni-12);
+      }
+    }
+
+    :global(.trakt-link) {
+      text-decoration: none;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import PostCreditsTag from "$lib/components/media/tags/PostCreditsTag.svelte";
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
   import DroppedTag from "./DroppedTag.svelte";
+  import RewatchingTag from "./RewatchingTag.svelte";
   import StartedTag from "./StartedTag.svelte";
   import WatchCountTag from "./WatchCountTag.svelte";
 
@@ -10,6 +13,7 @@
     watchCount: number;
     isDropped?: boolean;
     isStarted?: boolean;
+    isRewatching?: boolean;
   };
 
   const {
@@ -17,21 +21,30 @@
     watchCount,
     isDropped,
     isStarted,
+    isRewatching,
   }: SummaryPosterTagsProps = $props();
+
+  const { isEnabled } = useFeatureFlag();
+  const isRewatchingFeatureEnabled = $derived(
+    isEnabled(FeatureFlag.Rewatching),
+  );
+  const showRewatching = $derived(isRewatching && $isRewatchingFeatureEnabled);
 </script>
 
 {#if isDropped}
   <DroppedTag i18n={TagIntlProvider} />
 {/if}
 
-{#if postCreditsCount > 0 && watchCount === 0}
+{#if showRewatching}
+  <RewatchingTag />
+{:else if postCreditsCount > 0 && watchCount === 0}
   <PostCreditsTag count={postCreditsCount} i18n={TagIntlProvider} />
 {/if}
 
-{#if watchCount > 0}
+{#if !showRewatching && watchCount > 0}
   <WatchCountTag count={watchCount} i18n={TagIntlProvider} />
 {/if}
 
-{#if isStarted && watchCount === 0 && !isDropped}
+{#if !showRewatching && isStarted && watchCount === 0 && !isDropped}
   <StartedTag />
 {/if}

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -4,6 +4,7 @@
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
+  import { useIsRewatching } from "$lib/sections/media-actions/rewatching/useIsRewatching";
   import { useWatchCount } from "$lib/stores/useWatchCount";
   import {
     SummaryDrawers,
@@ -47,6 +48,7 @@
   const { ratings, isLoading } = $derived(useMediaMetaInfo(target));
   const { isDropped } = $derived(useIsDropped(media));
   const { isStarted } = $derived(useIsStarted(target));
+  const { isRewatching } = $derived(useIsRewatching(target));
 
   const { buildDrawerLink } = summaryDrawerNavigation();
   const ratingsDrawerLink = $derived(buildDrawerLink(SummaryDrawers.Ratings));
@@ -60,6 +62,7 @@
     watchCount={$watchCount}
     isDropped={$isDropped}
     isStarted={$isStarted}
+    isRewatching={$isRewatching}
   />
 {/snippet}
 

--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -7,6 +7,7 @@
   import type { MediaIntl } from "$lib/requests/models/MediaIntl";
   import type { MediaStudio } from "$lib/requests/models/MediaStudio";
   import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
+  import { useIsRewatching } from "$lib/sections/media-actions/rewatching/useIsRewatching";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { useWatchCount } from "$lib/stores/useWatchCount";
   import {
@@ -51,6 +52,7 @@
   const { isRateable } = $derived(useIsRateable(target));
   const { isDropped } = $derived(useIsDropped(media));
   const { isStarted } = $derived(useIsStarted(target));
+  const { isRewatching } = $derived(useIsRewatching(target));
 
   const { buildDrawerLink } = summaryDrawerNavigation();
   const ratingsDrawerLink = $derived(buildDrawerLink(SummaryDrawers.Ratings));
@@ -62,6 +64,7 @@
     watchCount={$watchCount}
     isDropped={$isDropped}
     isStarted={$isStarted}
+    isRewatching={$isRewatching}
   />
 {/snippet}
 

--- a/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/_internal/MediaPopupActions.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import * as m from "$lib/features/i18n/messages.ts";
   import ReportButton from "$lib/features/report/ReportButton.svelte";
   import type { ReportParams } from "$lib/features/report/models/ReportParams.ts";
   import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry";
   import ModerateAction from "$lib/sections/components/admin/ModerateAction.svelte";
   import ListAction from "$lib/sections/components/lists-drawer/ListAction.svelte";
   import SetCoverImageAction from "$lib/sections/media-actions/cover-image/SetCoverImageAction.svelte";
@@ -12,6 +15,11 @@
   import { useIsDropped } from "$lib/sections/media-actions/drop/useIsDropped";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
+  import RewatchingAction from "$lib/sections/media-actions/rewatching/RewatchingAction.svelte";
+  import {
+    SummaryDrawers,
+    summaryDrawerNavigation,
+  } from "$lib/sections/summary/_internal/summaryDrawerNavigation";
   import HistoryButton from "$lib/sections/summary/components/history/HistoryButton.svelte";
   import SideActions from "./SideActions.svelte";
 
@@ -21,10 +29,19 @@
     onListAction: () => void;
   };
 
-  const { media, title, onListAction }: MediaPopupActionsProps = $props();
+  const {
+    media,
+    title,
+    onListAction,
+  }: MediaPopupActionsProps = $props();
 
   const { isWatched } = $derived(useIsWatched({ media, type: media.type }));
   const { isDropped } = $derived(useIsDropped(media));
+  const show = $derived(media.type === "show" ? (media as ShowEntry) : null);
+  const { buildDrawerLink } = summaryDrawerNavigation();
+  const rewatchingDrawerLink = $derived(
+    buildDrawerLink(SummaryDrawers.Rewatching),
+  );
 
   const reportParams = $derived<ReportParams>(
     media.type === "show"
@@ -41,6 +58,19 @@
     {title}
     {media}
   />
+{/if}
+
+{#if show}
+  <RenderForFeature flag={FeatureFlag.Rewatching}>
+    {#snippet enabled()}
+      <RewatchingAction
+        {show}
+        {title}
+        startLink={rewatchingDrawerLink}
+        variant="primary"
+      />
+    {/snippet}
+  </RenderForFeature>
 {/if}
 
 <ListAction

--- a/projects/client/src/mocks/data/users/response/RewatchingShowsResponseMock.ts
+++ b/projects/client/src/mocks/data/users/response/RewatchingShowsResponseMock.ts
@@ -1,0 +1,9 @@
+import { ShowSiloMinimalResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloMinimalResponseMock.ts';
+
+export const RewatchingShowsResponseMock = [
+  {
+    hidden_at: '2025-03-30T23:18:42.000Z',
+    type: 'show',
+    show: ShowSiloMinimalResponseMock,
+  },
+];

--- a/projects/client/src/mocks/handlers/shows.ts
+++ b/projects/client/src/mocks/handlers/shows.ts
@@ -119,6 +119,22 @@ export const shows = [
       return HttpResponse.json(ShowSiloProgressResponseMock);
     },
   ),
+  http.post(
+    'http://localhost/shows/:id/progress/watched/reset',
+    () => {
+      return new HttpResponse(null, {
+        status: 204,
+      });
+    },
+  ),
+  http.delete(
+    'http://localhost/shows/:id/progress/watched/reset',
+    () => {
+      return new HttpResponse(null, {
+        status: 204,
+      });
+    },
+  ),
   http.get(
     `http://localhost/shows/${ShowSiloResponseMock.ids.slug}/seasons`,
     () => {

--- a/projects/client/src/mocks/handlers/sync.ts
+++ b/projects/client/src/mocks/handlers/sync.ts
@@ -8,6 +8,14 @@ import { UserPlexShowLibraryResponseMock } from '../data/users/response/UserPlex
 
 export const sync = [
   http.post(
+    'http://localhost/checkin',
+    () => {
+      return HttpResponse.json({}, {
+        status: 201,
+      });
+    },
+  ),
+  http.post(
     'http://localhost/sync/history',
     () => {
       return new HttpResponse(null, {

--- a/projects/client/src/mocks/handlers/users.ts
+++ b/projects/client/src/mocks/handlers/users.ts
@@ -22,6 +22,7 @@ import { MinimalLikedListsResponseMock } from '../data/users/response/MinimalLik
 import { MovieActivityHistoryResponseMock } from '../data/users/response/MovieActivityHistoryResponseMock.ts';
 import { RatedEpisodesResponseMock } from '../data/users/response/RatedEpisodesResponseMock.ts';
 import { RatedMoviesResponseMock } from '../data/users/response/RatedMoviesResponseMock.ts';
+import { RewatchingShowsResponseMock } from '../data/users/response/RewatchingShowsResponseMock.ts';
 import { ShowActivityHistoryResponseMock } from '../data/users/response/ShowActivityHistoryResponseMock.ts';
 import { SocialActivityResponseMock } from '../data/users/response/SocialActivityResponseMock.ts';
 import { UserBlockedResponseMock } from '../data/users/response/UserBlockedResponseMock.ts';
@@ -50,6 +51,9 @@ export const users = [
       return HttpResponse.json(ExtendedUserProfileHarryResponseMock);
     },
   ),
+  http.get('http://localhost/users/hidden/progress_watched_reset*', () => {
+    return HttpResponse.json(RewatchingShowsResponseMock);
+  }),
   http.get('http://localhost/users/hidden/progress_watched*', () => {
     return HttpResponse.json(HiddenShowProgressResponseMock);
   }),


### PR DESCRIPTION
## Summary

Adds a feature-flagged rewatching flow for shows.

Users who have watched at least one episode of a show can start a rewatching session from the show actions menu. The flow opens a drawer listing only episodes already watched at least once, using episode screenshots as visual context. From that drawer, users can start the rewatching session and immediately either check in to an episode or mark it watched just now.

This PR also updates show poster/status tags so an active rewatching session uses the existing tag system: full “Rewatching” tag on summary pages and icon-only status indicators elsewhere.

AI assisted with Codex 5.5.

Closes https://github.com/trakt/trakt-web/issues/2405

## What Changed

- Added `FeatureFlag.Rewatching` and gated the start/stop rewatching actions, rewatching drawer, status tags, and episode-page snackbar prompt.
- Added show rewatching API requests:
  - `POST /shows/:id/progress/watched/reset`
  - `DELETE /shows/:id/progress/watched/reset`
- Added current-user rewatching state to `useUser()` so poster tags and actions can react to active sessions.
- Added a rewatching drawer for shows:
  - lists only watched regular episodes, not every episode in the season
  - uses episode snapshot/screenshot images
  - excludes season 0 specials
  - de-dupes repeated history plays for the same episode
  - sorts by season and episode number
  - does not link the cell to the episode page
- Added drawer episode actions:
  - top-right menu with “Now watching” and “Just now”
  - bottom-right quick checkmark for “Just now”
  - shows the drawer loading state while rewatching/checkin/watched requests are running
- Added stop rewatching action when a show is already being rewatched.
- Added a centered snackbar after “Watch Again” from an episode page when the user chooses “Now watching” or “Just now”, asking whether they want to start a show rewatching session.
- Updated popup portal z-index handling so dropdowns render above overlay drawers.
- Added Fast Rewind Material icon usage for the rewatching action and tags.
- Added tests for rewatching API requests, current-user rewatching state, and popup layering.

## API Notes / Edge Cases

The current rewatching list intentionally uses:

`GET /users/hidden/progress_watched_reset?type=show&limit=1000`

This avoids `/progress` endpoints and keeps the active rewatching show set available for tags/actions.

Starting a rewatch sends `reset_at` as “now minus 1 minute” before the follow-up watched/checkin call. This gives the reset boundary a small buffer so the next action lands after the session start time and updates Up Next correctly.

If fetching the current rewatching list fails, the staged implementation treats the user as having no active rewatching sessions so the UI fails closed. VIP status is not checked because this capability should no longer be VIP-only.

## Screenshots

Continue Watching showing the next episode to watch of Spider-Noir (Episode 5):
<img width="1439" height="971" alt="Screenshot 2026-06-19 at 16 47 12" src="https://github.com/user-attachments/assets/ad222bfc-a1ae-4c65-8ed4-c77182e0c9b0" />

Start Rewatching in the drop-down:
<img width="1439" height="971" alt="Screenshot 2026-06-19 at 16 45 52" src="https://github.com/user-attachments/assets/236da1ef-77a6-4765-88cc-4f86ab67816b" />

The Rewatching drawer:
<img width="1439" height="971" alt="Screenshot 2026-06-19 at 16 45 59" src="https://github.com/user-attachments/assets/5a7205f8-8c7b-4747-822b-55ee690a4388" />

Loading state (restarted from Episode 2):
<img width="1439" height="971" alt="Screenshot 2026-06-19 at 16 46 06" src="https://github.com/user-attachments/assets/7b3dd27d-4644-4fcc-b1de-c7c316385505" />

Rewatching state (chip under poster):
<img width="1439" height="971" alt="Screenshot 2026-06-19 at 16 46 16" src="https://github.com/user-attachments/assets/af789afb-b4ff-4bed-b506-09771453e3b1" />

Continue Watching showing Episode 3:
<img width="1439" height="971" alt="Screenshot 2026-06-19 at 16 46 23" src="https://github.com/user-attachments/assets/333f2a3b-49bc-4acf-b325-f1138163b753" />

Alternative start of a rewatching session from Episode 2 itself, choosing Watch Again, Just Now or Watching Now:
<img width="1439" height="971" alt="Screenshot 2026-06-19 at 16 47 36" src="https://github.com/user-attachments/assets/ca775987-0882-4641-ba84-55f2a2c96755" />

Ending flow, open currently rewatching show and stop rewatching:
<img width="1439" height="971" alt="Screenshot 2026-06-19 at 16 48 11" src="https://github.com/user-attachments/assets/7c7e1310-badb-4f82-abc5-1d2e083f806c" />
