### PR TITLE
feat: reorder home and discover sidebar sections

### DIFF
--- a/projects/client/src/lib/sections/navbar/_internal/SideNavbarContent.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/SideNavbarContent.svelte
@@ -44,6 +44,7 @@
     <RenderFor audience="authenticated">
       {@render navSubLink(UrlBuilder.progress("me"), m.list_title_up_next())}
       {@render navSubLink(UrlBuilder.calendar(), m.page_title_calendar())}
+      {@render navSubLink(UrlBuilder.recommended(), m.list_title_recommended())}
     </RenderFor>
   </NavGroup>
 
@@ -56,12 +57,11 @@
       {isCollapsed}
     >
       {@render navSubLink(UrlBuilder.trending(), m.list_title_trending())}
-      {@render navSubLink(UrlBuilder.recommended(), m.list_title_recommended())}
+      {@render navSubLink(UrlBuilder.releases(), m.list_title_releases())}
       {@render navSubLink(
         UrlBuilder.anticipated(),
         m.list_title_most_anticipated(),
       )}
-      {@render navSubLink(UrlBuilder.releases(), m.list_title_releases())}
       {@render navSubLink(UrlBuilder.popular(), m.list_title_most_popular())}
     </NavGroup>
 

--- a/projects/client/src/lib/sections/navbar/components/UserMenu.svelte
+++ b/projects/client/src/lib/sections/navbar/components/UserMenu.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
-  import CelebrationIcon from "$lib/components/icons/CelebrationIcon.svelte";
   import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
   import GearIcon from "$lib/components/icons/GearIcon.svelte";
   import LibraryIcon from "$lib/components/icons/LibraryIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
-  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import * as m from "$lib/features/i18n/messages.ts";
-  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { Snippet } from "svelte";
 
@@ -58,7 +55,6 @@
 
 {#snippet iconHistory()}<ClockIcon />{/snippet}
 {#snippet iconLibrary()}<LibraryIcon />{/snippet}
-{#snippet iconYearInReview()}<CelebrationIcon />{/snippet}
 {#snippet iconSettings()}<GearIcon />{/snippet}
 
 <div
@@ -83,16 +79,6 @@
           m.page_title_library(),
           iconLibrary,
         )}
-        <RenderForFeature flag={FeatureFlag.YearInReview}>
-          {#snippet enabled()}
-            {@render navItem(
-              UrlBuilder.users("me").yearToDate(new Date().getFullYear()),
-              m.yir_title_year_in_review(),
-              m.yir_title_year_in_review(),
-              iconYearInReview,
-            )}
-          {/snippet}
-        </RenderForFeature>
         {@render navItem(
           UrlBuilder.settings.general(),
           m.button_label_settings(),

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -13,6 +13,7 @@
   import ActivityList from "$lib/sections/lists/activity/ActivityList.svelte";
   import PersonalHistoryList from "$lib/sections/lists/history/PersonalHistoryList.svelte";
   import UpNextList from "$lib/sections/lists/progress/UpNextList.svelte";
+  import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
   import UpcomingList from "$lib/sections/lists/UpcomingList.svelte";
   import WatchList from "$lib/sections/lists/watchlist/WatchList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
@@ -54,6 +55,13 @@
 
     <StreakCallout />
     <UpcomingList />
+    <RecommendedList
+      title={m.list_title_recommended()}
+      drilldownLabel={$mode === "show"
+        ? m.button_label_view_all_recommended_shows()
+        : m.button_label_view_all_recommended_movies()}
+      type={$mode}
+    />
     <PersonalHistoryList mode={$mode} />
     <ActivityList />
 

--- a/projects/client/src/routes/discover/+page.svelte
+++ b/projects/client/src/routes/discover/+page.svelte
@@ -10,7 +10,6 @@
   import AnticipatedList from "$lib/sections/lists/anticipated/AnticipatedList.svelte";
   import PopularList from "$lib/sections/lists/popular/PopularList.svelte";
   import ReleasesList from "$lib/sections/lists/ReleasesList.svelte";
-  import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
   import TrendingList from "$lib/sections/lists/trending/TrendingList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { DEFAULT_SHARE_SHOW_COVER } from "$lib/utils/assets";
@@ -75,16 +74,9 @@
     type={$type}
     filterOverride={getThemeFilters("trending")}
   />
-  <RenderFor audience="authenticated">
-    <RecommendedList
-      title={m.list_title_recommended()}
-      drilldownLabel={$type === "show"
-        ? m.button_label_view_all_recommended_shows()
-        : m.button_label_view_all_recommended_movies()}
-      type={$type}
-      filterOverride={getThemeFilters("recommended")}
-    />
-  </RenderFor>
+  
+  <ReleasesList />
+
   <AnticipatedList
     drilldownLabel={$type === "show"
       ? m.button_label_view_all_anticipated_shows()
@@ -93,9 +85,6 @@
     type={$type}
     filterOverride={getThemeFilters("anticipated")}
   />
-  <RenderFor audience="authenticated">
-    <ReleasesList />
-  </RenderFor>
   <PopularList
     drilldownLabel={$type === "show"
       ? m.button_label_view_all_popular_shows()


### PR DESCRIPTION
## Summary
- move Recommended section from Discover to Home
- update sidebar navigation to reflect the new Home and Discover ordering
- remove Year in Review from sidebar user menu