### PR TITLE
feat(filter): add streaming service availability filters

### DIFF
--- a/projects/client/src/lib/components/media/streaming-service/getWellKnownSourceGroup.spec.ts
+++ b/projects/client/src/lib/components/media/streaming-service/getWellKnownSourceGroup.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getWellKnownSourceGroup } from './getWellKnownSourceGroup.ts';
+
+describe('util: getWellKnownSourceGroup', () => {
+  it('should map amazon variants to a single brand group', () => {
+    expect(getWellKnownSourceGroup('amazon_prime_video')).toBe(
+      getWellKnownSourceGroup('amazon_video'),
+    );
+  });
+
+  it('should resolve a well-known source to its brand key', () => {
+    expect(getWellKnownSourceGroup('netflix')).toBe('netflix');
+  });
+
+  it('should return undefined for an unknown source', () => {
+    expect(getWellKnownSourceGroup('curiosity_stream')).toBeUndefined();
+  });
+});

--- a/projects/client/src/lib/components/media/streaming-service/getWellKnownSourceGroup.ts
+++ b/projects/client/src/lib/components/media/streaming-service/getWellKnownSourceGroup.ts
@@ -1,0 +1,7 @@
+import { WELL_KNOWN_SERVICES } from './_internal/constants/index.ts';
+
+export function getWellKnownSourceGroup(source: string): string | undefined {
+  return Object.entries(WELL_KNOWN_SERVICES).find(([, sources]) =>
+    sources.includes(source)
+  )?.at(0) as string | undefined;
+}

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/AdvancedFilters.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/AdvancedFilters.svelte
@@ -1,22 +1,29 @@
 <script lang="ts">
   import { FilterMode } from "$lib/features/filters/models/FilterMode";
+  import { FilterKey } from "$lib/features/filters/models/Filter";
   import { useFilter } from "$lib/features/filters/useFilter";
   import FilterGroup from "./_internal/FilterGroup.svelte";
   import { isMultiSelectFilter } from "./_internal/isMultiSelectFilter";
   import { isSliderFilter } from "./_internal/isSliderFilter";
   import MultiSelectFilter from "./_internal/MultiSelectFilter.svelte";
+  import StreamingServicesFilter from "./_internal/StreamingServicesFilter.svelte";
   import SliderFilter from "./SliderFilter.svelte";
 
   const { filters } = useFilter();
 
   const sliderFilters = $derived(filters.filter(isSliderFilter));
-  const multiSelectFilters = $derived(filters.filter(isMultiSelectFilter));
+  const multiSelectFilters = $derived(
+    filters
+      .filter(isMultiSelectFilter)
+      .filter((filter) => filter.key !== FilterKey.Streaming),
+  );
 </script>
 
 <FilterGroup>
   {#each multiSelectFilters as filter (filter.key)}
     <MultiSelectFilter {filter} />
   {/each}
+  <StreamingServicesFilter />
 </FilterGroup>
 
 {#each sliderFilters as filter (filter.key)}

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/SimpleFilters.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/SimpleFilters.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
+  import { FilterKey } from "$lib/features/filters/models/Filter";
   import { FilterMode } from "$lib/features/filters/models/FilterMode";
   import { useFilter } from "$lib/features/filters/useFilter";
   import FilterGroup from "./_internal/FilterGroup.svelte";
+  import StreamingAvailabilityFilter from "./_internal/StreamingAvailabilityFilter.svelte";
   import ListFilter from "./ListFilter.svelte";
   import SliderFilter from "./SliderFilter.svelte";
 
   const { filters } = useFilter();
 
   const listTypeFilters = $derived(
-    filters.filter((filter) => filter.type === "list"),
+    filters.filter(
+      (filter) =>
+        filter.type === "list" && filter.key !== FilterKey.Streaming,
+    ),
   );
   const ratingTypeFilters = $derived(
     filters.filter((filter) => filter.type === "slider"),
@@ -19,6 +24,7 @@
   {#each listTypeFilters as filter (filter.key)}
     <ListFilter {filter} />
   {/each}
+  <StreamingAvailabilityFilter />
 </FilterGroup>
 
 {#each ratingTypeFilters as filter (filter.key)}

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/StreamingAvailabilityFilter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/StreamingAvailabilityFilter.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import {
+    type Filter,
+    FilterKey,
+    type ListFilter as ListFilterModel,
+  } from "$lib/features/filters/models/Filter";
+  import { useFilter } from "$lib/features/filters/useFilter";
+  import ListFilter from "../ListFilter.svelte";
+  import { useStreamingServiceOptions } from "./useStreamingServiceOptions";
+
+  const { filters } = useFilter();
+
+  const isStreamingFilter = (filter: Filter): filter is ListFilterModel =>
+    filter.key === FilterKey.Streaming && filter.type === "list";
+
+  const baseFilter = $derived(filters.find(isStreamingFilter));
+
+  const options = useStreamingServiceOptions();
+
+  const augmentedFilter = $derived(
+    baseFilter
+      ? {
+        ...baseFilter,
+        options: [
+          ...baseFilter.options,
+          ...$options.top.map((brand) => ({
+            label: () => brand.name,
+            value: brand.slugs.join(","),
+          })),
+        ],
+      }
+      : undefined,
+  );
+</script>
+
+{#if augmentedFilter}
+  <ListFilter filter={augmentedFilter} />
+{/if}

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/StreamingServicesFilter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/StreamingServicesFilter.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import MultiSelect from "$lib/components/select/MultiSelect.svelte";
+  import { FilterKey } from "$lib/features/filters/models/Filter";
+  import { FilterMode } from "$lib/features/filters/models/FilterMode";
+  import { useFilter } from "$lib/features/filters/useFilter";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import Filter from "./Filter.svelte";
+  import { useFilterSetter } from "./useFilterSetter";
+  import { useStreamingServiceOptions } from "./useStreamingServiceOptions";
+
+  const resetValue = "__reset_filter__";
+
+  const { getFilterValue, filters } = useFilter();
+  const { gotoFilteredState } = useFilterSetter();
+
+  const options = useStreamingServiceOptions();
+  const currentValueRaw = $derived(getFilterValue(FilterKey.Streaming));
+
+  const selectedValues = $derived(
+    $currentValueRaw ? $currentValueRaw.split(",") : [],
+  );
+
+  const keywordOptions = $derived(
+    filters
+      .filter((filter) => filter.key === FilterKey.Streaming)
+      .flatMap((filter) => ("options" in filter ? filter.options : []))
+      .map((option) => ({ label: option.label(), value: option.value })),
+  );
+
+  const serviceOptions = $derived(
+    $options.all.map((option) => ({
+      label: option.name,
+      value: option.source,
+    })),
+  );
+
+  const optionsWithReset = $derived([
+    { label: m.button_label_reset_filter(), value: resetValue },
+    ...keywordOptions,
+    ...serviceOptions,
+  ]);
+
+  const onChange = (values: string[]) => {
+    const hasReset = values.includes(resetValue);
+    const hasValues = values.length > 0;
+
+    const value = !hasReset && hasValues ? values.join(",") : null;
+
+    gotoFilteredState({
+      value,
+      key: FilterKey.Streaming,
+      mode: FilterMode.Advanced,
+    });
+  };
+</script>
+
+<Filter title={m.header_streaming()}>
+  <MultiSelect
+    options={optionsWithReset}
+    value={selectedValues}
+    placeholder={m.option_text_all()}
+    {onChange}
+  />
+</Filter>

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/streamingBrands.ts
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/streamingBrands.ts
@@ -1,0 +1,44 @@
+export type StreamingBrand = {
+  key: string;
+  slugs: ReadonlyArray<string>;
+};
+
+// Top-tier brands for the simple view, ordered by global reach. Each brand
+// folds its store/channel/ad-supported slug variants so the picker shows one
+// logo per brand instead of every variant.
+export const STREAMING_BRANDS: ReadonlyArray<StreamingBrand> = [
+  {
+    key: 'netflix',
+    slugs: ['netflix', 'netflix_standard_with_ads', 'netflix_kids'],
+  },
+  {
+    key: 'apple_tv_plus',
+    slugs: ['apple_tv_plus', 'apple_tv_plus_amazon_channel'],
+  },
+  { key: 'disney_plus', slugs: ['disney_plus', 'disneynow'] },
+  {
+    key: 'amazon_prime_video',
+    slugs: [
+      'amazon_prime_video',
+      'amazon_prime_video_with_ads',
+      'amazon_prime_video_free_with_ads',
+    ],
+  },
+  {
+    key: 'hbo_max',
+    slugs: ['hbo_max', 'hbo_max_amazon_channel', 'max_stream'],
+  },
+  { key: 'hulu', slugs: ['hulu'] },
+  {
+    key: 'paramount_plus',
+    slugs: [
+      'paramount_plus',
+      'paramount_plus_amazon_channel',
+      'paramount_plus_apple_tv_channel',
+      'paramount_plus_premium',
+      'paramount_plus_basic_with_ads',
+    ],
+  },
+  { key: 'peacock', slugs: ['peacock', 'peacock_premium_plus'] },
+  { key: 'crunchyroll', slugs: ['crunchyroll', 'crunchyroll_amazon_channel'] },
+];

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/useStreamingServiceOptions.ts
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/useStreamingServiceOptions.ts
@@ -1,0 +1,126 @@
+import { getWellKnownSourceGroup } from '$lib/components/media/streaming-service/getWellKnownSourceGroup.ts';
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import { sortStreamingServices } from '$lib/requests/_internal/sortStreamingServices.ts';
+import type { StreamingSource } from '$lib/requests/models/StreamingSource.ts';
+import { streamingSourcesQuery } from '$lib/requests/queries/services/streamingSourcesQuery.ts';
+import { useStreamingPreferences } from '$lib/stores/useStreamingPreferences.ts';
+import { combineLatest, map, type Observable } from 'rxjs';
+import { STREAMING_BRANDS } from './streamingBrands.ts';
+
+export type StreamingServiceOption = {
+  source: string;
+  name: string;
+};
+
+export type StreamingBrandOption = {
+  key: string;
+  name: string;
+  source: string;
+  color: string | undefined;
+  slugs: string[];
+};
+
+type StreamingServiceOptions = {
+  all: StreamingServiceOption[];
+  top: StreamingBrandOption[];
+};
+
+function toOption(source: StreamingSource): StreamingServiceOption {
+  return { source: source.source, name: source.name };
+}
+
+function toBrandOptions(
+  services: ReadonlyArray<StreamingSource>,
+): StreamingBrandOption[] {
+  const bySlug = new Map(services.map((service) => [service.source, service]));
+
+  return STREAMING_BRANDS.flatMap((brand) => {
+    const slugs = brand.slugs.filter((slug) => bySlug.has(slug));
+    const representative = slugs.at(0);
+
+    if (representative == null) {
+      return [];
+    }
+
+    return [{
+      key: brand.key,
+      name: bySlug.get(representative)?.name ?? brand.key,
+      source: representative,
+      color: bySlug.get(representative)?.color ?? undefined,
+      slugs,
+    }];
+  });
+}
+
+function toFavoriteSlug(favorite: string): string {
+  return favorite.split('-').slice(1).join('-');
+}
+
+function toBrandKey(slug: string): string {
+  return getWellKnownSourceGroup(slug) ??
+    STREAMING_BRANDS.find((brand) => brand.slugs.includes(slug))?.key ??
+    slug;
+}
+
+function toFavoriteOptions(
+  favorites: ReadonlyArray<string>,
+  services: ReadonlyArray<StreamingSource>,
+): StreamingBrandOption[] {
+  const bySlug = new Map(services.map((service) => [service.source, service]));
+
+  const groups = favorites
+    .map(toFavoriteSlug)
+    .filter((slug) => bySlug.has(slug))
+    .reduce((acc, slug) => {
+      const key = toBrandKey(slug);
+      const slugs = acc.get(key) ?? [];
+
+      if (!slugs.includes(slug)) {
+        acc.set(key, [...slugs, slug]);
+      }
+
+      return acc;
+    }, new Map<string, string[]>());
+
+  return [...groups].flatMap(([key, slugs]) => {
+    const ranked = sortStreamingServices(
+      slugs
+        .map((slug) => bySlug.get(slug))
+        .filter((service): service is StreamingSource => service != null),
+    );
+    const representative = ranked.at(0);
+
+    if (representative == null) {
+      return [];
+    }
+
+    return [{
+      key,
+      name: representative.name,
+      source: representative.source,
+      color: representative.color ?? undefined,
+      slugs,
+    }];
+  });
+}
+
+export function useStreamingServiceOptions(): Observable<
+  StreamingServiceOptions
+> {
+  const { country, favorites } = useStreamingPreferences();
+  const query = useQuery(streamingSourcesQuery({}));
+
+  return combineLatest([country, favorites, query]).pipe(
+    map(([countryCode, $favorites, $query]) => {
+      const services = $query.data?.get(countryCode) ?? [];
+      const favoriteOptions = toFavoriteOptions($favorites, services);
+
+      return {
+        all: sortStreamingServices(services).map(toOption),
+        top: favoriteOptions.length > 0
+          ? favoriteOptions
+          : toBrandOptions(services),
+      };
+    }),
+  );
+}


### PR DESCRIPTION
Adds individual streaming services to the **Availability** filter.

## What changed
- **Simple view:** the Availability dropdown is augmented with the user's favorite streaming services. Favorites are deduped by brand (so the Prime Video store + subscription variants collapse to one entry), falling back to the top brands when no favorites are set.
- **Advanced view:** every available service is selectable in the multi-select.

## Notes
- Service options are scoped to the user's country.
- Reuses the existing availability (`watchnow`) param, so URL state, persistence, and the advanced/simple split all behave as before. No new filter keys.

Fixes https://github.com/trakt/trakt-web/issues/2627
Fixes https://github.com/trakt/trakt-web/issues/1632