### PR TITLE
feat(lists): compact my lists hub cards

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6963,6 +6963,75 @@
         }
       }
     },
+    "list_summary_range_up_to": {
+      "default": "Up to {value}",
+      "description": "Smart list filter summary for an upper-bound-only range, e.g. 'Up to 90'.",
+      "variables": {
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "list_summary_range_labeled_up_to": {
+      "default": "{label} up to {value}",
+      "description": "Smart list filter summary for a labeled upper-bound-only range, e.g. 'Trakt up to 80%'.",
+      "variables": {
+        "label": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "list_summary_range_between": {
+      "default": "{min} to {max}",
+      "description": "Smart list filter summary for a range with both bounds, e.g. '60 to 80'.",
+      "variables": {
+        "min": {
+          "type": "string"
+        },
+        "max": {
+          "type": "string"
+        }
+      }
+    },
+    "list_summary_range_labeled_between": {
+      "default": "{label} {min} to {max}",
+      "description": "Smart list filter summary for a labeled range with both bounds, e.g. 'Trakt 60% to 80%'.",
+      "variables": {
+        "label": {
+          "type": "string"
+        },
+        "min": {
+          "type": "string"
+        },
+        "max": {
+          "type": "string"
+        }
+      }
+    },
+    "list_summary_range_from": {
+      "default": "{value} and up",
+      "description": "Smart list filter summary for a lower-bound-only range, e.g. '60 and up'.",
+      "variables": {
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "list_summary_range_labeled_from": {
+      "default": "{label} {value} and up",
+      "description": "Smart list filter summary for a labeled lower-bound-only range, e.g. 'Trakt 60% and up'.",
+      "variables": {
+        "label": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
     "warning_smart_lists_limit": {
       "default": "You've reached your smart list limit",
       "description": "Warning text shown when a user has reached their smart list limit and attempts to create a new smart list."

--- a/projects/client/src/lib/sections/lists/components/ListSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/ListSummaryCard.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import Card from "$lib/components/card/Card.svelte";
+  import type { Snippet } from "svelte";
+
+  const {
+    children,
+    variant = "default",
+  }: {
+    children: Snippet;
+    variant?: "default" | "official";
+  } = $props();
+</script>
+
+<Card
+  --width-card="min(var(--width-list-card), 85vw)"
+  --height-card="var(--height-list-card)"
+>
+  <div class="trakt-list-summary-card" data-variant={variant}>
+    {@render children()}
+  </div>
+</Card>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-list-summary-card {
+    height: var(--height-list-card);
+    box-sizing: border-box;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: var(--gap-xs);
+
+    padding: var(--ni-12);
+
+    outline: var(--border-thickness-xs) solid transparent;
+    transition: outline-color var(--transition-increment) ease-in-out;
+
+    background-color: color-mix(
+      in srgb,
+      var(--color-card-background) 40%,
+      var(--color-background)
+    );
+    border-radius: var(--border-radius-m);
+
+    &[data-variant="official"] {
+      background-color: color-mix(
+        in srgb,
+        var(--color-official-list-background) 40%,
+        var(--color-background)
+      );
+    }
+  }
+
+  @include for-mouse() {
+    :global(.trakt-card-content:hover) .trakt-list-summary-card {
+      outline-color: var(--color-card-border-hover);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/components/list-summary/ListSummaryItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/ListSummaryItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import Card from "$lib/components/card/Card.svelte";
   import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary.ts";
+  import ListSummaryCard from "../ListSummaryCard.svelte";
   import ListHeader from "./_internal/ListHeader.svelte";
   import ListPosters from "./_internal/ListPosters.svelte";
 
@@ -22,54 +22,7 @@
   };
 </script>
 
-<Card
-  --width-card="min(var(--width-list-card), 85vw)"
-  --height-card="var(--height-list-card)"
->
-  <div
-    class="trakt-list-summary"
-    class:trakt-list-official={list.type === "official"}
-  >
-    <ListHeader {list} {type} {source} onclick={handler} />
-    <ListPosters {list} {type} {source} onclick={handler} />
-  </div>
-</Card>
-
-<style lang="scss">
-  @use "$style/scss/mixins/index" as *;
-
-  .trakt-list-summary {
-    height: var(--height-list-card);
-    box-sizing: border-box;
-
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-xs);
-
-    padding: var(--ni-12);
-
-    outline: var(--border-thickness-xs) solid transparent;
-    transition: outline-color var(--transition-increment) ease-in-out;
-
-    background-color: color-mix(
-      in srgb,
-      var(--color-card-background) 40%,
-      var(--color-background)
-    );
-    border-radius: var(--border-radius-m);
-
-    &.trakt-list-official {
-      background-color: color-mix(
-        in srgb,
-        var(--color-official-list-background) 40%,
-        var(--color-background)
-      );
-    }
-  }
-
-  @include for-mouse() {
-    :global(.trakt-card-content:hover) .trakt-list-summary {
-      outline-color: var(--color-card-border-hover);
-    }
-  }
-</style>
+<ListSummaryCard variant={list.type === "official" ? "official" : "default"}>
+  <ListHeader {list} {type} {source} onclick={handler} />
+  <ListPosters {list} {type} {source} onclick={handler} />
+</ListSummaryCard>

--- a/projects/client/src/lib/sections/lists/smart/SmartLists.svelte
+++ b/projects/client/src/lib/sections/lists/smart/SmartLists.svelte
@@ -1,24 +1,22 @@
 <script lang="ts">
-  import SmartListIcon from "$lib/components/icons/SmartListIcon.svelte";
   import SectionList from "$lib/components/lists/section-list/SectionList.svelte";
   import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode";
   import * as m from "$lib/features/i18n/messages.ts";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CtaItem from "../components/cta/CtaItem.svelte";
-  import ListsHeader from "../user/_internal/ListsHeader.svelte";
   import CreateSmartListButton from "./_internal/CreateSmartListButton.svelte";
-  import SmartListRenderer from "./SmartListRenderer.svelte";
+  import SmartListSummaryItem from "./_internal/SmartListSummaryItem.svelte";
   import { useSmartLists } from "./useSmartLists";
 
   const { mode }: { mode: DiscoverMode } = $props();
 
-  const { list } = $derived(useSmartLists({ mode }));
+  const { list, isLoading } = $derived(useSmartLists({ mode }));
 
   const drilldown = $derived({
     href: UrlBuilder.lists.smart.all(),
     label: m.button_label_view_all_lists(),
     source: { id: "smart-lists" },
-    mode: $list.length === 0 ? ("disabled" as const) : ("default" as const),
+    mode: "always" as const,
   });
 </script>
 
@@ -26,38 +24,26 @@
   <CreateSmartListButton />
 {/snippet}
 
-{#if $list.length === 0}
-  <SectionList
-    id={{
-      scope: "smart-lists",
-    }}
-    items={[]}
-    title="Smart Lists"
-    --height-list="var(--height-poster-list-sm)"
-    {drilldown}
-    {actions}
-  >
-    {#snippet item(_)}{/snippet}
-    {#snippet empty()}
+<SectionList
+  id={{
+    scope: "smart-lists",
+  }}
+  items={$list}
+  title={m.list_title_smart_lists()}
+  --height-list="var(--height-lists-list)"
+  --height-override-list={$list.length === 0
+    ? "var(--height-poster-list-sm)"
+    : undefined}
+  {drilldown}
+  {actions}
+>
+  {#snippet item(list)}
+    <SmartListSummaryItem {list} />
+  {/snippet}
+
+  {#snippet empty()}
+    {#if !$isLoading}
       <CtaItem cta={{ type: "smart-list" }} variant="placeholder" />
-    {/snippet}
-  </SectionList>
-{:else}
-  <div class="trakt-smart-lists">
-    <ListsHeader title="Smart Lists" {actions} {drilldown}>
-      {#snippet icon()}
-        <SmartListIcon />
-      {/snippet}
-    </ListsHeader>
-
-    <SmartListRenderer mode={mode ?? "media"} />
-  </div>
-{/if}
-
-<style>
-  .trakt-smart-lists {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-micro);
-  }
-</style>
+    {/if}
+  {/snippet}
+</SectionList>

--- a/projects/client/src/lib/sections/lists/smart/_internal/SmartListSummaryItem.svelte
+++ b/projects/client/src/lib/sections/lists/smart/_internal/SmartListSummaryItem.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import Card from "$lib/components/card/Card.svelte";
   import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
   import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import type { SmartList } from "$lib/requests/queries/users/smartListQuery.ts";
+  import ListSummaryCard from "$lib/sections/lists/components/ListSummaryCard.svelte";
   import { toTranslatedGenre } from "$lib/utils/formatting/string/toTranslatedGenre";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import SmartListActions from "./SmartListActions.svelte";
@@ -144,76 +144,46 @@
   }
 </script>
 
-<Card
-  --width-card="min(var(--width-list-card), 85vw)"
-  --height-card="var(--height-list-card)"
->
-  <div class="trakt-smart-list-summary">
-    <div class="trakt-smart-list-header">
-      <div class="trakt-smart-list-icon" aria-hidden="true">
-        {#if list.type === "movie"}
-          <MovieIcon />
-        {:else}
-          <ShowIcon />
-        {/if}
-      </div>
-
-      <div class="trakt-smart-list-title">
-        <Link {href}>
-          <p class="secondary bold ellipsis">{list.title}</p>
-        </Link>
-        <p class="secondary small ellipsis">
-          {filterSummary}
-        </p>
-      </div>
-
-      <SmartListActions {list} />
+<ListSummaryCard>
+  <div class="trakt-smart-list-header">
+    <div class="trakt-smart-list-icon" aria-hidden="true">
+      {#if list.type === "movie"}
+        <MovieIcon />
+      {:else}
+        <ShowIcon />
+      {/if}
     </div>
 
-    <Link {href} color="inherit">
-      <div
-        class="trakt-smart-list-posters"
-        style="--poster-count: {$posters.length}"
-      >
-        {#each $posters as poster, index (`${list.id}_poster_${index}`)}
-          <div class="poster-wrapper" style="--poster-index: {index}">
-            <CrossOriginImage
-              src={poster}
-              alt={m.image_alt_list_preview_poster({ title: list.title })}
-            />
-          </div>
-        {/each}
-      </div>
-    </Link>
+    <div class="trakt-smart-list-title">
+      <Link {href}>
+        <p class="secondary bold ellipsis">{list.title}</p>
+      </Link>
+      <p class="secondary small ellipsis">
+        {filterSummary}
+      </p>
+    </div>
+
+    <SmartListActions {list} />
   </div>
-</Card>
+
+  <Link {href} color="inherit">
+    <div
+      class="trakt-smart-list-posters"
+      style="--poster-count: {$posters.length}"
+    >
+      {#each $posters as poster, index (`${list.id}_poster_${index}`)}
+        <div class="poster-wrapper" style="--poster-index: {index}">
+          <CrossOriginImage
+            src={poster}
+            alt={m.image_alt_list_preview_poster({ title: list.title })}
+          />
+        </div>
+      {/each}
+    </div>
+  </Link>
+</ListSummaryCard>
 
 <style lang="scss">
-  @use "$style/scss/mixins/index" as *;
-
-  .trakt-smart-list-summary {
-    --smart-list-summary-background: color-mix(
-      in srgb,
-      var(--color-card-background) 88%,
-      var(--color-foreground)
-    );
-
-    height: var(--height-list-card);
-    box-sizing: border-box;
-
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-m);
-
-    padding: var(--ni-12);
-
-    outline: var(--border-thickness-xs) solid transparent;
-    transition: outline-color var(--transition-increment) ease-in-out;
-
-    background-color: var(--smart-list-summary-background);
-    border-radius: var(--border-radius-m);
-  }
-
   .trakt-smart-list-header {
     display: flex;
     align-items: center;
@@ -297,12 +267,6 @@
     :global(img) {
       width: 100%;
       height: 100%;
-    }
-  }
-
-  @include for-mouse() {
-    :global(.trakt-card-content:hover) .trakt-smart-list-summary {
-      outline-color: var(--color-card-border-hover);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/smart/_internal/SmartListSummaryItem.svelte
+++ b/projects/client/src/lib/sections/lists/smart/_internal/SmartListSummaryItem.svelte
@@ -2,10 +2,12 @@
   import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
   import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
+  import { languageTag } from "$lib/features/i18n/index.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import type { SmartList } from "$lib/requests/queries/users/smartListQuery.ts";
   import ListSummaryCard from "$lib/sections/lists/components/ListSummaryCard.svelte";
+  import { toPercentage } from "$lib/utils/formatting/number/toPercentage.ts";
   import { toTranslatedGenre } from "$lib/utils/formatting/string/toTranslatedGenre";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import SmartListActions from "./SmartListActions.svelte";
@@ -65,33 +67,53 @@
     const [min, max] = value.split("-");
 
     if (min && max) {
-      return `${min}-${max}`;
+      return m.list_summary_range_between({ min, max });
     }
 
     if (min) {
-      return `${min}+`;
+      return m.list_summary_range_from({ value: min });
     }
 
     if (max) {
-      return `Up to ${max}`;
+      return m.list_summary_range_up_to({ value: max });
     }
 
     return value;
+  }
+
+  function toRatingPercentage(value: string): string {
+    const numeric = Number(value);
+
+    if (Number.isNaN(numeric)) {
+      return value;
+    }
+
+    return toPercentage(numeric / 100, languageTag());
   }
 
   function formatPercentRange(value: string, label: string): string {
     const [min, max] = value.split("-");
 
     if (min && max) {
-      return `${label} ${min}-${max}%`;
+      return m.list_summary_range_labeled_between({
+        label,
+        min: toRatingPercentage(min),
+        max: toRatingPercentage(max),
+      });
     }
 
     if (min) {
-      return `${label} ${min}%+`;
+      return m.list_summary_range_labeled_from({
+        label,
+        value: toRatingPercentage(min),
+      });
     }
 
     if (max) {
-      return `${label} up to ${max}%`;
+      return m.list_summary_range_labeled_up_to({
+        label,
+        value: toRatingPercentage(max),
+      });
     }
 
     return `${label} ${value}`;

--- a/projects/client/src/lib/sections/lists/smart/_internal/SmartListSummaryItem.svelte
+++ b/projects/client/src/lib/sections/lists/smart/_internal/SmartListSummaryItem.svelte
@@ -1,0 +1,308 @@
+<script lang="ts">
+  import Card from "$lib/components/card/Card.svelte";
+  import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
+  import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
+  import type { SmartList } from "$lib/requests/queries/users/smartListQuery.ts";
+  import { toTranslatedGenre } from "$lib/utils/formatting/string/toTranslatedGenre";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import SmartListActions from "./SmartListActions.svelte";
+  import { useSmartListPreview } from "./useSmartListPreview";
+
+  const { list }: { list: SmartList } = $props();
+
+  const href = $derived(UrlBuilder.lists.smart.view(list.id));
+  const { posters } = $derived(useSmartListPreview(list));
+  const filterSummary = $derived(getFilterSummary(list));
+
+  function targetLabel(target: SmartList["target"]) {
+    switch (target) {
+      case "trending":
+        return m.list_title_trending();
+      case "popular":
+        return m.list_title_most_popular();
+      case "anticipated":
+        return m.list_title_most_anticipated();
+      case "unknown":
+        return m.list_title_smart_lists();
+    }
+  }
+
+  function splitValues(value: string): string[] {
+    return value.split(",").map((item) => item.trim()).filter(Boolean);
+  }
+
+  function toTitleCase(value: string): string {
+    return value
+      .replaceAll("-", " ")
+      .replaceAll("_", " ")
+      .replace(/\b\w/g, (character) => character.toUpperCase());
+  }
+
+  function formatRange(
+    value: string,
+    formatter: (range: { min: number; max: number }) => string,
+  ): string {
+    const [minValue, maxValue] = value.split("-");
+
+    if (!minValue || !maxValue) {
+      return formatPlainRange(value);
+    }
+
+    const min = Number(minValue);
+    const max = Number(maxValue);
+
+    if (Number.isNaN(min) || Number.isNaN(max)) {
+      return value;
+    }
+
+    return formatter({ min, max });
+  }
+
+  function formatPlainRange(value: string): string {
+    const [min, max] = value.split("-");
+
+    if (min && max) {
+      return `${min}-${max}`;
+    }
+
+    if (min) {
+      return `${min}+`;
+    }
+
+    if (max) {
+      return `Up to ${max}`;
+    }
+
+    return value;
+  }
+
+  function formatPercentRange(value: string, label: string): string {
+    const [min, max] = value.split("-");
+
+    if (min && max) {
+      return `${label} ${min}-${max}%`;
+    }
+
+    if (min) {
+      return `${label} ${min}%+`;
+    }
+
+    if (max) {
+      return `${label} up to ${max}%`;
+    }
+
+    return `${label} ${value}`;
+  }
+
+  function formatFilter(key: string, value: string): string[] {
+    if (value.length === 0) {
+      return [];
+    }
+
+    switch (key) {
+      case "genres":
+      case "subgenres":
+        return splitValues(value).map((genre) => toTranslatedGenre(genre));
+      case "years":
+        return [formatRange(value, m.advanced_filter_label_release_year)];
+      case "runtimes":
+        return [formatRange(value, m.advanced_filter_label_runtime)];
+      case "ratings":
+        return [formatPercentRange(value, "Trakt")];
+      case "imdb_ratings":
+        return [`IMDb ${formatPlainRange(value)}`];
+      case "rt_meters":
+        return [formatPercentRange(value, "RT")];
+      case "rt_user_meters":
+        return [formatPercentRange(value, "RT Audience")];
+      case "certifications":
+        return splitValues(value).map((certification) =>
+          certification.toUpperCase()
+        );
+      case "countries":
+        return splitValues(value).map((country) => country.toUpperCase());
+      case "statuses":
+      case "watchnow":
+        return splitValues(value).map(toTitleCase);
+      case "ignore_watched":
+        return value === "true" ? [m.header_hide_watched()] : [];
+      case "ignore_watchlisted":
+        return value === "true" ? [m.header_hide_watchlisted()] : [];
+      default:
+        return [`${toTitleCase(key)} ${value}`];
+    }
+  }
+
+  function getFilterSummary(list: SmartList): string {
+    const filters = Object.entries(list.params)
+      .flatMap(([key, value]) => formatFilter(key, value));
+
+    return [targetLabel(list.target), ...filters].join(", ");
+  }
+</script>
+
+<Card
+  --width-card="min(var(--width-list-card), 85vw)"
+  --height-card="var(--height-list-card)"
+>
+  <div class="trakt-smart-list-summary">
+    <div class="trakt-smart-list-header">
+      <div class="trakt-smart-list-icon" aria-hidden="true">
+        {#if list.type === "movie"}
+          <MovieIcon />
+        {:else}
+          <ShowIcon />
+        {/if}
+      </div>
+
+      <div class="trakt-smart-list-title">
+        <Link {href}>
+          <p class="secondary bold ellipsis">{list.title}</p>
+        </Link>
+        <p class="secondary small ellipsis">
+          {filterSummary}
+        </p>
+      </div>
+
+      <SmartListActions {list} />
+    </div>
+
+    <Link {href} color="inherit">
+      <div
+        class="trakt-smart-list-posters"
+        style="--poster-count: {$posters.length}"
+      >
+        {#each $posters as poster, index (`${list.id}_poster_${index}`)}
+          <div class="poster-wrapper" style="--poster-index: {index}">
+            <CrossOriginImage
+              src={poster}
+              alt={m.image_alt_list_preview_poster({ title: list.title })}
+            />
+          </div>
+        {/each}
+      </div>
+    </Link>
+  </div>
+</Card>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-smart-list-summary {
+    --smart-list-summary-background: color-mix(
+      in srgb,
+      var(--color-card-background) 88%,
+      var(--color-foreground)
+    );
+
+    height: var(--height-list-card);
+    box-sizing: border-box;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-m);
+
+    padding: var(--ni-12);
+
+    outline: var(--border-thickness-xs) solid transparent;
+    transition: outline-color var(--transition-increment) ease-in-out;
+
+    background-color: var(--smart-list-summary-background);
+    border-radius: var(--border-radius-m);
+  }
+
+  .trakt-smart-list-header {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    min-width: 0;
+  }
+
+  .trakt-smart-list-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: var(--ni-40);
+    height: var(--ni-40);
+    flex-shrink: 0;
+
+    color: var(--color-text-secondary);
+    background-color: color-mix(
+      in srgb,
+      var(--color-card-background) 78%,
+      var(--color-foreground)
+    );
+    border-radius: var(--border-radius-s);
+
+    :global(svg) {
+      width: var(--ni-24);
+      height: var(--ni-24);
+    }
+  }
+
+  .trakt-smart-list-title {
+    display: grid;
+    min-width: 0;
+    flex-grow: 1;
+
+    :global(.trakt-link) {
+      min-width: 0;
+      text-decoration: none;
+    }
+  }
+
+  .trakt-smart-list-posters {
+    --poster-width: var(--ni-120);
+    --poster-height: var(--ni-180);
+
+    height: var(--poster-height);
+    width: 100%;
+
+    display: flex;
+    flex-shrink: 0;
+
+    position: relative;
+
+    counter-reset: number;
+  }
+
+  .poster-wrapper {
+    --poster-index: 0;
+
+    --poster-overlap: calc(var(--poster-width) / 5);
+    --total-poster-width: calc(
+      (var(--poster-width) - var(--poster-overlap)) * var(--poster-count)
+    );
+    --poster-spread-width: min(100%, var(--total-poster-width));
+    --poster-offset: calc(
+      (var(--poster-spread-width) - var(--poster-width)) /
+        max(1, var(--poster-count) - 1)
+    );
+
+    position: absolute;
+    inset-inline-start: calc(var(--poster-offset) * var(--poster-index));
+
+    height: var(--poster-height);
+    width: var(--poster-width);
+
+    box-shadow: var(--shadow-floating);
+    border-radius: var(--border-radius-m);
+    overflow: hidden;
+
+    :global(img) {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  @include for-mouse() {
+    :global(.trakt-card-content:hover) .trakt-smart-list-summary {
+      outline-color: var(--color-card-border-hover);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/smart/_internal/useSmartListPreview.ts
+++ b/projects/client/src/lib/sections/lists/smart/_internal/useSmartListPreview.ts
@@ -1,0 +1,48 @@
+import { map, of } from 'rxjs';
+import type { SmartList } from '$lib/requests/queries/users/smartListQuery.ts';
+import { useAnticipatedList } from '../../anticipated/useAnticipatedList.ts';
+import { usePopularList } from '../../popular/usePopularList.ts';
+import { useTrendingList } from '../../trending/useTrendingList.ts';
+
+const previewLimit = 8;
+
+function smartListToPreviewQuery(list: SmartList) {
+  const params = {
+    limit: previewLimit,
+    search: list.params,
+    type: list.type,
+  };
+
+  switch (list.target) {
+    case 'trending':
+      return useTrendingList(params);
+    case 'popular':
+      return usePopularList(params);
+    case 'anticipated':
+      return useAnticipatedList(params);
+    case 'unknown':
+      return undefined;
+  }
+}
+
+export function useSmartListPreview(list: SmartList) {
+  const query = smartListToPreviewQuery(list);
+
+  if (!query) {
+    return {
+      isLoading: of(false),
+      posters: of([]),
+    };
+  }
+
+  return {
+    isLoading: query.isLoading,
+    posters: query.list.pipe(
+      map((items) =>
+        items
+          .map((item) => item.poster.url.thumb)
+          .slice(0, previewLimit)
+      ),
+    ),
+  };
+}

--- a/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
+++ b/projects/client/src/lib/sections/lists/user/PersonalLists.svelte
@@ -19,12 +19,19 @@
   import UserList from "./UserList.svelte";
 
   const previewLimit = 3;
+  type PersonalListsDisplay = "auto" | "compact";
 
   const {
     type,
     slug,
     mode,
-  }: { type: PersonalListType; slug: string; mode?: DiscoverMode } = $props();
+    display = "auto",
+  }: {
+    type: PersonalListType;
+    slug: string;
+    mode?: DiscoverMode;
+    display?: PersonalListsDisplay;
+  } = $props();
 
   const {
     list: lists,
@@ -35,13 +42,20 @@
   const { isMe } = $derived(useIsMe(slug));
 
   const variant = $derived.by(() => {
+    if (display === "compact") {
+      return "summary";
+    }
+
     const shouldShowSummary =
       $hasNextPage || $lists.length === 0 || $lists.length > previewLimit;
     return shouldShowSummary ? "summary" : "preview";
   });
 
   const isMine = $derived(type === "personal" && $isMe);
-  const isPresentable = $derived(isMine || (!$isLoading && $lists.length > 0));
+  const isPresentable = $derived(
+    (display === "compact" ? $isMe : isMine) ||
+      (!$isLoading && $lists.length > 0),
+  );
 
   const title = $derived.by(() => {
     switch (type) {
@@ -111,6 +125,7 @@
         href: UrlBuilder.lists.all(slug, type),
         label: m.button_label_view_all_lists(),
         source: { id: "personal-lists", type },
+        mode: "always",
       }}
       --height-list="var(--height-lists-list)"
       --height-override-list={$lists.length === 0
@@ -148,6 +163,6 @@
   .trakt-lists-preview {
     display: flex;
     flex-direction: column;
-    gap: var(--gap-micro);
+    gap: var(--content-gap);
   }
 </style>

--- a/projects/client/src/routes/users/[user]/lists/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/+page.svelte
@@ -9,6 +9,7 @@
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import SmartLists from "$lib/sections/lists/smart/SmartLists.svelte";
   import PersonalLists from "$lib/sections/lists/user/PersonalLists.svelte";
+  import type { PersonalListType } from "$lib/sections/lists/user/models/PersonalListType.ts";
   import WatchList from "$lib/sections/lists/watchlist/WatchList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
@@ -21,6 +22,12 @@
   const { user } = useUser();
 
   const { isMe } = $derived(useIsMe(params.user));
+
+  const personalListTypes: PersonalListType[] = [
+    "personal",
+    "liked",
+    "collaboration",
+  ];
 </script>
 
 <TraktPage
@@ -48,7 +55,7 @@
 
   <SmartLists mode={$mode} />
 
-  <PersonalLists slug={$user.slug} type="personal" mode={$mode} />
-  <PersonalLists slug={$user.slug} type="liked" mode={$mode} />
-  <PersonalLists slug={$user.slug} type="collaboration" mode={$mode} />
+  {#each personalListTypes as type (type)}
+    <PersonalLists slug={$user.slug} {type} mode={$mode} display="compact" />
+  {/each}
 </TraktPage>


### PR DESCRIPTION
## Summary

Refines the `/users/me/lists` hub so each list category is presented **consistently** in compact mode.

- Shows Smart Lists as compact cards instead of the previous rows.
- Adds Smart List cards with folded poster previews, media-type icons, and an ellipsized comma-separated filter summary.
- Forces Personal Lists, Liked Lists, and Collaborations into compact summary display on the hub.
- Keeps drilldown and create actions available from each relevant section.

## Why

The page is a hub, so the UX should prioritize quick scanning and consistent section structure over switching between compact summaries and larger previews.

## Screenshots / Video

Before screenshots in light
<img width="2032" height="1101" alt="Screenshot 2026-06-22 at 15 30 26" src="https://github.com/user-attachments/assets/bd23ab00-ab75-4676-8293-9fbc5d828e8b" />
After screenshots in light
<img width="2032" height="1101" alt="Screenshot 2026-06-22 at 15 30 03" src="https://github.com/user-attachments/assets/061e68a7-29b7-4617-82e1-a41ff3c19b9c" />
Before screenshots in light
<img width="2032" height="1101" alt="Screenshot 2026-06-22 at 15 32 41" src="https://github.com/user-attachments/assets/eb3960e1-48a8-4db6-b778-7a8d28176fb4" />
After screenshots in dark
<img width="2032" height="1101" alt="Screenshot 2026-06-22 at 15 32 27" src="https://github.com/user-attachments/assets/d05f54b5-dd32-40a0-960d-8501f09d19a1" />
