### PR TITLE
fix(stats): makes screen time drawer grid responsive

### DIFF
--- a/projects/client/src/lib/sections/stats/ScreenTimeDrawerHost.svelte
+++ b/projects/client/src/lib/sections/stats/ScreenTimeDrawerHost.svelte
@@ -53,7 +53,9 @@
   {/if}
 </Drawer>
 
-<style>
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .screen-time-drawer-content {
     display: flex;
     flex-direction: column;
@@ -76,5 +78,9 @@
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: var(--gap-s);
+
+    @include for-mobile {
+      grid-template-columns: repeat(2, 1fr);
+    }
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2685
- Screen time drawer switches to a 2 column grid on mobile

## 👀 Example 👀
Before/after:
<img width="371" height="807" alt="Screenshot 2026-06-22 at 16 15 48" src="https://github.com/user-attachments/assets/a4f8f5fc-b419-4e8d-a2a7-e7820ab78f03" />

<img width="371" height="807" alt="Screenshot 2026-06-22 at 16 15 41" src="https://github.com/user-attachments/assets/3715ed2f-6c6d-46dd-a5df-b30195226c7d" />
