### PR TITLE
fix(i18n): schedule loading state updates asynchronously

### DIFF
--- a/projects/client/src/lib/features/intl-overlay/createBulkIntlOverlay.ts
+++ b/projects/client/src/lib/features/intl-overlay/createBulkIntlOverlay.ts
@@ -1,13 +1,15 @@
 import { useAuth } from '$lib/features/auth/stores/useAuth.ts';
 import { getLanguageAndRegion, languageTag } from '$lib/features/i18n/index.ts';
-import { bulkIntlQuery } from '$lib/requests/queries/intl/bulkIntlQuery.ts';
 import { useQueryClient } from '$lib/features/query/_internal/queryClientContext.ts';
+import { bulkIntlQuery } from '$lib/requests/queries/intl/bulkIntlQuery.ts';
 import {
+  asapScheduler,
   BehaviorSubject,
   catchError,
   from,
   map,
   type Observable,
+  observeOn,
   of,
   type OperatorFunction,
   startWith,
@@ -92,5 +94,12 @@ export function createBulkIntlOverlay<T>(
       startWith([] as T[]),
     );
 
-  return { operator, intlLoading$ };
+  // Defer loading-state emissions to the microtask queue so subscribers
+  // reading `intlLoading$` inside a Svelte `$derived` don't observe a write
+  // mid-evaluation (state_unsafe_mutation). The `entries$` data stream stays
+  // synchronous.
+  return {
+    operator,
+    intlLoading$: intlLoading$.pipe(observeOn(asapScheduler)),
+  };
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2687
  - https://trakt-tv.sentry.io/issues/129605620
- Could not reproduce locally, guesstimate fix.
  - The `createBulkIntlOverlay` operator was synchronously calling `intlLoading$.next()` inside a switchMap while Svelte was in the middle of a reactive derived evaluation/render phase for the source entries stream. By wrapping the side-effect store updates with RxJS's native `asapScheduler.schedule(() => intlLoading$.next(...))`, the mutations are safely deferred to the microtask queue. This prevents the lock engine crash while keeping the primary entries$ data stream purely synchronous.