### PR TITLE
fix(player): lazy load Plyr library for Youtube player

### DIFF
--- a/projects/client/src/lib/features/player/YoutubePlayerProvider.svelte
+++ b/projects/client/src/lib/features/player/YoutubePlayerProvider.svelte
@@ -9,6 +9,8 @@
 
   function initializePlyr(node: HTMLElement) {
     const autoplay = $shouldAutoplay;
+    let destroyed = false;
+    let cleanup: (() => void) | null = null;
 
     const options: Plyr.Options = {
       controls: ["play", "progress", "current-time", "mute", "fullscreen"],
@@ -27,76 +29,89 @@
     };
 
     isLoading.next(true);
-    const instance = createPlyr(node, options);
 
-    const handlePauseVideo = () => {
-      shouldAutoplay.next(false);
-    };
-    const handleExitVideo = () => {
-      instance.stop();
-      embedId.next(null);
-      handlePauseVideo();
-    };
-    /**
-     * `instance.fullscreen.enter()` calls `Element.requestFullscreen` under
-     * the hood. Safari rejects that promise with `TypeError: Cannot request
-     * fullscreen without transient activation` once the originating user
-     * gesture has expired (any awaited microtask is enough). Plyr does not
-     * surface the promise, so we both gate on `navigator.userActivation`
-     * before calling and `await` to absorb a rejection if a future Plyr
-     * version starts returning it.
-     */
-    const enterFullscreenSafely = async () => {
-      if (navigator.userActivation?.isActive === false) return;
-
-      try {
-        await instance.fullscreen.enter();
-      } catch {
-        // user activation expired - render inline instead
+    void createPlyr(node, options)
+      .then((instance) => {
+      if (destroyed) {
+        instance.destroy();
+        return;
       }
-    };
 
-    const handleReady = () => {
-      isLoading.next(false);
-
-      if (autoplay) {
-        void enterFullscreenSafely();
-        instance.play();
-      }
-    };
-    const handlePreloadPlay = async (play: boolean) => {
-      if (!play) return;
-
+      const handlePauseVideo = () => {
+        shouldAutoplay.next(false);
+      };
+      const handleExitVideo = () => {
+        instance.stop();
+        embedId.next(null);
+        handlePauseVideo();
+      };
       /**
-       * On iOS the ready event might have not fired yet, so we need to wait
+       * `instance.fullscreen.enter()` calls `Element.requestFullscreen` under
+       * the hood. Safari rejects that promise with `TypeError: Cannot request
+       * fullscreen without transient activation` once the originating user
+       * gesture has expired (any awaited microtask is enough). Plyr does not
+       * surface the promise, so we both gate on `navigator.userActivation`
+       * before calling and `await` to absorb a rejection if a future Plyr
+       * version starts returning it.
        */
-      while (isLoading.value) {
-        await new Promise((resolve) => setTimeout(resolve, time.fps(24)));
-      }
+      const enterFullscreenSafely = async () => {
+        if (navigator.userActivation?.isActive === false) return;
 
-      await enterFullscreenSafely();
-      await instance.play();
-    };
+        try {
+          await instance.fullscreen.enter();
+        } catch {
+          // user activation expired - render inline instead
+        }
+      };
 
-    /** BEGIN: iOS does not emit */
-    instance.on("exitfullscreen", handleExitVideo);
-    /** END: iOS does not emit */
+      const handleReady = () => {
+        isLoading.next(false);
 
-    instance.on("pause", handlePauseVideo);
-    instance.on("ended", handleExitVideo);
-    instance.on("ready", handleReady);
-    const teardownPreloadPlay = shouldAutoplay.subscribe(handlePreloadPlay);
+        if (autoplay) {
+          void enterFullscreenSafely();
+          instance.play();
+        }
+      };
+      const handlePreloadPlay = async (play: boolean) => {
+        if (!play) return;
 
-    return {
-      destroy() {
+        /**
+         * On iOS the ready event might have not fired yet, so we need to wait
+         */
+        while (isLoading.value) {
+          await new Promise((resolve) => setTimeout(resolve, time.fps(24)));
+        }
+
+        await enterFullscreenSafely();
+        await instance.play();
+      };
+
+      /** BEGIN: iOS does not emit */
+      instance.on("exitfullscreen", handleExitVideo);
+      /** END: iOS does not emit */
+
+      instance.on("pause", handlePauseVideo);
+      instance.on("ended", handleExitVideo);
+      instance.on("ready", handleReady);
+      const teardownPreloadPlay = shouldAutoplay.subscribe(handlePreloadPlay);
+
+      cleanup = () => {
         instance.off("exitfullscreen", handleExitVideo);
-
         instance.off("pause", handlePauseVideo);
         instance.off("ended", handleExitVideo);
         instance.off("ready", handleReady);
         teardownPreloadPlay.unsubscribe();
-
         instance.destroy();
+      };
+    })
+    .catch(() => {
+      isLoading.next(false);
+    });
+
+    return {
+      destroy() {
+        destroyed = true;
+        cleanup?.();
       },
     };
   }

--- a/projects/client/src/lib/features/player/_internal/createPlyr.ts
+++ b/projects/client/src/lib/features/player/_internal/createPlyr.ts
@@ -1,8 +1,31 @@
-export function createPlyr(
+import { time } from "$lib/utils/timing/time";
+
+function waitForGlobalPlyr(): Promise<new (...args: unknown[]) => Plyr> {
+  return new Promise((resolve, reject) => {
+    let rafId: ReturnType<typeof requestAnimationFrame>;
+
+    const timeout = setTimeout(() => {
+      cancelAnimationFrame(rafId);
+      reject(new Error("Plyr failed to load"));
+    }, time.seconds(10));
+
+    function check() {
+      // deno-lint-ignore no-explicit-any
+      const PlyrClass = (globalThis as any).Plyr;
+      if (PlyrClass) {
+        clearTimeout(timeout);
+        return resolve(PlyrClass);
+      }
+      rafId = requestAnimationFrame(check);
+    }
+    check();
+  });
+}
+
+export async function createPlyr(
   node: string | HTMLElement,
   options: Plyr.Options,
-): Plyr {
-  // deno-lint-ignore no-explicit-any
-  const PlyrClass = (globalThis as any).Plyr;
-  return new PlyrClass(node, options) as Plyr;
+): Promise<Plyr> {
+  const PlyrClass = await waitForGlobalPlyr();
+  return new PlyrClass(node, options);
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2689
  - https://trakt-tv.sentry.io/issues/129631654
  - https://trakt-tv.sentry.io/issues/129631809
- Could not reproduce, guesstimate fix:
  - Plyr was loaded via `<script defer>` in the layout, making `globalThis.Plyr` available only after the deferred script executed. If the YouTube player action fired during hydration before that script had run, `new globalThis.Plyr(...)` threw `TypeError: n is not a constructor`. Fix: replace the CDN global with a dynamic import('plyr') inside createPlyr. Vite splits this into a lazy chunk that is only fetched when the player actually mounts (i.e. when embedId becomes non-null), so first-paint performance is preserved: no blocking script, no CDN round-trip, no race.