### PR TITLE
fix: gracefully handle setItem errors during setItem operations

### DIFF
--- a/projects/client/src/lib/utils/storage/safeStorage.ts
+++ b/projects/client/src/lib/utils/storage/safeStorage.ts
@@ -10,13 +10,33 @@ const Noop_storage: Storage = {
   clear: NOOP_FN,
 };
 
+function wrapStorage(storage: Storage): Storage {
+  return {
+    get length() {
+      return storage.length;
+    },
+    key: (index) => storage.key(index),
+    getItem: (key) => storage.getItem(key),
+    setItem: (key, value) => {
+      try {
+        storage.setItem(key, value);
+      } catch {
+        // QuotaExceededError: storage full or disabled
+      }
+    },
+    removeItem: (key) => storage.removeItem(key),
+    clear: () => storage.clear(),
+  };
+}
+
 function resolveStorage(getStorage: () => Storage | null): Storage {
   if (!browser) {
     return Noop_storage;
   }
 
   try {
-    return getStorage() ?? Noop_storage;
+    const storage = getStorage();
+    return storage ? wrapStorage(storage) : Noop_storage;
   } catch {
     return Noop_storage;
   }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Came across an [error on sentry](https://trakt-tv.sentry.io/issues/129638593): `QuotaExceededError`
- This fix adds a try/catch around setItem to suppress it. Try/catch error won't swallow other errors, [QuotaExceededError](https://html.spec.whatwg.org/multipage/webstorage.html#storage-2) is the only one it can throw, either if the disk is full, or the user has disabled local storage.