### PR TITLE
fix(tags): show partial status in indicator tag

### DIFF
--- a/projects/client/src/lib/components/media/tags/IndicatorTag.svelte
+++ b/projects/client/src/lib/components/media/tags/IndicatorTag.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import StemTag from "$lib/components/tags/StemTag.svelte";
 
-  const { children }: ChildrenProps = $props();
+  const {
+    children,
+    variant = "full",
+  }: { variant?: "partial" | "full" } & ChildrenProps = $props();
 </script>
 
-<trakt-indicator-tag>
+<trakt-indicator-tag data-variant={variant}>
   <StemTag
     --color-background-stem-tag="var(--color-background-indicator-tag)"
     --color-foreground-stem-tag="var(--color-text-indicator-tag)"
@@ -22,6 +25,16 @@
       :global(trakt-tag-icon svg) {
         width: var(--ni-10);
         height: var(--ni-10);
+      }
+    }
+
+    &[data-variant="partial"] {
+      :global(.trakt-tag) {
+        background: linear-gradient(
+          to right,
+          var(--color-background-stem-tag) 50%,
+          var(--shade-500) 50%
+        );
       }
     }
   }

--- a/projects/client/src/lib/features/player/_internal/createPlyr.ts
+++ b/projects/client/src/lib/features/player/_internal/createPlyr.ts
@@ -1,4 +1,4 @@
-import { time } from "$lib/utils/timing/time";
+import { time } from '$lib/utils/timing/time';
 
 function waitForGlobalPlyr(): Promise<new (...args: unknown[]) => Plyr> {
   return new Promise((resolve, reject) => {
@@ -6,7 +6,7 @@ function waitForGlobalPlyr(): Promise<new (...args: unknown[]) => Plyr> {
 
     const timeout = setTimeout(() => {
       cancelAnimationFrame(rafId);
-      reject(new Error("Plyr failed to load"));
+      reject(new Error('Plyr failed to load'));
     }, time.seconds(10));
 
     function check() {

--- a/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/DefaultMediaItem.svelte
@@ -31,7 +31,9 @@
     sortTag?: Snippet;
   } = $props();
 
-  const { isWatched } = $derived(useIsWatched({ type, media }));
+  const { isWatched, isPartiallyWatched } = $derived(
+    useIsWatched({ type, media }),
+  );
   const { isWatchlisted } = $derived(useIsWatchlisted({ type, media }));
 
   const isDeemphasized = $derived(canDeemphasize && $isWatched);
@@ -64,7 +66,11 @@
 {/snippet}
 
 {#snippet indicatorTags()}
-  <StatusIndicators isWatched={$isWatched} isWatchlisted={$isWatchlisted} />
+  <StatusIndicators
+    isWatched={$isWatched}
+    isPartiallyWatched={$isPartiallyWatched}
+    isWatchlisted={$isWatchlisted}
+  />
 {/snippet}
 
 {#snippet tag()}
@@ -101,7 +107,10 @@
 {/snippet}
 
 <MediaSwipe {type} {media} {style}>
-  <trakt-default-media-item role="listitem" class:is-deemphasized={isDeemphasized}>
+  <trakt-default-media-item
+    role="listitem"
+    class:is-deemphasized={isDeemphasized}
+  >
     <MediaItem
       {type}
       {media}

--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -38,7 +38,7 @@
 
   const { track } = useTrack(AnalyticsEvent.SummaryDrilldown);
 
-  const { isWatched } = $derived(
+  const { isWatched, isPartiallyWatched } = $derived(
     useIsWatched({ type: "season", media: season, show: media }),
   );
 
@@ -49,7 +49,11 @@
 </script>
 
 {#snippet indicatorTags()}
-  <StatusIndicators isWatched={$isWatched} isWatchlisted={false} />
+  <StatusIndicators
+    isWatched={$isWatched}
+    isPartiallyWatched={$isPartiallyWatched}
+    isWatchlisted={false}
+  />
 {/snippet}
 
 <div

--- a/projects/client/src/lib/sections/lists/components/StatusIndicators.svelte
+++ b/projects/client/src/lib/sections/lists/components/StatusIndicators.svelte
@@ -5,14 +5,19 @@
 
   type StatusIndicatorsProps = {
     isWatched: boolean;
+    isPartiallyWatched?: boolean;
     isWatchlisted: boolean;
   };
 
-  const { isWatched, isWatchlisted }: StatusIndicatorsProps = $props();
+  const {
+    isWatched,
+    isPartiallyWatched,
+    isWatchlisted,
+  }: StatusIndicatorsProps = $props();
 </script>
 
-{#if isWatched}
-  <IndicatorTag>
+{#if isWatched || isPartiallyWatched}
+  <IndicatorTag variant={isPartiallyWatched ? "partial" : "full"}>
     <TrackIcon />
   </IndicatorTag>
 {:else if isWatchlisted}

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
@@ -1,5 +1,5 @@
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
-import { map } from 'rxjs';
+import { map, shareReplay } from 'rxjs';
 import type { ExtendedMediaStoreProps } from '../../../models/MediaStoreProps.ts';
 
 export type IsWatchedProps = ExtendedMediaStoreProps;
@@ -20,32 +20,50 @@ export function useIsWatched(props: IsWatchedProps) {
     ? Array.isArray(props.media) ? props.media : [props.media]
     : [];
 
-  const isWatched = history.pipe(
+  const watchState = history.pipe(
     map(($history) => {
       if (!$history) {
-        return false;
+        return { isWatched: false, isPartiallyWatched: false };
       }
 
       switch (type) {
         case 'movie':
-          return media.every((m) => $history.movies.has(m.id));
+          return {
+            isWatched: media.every((m) => $history.movies.has(m.id)),
+            isPartiallyWatched: false,
+          };
         case 'episode': {
           const watchedEpisodes = $history.shows.get(showId)?.episodes ?? [];
 
-          return episodes.every((episode) =>
-            watchedEpisodes.some((e) => e.episodeId === episode.id)
-          );
+          return {
+            isWatched: episodes.every((episode) =>
+              watchedEpisodes.some((e) => e.episodeId === episode.id)
+            ),
+            isPartiallyWatched: false,
+          };
         }
         case 'season': {
           const countBySeason = $history.shows.get(showId)?.playsPerSeason ??
             new Map<number, number>();
 
-          return seasons.every((season) =>
+          const watchedCount = seasons.filter((season) =>
             (countBySeason.get(season.number) ?? 0) >= season.episodes.count
-          );
+          ).length;
+
+          const hasSomeCompleteSeasons = watchedCount > 0 &&
+            watchedCount < seasons.length;
+          const hasSomePartialSeasons = seasons.some((season) => {
+            const count = countBySeason.get(season.number) ?? 0;
+            return count > 0 && count < season.episodes.count;
+          });
+
+          return {
+            isWatched: watchedCount === seasons.length,
+            isPartiallyWatched: hasSomeCompleteSeasons || hasSomePartialSeasons,
+          };
         }
         case 'show': {
-          return shows.every((show) => {
+          const isWatched = shows.every((show) => {
             const watchedShow = $history.shows.get(show.id);
             const episodeCount = show.episode?.count;
 
@@ -56,15 +74,34 @@ export function useIsWatched(props: IsWatchedProps) {
             const watchedEpisodeCount = [
               ...watchedShow.playsPerSeason.entries(),
             ]
-              .filter(([season]) => season !== 0)
+              .filter(([season]) =>
+                season !== 0
+              )
               .reduce((sum, [, count]) => sum + count, 0);
 
             return watchedEpisodeCount >= episodeCount;
           });
+
+          const isPartiallyWatched = !isWatched && shows.some((show) => {
+            const watchedShow = $history.shows.get(show.id);
+
+            if (!watchedShow) {
+              return false;
+            }
+
+            return [...watchedShow.playsPerSeason.entries()]
+              .some(([season, count]) => season !== 0 && count > 0);
+          });
+
+          return { isWatched, isPartiallyWatched };
         }
       }
     }),
+    shareReplay({ bufferSize: 1, refCount: true }),
   );
 
-  return { isWatched };
+  const isWatched = watchState.pipe(map((s) => s.isWatched));
+  const isPartiallyWatched = watchState.pipe(map((s) => s.isPartiallyWatched));
+
+  return { isWatched, isPartiallyWatched };
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2696
- Status indicators are now also shown for partially watched shows and seasons
  - Background has a 50/50 split with a lighter color in those cases

## 👀 Examples 👀
<img width="462" height="296" alt="Screenshot 2026-06-23 at 17 10 49" src="https://github.com/user-attachments/assets/1ca13a07-184d-4a13-ab48-8ed21ca5a3e0" />

<img width="924" height="302" alt="Screenshot 2026-06-23 at 17 10 31" src="https://github.com/user-attachments/assets/7fc21411-efba-41f3-8d0a-154223f75271" />
