### PR TITLE
fix(summary): use navbar for filter button in people summary

### DIFF
--- a/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/PeopleSummary.svelte
@@ -2,8 +2,8 @@
   import ShareButton from "$lib/components/buttons/share/ShareButton.svelte";
   import SummaryPoster from "$lib/components/summary/SummaryPoster.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
-  import ReportButton from "$lib/features/report/ReportButton.svelte";
   import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
+  import ReportButton from "$lib/features/report/ReportButton.svelte";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
   import PersonTitle from "../_internal/PersonTitle.svelte";
   import SummaryContainer from "./../summary/SummaryContainer.svelte";
@@ -14,7 +14,6 @@
   import ImdbLink from "./v2/_internal/ImdbLink.svelte";
   import PersonDetails from "./v2/_internal/PersonDetails.svelte";
   import SocialMediaLinks from "./v2/_internal/SocialMediaLinks.svelte";
-  import FilterButton from "$lib/sections/navbar/components/filter/FilterButton.svelte";
 
   const { person }: { person: PersonSummary } = $props();
 </script>
@@ -25,23 +24,20 @@
   {/if}
 {/snippet}
 
-<SummaryContainer>
+<SummaryContainer variant="compact">
   {#snippet poster()}
     <SummaryPoster src={person.headshot.url.medium} alt={person.name} {tags} />
   {/snippet}
 
   <div class="trakt-summary-main-content">
     <SummaryHeader title={person.name}>
-      {#snippet headerActions()}
-        <FilterButton isDisabled={false} />
+      {#snippet popupActions()}
         <ShareButton
           title={person.name}
           textFactory={({ title: name }) => m.text_share_person({ name })}
           source={{ id: "person" }}
+          style="dropdown-item"
         />
-      {/snippet}
-
-      {#snippet popupActions()}
         <ReportButton
           params={{
             type: ReportableType.Person,

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
@@ -5,6 +5,7 @@
     poster?: Snippet;
     contextualContent?: Snippet;
     topActions?: Snippet;
+    variant?: "compact" | "default";
   } & ChildrenProps;
 
   const {
@@ -12,10 +13,15 @@
     contextualContent: content,
     children,
     topActions: actions,
+    variant = "default",
   }: SummaryContainerProps = $props();
 </script>
 
-<div class="trakt-summary-container" class:has-contextual-content={content}>
+<div
+  class="trakt-summary-container"
+  class:has-contextual-content={content}
+  data-variant={variant}
+>
   {#if poster}
     <div class="trakt-summary-poster-container">
       {@render poster()}
@@ -51,6 +57,11 @@
 
     margin: 0 var(--layout-distance-side);
     padding-top: var(--ni-38);
+
+    &[data-variant="compact"] {
+      padding-top: 0;
+      margin-top: calc(-1 * var(--gap-m));
+    }
 
     @include for-desktop {
       &.has-contextual-content {

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
@@ -53,7 +53,7 @@
     width: 100%;
 
     display: flex;
-    justify-content: flex-end;
+    justify-content: flex-start;
     align-items: center;
     gap: var(--gap-xs);
 

--- a/projects/client/src/routes/people/[slug]/+page.svelte
+++ b/projects/client/src/routes/people/[slug]/+page.svelte
@@ -5,6 +5,7 @@
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
   import PeopleSummary from "$lib/sections/summary/PeopleSummary.svelte";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { fromRune } from "$lib/utils/store/fromRune.svelte";
   import type { PageProps } from "./$types";
   import { usePerson } from "./usePerson";
@@ -23,6 +24,13 @@
 
     return { movies, shows };
   });
+
+  const isTabletLarge = useMedia(WellKnownMediaQuery.tabletLarge);
+  const isDesktop = useMedia(WellKnownMediaQuery.desktop);
+
+  const navbarMode = $derived(
+    $isTabletLarge || $isDesktop ? "full" : "minimal",
+  );
 </script>
 
 <TraktPage
@@ -31,7 +39,7 @@
   image={$person?.headshot?.url.medium}
 >
   <RenderFor audience="authenticated">
-    <NavbarStateSetter mode="minimal" hasFilters />
+    <NavbarStateSetter mode={navbarMode} hasFilters />
   </RenderFor>
 
   {#if !$isLoading}


### PR DESCRIPTION
## 🎶 Notes 🎶

- In the people summary page, for larger screens, the filter button is in the top navbar again.
- The actions behind the name are now all in the popup menu, and is aligned right after the name.

## 👀 Example 👀
Before/after:
<img width="1014" height="553" alt="Screenshot 2026-06-23 at 18 11 12" src="https://github.com/user-attachments/assets/8a0a8fa9-eecd-44ef-b3fd-af56a9b652d6" />

<img width="1014" height="570" alt="Screenshot 2026-06-23 at 18 09 41" src="https://github.com/user-attachments/assets/e608233a-8acd-4beb-a7c6-10febe3f0d39" />
