### PR TITLE
fix(filter): restore filters after client-side navigation

### DIFF
--- a/projects/client/src/lib/features/filters/FilterProvider.svelte
+++ b/projects/client/src/lib/features/filters/FilterProvider.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { useStoredFilters } from "./useStoredFilters";
 
   const { children }: ChildrenProps = $props();
 
   const { restoreFilters } = useStoredFilters();
-  restoreFilters();
+
+  onMount(() => {
+    restoreFilters();
+  });
 </script>
 
 {@render children()}

--- a/projects/client/src/lib/sections/navbar/components/filter/FilterButton.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/FilterButton.svelte
@@ -94,6 +94,8 @@
       color: var(--shade-10);
 
       line-height: 1;
+
+      pointer-events: none;
     }
   }
 </style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2705
- Stored filters are restored again.
  - The issue was caused by the fix that got rid of mutating reactive search params directly. That direct mutation was synchronous, it updated Svelte's reactive state immediately, so the single on-mount call worked. With the mutation removed, restoration now depends entirely on goto() completing async; afterNavigate ensures restoreFilters runs after navigation is settled.
- And a small fix to make the counter on the button non interactive.

## 👀 Example 👀

https://github.com/user-attachments/assets/aa88b0e2-7c43-455a-8427-6f9f4bafc43e

