### PR TITLE
Feat/local filters

### DIFF
--- a/projects/client/src/lib/features/filters/FilterScopeSetter.svelte
+++ b/projects/client/src/lib/features/filters/FilterScopeSetter.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import { onDestroy, untrack, type Snippet } from "svelte";
+  import { getSnapshotFilters } from "./_internal/getSnapshotFilters.ts";
+  import {
+    acquireFilterScope,
+    releaseFilterScope,
+  } from "./filterScopeStore.ts";
+  import type { FilterScope } from "./models/FilterScope.ts";
+
+  const {
+    filterScope = "local",
+    children,
+  }: { filterScope?: FilterScope; children: Snippet } = $props();
+
+  // Snapshot captured once at mount; later URL filter edits stay local and do
+  // not mutate the scope (that is what keeps outbound links on the snapshot).
+  const scope = untrack(() =>
+    acquireFilterScope(
+      filterScope === "local"
+        ? getSnapshotFilters(page.url.searchParams)
+        : null,
+    ),
+  );
+
+  onDestroy(() => releaseFilterScope(scope));
+</script>
+
+{@render children()}

--- a/projects/client/src/lib/features/filters/_internal/getSnapshotFilters.spec.ts
+++ b/projects/client/src/lib/features/filters/_internal/getSnapshotFilters.spec.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { FilterKey } from '../models/Filter.ts';
+import { STORED_FILTERS_KEY } from '../useStoredFilters.ts';
+import { getSnapshotFilters } from './getSnapshotFilters.ts';
+
+describe('util: getSnapshotFilters', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should capture filter params present in the URL', () => {
+    const params = new URLSearchParams({
+      [FilterKey.Genres]: 'action',
+      [FilterKey.Decade]: '2020',
+      page: '2',
+    });
+
+    expect(getSnapshotFilters(params)).toEqual({
+      [FilterKey.Genres]: 'action',
+      [FilterKey.Decade]: '2020',
+    });
+  });
+
+  it('should ignore non-filter params', () => {
+    const params = new URLSearchParams({ page: '2', sort_by: 'rank' });
+    expect(getSnapshotFilters(params)).toEqual({});
+  });
+
+  it('should fall back to the stored global filters when the URL has none', () => {
+    localStorage.setItem(
+      STORED_FILTERS_KEY,
+      JSON.stringify({ [FilterKey.Genres]: 'comedy' }),
+    );
+
+    expect(getSnapshotFilters(new URLSearchParams())).toEqual({
+      [FilterKey.Genres]: 'comedy',
+    });
+  });
+
+  it('should stringify non-string stored filter values', () => {
+    localStorage.setItem(
+      STORED_FILTERS_KEY,
+      JSON.stringify({ [FilterKey.IgnoreWatched]: true }),
+    );
+
+    expect(getSnapshotFilters(new URLSearchParams())).toEqual({
+      [FilterKey.IgnoreWatched]: 'true',
+    });
+  });
+
+  it('should return an empty object when there are no URL or stored filters', () => {
+    expect(getSnapshotFilters(new URLSearchParams())).toEqual({});
+  });
+});

--- a/projects/client/src/lib/features/filters/_internal/getSnapshotFilters.ts
+++ b/projects/client/src/lib/features/filters/_internal/getSnapshotFilters.ts
@@ -1,0 +1,26 @@
+import { FILTER_KEYS } from '../filterKeys.ts';
+import { getDefaultFilters } from './getDefaultFilters.ts';
+
+export function getSnapshotFilters(
+  searchParams: URLSearchParams,
+): Record<string, string> {
+  const urlFilters = FILTER_KEYS.reduce(
+    (acc, key) => {
+      const value = searchParams.get(key);
+      if (value) acc[key] = value;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+
+  if (Object.keys(urlFilters).length > 0) return urlFilters;
+
+  const defaults = getDefaultFilters();
+  if (!defaults) return {};
+
+  return Object.fromEntries(
+    Object.entries(defaults)
+      .filter(([, value]) => value != null)
+      .map(([key, value]) => [key, String(value)]),
+  );
+}

--- a/projects/client/src/lib/features/filters/filterKeys.ts
+++ b/projects/client/src/lib/features/filters/filterKeys.ts
@@ -1,0 +1,3 @@
+import { FilterKey } from './models/Filter.ts';
+
+export const FILTER_KEYS: ReadonlyArray<FilterKey> = Object.values(FilterKey);

--- a/projects/client/src/lib/features/filters/filterScopeStore.spec.ts
+++ b/projects/client/src/lib/features/filters/filterScopeStore.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  acquireFilterScope,
+  filterScopeStore,
+  releaseFilterScope,
+} from './filterScopeStore.ts';
+
+function currentValue() {
+  let value;
+  const sub = filterScopeStore.subscribe((v) => (value = v));
+  sub.unsubscribe();
+  return value;
+}
+
+describe('store: filterScopeStore', () => {
+  const acquired: symbol[] = [];
+
+  // Wraps acquire so afterEach can drain the module-level scope stack,
+  // keeping tests isolated even when they leave a scope dangling on purpose.
+  function acquire(value: Parameters<typeof acquireFilterScope>[0]) {
+    const token = acquireFilterScope(value);
+    acquired.push(token);
+    return token;
+  }
+
+  afterEach(() => {
+    acquired.splice(0).forEach(releaseFilterScope);
+  });
+
+  it('should push the acquired value to the store', () => {
+    acquire({ genres: 'action' });
+    expect(currentValue()).toEqual({ genres: 'action' });
+  });
+
+  it('should accept null for global scope', () => {
+    acquire({ genres: 'action' });
+    acquire(null);
+    expect(currentValue()).toBeNull();
+  });
+
+  it('should reset to null when the owning token releases', () => {
+    const token = acquire({ genres: 'action' });
+    releaseFilterScope(token);
+    expect(currentValue()).toBeNull();
+  });
+
+  it('should ignore a release from a stale (non-owning) token', () => {
+    const stale = acquire({ genres: 'action' });
+    acquire({ genres: 'comedy' });
+
+    releaseFilterScope(stale);
+
+    // The newest owner still holds the store - a destroyed predecessor
+    // must not wipe the active scope.
+    expect(currentValue()).toEqual({ genres: 'comedy' });
+  });
+
+  it('should restore the previous scope when the active nested scope is released', () => {
+    const outer = acquire({ genres: 'action' });
+    const inner = acquire({ genres: 'comedy' });
+
+    expect(currentValue()).toEqual({ genres: 'comedy' });
+
+    releaseFilterScope(inner);
+    expect(currentValue()).toEqual({ genres: 'action' });
+
+    releaseFilterScope(outer);
+    expect(currentValue()).toBeNull();
+  });
+});

--- a/projects/client/src/lib/features/filters/filterScopeStore.ts
+++ b/projects/client/src/lib/features/filters/filterScopeStore.ts
@@ -1,0 +1,30 @@
+import { BehaviorSubject } from 'rxjs';
+
+export type FilterScopeValue = Record<string, string> | null;
+
+export const filterScopeStore = new BehaviorSubject<FilterScopeValue>(null);
+
+type ScopeEntry = {
+  token: symbol;
+  value: FilterScopeValue;
+};
+
+// A stack so overlapping lifecycles (navigation transitions, nesting) restore
+// the previous scope instead of wiping it when an inner/older scope releases.
+const scopes: ScopeEntry[] = [];
+
+export function acquireFilterScope(value: FilterScopeValue): symbol {
+  const token = Symbol();
+  scopes.push({ token, value });
+  filterScopeStore.next(value);
+  return token;
+}
+
+export function releaseFilterScope(token: symbol): void {
+  const index = scopes.findIndex((scope) => scope.token === token);
+  if (index === -1) return;
+
+  scopes.splice(index, 1);
+  const active = scopes.at(-1);
+  filterScopeStore.next(active?.value ?? null);
+}

--- a/projects/client/src/lib/features/filters/models/FilterScope.ts
+++ b/projects/client/src/lib/features/filters/models/FilterScope.ts
@@ -1,0 +1,1 @@
+export type FilterScope = 'local' | 'global';

--- a/projects/client/src/lib/features/parameters/_internal/constants.ts
+++ b/projects/client/src/lib/features/parameters/_internal/constants.ts
@@ -1,9 +1,9 @@
-import { FilterKey } from '$lib/features/filters/models/Filter.ts';
+import { FILTER_KEYS } from '$lib/features/filters/filterKeys.ts';
 
 export const WHITE_LISTED_PARAMS: readonly string[] = [
   'navigation',
   'mode',
-  ...Object.values(FilterKey),
+  ...FILTER_KEYS,
 ];
 
 export const LOCAL_PARAMS: readonly string[] = ['sort_by', 'sort_how'];

--- a/projects/client/src/lib/features/parameters/appendGlobalParameters.spec.ts
+++ b/projects/client/src/lib/features/parameters/appendGlobalParameters.spec.ts
@@ -1,5 +1,12 @@
+import { BehaviorSubject } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FilterKey } from '$lib/features/filters/models/Filter.ts';
+import { filterScopeStore } from '$lib/features/filters/filterScopeStore.ts';
 import { appendGlobalParameters } from './appendGlobalParameters.ts';
+import {
+  PARAMETER_CONTEXT_KEY,
+  type ParameterType,
+} from './_internal/createParameterContext.ts';
 
 let pageUrl = new URL('https://app.trakt.tv/profile/userA');
 let afterNavigateCallback: (() => void) | undefined;
@@ -52,12 +59,24 @@ function makeAnchor(href: string): HTMLAnchorElement {
   return anchor;
 }
 
+/**
+ * Seeds the live parameter context so useParameters().search emits the given
+ * filters, mimicking filters currently applied to the page.
+ */
+function seedLiveParams(params: Record<string, ParameterType>) {
+  mockSvelteContextStore.set(PARAMETER_CONTEXT_KEY, {
+    parameters: new BehaviorSubject(new Map(Object.entries(params))),
+  });
+}
+
 describe('appendGlobalParameters', () => {
   beforeEach(() => {
     mockSvelteContextStore.clear();
     globalThis.window.history.pushState({}, '', '/profile/userA');
     pageUrl = new URL('/profile/userA', globalThis.window.location.href);
     afterNavigateCallback = undefined;
+    // Default to global scope; local-scope tests opt in explicitly.
+    filterScopeStore.next(null);
   });
 
   afterEach(() => {
@@ -115,6 +134,55 @@ describe('appendGlobalParameters', () => {
 
     expect(new URL(anchor.href).origin).toBe('https://example.com');
     expect(new URL(anchor.href).pathname).toBe('/page');
+  });
+
+  describe('local filter scope', () => {
+    it('applies the frozen snapshot to outbound (different-path) links', () => {
+      filterScopeStore.next({ [FilterKey.Genres]: 'action' });
+
+      const anchor = makeAnchor('/movies/heretic');
+      appendGlobalParameters(anchor, '/movies/heretic');
+
+      expect(new URL(anchor.href).searchParams.get(FilterKey.Genres)).toBe(
+        'action',
+      );
+    });
+
+    it('drops live filter edits from outbound links in favour of the snapshot', () => {
+      seedLiveParams({ [FilterKey.Genres]: 'comedy' });
+      filterScopeStore.next({ [FilterKey.Genres]: 'action' });
+
+      const anchor = makeAnchor('/movies/heretic');
+      appendGlobalParameters(anchor, '/movies/heretic');
+
+      expect(new URL(anchor.href).searchParams.get(FilterKey.Genres)).toBe(
+        'action',
+      );
+    });
+
+    it('preserves live filter edits on same-path links (toggles/sort)', () => {
+      seedLiveParams({ [FilterKey.Genres]: 'comedy' });
+      filterScopeStore.next({ [FilterKey.Genres]: 'action' });
+
+      const anchor = makeAnchor('/profile/userA');
+      appendGlobalParameters(anchor, '/profile/userA');
+
+      // Same path => the snapshot must NOT override the user's live edit.
+      expect(new URL(anchor.href).searchParams.get(FilterKey.Genres)).toBe(
+        'comedy',
+      );
+    });
+  });
+
+  it('passes live filters through unchanged under global scope', () => {
+    seedLiveParams({ [FilterKey.Genres]: 'comedy' });
+
+    const anchor = makeAnchor('/movies/heretic');
+    appendGlobalParameters(anchor, '/movies/heretic');
+
+    expect(new URL(anchor.href).searchParams.get(FilterKey.Genres)).toBe(
+      'comedy',
+    );
   });
 
   it('unsubscribes from the RxJS stream on destroy', () => {

--- a/projects/client/src/lib/features/parameters/appendGlobalParameters.ts
+++ b/projects/client/src/lib/features/parameters/appendGlobalParameters.ts
@@ -1,10 +1,38 @@
 import {
+  filterScopeStore,
+  type FilterScopeValue,
+} from '$lib/features/filters/filterScopeStore.ts';
+import {
   LOCAL_PARAMS,
   WHITE_LISTED_PARAMS,
 } from '$lib/features/parameters/_internal/constants.ts';
+import { FILTER_KEYS } from '$lib/features/filters/filterKeys.ts';
 import { useParameters } from '$lib/features/parameters/useParameters.ts';
 import { buildParamString } from '$lib/utils/url/buildParamString.ts';
 import { combineLatest } from 'rxjs';
+
+function buildEffectiveSearch({
+  search,
+  filterScope,
+  overrideKey,
+}: {
+  search: URLSearchParams;
+  filterScope: FilterScopeValue;
+  overrideKey: string;
+}): URLSearchParams {
+  if (!filterScope) return search;
+
+  const result = new URLSearchParams(search);
+  for (const key of FILTER_KEYS) {
+    result.delete(key);
+  }
+  for (const [key, value] of Object.entries(filterScope)) {
+    if (key !== overrideKey) {
+      result.set(key, value);
+    }
+  }
+  return result;
+}
 
 export function appendGlobalParameters(
   anchor: HTMLAnchorElement,
@@ -17,12 +45,14 @@ export function appendGlobalParameters(
   // in sync when the action parameter changes reactively.
   let originalHref = href ?? anchor.getAttribute('href') ?? '';
 
-  let latestValues: [URLSearchParams, string, boolean] | null = null;
+  let latestValues:
+    | [URLSearchParams, string, boolean, FilterScopeValue]
+    | null = null;
 
   const applyParams = () => {
     if (!latestValues) return;
 
-    const [$search, $override, $isEscaped] = latestValues;
+    const [$search, $override, $isEscaped, $filterScope] = latestValues;
 
     if ($isEscaped) return;
 
@@ -39,22 +69,31 @@ export function appendGlobalParameters(
         .filter(([key]) => LOCAL_PARAMS.includes(key))
       : [];
 
+    // Same-path navigation (type/sort toggles, etc.) must reflect the user's
+    // live filter edits. Only outbound (different-path) links fall back to the
+    // frozen local snapshot, so navigating away restores the global filters.
+    const effectiveSearch = isSamePath ? $search : buildEffectiveSearch({
+      search: $search,
+      filterScope: $filterScope,
+      overrideKey: $override,
+    });
+
     const params = Object.fromEntries([
       ...localParams,
       ...Array.from(url.searchParams.entries())
         .filter(([key]) =>
           key === $override || !WHITE_LISTED_PARAMS.includes(key)
         ),
-      ...$search.entries(),
+      ...effectiveSearch.entries(),
     ]);
 
     anchor.href = `${url.pathname}${buildParamString(params)}`;
   };
 
   const subscription = combineLatest(
-    [search, override, isEscaped],
+    [search, override, isEscaped, filterScopeStore],
   ).subscribe({
-    next: (values: [URLSearchParams, string, boolean]) => {
+    next: (values: [URLSearchParams, string, boolean, FilterScopeValue]) => {
       latestValues = values;
       applyParams();
     },

--- a/projects/client/src/lib/requests/_internal/getGlobalFilterDependencies.ts
+++ b/projects/client/src/lib/requests/_internal/getGlobalFilterDependencies.ts
@@ -1,8 +1,8 @@
-import { FilterKey } from '$lib/features/filters/models/Filter.ts';
+import { FILTER_KEYS } from '$lib/features/filters/filterKeys.ts';
 import { getRecordDependencies } from './getRecordDependencies.ts';
 
 export function getGlobalFilterDependencies(
   params: Record<string, string | number | boolean> | Nil,
 ): string[] {
-  return getRecordDependencies(params, Object.values(FilterKey));
+  return getRecordDependencies(params, FILTER_KEYS);
 }

--- a/projects/client/src/lib/requests/_internal/getRecordDependencies.ts
+++ b/projects/client/src/lib/requests/_internal/getRecordDependencies.ts
@@ -1,6 +1,6 @@
 export function getRecordDependencies(
   params: Record<string, string | number | boolean> | Nil,
-  whitelist?: string[],
+  whitelist?: readonly string[],
 ): string[] {
   if (!params) {
     return [];

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import FilterScopeSetter from "$lib/features/filters/FilterScopeSetter.svelte";
+  import type { FilterScope } from "$lib/features/filters/models/FilterScope.ts";
   import { getLanguageAndRegion } from "$lib/features/i18n";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import RenderFor from "$lib/guards/RenderFor.svelte";
@@ -30,6 +32,7 @@
     info?: MediaInfo;
     hasDynamicContent?: boolean;
     mode?: "default" | "content-only";
+    filterScope?: FilterScope;
   };
 
   const {
@@ -41,6 +44,7 @@
     info: _info,
     hasDynamicContent = false,
     mode = "default",
+    filterScope = "local",
   }: ChildrenProps & TraktPageProps & AudienceProps = $props();
 
   const websiteName = "Trakt Web";
@@ -276,25 +280,27 @@
   {/if}
 </svelte:head>
 
-<RenderFor {audience}>
-  {#if mode === "default"}
-    <NavbarStateSetter mode="full" />
-  {/if}
+<FilterScopeSetter {filterScope}>
+  <RenderFor {audience}>
+    {#if mode === "default"}
+      <NavbarStateSetter mode="full" />
+    {/if}
 
-  <main class="trakt-content" data-mode={mode} {...dynamicContentProps}>
-    {@render children()}
-  </main>
+    <main class="trakt-content" data-mode={mode} {...dynamicContentProps}>
+      {@render children()}
+    </main>
 
-  {#if mode === "default"}
-    <Footer />
-  {/if}
-</RenderFor>
-
-{#if audience === "authenticated"}
-  <RenderFor audience="public">
-    <Redirect to={UrlBuilder.home()} />
+    {#if mode === "default"}
+      <Footer />
+    {/if}
   </RenderFor>
-{/if}
+
+  {#if audience === "authenticated"}
+    <RenderFor audience="public">
+      <Redirect to={UrlBuilder.home()} />
+    </RenderFor>
+  {/if}
+</FilterScopeSetter>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -34,6 +34,7 @@
   info={{ overview: m.page_description_home() }}
   type="home"
   mode={pageMode}
+  filterScope="global"
 >
   <RenderFor audience="authenticated">
     <TraktPageCoverSetter />

--- a/projects/client/src/routes/discover/+page.svelte
+++ b/projects/client/src/routes/discover/+page.svelte
@@ -3,7 +3,6 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import SeasonalToggle from "$lib/features/theme/components/SeasonalToggle.svelte";
   import { useSeasonalTheme } from "$lib/features/theme/useSeasonalTheme";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
   import DiscoverToggles from "$lib/sections/discover/DiscoverToggles.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -53,6 +52,7 @@
   image={DEFAULT_SHARE_SHOW_COVER}
   {title}
   info={{ overview }}
+  filterScope="global"
 >
   <TraktPageCoverSetter />
 
@@ -74,7 +74,7 @@
     type={$type}
     filterOverride={getThemeFilters("trending")}
   />
-  
+
   <ReleasesList />
 
   <AnticipatedList

--- a/projects/client/src/routes/profile/[slug]/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/+page.svelte
@@ -42,6 +42,7 @@
   image={DEFAULT_SHARE_COVER}
   {title}
   hasDynamicContent={true}
+  filterScope="global"
 >
   <RenderFor audience="authenticated">
     <NavbarStateSetter>

--- a/projects/client/src/routes/profile/me/+page.svelte
+++ b/projects/client/src/routes/profile/me/+page.svelte
@@ -17,6 +17,7 @@
   image={DEFAULT_SHARE_COVER}
   title={m.page_title_profile()}
   hasDynamicContent={true}
+  filterScope="global"
 >
   <RenderFor audience="authenticated">
     <NavbarStateSetter>

--- a/projects/client/src/routes/users/[user]/lists/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/+page.svelte
@@ -27,6 +27,7 @@
   audience="authenticated"
   image={DEFAULT_SHARE_COVER}
   title={m.page_title_lists()}
+  filterScope="global"
 >
   {#if !$isMe}
     <Redirect to={UrlBuilder.profile.user(params.user)} />


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2472
- Filters can now be scoped locally. E.g. when drilling down, they can be changed, when navigating away from it, the global ones are leading again.
- "root" pages are using filter mode `global`
  - By default, it will be `local`
- `FilterScopeSetter` will on mount acquire a snapshot of the filters if mode is `local`
  - Filters in the local scope can then be changed at will.
  - Appending global parameters will take the values from the snapshot for outbound links.
  - Navigating away will release the snapshot
- Adds tests for the new logic.

## 👀 Example 👀
  

https://github.com/user-attachments/assets/269fc1bd-751d-4e08-ac5e-fb7a7f54065e

