### PR TITLE
feat(auth): keep OAuth redirects on the serving origin for workers.dev

### DIFF
--- a/projects/client/src/lib/utils/requests/getReferrer.ts
+++ b/projects/client/src/lib/utils/requests/getReferrer.ts
@@ -9,5 +9,12 @@ export function getReferrer() {
     return 'http://localhost:4173';
   }
 
+  // workers.dev hosts (worker-auth beta) serve from their own origin; return it
+  // so OAuth redirects come back to the same host, not the prod app origin.
+  const host = globalThis.window?.location.hostname;
+  if (host?.endsWith('.workers.dev')) {
+    return globalThis.window.location.origin;
+  }
+
   return 'https://app.trakt.tv';
 }


### PR DESCRIPTION
**Stage 1 of the worker-auth beta.** `getReferrer` hardcoded `https://app.trakt.tv`, so on the worker's `trakt-web.trakt.workers.dev` host the OAuth `redirect_uri` pointed off-host and login couldn't complete there. Now it returns `window.location.origin` on `*.workers.dev` hosts, so authorize/callback/silent-redirect stay on that origin.

This makes `trakt-web.trakt.workers.dev` a working login - still on the **standard Doorkeeper authority** (no auth-host change yet). A director creates an old-auth session there; stage 2 flips the authority to `auth.trakt.tv` so that session's next refresh migrates via the bridge.

Only caller of `getReferrer` is `getOidcConfig`, so the change is contained. `svelte-check` clean.

Follow-up (stage 2): runtime authority flip to `auth.trakt.tv` on the beta host + the worker honoring the workers.dev CORS origin for the token POST.