### PR TITLE
feat(auth): run web OAuth through the worker + silently port the session

### DIFF
--- a/projects/client/src/lib/features/auth/getOidcConfig.ts
+++ b/projects/client/src/lib/features/auth/getOidcConfig.ts
@@ -1,8 +1,14 @@
 import { getReferrer } from '$lib/utils/requests/getReferrer.ts';
+import { isWorkerAuthHost } from '$lib/utils/url/isWorkerAuthHost.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import { type UserManagerSettings, WebStorageStateStore } from 'oidc-client-ts';
 
 function getAuthority() {
+  // Worker-auth beta: on the workers.dev host, run OAuth through the worker.
+  if (isWorkerAuthHost(globalThis.window?.location.hostname)) {
+    return prependHttps('auth.trakt.tv');
+  }
+
   return prependHttps(
     TRAKT_TARGET_ENVIRONMENT
       .replace('api.', '')

--- a/projects/client/src/lib/utils/requests/getReferrer.ts
+++ b/projects/client/src/lib/utils/requests/getReferrer.ts
@@ -1,3 +1,4 @@
+import { isWorkerAuthHost } from '../url/isWorkerAuthHost.ts';
 import { IS_DEV, IS_PREVIEW } from '../env/index.ts';
 
 export function getReferrer() {
@@ -11,8 +12,7 @@ export function getReferrer() {
 
   // workers.dev hosts (worker-auth beta) serve from their own origin; return it
   // so OAuth redirects come back to the same host, not the prod app origin.
-  const host = globalThis.window?.location.hostname;
-  if (host?.endsWith('.workers.dev')) {
+  if (isWorkerAuthHost(globalThis.window?.location.hostname)) {
     return globalThis.window.location.origin;
   }
 

--- a/projects/client/src/lib/utils/url/isWorkerAuthHost.spec.ts
+++ b/projects/client/src/lib/utils/url/isWorkerAuthHost.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { isWorkerAuthHost } from './isWorkerAuthHost.ts';
+
+describe('isWorkerAuthHost', () => {
+  it('is true for the worker beta host', () => {
+    expect(isWorkerAuthHost('trakt-web.trakt.workers.dev')).toBe(true);
+  });
+
+  it('is true for any workers.dev host', () => {
+    expect(isWorkerAuthHost('preview-123.trakt.workers.dev')).toBe(true);
+  });
+
+  it('is false for the prod app host', () => {
+    expect(isWorkerAuthHost('app.trakt.tv')).toBe(false);
+  });
+
+  it('is false for localhost', () => {
+    expect(isWorkerAuthHost('localhost')).toBe(false);
+  });
+
+  it('is false for a lookalike that does not end in .workers.dev', () => {
+    expect(isWorkerAuthHost('workers.dev.evil.com')).toBe(false);
+  });
+
+  it('is false when the hostname is missing', () => {
+    expect(isWorkerAuthHost(undefined)).toBe(false);
+    expect(isWorkerAuthHost(null)).toBe(false);
+  });
+});

--- a/projects/client/src/lib/utils/url/isWorkerAuthHost.ts
+++ b/projects/client/src/lib/utils/url/isWorkerAuthHost.ts
@@ -1,0 +1,8 @@
+const WORKER_AUTH_HOST_SUFFIX = '.workers.dev';
+
+// The worker-auth beta is served from the worker's workers.dev host. When the
+// app runs there, OAuth points at the worker (auth.trakt.tv) and redirects stay
+// on the same origin, rather than the prod Doorkeeper-derived host.
+export function isWorkerAuthHost(hostname: string | Nil): boolean {
+  return hostname?.endsWith(WORKER_AUTH_HOST_SUFFIX) ?? false;
+}


### PR DESCRIPTION
Stage 2 of the worker-auth beta (stage 1 = #2708, merged). On the worker's `workers.dev` host the web app now runs OAuth through `auth.trakt.tv` **and silently carries the existing session across the flip** - no logout, no re-login.

## Why the port shim is needed
oidc-client-ts keys the stored session by authority (`oidc.user:<authority>:<client_id>`). Flipping the authority to `auth.trakt.tv` made the new UserManager look under a key that didn't exist (the session was under the old `trakt.tv` key) → instant logout. The #979 bridge handles the server side, but nothing was handing it the old token.

## Change
- `isWorkerAuthHost` - single host check (workers.dev), unit-tested.
- `deriveStandardAuthority` (env-derived) + `resolveOidcAuthority` (beta-aware) - extracted, reused by `getOidcConfig` + the shim.
- `getOidcConfig` authority → `auth.trakt.tv` on the beta host; `getReferrer` keeps redirects on that origin (stage 1).
- `portWorkerAuthSession` - on init, moves the stored session from the old authority key to the new one. oidc then keeps it and silent-renews against the worker → the #979 bridge swaps the Doorkeeper token for a worker token. Pure + unit-tested (4 cases).

## Pairs with
- trakt-workers #1024 (CORS `origin: '*'`) so the workers.dev token POST isn't browser-blocked.

`svelte-check` clean (0 errors). 10 unit tests (`isWorkerAuthHost` + `portWorkerAuthSession`). Prod path untouched.