### PR TITLE
feat(auth): silently port the web session across the worker-auth flip

### DIFF
--- a/projects/client/src/lib/features/auth/deriveStandardAuthority.ts
+++ b/projects/client/src/lib/features/auth/deriveStandardAuthority.ts
@@ -1,0 +1,11 @@
+import { prependHttps } from '$lib/utils/url/prependHttps.ts';
+
+export function deriveStandardAuthority(): HttpsUrl {
+  return prependHttps(
+    TRAKT_TARGET_ENVIRONMENT
+      .replace('api.', '')
+      .replace('apiz.', '')
+      .replace('hd.', '')
+      .replace('api-staging.', 'staging.'),
+  );
+}

--- a/projects/client/src/lib/features/auth/getOidcConfig.ts
+++ b/projects/client/src/lib/features/auth/getOidcConfig.ts
@@ -1,28 +1,12 @@
 import { getReferrer } from '$lib/utils/requests/getReferrer.ts';
-import { isWorkerAuthHost } from '$lib/utils/url/isWorkerAuthHost.ts';
-import { prependHttps } from '$lib/utils/url/prependHttps.ts';
 import { type UserManagerSettings, WebStorageStateStore } from 'oidc-client-ts';
-
-function getAuthority() {
-  // Worker-auth beta: on the workers.dev host, run OAuth through the worker.
-  if (isWorkerAuthHost(globalThis.window?.location.hostname)) {
-    return prependHttps('auth.trakt.tv');
-  }
-
-  return prependHttps(
-    TRAKT_TARGET_ENVIRONMENT
-      .replace('api.', '')
-      .replace('apiz.', '')
-      .replace('hd.', '')
-      .replace('api-staging.', 'staging.'),
-  );
-}
+import { resolveOidcAuthority } from './resolveOidcAuthority.ts';
 
 export function getOidcConfig(): UserManagerSettings {
   const referrer = getReferrer();
 
   return {
-    authority: getAuthority(),
+    authority: resolveOidcAuthority(),
     client_id: TRAKT_CLIENT_ID,
     redirect_uri: `${referrer}/callback`,
     silent_redirect_uri: `${referrer}/silent-redirect`,

--- a/projects/client/src/lib/features/auth/portWorkerAuthSession.spec.ts
+++ b/projects/client/src/lib/features/auth/portWorkerAuthSession.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { portWorkerAuthSession } from './portWorkerAuthSession.ts';
+
+const CLIENT_ID = 'cid';
+const FROM = 'https://trakt.tv';
+const TO = 'https://auth.trakt.tv';
+const fromKey = `oidc.user:${FROM}:${CLIENT_ID}`;
+const toKey = `oidc.user:${TO}:${CLIENT_ID}`;
+
+function makeStore(initial: Record<string, string> = {}) {
+  const data = new Map(Object.entries(initial));
+  return {
+    data,
+    store: {
+      getItem: (key: string) => data.get(key) ?? null,
+      setItem: (key: string, value: string) => void data.set(key, value),
+      removeItem: (key: string) => void data.delete(key),
+    },
+  };
+}
+
+describe('portWorkerAuthSession', () => {
+  it('moves the session from the old authority key to the new one', () => {
+    const { store, data } = makeStore({ [fromKey]: 'SESSION' });
+
+    const moved = portWorkerAuthSession({
+      store,
+      clientId: CLIENT_ID,
+      fromAuthority: FROM,
+      toAuthority: TO,
+    });
+
+    expect(moved).toBe(true);
+    expect(data.get(toKey)).toBe('SESSION');
+    expect(data.has(fromKey)).toBe(false);
+  });
+
+  it('no-ops when a session already exists on the new authority', () => {
+    const { store, data } = makeStore({ [fromKey]: 'OLD', [toKey]: 'NEW' });
+
+    const moved = portWorkerAuthSession({
+      store,
+      clientId: CLIENT_ID,
+      fromAuthority: FROM,
+      toAuthority: TO,
+    });
+
+    expect(moved).toBe(false);
+    expect(data.get(toKey)).toBe('NEW');
+    expect(data.get(fromKey)).toBe('OLD');
+  });
+
+  it('no-ops when there is no old session', () => {
+    const { store } = makeStore();
+
+    expect(
+      portWorkerAuthSession({
+        store,
+        clientId: CLIENT_ID,
+        fromAuthority: FROM,
+        toAuthority: TO,
+      }),
+    ).toBe(false);
+  });
+
+  it('no-ops when authorities match (not on the beta host)', () => {
+    const { store, data } = makeStore({ [fromKey]: 'SESSION' });
+
+    const moved = portWorkerAuthSession({
+      store,
+      clientId: CLIENT_ID,
+      fromAuthority: FROM,
+      toAuthority: FROM,
+    });
+
+    expect(moved).toBe(false);
+    expect(data.get(fromKey)).toBe('SESSION');
+  });
+});

--- a/projects/client/src/lib/features/auth/portWorkerAuthSession.ts
+++ b/projects/client/src/lib/features/auth/portWorkerAuthSession.ts
@@ -1,0 +1,36 @@
+type SessionStore = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+type PortWorkerAuthSessionProps = {
+  store: SessionStore;
+  clientId: string;
+  fromAuthority: string;
+  toAuthority: string;
+};
+
+const userStoreKey = (authority: string, clientId: string) =>
+  `oidc.user:${authority}:${clientId}`;
+
+// oidc-client-ts keys the stored session by authority. When the authority
+// changes, the session is orphaned under the old key and the user is logged
+// out; move it to the new key so the session is kept. Returns true if moved.
+export function portWorkerAuthSession(
+  { store, clientId, fromAuthority, toAuthority }: PortWorkerAuthSessionProps,
+): boolean {
+  if (fromAuthority === toAuthority) {
+    return false;
+  }
+
+  const toKey = userStoreKey(toAuthority, clientId);
+  if (store.getItem(toKey) != null) {
+    return false;
+  }
+
+  const stored = store.getItem(userStoreKey(fromAuthority, clientId));
+  if (stored == null) {
+    return false;
+  }
+
+  store.setItem(toKey, stored);
+  store.removeItem(userStoreKey(fromAuthority, clientId));
+  return true;
+}

--- a/projects/client/src/lib/features/auth/resolveOidcAuthority.ts
+++ b/projects/client/src/lib/features/auth/resolveOidcAuthority.ts
@@ -1,0 +1,11 @@
+import { isWorkerAuthHost } from '$lib/utils/url/isWorkerAuthHost.ts';
+import { prependHttps } from '$lib/utils/url/prependHttps.ts';
+import { deriveStandardAuthority } from './deriveStandardAuthority.ts';
+
+export function resolveOidcAuthority(): HttpsUrl {
+  if (isWorkerAuthHost(globalThis.window?.location.hostname)) {
+    return prependHttps('auth.trakt.tv');
+  }
+
+  return deriveStandardAuthority();
+}

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -6,7 +6,11 @@ import { workerRequest } from '$worker/workerRequest.ts';
 import { type User, UserManager } from 'oidc-client-ts';
 import { BehaviorSubject, of } from 'rxjs';
 import { onMount } from 'svelte';
+import { deriveStandardAuthority } from '../deriveStandardAuthority.ts';
 import { getOidcConfig } from '../getOidcConfig.ts';
+import { portWorkerAuthSession } from '../portWorkerAuthSession.ts';
+import { resolveOidcAuthority } from '../resolveOidcAuthority.ts';
+import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
 import { setToken, type Token } from '../token/index.ts';
 import { postToken } from './_internal/postToken.ts';
 import type { AuthContextType } from './createAuthContext.ts';
@@ -38,6 +42,15 @@ export function initializeUserManager(
   const isInitializing = new BehaviorSubject(true);
 
   onMount(() => {
+    // Carry an existing session across an authority change so it is kept
+    // instead of orphaned under the old key (which logs the user out).
+    portWorkerAuthSession({
+      store: safeLocalStorage,
+      clientId: TRAKT_CLIENT_ID,
+      fromAuthority: deriveStandardAuthority(),
+      toAuthority: resolveOidcAuthority(),
+    });
+
     const manager = new UserManager(
       getOidcConfig(),
     );

--- a/projects/client/src/lib/utils/requests/getReferrer.ts
+++ b/projects/client/src/lib/utils/requests/getReferrer.ts
@@ -10,8 +10,8 @@ export function getReferrer() {
     return 'http://localhost:4173';
   }
 
-  // workers.dev hosts (worker-auth beta) serve from their own origin; return it
-  // so OAuth redirects come back to the same host, not the prod app origin.
+  // On workers.dev hosts, return the serving origin so OAuth redirects come
+  // back to the same host.
   if (isWorkerAuthHost(globalThis.window?.location.hostname)) {
     return globalThis.window.location.origin;
   }

--- a/projects/client/src/lib/utils/url/isWorkerAuthHost.ts
+++ b/projects/client/src/lib/utils/url/isWorkerAuthHost.ts
@@ -1,8 +1,5 @@
 const WORKER_AUTH_HOST_SUFFIX = '.workers.dev';
 
-// The worker-auth beta is served from the worker's workers.dev host. When the
-// app runs there, OAuth points at the worker (auth.trakt.tv) and redirects stay
-// on the same origin, rather than the prod Doorkeeper-derived host.
 export function isWorkerAuthHost(hostname: string | Nil): boolean {
   return hostname?.endsWith(WORKER_AUTH_HOST_SUFFIX) ?? false;
 }


### PR DESCRIPTION
Follow-up to the worker-auth flip (#2709, merged). After the flip, the web app logged users out on reload: oidc-client-ts keys the stored session by authority, so changing the authority orphaned the existing session under the old key. This carries it across so the session is kept - no logout, no re-login.

## Change
- `portWorkerAuthSession` - on init, moves the stored session from the old authority key to the new one (`oidc.user:<authority>:<client_id>`). oidc then keeps it and silent-renews it. Pure + unit-tested (4 cases).
- Authority resolution split into `deriveStandardAuthority` + `resolveOidcAuthority`, reused by `getOidcConfig` and the shim.
- Comment hygiene: the worker-auth files' comments are kept client-only (no server-side internals), since this client is open source.

`svelte-check` clean. 10 unit tests (`portWorkerAuthSession` + `isWorkerAuthHost`).