### PR TITLE
feat(auth): real logout on the worker auth host (RP-initiated)

### DIFF
--- a/projects/client/src/lib/features/auth/stores/useAuth.ts
+++ b/projects/client/src/lib/features/auth/stores/useAuth.ts
@@ -1,5 +1,6 @@
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
+import { isWorkerAuthHost } from '$lib/utils/url/isWorkerAuthHost.ts';
 import { WorkerMessage } from '$worker/WorkerMessage.ts';
 import { workerRequest } from '$worker/workerRequest.ts';
 import { setToken } from '../token/index.ts';
@@ -14,7 +15,6 @@ export function useAuth() {
     const manager = getUserManager();
 
     await manager?.revokeTokens();
-    await manager?.removeUser();
 
     setToken(null);
     isAuthorized.next(false);
@@ -22,6 +22,19 @@ export function useAuth() {
     await invalidate(InvalidateAction.Auth);
     await workerRequest(WorkerMessage.CacheBust);
 
+    // On the worker auth host, end the session at the provider (RP-initiated
+    // logout) so it's a real logout, not just a local token revoke. signoutRedirect
+    // clears the local user and navigates, returning to this origin.
+    if (manager && isWorkerAuthHost(globalThis.window?.location?.hostname)) {
+      await manager.signoutRedirect({
+        post_logout_redirect_uri: globalThis.window?.location?.origin,
+      });
+      return;
+    }
+
+    await manager?.removeUser();
+    // FIXME: legacy logout path. Remove once the new auth host is used
+    // everywhere - then logout is just revokeTokens() + signoutRedirect().
     globalThis.window.location.href = 'https://trakt.tv/logout';
   };
 


### PR DESCRIPTION
Logout did `revokeTokens()` + redirect to `trakt.tv/logout`, which leaves the worker's `auth.trakt.tv` session cookie alive → the next login silently re-auths through it (not a real logout).

On the worker auth host, call `signoutRedirect()` so the provider session is actually ended - the worker's `end_session_endpoint` (`/signout`) clears the cookie and returns to this origin. `signoutRedirect` also clears the local user before navigating. The standard Doorkeeper path (prod app.trakt.tv) is unchanged.

Pairs with trakt-workers #1027 (the `/signout` end_session endpoint + open-redirect-guarded `post_logout_redirect_uri`).

`svelte-check` clean.