### PR TITLE
Fix/filter restore

### DIFF
--- a/projects/client/src/lib/features/filters/FilterProvider.spec.ts
+++ b/projects/client/src/lib/features/filters/FilterProvider.spec.ts
@@ -1,0 +1,88 @@
+import { afterNavigate, goto } from '$app/navigation';
+import { renderComponent } from '$test/beds/component/renderComponent.ts';
+import { waitFor } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import FilterProvider from './FilterProvider.svelte';
+import { FilterKey } from './models/Filter.ts';
+import { STORED_FILTERS_KEY } from './useStoredFilters.ts';
+
+const children = createRawSnippet(() => ({
+  render: () => '<span>child</span>',
+}));
+
+describe('FilterProvider', () => {
+  /*
+    afterNavigate is mocked as a no-op, so it never invokes its callback.
+    Capture every registered callback and replay them to simulate a
+    navigation landing on the page.
+  */
+  let navigationCallbacks: Array<() => void> = [];
+
+  const replayNavigation = () =>
+    navigationCallbacks.forEach((callback) => callback());
+
+  /*
+    The component mounts behind async providers, so wait until it has
+    registered with afterNavigate before replaying a navigation.
+  */
+  const renderProvider = async () => {
+    renderComponent(FilterProvider, { props: { children } });
+    await waitFor(() => expect(navigationCallbacks.length).toBeGreaterThan(0));
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    navigationCallbacks = [];
+
+    vi.mocked(afterNavigate).mockImplementation((callback) => {
+      navigationCallbacks.push(callback as () => void);
+    });
+
+    window.history.replaceState({}, '', '/movies');
+  });
+
+  it('should restore stored filters into the URL on navigation', async () => {
+    localStorage.setItem(
+      STORED_FILTERS_KEY,
+      JSON.stringify({ [FilterKey.Genres]: 'action' }),
+    );
+
+    await renderProvider();
+    replayNavigation();
+
+    expect(goto).toHaveBeenCalledTimes(1);
+
+    const target = new URL(vi.mocked(goto).mock.calls.at(0)?.[0] ?? '');
+    expect(target.searchParams.get(FilterKey.Genres)).toBe('action');
+  });
+
+  it('should not navigate when there are no stored filters', async () => {
+    await renderProvider();
+    replayNavigation();
+
+    expect(goto).not.toHaveBeenCalled();
+  });
+
+  it('should not navigate when stored filters are empty', async () => {
+    localStorage.setItem(STORED_FILTERS_KEY, JSON.stringify({}));
+
+    await renderProvider();
+    replayNavigation();
+
+    expect(goto).not.toHaveBeenCalled();
+  });
+
+  it('should not override filters already present in the URL', async () => {
+    window.history.replaceState({}, '', `/movies?${FilterKey.Genres}=comedy`);
+    localStorage.setItem(
+      STORED_FILTERS_KEY,
+      JSON.stringify({ [FilterKey.Genres]: 'action' }),
+    );
+
+    await renderProvider();
+    replayNavigation();
+
+    expect(goto).not.toHaveBeenCalled();
+  });
+});

--- a/projects/client/src/lib/features/filters/FilterProvider.svelte
+++ b/projects/client/src/lib/features/filters/FilterProvider.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { afterNavigate } from "$app/navigation";
   import { useStoredFilters } from "./useStoredFilters";
 
   const { children }: ChildrenProps = $props();
 
   const { restoreFilters } = useStoredFilters();
 
-  onMount(() => {
+  afterNavigate(() => {
     restoreFilters();
   });
 </script>

--- a/projects/client/src/lib/features/filters/useStoredFilters.ts
+++ b/projects/client/src/lib/features/filters/useStoredFilters.ts
@@ -71,6 +71,12 @@ export function useStoredFilters() {
       },
     );
 
+    // No-op navigations (e.g. empty stored filters) would otherwise loop
+    // forever under afterNavigate, since the URL never changes.
+    if (url.href === page.url.href) {
+      return;
+    }
+
     goto(url, { replaceState: true });
   };
 


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2705
- Saved filters should now be restored properly.
  - `FilterProvider` is in the root layout (mounts once per session), so the previous `onMount` fix only attempted restore at boot; and even then flakily, since its `goto` raced the initial hydration/navigation and could be dropped.
  - Switched to `afterNavigate`, which fires after the navigation fully resolves (router ready) on both initial load and every client-side navigation, so the `goto` reliably lands.
  - Guarded `goToStoredFilters()` to skip `goto` when the URL is unchanged, preventing an infinite redirect loop when stored filters are empty.
- Also adds tests for it.