### PR TITLE
feat(i18n): add localized strings for list reordering actions

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -8102,6 +8102,36 @@
     "text_info_update_downloaded": {
       "default": "Update is ready to install.",
       "description": "Text shown when a new version of the app has been downloaded and is ready to be installed."
+    },
+    "button_text_move_to_bottom": {
+      "default": "Move to Bottom",
+      "description": "Context menu action to move a list item to the bottom of the list."
+    },
+    "button_text_move_to_position": {
+      "default": "Move to...",
+      "description": "Context menu action to move a list item to a specific position."
+    },
+    "button_text_move_to_top": {
+      "default": "Move to Top",
+      "description": "Context menu action to move a list item to the top of the list."
+    },
+    "input_placeholder_reorder_position": {
+      "default": "Position (1–{count})",
+      "description": "Placeholder for the position text field in the move-to-position alert. {count} is replaced with the total item count.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
+    "dialog_prompt_move_to_position": {
+      "default": "Enter a new position for \"{title}\".",
+      "description": "Body of the move-to-position alert. {title} is replaced with the item title.",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Adds translation keys required for the new list item reordering feature, including:
- Context menu button labels (Move to Top, Move to Bottom, Move to...)
- Dialog prompt and input placeholder for moving an item to a specific position

Open to any copy changes

<img height="300" alt="Actions" src="https://github.com/user-attachments/assets/6cf8bf5a-33fd-4a3c-b3db-98d2eb0919d0" />
<img height="300" alt="Dialog" src="https://github.com/user-attachments/assets/5870cd00-f6e2-4c49-9c91-b21a0269edac" />
