### PR TITLE
feat(i18n): RTL text-direction support + logical-property migration

### DIFF
--- a/.agents/rules/components.md
+++ b/.agents/rules/components.md
@@ -648,6 +648,77 @@ the appropriate helper component instead:
 
 ---
 
+## Direction & Logical Properties (RTL)
+
+The app renders in RTL locales (e.g. `fa-IR`); `<html dir>` is set per request
+(SSR) and synced on client locale switch. Components must mirror automatically.
+
+**Always use logical properties, never physical sides, for layout:**
+
+| Physical (forbidden for layout)  | Logical (use this)                            |
+| -------------------------------- | --------------------------------------------- |
+| `left` / `right`                 | `inset-inline-start` / `inset-inline-end`     |
+| `padding-left` / `padding-right` | `padding-inline-start` / `padding-inline-end` |
+| `margin-left` / `margin-right`   | `margin-inline-start` / `margin-inline-end`   |
+| `border-left` / `border-right`   | `border-inline-start` / `border-inline-end`   |
+| `border-top-left-radius` (etc.)  | `border-start-start-radius` (etc.)            |
+| `text-align: left / right`       | `text-align: start / end`                     |
+| `float: left / right`            | `float: inline-start / inline-end`            |
+
+Flex/grid already follow `dir`, so `justify-content`, `gap`, and source order
+flip for free - prefer them over absolute positioning.
+
+**Transforms are NOT direction-aware.** A `translateX(+n)` points the same way
+in RTL. For translate-driven motion (sliding indicators, offset badges),
+multiply the inline offset by the global `--rtl-sign` custom property (`1` in
+LTR, `-1` in RTL, defined in `style/direction/index.css`):
+
+```scss
+transform: translateX(calc(var(--rtl-sign) * var(--offset)));
+```
+
+**Directional icons** (chevrons, arrows, carets pointing along the reading axis)
+must flip. Add the `trakt-icon-directional` class to the icon's `<svg>`; a
+global rule mirrors it under `:dir(rtl)`. Icons with no directional meaning must
+NOT carry the class.
+
+**Keep physical `left`/`right` ONLY when the value is not a layout side:**
+
+- JS-measured viewport coordinates (`getBoundingClientRect`, drag ghosts,
+  pointer positions) - these are absolute screen coords, never flip them.
+- Horizontal centering tricks: `left: 50%` + `transform: translate(-50%, …)` is
+  direction-symmetric; leave it physical (a logical inset mis-centers).
+- Off-screen hiding (`left: -100dvw`).
+- Inside `@keyframes` or purely decorative shimmer/sweep animations.
+- Third-party JS config keys that happen to be named `left`/`right` (e.g.
+  carbon-charts axis keys) - these are not CSS.
+
+When you add or move a `transition`/`will-change` list, name the LOGICAL
+property (`inset-inline-start`, not `left`), or the animation silently dies.
+
+## Accessibility
+
+- **Every interactive control needs an accessible name.** Icon-only buttons (no
+  visible text) MUST have an `aria-label` sourced from a Paraglide message
+  - never ship a `<button>` whose only child is an `<svg>`.
+
+  ```svelte
+  <button aria-label={m.button_label_next()} onclick={next}>
+    <CaretRightIcon />
+  </button>
+  ```
+
+- Use native semantic elements (`<button>`, `<a>`, `<nav>`, `<dialog>`) over
+  `<div>` with click handlers. A clickable `<div>` needs `role` + `tabindex` +
+  keyboard handlers and is almost always the wrong choice.
+- Preserve focus styling - rely on `:focus-visible`; never blanket
+  `outline: none` without a replacement focus indicator.
+- Pair every icon/color-only signal with text or an `aria-*` attribute; do not
+  encode meaning in color alone.
+- Decorative imagery uses empty `alt=""`; meaningful imagery has descriptive
+  `alt`. Decorative SVGs that are not directional need no label.
+- Respect `prefers-reduced-motion` for non-essential animation.
+
 ## Where to Place a New Component
 
 | Question                                              | Place in                                     |
@@ -693,3 +764,14 @@ the appropriate helper component instead:
       `.tag`, etc.) - no manual `font-weight`/`font-size` when a class covers it
 - [ ] When `font-size` overrides are needed, uses semantic variables
       (`--font-size-tag`, `--font-size-text`) not raw tokens (`--ni-10`)
+- [ ] RTL-safe: logical properties only (`inset-inline-*`,
+      `padding/margin-inline-*`, `text-align: start/end`, logical radii) - no
+      physical `left`/`right` for layout; `translateX` offsets multiplied by
+      `--rtl-sign`
+- [ ] Directional icons carry `trakt-icon-directional`; non-directional ones do
+      not
+- [ ] Physical `left`/`right` only for JS-measured coords, `left:50%` centering,
+      off-screen hide, keyframes, or third-party JS keys
+- [ ] Icon-only buttons have an `aria-label` from a Paraglide message; native
+      semantic elements used over click-handler `<div>`s; `:focus-visible`
+      preserved

--- a/.agents/rules/project.md
+++ b/.agents/rules/project.md
@@ -9,7 +9,8 @@ applyTo: '**'
 
 ## Tech Stack
 
-SvelteKit + TypeScript app (Svelte 5, runes mode) deployed to Cloudflare Workers. Monorepo using Deno workspaces with app at `projects/client/`.
+SvelteKit + TypeScript app (Svelte 5, runes mode) deployed to Cloudflare
+Workers. Monorepo using Deno workspaces with app at `projects/client/`.
 
 ## Project Structure
 
@@ -45,45 +46,66 @@ projects/client/src/
 
 ### Pages are thin shells
 
-Route pages compose features and sections. Business logic lives in `lib/features/`, not in route files. Layouts wrap children with providers (e.g., `CalendarProvider`).
+Route pages compose features and sections. Business logic lives in
+`lib/features/`, not in route files. Layouts wrap children with providers (e.g.,
+`CalendarProvider`).
 
 ### Features are self-contained
 
-Each feature directory in `lib/features/` owns its state, components, queries. Features expose a public API; keep internals in `_internal/` subdirectories.
+Each feature directory in `lib/features/` owns its state, components, queries.
+Features expose a public API; keep internals in `_internal/` subdirectories.
 
 ### Components use data attributes for variants
 
-Components use `data-variant`, `data-style`, `data-color` attributes for styling variants rather than prop-driven class concatenation.
+Components use `data-variant`, `data-style`, `data-color` attributes for styling
+variants rather than prop-driven class concatenation.
 
 ### Snippets for flexible content
 
-Use Svelte 5 `{#snippet}` for reusable template fragments and component slot alternatives.
+Use Svelte 5 `{#snippet}` for reusable template fragments and component slot
+alternatives.
 
 ### Guards for conditional rendering
 
-Use `RenderFor`, `RenderForFeature` components instead of inline `{#if}` blocks for auth/feature/audience gating.
+Use `RenderFor`, `RenderForFeature` components instead of inline `{#if}` blocks
+for auth/feature/audience gating.
 
 ### Stores use RxJS + localStorage
 
-State management uses `BehaviorSubject` from RxJS, often backed by `localStorage` for persistence. Prefer `$derived()` for computed values over additional stores.
+State management uses `BehaviorSubject` from RxJS, often backed by
+`localStorage` for persistence. Prefer `$derived()` for computed values over
+additional stores.
 
 ### API requests use mappers
 
-`lib/requests/` contains query definitions via `defineQuery()` and pure mapper functions that transform API responses to domain models. Zod validates at the boundary.
+`lib/requests/` contains query definitions via `defineQuery()` and pure mapper
+functions that transform API responses to domain models. Zod validates at the
+boundary.
 
 ### i18n via Paraglide
 
-Internationalization uses Paraglide JS (Inlang). Messages are type-safe functions: `m.page_title_home()`. Source definitions live in `i18n/meta/`, generated output in `lib/paraglide/`. Never edit generated files.
+Internationalization uses Paraglide JS (Inlang). Messages are type-safe
+functions: `m.page_title_home()`. Source definitions live in `i18n/meta/`,
+generated output in `lib/paraglide/`. Never edit generated files.
 
 ## Styling
 
 - SCSS with scoped Svelte `<style lang="scss">` blocks.
-- All values via CSS custom properties (`--ni-*`, `--color-*`, `--gap-*`, `--border-radius-*`).
-- Responsive mixins: `for-mobile`, `for-tablet-sm`, `for-desktop`, `for-mouse`, `for-touch`.
+- All values via CSS custom properties (`--ni-*`, `--color-*`, `--gap-*`,
+  `--border-radius-*`).
+- Responsive mixins: `for-mobile`, `for-tablet-sm`, `for-desktop`, `for-mouse`,
+  `for-touch`.
 - Import mixins as: `@use "$style/scss/mixins/index" as *;`
-- Full light/dark theme support. Never use raw hex values - use semantic CSS variables.
+- Full light/dark theme support. Never use raw hex values - use semantic CSS
+  variables.
 - Use kebab-case for CSS class names.
 - Component-scoped styles preferred.
+- **RTL-safe by default.** The app ships in RTL locales (e.g. `fa-IR`), so never
+  hardcode a physical side for layout. Use logical properties:
+  `padding-inline-*`/`margin-inline-*`, `inset-inline-start`/`inset-inline-end`
+  (not `left`/`right`), `text-align: start/end`, `border-inline-*`, and logical
+  corner radii (`border-start-start-radius`, etc.). See `components.md` for the
+  full direction + accessibility rules.
 
 ## Path Aliases
 
@@ -101,6 +123,8 @@ Always use aliases over deep relative paths (`../../../`).
 ## Tooling
 
 - **Formatter**: Use `deno fmt`, not prettier.
-- **Linter**: ESLint with TypeScript + Svelte plugins. Config at `eslint.config.js`.
-- **Build**: Vite + SvelteKit adapter-cloudflare. Paraglide generates i18n before build.
+- **Linter**: ESLint with TypeScript + Svelte plugins. Config at
+  `eslint.config.js`.
+- **Build**: Vite + SvelteKit adapter-cloudflare. Paraglide generates i18n
+  before build.
 - **Dev**: `deno task client:dev` starts the dev server.

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2074,6 +2074,14 @@
       "default": "Back",
       "description": "Aria-label for the back button on summary pages that returns to the previous page."
     },
+    "button_label_carousel_scroll_start": {
+      "default": "Scroll to start",
+      "description": "Aria-label for the carousel button that scrolls toward the start of the items."
+    },
+    "button_label_carousel_scroll_end": {
+      "default": "Scroll to end",
+      "description": "Aria-label for the carousel button that scrolls toward the end of the items."
+    },
     "button_label_comment_replies": {
       "default": "Review Replies",
       "description": "Aria-label for the button that opens the review replies dialog."

--- a/projects/client/src/lib/components/Crossfade.svelte
+++ b/projects/client/src/lib/components/Crossfade.svelte
@@ -48,7 +48,7 @@
   .crossfade-content {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: 100%;
     height: 100%;
   }

--- a/projects/client/src/lib/components/background/CoverImage.svelte
+++ b/projects/client/src/lib/components/background/CoverImage.svelte
@@ -60,7 +60,7 @@
     :global(img) {
       width: 100%;
       height: 100%;
-      left: 0;
+      inset-inline-start: 0;
       position: relative;
 
       filter: grayscale(0.5);
@@ -70,20 +70,20 @@
 
       @include for-tablet-sm-and-below {
         width: 150%;
-        left: -25%;
+        inset-inline-start: -25%;
         object-fit: cover;
       }
 
       @include for-mobile {
         width: 220%;
-        left: -60%;
+        inset-inline-start: -60%;
       }
     }
   }
 
   .trakt-background-cover-image {
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
 
     &::after,
     &::before {
@@ -92,7 +92,7 @@
       height: 100%;
       position: absolute;
       bottom: 0;
-      left: 0;
+      inset-inline-start: 0;
       pointer-events: none;
       z-index: var(--layer-floating);
     }

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -302,7 +302,7 @@
 
       position: absolute;
       top: 0;
-      left: 0;
+      inset-inline-start: 0;
 
       opacity: 0;
       transition: opacity var(--transition-increment) ease-in-out;

--- a/projects/client/src/lib/components/card/Card.svelte
+++ b/projects/client/src/lib/components/card/Card.svelte
@@ -74,7 +74,7 @@
 
           position: absolute;
           top: 0;
-          left: 0;
+          inset-inline-start: 0;
 
           width: var(--width-override-card, var(--width-card));
           height: var(--height-override-card, var(--height-card));

--- a/projects/client/src/lib/components/card/CardActionBar.svelte
+++ b/projects/client/src/lib/components/card/CardActionBar.svelte
@@ -28,13 +28,19 @@
     height: var(--height-action-bar);
 
     top: 0;
-    right: 0;
-    left: 0;
+    inset-inline-end: 0;
+    inset-inline-start: 0;
     z-index: var(--layer-floating);
 
     pointer-events: none;
 
     &[data-variant="default"] {
+      --action-bar-shadow-origin: top right;
+
+      &:dir(rtl) {
+        --action-bar-shadow-origin: top left;
+      }
+
       &::before {
         content: "";
 
@@ -43,12 +49,12 @@
 
         position: absolute;
         top: 0;
-        right: 0;
+        inset-inline-end: 0;
 
-        border-top-right-radius: var(--border-radius-m);
+        border-start-end-radius: var(--border-radius-m);
 
         background-image: radial-gradient(
-          circle at top right,
+          circle at var(--action-bar-shadow-origin),
           color-mix(in srgb, var(--color-shadow) 30%, transparent) 15%,
           transparent 65%
         );
@@ -57,7 +63,7 @@
 
     :global(.trakt-popup-menu-button) {
       position: absolute;
-      right: 0;
+      inset-inline-end: 0;
     }
 
     :global(> *) {

--- a/projects/client/src/lib/components/card/CardCover.svelte
+++ b/projects/client/src/lib/components/card/CardCover.svelte
@@ -112,12 +112,12 @@
 
     .trakt-card-cover-badge {
       top: 0;
-      left: 0;
+      inset-inline-start: 0;
     }
 
     .trakt-card-cover-tag {
       bottom: 0;
-      left: 0;
+      inset-inline-start: 0;
 
       justify-content: flex-start;
       gap: var(--gap-xxs);
@@ -182,7 +182,7 @@
 
       position: absolute;
       bottom: 0;
-      left: calc((100% - var(--logo-width)) / 2);
+      inset-inline-start: calc((100% - var(--logo-width)) / 2);
 
       object-fit: contain;
       object-position: bottom;
@@ -194,7 +194,7 @@
 
       position: absolute;
       bottom: 0;
-      left: 0;
+      inset-inline-start: 0;
 
       color: var(--color-overlay-foreground);
       text-align: center;
@@ -217,7 +217,7 @@
 
       position: absolute;
       bottom: 0;
-      left: 0;
+      inset-inline-start: 0;
 
       width: 100%;
       height: 75%;

--- a/projects/client/src/lib/components/carousel/Carousel.svelte
+++ b/projects/client/src/lib/components/carousel/Carousel.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
+  import * as m from "$lib/features/i18n/messages";
   import ScrollLeftIcon from "../icons/ScrollLeftIcon.svelte";
   import ScrollRightIcon from "../icons/ScrollRightIcon.svelte";
   import { useCarouselScroll } from "./_internal/useCarouselScroll";
 
   const { items }: { items: Snippet[] } = $props();
 
-  const { canScrollLeft, canScrollRight, scrollObserver, scroll } =
+  const { canScrollToStart, canScrollToEnd, scrollObserver, scroll } =
     useCarouselScroll();
 
   // FIXME: find existing component to replace this with
@@ -14,9 +15,10 @@
 
 <div class="trakt-carousel">
   <button
-    class="scroll-button left"
-    onclick={() => scroll("left")}
-    disabled={!$canScrollLeft}
+    class="scroll-button start"
+    onclick={() => scroll("start")}
+    disabled={!$canScrollToStart}
+    aria-label={m.button_label_carousel_scroll_start()}
   >
     <ScrollLeftIcon />
   </button>
@@ -30,9 +32,10 @@
   </ul>
 
   <button
-    class="scroll-button right"
-    onclick={() => scroll("right")}
-    disabled={!$canScrollRight}
+    class="scroll-button end"
+    onclick={() => scroll("end")}
+    disabled={!$canScrollToEnd}
+    aria-label={m.button_label_carousel_scroll_end()}
   >
     <ScrollRightIcon />
   </button>
@@ -88,12 +91,12 @@
 
     transition: opacity var(--transition-increment) ease-in-out;
 
-    &.left {
-      left: 0;
+    &.start {
+      inset-inline-start: 0;
     }
 
-    &.right {
-      right: 0;
+    &.end {
+      inset-inline-end: 0;
     }
 
     :global(svg) {

--- a/projects/client/src/lib/components/carousel/_internal/scrollSign.spec.ts
+++ b/projects/client/src/lib/components/carousel/_internal/scrollSign.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { scrollSign } from './scrollSign.ts';
+
+describe('util: scrollSign', () => {
+  describe('in LTR', () => {
+    it('should scroll positive toward the end', () => {
+      expect(scrollSign({ target: 'end', isRtl: false })).toBe(1);
+    });
+
+    it('should scroll negative toward the start', () => {
+      expect(scrollSign({ target: 'start', isRtl: false })).toBe(-1);
+    });
+  });
+
+  describe('in RTL', () => {
+    it('should invert and scroll negative toward the end', () => {
+      expect(scrollSign({ target: 'end', isRtl: true })).toBe(-1);
+    });
+
+    it('should invert and scroll positive toward the start', () => {
+      expect(scrollSign({ target: 'start', isRtl: true })).toBe(1);
+    });
+  });
+});

--- a/projects/client/src/lib/components/carousel/_internal/scrollSign.ts
+++ b/projects/client/src/lib/components/carousel/_internal/scrollSign.ts
@@ -1,0 +1,10 @@
+// Physical scrollBy() sign for a logical scroll target. In LTR the inline end
+// is the positive direction and the start negative; RTL mirrors both, so the
+// sign is the product of the target and the direction factor.
+export function scrollSign(
+  { target, isRtl }: { target: 'start' | 'end'; isRtl: boolean },
+): 1 | -1 {
+  const towardEnd = target === 'end' ? 1 : -1;
+  const directionFactor = isRtl ? -1 : 1;
+  return (towardEnd * directionFactor) as 1 | -1;
+}

--- a/projects/client/src/lib/components/carousel/_internal/useCarouselScroll.spec.ts
+++ b/projects/client/src/lib/components/carousel/_internal/useCarouselScroll.spec.ts
@@ -1,0 +1,87 @@
+import { firstValueFrom } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { useCarouselScroll } from './useCarouselScroll.ts';
+
+type ScrollPosition = {
+  scrollLeft: number;
+  scrollWidth: number;
+  clientWidth: number;
+};
+
+function listAt({ scrollLeft, scrollWidth, clientWidth }: ScrollPosition) {
+  const node = globalThis.document.createElement('ul');
+  Object.defineProperty(node, 'scrollWidth', { value: scrollWidth });
+  Object.defineProperty(node, 'clientWidth', { value: clientWidth });
+  node.scrollLeft = scrollLeft;
+  return node;
+}
+
+describe('util: useCarouselScroll', () => {
+  describe('affordances at the start', () => {
+    it('should not allow scrolling further toward the start', async () => {
+      const { canScrollToStart, scrollObserver } = useCarouselScroll();
+      scrollObserver(
+        listAt({ scrollLeft: 0, scrollWidth: 1000, clientWidth: 300 }),
+      );
+
+      expect(await firstValueFrom(canScrollToStart)).toBe(false);
+    });
+
+    it('should allow scrolling toward the end', async () => {
+      const { canScrollToEnd, scrollObserver } = useCarouselScroll();
+      scrollObserver(
+        listAt({ scrollLeft: 0, scrollWidth: 1000, clientWidth: 300 }),
+      );
+
+      expect(await firstValueFrom(canScrollToEnd)).toBe(true);
+    });
+  });
+
+  describe('when content fits without overflow', () => {
+    it('should disable both affordances', async () => {
+      const { canScrollToStart, canScrollToEnd, scrollObserver } =
+        useCarouselScroll();
+      scrollObserver(
+        listAt({ scrollLeft: 0, scrollWidth: 300, clientWidth: 300 }),
+      );
+
+      expect(await firstValueFrom(canScrollToStart)).toBe(false);
+      expect(await firstValueFrom(canScrollToEnd)).toBe(false);
+    });
+  });
+
+  describe('mid-scroll in LTR (positive scrollLeft)', () => {
+    it('should allow scrolling toward both edges', async () => {
+      const { canScrollToStart, canScrollToEnd, scrollObserver } =
+        useCarouselScroll();
+      scrollObserver(
+        listAt({ scrollLeft: 350, scrollWidth: 1000, clientWidth: 300 }),
+      );
+
+      expect(await firstValueFrom(canScrollToStart)).toBe(true);
+      expect(await firstValueFrom(canScrollToEnd)).toBe(true);
+    });
+  });
+
+  describe('mid-scroll in RTL (negative scrollLeft)', () => {
+    it('should normalize the sign and allow scrolling toward both edges', async () => {
+      const { canScrollToStart, canScrollToEnd, scrollObserver } =
+        useCarouselScroll();
+      scrollObserver(
+        listAt({ scrollLeft: -350, scrollWidth: 1000, clientWidth: 300 }),
+      );
+
+      expect(await firstValueFrom(canScrollToStart)).toBe(true);
+      expect(await firstValueFrom(canScrollToEnd)).toBe(true);
+    });
+
+    it('should not allow scrolling past the RTL end', async () => {
+      const { canScrollToEnd, scrollObserver } = useCarouselScroll();
+      scrollObserver(
+        listAt({ scrollLeft: -700, scrollWidth: 1000, clientWidth: 300 }),
+      );
+
+      expect(await firstValueFrom(canScrollToEnd)).toBe(false);
+    });
+  });
+});

--- a/projects/client/src/lib/components/carousel/_internal/useCarouselScroll.ts
+++ b/projects/client/src/lib/components/carousel/_internal/useCarouselScroll.ts
@@ -1,7 +1,6 @@
 import { BehaviorSubject } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
-
-type Direction = 'left' | 'right';
+import { scrollSign } from './scrollSign.ts';
 
 type ScrollState = {
   readonly scrollLeft: number;
@@ -15,28 +14,37 @@ const INITIAL_SCROLL_STATE: ScrollState = {
   clientWidth: 0,
 };
 
+// RTL browsers report scrollLeft as <= 0 (0 at the inline start, growing
+// negative toward the end). Normalizing on the absolute value keeps the
+// scroll-affordance math direction-agnostic.
+const distanceFromStart = ({ scrollLeft }: ScrollState) => Math.abs(scrollLeft);
+const distanceFromEnd = (
+  { scrollLeft, scrollWidth, clientWidth }: ScrollState,
+) => scrollWidth - clientWidth - Math.abs(scrollLeft);
+
 export function useCarouselScroll() {
   const scrollState$ = new BehaviorSubject<ScrollState>(INITIAL_SCROLL_STATE);
 
-  const canScrollLeft = scrollState$.pipe(
-    map(({ scrollLeft }) => scrollLeft > 0),
+  const canScrollToStart = scrollState$.pipe(
+    map((state) => distanceFromStart(state) > 0),
     distinctUntilChanged(),
   );
 
-  const canScrollRight = scrollState$.pipe(
-    map(({ scrollLeft, scrollWidth, clientWidth }) =>
-      scrollLeft < scrollWidth - clientWidth - 1
-    ),
+  const canScrollToEnd = scrollState$.pipe(
+    map((state) => distanceFromEnd(state) > 1),
     distinctUntilChanged(),
   );
 
   let listElement: HTMLUListElement | null = null;
 
-  const scroll = (direction: Direction) => {
+  const scroll = (target: 'start' | 'end') => {
     if (!listElement) return;
-    const amount = listElement.clientWidth;
+    const sign = scrollSign({
+      target,
+      isRtl: getComputedStyle(listElement).direction === 'rtl',
+    });
     listElement.scrollBy({
-      left: direction === 'left' ? -amount : amount,
+      left: sign * listElement.clientWidth,
       behavior: 'smooth',
     });
   };
@@ -79,8 +87,8 @@ export function useCarouselScroll() {
   };
 
   return {
-    canScrollLeft,
-    canScrollRight,
+    canScrollToStart,
+    canScrollToEnd,
     scrollObserver,
     scroll,
   };

--- a/projects/client/src/lib/components/date-time/_internal/DateInput.svelte
+++ b/projects/client/src/lib/components/date-time/_internal/DateInput.svelte
@@ -105,7 +105,7 @@
     box-sizing: border-box;
 
     padding: var(--ni-8) var(--ni-16);
-    padding-left: calc(
+    padding-inline-start: calc(
       var(--date-time-icon-size) + var(--date-time-icon-offset) + var(--ni-16)
     );
 
@@ -133,7 +133,7 @@
     position: absolute;
     z-index: calc(var(--layer-top) + var(--layer-overlay));
     top: var(--date-time-icon-offset);
-    left: var(--date-time-icon-offset);
+    inset-inline-start: var(--date-time-icon-offset);
 
     &.is-disabled {
       cursor: default;

--- a/projects/client/src/lib/components/drawer/Drawer.svelte
+++ b/projects/client/src/lib/components/drawer/Drawer.svelte
@@ -196,7 +196,7 @@
 
     top: 0;
     bottom: 0;
-    right: 0;
+    inset-inline-end: 0;
 
     width: var(--drawer-size);
     padding-top: var(--drawer-padding);
@@ -213,9 +213,9 @@
     gap: var(--drawer-gap);
 
     overflow: hidden;
-    border-top-left-radius: var(--drawer-border-radius);
-    border-bottom-left-radius: var(--drawer-border-radius);
-    border-left: var(--ni-1) solid var(--color-drawer-border);
+    border-start-start-radius: var(--drawer-border-radius);
+    border-end-start-radius: var(--drawer-border-radius);
+    border-inline-start: var(--ni-1) solid var(--color-drawer-border);
 
     backdrop-filter: blur(var(--ni-12));
 
@@ -229,8 +229,7 @@
         position: absolute;
         z-index: var(--layer-top);
         top: 0;
-        left: 0;
-        right: 0;
+        inset-inline: 0;
         align-items: flex-start;
 
         box-sizing: border-box;
@@ -325,14 +324,14 @@
       --mobile-drawer-height: var(--drawer-size);
 
       top: initial;
-      left: 0;
+      inset-inline-start: 0;
 
       width: initial;
       height: calc(var(--mobile-drawer-height) - var(--drag-offset, 0px));
 
-      border-bottom-left-radius: initial;
-      border-top-right-radius: var(--drawer-border-radius);
-      border-left: none;
+      border-end-start-radius: initial;
+      border-start-end-radius: var(--drawer-border-radius);
+      border-inline-start: none;
       border-top: var(--ni-1) solid var(--color-drawer-border);
 
       &:global(:not(.is-dragging)) {
@@ -426,14 +425,14 @@
 
   .trakt-drawer-header,
   .trakt-drawer-content {
-    padding-left: var(--drawer-padding);
-    padding-right: var(--drawer-padding);
+    padding-inline-start: var(--drawer-padding);
+    padding-inline-end: var(--drawer-padding);
   }
 
   .trakt-drawer-vip-background {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: 100%;
     height: 100%;
 

--- a/projects/client/src/lib/components/frame/Frame.svelte
+++ b/projects/client/src/lib/components/frame/Frame.svelte
@@ -54,7 +54,7 @@
     &[data-mode="cover"] {
       position: absolute;
       top: 0;
-      left: 0;
+      inset-inline-start: 0;
 
       @include for-tablet-sm-and-below {
         .trakt-frame-spacer {

--- a/projects/client/src/lib/components/gestures/SwipeX.svelte
+++ b/projects/client/src/lib/components/gestures/SwipeX.svelte
@@ -150,8 +150,8 @@
 
     height: var(--indicator-height, 100%);
 
-    left: var(--indicator-left);
-    right: var(--indicator-right);
+    inset-inline-start: var(--indicator-left);
+    inset-inline-end: var(--indicator-right);
     width: var(--indicator-width, 0);
 
     background-color: var(--indicator-color, transparent);
@@ -165,8 +165,8 @@
       opacity var(--transition-increment) ease-out,
       width var(--transition-increment) ease-out,
       background-color var(--transition-increment) ease-out,
-      left var(--transition-increment) ease-out,
-      right var(--transition-increment) ease-out,
+      inset-inline-start var(--transition-increment) ease-out,
+      inset-inline-end var(--transition-increment) ease-out,
       color var(--transition-increment) ease-out,
       outline-color var(--transition-increment) ease-out;
   }

--- a/projects/client/src/lib/components/icons/ArrowLeftIcon.svelte
+++ b/projects/client/src/lib/components/icons/ArrowLeftIcon.svelte
@@ -1,4 +1,5 @@
 <svg
+  class="trakt-icon-directional"
   xmlns="http://www.w3.org/2000/svg"
   height="40px"
   viewBox="0 -960 960 960"

--- a/projects/client/src/lib/components/icons/ArrowRightIcon.svelte
+++ b/projects/client/src/lib/components/icons/ArrowRightIcon.svelte
@@ -1,4 +1,5 @@
 <svg
+  class="trakt-icon-directional"
   width="24"
   height="24"
   viewBox="0 0 24 24"

--- a/projects/client/src/lib/components/icons/CaretLeftIcon.svelte
+++ b/projects/client/src/lib/components/icons/CaretLeftIcon.svelte
@@ -1,4 +1,5 @@
 <svg
+  class="trakt-icon-directional"
   width="16"
   height="16"
   viewBox="0 0 16 16"

--- a/projects/client/src/lib/components/icons/CaretRightIcon.svelte
+++ b/projects/client/src/lib/components/icons/CaretRightIcon.svelte
@@ -1,4 +1,5 @@
 <svg
+  class="trakt-icon-directional"
   width="16"
   height="16"
   viewBox="0 0 16 16"

--- a/projects/client/src/lib/components/icons/ScrollLeftIcon.svelte
+++ b/projects/client/src/lib/components/icons/ScrollLeftIcon.svelte
@@ -1,4 +1,5 @@
 <svg
+  class="trakt-icon-directional"
   width="24"
   height="40"
   viewBox="0 0 24 40"

--- a/projects/client/src/lib/components/icons/ScrollRightIcon.svelte
+++ b/projects/client/src/lib/components/icons/ScrollRightIcon.svelte
@@ -1,4 +1,5 @@
 <svg
+  class="trakt-icon-directional"
   width="24"
   height="40"
   viewBox="0 0 24 40"

--- a/projects/client/src/lib/components/legal/LegalPage.svelte
+++ b/projects/client/src/lib/components/legal/LegalPage.svelte
@@ -49,7 +49,7 @@
     :global(ul),
     :global(ol) {
       margin: 0 0 var(--gap-m);
-      padding-left: var(--gap-l);
+      padding-inline-start: var(--gap-l);
 
       :global(li) {
         margin-bottom: var(--gap-xs);
@@ -96,13 +96,13 @@
         align-items: center;
         gap: var(--gap-s);
         margin: 0 0 var(--gap-m);
-        padding-left: calc(var(--number-width) + var(--gap-s));
+        padding-inline-start: calc(var(--number-width) + var(--gap-s));
         position: relative;
       }
 
       :global(.number) {
         position: absolute;
-        left: 0;
+        inset-inline-start: 0;
         display: flex;
         align-items: center;
         justify-content: center;

--- a/projects/client/src/lib/components/lists/SkeletonList.svelte
+++ b/projects/client/src/lib/components/lists/SkeletonList.svelte
@@ -22,13 +22,9 @@
   .trakt-skeleton-list {
     overflow: hidden;
 
-    padding-left: var(--layout-distance-side);
+    padding-inline-start: var(--layout-distance-side);
 
-    mask-image: linear-gradient(
-      to right,
-      black calc(100% - var(--layout-distance-side)),
-      transparent calc(100% - var(--layout-distance-side))
-    );
+    @include list-mask(var(--layout-distance-side));
 
     @supports (-moz-appearance: none) {
       mask-image: none;

--- a/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
@@ -68,12 +68,12 @@
 
   .trakt-list-inset-title {
     margin: 0;
-    margin-left: var(--layout-distance-side);
-    margin-right: var(--layout-distance-side);
-    transition: margin-left calc(var(--transition-increment) * 2) ease-in-out;
+    margin-inline-start: var(--layout-distance-side);
+    margin-inline-end: var(--layout-distance-side);
+    transition: margin-inline-start calc(var(--transition-increment) * 2) ease-in-out;
 
     @include for-tablet-sm-and-below {
-      margin-left: calc(var(--layout-distance-side));
+      margin-inline-start: calc(var(--layout-distance-side));
     }
   }
 

--- a/projects/client/src/lib/components/lists/_internal/list.css
+++ b/projects/client/src/lib/components/lists/_internal/list.css
@@ -4,6 +4,6 @@
 }
 
 .section-list-empty-state:has(.trakt-skeleton-list) {
-  padding-right: 0;
-  padding-left: 0;
+  padding-inline-end: 0;
+  padding-inline-start: 0;
 }

--- a/projects/client/src/lib/components/lists/section-list/SectionList.svelte
+++ b/projects/client/src/lib/components/lists/section-list/SectionList.svelte
@@ -243,8 +243,8 @@
       }
 
       .trakt-list-item-container {
-        padding-left: var(--ni-2);
-        padding-right: var(--ni-2);
+        padding-inline-start: var(--ni-2);
+        padding-inline-end: var(--ni-2);
       }
 
       .section-list-empty-state {
@@ -322,11 +322,7 @@
   .section-list-has-multiple-items:has(:global(.trakt-view-all-button)) {
     .section-list-horizontal-scroll {
       overflow-x: hidden;
-      mask-image: linear-gradient(
-        to right,
-        black calc(100% - var(--list-mask-offset)),
-        transparent calc(100% - var(--list-mask-offset))
-      );
+      @include list-mask(var(--list-mask-offset));
 
       @supports (-moz-appearance: none) {
         overflow-x: auto;

--- a/projects/client/src/lib/components/media/tags/ProgressTag.svelte
+++ b/projects/client/src/lib/components/media/tags/ProgressTag.svelte
@@ -65,7 +65,7 @@
         content: "";
         display: block;
         position: absolute;
-        left: var(--progress-bar-offset);
+        inset-inline-start: var(--progress-bar-offset);
         top: var(--progress-bar-offset);
         width: calc(100% - var(--progress-bar-spacing));
         height: calc(100% - var(--progress-bar-spacing));

--- a/projects/client/src/lib/components/media/tags/WatchCountTag.svelte
+++ b/projects/client/src/lib/components/media/tags/WatchCountTag.svelte
@@ -48,13 +48,13 @@
     gap: var(--ni-1);
 
     :global(.trakt-tag-label .trakt-tag) {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
+      border-start-end-radius: 0;
+      border-end-end-radius: 0;
     }
 
     :global(.trakt-tag-count .trakt-tag) {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
+      border-start-start-radius: 0;
+      border-end-start-radius: 0;
 
       min-width: var(--ni-12);
 

--- a/projects/client/src/lib/components/summary/RatingItem.svelte
+++ b/projects/client/src/lib/components/summary/RatingItem.svelte
@@ -56,7 +56,7 @@
           position: absolute;
 
           bottom: var(--ni-neg-4);
-          left: 0;
+          inset-inline-start: 0;
 
           width: 100%;
 

--- a/projects/client/src/lib/components/summary/SummaryPoster.svelte
+++ b/projects/client/src/lib/components/summary/SummaryPoster.svelte
@@ -137,8 +137,7 @@
     z-index: var(--layer-raised);
 
     bottom: 0;
-    left: 0;
-    right: 0;
+    inset-inline: 0;
 
     transform: translateY(50%);
   }

--- a/projects/client/src/lib/components/tabs/TabView.svelte
+++ b/projects/client/src/lib/components/tabs/TabView.svelte
@@ -73,14 +73,16 @@
       --tab-width: calc(var(--available-width) / var(--tab-count));
 
       position: absolute;
-      margin-left: var(--tab-list-padding);
+      margin-inline-start: var(--tab-list-padding);
 
       top: var(--tab-list-padding);
       bottom: var(--tab-list-padding);
-      left: 0;
+      inset-inline-start: 0;
       width: var(--tab-width);
       transform: translateX(
-        calc(var(--active-index) * (100% + var(--tab-list-gap)))
+        calc(
+          var(--rtl-sign) * var(--active-index) * (100% + var(--tab-list-gap))
+        )
       );
 
       background-color: var(--color-tab-background);

--- a/projects/client/src/lib/components/toggles/Switch.svelte
+++ b/projects/client/src/lib/components/toggles/Switch.svelte
@@ -174,7 +174,10 @@
 
       .trakt-switch-tick {
         transform: translateX(
-          calc(var(--button-width) - var(--tick-size) - 2 * var(--tick-offset))
+          calc(
+            var(--rtl-sign) *
+              (var(--button-width) - var(--tick-size) - 2 * var(--tick-offset))
+          )
         );
 
         :global(svg) {
@@ -187,7 +190,8 @@
       .trakt-switch-tick {
         transform: translateX(
           calc(
-            (var(--button-width) - var(--tick-size) - 2 * var(--tick-offset)) /
+            var(--rtl-sign) *
+              (var(--button-width) - var(--tick-size) - 2 * var(--tick-offset)) /
               2
           )
         );
@@ -210,11 +214,14 @@
       transition-property: color, transform;
 
       position: absolute;
-      left: var(--text-offset);
+      inset-inline-start: var(--text-offset);
       width: var(--text-width);
 
       transform: translateX(
-        calc(var(--button-width) - var(--text-width) - 2 * var(--text-offset))
+        calc(
+          var(--rtl-sign) *
+            (var(--button-width) - var(--text-width) - 2 * var(--text-offset))
+        )
       );
     }
 
@@ -225,7 +232,7 @@
 
       position: absolute;
       top: var(--tick-offset);
-      left: var(--tick-offset);
+      inset-inline-start: var(--tick-offset);
 
       width: var(--tick-size);
       height: var(--tick-size);
@@ -246,7 +253,7 @@
 
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
 
         width: 100%;
         height: 100%;

--- a/projects/client/src/lib/components/toggles/Toggler.svelte
+++ b/projects/client/src/lib/components/toggles/Toggler.svelte
@@ -34,7 +34,7 @@
   };
 
   const handleTransitionEnd = (event: TransitionEvent) => {
-    if (event.propertyName !== "left" || !pending) return;
+    if (event.propertyName === "opacity" || !pending) return;
 
     (event.currentTarget as HTMLDivElement).classList.remove("moving");
 
@@ -124,13 +124,15 @@
     --scale-transform: scaleX(1.1) scaleY(0.75);
 
     --tracker-offset: calc(var(--tracker-index) * var(--gap-xxs));
-    --tracker-left: calc(var(--tracker-index) * var(--toggle-small-width));
+    --tracker-inline-start: calc(
+      var(--tracker-index) * var(--toggle-small-width)
+    );
     --tracker-animation-duration: calc(
       var(--toggler-animation-duration) + var(--toggle-animation-delay)
     );
 
-    left: calc(var(--tracker-left) + var(--tracker-offset));
-    margin-left: var(--ni-4);
+    inset-inline-start: calc(var(--tracker-inline-start) + var(--tracker-offset));
+    margin-inline-start: var(--ni-4);
 
     position: absolute;
 
@@ -141,7 +143,7 @@
     background-color: var(--toggler-tracker-color);
 
     transition: var(--tracker-animation-duration) ease-in-out;
-    transition-property: left, opacity;
+    transition-property: inset-inline-start, opacity;
     transform-origin: center;
 
     &:global(.moving) {

--- a/projects/client/src/lib/features/calendar/CalendarLayout.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarLayout.svelte
@@ -137,8 +137,8 @@
 
     gap: var(--gap-s);
 
-    margin-left: var(--layout-distance-side);
-    margin-right: var(--layout-distance-side);
+    margin-inline-start: var(--layout-distance-side);
+    margin-inline-end: var(--layout-distance-side);
 
     flex-grow: 1;
   }

--- a/projects/client/src/lib/features/edit-mode/EditModeBar.svelte
+++ b/projects/client/src/lib/features/edit-mode/EditModeBar.svelte
@@ -33,7 +33,7 @@
     background-color: var(--color-floating-background);
     border-radius: var(--ni-60);
     padding: var(--ni-8);
-    padding-left: var(--ni-16);
+    padding-inline-start: var(--ni-16);
 
     box-shadow: var(--shadow-floating);
 

--- a/projects/client/src/lib/features/i18n/components/useLocale.ts
+++ b/projects/client/src/lib/features/i18n/components/useLocale.ts
@@ -3,6 +3,7 @@ import {
   type AvailableLocale,
   defaultLocale,
   getLocale,
+  getTextDirection,
   setLocale,
 } from '$lib/features/i18n/index.ts';
 import { BehaviorSubject, type PartialObserver, type Subscription } from 'rxjs';
@@ -42,10 +43,13 @@ export function useLocale(): LocaleStore {
   return {
     subscribe: locale.subscribe.bind(locale),
     set: (value: string) => {
-      locale.next(setLocale(value));
+      const sanitized = setLocale(value);
+      locale.next(sanitized);
 
       if (browser) {
-        globalThis.document.documentElement.lang = value;
+        const root = globalThis.document.documentElement;
+        root.lang = sanitized;
+        root.dir = getTextDirection(sanitized);
       }
     },
   };

--- a/projects/client/src/lib/features/i18n/handle.spec.ts
+++ b/projects/client/src/lib/features/i18n/handle.spec.ts
@@ -28,6 +28,50 @@ describe('handle: i18n', () => {
     expect(transformed).toContain('dir="ltr"');
   });
 
+  it('should render dir="rtl" for an RTL locale', async () => {
+    const html = `<html
+                  lang="${LANG_PLACEHOLDER}"
+                  dir="${DIR_PLACEHOLDER}">
+                ></html>`;
+
+    const { transformPageChunk } = await interceptHandleResolveOptions(
+      handle,
+      new Request('http://localhost', {
+        headers: new Headers({
+          'Accept-Language': 'fa-IR',
+        }),
+      }),
+    );
+
+    const transformed = transformPageChunk?.({ html, done: true });
+
+    expect(transformed).toContain('lang="fa-IR"');
+    expect(transformed).toContain('dir="rtl"');
+  });
+
+  it('should render dir="rtl" when the locale cookie is RTL', async () => {
+    const html = `<html
+                  lang="${LANG_PLACEHOLDER}"
+                  dir="${DIR_PLACEHOLDER}">
+                ></html>`;
+
+    // LTR Accept-Language, but an RTL cookie must still flip the direction.
+    const { transformPageChunk } = await interceptHandleResolveOptions(
+      handle,
+      new Request('http://localhost', {
+        headers: new Headers({
+          'Accept-Language': 'en-us',
+        }),
+      }),
+      (key) => (key === LOCALE_COOKIE_NAME ? 'fa-IR' : null),
+    );
+
+    const transformed = transformPageChunk?.({ html, done: true });
+
+    expect(transformed).toContain('lang="fa-IR"');
+    expect(transformed).toContain('dir="rtl"');
+  });
+
   it('should set locale cookie', async () => {
     const event = mockRequestEvent({
       url: 'http://localhost/_features/locale/set',

--- a/projects/client/src/lib/features/i18n/index.spec.ts
+++ b/projects/client/src/lib/features/i18n/index.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { getTextDirection } from './index.ts';
+
+describe('util: getTextDirection', () => {
+  it('should return rtl for an RTL locale', () => {
+    expect(getTextDirection('fa-IR')).toBe('rtl');
+  });
+
+  it('should return ltr for an LTR locale', () => {
+    expect(getTextDirection('en')).toBe('ltr');
+  });
+});

--- a/projects/client/src/lib/features/search/SearchInput.svelte
+++ b/projects/client/src/lib/features/search/SearchInput.svelte
@@ -146,7 +146,7 @@
       position: absolute;
       z-index: calc(var(--layer-top) + var(--layer-overlay));
       top: var(--search-icon-offset);
-      left: var(--search-icon-offset);
+      inset-inline-start: var(--search-icon-offset);
     }
 
     .trakt-search-input {
@@ -154,7 +154,7 @@
       height: 100%;
       width: 100%;
       padding: var(--ni-8) var(--ni-16);
-      padding-left: calc(
+      padding-inline-start: calc(
         var(--search-icon-size) + var(--search-icon-offset) + var(--ni-16)
       );
       box-sizing: border-box;
@@ -164,7 +164,8 @@
 
       transition: var(--transition-increment) ease-in-out;
       transition-property:
-        border-color, background-color, padding, width, top, left, opacity;
+        border-color, background-color, padding, width, top, inset-inline-start,
+        opacity;
 
       backdrop-filter: blur(var(--ni-8));
 
@@ -219,8 +220,8 @@
 
         position: absolute;
         bottom: var(--ni-neg-2);
-        left: calc(var(--search-side-distance) / 2);
-        right: 0;
+        inset-inline-start: calc(var(--search-side-distance) / 2);
+        inset-inline-end: 0;
 
         border-radius: 50%;
         background: linear-gradient(

--- a/projects/client/src/lib/features/search/SearchModeToggles.svelte
+++ b/projects/client/src/lib/features/search/SearchModeToggles.svelte
@@ -67,8 +67,8 @@
     align-items: center;
     justify-content: center;
 
-    margin-left: var(--layout-distance-side);
-    margin-right: var(--layout-distance-side);
+    margin-inline-start: var(--layout-distance-side);
+    margin-inline-end: var(--layout-distance-side);
 
     gap: var(--gap-m);
     transition: gap var(--transition-increment) ease-in-out;

--- a/projects/client/src/lib/features/share/_internal/OpenGraphContent.svelte
+++ b/projects/client/src/lib/features/share/_internal/OpenGraphContent.svelte
@@ -25,7 +25,7 @@
 
 <style>
   .trakt-open-graph-content {
-    padding-left: 48px;
+    padding: 48px;
 
     box-sizing: border-box;
 

--- a/projects/client/src/lib/features/theme/components/SeasonalActionBarImage.svelte
+++ b/projects/client/src/lib/features/theme/components/SeasonalActionBarImage.svelte
@@ -26,7 +26,7 @@
 
     &:global(.theme-halloween) {
       top: calc(-0.5 * var(--image-size));
-      right: calc(0.5 * var(--image-size));
+      inset-inline-end: calc(0.5 * var(--image-size));
       animation: lift-and-swing 5s infinite;
     }
 
@@ -34,7 +34,7 @@
       z-index: 1;
 
       top: calc(-0.5 * var(--image-size));
-      right: calc(-0.35 * var(--image-size));
+      inset-inline-end: calc(-0.35 * var(--image-size));
 
       transform: rotate(15deg);
     }

--- a/projects/client/src/lib/features/theme/components/_internal/BaseSplashscreen.svelte
+++ b/projects/client/src/lib/features/theme/components/_internal/BaseSplashscreen.svelte
@@ -30,7 +30,7 @@
     z-index: var(--layer-top);
 
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: 100vw;
     height: 100vh;
 

--- a/projects/client/src/lib/features/theme/components/_internal/christmas/SnowBackground.svelte
+++ b/projects/client/src/lib/features/theme/components/_internal/christmas/SnowBackground.svelte
@@ -8,7 +8,7 @@
   .trakt-snow-canvas {
     position: fixed;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: 100vw;
     height: 100vh;
 

--- a/projects/client/src/lib/pages/errors/UnexpectedErrorPage.svelte
+++ b/projects/client/src/lib/pages/errors/UnexpectedErrorPage.svelte
@@ -84,7 +84,7 @@
     border-radius: var(--border-radius-m);
     border: var(--ni-1) solid var(--color-border);
 
-    text-align: left;
+    text-align: start;
 
     .trakt-error-details-header {
       grid-column: 1 / -1;

--- a/projects/client/src/lib/sections/banner/_internal/BannerContainer.svelte
+++ b/projects/client/src/lib/sections/banner/_internal/BannerContainer.svelte
@@ -24,8 +24,8 @@
 
 <style>
   .trakt-banner-container {
-    margin-left: var(--layout-distance-side);
-    margin-right: var(--layout-distance-side);
+    margin-inline-start: var(--layout-distance-side);
+    margin-inline-end: var(--layout-distance-side);
 
     gap: var(--gap-xs);
     display: flex;

--- a/projects/client/src/lib/sections/banner/black-friday/BlackFriday.svelte
+++ b/projects/client/src/lib/sections/banner/black-friday/BlackFriday.svelte
@@ -96,20 +96,20 @@
     height: auto;
 
     top: 0;
-    left: 50%;
+    inset-inline-start: 50%;
 
     filter: grayscale(100%);
 
     transition: var(--transition-increment) ease-in-out;
-    transition-property: left, right;
+    transition-property: inset-inline-start, inset-inline-end;
 
     @include for-tablet-lg {
-      left: 60%;
+      inset-inline-start: 60%;
     }
 
     @include for-tablet-sm-and-below {
-      left: auto;
-      right: var(--ni-neg-32);
+      inset-inline-start: auto;
+      inset-inline-end: var(--ni-neg-32);
       top: var(--ni-32);
     }
   }

--- a/projects/client/src/lib/sections/banner/month-in-review/MonthInReview.svelte
+++ b/projects/client/src/lib/sections/banner/month-in-review/MonthInReview.svelte
@@ -67,7 +67,7 @@
     }
 
     :global(.trakt-review-content-footer) {
-      margin-left: auto;
+      margin-inline-start: auto;
     }
 
     @include for-tablet-sm-and-below {
@@ -77,7 +77,7 @@
       }
 
       :global(.trakt-review-content-footer) {
-        margin-left: 0;
+        margin-inline-start: 0;
       }
 
       :global(.trakt-review-content) {

--- a/projects/client/src/lib/sections/banner/year-in-review/YearInReview.svelte
+++ b/projects/client/src/lib/sections/banner/year-in-review/YearInReview.svelte
@@ -81,12 +81,12 @@
     }
 
     :global(.trakt-review-content-footer) {
-      margin-left: auto;
+      margin-inline-start: auto;
     }
 
     @include for-tablet-sm-and-below {
       :global(.trakt-review-content-footer) {
-        margin-left: 0;
+        margin-inline-start: 0;
       }
 
       :global(.trakt-review-content) {

--- a/projects/client/src/lib/sections/banner/year-in-review/_internal/YirBackground.svelte
+++ b/projects/client/src/lib/sections/banner/year-in-review/_internal/YirBackground.svelte
@@ -25,7 +25,7 @@
     z-index: var(--layer-background);
 
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: 100%;
     height: 100%;
 

--- a/projects/client/src/lib/sections/branding/components/BrandingLogos.svelte
+++ b/projects/client/src/lib/sections/branding/components/BrandingLogos.svelte
@@ -313,7 +313,7 @@
   .logo-download {
     position: absolute;
     top: var(--gap-s);
-    right: var(--gap-s);
+    inset-inline-end: var(--gap-s);
 
     display: flex;
     align-items: center;

--- a/projects/client/src/lib/sections/branding/components/BrandingRequirements.svelte
+++ b/projects/client/src/lib/sections/branding/components/BrandingRequirements.svelte
@@ -33,7 +33,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-s);
-    padding-left: var(--gap-l);
+    padding-inline-start: var(--gap-l);
 
     li {
       font-size: var(--font-size-text);

--- a/projects/client/src/lib/sections/components/ReviewContent.svelte
+++ b/projects/client/src/lib/sections/components/ReviewContent.svelte
@@ -86,7 +86,7 @@
   .trakt-review-content-cover-image {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
 
     width: 100%;
     height: 100%;

--- a/projects/client/src/lib/sections/cookie/CookieNotice.svelte
+++ b/projects/client/src/lib/sections/cookie/CookieNotice.svelte
@@ -79,8 +79,8 @@
     z-index: var(--layer-top);
 
     margin: auto;
-    right: 0;
-    left: 0;
+    inset-inline-end: 0;
+    inset-inline-start: 0;
     bottom: calc(
       var(--cookie-notice-distance-size) + env(safe-area-inset-bottom, 0)
     );
@@ -92,14 +92,14 @@
 
     box-sizing: border-box;
     padding: var(--ni-24);
-    padding-left: var(--ni-40);
+    padding-inline-start: var(--ni-40);
 
     width: min(var(--ni-480), 85%);
     background-color: var(--color-cookie-background);
     box-shadow: var(--shadow-dialog);
 
     transition: var(--transition-increment) ease-in-out;
-    transition-property: bottom, right, width;
+    transition-property: bottom, inset-inline-end, width;
 
     .trakt-cookie {
       --cookie-size: var(--ni-60);
@@ -107,7 +107,7 @@
       --cookie-quarter-size: calc(var(--cookie-size) / 4);
 
       position: absolute;
-      left: calc(-1 * var(--cookie-half-size));
+      inset-inline-start: calc(-1 * var(--cookie-half-size));
       top: var(--cookie-quarter-size);
 
       font-size: var(--cookie-size);
@@ -117,13 +117,13 @@
     backdrop-filter: blur(var(--ni-16));
 
     @include for-mobile {
-      padding-left: var(--ni-24);
+      padding-inline-start: var(--ni-24);
       padding-top: var(--ni-40);
       flex-direction: column;
 
       .trakt-cookie {
         position: absolute;
-        left: calc(50% - var(--cookie-half-size));
+        inset-inline-start: calc(50% - var(--cookie-half-size));
         top: calc(-1 * var(--cookie-half-size));
       }
     }
@@ -145,8 +145,7 @@
 
     position: fixed;
     top: 0;
-    left: 0;
-    right: 0;
+    inset-inline: 0;
     bottom: 0;
 
     background-color: color-mix(

--- a/projects/client/src/lib/sections/footer/Footer.svelte
+++ b/projects/client/src/lib/sections/footer/Footer.svelte
@@ -21,10 +21,10 @@
     height: var(--ni-256);
 
     margin-top: var(--gap-xxl);
-    margin-left: var(--layout-sidebar-distance);
+    margin-inline-start: var(--layout-sidebar-distance);
 
-    padding-left: var(--layout-distance-side);
-    padding-right: var(--layout-distance-side);
+    padding-inline-start: var(--layout-distance-side);
+    padding-inline-end: var(--layout-distance-side);
 
     &.has-toast {
       margin-top: calc(var(--height-toast-card) + var(--gap-xxl));

--- a/projects/client/src/lib/sections/landing/Landing.svelte
+++ b/projects/client/src/lib/sections/landing/Landing.svelte
@@ -78,7 +78,7 @@
     --popcorn-safe-area: var(--popcorn-height);
 
     position: absolute;
-    left: 0;
+    inset-inline-start: 0;
     top: 0;
     width: calc(
       100dvw - 2 * var(--landing-padding) - var(--layout-scrollbar-width)

--- a/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
+++ b/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
@@ -107,7 +107,7 @@
 
     .trakt-team-member {
       position: absolute;
-      left: calc(var(--user-index) * var(--avatar-offset));
+      inset-inline-start: calc(var(--user-index) * var(--avatar-offset));
     }
 
     :global(.trakt-user-avatar) {

--- a/projects/client/src/lib/sections/landing/components/JoinForFreeButton.svelte
+++ b/projects/client/src/lib/sections/landing/components/JoinForFreeButton.svelte
@@ -33,7 +33,7 @@
 
         position: absolute;
         top: calc(-1 * var(--glow-size));
-        left: calc(-1 * var(--glow-size));
+        inset-inline-start: calc(-1 * var(--glow-size));
 
         width: calc(100% + 2 * var(--glow-size));
         height: calc(100% + 2 * var(--glow-size));

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -317,7 +317,7 @@
 
     min-height: 100vh;
 
-    padding-left: var(--layout-sidebar-distance);
+    padding-inline-start: var(--layout-sidebar-distance);
     margin-top: calc(var(--gap-m) + env(safe-area-inset-top));
 
     @include for-tablet-sm-and-below {
@@ -334,7 +334,7 @@
     }
 
     &[data-mode="content-only"] {
-      padding-left: 0;
+      padding-inline-start: 0;
       margin-top: 0;
       gap: 0;
     }

--- a/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
+++ b/projects/client/src/lib/sections/lists/activity/_internal/SocialActivityItem.svelte
@@ -100,7 +100,7 @@
       gap: var(--gap-xs);
       align-items: center;
 
-      padding-left: var(--ni-12);
+      padding-inline-start: var(--ni-12);
       background: color-mix(
         in srgb,
         var(--color-card-background) 50%,

--- a/projects/client/src/lib/sections/lists/components/CreditMemberItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditMemberItem.svelte
@@ -274,7 +274,7 @@
   .trakt-credit-member-description {
     color: var(--color-text-secondary);
     overflow-wrap: anywhere;
-    padding-right: 0;
+    padding-inline-end: 0;
     white-space: normal;
     word-break: break-word;
   }

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -328,7 +328,7 @@
     flex-shrink: 0;
 
     :global(.trakt-indicator-tags) {
-      left: 0;
+      inset-inline-start: 0;
       width: var(--poster-width);
     }
   }
@@ -340,7 +340,7 @@
   .trakt-card-title,
   .trakt-card-subtitle,
   :global(.trakt-card-subtitle) {
-    padding-right: var(--ni-18);
+    padding-inline-end: var(--ni-18);
   }
 
   :global(.multi-line-titles) {

--- a/projects/client/src/lib/sections/lists/components/SkeletonCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/SkeletonCard.svelte
@@ -74,6 +74,13 @@
       var(--index);
   }
 
+  .trakt-skeleton-card-cover,
+  .trakt-skeleton-card-footer {
+    &:dir(rtl)::after {
+      animation-direction: reverse;
+    }
+  }
+
   .trakt-skeleton-card-cover::after,
   .trakt-skeleton-card-footer::after {
     content: "";

--- a/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBackgroundImage.svelte
+++ b/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBackgroundImage.svelte
@@ -14,18 +14,25 @@
     overflow: hidden;
 
     top: 0;
-    right: 0;
+    inset-inline-end: 0;
     bottom: 0;
-    left: 0;
+    inset-inline-start: 0;
 
     border-radius: var(--border-radius-m);
 
     opacity: 0.35;
-    mask-image: linear-gradient(240deg, #000 0%, #000 15%, transparent 50%);
+
+    --mask-angle: 240deg;
+
+    &:dir(rtl) {
+      --mask-angle: 120deg;
+    }
+
+    mask-image: linear-gradient(var(--mask-angle), #000 0%, #000 15%, transparent 50%);
 
     :global(img) {
       position: absolute;
-      right: 0;
+      inset-inline-end: 0;
 
       height: 100%;
       width: 75%;

--- a/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBottomBar.svelte
+++ b/projects/client/src/lib/sections/lists/components/_internal/SummaryCardBottomBar.svelte
@@ -54,7 +54,7 @@
 
     position: absolute;
     bottom: 0;
-    right: 0;
+    inset-inline-end: 0;
     width: calc(100% - var(--poster-width));
 
     display: flex;

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/CtaContent.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/CtaContent.svelte
@@ -60,7 +60,7 @@
 
       position: absolute;
       top: 0;
-      left: 0;
+      inset-inline-start: 0;
       width: var(--content-width);
       height: var(--content-height);
 
@@ -92,24 +92,30 @@
   .trakt-cta-cover {
     position: absolute;
     top: 0;
-    right: 0;
+    inset-inline-end: 0;
     width: var(--content-width);
     height: var(--content-height);
 
     overflow: hidden;
     border-radius: var(--border-radius-m);
 
+    --cta-mask-dir: to right;
+
+    &:dir(rtl) {
+      --cta-mask-dir: to left;
+    }
+
     :global(img) {
       position: absolute;
       top: 0;
-      right: 0;
+      inset-inline-end: 0;
 
       width: min(100%, var(--ni-640));
       height: var(--content-height);
 
       object-fit: cover;
 
-      mask: linear-gradient(to right, transparent 0%, black 30%);
+      mask: linear-gradient(var(--cta-mask-dir), transparent 0%, black 30%);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/TraktTeam.svelte
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/TraktTeam.svelte
@@ -65,7 +65,7 @@
 
       position: absolute;
       top: var(--ni-neg-8);
-      right: var(--ni-neg-4);
+      inset-inline-end: var(--ni-neg-4);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
@@ -79,7 +79,7 @@
     );
 
     position: absolute;
-    left: calc(var(--poster-offset) * var(--poster-index));
+    inset-inline-start: calc(var(--poster-offset) * var(--poster-index));
 
     height: var(--poster-height);
     width: var(--poster-width);

--- a/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/ListReorderDrawer.svelte
@@ -376,7 +376,7 @@
     box-sizing: border-box;
     position: relative;
     padding: var(--ni-8);
-    text-align: left;
+    text-align: start;
     vertical-align: middle;
   }
 
@@ -402,13 +402,13 @@
       background: var(--reorder-row-background);
 
       &:first-child {
-        border-top-left-radius: var(--border-radius-m);
-        border-bottom-left-radius: var(--border-radius-m);
+        border-start-start-radius: var(--border-radius-m);
+        border-end-start-radius: var(--border-radius-m);
       }
 
       &:last-child {
-        border-top-right-radius: var(--border-radius-m);
-        border-bottom-right-radius: var(--border-radius-m);
+        border-start-end-radius: var(--border-radius-m);
+        border-end-end-radius: var(--border-radius-m);
       }
     }
   }
@@ -435,19 +435,19 @@
 
       &:first-child {
         &::after {
-          border-left: var(--border-thickness-xxs) dashed
+          border-inline-start: var(--border-thickness-xxs) dashed
             color-mix(in srgb, var(--color-background-purple) 48%, transparent);
-          border-top-left-radius: var(--border-radius-m);
-          border-bottom-left-radius: var(--border-radius-m);
+          border-start-start-radius: var(--border-radius-m);
+          border-end-start-radius: var(--border-radius-m);
         }
       }
 
       &:last-child {
         &::after {
-          border-right: var(--border-thickness-xxs) dashed
+          border-inline-end: var(--border-thickness-xxs) dashed
             color-mix(in srgb, var(--color-background-purple) 48%, transparent);
-          border-top-right-radius: var(--border-radius-m);
-          border-bottom-right-radius: var(--border-radius-m);
+          border-start-end-radius: var(--border-radius-m);
+          border-end-end-radius: var(--border-radius-m);
         }
       }
     }

--- a/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/MobileNavbar.svelte
@@ -101,15 +101,14 @@
 
     position: fixed;
     bottom: 0;
-    left: 0;
-    right: 0;
+    inset-inline: 0;
     z-index: var(--layer-overlay);
 
     background-color: var(--color-background-mobile-navbar);
     box-shadow: var(--shadow-navbar);
 
-    border-top-left-radius: var(--border-radius-xxl);
-    border-top-right-radius: var(--border-radius-xxl);
+    border-start-start-radius: var(--border-radius-xxl);
+    border-start-end-radius: var(--border-radius-xxl);
 
     transition: var(--transition-increment) ease-in-out;
     transition-property: height, gap;

--- a/projects/client/src/lib/sections/navbar/SideNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/SideNavbar.svelte
@@ -95,7 +95,7 @@
 
     position: fixed;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: var(--side-navbar-width);
     height: calc(
       100dvh - var(--navbar-margin-top) - var(--navbar-margin-bottom)

--- a/projects/client/src/lib/sections/navbar/TopNavbar.svelte
+++ b/projects/client/src/lib/sections/navbar/TopNavbar.svelte
@@ -83,7 +83,7 @@
     z-index: var(--layer-overlay);
     position: fixed;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
 
     box-sizing: border-box;
     display: flex;
@@ -99,8 +99,8 @@
     gap: var(--gap-l);
 
     border-radius: 0%;
-    border-bottom-left-radius: var(--border-radius-xxl);
-    border-bottom-right-radius: var(--border-radius-xxl);
+    border-end-start-radius: var(--border-radius-xxl);
+    border-end-end-radius: var(--border-radius-xxl);
 
     transition: calc(2 * var(--transition-increment)) ease-in-out;
     transition-property: width, background-color, box-shadow, top, opacity;

--- a/projects/client/src/lib/sections/navbar/_internal/NavGroup.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/NavGroup.svelte
@@ -97,7 +97,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-xs);
-    padding-left: calc(var(--nav-icon-size) + var(--gap-s));
+    padding-inline-start: calc(var(--nav-icon-size) + var(--gap-s));
 
     :global(.trakt-link) {
       text-decoration: none;

--- a/projects/client/src/lib/sections/navbar/_internal/NavbarActions.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/NavbarActions.svelte
@@ -90,8 +90,7 @@
     transition-property: opacity;
     position: fixed;
     top: 0;
-    left: 0;
-    right: 0;
+    inset-inline: 0;
     z-index: var(--layer-overlay);
     display: flex;
     justify-content: space-between;
@@ -99,7 +98,7 @@
     gap: var(--gap-m);
     padding: var(--gap-m);
     margin-top: env(safe-area-inset-top);
-    padding-left: calc(
+    padding-inline-start: calc(
       var(--layout-distance-side) + var(--layout-sidebar-distance)
     );
 

--- a/projects/client/src/lib/sections/navbar/components/filter/FilterButton.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/FilterButton.svelte
@@ -78,7 +78,7 @@
     .filter-count-badge {
       position: absolute;
       top: 0;
-      right: 0;
+      inset-inline-end: 0;
 
       min-width: var(--ni-16);
       height: var(--ni-16);

--- a/projects/client/src/lib/sections/privacy/Privacy.svelte
+++ b/projects/client/src/lib/sections/privacy/Privacy.svelte
@@ -837,7 +837,7 @@
     td {
       border: 1px solid var(--color-border);
       padding: var(--gap-xs) var(--gap-s);
-      text-align: left;
+      text-align: start;
       vertical-align: top;
     }
 

--- a/projects/client/src/lib/sections/profile-banner/ProfileImage.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfileImage.svelte
@@ -199,7 +199,7 @@
       height: var(--ni-24);
 
       top: var(--ni-neg-8);
-      right: var(--ni-neg-8);
+      inset-inline-end: var(--ni-neg-8);
 
       z-index: var(--layer-raised);
     }
@@ -242,8 +242,8 @@
   .edit-badge {
     position: absolute;
     bottom: 0;
-    right: 0;
-    transform: translate(15%, 15%);
+    inset-inline-end: 0;
+    transform: translate(calc(var(--rtl-sign) * 15%), 15%);
 
     width: var(--ni-24);
     height: var(--ni-24);
@@ -272,13 +272,13 @@
   .trakt-profile-image:has(.editable-image-wrapper:focus-visible)
     .edit-badge {
     opacity: 1;
-    transform: translate(15%, 15%) scale(1.1);
+    transform: translate(calc(var(--rtl-sign) * 15%), 15%) scale(1.1);
   }
 
   .upload-overlay {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: var(--image-size);
     height: var(--image-size);
     border-radius: 50%;

--- a/projects/client/src/lib/sections/profile-banner/_internal/BlockedUserTag.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/BlockedUserTag.svelte
@@ -21,7 +21,7 @@
 
       border-radius: var(--border-radius-xxl);
       padding: var(--ni-8) var(--ni-10);
-      padding-left: var(--ni-8);
+      padding-inline-start: var(--ni-8);
 
       :global(svg) {
         width: var(--ni-14);

--- a/projects/client/src/lib/sections/profile-banner/_internal/PendingFollowTag.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/PendingFollowTag.svelte
@@ -21,7 +21,7 @@
 
       border-radius: var(--border-radius-xxl);
       padding: var(--ni-8) var(--ni-10);
-      padding-left: var(--ni-8);
+      padding-inline-start: var(--ni-8);
 
       :global(svg) {
         width: var(--ni-14);

--- a/projects/client/src/lib/sections/profile/components/MatchDrawer.svelte
+++ b/projects/client/src/lib/sections/profile/components/MatchDrawer.svelte
@@ -242,7 +242,7 @@
   .trakt-match-drawer-suffix {
     font-size: var(--font-size-separator);
     opacity: 0.6;
-    margin-left: var(--ni-2);
+    margin-inline-start: var(--ni-2);
   }
 
   .trakt-match-drawer-hero-avatars {
@@ -308,7 +308,7 @@
   }
 
   .trakt-match-drawer-breakdown-value {
-    text-align: right;
+    text-align: end;
     font-variant-numeric: tabular-nums;
   }
 

--- a/projects/client/src/lib/sections/profile/components/MatchPill.svelte
+++ b/projects/client/src/lib/sections/profile/components/MatchPill.svelte
@@ -140,7 +140,7 @@
 
   .trakt-match-pill-suffix {
     opacity: 0.7;
-    margin-left: var(--ni-1);
+    margin-inline-start: var(--ni-1);
   }
 
   .trakt-match-pill-anchor {
@@ -153,7 +153,7 @@
     display: inline-flex;
     align-items: center;
     opacity: 0.55;
-    margin-left: var(--ni-6);
+    margin-inline-start: var(--ni-6);
     font-size: var(--font-size-tag);
     transition:
       transform var(--transition-increment) ease-out,

--- a/projects/client/src/lib/sections/profile/components/MonthToDate.svelte
+++ b/projects/client/src/lib/sections/profile/components/MonthToDate.svelte
@@ -120,7 +120,7 @@
   .trakt-mtd-title-overlay {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
   }
 
   .trakt-mtd-footer {

--- a/projects/client/src/lib/sections/profile/components/ProfileDetails.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileDetails.svelte
@@ -128,7 +128,7 @@
     &::before {
       content: "";
       position: absolute;
-      left: calc(-0.5 * var(--profile-details-gap));
+      inset-inline-start: calc(-0.5 * var(--profile-details-gap));
       top: 0;
       bottom: 0;
       width: var(--ni-1);

--- a/projects/client/src/lib/sections/profile/components/ProfileItem.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileItem.svelte
@@ -76,8 +76,8 @@
       opacity: 0;
 
       top: var(--offset);
-      left: var(--offset);
-      right: var(--offset);
+      inset-inline-start: var(--offset);
+      inset-inline-end: var(--offset);
       bottom: var(--offset);
 
       background: conic-gradient(

--- a/projects/client/src/lib/sections/settings/_internal/SettingsGroupRow.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsGroupRow.svelte
@@ -94,7 +94,7 @@
     min-height: var(--ni-64);
     width: 100%;
     box-sizing: border-box;
-    text-align: left;
+    text-align: start;
     background: transparent;
     border: none;
     text-decoration: none;
@@ -176,7 +176,7 @@
   .row-value {
     flex-shrink: 0;
     white-space: nowrap;
-    margin-right: var(--gap-xxs);
+    margin-inline-end: var(--gap-xxs);
   }
 
   .row-caret {

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
@@ -90,7 +90,7 @@
     gap: var(--gap-xs);
 
     margin: 0;
-    padding-left: var(--ni-20);
+    padding-inline-start: var(--ni-20);
   }
 
   .import-guide-action {

--- a/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncSettings.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/plex/PlexSyncSettings.svelte
@@ -189,7 +189,7 @@
   .skeleton-tags {
     display: flex;
     gap: var(--gap-xs);
-    margin-left: auto;
+    margin-inline-start: auto;
   }
 
   .skeleton {

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/FavoriteServiceTile.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/FavoriteServiceTile.svelte
@@ -63,7 +63,7 @@
   .tile-check {
     position: absolute;
     top: var(--ni-neg-6);
-    right: var(--ni-neg-4);
+    inset-inline-end: var(--ni-neg-4);
 
     display: flex;
     align-items: center;

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/FavoriteServicesDrawerHost.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/FavoriteServicesDrawerHost.svelte
@@ -182,8 +182,8 @@
   .limit-label {
     margin: 0;
     padding-top: var(--gap-xs);
-    padding-right: var(--gap-xs);
-    text-align: right;
+    padding-inline-end: var(--gap-xs);
+    text-align: end;
 
     &.invisible {
       visibility: hidden;

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceTile.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceTile.svelte
@@ -193,7 +193,7 @@
     box-sizing: border-box;
     padding: var(--ni-14) var(--ni-16);
 
-    text-align: left;
+    text-align: start;
     background: transparent;
     border: none;
     color: inherit;

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/SyncItemRow.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/SyncItemRow.svelte
@@ -217,7 +217,7 @@
 
     font-size: var(--font-size-tag);
     color: var(--color-text-primary);
-    text-align: right;
+    text-align: end;
   }
 
   .trakt-sync-item-row :global(.trakt-link) {

--- a/projects/client/src/lib/sections/stats/StreakCallout.svelte
+++ b/projects/client/src/lib/sections/stats/StreakCallout.svelte
@@ -151,7 +151,7 @@
     background: var(--color-streak-surface);
 
     padding: var(--ni-12);
-    padding-right: var(--ni-18);
+    padding-inline-end: var(--ni-18);
 
     display: flex;
     align-items: center;

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraphPeakHours.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraphPeakHours.svelte
@@ -39,7 +39,7 @@
   .peak-label {
     width: var(--ni-64);
     flex-shrink: 0;
-    text-align: left;
+    text-align: start;
   }
 
   .peak-bar-track {
@@ -60,7 +60,7 @@
 
   .peak-count {
     width: var(--ni-28);
-    text-align: right;
+    text-align: end;
     flex-shrink: 0;
   }
 </style>

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
@@ -107,8 +107,7 @@
     position: absolute;
 
     bottom: calc(100% + var(--ni-4));
-    left: 0;
-    right: 0;
+    inset-inline: 0;
 
     text-align: center;
   }

--- a/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
@@ -42,7 +42,7 @@
     flex: 1;
     min-width: 0;
     max-width: var(--ni-160);
-    margin-left: auto;
+    margin-inline-start: auto;
     padding-block: var(--ni-2);
 
     @include for-tablet-sm-and-below {

--- a/projects/client/src/lib/sections/summary/components/_internal/CollapsableContent.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/CollapsableContent.svelte
@@ -64,7 +64,7 @@
     justify-content: center;
 
     padding: var(--ni-8);
-    padding-left: var(--ni-12);
+    padding-inline-start: var(--ni-12);
 
     background-color: transparent;
 

--- a/projects/client/src/lib/sections/summary/components/_internal/InfoCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/InfoCard.svelte
@@ -48,7 +48,7 @@
 
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         height: 100%;
 

--- a/projects/client/src/lib/sections/summary/components/_internal/SocialActivitiesButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SocialActivitiesButton.svelte
@@ -170,14 +170,14 @@
     height: var(--watched-by-avatar-size);
     flex: 0 0 var(--watched-by-avatar-size);
 
-    margin-left: calc(var(--watched-by-avatar-size) * -0.5);
+    margin-inline-start: calc(var(--watched-by-avatar-size) * -0.5);
 
     border-radius: 50%;
     overflow: hidden;
     box-sizing: border-box;
 
     &:first-child {
-      margin-left: 0;
+      margin-inline-start: 0;
     }
 
     :global(.trakt-user-avatar) {
@@ -195,7 +195,7 @@
     align-items: center;
     gap: var(--ni-4);
     height: var(--height-watched-by-label);
-    padding-right: var(--ni-4);
+    padding-inline-end: var(--ni-4);
 
     &.is-text-only {
       padding-inline: var(--ni-8);

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryActionsBar.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryActionsBar.svelte
@@ -74,8 +74,8 @@
     }
 
     &:global(:has(.trakt-media-actions-popup-button.is-opened)) {
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
+      border-end-start-radius: 0;
+      border-end-end-radius: 0;
       transition-delay: 0s;
     }
 

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryActionsSlider.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryActionsSlider.svelte
@@ -40,7 +40,7 @@
   .trakt-summary-actions-underlay {
     position: fixed;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: 100vw;
     height: 100vh;
 
@@ -53,14 +53,14 @@
     position: absolute;
     top: 100%;
     width: 100%;
-    left: 0;
+    inset-inline-start: 0;
 
     box-shadow: var(--shadow-raised);
     clip-path: inset(0 -100vmax -100vmax -100vmax);
 
     background: var(--color-actions-bar-background);
-    border-bottom-left-radius: var(--border-radius-l);
-    border-bottom-right-radius: var(--border-radius-l);
+    border-end-start-radius: var(--border-radius-l);
+    border-end-end-radius: var(--border-radius-l);
 
     padding: var(--ni-12);
     box-sizing: border-box;

--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryCover.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryCover.svelte
@@ -30,15 +30,21 @@
     position: absolute;
     overflow: hidden;
 
-    left: 0;
+    inset-inline-start: 0;
     top: 0;
     width: var(--ni-920);
     height: var(--ni-920);
 
     opacity: 0.35;
 
+    --spotlight-origin: top left;
+
+    &:dir(rtl) {
+      --spotlight-origin: top right;
+    }
+
     background: radial-gradient(
-      circle at top left,
+      circle at var(--spotlight-origin),
       var(--trakt-cover-primary-color) 0%,
       color-mix(in srgb, var(--trakt-cover-primary-color) 80%, transparent) 20%,
       transparent 70%

--- a/projects/client/src/lib/sections/summary/components/_internal/WatchCountTag.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/WatchCountTag.svelte
@@ -61,7 +61,7 @@
 
     :global(.counter[inert]) {
       position: absolute;
-      left: var(--ni-20);
+      inset-inline-start: var(--ni-20);
     }
 
     :global(.trakt-link) {

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentHeader.svelte
@@ -80,7 +80,7 @@
     :global(.trakt-user-rating-icon) {
       position: absolute;
       top: var(--ni-neg-4);
-      right: var(--ni-neg-10);
+      inset-inline-end: var(--ni-neg-10);
     }
   }
 

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-actions/ReactButton.svelte
@@ -134,7 +134,7 @@
     transition-property: background-color, filter, opacity;
 
     &.has-summary {
-      padding-right: var(--ni-10);
+      padding-inline-end: var(--ni-10);
     }
 
     &[disabled]:not([data-popup-state="opened"]) {

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/comment-input/CommentInput.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/comment-input/CommentInput.svelte
@@ -117,7 +117,7 @@
     gap: var(--gap-s);
 
     padding: var(--ni-8);
-    padding-left: var(--ni-16);
+    padding-inline-start: var(--ni-16);
     box-sizing: border-box;
 
     border-radius: var(--border-radius-s);

--- a/projects/client/src/lib/sections/summary/components/comments/drawers/CommentReplies.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/drawers/CommentReplies.svelte
@@ -70,7 +70,7 @@
     flex-direction: column;
     gap: var(--gap-xl);
 
-    padding-left: var(--ni-32);
+    padding-inline-start: var(--ni-32);
   }
 
   .toggle-replies-button {

--- a/projects/client/src/lib/sections/summary/components/overlay/StreamOnOverlay.svelte
+++ b/projects/client/src/lib/sections/summary/components/overlay/StreamOnOverlay.svelte
@@ -46,8 +46,7 @@
       content: "";
       position: absolute;
       top: 0;
-      left: 0;
-      right: 0;
+      inset-inline: 0;
       bottom: 0;
       background: linear-gradient(
         to bottom,

--- a/projects/client/src/lib/sections/summary/components/people/v2/_internal/Celebration.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/_internal/Celebration.svelte
@@ -17,7 +17,7 @@
 <style>
   .trakt-celebration {
     position: absolute;
-    left: 50%;
+    inset-inline-start: 50%;
     top: 50%;
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonProgressCard.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonProgressCard.svelte
@@ -137,7 +137,7 @@
 
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
 
     width: 300%;
     height: 100%;

--- a/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentAspects.svelte
+++ b/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentAspects.svelte
@@ -62,7 +62,7 @@
 
     margin: 0;
     padding: 0;
-    padding-left: var(--ni-12);
+    padding-inline-start: var(--ni-12);
 
     font-size: var(--font-size-text);
 

--- a/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentSummary.svelte
@@ -48,7 +48,7 @@
 
     margin: 0;
     padding: 0;
-    padding-left: var(--ni-18);
+    padding-inline-start: var(--ni-18);
 
     font-size: var(--font-size-text);
 

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryContainer.svelte
@@ -102,7 +102,7 @@
   }
 
   .trakt-summary-actions {
-    margin-left: var(--ni-neg-16);
+    margin-inline-start: var(--ni-neg-16);
   }
 
   .trakt-summary-poster-container {

--- a/projects/client/src/lib/sections/summary/components/trivia/TriviaDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/trivia/TriviaDrawerHost.svelte
@@ -141,7 +141,7 @@
 
   .category-filter {
     display: flex;
-    margin-left: auto;
+    margin-inline-start: auto;
     min-width: 0;
   }
 

--- a/projects/client/src/lib/sections/toast/_internal/NowPlayingContent.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/NowPlayingContent.svelte
@@ -104,7 +104,7 @@
       --stop-button-offset: var(--ni-neg-6);
       position: absolute;
       top: calc(var(--stop-button-offset) - var(--content-vertical-padding));
-      right: var(--stop-button-offset);
+      inset-inline-end: var(--stop-button-offset);
     }
   }
 

--- a/projects/client/src/lib/sections/toast/_internal/ProgressBar.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/ProgressBar.svelte
@@ -26,7 +26,7 @@
       content: "";
       position: absolute;
       top: 0;
-      left: 0;
+      inset-inline-start: 0;
       height: 100%;
       width: var(--play-progress);
       background-color: var(--color-toast-progress-bar-progress);

--- a/projects/client/src/lib/sections/vip/_internal/BuiltToLast.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/BuiltToLast.svelte
@@ -50,7 +50,7 @@
 
     ul {
       padding: 0;
-      padding-left: var(--ni-18);
+      padding-inline-start: var(--ni-18);
       margin: var(--ni-20) 0 0 0;
 
       li {

--- a/projects/client/src/lib/sections/vip/_internal/SubscriptionManagement.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/SubscriptionManagement.svelte
@@ -81,8 +81,8 @@
 
     /* To compensate for the buttons' padding */
     margin-bottom: var(--ni-neg-12);
-    margin-left: var(--ni-neg-12);
-    margin-right: var(--ni-neg-12);
+    margin-inline-start: var(--ni-neg-12);
+    margin-inline-end: var(--ni-neg-12);
 
     :global(.trakt-button) {
       flex-direction: row-reverse;

--- a/projects/client/src/lib/sections/vip/_internal/UsageBar.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/UsageBar.svelte
@@ -37,7 +37,10 @@
       class="trakt-limit-zone free-limit"
       style:width="{limitedPercentage}%"
     ></div>
-    <div class="trakt-limit-zone vip-limit" style:left="{limitedPercentage}%">
+    <div
+      class="trakt-limit-zone vip-limit"
+      style:inset-inline-start="{limitedPercentage}%"
+    >
       <span class="vip-limit-label tag secondary">
         {toHumanNumber(vipLimit, languageTag())}
       </span>
@@ -86,10 +89,10 @@
       }
 
       .vip-limit {
-        right: 0;
-        margin-left: var(--ni-neg-24);
+        inset-inline-end: 0;
+        margin-inline-start: var(--ni-neg-24);
 
-        border-left: none;
+        border-inline-start: none;
         border-style: dashed;
 
         background-color: transparent;
@@ -106,7 +109,7 @@
 
   .vip-limit-label {
     position: absolute;
-    right: var(--ni-8);
+    inset-inline-end: var(--ni-8);
     top: 50%;
     transform: translateY(-50%);
   }
@@ -115,7 +118,7 @@
     z-index: var(--layer-raised);
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     bottom: 0;
 
     width: var(--progress);

--- a/projects/client/src/lib/sections/vip/_internal/VipHeader.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/VipHeader.svelte
@@ -46,7 +46,7 @@
     :global(.trakt-vip-badge) {
       display: inline-flex;
       vertical-align: middle;
-      margin-left: var(--gap-xxs);
+      margin-inline-start: var(--gap-xxs);
     }
 
     font-size: var(--ni-40);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024GenresSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024GenresSection.svelte
@@ -101,8 +101,8 @@
   .yir-2024-genres-watermark {
     position: absolute;
     top: var(--ni-72);
-    left: var(--panel-padding-x);
-    right: 0;
+    inset-inline-start: var(--panel-padding-x);
+    inset-inline-end: 0;
     font-size: clamp(var(--ni-72), 12vw, var(--ni-160));
     line-height: 1;
     white-space: nowrap;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PeopleSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PeopleSection.svelte
@@ -87,12 +87,12 @@
 
   // Vertical divider between the two columns (pad each side toward the line).
   .yir-2024-people-cell:nth-child(odd) {
-    padding-right: var(--ni-48);
-    border-right: var(--border-thickness-xs) solid var(--people-divider);
+    padding-inline-end: var(--ni-48);
+    border-inline-end: var(--border-thickness-xs) solid var(--people-divider);
   }
 
   .yir-2024-people-cell:nth-child(even) {
-    padding-left: var(--ni-48);
+    padding-inline-start: var(--ni-48);
   }
 
   // Horizontal divider between the two rows.
@@ -110,12 +110,12 @@
   // Stacked: drop the vertical divider, keep horizontal dividers between all.
   @include for-tablet-sm-and-below {
     .yir-2024-people-cell:nth-child(odd) {
-      padding-right: 0;
-      border-right: none;
+      padding-inline-end: 0;
+      border-inline-end: none;
     }
 
     .yir-2024-people-cell:nth-child(even) {
-      padding-left: 0;
+      padding-inline-start: 0;
     }
 
     .yir-2024-people-cell:nth-child(1) {

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsMonthlySection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsMonthlySection.svelte
@@ -305,27 +305,27 @@
   }
 
   .yir-2024-stats-summary {
-    border-top-left-radius: var(--panel-radius);
-    border-top-right-radius: var(--panel-radius);
+    border-start-start-radius: var(--panel-radius);
+    border-start-end-radius: var(--panel-radius);
   }
 
   .yir-2024-stats-card-hours {
-    border-bottom-left-radius: var(--panel-radius);
+    border-end-start-radius: var(--panel-radius);
   }
 
   .yir-2024-stats-card-plays {
-    border-bottom-right-radius: var(--panel-radius);
+    border-end-end-radius: var(--panel-radius);
   }
 
   @include for-tablet-sm-and-below {
     .yir-2024-stats-card-hours {
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
+      border-end-start-radius: 0;
+      border-end-end-radius: 0;
     }
 
     .yir-2024-stats-card-plays {
-      border-bottom-left-radius: var(--panel-radius);
-      border-bottom-right-radius: var(--panel-radius);
+      border-end-start-radius: var(--panel-radius);
+      border-end-end-radius: var(--panel-radius);
     }
   }
 
@@ -371,8 +371,8 @@
     margin: 0 calc(-1 * var(--panel-padding-x));
 
     @include for-tablet-sm-and-below {
-      margin-left: 0;
-      margin-right: 0;
+      margin-inline-start: 0;
+      margin-inline-end: 0;
     }
   }
 
@@ -474,8 +474,8 @@
 
     position: absolute;
     bottom: 0;
-    left: var(--watermark-inset);
-    right: var(--watermark-inset);
+    inset-inline-start: var(--watermark-inset);
+    inset-inline-end: var(--watermark-inset);
     transform: translateY(35%);
     text-align: center;
     font-family: inherit;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
@@ -319,18 +319,18 @@
 
   // Summary panel sits on top of the row pair: pill-rounded only on top.
   .yir-2024-stats-summary {
-    border-top-left-radius: var(--panel-radius);
-    border-top-right-radius: var(--panel-radius);
+    border-start-start-radius: var(--panel-radius);
+    border-start-end-radius: var(--panel-radius);
   }
 
   // Hours card is the bottom-left of the desktop row.
   .yir-2024-stats-card-hours {
-    border-bottom-left-radius: var(--panel-radius);
+    border-end-start-radius: var(--panel-radius);
   }
 
   // Plays card is the bottom-right of the desktop row.
   .yir-2024-stats-card-plays {
-    border-bottom-right-radius: var(--panel-radius);
+    border-end-end-radius: var(--panel-radius);
   }
 
   // Once the cards stack vertically (tablet-sm-and-below), the hours card
@@ -339,13 +339,13 @@
   // corners pick up --panel-radius.
   @include for-tablet-sm-and-below {
     .yir-2024-stats-card-hours {
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
+      border-end-start-radius: 0;
+      border-end-end-radius: 0;
     }
 
     .yir-2024-stats-card-plays {
-      border-bottom-left-radius: var(--panel-radius);
-      border-bottom-right-radius: var(--panel-radius);
+      border-end-start-radius: var(--panel-radius);
+      border-end-end-radius: var(--panel-radius);
     }
   }
 
@@ -398,8 +398,8 @@
     margin: 0 calc(-1 * var(--panel-padding-x));
 
     @include for-tablet-sm-and-below {
-      margin-left: 0;
-      margin-right: 0;
+      margin-inline-start: 0;
+      margin-inline-end: 0;
     }
   }
 
@@ -514,8 +514,8 @@
 
     position: absolute;
     bottom: 0;
-    left: var(--watermark-inset);
-    right: var(--watermark-inset);
+    inset-inline-start: var(--watermark-inset);
+    inset-inline-end: var(--watermark-inset);
     transform: translateY(35%);
     text-align: center;
     font-family: inherit;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024ThanksSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024ThanksSection.svelte
@@ -109,7 +109,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--ni-20);
-    text-align: left;
+    text-align: start;
     color: var(--shade-10);
 
     // Set on the <p> directly — a global `p { font-size }` rule beats the

--- a/projects/client/src/lib/sections/yir/_internal/MirHeader.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/MirHeader.svelte
@@ -177,8 +177,7 @@
   .trakt-mir-header {
     position: fixed;
     top: 0;
-    left: 0;
-    right: 0;
+    inset-inline: 0;
     z-index: 10;
 
     display: flex;
@@ -338,7 +337,7 @@
     }
 
     .mir-header-user {
-      margin-right: auto;
+      margin-inline-end: auto;
     }
   }
 </style>

--- a/projects/client/src/lib/sections/yir/_internal/YirGenreBars.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirGenreBars.svelte
@@ -130,8 +130,8 @@
       display: flex;
       flex-direction: column;
       margin-bottom: var(--ni-2);
-      padding-left: var(--ni-6);
-      border-left: var(--border-thickness-xxs) solid var(--genre-color);
+      padding-inline-start: var(--ni-6);
+      border-inline-start: var(--border-thickness-xxs) solid var(--genre-color);
     }
   }
 
@@ -153,7 +153,7 @@
 
   .yir-genre-bar {
     height: var(--ni-30);
-    margin-left: var(--ni-2);
+    margin-inline-start: var(--ni-2);
     position: relative;
     min-width: var(--ni-44);
     width: var(--bar-width);
@@ -169,14 +169,14 @@
       height: var(--ni-30);
       min-height: var(--ni-30);
       width: var(--mobile-bar-width);
-      margin-left: 0;
+      margin-inline-start: 0;
       margin-bottom: 0;
       display: block;
     }
   }
 
   .yir-genre-row:first-child .yir-genre-bar {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 
   .yir-genre-percentage {
@@ -184,7 +184,7 @@
     position: absolute;
     width: 100%;
     text-align: center;
-    left: 0;
+    inset-inline-start: 0;
     top: var(--ni-8);
     font-size: var(--font-size-text-small);
     opacity: 0;
@@ -197,7 +197,7 @@
 
   .yir-genre-label {
     position: absolute;
-    left: 0;
+    inset-inline-start: 0;
     bottom: var(--ni-30);
     width: 200%;
     box-sizing: border-box;
@@ -205,7 +205,7 @@
     white-space: nowrap;
     padding: var(--ni-4) var(--ni-6);
     color: var(--shade-10);
-    border-left: var(--border-thickness-xs) solid var(--genre-color);
+    border-inline-start: var(--border-thickness-xs) solid var(--genre-color);
     pointer-events: none;
 
     @include for-tablet-sm-and-below {
@@ -240,7 +240,7 @@
       background-color: color-mix(in srgb, var(--genre-color) 31%, transparent);
       // Full-color 1px left border on top of the translucent fill (matches
       // v2: solid border-color + `#RRGGBB50` background tint).
-      border-left: var(--border-thickness-xxs) solid var(--genre-color);
+      border-inline-start: var(--border-thickness-xxs) solid var(--genre-color);
       text-transform: uppercase;
     }
 

--- a/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
@@ -150,8 +150,7 @@
   .yir-header {
     position: fixed;
     top: 0;
-    left: 0;
-    right: 0;
+    inset-inline: 0;
     z-index: 10;
 
     display: flex;
@@ -313,7 +312,7 @@
     }
 
     .yir-header-user {
-      margin-right: auto;
+      margin-inline-end: auto;
     }
   }
 </style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
@@ -177,12 +177,12 @@
     text-transform: uppercase;
     font-size: var(--ni-18);
     font-weight: bold;
-    text-align: left;
+    text-align: start;
   }
 
   .yir-calendar-time {
     font-size: var(--ni-18);
-    text-align: left;
+    text-align: start;
     padding-top: 2px;
   }
 </style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
@@ -256,13 +256,13 @@
   }
 
   .yir-grid-item:first-child .yir-grid-thumb {
-    border-top-left-radius: var(--border-radius-s);
-    border-bottom-left-radius: var(--border-radius-s);
+    border-start-start-radius: var(--border-radius-s);
+    border-end-start-radius: var(--border-radius-s);
   }
 
   .yir-grid-item:last-child .yir-grid-thumb {
-    border-top-right-radius: var(--border-radius-s);
-    border-bottom-right-radius: var(--border-radius-s);
+    border-start-end-radius: var(--border-radius-s);
+    border-end-end-radius: var(--border-radius-s);
   }
 
   @include for-tablet-sm-and-below {
@@ -290,7 +290,7 @@
   .yir-rank-wrapper {
     position: absolute;
     z-index: 1;
-    left: 0;
+    inset-inline-start: 0;
     top: var(--ni-neg-12);
     text-align: center;
     width: 100%;

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
@@ -298,7 +298,7 @@
   .yir-rank {
     position: absolute;
     top: 0;
-    left: var(--ni-14);
+    inset-inline-start: var(--ni-14);
     color: var(--shade-10);
     font-weight: bold;
     font-size: var(--ni-12);
@@ -317,7 +317,7 @@
     &::before {
       content: "";
       padding-top: 100%;
-      float: left;
+      float: inline-start;
     }
 
     &::after {
@@ -327,7 +327,7 @@
       width: 100%;
       height: 100%;
       box-shadow: 0 0 0 var(--ni-104) var(--shade-1000);
-      left: 0;
+      inset-inline-start: 0;
       top: 0;
       border: var(--border-thickness-xxs) solid var(--shade-600);
       transition: border-color 0.5s;
@@ -338,7 +338,7 @@
     width: 100%;
     position: absolute;
     top: -10%;
-    left: 0;
+    inset-inline-start: 0;
 
     &.is-default {
       top: 0;

--- a/projects/client/src/lib/sections/yir/default/_internal/YirSectionHeader.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirSectionHeader.svelte
@@ -70,7 +70,7 @@
       background-color: var(--shade-10);
       color: var(--shade-1000);
       padding: var(--ni-6) var(--ni-8);
-      margin-right: var(--ni-neg-4);
+      margin-inline-end: var(--ni-neg-4);
     }
 
     .yir-hash {

--- a/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
@@ -160,13 +160,13 @@
     }
 
     @include for-tablet-sm-and-below {
-      padding-left: 5%;
-      padding-right: 5%;
+      padding-inline-start: 5%;
+      padding-inline-end: 5%;
     }
 
     @include for-mobile {
-      padding-left: 3%;
-      padding-right: 3%;
+      padding-inline-start: 3%;
+      padding-inline-end: 3%;
       flex-wrap: wrap;
 
       .yir-stat {
@@ -294,8 +294,8 @@
     // Extra horizontal breathing room around the charts on smaller
     // screens so the bars don't hug the viewport edges.
     @include for-tablet-sm-and-below {
-      padding-left: var(--ni-20);
-      padding-right: var(--ni-20);
+      padding-inline-start: var(--ni-20);
+      padding-inline-end: var(--ni-20);
     }
 
     @include for-mobile {

--- a/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
@@ -116,13 +116,13 @@
     }
 
     @include for-tablet-sm-and-below {
-      padding-left: 10%;
-      padding-right: 10%;
+      padding-inline-start: 10%;
+      padding-inline-end: 10%;
     }
 
     @include for-mobile {
-      padding-left: 3%;
-      padding-right: 3%;
+      padding-inline-start: 3%;
+      padding-inline-end: 3%;
     }
   }
 

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -243,6 +243,15 @@
     opacity: 0.25;
   }
 
+  // Dev-only TanStack toggle defaults to the physical bottom-right. Under RTL
+  // the side navbar (and its avatar) dock to the right, so relocate the toggle
+  // to the opposite bottom corner to avoid overlapping them. !important beats
+  // the library's inline positioning.
+  :global(.tsqd-open-btn-container:dir(rtl)) {
+    inset-inline-end: auto !important;
+    inset-inline-start: var(--ni-16) !important;
+  }
+
   @include for-mouse {
     :global(::-webkit-scrollbar) {
       width: var(--ni-8);

--- a/projects/client/src/routes/_design_system/+layout.svelte
+++ b/projects/client/src/routes/_design_system/+layout.svelte
@@ -76,14 +76,14 @@
   .trakt-design-system-route {
     box-sizing: border-box;
     min-height: 100vh;
-    padding-left: var(--layout-sidebar-distance);
+    padding-inline-start: var(--layout-sidebar-distance);
     margin-top: calc(var(--gap-m) + env(safe-area-inset-top));
 
     transition: var(--transition-increment) ease-in-out;
     transition-property: margin, padding;
 
     @include for-tablet-sm-and-below {
-      padding-left: 0;
+      padding-inline-start: 0;
       margin-top: var(--gap-m);
     }
 

--- a/projects/client/src/routes/_design_system/_internal/table/TableCell.svelte
+++ b/projects/client/src/routes/_design_system/_internal/table/TableCell.svelte
@@ -16,7 +16,7 @@
   th,
   td {
     padding: 0.75rem;
-    text-align: left;
+    text-align: start;
     border: 1px solid var(--color-border);
   }
 

--- a/projects/client/src/routes/_design_system/pwa/android/+page.svelte
+++ b/projects/client/src/routes/_design_system/pwa/android/+page.svelte
@@ -164,8 +164,7 @@
     .trakt-android-phone-top-bar {
       position: absolute;
       top: 0;
-      left: 0;
-      right: 0;
+      inset-inline: 0;
       height: calc(
         var(--height-android) - var(--height-pwa) -
           var(--height-android-gesture)
@@ -183,7 +182,7 @@
       .trakt-android-phone-top-bar-left {
         font-size: var(--font-size-m);
         font-weight: var(--font-weight-bold);
-        text-align: left;
+        text-align: start;
         flex-grow: 1;
         color: var(--background-android-theme-color);
         filter: invert(1);
@@ -212,8 +211,7 @@
     .trakt-android-gesture-navbar {
       position: absolute;
       bottom: 0;
-      left: 0;
-      right: 0;
+      inset-inline: 0;
       height: var(--height-android-gesture);
       background-color: black;
       display: flex;

--- a/projects/client/src/routes/_design_system/share-card/+page.svelte
+++ b/projects/client/src/routes/_design_system/share-card/+page.svelte
@@ -326,8 +326,7 @@
         content: "";
         position: absolute;
         top: 0;
-        left: 0;
-        right: 0;
+        inset-inline: 0;
         height: 1px;
         background: linear-gradient(
           90deg,

--- a/projects/client/src/style/direction/index.css
+++ b/projects/client/src/style/direction/index.css
@@ -1,0 +1,21 @@
+/*
+  Directional glyphs (chevrons, carets, arrows) point along the reading axis,
+  so they must mirror under RTL. Opt a glyph in with `trakt-icon-directional`;
+  icons that read the same in both directions stay untouched.
+*/
+.trakt-icon-directional:dir(rtl) {
+  transform: scaleX(-1);
+}
+
+/*
+  Transforms are never direction-aware, so a physical translateX(+n) keeps
+  pointing the same way under RTL. Multiply the inline offset by --rtl-sign
+  (1 in LTR, -1 in RTL) to mirror translate-driven motion.
+*/
+:root {
+  --rtl-sign: 1;
+}
+
+:root:dir(rtl) {
+  --rtl-sign: -1;
+}

--- a/projects/client/src/style/index.ts
+++ b/projects/client/src/style/index.ts
@@ -25,5 +25,7 @@ import './layers/index.css';
 
 import './states/index.css';
 
+import './direction/index.css';
+
 import './theme/seasonal/christmas.css';
 import './theme/seasonal/halloween.css';

--- a/projects/client/src/style/scss/mixins/index.scss
+++ b/projects/client/src/style/scss/mixins/index.scss
@@ -118,6 +118,20 @@
   }
 }
 
+@mixin list-mask($offset) {
+  --list-mask-dir: to right;
+
+  &:dir(rtl) {
+    --list-mask-dir: to left;
+  }
+
+  mask-image: linear-gradient(
+    var(--list-mask-dir),
+    black calc(100% - $offset),
+    transparent calc(100% - $offset)
+  );
+}
+
 @mixin dynamic-card-width($widthVariable, $minCardWidth, $itemCount) {
   $listGaps: calc($itemCount * var(--list-gap));
   $listUsableWidth: calc(var(--list-inner-width) - $listGaps);


### PR DESCRIPTION
Adds right-to-left rendering support and migrates the app's directional CSS to logical properties so every surface mirrors correctly under RTL locales (e.g. `fa-IR`).

## What's in here

Three logical commits:

1. **feat(i18n): RTL text-direction support** - the mechanism
   - sync `<html dir>` on client locale switch (from the sanitized locale)
   - mirror directional glyphs (arrows, carets, chevrons) via a `trakt-icon-directional` class flipped under `:dir(rtl)`
   - `--rtl-sign` custom property (1 LTR / -1 RTL) for direction-aware transforms
   - direction-aware carousel: logical button placement, start/end scroll semantics, a pure `scrollSign` helper, affordance detection normalized on `abs(scrollLeft)`
   - tests: `getTextDirection`, `scrollSign` quadrants, carousel affordances, SSR `dir=rtl` via Accept-Language and cookie

2. **refactor(layout): migrate physical CSS properties to logical** - app-wide
   - `padding`/`margin`/`border-left|right` -> `*-inline-*`, `text-align: left/right` -> `start/end`, `float` -> `inline-start/end`
   - corner radii -> logical (`border-start-start-radius`, etc.)
   - `left`/`right` positioning -> `inset-inline-start/end`
   - transform-driven UI (tab indicator, switch label, profile badge) made direction-aware via `--rtl-sign`
   - targeted anchors: navbar docks + gutters, search input, drawers, toggler tracker, usage bar, dev-only query devtools toggle
   - transition lists updated to name the logical properties

3. **docs(i18n): RTL- and a11y-aware agent rules** - codifies the conventions in `project.md` + `components.md` (logical properties, `--rtl-sign`, `trakt-icon-directional`, accessible names on icon-only buttons) so future work stays mirror-safe.

## Kept physical (intentionally)

Values that are not a layout side: JS-measured viewport coordinates (drag ghost, share-card geometry, chart pointer), `left: 50%` centering paired with `translate(-50%)`, off-screen hiding, `@keyframes`, and third-party JS config keys (carbon-charts axes).

## Follow-ups (out of scope)

JS-driven direction that lives outside CSS:
- SwipeX gesture sign under RTL
- DropdownList popup placement under RTL

## Testing

Verified locally by temporarily hardcoding the locale to RTL across the app and walking the main surfaces (navbar, search, toggler, carousels, drawers, gutters, profile). Unit tests green.

https://github.com/user-attachments/assets/8aa0c4ba-065b-4998-8f60-863cee142ec5


