### PR TITLE
fix(search): restore on-screen keyboard on mobile PWA

### DIFF
--- a/projects/client/src/lib/features/search/SearchInput.svelte
+++ b/projects/client/src/lib/features/search/SearchInput.svelte
@@ -13,25 +13,21 @@
 
   const isMouse = useMedia(WellKnownMediaQuery.mouse);
 
-  function onSearch(ev: Event) {
-    const inputElement = ev.target as HTMLInputElement;
-    const value = inputElement.value.trim();
-
-    if (value.length === 0) {
-      goto(pathName, {
-        replaceState: page.url.pathname === pathName,
-        keepFocus: true,
-      });
-    }
-
+  function navigateToSearch(rawValue: string) {
+    // An empty q is kept in the URL on purpose: it resets the persisted
+    // query in SearchProvider (which only reacts when the q param exists).
     const params = buildParamString({
       m: $mode,
-      q: inputElement.value.trim(),
+      q: rawValue.trim(),
     });
     goto(`${pathName}${params}`, {
       replaceState: page.url.pathname === pathName,
       keepFocus: true,
     });
+  }
+
+  function onSearch(ev: Event) {
+    navigateToSearch((ev.target as HTMLInputElement).value);
   }
 
   let inputElement: HTMLInputElement;
@@ -66,16 +62,20 @@
   });
 
   onMount(() => {
-    if (!$isMouse) {
-      return;
+    const length = inputElement.value.length;
+
+    // Autofocus only with a mouse; on touch it would pop the keyboard on
+    // every navigation to the search page.
+    if ($isMouse) {
+      inputElement.setSelectionRange(length, length);
+      inputElement.focus();
     }
 
-    const length = inputElement.value.length;
-    inputElement.setSelectionRange(length, length);
-    inputElement.focus();
-
-    if (length > 0) {
-      inputElement.click();
+    // Apply a persisted query (e.g. arriving from the sidebar link, which
+    // points at /search with no params) on every platform. Skip when the URL
+    // already carries it, as the page already searches from the q param.
+    if (length > 0 && page.url.searchParams.get("q") !== inputElement.value.trim()) {
+      navigateToSearch(inputElement.value);
     }
   });
 </script>
@@ -92,7 +92,6 @@
   <input
     use:clickOutside
     bind:this={inputElement}
-    onclick={onSearch}
     onclickoutside={clear}
     class="trakt-search-input"
     type="search"


### PR DESCRIPTION
## Problem

In the iOS PWA (and some Android devices), tapping the search input stopped opening the on-screen keyboard.

## Cause

SearchInput ran goto() from the input's onclick on every tap. The navigation dropped the input's native focus mid-gesture; keepFocus: true re-focused asynchronously, and mobile browsers won't raise the soft keyboard for a programmatic focus that happens outside the original user gesture.

## Fix
- Remove the click-triggered goto. A tap now should focus the input natively and the keyboard opens.
- Move the "reapply persisted query on open" behaviour into onMount for all platforms (previously mobile only got it via the keyboard-breaking onclick). Reopening search now re-runs the existing query automatically, no tap required.
- Keep autofocus mouse-only; keep the empty q param on clear so the persisted query still resets.
- ⚠️ Blind fix, to be verified on prod. Will revert if it doesn't work