### PR TITLE
refactor(button): port to bits-ui and remove textured style

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import { appendGlobalParameters } from "$lib/features/parameters/appendGlobalParameters";
   import { useActiveLink } from "$lib/stores/useActiveLink";
-  import { appendClassList } from "$lib/utils/actions/appendClassList";
-  import { disableNavigation } from "$lib/utils/actions/disableNavigation";
-  import { triggerWithKeyboard } from "$lib/utils/actions/triggerWithKeyboard";
+  import { Button } from "bits-ui";
   import { useGuardedHref } from "../../features/auth/stores/useGuardedHref";
+  import { createButtonHost } from "./_internal/createButtonHost.svelte";
   import type { TraktActionButtonProps } from "./TraktActionButtonProps";
 
   type TraktActionButtonAnchorProps = HTMLAnchorProps & TraktActionButtonProps;
@@ -22,112 +20,114 @@
     ...props
   }: TraktActionButtonProps | TraktActionButtonAnchorProps = $props();
 
-  const rest = $derived({ ...props, disabled: disabled || undefined });
-
   const { guardedHref, originalHref } = $derived(
-    useGuardedHref((rest as TraktActionButtonAnchorProps).href),
+    useGuardedHref((props as TraktActionButtonAnchorProps).href),
   );
 
-  const noscroll = $derived((rest as TraktActionButtonAnchorProps).noscroll);
+  const noscroll = $derived((props as TraktActionButtonAnchorProps).noscroll);
   const replacestate = $derived(
-    (rest as TraktActionButtonAnchorProps).replacestate,
+    (props as TraktActionButtonAnchorProps).replacestate,
   );
 
   const href = $derived($guardedHref);
   const { isActive } = $derived(useActiveLink($originalHref));
+
+  const classNames = $derived(
+    [
+      "trakt-action-button",
+      "trakt-button-link",
+      $isActive && "trakt-link-active",
+      classList,
+    ]
+      .filter(Boolean)
+      .join(" "),
+  );
+
+  const host = createButtonHost({
+    getProps: () => props,
+    getHref: () => href,
+    getDisabled: () => disabled,
+    getClassName: () => classNames,
+    getNoscroll: () => noscroll,
+    getReplacestate: () => replacestate,
+    getAttrs: () => ({
+      "aria-label": label,
+      "data-color": color,
+      "data-variant": variant,
+      "data-size": size,
+      "data-style": style,
+      "data-dpad-navigation": navigationType,
+    }),
+  });
 </script>
 
-{#if href != null}
-  <a
-    use:triggerWithKeyboard
-    use:appendGlobalParameters={href}
-    use:disableNavigation={rest.disabled}
-    use:appendClassList={classList}
-    data-sveltekit-keepfocus
-    data-sveltekit-noscroll={noscroll}
-    data-sveltekit-replacestate={replacestate}
-    class="trakt-action-button trakt-button-link"
-    class:trakt-link-active={$isActive}
-    aria-label={label}
-    data-color={color}
-    data-variant={variant}
-    data-size={size}
-    data-style={style}
-    data-dpad-navigation={navigationType}
-    {...rest}
-    {href}
-  >
-    {@render children()}
-  </a>
-{:else}
-  <button
-    use:appendClassList={classList}
-    class="trakt-action-button trakt-button-link"
-    aria-label={label}
-    data-color={color}
-    data-variant={variant}
-    data-size={size}
-    data-style={style}
-    data-dpad-navigation={navigationType}
-    {...rest}
-  >
-    {@render children()}
-  </button>
-{/if}
+<Button.Root {...host.rootProps}>
+  {@render children()}
+</Button.Root>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  @mixin variant-styles($variant, $background-color, $foreground-color) {
-    &[data-variant="#{$variant}"] {
-      --color-background-action-button: #{$background-color};
-      --color-foreground-action-button: #{$foreground-color};
+  // bits-ui renders the underlying element, so it never receives this
+  // component's scope hash. Every selector is therefore wrapped in :global(),
+  // anchored to the namespaced root, to survive Svelte's scoped-CSS pruning.
+  $b: ".trakt-action-button";
+  $on: ":not([disabled]):not([aria-disabled=true])";
 
-      @include for-mouse {
-        &:hover,
-        &:focus-visible {
-          --color-background-action-button: #{$foreground-color};
-          --color-foreground-action-button: #{$background-color};
+  @mixin variant-styles($base, $color, $variant, $bg, $fg) {
+    :global(#{$base}[data-color=#{$color}][data-variant=#{$variant}]) {
+      --color-background-action-button: #{$bg};
+      --color-foreground-action-button: #{$fg};
+    }
 
-          &[data-style="ghost"][data-variant="secondary"] {
-            --color-foreground-action-button: var(--color-foreground);
-          }
-        }
+    @include for-mouse {
+      :global(#{$base}[data-color=#{$color}][data-variant=#{$variant}]:hover),
+      :global(
+          #{$base}[data-color=#{$color}][data-variant=#{$variant}]:focus-visible
+        ) {
+        --color-background-action-button: #{$fg};
+        --color-foreground-action-button: #{$bg};
+      }
+    }
+  }
+
+  @mixin color-styles($base, $color) {
+    $bg: var(--color-background-#{$color});
+    $fg: var(--color-foreground-#{$color});
+
+    @include variant-styles($base, $color, primary, $bg, $fg);
+    @include variant-styles($base, $color, secondary, $fg, $bg);
+
+    // Ghost foreground/background overrides are variant-pinned, so they are
+    // emitted once per color rather than inside the per-variant block.
+    :global(#{$base}[data-color=#{$color}][data-style=ghost][data-variant=primary]) {
+      --color-foreground-action-button: var(--color-foreground);
+    }
+
+    :global(
+        #{$base}[data-color=#{$color}][data-style=ghost][data-variant=secondary]
+      ) {
+      --color-background-action-button: var(--color-foreground);
+    }
+
+    @include for-mouse {
+      :global(#{$base}[data-color=#{$color}]:focus-visible) {
+        outline: var(--border-thickness-xs) solid
+          var(--color-background-action-button);
       }
 
-      &[data-style="ghost"][data-variant="primary"] {
+      :global(
+          #{$base}[data-color=#{$color}][data-style=ghost][data-variant=secondary]:hover
+        ),
+      :global(
+          #{$base}[data-color=#{$color}][data-style=ghost][data-variant=secondary]:focus-visible
+        ) {
         --color-foreground-action-button: var(--color-foreground);
       }
-
-      &[data-style="ghost"][data-variant="secondary"] {
-        --color-background-action-button: var(--color-foreground);
-      }
     }
   }
 
-  @mixin color-styles($color) {
-    &[data-color="#{$color}"] {
-      $background-color: var(--color-background-#{$color});
-      $foreground-color: var(--color-foreground-#{$color});
-
-      @include variant-styles("primary", $background-color, $foreground-color);
-
-      @include variant-styles(
-        "secondary",
-        $foreground-color,
-        $background-color
-      );
-
-      @include for-mouse {
-        &:focus-visible {
-          outline: var(--border-thickness-xs) solid
-            var(--color-background-action-button);
-        }
-      }
-    }
-  }
-
-  .trakt-action-button {
+  :global(#{$b}) {
     --button-size: var(--ni-40);
 
     all: unset;
@@ -149,78 +149,98 @@
     background-color: var(--color-background-action-button);
     color: var(--color-foreground-action-button);
 
-    transition: background-color var(--transition-increment) ease-in-out;
+    transition: var(--transition-increment) cubic-bezier(0.22, 1, 0.36, 1);
+    transition-property:
+      background-color, color, box-shadow, transform, outline, outline-offset;
+  }
 
-    @each $color in "purple", "red", "blue", "orange", "default" {
-      @include color-styles($color);
-    }
+  @each $color in "purple", "red", "blue", "orange", "default" {
+    @include color-styles($b, $color);
+  }
 
-    &[disabled] {
-      cursor: not-allowed;
-      color: var(--color-foreground-button-disabled);
-      background: var(
-        --color-background-button-disabled,
-        var(--color-surface-button-disabled)
-      );
+  :global(#{$b}:focus-visible) {
+    outline-offset: var(--ni-2);
+  }
 
-      &::before {
-        display: none;
-      }
-    }
+  :global(#{$b}[disabled]),
+  :global(#{$b}[aria-disabled=true]) {
+    cursor: not-allowed;
+    color: var(--color-foreground-button-disabled);
+    background: var(
+      --color-background-button-disabled,
+      var(--color-surface-button-disabled)
+    );
+  }
 
-    &:active {
-      transform: scale(0.95);
+  :global(#{$b}[disabled]::before),
+  :global(#{$b}[aria-disabled=true]::before) {
+    display: none;
+  }
 
-      &[disabled] {
-        animation: jiggle-wiggle var(--animation-duration-jiggle-wiggle)
-          infinite;
-      }
-    }
-
-    &[data-size="small"] {
-      scale: 0.8;
-      margin: var(--ni-neg-8);
-    }
-
-    &[data-size="large"] {
-      scale: 1.2;
-      margin: var(--ni-4);
-    }
-
-    &[data-variant="secondary"]:not([data-style="ghost"]):not([disabled]) {
-      background-color: color-mix(
-        in srgb,
-        var(--color-foreground-action-button) 5%,
-        transparent
-      );
-      border: var(--border-thickness-xxs) solid
+  @include for-mouse {
+    :global(#{$b}:hover#{$on}) {
+      box-shadow: 0 var(--ni-2) var(--ni-8) var(--ni-neg-2)
         color-mix(
           in srgb,
-          var(--color-foreground-action-button) 50%,
+          var(--color-background-action-button) 50%,
           transparent
         );
-      color: var(--color-text-primary);
-
-      @include for-mouse {
-        &:hover {
-          background-color: var(--color-background-action-button);
-          color: var(--color-foreground-action-button);
-        }
-      }
     }
+  }
 
-    &[data-style="ghost"] {
-      background-color: transparent;
+  :global(#{$b}:active#{$on}) {
+    transform: scale(0.92);
+    box-shadow: none;
+  }
 
-      @include for-mouse {
-        &:hover {
-          background-color: color-mix(
-            in srgb,
-            var(--color-foreground) 10%,
-            transparent
-          );
-        }
-      }
+  :global(#{$b}:active[disabled]),
+  :global(#{$b}:active[aria-disabled=true]) {
+    animation: jiggle-wiggle var(--animation-duration-jiggle-wiggle) infinite;
+  }
+
+  :global(#{$b}[data-size=small]) {
+    scale: 0.8;
+    margin: var(--ni-neg-8);
+  }
+
+  :global(#{$b}[data-size=large]) {
+    scale: 1.2;
+    margin: var(--ni-4);
+  }
+
+  :global(#{$b}[data-variant=secondary]:not([data-style=ghost])#{$on}) {
+    background-color: color-mix(
+      in srgb,
+      var(--color-foreground-action-button) 5%,
+      transparent
+    );
+    border: var(--border-thickness-xxs) solid
+      color-mix(
+        in srgb,
+        var(--color-foreground-action-button) 50%,
+        transparent
+      );
+    color: var(--color-text-primary);
+  }
+
+  @include for-mouse {
+    :global(#{$b}[data-variant=secondary]:not([data-style=ghost])#{$on}:hover) {
+      background-color: var(--color-background-action-button);
+      color: var(--color-foreground-action-button);
+    }
+  }
+
+  :global(#{$b}[data-style=ghost]) {
+    background-color: transparent;
+  }
+
+  @include for-mouse {
+    :global(#{$b}[data-style=ghost]:hover) {
+      background-color: color-mix(
+        in srgb,
+        var(--color-foreground) 10%,
+        transparent
+      );
     }
   }
 </style>

--- a/projects/client/src/lib/components/buttons/Button.spec.ts
+++ b/projects/client/src/lib/components/buttons/Button.spec.ts
@@ -106,7 +106,7 @@ describe('Button', () => {
           ...defaultProps,
           variant: 'secondary',
           size: 'small',
-          style: 'textured',
+          style: 'flat',
           color: 'red',
         },
       });
@@ -114,7 +114,7 @@ describe('Button', () => {
       await waitFor(() => {
         const button = screen.getByRole('button');
         expect(button).toHaveAttribute('data-variant', 'secondary');
-        expect(button).toHaveAttribute('data-style', 'textured');
+        expect(button).toHaveAttribute('data-style', 'flat');
         expect(button).toHaveAttribute('data-size', 'small');
         expect(button).toHaveAttribute('data-alignment', 'centered');
         expect(button).toHaveAttribute('data-color', 'red');

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -126,7 +126,7 @@
       --color-background-button: #{$background-color};
       --color-foreground-button: #{$foreground-color};
 
-      &:not([data-style="textured"]):not([data-style="ghost"]) {
+      &:not([data-style="ghost"]) {
         @include for-mouse {
           &:hover,
           &:focus-visible {
@@ -168,15 +168,6 @@
 
     --scale-factor-button: 1;
     --button-height: var(--ni-52);
-
-    --color-background-button-light: color-mix(
-      in srgb,
-      var(--color-background-button) 35%,
-      white 65%
-    );
-
-    --color-highlight: rgba(255, 255, 255, 0.52);
-    --color-shadow: rgba(0, 0, 0, 0.32);
 
     all: unset;
     display: flex;
@@ -380,37 +371,6 @@
 
       &[data-size="tag"] {
         outline: var(--border-thickness-xxs) solid var(--color-foreground);
-      }
-    }
-
-    &[data-style="textured"] {
-      &:not([data-size="tag"]) {
-        padding-top: var(--ni-12);
-      }
-
-      &,
-      &::before {
-        box-shadow:
-          0px 1px 2px 0px var(--color-highlight) inset,
-          2px -4px 2px 0px var(--color-shadow) inset,
-          0px 2px 8px 0px var(--color-shadow);
-      }
-
-      &::before {
-        background: radial-gradient(
-          59.13% 72.55% at 50.22% 118.63%,
-          var(--color-background-button-light) 0%,
-          var(--color-background-button) 100%
-        );
-      }
-
-      &:not([disabled]):active {
-        padding-top: var(--ni-16);
-
-        box-shadow:
-          0px -1px 2px 0px var(--color-highlight) inset,
-          2px 4px 2px 0px var(--color-shadow) inset,
-          0px 2px 8px 0px var(--color-shadow);
       }
     }
 

--- a/projects/client/src/lib/components/buttons/Button.svelte
+++ b/projects/client/src/lib/components/buttons/Button.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import { appendGlobalParameters } from "$lib/features/parameters/appendGlobalParameters";
   import { useActiveLink } from "$lib/stores/useActiveLink";
   import { clickOutside } from "$lib/utils/actions/clickOutside";
-  import { disableNavigation } from "$lib/utils/actions/disableNavigation";
   import { disableTransitionOn } from "$lib/utils/actions/disableTransitionOn";
-  import { triggerWithKeyboard } from "$lib/utils/actions/triggerWithKeyboard";
-  import { onMount } from "svelte";
+  import { Button } from "bits-ui";
   import { useGuardedHref } from "../../features/auth/stores/useGuardedHref";
+  import { createButtonHost } from "./_internal/createButtonHost.svelte";
   import type { TraktButtonProps } from "./TraktButtonProps";
 
   type TraktButtonAnchorProps = HTMLAnchorProps &
@@ -28,28 +26,49 @@
     ...props
   }: TraktButtonProps | TraktButtonAnchorProps = $props();
 
-  const rest = $derived({
-    ...props,
-    disabled: disabled || undefined,
-  });
-
-  const hasIcon = $derived(icon != null);
-  const isDefaultAlignment = $derived(hasIcon);
-  const alignment = $derived(isDefaultAlignment ? "default" : "centered");
   const { guardedHref, originalHref } = $derived(
-    useGuardedHref((rest as TraktButtonAnchorProps).href),
+    useGuardedHref((props as TraktButtonAnchorProps).href),
   );
-  const noscroll = $derived((rest as TraktButtonAnchorProps).noscroll);
-  const replacestate = $derived((rest as TraktButtonAnchorProps).replacestate);
+  const noscroll = $derived((props as TraktButtonAnchorProps).noscroll);
+  const replacestate = $derived((props as TraktButtonAnchorProps).replacestate);
 
   const href = $derived($guardedHref);
   const { isActive } = $derived(useActiveLink($originalHref));
 
-  const appendTestId = $derived((element: HTMLElement) => {
-    onMount(() => {
-      if (!dataTestId) return;
-      element.setAttribute("data-testid", dataTestId);
-    });
+  const hasIcon = $derived(icon != null);
+  const alignment = $derived(hasIcon ? "default" : "centered");
+
+  const classList = $derived(
+    [
+      "trakt-button",
+      href != null && "trakt-button-link",
+      $isActive && "trakt-link-active",
+    ]
+      .filter(Boolean)
+      .join(" "),
+  );
+
+  const host = createButtonHost({
+    getProps: () => props,
+    getHref: () => href,
+    getDisabled: () => disabled,
+    getClassName: () => classList,
+    getNoscroll: () => noscroll,
+    getReplacestate: () => replacestate,
+    getAttrs: () => ({
+      "aria-label": label,
+      "data-variant": variant,
+      "data-alignment": alignment,
+      "data-style": style,
+      "data-color": color,
+      "data-size": size,
+      "data-dpad-navigation": navigationType,
+      "data-testid": dataTestId,
+    }),
+    commonActions: [
+      (node) => disableTransitionOn(node, "touch"),
+      (node) => clickOutside(node),
+    ],
   });
 </script>
 
@@ -74,92 +93,54 @@
   {/if}
 {/snippet}
 
-{#if href != null}
-  <a
-    use:disableTransitionOn={"touch"}
-    use:clickOutside
-    use:triggerWithKeyboard
-    use:appendGlobalParameters={href}
-    use:disableNavigation={rest.disabled}
-    use:appendTestId
-    data-sveltekit-keepfocus
-    data-sveltekit-noscroll={noscroll}
-    data-sveltekit-replacestate={replacestate}
-    class="trakt-button trakt-button-link"
-    class:trakt-link-active={$isActive}
-    aria-label={label}
-    data-variant={variant}
-    data-alignment={alignment}
-    data-style={style}
-    data-color={color}
-    data-size={size}
-    data-dpad-navigation={navigationType}
-    {...rest}
-    {href}
-  >
-    {@render contents()}
-  </a>
-{:else}
-  <button
-    use:disableTransitionOn={"touch"}
-    use:clickOutside
-    use:appendTestId
-    class="trakt-button"
-    aria-label={label}
-    data-variant={variant}
-    data-alignment={alignment}
-    data-style={style}
-    data-color={color}
-    data-size={size}
-    data-dpad-navigation={navigationType}
-    {...rest}
-  >
-    {@render contents()}
-  </button>
-{/if}
+<Button.Root {...host.rootProps}>
+  {@render contents()}
+</Button.Root>
 
 <style lang="scss">
   @use "$style/scss/mixins/index.scss" as *;
 
-  @mixin variant-styles($variant, $background-color, $foreground-color) {
-    &[data-variant="#{$variant}"] {
-      --color-background-button: #{$background-color};
-      --color-foreground-button: #{$foreground-color};
+  // bits-ui renders the underlying element, so it never receives this
+  // component's scope hash. Every selector is therefore wrapped in :global(),
+  // anchored to the namespaced root, to survive Svelte's scoped-CSS pruning.
+  $b: ".trakt-button";
+  $on: ":not([disabled]):not([aria-disabled=true])";
 
-      &:not([data-style="ghost"]) {
-        @include for-mouse {
-          &:hover,
-          &:focus-visible {
-            --color-foreground-button: #{$background-color};
-            --color-background-button: #{$foreground-color};
-          }
-        }
+  @mixin variant-styles($base, $color, $variant, $bg, $fg) {
+    :global(#{$base}[data-color=#{$color}][data-variant=#{$variant}]) {
+      --color-background-button: #{$bg};
+      --color-foreground-button: #{$fg};
+    }
+
+    @include for-mouse {
+      :global(
+          #{$base}[data-color=#{$color}][data-variant=#{$variant}]:not([data-style=ghost]):hover
+        ),
+      :global(
+          #{$base}[data-color=#{$color}][data-variant=#{$variant}]:not([data-style=ghost]):focus-visible
+        ) {
+        --color-foreground-button: #{$bg};
+        --color-background-button: #{$fg};
       }
     }
   }
 
-  @mixin color-styles($color) {
-    &[data-color="#{$color}"] {
-      $background-color: var(--color-background-#{$color});
-      $foreground-color: var(--color-foreground-#{$color});
+  @mixin color-styles($base, $color) {
+    $bg: var(--color-background-#{$color});
+    $fg: var(--color-foreground-#{$color});
 
-      @include variant-styles("primary", $background-color, $foreground-color);
-      @include variant-styles(
-        "secondary",
-        $foreground-color,
-        $background-color
-      );
+    @include variant-styles($base, $color, primary, $bg, $fg);
+    @include variant-styles($base, $color, secondary, $fg, $bg);
 
-      @include for-mouse {
-        &:focus-visible {
-          outline: var(--border-thickness-xs) solid
-            var(--color-foreground-button);
-        }
+    @include for-mouse {
+      :global(#{$base}[data-color=#{$color}]:focus-visible) {
+        outline: var(--border-thickness-xs) solid
+          var(--color-foreground-button);
       }
     }
   }
 
-  .trakt-button {
+  :global(#{$b}) {
     --color-background-button-outline: color-mix(
       in srgb,
       var(--color-background-button) 10%,
@@ -186,230 +167,226 @@
     position: relative;
     overflow: hidden;
 
-    transition: var(--transition-increment) ease-in-out;
+    transition: var(--transition-increment) cubic-bezier(0.22, 1, 0.36, 1);
     transition-property:
-      box-shadow, outline, padding, transform, color, background,
-      text-decoration;
+      box-shadow, outline, outline-offset, padding, transform, color,
+      background, text-decoration;
+  }
 
-    &.trakt-button-link {
-      &[data-style="ghost"] {
-        &.trakt-link-active {
-          color: var(--color-background-button);
-        }
-      }
+  :global(#{$b} .button-icon) {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+  }
 
-      &[data-style="underlined"] {
-        &.trakt-link-active {
-          text-decoration-color: color-mix(
-            in srgb,
-            var(--color-background-button) 80%,
-            white 20%
-          );
-          text-decoration-line: underline;
-        }
-      }
+  // Needed to make ellipses work with flex
+  // https://css-tricks.com/flexbox-truncated-text/
+  :global(#{$b} .button-label) {
+    min-width: 0;
+  }
+
+  :global(#{$b} p),
+  :global(#{$b} .button-label),
+  :global(#{$b} .button-icon) {
+    z-index: var(--layer-base);
+  }
+
+  :global(#{$b}.trakt-button-link[data-style=ghost].trakt-link-active) {
+    color: var(--color-background-button);
+  }
+
+  :global(#{$b}.trakt-button-link[data-style=underlined].trakt-link-active) {
+    text-decoration-color: color-mix(
+      in srgb,
+      var(--color-background-button) 80%,
+      white 20%
+    );
+    text-decoration-line: underline;
+  }
+
+  @each $color in "purple", "red", "blue", "orange", "default", "custom" {
+    @include color-styles($b, $color);
+  }
+
+  :global(#{$b}[data-alignment=default]) {
+    justify-content: space-between;
+  }
+
+  :global(#{$b}[data-alignment=centered]) {
+    justify-content: center;
+  }
+
+  // TODO: revert this once the dynamic scaling is figured out
+  :global(#{$b}[data-size=small] .button-label p),
+  :global(#{$b}[data-size=tag] .button-label p) {
+    font-size: 0.75rem;
+  }
+
+  :global(#{$b}[data-size=small] .button-icon svg),
+  :global(#{$b}[data-size=tag] .button-icon svg) {
+    width: auto;
+    height: var(--ni-18);
+  }
+
+  :global(#{$b}[data-size=small]) {
+    --button-height: var(--ni-40);
+    border-radius: calc(var(--border-radius-m) * 0.8);
+    padding: var(--ni-12);
+    gap: var(--ni-12);
+  }
+
+  :global(#{$b}[data-size=tag]) {
+    --button-height: var(--ni-18);
+    padding: var(--ni-2) var(--ni-10);
+    min-width: var(--ni-48);
+    box-sizing: border-box;
+  }
+
+  :global(#{$b}[data-size=tag][data-style=ghost]) {
+    margin: 0;
+  }
+
+  :global(#{$b}),
+  :global(#{$b}::before),
+  :global(#{$b}:active[disabled]) {
+    height: var(--button-height);
+    box-sizing: border-box;
+    border-radius: var(--border-radius-m);
+  }
+
+  :global(#{$b}::before) {
+    content: "";
+
+    position: absolute;
+    top: 0;
+    inset-inline-start: 0;
+    width: 100%;
+
+    opacity: 0;
+    transition: opacity var(--transition-increment) ease-in-out;
+  }
+
+  @include for-mouse {
+    :global(#{$b}:hover::before),
+    :global(#{$b}:focus-visible::before) {
+      opacity: 1;
+    }
+  }
+
+  :global(#{$b}:active::before) {
+    opacity: 0;
+  }
+
+  :global(#{$b}:active[disabled]) {
+    animation: jiggle-wiggle var(--animation-duration-jiggle-wiggle) infinite;
+  }
+
+  :global(#{$b}:focus-visible) {
+    outline: var(--border-thickness-xs) solid
+      var(--color-background-button-outline);
+    outline-offset: var(--ni-2);
+  }
+
+  :global(#{$b}[disabled]),
+  :global(#{$b}[aria-disabled=true]) {
+    cursor: not-allowed;
+    color: var(--color-foreground-button-disabled);
+    background: var(--color-surface-button-disabled);
+  }
+
+  :global(#{$b}[disabled]::before),
+  :global(#{$b}[aria-disabled=true]::before) {
+    display: none;
+  }
+
+  :global(#{$b}[data-style=ghost]) {
+    margin: var(--ni-neg-4) var(--ni-neg-10);
+    transform: scale(calc(var(--scale-factor-button) * 0.76925));
+    background: transparent;
+  }
+
+  :global(#{$b}[data-style=ghost]:not([data-variant=secondary])) {
+    color: var(--color-foreground);
+  }
+
+  :global(#{$b}[data-style=ghost][disabled]),
+  :global(#{$b}[data-style=ghost][aria-disabled=true]) {
+    color: var(--color-foreground-button-disabled);
+  }
+
+  @include for-mouse {
+    :global(#{$b}[data-style=ghost]:hover#{$on}) {
+      color: var(--color-foreground-button);
     }
 
-    @each $color in "purple", "red", "blue", "orange", "default", "custom" {
-      @include color-styles($color);
+    :global(#{$b}[data-style=ghost]:hover#{$on}[data-size=tag]) {
+      outline: var(--border-thickness-xs) solid var(--color-background-button);
     }
 
-    &[data-alignment="default"] {
-      justify-content: space-between;
+    :global(#{$b}[data-style=ghost]:hover#{$on}[data-variant=primary]) {
+      background: var(--color-background-button);
     }
 
-    &[data-alignment="centered"] {
-      justify-content: center;
+    :global(#{$b}[data-style=ghost]:hover#{$on}[data-variant=secondary]) {
+      background: color-mix(
+        in srgb,
+        var(--color-foreground-button) 10%,
+        transparent 90%
+      );
+    }
+  }
+
+  :global(#{$b}[data-style=ghost]:active#{$on}) {
+    transform: scale(calc(var(--scale-factor-button) * 0.7));
+  }
+
+  :global(#{$b}[data-style=ghost][data-size=tag]) {
+    outline: var(--border-thickness-xxs) solid var(--color-foreground);
+  }
+
+  @include for-mouse {
+    :global(#{$b}[data-style=flat]:hover#{$on}) {
+      box-shadow: 0 var(--ni-4) var(--ni-12) var(--ni-neg-2)
+        color-mix(in srgb, var(--color-background-button) 45%, transparent);
+      transform: translateY(calc(var(--ni-1) * -1));
+    }
+  }
+
+  :global(#{$b}[data-style=flat]:active#{$on}) {
+    transform: scale(calc(var(--scale-factor-button) * 0.97));
+    box-shadow: none;
+  }
+
+  :global(#{$b}[data-style=underlined]) {
+    --underline-offset: var(--ni-4);
+    --line-thickness: var(--ni-2);
+
+    background: transparent;
+    text-decoration-color: transparent;
+    color: var(--color-foreground);
+
+    text-underline-offset: var(--underline-offset);
+    text-decoration-thickness: var(--line-thickness);
+    line-height: calc(100% + var(--underline-offset) + var(--line-thickness));
+  }
+
+  :global(#{$b}[data-style=underlined][disabled]),
+  :global(#{$b}[data-style=underlined][aria-disabled=true]) {
+    color: var(--color-foreground-button-disabled);
+  }
+
+  @include for-mouse {
+    :global(#{$b}[data-style=underlined]:hover#{$on}) {
+      text-decoration-line: underline;
+      text-decoration-color: var(--color-foreground);
     }
 
-    &[data-size="small"],
-    &[data-size="tag"] {
-      // TODO: revert this once the dynamic scaling is figured out
-
-      .button-label {
-        p {
-          font-size: 0.75rem;
-        }
-      }
-
-      .button-icon {
-        :global(svg) {
-          width: auto;
-          height: var(--ni-18);
-        }
-      }
-    }
-
-    &[data-size="small"] {
-      --button-height: var(--ni-40);
-      border-radius: calc(var(--border-radius-m) * 0.8);
-      padding: var(--ni-12);
-      gap: var(--ni-12);
-    }
-
-    &[data-size="tag"] {
-      --button-height: var(--ni-18);
-      padding: var(--ni-2) var(--ni-10);
-      min-width: var(--ni-48);
-      box-sizing: border-box;
-
-      &[data-style="ghost"] {
-        margin: 0;
-      }
-    }
-
-    &,
-    &::before,
-    &:active[disabled] {
-      height: var(--button-height);
-      box-sizing: border-box;
-      border-radius: var(--border-radius-m);
-    }
-
-    &::before {
-      width: 100%;
-    }
-
-    .button-icon {
-      display: flex;
-      align-items: center;
-      gap: var(--gap-xs);
-    }
-
-    .button-label {
-      // Needed to make ellipses work with flex
-      // https://css-tricks.com/flexbox-truncated-text/
-      min-width: 0;
-    }
-
-    p,
-    .button-label,
-    .button-icon {
-      z-index: var(--layer-base);
-    }
-
-    &::before {
-      content: "";
-
-      position: absolute;
-      top: 0;
-      inset-inline-start: 0;
-
-      opacity: 0;
-      transition: opacity var(--transition-increment) ease-in-out;
-    }
-
-    @include for-mouse {
-      &:hover::before,
-      &:focus-visible::before {
-        opacity: 1;
-      }
-    }
-
-    &:active::before {
-      opacity: 0;
-    }
-
-    &:active[disabled] {
-      animation: jiggle-wiggle var(--animation-duration-jiggle-wiggle) infinite;
-    }
-
-    &:focus-visible {
-      outline: var(--border-thickness-xs) solid
-        var(--color-background-button-outline);
-    }
-
-    &[disabled] {
-      cursor: not-allowed;
-      color: var(--color-foreground-button-disabled);
-      background: var(--color-surface-button-disabled);
-
-      &::before {
-        display: none;
-      }
-    }
-
-    &[data-style="ghost"] {
-      margin: var(--ni-neg-4) var(--ni-neg-10);
-      transform: scale(calc(var(--scale-factor-button) * 0.76925));
-      background: transparent;
-
-      &:not([data-variant="secondary"]) {
-        color: var(--color-foreground);
-      }
-
-      &[disabled] {
-        color: var(--color-foreground-button-disabled);
-      }
-
-      @include for-mouse {
-        &:hover:not([disabled]) {
-          color: var(--color-foreground-button);
-
-          &[data-size="tag"] {
-            outline: var(--border-thickness-xs) solid
-              var(--color-background-button);
-          }
-
-          &[data-variant="primary"] {
-            background: var(--color-background-button);
-          }
-
-          &[data-variant="secondary"] {
-            background: color-mix(
-              in srgb,
-              var(--color-foreground-button) 10%,
-              transparent 90%
-            );
-          }
-        }
-      }
-
-      &:active:not([disabled]) {
-        transform: scale(calc(var(--scale-factor-button) * 0.7));
-      }
-
-      &[data-size="tag"] {
-        outline: var(--border-thickness-xxs) solid var(--color-foreground);
-      }
-    }
-
-    &[data-style="flat"] {
-      &:active:not([disabled]) {
-        transform: scale(calc(var(--scale-factor-button) * 0.97));
-      }
-    }
-
-    &[data-style="underlined"] {
-      --underline-offset: var(--ni-4);
-      --line-thickness: var(--ni-2);
-
-      background: transparent;
-      text-decoration-color: transparent;
-      color: var(--color-foreground);
-
-      text-underline-offset: var(--underline-offset);
-      text-decoration-thickness: var(--line-thickness);
-      line-height: calc(100% + var(--underline-offset) + var(--line-thickness));
-
-      &[disabled] {
-        color: var(--color-foreground-button-disabled);
-      }
-
-      @include for-mouse {
-        &:hover:not([disabled]) {
-          text-decoration-line: underline;
-          text-decoration-color: var(--color-foreground);
-
-          &:not(.trakt-link-active) {
-            color: color-mix(
-              in srgb,
-              var(--color-foreground-button) 80%,
-              white 20%
-            );
-          }
-        }
-      }
+    :global(#{$b}[data-style=underlined]:hover#{$on}:not(.trakt-link-active)) {
+      color: color-mix(
+        in srgb,
+        var(--color-foreground-button) 80%,
+        white 20%
+      );
     }
   }
 </style>

--- a/projects/client/src/lib/components/buttons/TraktButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/TraktButtonProps.ts
@@ -4,7 +4,7 @@ import type { Snippet } from 'svelte';
 export type TraktButtonProps = ButtonProps & {
   color?: 'purple' | 'red' | 'blue' | 'orange' | 'default' | 'custom';
   variant?: 'primary' | 'secondary';
-  style?: 'textured' | 'flat' | 'ghost' | 'underlined';
+  style?: 'flat' | 'ghost' | 'underlined';
   icon?: Snippet;
   subtitle?: Snippet;
   size?: 'normal' | 'small' | 'tag';

--- a/projects/client/src/lib/components/buttons/_internal/createButtonHost.svelte.ts
+++ b/projects/client/src/lib/components/buttons/_internal/createButtonHost.svelte.ts
@@ -1,0 +1,84 @@
+import { appendGlobalParameters } from '$lib/features/parameters/appendGlobalParameters.ts';
+import { triggerWithKeyboard } from '$lib/utils/actions/triggerWithKeyboard.ts';
+import { Button } from 'bits-ui';
+import type { Attachment } from 'svelte/attachments';
+import { createAttachmentKey } from 'svelte/attachments';
+
+// A Svelte action invoked node-only; its `destroy` becomes the attachment
+// cleanup. bits-ui's Button.Root exposes no `child` snippet, so `use:` directives
+// can't reach the rendered element — actions are forwarded as attachments.
+type ButtonAction = (node: HTMLElement) => { destroy?: () => void } | void;
+
+function toAttachment(run: ButtonAction): Attachment<HTMLElement> {
+  return (node) => run(node)?.destroy;
+}
+
+type ButtonHostConfig = {
+  /** The remaining `...props` bag to spread onto the element. */
+  getProps: () => Record<string, unknown>;
+  /** The guarded, resolved href (anchor when present, button otherwise). */
+  getHref: () => string | Nil;
+  getDisabled: () => boolean | undefined;
+  /** Full class string, including any `trakt-link-active` state. */
+  getClassName: () => string;
+  /** Component-owned attributes (aria-label, data-variant, …). */
+  getAttrs: () => Record<string, unknown>;
+  getNoscroll: () => boolean | undefined;
+  getReplacestate: () => boolean | undefined;
+  /** Non-anchor actions a component always wants (e.g. clickOutside). */
+  commonActions?: ButtonAction[];
+};
+
+export function createButtonHost(config: ButtonHostConfig) {
+  // Re-created only when href changes, so unrelated prop updates (including
+  // disabled toggles) don't tear down and re-attach the actions. bits-ui's
+  // Button.Root natively neutralises a disabled element (drops href, sets
+  // aria-disabled/tabindex), so no disableNavigation action is needed.
+  const attachments = $derived.by(() => {
+    const href = config.getHref();
+    const runs: ButtonAction[] = [...(config.commonActions ?? [])];
+
+    if (href != null) {
+      runs.push(
+        (node) => triggerWithKeyboard(node),
+        (node) => appendGlobalParameters(node as HTMLAnchorElement, href),
+      );
+    }
+
+    return Object.fromEntries(
+      runs.map((run) => [createAttachmentKey(), toAttachment(run)]),
+    );
+  });
+
+  // href is replaced by the guarded value; noscroll/replacestate map to
+  // data-sveltekit-* attributes, so strip them before spreading the remainder.
+  const restProps = $derived.by(() => {
+    const {
+      href: _href,
+      noscroll: _noscroll,
+      replacestate: _replacestate,
+      ...rest
+    } = config.getProps() as Record<string, unknown> & Partial<HTMLAnchorProps>;
+    return rest;
+  });
+
+  const rootProps = $derived({
+    ...restProps,
+    ...attachments,
+    href: config.getHref() ?? undefined,
+    disabled: config.getDisabled() || undefined,
+    class: config.getClassName(),
+    'data-sveltekit-keepfocus': config.getHref() != null ? '' : undefined,
+    'data-sveltekit-noscroll': config.getNoscroll(),
+    'data-sveltekit-replacestate': config.getReplacestate(),
+    ...config.getAttrs(),
+    // bits-ui's Button.Root props are a discriminated union (anchor vs button)
+    // that a dynamic href + type can't statically satisfy.
+  } as unknown as Button.RootProps);
+
+  return {
+    get rootProps() {
+      return rootProps;
+    },
+  };
+}

--- a/projects/client/src/lib/components/dropdown/DropdownList.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownList.svelte
@@ -113,7 +113,6 @@
   data-size={size}
 >
   <Button
-    style="textured"
     navigationType={buttonNavigationType}
     type="button"
     {size}

--- a/projects/client/src/routes/_design_system/buttons/+page.svelte
+++ b/projects/client/src/routes/_design_system/buttons/+page.svelte
@@ -7,12 +7,7 @@
   import type { TraktActionButtonProps } from "$lib/components/buttons/TraktActionButtonProps";
   import type { TraktButtonProps } from "$lib/components/buttons/TraktButtonProps";
 
-  const styles: TraktButtonProps["style"][] = [
-    "textured",
-    "flat",
-    "ghost",
-    "underlined",
-  ];
+  const styles: TraktButtonProps["style"][] = ["flat", "ghost", "underlined"];
   const colors: TraktActionButtonProps["color"][] = [
     "purple",
     "red",

--- a/projects/client/src/routes/_design_system/dropdown/+page.svelte
+++ b/projects/client/src/routes/_design_system/dropdown/+page.svelte
@@ -9,7 +9,7 @@
     "primary",
     "secondary",
   ];
-  const styles: TraktDropdownListProps["style"][] = ["textured", "flat"];
+  const styles: TraktDropdownListProps["style"][] = ["flat"];
 </script>
 
 {#snippet items()}

--- a/projects/client/src/routes/_design_system/links/+page.svelte
+++ b/projects/client/src/routes/_design_system/links/+page.svelte
@@ -17,20 +17,7 @@
       <Button
         href={externalLink}
         target="_blank"
-        label="This is the primary textured link"
-        style="textured"
-        color="purple"
-      >
-        Textured Icon
-        {#snippet icon()}
-          <WatchNowIcon />
-        {/snippet}
-      </Button>
-
-      <Button
-        href={externalLink}
-        target="_blank"
-        label="This is the primary textured link"
+        label="This is the primary flat link"
         style="flat"
         color="purple"
       >
@@ -40,7 +27,7 @@
       <Button
         href={externalLink}
         target="_blank"
-        label="This is the primary textured link in a disabled"
+        label="This is the primary link in a disabled"
         style="ghost"
         color="purple"
       >
@@ -51,7 +38,7 @@
         <ActionButton
           href={page.url.pathname}
           target="_blank"
-          label="This is the primary textured link"
+          label="This is the primary link"
           color="purple"
         >
           <WatchNowIcon />
@@ -60,7 +47,7 @@
         <ActionButton
           href={page.url.pathname}
           target="_blank"
-          label="This is the primary textured link"
+          label="This is the primary link"
           color="blue"
         >
           <WatchNowIcon />
@@ -69,7 +56,7 @@
         <ActionButton
           href={page.url.pathname}
           target="_blank"
-          label="This is the primary textured link in a disabled"
+          label="This is the primary link in a disabled"
           color="red"
         >
           <WatchNowIcon />
@@ -84,20 +71,7 @@
       <Button
         href={page.url.pathname}
         target="_blank"
-        label="This is the primary textured link"
-        style="textured"
-        color="purple"
-      >
-        Textured Icon
-        {#snippet icon()}
-          <WatchNowIcon />
-        {/snippet}
-      </Button>
-
-      <Button
-        href={page.url.pathname}
-        target="_blank"
-        label="This is the primary textured link"
+        label="This is the primary flat link"
         style="flat"
         color="purple"
       >
@@ -107,7 +81,7 @@
       <Button
         href={page.url.pathname}
         target="_blank"
-        label="This is the primary textured link in a disabled"
+        label="This is the primary link in a disabled"
         style="ghost"
         color="purple"
       >
@@ -118,7 +92,7 @@
         <ActionButton
           href={page.url.pathname}
           target="_blank"
-          label="This is the primary textured link"
+          label="This is the primary link"
           color="purple"
         >
           <WatchNowIcon />
@@ -127,7 +101,7 @@
         <ActionButton
           href={page.url.pathname}
           target="_blank"
-          label="This is the primary textured link"
+          label="This is the primary link"
           color="blue"
         >
           <WatchNowIcon />
@@ -136,7 +110,7 @@
         <ActionButton
           href={page.url.pathname}
           target="_blank"
-          label="This is the primary textured link in a disabled"
+          label="This is the primary link in a disabled"
           color="red"
         >
           <WatchNowIcon />
@@ -152,20 +126,7 @@
         href="/"
         color="purple"
         target="_blank"
-        label="This is the primary textured link"
-        style="textured"
-      >
-        Textured Icon
-        {#snippet icon()}
-          <WatchNowIcon />
-        {/snippet}
-      </Button>
-
-      <Button
-        href="/"
-        color="purple"
-        target="_blank"
-        label="This is the primary textured link"
+        label="This is the primary flat link"
         style="flat"
       >
         Flat primary
@@ -175,7 +136,7 @@
         href="/"
         color="purple"
         target="_blank"
-        label="This is the primary textured link in a disabled"
+        label="This is the primary link in a disabled"
         style="ghost"
       >
         Ghost primary
@@ -185,7 +146,7 @@
         <ActionButton
           href="/"
           target="_blank"
-          label="This is the primary textured link"
+          label="This is the primary link"
           color="purple"
         >
           <WatchNowIcon />
@@ -194,7 +155,7 @@
         <ActionButton
           href="/"
           target="_blank"
-          label="This is the primary textured link"
+          label="This is the primary link"
           color="blue"
         >
           <WatchNowIcon />
@@ -203,7 +164,7 @@
         <ActionButton
           href="/"
           target="_blank"
-          label="This is the primary textured link in a disabled"
+          label="This is the primary link in a disabled"
           color="red"
         >
           <WatchNowIcon />


### PR DESCRIPTION
## What

Redesign pass on the core button components.

- **Remove the `textured` button style** entirely - the style union member, its SCSS block, orphaned shadow/highlight/gradient vars, the dropdown's hardcoded textured default, and all design-system showcase references.
- **Port `Button` and `ActionButton` to `bits-ui` `Button.Root`** for native button/anchor switching and a11y disabled handling (`aria-disabled`, `role="link"`, `tabindex` for disabled links), dropping the duplicated `{#if href}` branches.
- **Forward Svelte actions as attachments.** Button.Root exposes no `child` snippet, so `use:` directives can't reach the rendered element; they are adapted to attachments and spread through.
- **Shared host logic** (guarded href, restProps strip, attachment forwarding, rootProps assembly) extracted into `_internal/createButtonHost.svelte.ts`. Both components stay thin shells with their own snippet + styles.
- **Styling refresh:** springier easing, focus-ring offset, flat-button hover lift with soft shadow, deeper action-button active scale. Layout footprint unchanged (box-shadow/transform only).

## Notes

- bits-ui renders the underlying element outside this component's scope, so all button CSS is wrapped in fully-anchored `:global(...)` selectors (a partially-wrapped `:global(.x)[attr]` gets a scope hash and is pruned). Same pattern as `TabView.svelte`.
- `DropdownList` keeps consuming `<Button>` as its trigger; `DropdownItem` is a distinct `<li>` menu-item primitive and is intentionally left alone.

## Test

- `deno task check`: 0 errors / 0 warnings
- `deno task test:unit` (buttons + dropdown): 35 passed