### PR TITLE
feat(popup): opens popup menu in a drawer on mobile

### DIFF
--- a/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
+++ b/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
   import MoreIcon from "$lib/components/icons/MoreIcon.svelte";
-  import { usePortal } from "$lib/features/portal/usePortal";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { disableTransitionOn } from "$lib/utils/actions/disableTransitionOn";
   import { slide } from "svelte/transition";
   import type { PopupMenuProps } from "./PopupMenuProps";
+  import { usePopupMenu } from "./_internal/usePopupMenu";
 
   const {
     items,
@@ -11,42 +13,62 @@
     size = "small",
     icon,
     label,
+    title,
     ...props
   }: PopupMenuProps = $props();
 
-  const { portalTrigger, portal, isOpened } = usePortal();
+  const isMobile = useMedia(WellKnownMediaQuery.mobile);
+  const variant = $derived($isMobile ? "drawer" : "portal");
+
+  const { menuTrigger, portal, isOpened, close } = $derived(
+    usePopupMenu({ variant }),
+  );
 </script>
 
-<button
-  use:disableTransitionOn={"touch"}
-  use:portalTrigger
-  aria-haspopup="true"
-  aria-label={label}
-  aria-expanded={$isOpened}
-  class="trakt-popup-menu-button"
-  data-mode={mode}
-  data-size={size}
-  class:has-custom-icon={!!icon}
-  {...props}
->
-  {#if icon}
-    {@render icon()}
-  {:else}
-    <MoreIcon {size} />
-  {/if}
-</button>
-
-{#if $isOpened}
-  <div
-    use:portal
-    class="trakt-popup-menu-container"
-    transition:slide={{ duration: 150 }}
+{#key variant}
+  <button
+    use:disableTransitionOn={"touch"}
+    use:menuTrigger
+    aria-haspopup="true"
+    aria-label={label}
+    aria-expanded={$isOpened}
+    class="trakt-popup-menu-button"
+    data-mode={mode}
+    data-size={size}
+    data-variant={variant}
+    class:has-custom-icon={!!icon}
+    class:has-drawer-open={$isOpened && variant === "drawer"}
+    {...props}
   >
-    <div class="spacer"></div>
-    <ul>
-      {@render items()}
-    </ul>
-  </div>
+    {#if icon}
+      {@render icon()}
+    {:else}
+      <MoreIcon {size} />
+    {/if}
+  </button>
+{/key}
+
+{#if variant === "drawer"}
+  {#if $isOpened}
+    <Drawer onClose={close} {title} size="auto">
+      <ul class="popup-menu-drawer-item">
+        {@render items()}
+      </ul>
+    </Drawer>
+  {/if}
+{:else}
+  {#if $isOpened}
+    <div
+      use:portal
+      class="trakt-popup-menu-container"
+      transition:slide={{ duration: 150 }}
+    >
+      <div class="spacer"></div>
+      <ul>
+        {@render items()}
+      </ul>
+    </div>
+  {/if}
 {/if}
 
 <style lang="scss">
@@ -143,6 +165,7 @@
       }
     }
 
+    &.has-drawer-open,
     &[data-popup-state="opened"] {
       :global(svg) {
         transform: rotate(90deg);
@@ -185,6 +208,19 @@
 
     div.spacer {
       height: calc($button-size + $button-padding * 2 + var(--list-padding));
+    }
+  }
+
+  .popup-menu-drawer-item {
+    all: unset;
+
+    display: grid;
+    grid-template-columns: 100%;
+    gap: var(--gap-xxs);
+
+    :global(li) {
+      width: 100%;
+      box-sizing: border-box;
     }
   }
 </style>

--- a/projects/client/src/lib/components/buttons/popup/PopupMenuProps.ts
+++ b/projects/client/src/lib/components/buttons/popup/PopupMenuProps.ts
@@ -3,6 +3,7 @@ import type { Snippet } from 'svelte';
 export type PopupMenuProps =
   & {
     items: Snippet;
+    title: string;
     icon?: Snippet;
     mode?: 'overlay' | 'standalone';
     size?: 'small' | 'normal';

--- a/projects/client/src/lib/components/buttons/popup/_internal/usePopupMenu.ts
+++ b/projects/client/src/lib/components/buttons/popup/_internal/usePopupMenu.ts
@@ -1,0 +1,43 @@
+import { usePortal } from '$lib/features/portal/usePortal.ts';
+import { NOOP_FN } from '$lib/utils/constants.ts';
+import { BehaviorSubject } from 'rxjs';
+
+type UsePopupMenuProps = {
+  variant: 'portal' | 'drawer';
+};
+
+export function usePopupMenu({ variant }: UsePopupMenuProps) {
+  if (variant === 'portal') {
+    const { portalTrigger, ...rest } = usePortal();
+
+    return {
+      menuTrigger: portalTrigger,
+      ...rest,
+    };
+  }
+
+  const isOpened = new BehaviorSubject(false);
+
+  const openMenu = () => {
+    isOpened.next(true);
+  };
+
+  const menuTrigger = (targetNode: HTMLElement) => {
+    targetNode.addEventListener('click', openMenu);
+
+    return {
+      destroy() {
+        targetNode.removeEventListener('click', openMenu);
+      },
+    };
+  };
+
+  return {
+    menuTrigger,
+    portal: NOOP_FN,
+    isOpened: isOpened.asObservable(),
+    close: () => {
+      isOpened.next(false);
+    },
+  };
+}

--- a/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
@@ -69,7 +69,10 @@
   <RenderFor audience="authenticated">
     <CardActionBar>
       {#snippet actions()}
-        <PopupMenu label={m.button_label_popup_menu({ title: media.title })}>
+        <PopupMenu
+          label={m.button_label_popup_menu({ title: media.title })}
+          title={media.title}
+        >
           {#snippet items()}
             {@render popupActions()}
           {/snippet}

--- a/projects/client/src/lib/features/portal/usePortal.ts
+++ b/projects/client/src/lib/features/portal/usePortal.ts
@@ -5,7 +5,6 @@ import { usePopupHelpers } from '$lib/features/portal/_internal/usePopupHelpers.
 import { clickOutside } from '$lib/utils/actions/clickOutside.ts';
 import { NOOP_FN } from '$lib/utils/constants.ts';
 import { BehaviorSubject } from 'rxjs';
-import { onMount } from 'svelte';
 import { isTargetContained } from './_internal/isTargetContained.ts';
 import type { PopupPlacement } from './_internal/models/PopupPlacement.ts';
 
@@ -74,15 +73,14 @@ export function usePortal(props?: PortalProps) {
       closeHandler();
     };
     const toggleAroundTarget = () => toggleHandler(targetNode);
+    const { destroy: destroyClickOutside } = clickOutside(targetNode);
 
-    onMount(() => {
-      clickOutside(targetNode);
-      targetNode.addEventListener('clickoutside', closeAroundTarget);
-      targetNode.addEventListener('click', toggleAroundTarget);
-    });
+    targetNode.addEventListener('clickoutside', closeAroundTarget);
+    targetNode.addEventListener('click', toggleAroundTarget);
 
     return {
       destroy() {
+        destroyClickOutside();
         targetNode.removeEventListener('clickoutside', closeAroundTarget);
         targetNode.removeEventListener('click', toggleAroundTarget);
         removeHelpers(null);

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -46,7 +46,10 @@
   {#if externalPopupActions}
     <CardActionBar>
       {#snippet actions()}
-        <PopupMenu label={m.button_label_popup_menu({ title: episode.title })}>
+        <PopupMenu
+          label={m.button_label_popup_menu({ title: episode.title })}
+          title={episode.title}
+        >
           {#snippet items()}
             {@render externalPopupActions()}
           {/snippet}

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -42,7 +42,10 @@
   {#if popupActions}
     <CardActionBar>
       {#snippet actions()}
-        <PopupMenu label={m.button_label_popup_menu({ title: media.title })}>
+        <PopupMenu
+          label={m.button_label_popup_menu({ title: media.title })}
+          title={media.title}
+        >
           {#snippet items()}
             {@render popupActions()}
           {/snippet}

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -38,9 +38,7 @@
   } & SeasonCardProps;
 
   type ItemCardProps =
-    | MediaCardProps
-    | EpisodeSummaryProps
-    | SeasonSummaryProps;
+    MediaCardProps | EpisodeSummaryProps | SeasonSummaryProps;
 
   type SummaryCardProps = {
     contextualTag?: Snippet;
@@ -159,6 +157,7 @@
         <PopupMenu
           label={m.button_label_popup_menu({ title: media.title })}
           mode="standalone"
+          title={media.title}
         >
           {#snippet items()}
             {@render popupActions()}

--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -77,6 +77,7 @@
               label={m.button_label_popup_menu({
                 title: seasonLabel(season.number),
               })}
+              title={seasonLabel(season.number)}
             >
               {#snippet items()}
                 {@render popupActions()}

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonPopupMenu.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonPopupMenu.svelte
@@ -23,6 +23,7 @@
 <PopupMenu
   label={m.button_label_popup_menu({ title })}
   mode="standalone"
+  {title}
   {disabled}
 >
   {#snippet items()}

--- a/projects/client/src/lib/sections/lists/smart/_internal/SmartListActions.svelte
+++ b/projects/client/src/lib/sections/lists/smart/_internal/SmartListActions.svelte
@@ -13,6 +13,7 @@
 <PopupMenu
   label={m.button_label_popup_menu({ title: list.title })}
   mode="standalone"
+  title={list.title}
 >
   {#snippet items()}
     <DeleteSmartListButton

--- a/projects/client/src/lib/sections/lists/user/ListActions.svelte
+++ b/projects/client/src/lib/sections/lists/user/ListActions.svelte
@@ -5,8 +5,8 @@
   import Redirect from "$lib/components/router/Redirect.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
-  import ReportButton from "$lib/features/report/ReportButton.svelte";
   import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
+  import ReportButton from "$lib/features/report/ReportButton.svelte";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaListSummary } from "$lib/requests/models/MediaListSummary";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
@@ -64,6 +64,7 @@
   <PopupMenu
     label={m.button_label_popup_menu({ title: list.name })}
     mode="standalone"
+    title={list.name}
   >
     {#snippet items()}
       {#if isListOwner}

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/FiltersPopupMenu.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/FiltersPopupMenu.svelte
@@ -10,6 +10,7 @@
 <PopupMenu
   label={m.button_label_popup_menu({ title: m.header_filters() })}
   mode="standalone"
+  title={m.header_filters()}
 >
   {#snippet items()}
     <ResetAllButton />

--- a/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
+++ b/projects/client/src/lib/sections/profile-banner/_internal/ProfileOverflowMenu.svelte
@@ -143,6 +143,7 @@
   label={m.button_label_profile_actions({ username: userDisplayName })}
   mode="standalone"
   size="normal"
+  title={userDisplayName}
 >
   {#snippet items()}
     {#if $incomingFollowRequest}

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceTile.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/StreamingServiceTile.svelte
@@ -86,7 +86,11 @@
 
   <div class="action">
     {#if connection.isConnected && connection.isActive}
-      <PopupMenu size="small" label={m.button_label_sync_options()}>
+      <PopupMenu
+        size="small"
+        label={m.button_label_sync_options()}
+        title={m.button_label_sync_options()}
+      >
         {#snippet items()}
           <DropdownItem onclick={() => run(() => actions.sync(connection.id))}>
             {m.button_text_sync_new_data()}
@@ -120,7 +124,11 @@
       >
         {m.button_text_reconnect()}
       </Button>
-      <PopupMenu size="small" label={m.button_label_sync_options()}>
+      <PopupMenu
+        size="small"
+        label={m.button_label_sync_options()}
+        title={m.button_label_sync_options()}
+      >
         {#snippet items()}
           <DropdownItem
             color="red"

--- a/projects/client/src/lib/sections/summary/components/comments/CommentActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/CommentActions.svelte
@@ -20,6 +20,7 @@
 <PopupMenu
   label={m.button_label_popup_menu({ title: m.list_title_comments() })}
   mode="standalone"
+  title={m.list_title_comments()}
 >
   {#snippet items()}
     {#if isOwnComment}

--- a/projects/client/src/lib/sections/summary/components/notes/_internal/note-actions/NoteActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/notes/_internal/note-actions/NoteActions.svelte
@@ -15,7 +15,11 @@
   const { note, media, onEdit }: NoteActionsProps = $props();
 </script>
 
-<PopupMenu label={m.button_label_popup_menu_notes()} mode="standalone">
+<PopupMenu
+  label={m.button_label_popup_menu_notes()}
+  mode="standalone"
+  title={m.button_label_popup_menu_notes()}
+>
   {#snippet items()}
     <EditNoteButton onclick={onEdit} />
     <DeleteNoteButton {note} {media} />

--- a/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/people/v2/PeopleSummary.svelte
@@ -7,6 +7,7 @@
   import { ReportableType } from "$lib/features/report/models/ReportableType.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
+  import FilterButton from "$lib/sections/navbar/components/filter/FilterButton.svelte";
   import PersonTitle from "../../_internal/PersonTitle.svelte";
   import Summary from "./../../_internal/Summary.svelte";
   import SummaryOverview from "./../../summary/SummaryOverview.svelte";
@@ -14,7 +15,6 @@
   import PersonDetails from "./_internal/PersonDetails.svelte";
   import SocialMediaLinks from "./_internal/SocialMediaLinks.svelte";
   import { hasSocialMediaLinks } from "./_internal/hasSocialMediaLinks";
-  import FilterButton from "$lib/sections/navbar/components/filter/FilterButton.svelte";
 
   const { person }: { person: PersonSummary } = $props();
 </script>
@@ -46,6 +46,7 @@
         label={m.button_label_popup_menu({ title: person.name })}
         mode="standalone"
         size="normal"
+        title={person.name}
       >
         {#snippet items()}
           <ReportButton

--- a/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/summary/SummaryHeader.svelte
@@ -35,6 +35,7 @@
             label={m.button_label_popup_menu({ title })}
             size="normal"
             mode="standalone"
+            {title}
           >
             {#snippet items()}
               {@render popupActions()}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2736
- On mobile, all popup menus are opened in a drawer.
  - Note: styling/color of the items aren't great yet; will be tackled when tackling the popup variant changes.

## 👀 Example 👀
Before:

https://github.com/user-attachments/assets/a43a28f3-8223-4ee8-9c82-e62319afa78c

After:

https://github.com/user-attachments/assets/cb63ca16-a284-4fc3-97b3-cfe0c581d92a

