### PR TITLE
feat(summary): add parental guide preview to details drawer

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -8140,6 +8140,10 @@
       "default": "Rank the people you follow by watch time and see where you land among them.",
       "description": "Description for the Pantheon (follows watch-time ranking) preview feature."
     },
+    "preview_feature_description_parental_guide": {
+      "default": "Show content risk levels in the details drawer for movies, shows, and episodes.",
+      "description": "Description for the Parental Guidance preview feature."
+    },
     "header_official_links": {
       "default": "Official Links",
       "description": "Header for the official links section, with official links for a show or movie, like the official site, instagram, etc.."
@@ -9198,6 +9202,10 @@
     "error_text_sync_load_failed": {
       "default": "We couldn't load this right now. Please try again.",
       "description": "Inline error message shown when a streaming sync detail or its items fail to load."
+    },
+    "error_text_parental_guide_load_failed": {
+      "default": "Loading Error",
+      "description": "Short label shown in the parental guide when its content fails to load."
     },
     "text_streaming_tmdb_pill": {
       "default": "TMDB {id}",

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -6,4 +6,5 @@ export enum FeatureFlag {
   UpNextSmartSort = 'up-next-smart-sort',
   Rewatching = 'rewatching',
   Leaderboard = 'leaderboard',
+  ParentalGuide = 'parental-guide',
 }

--- a/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
+++ b/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
@@ -2,6 +2,7 @@ import BrainIcon from '$lib/components/icons/BrainIcon.svelte';
 import EditModeIcon from '$lib/components/icons/EditModeIcon.svelte';
 import FastRewindIcon from '$lib/components/icons/FastRewindIcon.svelte';
 import FavoriteIcon from '$lib/components/icons/FavoriteIcon.svelte';
+import NoSpoilerIcon from '$lib/components/icons/NoSpoilerIcon.svelte';
 import PeopleIcon from '$lib/components/icons/PeopleIcon.svelte';
 import SmartListIcon from '$lib/components/icons/SmartListIcon.svelte';
 import { m } from '$lib/features/i18n/messages.ts';
@@ -76,5 +77,11 @@ export const featureFlagDefinitions: FeatureFlagDefinitions = {
     icon: PeopleIcon,
     title: () => m.preview_feature_title_leaderboard(),
     description: () => m.preview_feature_description_leaderboard(),
+  },
+  [FeatureFlag.ParentalGuide]: {
+    icon: NoSpoilerIcon,
+    title: () => m.option_text_certification_parental_guidance(),
+    description: () => m.preview_feature_description_parental_guide(),
+    audience: 'director',
   },
 };

--- a/projects/client/src/lib/requests/_internal/mapToEpisodeEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToEpisodeEntry.ts
@@ -35,6 +35,7 @@ export function mapToEpisodeEntry(
 
   return {
     id: episode.ids.trakt,
+    imdbId: episode.ids.imdb,
     key: `episode-${episode.ids.trakt}`,
     type: episode.episode_type as EpisodeType ??
       EpisodeUnknownType.unknown,

--- a/projects/client/src/lib/requests/models/EpisodeEntry.ts
+++ b/projects/client/src/lib/requests/models/EpisodeEntry.ts
@@ -6,6 +6,7 @@ import { PostCreditsSchema } from './PostCreditsSchema.ts';
 
 const BaseEpisodeEntrySchema = z.object({
   id: z.number(),
+  imdbId: z.string().nullish(),
   key: z.string(),
   season: z.number(),
   number: z.number(),

--- a/projects/client/src/lib/requests/models/MediaParentalGuide.ts
+++ b/projects/client/src/lib/requests/models/MediaParentalGuide.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+const MediaParentalGuideVotesSchema = z.object({
+  none: z.number(),
+  mild: z.number(),
+  moderate: z.number(),
+  severe: z.number(),
+});
+
+const MediaParentalGuideCategorySchema = z.object({
+  categoryId: z.string().nullish(),
+  label: z.string(),
+  severity: z.string(),
+  severityLabel: z.string().nullish(),
+  votes: MediaParentalGuideVotesSchema,
+  totalVotes: z.number(),
+});
+
+export const MediaParentalGuideSchema = z.object({
+  id: z.string(),
+  title: z.string().nullish(),
+  categories: z.record(MediaParentalGuideCategorySchema),
+});
+
+export type MediaParentalGuide = z.infer<typeof MediaParentalGuideSchema>;

--- a/projects/client/src/lib/requests/queries/media/mediaParentalGuideQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/media/mediaParentalGuideQuery.spec.ts
@@ -1,0 +1,86 @@
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { server } from '$mocks/server.ts';
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { mediaParentalGuideQuery } from './mediaParentalGuideQuery.ts';
+
+const MediaParentalGuideMock = {
+  id: 'tt14693272',
+  title: 'Freedom Day',
+  categories: {
+    sex_nudity: {
+      categoryId: 'NUDITY',
+      label: 'Sex & Nudity',
+      severity: 'NONE',
+      severityLabel: 'None',
+      votes: {
+        none: 10,
+        mild: 1,
+        moderate: 0,
+        severe: 0,
+      },
+      totalVotes: 11,
+    },
+    violence_gore: {
+      categoryId: 'VIOLENCE',
+      label: 'Violence & Gore',
+      severity: 'MODERATE',
+      severityLabel: 'Moderate',
+      votes: {
+        none: 1,
+        mild: 4,
+        moderate: 12,
+        severe: 2,
+      },
+      totalVotes: 19,
+    },
+  },
+};
+
+describe('mediaParentalGuideQuery', () => {
+  it('should be disabled without an IMDb id', () => {
+    const query = mediaParentalGuideQuery({ imdbId: null });
+
+    expect(query.enabled).to.equal(false);
+  });
+
+  it('should query for a media parental guide by IMDb id', async () => {
+    server.use(
+      http.get(
+        `http://localhost/v3/media/imdb/${MediaParentalGuideMock.id}/parental-guide`,
+        () => HttpResponse.json(MediaParentalGuideMock),
+      ),
+    );
+
+    const result = await runQuery({
+      factory: () =>
+        createTestBedQuery(
+          mediaParentalGuideQuery({ imdbId: MediaParentalGuideMock.id }),
+        ),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(MediaParentalGuideMock);
+  });
+
+  it('should return null when a media parental guide is unavailable', async () => {
+    server.use(
+      http.get(
+        `http://localhost/v3/media/imdb/${MediaParentalGuideMock.id}/parental-guide`,
+        () => new HttpResponse(null, { status: 204 }),
+      ),
+    );
+
+    const result = await runQuery({
+      factory: () =>
+        createTestBedQuery(
+          mediaParentalGuideQuery({ imdbId: MediaParentalGuideMock.id }),
+        ),
+      mapper: (response) => response?.data,
+      waitFor: (response) => response === null,
+    });
+
+    expect(result).to.equal(null);
+  });
+});

--- a/projects/client/src/lib/requests/queries/media/mediaParentalGuideQuery.ts
+++ b/projects/client/src/lib/requests/queries/media/mediaParentalGuideQuery.ts
@@ -1,0 +1,57 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import {
+  type MediaParentalGuide,
+  MediaParentalGuideSchema,
+} from '$lib/requests/models/MediaParentalGuide.ts';
+import { time } from '$lib/utils/timing/time.ts';
+
+type MediaParentalGuideParams = {
+  imdbId?: string | null;
+} & ApiParams;
+
+const mediaParentalGuideRequest = async (
+  { fetch, imdbId }: MediaParentalGuideParams,
+) => {
+  if (!imdbId) {
+    return {
+      body: undefined,
+      status: 204,
+    };
+  }
+
+  const response = await rawApiFetch({
+    fetch,
+    path: `/v3/media/imdb/${encodeURIComponent(imdbId)}/parental-guide`,
+  });
+
+  if (response.status === 204) {
+    return {
+      body: undefined,
+      status: 204,
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      body: undefined,
+      status: response.status,
+    };
+  }
+
+  return {
+    body: MediaParentalGuideSchema.parse(await response.json()),
+    status: 200,
+  };
+};
+
+export const mediaParentalGuideQuery = defineQuery({
+  key: 'mediaParentalGuide',
+  invalidations: [],
+  dependencies: (params) => [params.imdbId ?? ''],
+  request: mediaParentalGuideRequest,
+  mapper: (response): MediaParentalGuide | null => response.body ?? null,
+  schema: MediaParentalGuideSchema.nullish(),
+  ttl: time.hours(3),
+  enabled: (params) => Boolean(params.imdbId),
+});

--- a/projects/client/src/lib/sections/summary/components/_internal/useParentalGuideCategories.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/useParentalGuideCategories.ts
@@ -1,0 +1,83 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { MediaParentalGuide as Guide } from '$lib/requests/models/MediaParentalGuide.ts';
+import { mediaParentalGuideQuery } from '$lib/requests/queries/media/mediaParentalGuideQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { distinctUntilChanged, map, type Observable } from 'rxjs';
+
+type SeverityTone = 'none' | 'mild' | 'moderate' | 'severe' | 'unknown';
+
+type DisplayableCategory = {
+  key: string;
+  label: string;
+  severityLabel: string;
+  severityTone: SeverityTone;
+};
+
+const CATEGORY_ORDER = [
+  'sex_nudity',
+  'violence_gore',
+  'profanity',
+  'alcohol_drugs_smoking',
+  'frightening_intense_scenes',
+];
+
+function toSeverityTone(severity: string): SeverityTone {
+  switch (severity.toUpperCase()) {
+    case 'NONE':
+      return 'none';
+    case 'MILD':
+      return 'mild';
+    case 'MODERATE':
+      return 'moderate';
+    case 'SEVERE':
+      return 'severe';
+    default:
+      return 'unknown';
+  }
+}
+
+function toDisplayableSeverity(severity: string): string {
+  return severity
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function categoryRank(key: string): number {
+  const index = CATEGORY_ORDER.indexOf(key);
+  return index === -1 ? CATEGORY_ORDER.length : index;
+}
+
+function toDisplayableCategories(
+  parentalGuide: Guide | null | undefined,
+): DisplayableCategory[] {
+  return Object.entries(parentalGuide?.categories ?? {})
+    .filter(([, category]) => category.label.length > 0)
+    .sort(([keyA], [keyB]) => categoryRank(keyA) - categoryRank(keyB))
+    .map(([key, category]) => ({
+      key,
+      label: category.label,
+      severityLabel: category.severityLabel ??
+        toDisplayableSeverity(category.severity),
+      severityTone: toSeverityTone(category.severity),
+    }));
+}
+
+export function useParentalGuideCategories(
+  { imdbId$ }: { imdbId$: Observable<string | null | undefined> },
+) {
+  const query = useQuery(
+    imdbId$.pipe(
+      distinctUntilChanged(),
+      map((imdbId) => mediaParentalGuideQuery({ imdbId })),
+    ),
+  );
+
+  return {
+    categories: query.pipe(
+      map(($query) => toDisplayableCategories($query.data)),
+    ),
+    isError: query.pipe(map(($query) => $query.isError)),
+    isLoading: query.pipe(map(toLoadingState)),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/details/DetailsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/DetailsDrawer.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag.ts";
   import * as m from "$lib/features/i18n/messages.ts";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import { fade } from "svelte/transition";
   import MediaDetails from "./_internal/MediaDetails.svelte";
   import MediaLinks from "./_internal/MediaLinks.svelte";
+  import MediaParentalGuide from "./_internal/MediaParentalGuide.svelte";
   import MediaStats from "./_internal/MediaStats.svelte";
   import type { MediaDetailsProps } from "./MediaDetailsProps";
 
@@ -11,6 +14,10 @@
     $props();
 
   let isOpen = $state(false);
+
+  const imdbId = $derived(
+    props.type === "episode" ? props.episode.imdbId : props.media.imdbId,
+  );
 </script>
 
 <Drawer
@@ -30,6 +37,12 @@
       {#if props.type !== "episode"}
         <MediaLinks media={props.media} />
       {/if}
+
+      <RenderForFeature flag={FeatureFlag.ParentalGuide} audience="director">
+        {#snippet enabled()}
+          <MediaParentalGuide {imdbId} />
+        {/snippet}
+      </RenderForFeature>
     </div>
   {/if}
 </Drawer>
@@ -41,5 +54,13 @@
     display: flex;
     flex-direction: column;
     gap: var(--details-gap);
+  }
+
+  .trakt-details-drawer-content :global(
+    .trakt-media-links + .trakt-media-parental-guide
+  ) {
+    margin-top: calc(-1 * var(--details-gap));
+
+    border-top: none;
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/details/_internal/MediaParentalGuide.svelte
+++ b/projects/client/src/lib/sections/summary/components/details/_internal/MediaParentalGuide.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte";
+  import { useParentalGuideCategories } from "../../_internal/useParentalGuideCategories.ts";
+
+  const LOADING_ROWS = Array.from({ length: 5 });
+
+  const { imdbId }: { imdbId?: string | null } = $props();
+
+  const { categories, isError, isLoading } = useParentalGuideCategories({
+    imdbId$: fromRune(() => imdbId),
+  });
+
+  const guideState = $derived.by(() => {
+    if ($isLoading) {
+      return "loading";
+    }
+
+    if ($isError) {
+      return "error";
+    }
+
+    return $categories.length > 0 ? "ready" : "empty";
+  });
+
+  const guideNotice = $derived.by(() => {
+    if (guideState === "error") {
+      return {
+        label: m.error_text_parental_guide_load_failed(),
+        severityTone: "severe",
+      };
+    }
+
+    if (guideState === "empty") {
+      return {
+        label: m.text_unavailable(),
+        severityTone: "none",
+      };
+    }
+
+    return null;
+  });
+</script>
+
+<section
+  class="trakt-media-parental-guide"
+  aria-busy={guideState === "loading"}
+  data-state={guideState}
+>
+  <p class="bold secondary">
+    {m.option_text_certification_parental_guidance()}
+  </p>
+
+  {#if guideState === "ready"}
+    <ul class="guide-list">
+      {#each $categories as category (category.key)}
+        <li class="guide-row" data-severity={category.severityTone}>
+          <span class="severity-rail" aria-hidden="true"></span>
+          <span class="guide-copy">
+            <span class="guide-label bold">{category.label}</span>
+            <span class="guide-severity secondary">{category.severityLabel}</span>
+          </span>
+        </li>
+      {/each}
+    </ul>
+  {:else if guideState === "loading"}
+    <div class="guide-list" aria-hidden="true">
+      {#each LOADING_ROWS as _, index (index)}
+        <div class="guide-row is-loading">
+          <span class="severity-rail"></span>
+          <span class="guide-copy">
+            <span class="guide-label"></span>
+            <span class="guide-severity"></span>
+          </span>
+        </div>
+      {/each}
+    </div>
+  {:else if guideNotice}
+    <div class="guide-list">
+      <div class="guide-row" data-severity={guideNotice.severityTone}>
+        <span class="severity-rail" aria-hidden="true"></span>
+        <span class="guide-copy">
+          <span class="guide-label bold secondary">{guideNotice.label}</span>
+        </span>
+      </div>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .trakt-media-parental-guide {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+
+    padding-top: var(--gap-l);
+
+    border-top: var(--ni-1) solid var(--color-border);
+  }
+
+  .trakt-media-parental-guide .guide-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+
+    padding: 0;
+    margin: 0;
+
+    list-style: none;
+  }
+
+  .trakt-media-parental-guide .guide-row {
+    display: grid;
+    grid-template-columns: var(--ni-6) minmax(0, 1fr);
+    align-items: center;
+    gap: var(--gap-s);
+    min-height: var(--ni-32);
+  }
+
+  .trakt-media-parental-guide .severity-rail {
+    width: var(--ni-6);
+    height: var(--ni-28);
+
+    border-radius: var(--border-radius-xs);
+    background: var(--guide-severity-color, var(--shade-500));
+  }
+
+  .trakt-media-parental-guide .guide-copy {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: var(--gap-xs);
+    min-width: 0;
+  }
+
+  .trakt-media-parental-guide .guide-label,
+  .trakt-media-parental-guide .guide-severity {
+    overflow-wrap: anywhere;
+  }
+
+  .trakt-media-parental-guide .guide-row[data-severity="none"] {
+    --guide-severity-color: var(--shade-300);
+  }
+
+  .trakt-media-parental-guide .guide-row[data-severity="mild"] {
+    --guide-severity-color: var(--green-500);
+  }
+
+  .trakt-media-parental-guide .guide-row[data-severity="moderate"] {
+    --guide-severity-color: var(--yellow-500);
+  }
+
+  .trakt-media-parental-guide .guide-row[data-severity="severe"] {
+    --guide-severity-color: var(--red-500);
+  }
+
+  .trakt-media-parental-guide .guide-row.is-loading .severity-rail,
+  .trakt-media-parental-guide .guide-row.is-loading .guide-label,
+  .trakt-media-parental-guide .guide-row.is-loading .guide-severity {
+    background: color-mix(
+      in srgb,
+      var(--color-text-secondary) 18%,
+      transparent
+    );
+  }
+
+  .trakt-media-parental-guide .guide-row.is-loading .guide-label,
+  .trakt-media-parental-guide .guide-row.is-loading .guide-severity {
+    display: block;
+    height: var(--ni-14);
+
+    border-radius: var(--border-radius-xs);
+  }
+
+  .trakt-media-parental-guide .guide-row.is-loading .guide-label {
+    width: min(var(--ni-192), 60%);
+  }
+
+  .trakt-media-parental-guide .guide-row.is-loading .guide-severity {
+    width: var(--ni-72);
+  }
+</style>

--- a/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloMappedMock.ts
@@ -3,6 +3,7 @@ import { EpisodePremiereType } from '$lib/requests/models/EpisodeType.ts';
 
 export const EpisodeSiloMappedMock: EpisodeEntry = {
   'id': 5165667,
+  'imdbId': 'tt14693272',
   'key': 'episode-5165667',
   'type': EpisodePremiereType.series_premiere,
   'title': 'Freedom Day',

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonEpisodesMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonEpisodesMappedMock.ts
@@ -11,6 +11,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
     },
     'genres': [],
     'id': 5165667,
+    'imdbId': 'tt14693272',
     'key': 'episode-5165667',
     'number': 1,
     'overview':
@@ -33,6 +34,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
     },
     'genres': [],
     'id': 7374195,
+    'imdbId': 'tt17057038',
     'key': 'episode-7374195',
     'number': 2,
     'overview':
@@ -55,6 +57,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
     },
     'genres': [],
     'id': 7374298,
+    'imdbId': 'tt17057042',
     'key': 'episode-7374298',
     'number': 3,
     'overview':
@@ -77,6 +80,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
     },
     'genres': [],
     'id': 7374307,
+    'imdbId': 'tt16091606',
     'key': 'episode-7374307',
     'number': 4,
     'overview':
@@ -99,6 +103,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
     },
     'genres': [],
     'id': 7374308,
+    'imdbId': 'tt17073696',
     'key': 'episode-7374308',
     'number': 5,
     'overview':
@@ -121,6 +126,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
     },
     'genres': [],
     'id': 7374309,
+    'imdbId': 'tt18078232',
     'key': 'episode-7374309',
     'number': 6,
     'overview':
@@ -143,6 +149,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
     },
     'genres': [],
     'id': 7374310,
+    'imdbId': 'tt19782800',
     'key': 'episode-7374310',
     'number': 7,
     'overview':
@@ -165,6 +172,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
     },
     'genres': [],
     'id': 7374312,
+    'imdbId': 'tt19782808',
     'key': 'episode-7374312',
     'number': 8,
     'overview':
@@ -187,6 +195,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
     },
     'genres': [],
     'id': 7374313,
+    'imdbId': 'tt19782850',
     'key': 'episode-7374313',
     'number': 9,
     'overview':
@@ -209,6 +218,7 @@ export const ShowSiloSeasonEpisodesMappedMock: EpisodeEntry[] = [
     },
     'genres': [],
     'id': 7374314,
+    'imdbId': 'tt19782854',
     'key': 'episode-7374314',
     'number': 10,
     'overview':

--- a/projects/client/src/mocks/data/sync/mapped/LibraryMappedMock.ts
+++ b/projects/client/src/mocks/data/sync/mapped/LibraryMappedMock.ts
@@ -14,6 +14,7 @@ export const LibraryMappedMock: LibraryItem[] = [
       },
       'genres': [],
       'id': 13352063,
+      'imdbId': 'tt37976114',
       'key': 'episode-13352063',
       'number': 4,
       'overview':
@@ -264,6 +265,7 @@ export const LibraryMappedMock: LibraryItem[] = [
       },
       'genres': [],
       'id': 298461,
+      'imdbId': 'tt0642348',
       'key': 'episode-298461',
       'number': 1,
       'overview':


### PR DESCRIPTION
## Summary

Adds a Director-only Preview flag for Parental Guidance and renders parental guide severity categories at the bottom of movie, show, and episode detail drawers when data is available.

This is a V0 to gauge team interest and data availability. It depends on https://github.com/trakt/trakt-workers/pull/1059, which needs to be merged before this can show the data.

If the team is interested, the next step is to ingest the data into our pipeline so we can build a better aggregated, glanceable UI and eventually filter on it, including in Smart Lists.

## Changes

- Adds the `parental-guide` Director Preview flag.
- Fetches parental guide data and maps category severities into the drawer UI.
- Adds stable loading, unavailable, and loading error states.
- Adds episode IMDb IDs so episode drawers can query the same guide endpoint.

## Screenshots

<img width="1444" height="927" alt="Screenshot 2026-06-30 at 10 34 11" src="https://github.com/user-attachments/assets/6f4a875f-765e-40d5-9a24-57ba8167e5e2" />
<img width="1444" height="927" alt="Screenshot 2026-06-30 at 10 28 00" src="https://github.com/user-attachments/assets/8d4fcde2-cd98-4b63-9ef6-01da05d3837c" />
<img width="1444" height="927" alt="Screenshot 2026-06-30 at 10 28 11" src="https://github.com/user-attachments/assets/093f8993-bbd5-4285-a56f-ac354d204bfa" />
<img width="1444" height="927" alt="Screenshot 2026-06-30 at 10 28 19" src="https://github.com/user-attachments/assets/7d3e6c65-e32b-4853-af5d-44af3ab006fe" />
<img width="1444" height="927" alt="Screenshot 2026-06-30 at 10 27 49" src="https://github.com/user-attachments/assets/8f407e39-e054-4de8-9170-da2caaf468e4" />
<img width="1444" height="927" alt="Screenshot 2026-06-30 at 10 30 30" src="https://github.com/user-attachments/assets/8b6596b3-de4d-4411-952c-a9439e077479" />



