### PR TITLE
feat(ds): hand-rolled chart design system

### DIFF
--- a/projects/client/src/lib/components/charts/AreaChart.svelte
+++ b/projects/client/src/lib/components/charts/AreaChart.svelte
@@ -1,184 +1,33 @@
 <script lang="ts">
-  import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
-  import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
-  import { time } from "$lib/utils/timing/time";
-  import { ScaleTypes } from "@carbon/charts";
-  import { AreaChart, type AreaChartOptions } from "@carbon/charts-svelte";
-  import "@carbon/charts-svelte/styles.css";
-  import { flushSync } from "svelte";
-  import type { AreaChartProps, TooltipArgs } from "./models/AreaChartProps";
+  import LineChart from "./LineChart.svelte";
+  import type { AreaChartProps } from "./models/AreaChartProps.ts";
 
-  const dotRadius = 7;
-  const chartPaddingVar = "var(--ni-12)";
-
+  // Compose, don't fork: an area chart is a LineChart with the floor filled in.
+  // The legacy color props are preserved so existing consumers stay drop-in;
+  // omit them to fall back to the seriesIndex-driven --viz-* tokens (which also
+  // gives the gradient fade + glow for free).
   const {
     data,
     tooltip,
-    lineColor = "var(--color-text-primary)",
-    fillColor = "transparent",
+    seriesIndex = 0,
+    lineColor,
+    fillColor,
     dotColor,
-    dotHaloColor = "transparent",
+    dotHaloColor,
+    label = "Area chart",
+    height = "var(--height-area-chart)",
   }: AreaChartProps = $props();
-
-  // Default the dot to the line color so a consumer that just picks a line
-  // color gets a coherent hover marker without extra plumbing.
-  const resolvedDotColor = $derived(dotColor ?? lineColor);
-
-  // Carbon Charts groups area data by `group`; everything sits in a single
-  // group so the area is one continuous shape.
-  const carbonData = $derived(
-    data.map((d) => ({ group: "value", date: d.label, value: d.value })),
-  );
-  const labels = $derived(data.map((d) => d.label));
-
-  const chartPadding = useVarToPixels(chartPaddingVar);
-  const { observedDimension: observedContainerDimension, observeDimension } =
-    useDimensionObserver("width", time.fps(30));
-
-  const observedDimension = $derived(
-    $observedContainerDimension - $chartPadding * 2,
-  );
-
-  let tooltipContainer: HTMLDivElement | undefined = $state();
-  let tooltipArgs: TooltipArgs | null = $state(null);
-
-  const customHTML = $derived(
-    (points: Array<{ value: number; date: string }>) => {
-      if (!tooltip || !tooltipContainer || !points?.length) return "";
-      const point = points[0];
-      const index = labels.indexOf(point.date);
-      tooltipArgs = { value: point.value, label: point.date, index };
-      flushSync();
-      return tooltipContainer.innerHTML;
-    },
-  );
-
-  const options: AreaChartOptions = $derived({
-    axes: {
-      bottom: {
-        mapsTo: "date",
-        scaleType: ScaleTypes.LABELS,
-      },
-      left: {
-        mapsTo: "value",
-        visible: false,
-      },
-    },
-    grid: {
-      x: { enabled: false },
-      y: { enabled: false },
-    },
-    // Points render at a fixed radius but invisible by default
-    // (fillOpacity: 0). The CSS below fades them in on hover so we get a
-    // stable pin at the active data point. Keeping `r` constant avoids
-    // fighting Carbon's own hover animation, which writes inline `r`
-    // attributes that would clobber a CSS transition.
-    points: { enabled: true, radius: dotRadius, fillOpacity: 0 },
-    legend: { enabled: false },
-    toolbar: { enabled: false },
-    tooltip: {
-      enabled: tooltip != null,
-      customHTML,
-    },
-    resizable: false,
-    width: `${observedDimension}px`,
-    height: "var(--height-area-chart)",
-    // Colors are passed as resolved CSS strings (props), not via wrapper-set
-    // CSS vars, because Carbon resolves `color.scale.value` at chart-init
-    // context where the wrapper's scoped vars aren't accessible. Passing
-    // globally-defined references (e.g. `var(--shade-10)`) keeps the values
-    // theme-aware while still resolving anywhere.
-    color: {
-      scale: { value: lineColor },
-    },
-    getStrokeColor: () => lineColor,
-    getFillColor: () => fillColor,
-  });
 </script>
 
-<div
-  class="trakt-area-chart"
-  use:observeDimension
-  style="--chart-padding: {$chartPadding}px; --area-chart-dot: {resolvedDotColor}; --area-chart-dot-halo: {dotHaloColor};"
->
-  <AreaChart data={carbonData} {options} />
-
-  <!--
-    CarbonCharts does not support snippets as tooltips. So we render them to a
-    hidden container and pull the HTML into Carbon's custom tooltip renderer.
-    This way, at least from a consumer pov, a snippet can be passed in.
-  -->
-  <div bind:this={tooltipContainer} style="display:none" aria-hidden="true">
-    {#if tooltip && tooltipArgs}
-      {@render tooltip(tooltipArgs)}
-    {/if}
-  </div>
-</div>
-
-<style lang="scss">
-  .trakt-area-chart {
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-    padding: var(--chart-padding);
-    box-sizing: border-box;
-
-    :global(.cds--chart-holder) {
-      --cds-grid-bg: transparent;
-      --cds-text-primary: var(
-        --color-area-chart-text-primary,
-        var(--color-text-primary)
-      );
-      --cds-text-secondary: var(
-        --color-area-chart-text-secondary,
-        var(--color-text-secondary)
-      );
-    }
-
-    // Area + line colors come from Carbon's getFillColor / getStrokeColor
-    // callbacks (see options above), so we only need width + opacity here.
-    :global(.area) {
-      fill-opacity: 1;
-    }
-
-    :global(.line) {
-      stroke-width: var(--width-area-chart-line, var(--ni-2));
-    }
-
-    // Hover marker for the active data point. Hidden by default (radius is
-    // set via Carbon's points option but opacity stays 0 so the dots are
-    // invisible). On `.hovered` the dot fades in. We avoid any CSS
-    // `transform` here because Safari's SVG transform handling fights
-    // Carbon's own inline `r` updates, causing the dot to flicker.
-    :global(circle.dot) {
-      fill: var(--area-chart-dot);
-      stroke: var(--area-chart-dot-halo);
-      stroke-width: var(--ni-2);
-      fill-opacity: 0;
-      stroke-opacity: 0;
-      transition:
-        fill-opacity var(--transition-increment) ease-out,
-        stroke-opacity var(--transition-increment) ease-out;
-    }
-
-    :global(circle.dot.hovered) {
-      fill-opacity: 1;
-      stroke-opacity: 0.8;
-    }
-
-    :global(.tick line),
-    :global(.domain) {
-      stroke: transparent;
-    }
-  }
-
-  // Carbon mounts the tooltip wrapper outside .cds--chart-holder, so consumer
-  // tooltip styles can't reach it through the normal cascade. Flatten the
-  // wrapper here so consumer tooltip styling shows through cleanly.
-  :global(.cds--cc--tooltip) {
-    background: transparent;
-    border: none;
-    box-shadow: none;
-    padding: 0;
-  }
-</style>
+<LineChart
+  {data}
+  {tooltip}
+  {seriesIndex}
+  {dotHaloColor}
+  {label}
+  {height}
+  showArea
+  color={lineColor}
+  {fillColor}
+  {dotColor}
+/>

--- a/projects/client/src/lib/components/charts/BarChart.svelte
+++ b/projects/client/src/lib/components/charts/BarChart.svelte
@@ -1,161 +1,313 @@
 <script lang="ts">
   import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
-  import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
   import { time } from "$lib/utils/timing/time";
-  import { ScaleTypes } from "@carbon/charts";
-  import { BarChartSimple, type BarChartOptions } from "@carbon/charts-svelte";
-  import "@carbon/charts-svelte/styles.css";
-  import { flushSync } from "svelte";
-  import type { BarChartProps, TooltipArgs } from "./models/BarChartProps";
+  import { scaleBand, scaleLinear } from "d3";
+  import { createPlotInteraction } from "./_internal/createPlotInteraction.svelte.ts";
+  import { nearestIndex } from "./_internal/nearestIndex.ts";
+  import { nextVizId } from "./_internal/nextVizId.ts";
+  import { vizSeriesSlot } from "./vizSeriesSlot.ts";
+  import VizDefs from "./_internal/VizDefs.svelte";
+  import type { BarChartProps, TooltipArgs } from "./models/BarChartProps.ts";
 
-  const chartPaddingVar = "var(--ni-12)";
+  const LABEL_BAND = 18;
+  // When the active bar's top is within this many px of the plot top, flip the
+  // tooltip below it so it isn't clipped by the chart's container.
+  const TOOLTIP_FLIP_THRESHOLD = 52;
 
   const {
     data,
-    tooltip,
     tickLabels,
+    tooltip,
     barSpacing = 2,
+    seriesIndex = 0,
+    highlightPeak = true,
+    label = "Bar chart",
+    height = "var(--height-bar-chart)",
   }: BarChartProps = $props();
 
-  // Carbon Charts keys bars by `group`; remap label → group so D3 join is stable on resize.
-  const carbonData = $derived(
-    data.map((d) => ({ group: d.label, value: d.value })),
-  );
+  const prefix = nextVizId("viz-bar");
+
+  const { observedDimension: observedWidth, observeDimension: observeWidth } =
+    useDimensionObserver("width", time.fps(30));
+  const { observedDimension: observedHeight, observeDimension: observeHeight } =
+    useDimensionObserver("height", time.fps(30));
+
+  const slot = $derived(vizSeriesSlot(seriesIndex));
+  const barFill = $derived(`url(#${prefix}-fill-${slot})`);
+  const seriesColor = $derived(`var(--viz-${slot})`);
+
+  const width = $derived($observedWidth);
+  const height$ = $derived($observedHeight);
+  const margin = 3;
+  const labelBand = $derived(tickLabels ? LABEL_BAND : 0);
+  const baseline = $derived(Math.max(height$ - margin - labelBand, 0));
+  const innerWidth = $derived(Math.max(width - margin * 2, 0));
 
   const values = $derived(data.map((d) => d.value));
-  const labels = $derived(data.map((d) => d.label));
-
   const maxValue = $derived(Math.max(...values, 0));
+  const hasPlot = $derived(width > 0 && height$ > 0 && data.length > 0);
 
-  const chartPadding = useVarToPixels(chartPaddingVar);
-  const { observedDimension: observedContainerDimension, observeDimension } =
-    useDimensionObserver("width", time.fps(30));
-
-  const observedDimension = $derived(
-    $observedContainerDimension - $chartPadding * 2,
-  );
-
-  const barWidth = $derived(
-    data.length > 0
-      ? Math.floor(observedDimension / data.length) - barSpacing
-      : 0,
-  );
-
-  const getFillColor = $derived(
-    (_: unknown, __: unknown, data: { value: number } | undefined) => {
-      const barColor =
-        data?.value === maxValue
-          ? "var(--color-bar-custom-highlight, var(--color-bar-chart-bar-highlight))"
-          : "var(--color-bar-custom-default, var(--color-bar-chart-bar-default))";
-
-      return `var(--color-bar-hover, ${barColor})`;
-    },
-  );
-
-  let tooltipContainer: HTMLDivElement | undefined = $state();
-  let tooltipArgs: TooltipArgs | null = $state(null);
-
-  const customHTML = $derived(
-    (points: Array<{ value: number; group: string }>) => {
-      if (!tooltip || !tooltipContainer) return "";
-      if (!points?.length) return "";
-      const point = points[0];
-      const index = labels.indexOf(point.group);
-      tooltipArgs = { value: point.value, label: point.group, index };
-      flushSync();
-      return tooltipContainer.innerHTML;
-    },
-  );
-
-  const options: BarChartOptions = $derived({
-    axes: {
-      left: { mapsTo: "value", visible: false },
-      bottom: {
-        mapsTo: "group",
-        scaleType: ScaleTypes.LABELS,
-        ticks: tickLabels ? { values: tickLabels } : undefined,
-      },
-    },
-    grid: {
-      x: { enabled: false },
-      y: { enabled: false },
-    },
-    bars: { width: barWidth },
-    legend: { enabled: false },
-    toolbar: { enabled: false },
-    tooltip: {
-      enabled: tooltip != null,
-      customHTML,
-    },
-    resizable: false,
-    width: `${observedDimension}px`,
-    height: "var(--height-bar-chart)",
-    getFillColor,
+  const xScale = $derived.by(() => {
+    const step = data.length > 0 ? innerWidth / data.length : innerWidth;
+    // Translate the px gap into d3's ratio padding, capped so bars never vanish.
+    const padding = step > 0 ? Math.min(barSpacing / step, 0.9) : 0;
+    return scaleBand<number>()
+      .domain(data.map((_, index) => index))
+      .range([margin, width - margin])
+      .paddingInner(padding)
+      .paddingOuter(padding / 2);
   });
+
+  const yScale = $derived.by(() => {
+    // Flat-span guard: a zero span divides by zero and turns float noise into a
+    // jittering baseline. Pad to a unit span so equal values render flat.
+    const max = maxValue === 0 ? 1 : maxValue;
+    return scaleLinear().domain([0, max]).range([baseline, margin]);
+  });
+
+  const bars = $derived(
+    data.map((d, index) => {
+      const x = xScale(index) ?? margin;
+      const y = yScale(d.value);
+      return {
+        x,
+        y,
+        width: xScale.bandwidth(),
+        height: Math.max(baseline - y, 0),
+        center: x + xScale.bandwidth() / 2,
+        isPeak: highlightPeak && d.value === maxValue && maxValue > 0,
+      };
+    }),
+  );
+
+  const interaction = createPlotInteraction({
+    resolveIndex: (clientX, rect) =>
+      nearestIndex({
+        positions: bars.map((bar) => bar.center),
+        target: clientX - rect.left,
+      }),
+    count: () => data.length,
+  });
+
+  const ticks = $derived(
+    (tickLabels ?? []).map((text, index) => ({
+      text,
+      center: bars[index]?.center ?? 0,
+    })).filter((tick) => tick.text !== ""),
+  );
+
+  const tooltipArgs = $derived.by<TooltipArgs | null>(() => {
+    const index = interaction.activeIndex;
+    if (index == null || !data[index]) return null;
+    return { value: data[index].value, label: data[index].label, index };
+  });
+  const activeBar = $derived(
+    interaction.activeIndex != null ? bars[interaction.activeIndex] : null,
+  );
+  // Screen-reader readout of the focused/active point (aria-live region).
+  const activeReadout = $derived(
+    tooltipArgs ? `${tooltipArgs.label}: ${tooltipArgs.value}` : "",
+  );
 </script>
 
-<div
+<figure
   class="trakt-bar-chart"
-  use:observeDimension
-  style="--chart-padding: {$chartPadding}px"
+  class:has-peak={highlightPeak}
+  use:observeWidth
+  use:observeHeight
+  style="--bar-chart-height: {height}; --viz-series: {seriesColor};"
 >
-  <BarChartSimple data={carbonData} {options} />
+  <figcaption class="viz-caption">{label}</figcaption>
+  <div class="viz-caption" aria-live="polite">{activeReadout}</div>
 
   <!--
-    CarbonCharts does not support snippets as tooltips. So we render them to a
-    hidden container and pull the HTML into Carbon's custom tooltip renderer.
-    This way, at least from a consumer pov, a snippet can be passed in.
+    role="img" keeps the static screen-reader summary; the chart is also a
+    keyboard widget (focusable, arrow-key scrub, aria-live readout), so the
+    tabindex + key handlers are intentional here.
   -->
-  <div bind:this={tooltipContainer} style="display:none" aria-hidden="true">
-    {#if tooltip && tooltipArgs}
-      {@render tooltip(tooltipArgs)}
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <svg
+    {width}
+    height={height$}
+    role="img"
+    aria-label={label}
+    aria-roledescription="interactive bar chart"
+    tabindex="0"
+    class="bar-chart-plot"
+    onpointerdown={interaction.handlers.pointerdown}
+    onpointermove={interaction.handlers.pointermove}
+    onpointerup={interaction.handlers.pointerup}
+    onpointerleave={interaction.handlers.pointerleave}
+    onkeydown={interaction.handlers.keydown}
+    onblur={interaction.handlers.blur}
+  >
+    <VizDefs {prefix} />
+
+    {#if hasPlot}
+      {#each bars as bar, index (data[index].label)}
+        <g
+          class="bar"
+          class:is-peak={bar.isPeak}
+          class:is-active={index === interaction.activeIndex}
+          style="--i: {index};"
+        >
+          <rect
+            class="bar-fill"
+            x={bar.x}
+            y={bar.y}
+            width={bar.width}
+            height={bar.height}
+            style="y: {bar.y}px; height: {bar.height}px; fill: {barFill}; --bar-base: {baseline}px;"
+          />
+          <!-- High-contrast hatch overlay; gated by --viz-pattern-opacity. -->
+          <rect
+            class="bar-pattern"
+            x={bar.x}
+            y={bar.y}
+            width={bar.width}
+            height={bar.height}
+            fill={`url(#${prefix}-pattern-${slot})`}
+            style="y: {bar.y}px; height: {bar.height}px;"
+          />
+        </g>
+      {/each}
+
+      {#each ticks as tick (tick.center)}
+        <text
+          class="bar-tick"
+          x={tick.center}
+          y={height$ - margin}
+          text-anchor="middle"
+        >
+          {tick.text}
+        </text>
+      {/each}
     {/if}
-  </div>
-</div>
+  </svg>
+
+  {#if tooltip && tooltipArgs && activeBar}
+    <div
+      class="bar-chart-tooltip"
+      class:is-pinned={interaction.pinned}
+      class:is-below={activeBar.y < TOOLTIP_FLIP_THRESHOLD}
+      style:left="{activeBar.center}px"
+      style:top="{activeBar.y}px"
+    >
+      {@render tooltip(tooltipArgs)}
+    </div>
+  {/if}
+</figure>
 
 <style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .trakt-bar-chart {
+    position: relative;
+    width: 100%;
+    height: var(--bar-chart-height);
+    margin: 0;
+    color: var(--viz-series);
+  }
+
+  .bar-chart-plot {
+    display: block;
     width: 100%;
     height: 100%;
-    overflow: hidden;
+    // SVG defaults to overflow:hidden, which slices the active bar's glow into a
+    // hard straight edge at the plot boundary. Let the soft bloom bleed out.
+    overflow: visible;
+    touch-action: pan-y;
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
+    outline: none;
 
-    padding: var(--chart-padding);
-    box-sizing: border-box;
-
-    :global(.cds--chart-holder) {
-      --cds-grid-bg: transparent;
-      --cds-text-primary: var(
-        --color-bar-chart-text-primary,
-        var(--color-text-primary)
-      );
-      --cds-text-secondary: var(
-        --color-bar-chart-text-secondary,
-        var(--color-text-secondary)
-      );
-      --cds-charts-font-family: "Roboto", Arial, sans-serif;
-      --cds-charts-font-family-condensed: "Roboto", Arial, sans-serif;
-    }
-
-    :global(.bar) {
-      transition: fill var(--transition-increment) ease-in-out;
-    }
-
-    :global(.bar:hover) {
-      --color-bar-hover: var(
-        --color-bar-custom-hover,
-        var(--color-bar-chart-bar-hover)
-      );
+    &:focus-visible {
+      @include viz-focus-ring;
     }
   }
 
-  // Carbon renders its tooltip wrapper outside the chart-holder DOM, so its
-  // `--cds-layer-02` background and hardcoded box-shadow can't be reached
-  // through CSS-variable cascade. These overrides flatten the wrapper so the
-  // YirTooltip styling shows through cleanly.
-  :global(.cds--cc--tooltip) {
-    background: transparent;
-    border: none;
-    box-shadow: none;
-    padding: 0;
+  .bar-fill {
+    rx: var(--viz-bar-radius);
+    // Geometry props (y/height/rx) are CSS-animatable in SVG2, so the bars tween
+    // their top + height instead of redrawing on data change. rx lives here
+    // (not as an attribute) so it can read the CSS var token.
+    transition:
+      y var(--viz-morph-duration) ease,
+      height var(--viz-morph-duration) ease,
+      fill-opacity var(--transition-increment) ease,
+      filter var(--transition-increment) ease;
+    fill-opacity: 0.62;
+    // Rise from the baseline on first paint, staggered left-to-right.
+    transform-box: fill-box;
+    transform-origin: bottom;
+    animation: viz-bar-rise var(--viz-enter-duration) var(--viz-enter-ease)
+      calc(var(--i) * 45ms) both;
+  }
+
+  .bar-pattern {
+    rx: var(--viz-bar-radius);
+    color: var(--viz-series);
+    opacity: var(--viz-pattern-opacity);
+    transition:
+      y var(--viz-morph-duration) ease,
+      height var(--viz-morph-duration) ease;
+  }
+
+  // When no peak highlight, every bar reads at full strength.
+  .trakt-bar-chart:not(.has-peak) .bar-fill {
+    fill-opacity: 1;
+  }
+
+  // Peak just reads at full strength at rest - no resting bloom, which looked
+  // like a stray haze on small distributions. The glow is reserved for the
+  // active (hover/pin) bar so it stays an interaction affordance.
+  .bar.is-peak .bar-fill {
+    fill-opacity: 1;
+  }
+
+  .bar.is-active .bar-fill {
+    fill-opacity: 1;
+    @include viz-hover-active;
+  }
+
+  .bar-tick {
+    fill: var(--viz-label);
+    font-size: var(--font-size-tag);
+    text-anchor: middle;
+  }
+
+  .bar-chart-tooltip {
+    position: absolute;
+    pointer-events: none;
+    transform: translate(-50%, calc(-100% - var(--ni-8)));
+    z-index: var(--layer-top);
+
+    // Tall bar near the top: anchor below the bar's top edge instead so the
+    // tooltip stays inside the chart and isn't clipped.
+    &.is-below {
+      transform: translate(-50%, var(--ni-8));
+    }
+  }
+
+  .viz-caption {
+    @include visually-hidden;
+  }
+
+  @keyframes viz-bar-rise {
+    from {
+      transform: scaleY(0);
+      opacity: 0;
+    }
+    to {
+      transform: scaleY(1);
+      opacity: 1;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bar-fill {
+      animation: none;
+    }
   }
 </style>

--- a/projects/client/src/lib/components/charts/BubbleChart.svelte
+++ b/projects/client/src/lib/components/charts/BubbleChart.svelte
@@ -9,6 +9,7 @@
     BubbleChartTooltipArgs,
   } from "./models/BubbleChartProps";
 
+  const chartPadding = 12;
   const { items, tooltip, label = "Bubble chart" }: BubbleChartProps = $props();
 
   type HierarchyDatum = {
@@ -160,6 +161,7 @@
     height={$observedHeight}
     role="img"
     aria-label={label}
+    viewBox={`-${chartPadding} -${chartPadding} ${$observedWidth + chartPadding * 2} ${$observedHeight + chartPadding * 2}`}
   >
     <defs>
       <filter id={filterId}>

--- a/projects/client/src/lib/components/charts/BubbleChart.svelte
+++ b/projects/client/src/lib/components/charts/BubbleChart.svelte
@@ -2,13 +2,14 @@
   import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
   import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
   import { hierarchy, pack } from "d3";
+  import { nextVizId } from "./_internal/nextVizId.ts";
   import type {
     BubbleChartItem,
     BubbleChartProps,
     BubbleChartTooltipArgs,
   } from "./models/BubbleChartProps";
 
-  const { items, tooltip }: BubbleChartProps = $props();
+  const { items, tooltip, label = "Bubble chart" }: BubbleChartProps = $props();
 
   type HierarchyDatum = {
     item?: BubbleChartItem;
@@ -25,7 +26,7 @@
   };
 
   const padding = 3;
-  const filterId = `bubble-chart-whiteimage-${crypto.randomUUID()}`;
+  const filterId = nextVizId("bubble-chart-whiteimage");
 
   const minContentRadius = useVarToPixels("var(--min-radius-bubble-chart)");
 
@@ -70,6 +71,20 @@
       });
   });
 
+  // SVG paints in document order with no z-index, so a hovered (scaled) bubble
+  // gets clipped by later siblings. Render the hovered node last so it paints on
+  // top; keyed `each` just moves the existing element, preserving its transition.
+  const orderedNodes = $derived.by(() => {
+    const active = hovered;
+    if (!active) {
+      return nodes;
+    }
+    return [
+      ...nodes.filter((node) => node.item.id !== active.item.id),
+      ...nodes.filter((node) => node.item.id === active.item.id),
+    ];
+  });
+
   function imageSizeFor(r: number): number {
     return Math.min(r * 1.2, 80);
   }
@@ -93,8 +108,32 @@
     pointer = { x: event.clientX, y: event.clientY };
   }
 
-  function handlePointerLeave() {
+  function handlePointerLeave(event: PointerEvent) {
+    // Touch fires a synthetic leave right after the tap - ignore it so the
+    // tapped bubble's tooltip stays pinned (mirrors the chart interaction hook).
+    if (event.pointerType !== "mouse") {
+      return;
+    }
     hovered = null;
+  }
+
+  // Keyboard: each bubble is focusable (Tab between them); focus shows its
+  // tooltip anchored at the bubble centre, Escape clears + blurs.
+  function handleFocus(node: PackedNode, event: FocusEvent) {
+    hovered = node;
+    const rect = (event.currentTarget as Element).getBoundingClientRect();
+    pointer = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  }
+
+  function handleBlur() {
+    hovered = null;
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      hovered = null;
+      (event.currentTarget as SVGElement).blur();
+    }
   }
 
   function handleImageError(id: number) {
@@ -106,7 +145,7 @@
   );
 </script>
 
-<div
+<figure
   class="trakt-bubble-chart"
   use:observeWidth
   use:observeHeight
@@ -114,11 +153,13 @@
   onpointerleave={handlePointerLeave}
   role="presentation"
 >
+  <figcaption class="viz-caption">{label}</figcaption>
+
   <svg
     width={$observedWidth}
     height={$observedHeight}
     role="img"
-    aria-label="Bubble chart"
+    aria-label={label}
   >
     <defs>
       <filter id={filterId}>
@@ -130,16 +171,29 @@
       </filter>
     </defs>
 
-    {#each nodes as node (node.item.id)}
+    {#each orderedNodes as node (node.item.id)}
       {@const showImage = node.item.imageUrl && !failedImages.has(node.item.id)}
       {@const hasRoomForContent = node.r >= $minContentRadius}
       {@const imageSize = imageSizeFor(node.r)}
 
+      <!--
+        role="img" labels each bubble for screen readers; bubbles are also
+        keyboard-focusable (Tab between them, Escape clears), so the tabindex +
+        listeners are intentional.
+      -->
+      <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
       <g
         class="node"
         onpointerenter={(event) => handlePointerEnter(node, event)}
+        onpointerdown={(event) => handlePointerEnter(node, event)}
+        onfocus={(event) => handleFocus(node, event)}
+        onblur={handleBlur}
+        onkeydown={handleKeydown}
         role="img"
         aria-label={node.item.label}
+        tabindex="0"
+        style="--viz-series: {node.fill};"
       >
         <circle cx={node.x} cy={node.y} r={node.r} fill={node.fill} />
 
@@ -185,13 +239,21 @@
       {@render tooltip(tooltipArgs)}
     </div>
   {/if}
-</div>
+</figure>
 
 <style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .trakt-bubble-chart {
     position: relative;
     width: 100%;
     height: 100%;
+    margin: 0;
+    // Let the page scroll vertically over the chart while the bubbles own taps;
+    // suppress native tap highlight + selection during hover/scrub.
+    touch-action: pan-y;
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
 
     svg {
       display: block;
@@ -201,11 +263,27 @@
       cursor: pointer;
       transform-box: fill-box;
       transform-origin: center;
-      transition: transform var(--transition-increment) ease;
+      transition:
+        transform var(--transition-increment) ease,
+        filter var(--transition-increment) ease;
 
-      &:hover {
-        transform: scale(1.05);
+      &:hover,
+      &:focus-visible {
+        transform: scale(1.06);
+        @include viz-hover-active;
       }
+
+      outline: none;
+
+      &:focus-visible {
+        outline: var(--ni-2) solid var(--shade-10);
+        outline-offset: var(--ni-2);
+        border-radius: var(--border-radius-s);
+      }
+    }
+
+    .viz-caption {
+      @include visually-hidden;
     }
   }
 

--- a/projects/client/src/lib/components/charts/DistributionBar.svelte
+++ b/projects/client/src/lib/components/charts/DistributionBar.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+  import { clamp } from "$lib/utils/number/clamp.ts";
+  import { vizSeriesSlot } from "./vizSeriesSlot.ts";
+  import type { DistributionBarProps } from "./models/DistributionBarProps.ts";
+
+  // SOT meter bar: the single-fill building block every non-axis bar viz
+  // composes (distribution rows, peak-hour bars, daily columns, usage meters).
+  // One DS treatment - gradient fade, gloss, active glow, HC hatch, crisp
+  // rounded ends - so a "bar" looks identical everywhere it appears.
+  const {
+    fraction,
+    orientation = "horizontal",
+    seriesIndex = 0,
+    color,
+    active = false,
+    track = true,
+    rounded = true,
+    minVisible = 0,
+    index = 0,
+    label,
+  }: DistributionBarProps = $props();
+
+  const slot = $derived(vizSeriesSlot(seriesIndex));
+  const seriesColor = $derived(color ?? `var(--viz-${slot})`);
+
+  const clamped = $derived(clamp({ value: fraction, min: 0, max: 1 }));
+  // Floor a non-zero value to `minVisible` so it never disappears.
+  const shown = $derived(
+    clamped > 0 ? Math.max(clamped, minVisible) : clamped,
+  );
+  const percent = $derived(`${shown * 100}%`);
+</script>
+
+<div
+  class="trakt-distribution-bar"
+  data-orientation={orientation}
+  class:is-active={active}
+  class:has-track={track}
+  class:is-rounded={rounded}
+  role="progressbar"
+  aria-valuenow={Math.round(clamped * 100)}
+  aria-valuemin={0}
+  aria-valuemax={100}
+  aria-label={label}
+  style="--viz-series: {seriesColor}; --viz-fill: {percent}; --i: {index};"
+>
+  <div class="distribution-bar-fill"></div>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-distribution-bar {
+    // Cross-axis size; override per consumer via the
+    // `--distribution-bar-thickness` custom property (e.g. wide daily columns).
+    position: relative;
+    overflow: hidden;
+    color: var(--viz-series);
+
+    &.is-rounded {
+      border-radius: var(--viz-bar-radius);
+    }
+
+    &.has-track {
+      // Track tint; override per consumer via `--distribution-bar-track`.
+      background: var(--distribution-bar-track, var(--viz-track));
+    }
+
+    &[data-orientation="horizontal"] {
+      width: 100%;
+      height: var(--distribution-bar-thickness, var(--ni-8));
+    }
+
+    &[data-orientation="vertical"] {
+      width: var(--distribution-bar-thickness, var(--ni-8));
+      height: 100%;
+    }
+  }
+
+  .distribution-bar-fill {
+    position: absolute;
+    // Width/height (not scale) keeps the rounded end crisp at any fill level;
+    // the entrance grow uses transform for a one-shot juicy reveal only.
+    border-radius: inherit;
+    // Opaque sheen -> full hue. Staying opaque (no fade to transparent) keeps the
+    // track from bleeding through and muddying the fill; the white-mix start is a
+    // glossy highlight, the full hue carries the saturation.
+    background: linear-gradient(
+      var(--fill-angle),
+      color-mix(in srgb, var(--viz-series) 78%, white) 0%,
+      var(--viz-series) 70%
+    );
+  }
+
+  // High-contrast hatch overlay (shape encoding); invisible until a HC mode
+  // sets --viz-pattern-opacity to 1.
+  .distribution-bar-fill::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    opacity: var(--viz-pattern-opacity);
+    background: repeating-linear-gradient(
+      45deg,
+      transparent 0,
+      transparent 3px,
+      currentColor 3px,
+      currentColor 4.5px
+    );
+  }
+
+  .trakt-distribution-bar[data-orientation="horizontal"] .distribution-bar-fill {
+    --fill-angle: 90deg;
+    top: 0;
+    bottom: 0;
+    // Anchor + grow from the inline-start edge so the fill mirrors under RTL.
+    inset-inline-start: 0;
+    width: var(--viz-fill);
+    // transform-origin has no logical keyword; physical left only affects the
+    // brief one-shot entrance scale, so RTL impact is negligible.
+    transform-origin: left center;
+    transition:
+      width var(--viz-morph-duration) ease,
+      filter var(--transition-increment) ease;
+    animation: distribution-bar-grow-x var(--viz-enter-duration, 720ms)
+      var(--viz-enter-ease, cubic-bezier(0.16, 1, 0.3, 1)) calc(var(--i) * 60ms)
+      both;
+  }
+
+  .trakt-distribution-bar[data-orientation="vertical"] .distribution-bar-fill {
+    --fill-angle: 0deg;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: var(--viz-fill);
+    transform-origin: center bottom;
+    transition:
+      height var(--viz-morph-duration) ease,
+      filter var(--transition-increment) ease;
+    animation: distribution-bar-grow-y var(--viz-enter-duration, 720ms)
+      var(--viz-enter-ease, cubic-bezier(0.16, 1, 0.3, 1)) calc(var(--i) * 60ms)
+      both;
+  }
+
+  // Spotlight the active bar via the selectable hover treatment.
+  .trakt-distribution-bar.is-active .distribution-bar-fill {
+    @include viz-hover-active;
+  }
+
+  @keyframes distribution-bar-grow-x {
+    from {
+      transform: scaleX(0);
+      opacity: 0;
+    }
+    to {
+      transform: scaleX(1);
+      opacity: 1;
+    }
+  }
+
+  @keyframes distribution-bar-grow-y {
+    from {
+      transform: scaleY(0);
+      opacity: 0;
+    }
+    to {
+      transform: scaleY(1);
+      opacity: 1;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .distribution-bar-fill {
+      animation: none;
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/charts/LineChart.svelte
+++ b/projects/client/src/lib/components/charts/LineChart.svelte
@@ -1,0 +1,340 @@
+<script lang="ts">
+  import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
+  import { useVarToPixels } from "$lib/stores/css/useVarToPixels";
+  import { resampleSeries } from "$lib/utils/number/resampleSeries.ts";
+  import { time } from "$lib/utils/timing/time";
+  import { scaleLinear, scalePoint } from "d3";
+  import { buildAreaPath } from "./_internal/buildAreaPath.ts";
+  import { buildLinePath } from "./_internal/buildLinePath.ts";
+  import { createPlotInteraction } from "./_internal/createPlotInteraction.svelte.ts";
+  import { nearestIndex } from "./_internal/nearestIndex.ts";
+  import { nextVizId } from "./_internal/nextVizId.ts";
+  import { vizSeriesSlot } from "./vizSeriesSlot.ts";
+  import VizDefs from "./_internal/VizDefs.svelte";
+  import type { LineChartProps, TooltipArgs } from "./models/LineChartProps.ts";
+
+  // Fixed sample count keeps the rendered path's command count constant across
+  // data changes, so CSS `transition: d` can morph it instead of snapping.
+  const MORPH_SAMPLES = 48;
+  // Flip the tooltip below the point when it's near the plot top, so it isn't
+  // clipped by the chart's container.
+  const TOOLTIP_FLIP_THRESHOLD = 52;
+
+  const {
+    data,
+    tooltip,
+    seriesIndex = 0,
+    color,
+    showArea = false,
+    fillColor,
+    dotColor,
+    dotHaloColor,
+    label = "Line chart",
+    height = "var(--height-area-chart)",
+  }: LineChartProps = $props();
+
+  const prefix = nextVizId("viz-line");
+
+  const dotRadius = useVarToPixels("var(--viz-dot-radius)");
+  const { observedDimension: observedWidth, observeDimension: observeWidth } =
+    useDimensionObserver("width", time.fps(30));
+  const { observedDimension: observedHeight, observeDimension: observeHeight } =
+    useDimensionObserver("height", time.fps(30));
+
+  const slot = $derived(vizSeriesSlot(seriesIndex));
+  const lineColor = $derived(color ?? `var(--viz-${slot})`);
+  const areaFill = $derived(fillColor ?? `url(#${prefix}-area)`);
+  const resolvedDot = $derived(dotColor ?? lineColor);
+  const resolvedHalo = $derived(dotHaloColor ?? "var(--color-card-background)");
+
+  const margin = $derived(Math.max($dotRadius + 3, 5));
+  const width = $derived($observedWidth);
+  const height$ = $derived($observedHeight);
+  const innerWidth = $derived(Math.max(width - margin * 2, 0));
+
+  const values = $derived(data.map((d) => d.value));
+  const hasPlot = $derived(width > 0 && height$ > 0 && data.length > 0);
+
+  const yScale = $derived.by(() => {
+    const dataMin = Math.min(...values);
+    const dataMax = Math.max(...values);
+    const min = Math.min(dataMin, 0);
+    // Flat-span guard: a zero-height domain divides by zero and amplifies
+    // float jitter into a jumping baseline; pad it to a unit span.
+    const max = min === Math.max(dataMax, 0) ? min + 1 : Math.max(dataMax, 0);
+    return scaleLinear().domain([min, max]).range([height$ - margin, margin]);
+  });
+
+  const xScale = $derived(
+    scalePoint<number>()
+      .domain(data.map((_, index) => index))
+      .range([margin, width - margin]),
+  );
+
+  // Original data positions drive markers + hit-testing.
+  const points = $derived(
+    data.map((d, index) => ({
+      x: xScale(index) ?? margin,
+      y: yScale(d.value),
+    })),
+  );
+
+  // A fixed-length monotone resample drives the morphing line/area path.
+  const smoothPoints = $derived.by(() => {
+    const sampled = resampleSeries({ values, targetLength: MORPH_SAMPLES });
+    return sampled.map((value, index) => ({
+      x: margin + (index / (MORPH_SAMPLES - 1)) * innerWidth,
+      y: yScale(value),
+    }));
+  });
+
+  const baseline = $derived(
+    Math.min(Math.max(yScale(0), margin), height$ - margin),
+  );
+  const linePath = $derived(hasPlot ? buildLinePath(smoothPoints) : "");
+  const areaPath = $derived(
+    hasPlot ? buildAreaPath({ points: smoothPoints, baseline }) : "",
+  );
+
+  const interaction = createPlotInteraction({
+    resolveIndex: (clientX, rect) =>
+      nearestIndex({
+        positions: points.map((p) => p.x),
+        target: clientX - rect.left,
+      }),
+    count: () => data.length,
+  });
+
+  const activePoint = $derived(
+    interaction.activeIndex != null ? points[interaction.activeIndex] : null,
+  );
+  const tooltipArgs = $derived.by<TooltipArgs | null>(() => {
+    const index = interaction.activeIndex;
+    if (index == null || !data[index]) return null;
+    return { value: data[index].value, label: data[index].label, index };
+  });
+  // Screen-reader readout of the focused/active point (aria-live region).
+  const activeReadout = $derived(
+    tooltipArgs ? `${tooltipArgs.label}: ${tooltipArgs.value}` : "",
+  );
+</script>
+
+<figure
+  class="trakt-line-chart"
+  use:observeWidth
+  use:observeHeight
+  style="--line-chart-height: {height}; --viz-series: {lineColor};"
+>
+  <figcaption class="viz-caption">{label}</figcaption>
+  <div class="viz-caption" aria-live="polite">{activeReadout}</div>
+
+  <!--
+    role="img" keeps the static screen-reader summary; the chart is also a
+    keyboard widget (focusable, arrow-key scrub, aria-live readout), so the
+    tabindex + key handlers are intentional here.
+  -->
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <svg
+    {width}
+    height={height$}
+    role="img"
+    aria-label={label}
+    aria-roledescription="interactive line chart"
+    tabindex="0"
+    class="line-chart-plot"
+    onpointerdown={interaction.handlers.pointerdown}
+    onpointermove={interaction.handlers.pointermove}
+    onpointerup={interaction.handlers.pointerup}
+    onpointerleave={interaction.handlers.pointerleave}
+    onkeydown={interaction.handlers.keydown}
+    onblur={interaction.handlers.blur}
+  >
+    <VizDefs {prefix} />
+
+    {#if hasPlot}
+      {#if showArea}
+        <path
+          class="area-path"
+          d={areaPath}
+          style="d: path('{areaPath}'); fill: {areaFill};"
+        />
+        <!-- High-contrast hatch overlay; invisible until --viz-pattern-opacity > 0. -->
+        <path
+          class="area-pattern"
+          d={areaPath}
+          fill={`url(#${prefix}-pattern-${slot})`}
+          style="d: path('{areaPath}');"
+        />
+      {/if}
+
+      <path
+        class="line-path"
+        d={linePath}
+        fill="none"
+        pathLength="1"
+        style="d: path('{linePath}');"
+      />
+
+      {#if activePoint}
+        <line
+          class="active-guide"
+          x1={activePoint.x}
+          y1={margin}
+          x2={activePoint.x}
+          y2={height$ - margin}
+        />
+        <circle
+          class="active-dot"
+          cx={activePoint.x}
+          cy={activePoint.y}
+          r={$dotRadius}
+          style="fill: {resolvedDot}; stroke: {resolvedHalo};"
+        />
+      {/if}
+    {/if}
+  </svg>
+
+  {#if tooltip && tooltipArgs && activePoint}
+    <div
+      class="line-chart-tooltip"
+      class:is-pinned={interaction.pinned}
+      class:is-below={activePoint.y < TOOLTIP_FLIP_THRESHOLD}
+      style:left="{activePoint.x}px"
+      style:top="{activePoint.y}px"
+    >
+      {@render tooltip(tooltipArgs)}
+    </div>
+  {/if}
+</figure>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-line-chart {
+    position: relative;
+    width: 100%;
+    height: var(--line-chart-height);
+    margin: 0;
+    // Tint the area gradient + glow off the series color.
+    color: var(--viz-series);
+  }
+
+  .line-chart-plot {
+    display: block;
+    width: 100%;
+    height: 100%;
+    // SVG defaults to overflow:hidden, which clips the line/dot glow into a hard
+    // straight edge at the plot boundary. Let the soft bloom bleed out.
+    overflow: visible;
+    // Keep the page scrollable vertically over the plot while letting the chart
+    // own horizontal gestures; kill native tap highlight + text selection so
+    // scrubbing reads as a chart interaction, not a browser one.
+    touch-action: pan-y;
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
+    outline: none;
+
+    &:focus-visible {
+      @include viz-focus-ring;
+    }
+  }
+
+  .line-path {
+    stroke: var(--viz-series);
+    stroke-width: var(--viz-line-width);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    // Soft bloom in the series hue gives the line presence over flat strokes;
+    // the percentage is theme-driven and drops to 0 in high-contrast mode.
+    filter: drop-shadow(
+      0 1px var(--viz-glow-blur)
+        color-mix(in srgb, var(--viz-series) var(--viz-glow-percent), transparent)
+    );
+    transition:
+      d var(--viz-morph-duration) ease,
+      stroke var(--transition-increment) ease;
+    // Draw the line on first paint (pathLength normalized to 1).
+    animation: viz-line-draw var(--viz-enter-duration) var(--viz-enter-ease)
+      both;
+  }
+
+  .area-path {
+    transition: d var(--viz-morph-duration) ease;
+    animation: viz-fade-in var(--viz-enter-duration) var(--viz-enter-ease) both;
+  }
+
+  .area-pattern {
+    color: var(--viz-series);
+    opacity: var(--viz-pattern-opacity);
+    transition: d var(--viz-morph-duration) ease;
+  }
+
+  .active-guide {
+    stroke: var(--viz-axis);
+    stroke-width: var(--viz-axis-width);
+    stroke-dasharray: 3 4;
+    opacity: 0.7;
+  }
+
+  .active-dot {
+    stroke-width: var(--viz-line-width);
+    transform-box: fill-box;
+    transform-origin: center;
+    @include viz-hover-active;
+    animation: viz-pop calc(0.6 * var(--viz-enter-duration)) var(--viz-enter-ease)
+      both;
+  }
+
+  .line-chart-tooltip {
+    position: absolute;
+    pointer-events: none;
+    transform: translate(-50%, calc(-100% - var(--ni-12)));
+    z-index: var(--layer-top);
+
+    &.is-below {
+      transform: translate(-50%, var(--ni-12));
+    }
+  }
+
+  .viz-caption {
+    @include visually-hidden;
+  }
+
+  @keyframes viz-line-draw {
+    from {
+      stroke-dasharray: 1;
+      stroke-dashoffset: 1;
+    }
+    to {
+      stroke-dasharray: 1;
+      stroke-dashoffset: 0;
+    }
+  }
+
+  @keyframes viz-fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes viz-pop {
+    from {
+      transform: scale(0);
+    }
+    to {
+      transform: scale(1);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .line-path,
+    .area-path,
+    .active-dot {
+      animation: none;
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/charts/SegmentedBar.svelte
+++ b/projects/client/src/lib/components/charts/SegmentedBar.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import { ratio } from "$lib/utils/number/ratio.ts";
+  import { sum } from "$lib/utils/number/sum.ts";
+  import type { SegmentedBarProps } from "./models/SegmentedBarProps.ts";
+  import { vizSeriesSlot } from "./vizSeriesSlot.ts";
+
+  // SOT for the single proportional segmented bar (e.g. a genre breakdown):
+  // one continuous bar split into shares, each segment on the categorical viz
+  // palette with the shared glossy fill + outer-corner rounding. Labels
+  // alternate above/below so adjacent ones don't collide. Hovering a segment
+  // dims the rest, lifts it, and reveals its share via the shared tooltip.
+  const {
+    items,
+    label = "Segmented distribution",
+    minSegment = 0.04,
+  }: SegmentedBarProps = $props();
+
+  const total = $derived(sum(items.map((item) => item.value)));
+
+  const segments = $derived(
+    items.map((item, index) => {
+      const share = ratio({ value: item.value, total });
+      return {
+        ...item,
+        index,
+        slot: vizSeriesSlot(item.seriesIndex ?? index),
+        percent: Math.round(share * 100),
+        grow: item.value > 0 ? Math.max(share, minSegment) : minSegment,
+      };
+    }),
+  );
+</script>
+
+<figure class="trakt-segmented-bar" role="img" aria-label={label}>
+  <figcaption class="viz-caption">{label}</figcaption>
+
+  <div class="segmented-track">
+    {#each segments as segment (segment.label)}
+      <div
+        class="segment"
+        class:is-below={segment.index % 2 === 1}
+        style="--seg-grow: {segment.grow}; --seg-color: var(--viz-{segment.slot}); --viz-series: var(--viz-{segment.slot}); --i: {segment.index};"
+      >
+        <span class="segment-label">
+          <span class="segment-name bold ellipsis">{segment.label}</span>
+          {#if segment.sublabel}
+            <span class="segment-sub tag secondary ellipsis">
+              {segment.sublabel}
+            </span>
+          {/if}
+        </span>
+        <Tooltip content="{segment.percent}%" variant="compact" sideOffset={4}>
+          <div class="segment-fill"></div>
+        </Tooltip>
+      </div>
+    {/each}
+  </div>
+</figure>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-segmented-bar {
+    position: relative;
+    width: 100%;
+    margin: 0;
+    // Room above + below the bar for the alternating labels.
+    padding-block: var(--ni-44);
+  }
+
+  .segmented-track {
+    display: flex;
+    gap: var(--ni-2);
+    width: 100%;
+    height: var(--ni-32);
+
+    // Hovering one segment dims the rest so the focused share stands out.
+    @include for-mouse {
+      &:hover .segment:not(:hover) {
+        opacity: 0.45;
+      }
+    }
+  }
+
+  .segment {
+    position: relative;
+    flex: var(--seg-grow) 1 0;
+    min-width: 0;
+    transition: opacity var(--transition-increment) ease;
+
+    :global(.trakt-tooltip-trigger) {
+      display: block;
+      height: 100%;
+    }
+  }
+
+  .segment-fill {
+    height: 100%;
+    // Glossy sheen -> full hue, opaque, matching the rest of the suite.
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--seg-color) 80%, white) 0%,
+      var(--seg-color) 70%
+    );
+    // Square inner seams so the run reads as one bar; only the ends round.
+    border-radius: 0;
+    transition: filter var(--transition-increment) ease;
+  }
+
+  @include for-mouse {
+    .segment:hover .segment-fill {
+      @include viz-hover-active;
+    }
+  }
+
+  // Round only the run's outer corners (logical, so they mirror under RTL).
+  .segment:first-child .segment-fill {
+    border-start-start-radius: var(--viz-bar-radius);
+    border-end-start-radius: var(--viz-bar-radius);
+  }
+
+  .segment:last-child .segment-fill {
+    border-start-end-radius: var(--viz-bar-radius);
+    border-end-end-radius: var(--viz-bar-radius);
+  }
+
+  .segment-label {
+    position: absolute;
+    inset-inline-start: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-1);
+    max-width: 200%;
+    white-space: nowrap;
+    // Colored tick tying the label to its segment (inline-start so it mirrors).
+    padding-inline-start: var(--ni-6);
+    border-inline-start: var(--border-thickness-xs) solid var(--seg-color);
+    box-sizing: border-box;
+    pointer-events: none;
+  }
+
+  // Default: label sits above the bar; even-indexed segments drop below so
+  // neighbours never overlap.
+  .segment:not(.is-below) .segment-label {
+    bottom: calc(100% + var(--ni-8));
+  }
+
+  .segment.is-below .segment-label {
+    top: calc(100% + var(--ni-8));
+  }
+
+  .segment-name {
+    font-size: var(--font-size-text);
+    color: var(--color-text-primary);
+  }
+
+  .segment-sub {
+    color: var(--color-text-secondary);
+  }
+
+  .viz-caption {
+    @include visually-hidden;
+  }
+</style>

--- a/projects/client/src/lib/components/charts/Sparkline.svelte
+++ b/projects/client/src/lib/components/charts/Sparkline.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+  import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
+  import { resampleSeries } from "$lib/utils/number/resampleSeries.ts";
+  import { time } from "$lib/utils/timing/time";
+  import { scaleLinear } from "d3";
+  import { buildAreaPath } from "./_internal/buildAreaPath.ts";
+  import { buildLinePath } from "./_internal/buildLinePath.ts";
+  import { nextVizId } from "./_internal/nextVizId.ts";
+  import { vizSeriesSlot } from "./vizSeriesSlot.ts";
+  import VizDefs from "./_internal/VizDefs.svelte";
+  import type { SparklineProps } from "./models/SparklineProps.ts";
+
+  // Minimal, non-interactive trend line: shares the morph resampling + path +
+  // gradient helpers with LineChart but drops axes, tooltips, and hit-testing.
+  const MORPH_SAMPLES = 48;
+
+  const {
+    values,
+    seriesIndex = 0,
+    color,
+    showArea = false,
+    label = "Sparkline",
+    height = "var(--ni-32)",
+  }: SparklineProps = $props();
+
+  const prefix = nextVizId("viz-spark");
+
+  const { observedDimension: observedWidth, observeDimension: observeWidth } =
+    useDimensionObserver("width", time.fps(30));
+  const { observedDimension: observedHeight, observeDimension: observeHeight } =
+    useDimensionObserver("height", time.fps(30));
+
+  const slot = $derived(vizSeriesSlot(seriesIndex));
+  const lineColor = $derived(color ?? `var(--viz-${slot})`);
+
+  const margin = 2;
+  const width = $derived($observedWidth);
+  const height$ = $derived($observedHeight);
+  const innerWidth = $derived(Math.max(width - margin * 2, 0));
+  const hasPlot = $derived(width > 0 && height$ > 0 && values.length > 0);
+
+  const yScale = $derived.by(() => {
+    const min = Math.min(...values, 0);
+    const dataMax = Math.max(...values, 0);
+    const max = min === dataMax ? min + 1 : dataMax;
+    return scaleLinear().domain([min, max]).range([height$ - margin, margin]);
+  });
+
+  const points = $derived.by(() => {
+    const sampled = resampleSeries({ values, targetLength: MORPH_SAMPLES });
+    return sampled.map((value, index) => ({
+      x: margin + (index / (MORPH_SAMPLES - 1)) * innerWidth,
+      y: yScale(value),
+    }));
+  });
+
+  const baseline = $derived(
+    Math.min(Math.max(yScale(0), margin), height$ - margin),
+  );
+  const linePath = $derived(hasPlot ? buildLinePath(points) : "");
+  const areaPath = $derived(
+    hasPlot ? buildAreaPath({ points, baseline }) : "",
+  );
+</script>
+
+<figure
+  class="trakt-sparkline"
+  use:observeWidth
+  use:observeHeight
+  style="--sparkline-height: {height}; --viz-series: {lineColor};"
+>
+  <figcaption class="viz-caption">{label}</figcaption>
+
+  <svg {width} height={height$} role="img" aria-label={label}>
+    <VizDefs {prefix} />
+
+    {#if hasPlot}
+      {#if showArea}
+        <path
+          class="sparkline-area"
+          d={areaPath}
+          style="d: path('{areaPath}'); fill: url(#{prefix}-area);"
+        />
+      {/if}
+      <path
+        class="sparkline-line"
+        d={linePath}
+        fill="none"
+        pathLength="1"
+        style="d: path('{linePath}');"
+      />
+    {/if}
+  </svg>
+</figure>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-sparkline {
+    position: relative;
+    width: 100%;
+    height: var(--sparkline-height);
+    margin: 0;
+    color: var(--viz-series);
+
+    svg {
+      display: block;
+      width: 100%;
+      height: 100%;
+      // Let the line glow bleed past the edge rather than clip (SVG defaults to
+      // overflow:hidden).
+      overflow: visible;
+    }
+  }
+
+  .sparkline-line {
+    stroke: var(--viz-series);
+    stroke-width: var(--viz-line-width);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    transition: d var(--viz-morph-duration) ease;
+    animation: viz-spark-draw var(--viz-enter-duration) var(--viz-enter-ease)
+      both;
+  }
+
+  .sparkline-area {
+    transition: d var(--viz-morph-duration) ease;
+    animation: viz-spark-fade var(--viz-enter-duration) var(--viz-enter-ease)
+      both;
+  }
+
+  .viz-caption {
+    @include visually-hidden;
+  }
+
+  @keyframes viz-spark-draw {
+    from {
+      stroke-dasharray: 1;
+      stroke-dashoffset: 1;
+    }
+    to {
+      stroke-dasharray: 1;
+      stroke-dashoffset: 0;
+    }
+  }
+
+  @keyframes viz-spark-fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sparkline-line,
+    .sparkline-area {
+      animation: none;
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/charts/StackedBarChart.svelte
+++ b/projects/client/src/lib/components/charts/StackedBarChart.svelte
@@ -1,0 +1,342 @@
+<script lang="ts">
+  import { useDimensionObserver } from "$lib/stores/css/useDimensionObserver";
+  import { sum } from "$lib/utils/number/sum.ts";
+  import { time } from "$lib/utils/timing/time";
+  import { scaleBand, scaleLinear } from "d3";
+  import { createPlotInteraction } from "./_internal/createPlotInteraction.svelte.ts";
+  import { nearestIndex } from "./_internal/nearestIndex.ts";
+  import { nextVizId } from "./_internal/nextVizId.ts";
+  import { vizSeriesSlot } from "./vizSeriesSlot.ts";
+  import VizDefs from "./_internal/VizDefs.svelte";
+  import type {
+    StackedBarChartProps,
+    StackedTooltipArgs,
+  } from "./models/StackedBarChartProps.ts";
+
+  const LABEL_BAND = 18;
+  // Flip the tooltip below a tall column's top so it isn't clipped by the
+  // chart's container.
+  const TOOLTIP_FLIP_THRESHOLD = 52;
+
+  const {
+    data,
+    seriesLabels,
+    tickLabels,
+    tooltip,
+    barSpacing = 2,
+    label = "Stacked bar chart",
+    height = "var(--height-bar-chart)",
+  }: StackedBarChartProps = $props();
+
+  const prefix = nextVizId("viz-stack");
+
+  const { observedDimension: observedWidth, observeDimension: observeWidth } =
+    useDimensionObserver("width", time.fps(30));
+  const { observedDimension: observedHeight, observeDimension: observeHeight } =
+    useDimensionObserver("height", time.fps(30));
+
+  const width = $derived($observedWidth);
+  const height$ = $derived($observedHeight);
+  const margin = 3;
+  const labelBand = $derived(tickLabels ? LABEL_BAND : 0);
+  const baseline = $derived(Math.max(height$ - margin - labelBand, 0));
+  const innerWidth = $derived(Math.max(width - margin * 2, 0));
+
+  const totals = $derived(data.map((d) => sum(d.values)));
+  const maxTotal = $derived(Math.max(...totals, 0));
+  const hasPlot = $derived(width > 0 && height$ > 0 && data.length > 0);
+
+  const xScale = $derived.by(() => {
+    const step = data.length > 0 ? innerWidth / data.length : innerWidth;
+    const padding = step > 0 ? Math.min(barSpacing / step, 0.9) : 0;
+    return scaleBand<number>()
+      .domain(data.map((_, index) => index))
+      .range([margin, width - margin])
+      .paddingInner(padding)
+      .paddingOuter(padding / 2);
+  });
+
+  const yScale = $derived.by(() => {
+    // Flat-span guard so an all-zero dataset renders flat, not NaN.
+    const max = maxTotal === 0 ? 1 : maxTotal;
+    return scaleLinear().domain([0, max]).range([baseline, margin]);
+  });
+
+  const columns = $derived(
+    data.map((datum, index) => {
+      const x = xScale(index) ?? margin;
+      const bandwidth = xScale.bandwidth();
+      let cumulative = 0;
+      const segments = datum.values.map((value, series) => {
+        const yBottom = yScale(cumulative);
+        cumulative += value;
+        const yTop = yScale(cumulative);
+        return {
+          series,
+          slot: vizSeriesSlot(series),
+          y: yTop,
+          height: Math.max(yBottom - yTop, 0),
+        };
+      });
+      // Column extent (top of the top segment -> baseline) for the single
+      // full-stack sheen overlay.
+      const top = yScale(cumulative);
+      return {
+        x,
+        width: bandwidth,
+        center: x + bandwidth / 2,
+        top,
+        height: Math.max(baseline - top, 0),
+        segments,
+      };
+    }),
+  );
+
+  const interaction = createPlotInteraction({
+    resolveIndex: (clientX, rect) =>
+      nearestIndex({
+        positions: columns.map((column) => column.center),
+        target: clientX - rect.left,
+      }),
+    count: () => data.length,
+  });
+
+  const ticks = $derived(
+    (tickLabels ?? []).map((text, index) => ({
+      text,
+      center: columns[index]?.center ?? 0,
+    })).filter((tick) => tick.text !== ""),
+  );
+
+  const tooltipArgs = $derived.by<StackedTooltipArgs | null>(() => {
+    const index = interaction.activeIndex;
+    const datum = index != null ? data[index] : undefined;
+    if (index == null || !datum) return null;
+    return {
+      label: datum.label,
+      index,
+      total: totals[index] ?? 0,
+      segments: datum.values.map((value, series) => ({
+        value,
+        seriesIndex: series,
+        label: seriesLabels?.[series] ?? `Series ${series + 1}`,
+      })),
+    };
+  });
+  const activeColumn = $derived(
+    interaction.activeIndex != null ? columns[interaction.activeIndex] : null,
+  );
+  // Screen-reader readout of the focused/active column (aria-live region).
+  const activeReadout = $derived(
+    tooltipArgs ? `${tooltipArgs.label}: ${tooltipArgs.total}` : "",
+  );
+</script>
+
+<figure
+  class="trakt-stacked-bar-chart"
+  use:observeWidth
+  use:observeHeight
+  style="--stacked-bar-chart-height: {height};"
+>
+  <figcaption class="viz-caption">{label}</figcaption>
+  <div class="viz-caption" aria-live="polite">{activeReadout}</div>
+
+  <!--
+    role="img" keeps the static screen-reader summary; the chart is also a
+    keyboard widget (focusable, arrow-key scrub, aria-live readout), so the
+    tabindex + key handlers are intentional here.
+  -->
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <svg
+    {width}
+    height={height$}
+    role="img"
+    aria-label={label}
+    aria-roledescription="interactive stacked bar chart"
+    tabindex="0"
+    class="stacked-bar-chart-plot"
+    onpointerdown={interaction.handlers.pointerdown}
+    onpointermove={interaction.handlers.pointermove}
+    onpointerup={interaction.handlers.pointerup}
+    onpointerleave={interaction.handlers.pointerleave}
+    onkeydown={interaction.handlers.keydown}
+    onblur={interaction.handlers.blur}
+  >
+    <VizDefs {prefix} />
+
+    {#if hasPlot}
+      {#each columns as column, index (data[index].label)}
+        <g
+          class="column"
+          class:is-active={index === interaction.activeIndex}
+          style="--i: {index};"
+        >
+          {#each column.segments as segment (segment.series)}
+            <rect
+              class="segment-fill"
+              x={column.x}
+              y={segment.y}
+              width={column.width}
+              height={segment.height}
+              style="y: {segment.y}px; height: {segment.height}px; fill: var(--viz-{segment.slot}); --viz-series: var(--viz-{segment.slot});"
+            />
+            <rect
+              class="segment-pattern"
+              x={column.x}
+              y={segment.y}
+              width={column.width}
+              height={segment.height}
+              fill={`url(#${prefix}-pattern-${segment.slot})`}
+              style="y: {segment.y}px; height: {segment.height}px; color: var(--viz-{segment.slot});"
+            />
+          {/each}
+          <!--
+            One sheen across the whole stack = a single light source, so the
+            column reads as one unit instead of each segment looking self-lit.
+          -->
+          <rect
+            class="column-sheen"
+            x={column.x}
+            y={column.top}
+            width={column.width}
+            height={column.height}
+            fill={`url(#${prefix}-sheen)`}
+            style="y: {column.top}px; height: {column.height}px;"
+            pointer-events="none"
+          />
+        </g>
+      {/each}
+
+      {#each ticks as tick (tick.center)}
+        <text
+          class="stacked-bar-tick"
+          x={tick.center}
+          y={height$ - margin}
+          text-anchor="middle"
+        >
+          {tick.text}
+        </text>
+      {/each}
+    {/if}
+  </svg>
+
+  {#if tooltip && tooltipArgs && activeColumn}
+    <div
+      class="stacked-bar-chart-tooltip"
+      class:is-pinned={interaction.pinned}
+      class:is-below={(activeColumn.segments.at(-1)?.y ?? 0) <
+        TOOLTIP_FLIP_THRESHOLD}
+      style:left="{activeColumn.center}px"
+      style:top="{activeColumn.segments.at(-1)?.y ?? 0}px"
+    >
+      {@render tooltip(tooltipArgs)}
+    </div>
+  {/if}
+</figure>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-stacked-bar-chart {
+    position: relative;
+    width: 100%;
+    height: var(--stacked-bar-chart-height);
+    margin: 0;
+  }
+
+  .stacked-bar-chart-plot {
+    display: block;
+    width: 100%;
+    height: 100%;
+    // Let the active column glow bleed past the plot edge instead of clipping it
+    // to a hard line (SVG defaults to overflow:hidden).
+    overflow: visible;
+    touch-action: pan-y;
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
+    outline: none;
+
+    &:focus-visible {
+      @include viz-focus-ring;
+    }
+  }
+
+  .column {
+    // Round only the stack's outer silhouette (top of the top segment + bottom
+    // of the bottom segment); inner segment seams stay square so the stack reads
+    // as one continuous bar, like a single rounded column.
+    clip-path: inset(0 round var(--viz-bar-radius));
+    // Rise the whole stack from the baseline on first paint, staggered.
+    transform-box: fill-box;
+    transform-origin: bottom;
+    animation: viz-stack-rise var(--viz-enter-duration) var(--viz-enter-ease)
+      calc(var(--i) * 45ms) both;
+  }
+
+  .segment-fill {
+    transition:
+      y var(--viz-morph-duration) ease,
+      height var(--viz-morph-duration) ease,
+      fill-opacity var(--transition-increment) ease,
+      filter var(--transition-increment) ease;
+    fill-opacity: 0.78;
+  }
+
+  .segment-pattern {
+    opacity: var(--viz-pattern-opacity);
+    transition:
+      y var(--viz-morph-duration) ease,
+      height var(--viz-morph-duration) ease;
+  }
+
+  .column-sheen {
+    transition:
+      y var(--viz-morph-duration) ease,
+      height var(--viz-morph-duration) ease;
+  }
+
+  // Spotlight the hovered/pinned column via the selectable hover treatment.
+  .column.is-active .segment-fill {
+    fill-opacity: 1;
+    @include viz-hover-active;
+  }
+
+  .stacked-bar-tick {
+    fill: var(--viz-label);
+    font-size: var(--font-size-tag);
+    text-anchor: middle;
+  }
+
+  .stacked-bar-chart-tooltip {
+    position: absolute;
+    pointer-events: none;
+    transform: translate(-50%, calc(-100% - var(--ni-8)));
+    z-index: var(--layer-top);
+
+    &.is-below {
+      transform: translate(-50%, var(--ni-8));
+    }
+  }
+
+  .viz-caption {
+    @include visually-hidden;
+  }
+
+  @keyframes viz-stack-rise {
+    from {
+      transform: scaleY(0);
+      opacity: 0;
+    }
+    to {
+      transform: scaleY(1);
+      opacity: 1;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .column {
+      animation: none;
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/charts/_internal/VizDefs.svelte
+++ b/projects/client/src/lib/components/charts/_internal/VizDefs.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  // Shared SVG <defs> for every chart primitive: per-slot vertical fade
+  // gradients (the "juicy" top-bright -> bottom-faded look), a generic
+  // currentColor area gradient for lines/areas, and the high-contrast hatch
+  // patterns. Ids are namespaced by `prefix` so charts never collide.
+  //
+  // stop-color/stop-opacity are CSS properties, so they resolve the --viz-*
+  // tokens directly - no hardcoded colors leak in here.
+  const { prefix }: { prefix: string } = $props();
+
+  const slots = [1, 2, 3, 4, 5, 6, 7, 8];
+  // Distinct hatch angle per slot for high-contrast shape encoding.
+  const patternAngles = [0, 45, 90, 135, 22.5, 67.5, 112.5, 157.5];
+  const patternSize = 6;
+</script>
+
+<defs>
+  {#each slots as slot (slot)}
+    <!--
+      Bar/column fill: glossy lighter crest -> full saturated hue, fully opaque.
+      Staying opaque (no fade toward transparent) stops the background bleeding
+      through and keeps the fill rich instead of washed-out/cheap.
+    -->
+    <linearGradient id={`${prefix}-fill-${slot}`} x1="0" y1="0" x2="0" y2="1">
+      <stop
+        offset="0%"
+        style={`stop-color: color-mix(in srgb, var(--viz-${slot}) 78%, white); stop-opacity: 1;`}
+      />
+      <stop
+        offset="100%"
+        style={`stop-color: var(--viz-${slot}); stop-opacity: 1;`}
+      />
+    </linearGradient>
+
+    <pattern
+      id={`${prefix}-pattern-${slot}`}
+      width={patternSize}
+      height={patternSize}
+      patternUnits="userSpaceOnUse"
+      patternTransform={`rotate(${patternAngles[slot - 1]})`}
+    >
+      <line
+        x1="0"
+        y1="0"
+        x2="0"
+        y2={patternSize}
+        stroke="currentColor"
+        style="stroke-width: var(--viz-pattern-stroke-width);"
+      />
+    </pattern>
+  {/each}
+
+  <!-- Single top-down sheen, overlaid once across a whole stacked column so it
+       reads as one lit unit rather than per-segment self-lit slices. -->
+  <linearGradient id={`${prefix}-sheen`} x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" style="stop-color: #fff; stop-opacity: 0.22;" />
+    <stop offset="45%" style="stop-color: #fff; stop-opacity: 0.04;" />
+    <stop offset="100%" style="stop-color: #fff; stop-opacity: 0;" />
+  </linearGradient>
+
+  <!-- Generic area fade keyed off the referencing element's `color`. -->
+  <linearGradient id={`${prefix}-area`} x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" style="stop-color: currentColor; stop-opacity: 0.55;" />
+    <stop offset="60%" style="stop-color: currentColor; stop-opacity: 0.2;" />
+    <stop
+      offset="100%"
+      style="stop-color: currentColor; stop-opacity: var(--viz-fade-floor);"
+    />
+  </linearGradient>
+</defs>

--- a/projects/client/src/lib/components/charts/_internal/buildAreaPath.ts
+++ b/projects/client/src/lib/components/charts/_internal/buildAreaPath.ts
@@ -1,0 +1,26 @@
+import { area, curveMonotoneX } from 'd3';
+
+type Point = { x: number; y: number };
+
+type BuildAreaPathProps = {
+  points: ReadonlyArray<Point>;
+  /** Plot-space y of the area's flat base (usually the x-axis). */
+  baseline: number;
+};
+
+/**
+ * SVG path `d` for a filled area between `baseline` and a smooth line through
+ * `points`. Shares the monotone curve with {@link buildLinePath} so a line and
+ * its area fill trace the same crest.
+ */
+export function buildAreaPath(
+  { points, baseline }: BuildAreaPathProps,
+): string {
+  const generator = area<Point>()
+    .x((point) => point.x)
+    .y0(baseline)
+    .y1((point) => point.y)
+    .curve(curveMonotoneX);
+
+  return generator([...points]) ?? '';
+}

--- a/projects/client/src/lib/components/charts/_internal/buildLinePath.ts
+++ b/projects/client/src/lib/components/charts/_internal/buildLinePath.ts
@@ -1,0 +1,17 @@
+import { curveMonotoneX, line } from 'd3';
+
+type Point = { x: number; y: number };
+
+/**
+ * SVG path `d` for a smooth (monotone) line through `points`. d3 is used purely
+ * for the path math; rendering stays in Svelte. Monotone curvature avoids the
+ * overshoot a plain cubic adds between points.
+ */
+export function buildLinePath(points: ReadonlyArray<Point>): string {
+  const generator = line<Point>()
+    .x((point) => point.x)
+    .y((point) => point.y)
+    .curve(curveMonotoneX);
+
+  return generator([...points]) ?? '';
+}

--- a/projects/client/src/lib/components/charts/_internal/createPlotInteraction.svelte.ts
+++ b/projects/client/src/lib/components/charts/_internal/createPlotInteraction.svelte.ts
@@ -1,0 +1,161 @@
+type IndexResolver = (clientX: number, rect: DOMRect) => number;
+
+type PlotInteractionConfig = {
+  /** Map a pointer's client x (and the plot rect) onto a data-point index. */
+  resolveIndex: IndexResolver;
+  /** Current data-point count, for clamping keyboard navigation. */
+  count: () => number;
+};
+
+/**
+ * Shared pointer plumbing for the chart primitives, covering the mobile a11y
+ * contract:
+ *
+ * - Mouse: hover scrubs, leaving the plot clears the readout.
+ * - Touch: a tap pins a tooltip; dragging scrubs the pin; tapping the pinned
+ *   point dismisses it; tapping elsewhere moves it.
+ * - The browser fires a synthetic `pointerleave` after a touch tap - we ignore
+ *   non-mouse leaves so a pinned tooltip survives it.
+ * - Keyboard: arrow keys / Home / End scrub the active point, Enter or Space
+ *   pins it, Escape clears, and blurring the plot clears an unpinned readout.
+ *
+ * Returns reactive getters plus a ready-to-spread handler bag so every chart
+ * gets identical behaviour without forking it.
+ */
+export function createPlotInteraction(
+  { resolveIndex, count }: PlotInteractionConfig,
+) {
+  let activeIndex = $state<number | null>(null);
+  let pinned = $state(false);
+  let dragging = $state(false);
+
+  const rectOf = (event: PointerEvent): DOMRect =>
+    (event.currentTarget as Element).getBoundingClientRect();
+
+  function pointerdown(event: PointerEvent) {
+    const index = resolveIndex(event.clientX, rectOf(event));
+
+    if (event.pointerType !== 'mouse') {
+      // Tap the already-pinned point to dismiss; otherwise (re)pin here.
+      if (pinned && activeIndex === index) {
+        pinned = false;
+        activeIndex = null;
+        return;
+      }
+      pinned = true;
+    }
+
+    dragging = true;
+    activeIndex = index;
+  }
+
+  function pointermove(event: PointerEvent) {
+    // Touch only scrubs while a finger is down; mouse tracks freely.
+    if (event.pointerType !== 'mouse' && !dragging) {
+      return;
+    }
+
+    activeIndex = resolveIndex(event.clientX, rectOf(event));
+  }
+
+  function pointerup() {
+    dragging = false;
+  }
+
+  function pointerleave(event: PointerEvent) {
+    // Synthetic touch leaves must not vanish a pinned tooltip.
+    if (event.pointerType !== 'mouse') {
+      return;
+    }
+
+    dragging = false;
+    activeIndex = null;
+  }
+
+  function step(delta: number) {
+    const total = count();
+    if (total <= 0) {
+      return;
+    }
+    const current = activeIndex ?? (delta > 0 ? -1 : total);
+    activeIndex = Math.min(Math.max(current + delta, 0), total - 1);
+  }
+
+  function keydown(event: KeyboardEvent) {
+    const total = count();
+    if (total <= 0) {
+      return;
+    }
+
+    // Horizontal arrows follow the reading direction; mirror them in RTL so
+    // ArrowRight always moves toward the visual start. Vertical arrows don't flip.
+    const target = event.currentTarget;
+    const rtl = target instanceof Element &&
+      getComputedStyle(target).direction === 'rtl';
+    const forward = rtl ? -1 : 1;
+
+    switch (event.key) {
+      case 'ArrowRight':
+        step(forward);
+        break;
+      case 'ArrowUp':
+        step(1);
+        break;
+      case 'ArrowLeft':
+        step(-forward);
+        break;
+      case 'ArrowDown':
+        step(-1);
+        break;
+      case 'Home':
+        activeIndex = 0;
+        break;
+      case 'End':
+        activeIndex = total - 1;
+        break;
+      case 'Enter':
+      case ' ':
+        if (activeIndex == null) {
+          activeIndex = 0;
+        }
+        pinned = !pinned;
+        break;
+      case 'Escape':
+        activeIndex = null;
+        pinned = false;
+        break;
+      default:
+        return;
+    }
+
+    // We handled it - stop the key from scrolling the page.
+    event.preventDefault();
+  }
+
+  function blur() {
+    // Leaving the plot clears a keyboard/hover readout unless it's pinned.
+    if (!pinned) {
+      activeIndex = null;
+    }
+  }
+
+  return {
+    get activeIndex() {
+      return activeIndex;
+    },
+    get isActive() {
+      return activeIndex !== null;
+    },
+    get pinned() {
+      return pinned;
+    },
+    handlers: {
+      pointerdown,
+      pointermove,
+      pointerup,
+      pointerleave,
+      keydown,
+      blur,
+    },
+  };
+}

--- a/projects/client/src/lib/components/charts/_internal/nearestIndex.spec.ts
+++ b/projects/client/src/lib/components/charts/_internal/nearestIndex.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { nearestIndex } from './nearestIndex.ts';
+
+describe('util: nearestIndex', () => {
+  const positions = [0, 10, 20, 30];
+
+  it('should find the closest position', () => {
+    expect(nearestIndex({ positions, target: 12 })).toBe(1);
+    expect(nearestIndex({ positions, target: 26 })).toBe(3);
+  });
+
+  it('should clamp to the ends', () => {
+    expect(nearestIndex({ positions, target: -5 })).toBe(0);
+    expect(nearestIndex({ positions, target: 999 })).toBe(3);
+  });
+
+  it('should pick the lower index on a tie', () => {
+    expect(nearestIndex({ positions, target: 15 })).toBe(1);
+  });
+
+  it('should return -1 for an empty set', () => {
+    expect(nearestIndex({ positions: [], target: 5 })).toBe(-1);
+  });
+});

--- a/projects/client/src/lib/components/charts/_internal/nearestIndex.ts
+++ b/projects/client/src/lib/components/charts/_internal/nearestIndex.ts
@@ -1,0 +1,22 @@
+type NearestIndexProps = {
+  positions: ReadonlyArray<number>;
+  target: number;
+};
+
+/**
+ * Index of the position closest to `target` (used to map a pointer x onto the
+ * nearest plotted point). Returns `-1` for an empty set. On ties the lower
+ * index wins, keeping scrubbing deterministic.
+ */
+export function nearestIndex({ positions, target }: NearestIndexProps): number {
+  if (positions.length === 0) {
+    return -1;
+  }
+
+  return positions.reduce((best, position, index) => {
+    const closest = positions[best] ?? Infinity;
+    return Math.abs(position - target) < Math.abs(closest - target)
+      ? index
+      : best;
+  }, 0);
+}

--- a/projects/client/src/lib/components/charts/_internal/nextVizId.ts
+++ b/projects/client/src/lib/components/charts/_internal/nextVizId.ts
@@ -1,0 +1,13 @@
+let counter = 0;
+
+/**
+ * Stable, incrementing id for chart `<defs>` (gradient/pattern/filter) so the
+ * `url(#...)` references resolve uniquely per instance. Unlike
+ * `crypto.randomUUID()` this never throws in non-secure contexts (HTTP) and is
+ * deterministic, and the def id + its reference are derived from the same value
+ * so they always match within a render.
+ */
+export function nextVizId(prefix: string): string {
+  counter += 1;
+  return `${prefix}-${counter}`;
+}

--- a/projects/client/src/lib/components/charts/models/AreaChartProps.ts
+++ b/projects/client/src/lib/components/charts/models/AreaChartProps.ts
@@ -1,16 +1,20 @@
 import type { Snippet } from 'svelte';
+import type { VizPoint } from './VizPoint.ts';
+import type { VizTooltipArgs } from './VizTooltipArgs.ts';
 
-type AreaChartData = {
-  value: number;
-  label: string;
-};
+type AreaChartData = VizPoint;
 
-export type TooltipArgs = { value: number; label: string; index: number };
+export type TooltipArgs = VizTooltipArgs;
 
 export type AreaChartProps = {
   data: AreaChartData[];
   tooltip?: Snippet<[TooltipArgs]>;
-  /** CSS color used for the line stroke. */
+  /**
+   * Zero-based series slot driving color + hatch pattern via `--viz-*` tokens.
+   * Ignored for any color explicitly supplied below.
+   */
+  seriesIndex?: number;
+  /** CSS color used for the line stroke. Defaults to the seriesIndex token. */
   lineColor?: string;
   /** CSS color used to fill the area beneath the line. */
   fillColor?: string;
@@ -18,4 +22,8 @@ export type AreaChartProps = {
   dotColor?: string;
   /** CSS color used for the hover marker dot's outer halo. */
   dotHaloColor?: string;
+  /** Accessible chart summary; rendered as a screen-reader figcaption. */
+  label?: string;
+  /** CSS height for the plot. Defaults to `var(--height-area-chart)`. */
+  height?: string;
 };

--- a/projects/client/src/lib/components/charts/models/BarChartProps.ts
+++ b/projects/client/src/lib/components/charts/models/BarChartProps.ts
@@ -1,16 +1,27 @@
 import type { Snippet } from 'svelte';
+import type { VizPoint } from './VizPoint.ts';
+import type { VizTooltipArgs } from './VizTooltipArgs.ts';
 
-type BarChartData = {
-  value: number;
-  label: string;
-};
+type BarChartData = VizPoint;
 
-export type TooltipArgs = { value: number; label: string; index: number };
+export type TooltipArgs = VizTooltipArgs;
 
 export type BarChartProps = {
   data: BarChartData[];
+  /** Sparse labels rendered under the axis; empty strings are skipped. */
   tickLabels?: string[];
   tooltip?: Snippet<[TooltipArgs]>;
   /** Pixel gap between bars. Defaults to 2px. */
   barSpacing?: number;
+  /** Zero-based series slot driving color + hatch pattern via `--viz-*`. */
+  seriesIndex?: number;
+  /**
+   * Highlight the tallest bar at full strength and dim the rest. Defaults to
+   * true; set false for an evenly-weighted distribution.
+   */
+  highlightPeak?: boolean;
+  /** Accessible chart summary; rendered as a screen-reader figcaption. */
+  label?: string;
+  /** CSS height for the plot. Defaults to `var(--height-bar-chart)`. */
+  height?: string;
 };

--- a/projects/client/src/lib/components/charts/models/BubbleChartProps.ts
+++ b/projects/client/src/lib/components/charts/models/BubbleChartProps.ts
@@ -15,4 +15,6 @@ export type BubbleChartTooltipArgs = {
 export type BubbleChartProps = {
   items: BubbleChartItem[];
   tooltip?: Snippet<[BubbleChartTooltipArgs]>;
+  /** Accessible chart summary; rendered as a screen-reader figcaption. */
+  label?: string;
 };

--- a/projects/client/src/lib/components/charts/models/DistributionBarProps.ts
+++ b/projects/client/src/lib/components/charts/models/DistributionBarProps.ts
@@ -1,0 +1,25 @@
+export type DistributionBarProps = {
+  /** Fill level, 0..1. Values outside the range are clamped. */
+  fraction: number;
+  /** Fill axis. `horizontal` grows left-to-right, `vertical` bottom-to-top. */
+  orientation?: 'horizontal' | 'vertical';
+  /** Zero-based palette slot driving color + hatch pattern via `--viz-*`. */
+  seriesIndex?: number;
+  /** Explicit CSS color override; defaults to the `seriesIndex` viz token. */
+  color?: string;
+  /** Spotlight this bar (full strength + glow) - e.g. hovered/selected row. */
+  active?: boolean;
+  /** Render the muted track behind the fill. Defaults to true. */
+  track?: boolean;
+  /** Round the fill + track ends. Defaults to true. */
+  rounded?: boolean;
+  /**
+   * Minimum visible fill as a fraction, so a non-zero value never collapses to
+   * an invisible sliver. Defaults to 0 (no floor).
+   */
+  minVisible?: number;
+  /** Stagger index for the entrance animation (later bars animate later). */
+  index?: number;
+  /** Accessible label for the progressbar role. */
+  label?: string;
+};

--- a/projects/client/src/lib/components/charts/models/LineChartProps.ts
+++ b/projects/client/src/lib/components/charts/models/LineChartProps.ts
@@ -1,0 +1,31 @@
+import type { Snippet } from 'svelte';
+import type { VizPoint } from './VizPoint.ts';
+import type { VizTooltipArgs } from './VizTooltipArgs.ts';
+
+export type LineChartData = VizPoint;
+
+export type TooltipArgs = VizTooltipArgs;
+
+export type LineChartProps = {
+  data: LineChartData[];
+  tooltip?: Snippet<[TooltipArgs]>;
+  /**
+   * Zero-based series slot driving color + high-contrast hatch pattern via the
+   * `--viz-*` tokens. Wraps past eight series. Ignored when `color` is set.
+   */
+  seriesIndex?: number;
+  /** Explicit CSS color override; defaults to the `seriesIndex` viz token. */
+  color?: string;
+  /** Fill the area beneath the line (turns the primitive into an area chart). */
+  showArea?: boolean;
+  /** CSS color for the area fill; defaults to a `color` vertical fade gradient. */
+  fillColor?: string;
+  /** CSS color for the hover/pin marker dot. Defaults to `color`. */
+  dotColor?: string;
+  /** CSS color for the marker dot's outer halo. */
+  dotHaloColor?: string;
+  /** Accessible chart summary; also rendered as the screen-reader figcaption. */
+  label?: string;
+  /** CSS height for the plot. Defaults to `var(--height-area-chart)`. */
+  height?: string;
+};

--- a/projects/client/src/lib/components/charts/models/SegmentedBarProps.ts
+++ b/projects/client/src/lib/components/charts/models/SegmentedBarProps.ts
@@ -1,0 +1,21 @@
+export type SegmentedBarItem = {
+  /** Primary label (e.g. "Fantasy"). */
+  label: string;
+  /** Magnitude; segment width is its share of the total. */
+  value: number;
+  /** Optional secondary line (e.g. "15 shows"). */
+  sublabel?: string;
+  /** Palette slot override; defaults to the item's position. */
+  seriesIndex?: number;
+};
+
+export type SegmentedBarProps = {
+  items: SegmentedBarItem[];
+  /** Accessible summary; rendered as a screen-reader figcaption. */
+  label?: string;
+  /**
+   * Minimum segment width as a fraction so small-but-nonzero categories stay
+   * visible + labelable. Defaults to 0.04.
+   */
+  minSegment?: number;
+};

--- a/projects/client/src/lib/components/charts/models/SparklineProps.ts
+++ b/projects/client/src/lib/components/charts/models/SparklineProps.ts
@@ -1,0 +1,13 @@
+export type SparklineProps = {
+  values: number[];
+  /** Zero-based series slot driving color via `--viz-*`. Ignored if `color` set. */
+  seriesIndex?: number;
+  /** Explicit CSS color override; defaults to the `seriesIndex` viz token. */
+  color?: string;
+  /** Fill the area beneath the line with a vertical fade. */
+  showArea?: boolean;
+  /** Accessible summary; rendered as a screen-reader figcaption. */
+  label?: string;
+  /** CSS height for the sparkline. Defaults to `var(--ni-32)`. */
+  height?: string;
+};

--- a/projects/client/src/lib/components/charts/models/StackedBarChartProps.ts
+++ b/projects/client/src/lib/components/charts/models/StackedBarChartProps.ts
@@ -1,0 +1,28 @@
+import type { Snippet } from 'svelte';
+
+export type StackedBarChartData = {
+  label: string;
+  /** One value per series; index aligns with `seriesLabels`. */
+  values: number[];
+};
+
+export type StackedTooltipArgs = {
+  label: string;
+  index: number;
+  total: number;
+  segments: { value: number; seriesIndex: number; label: string }[];
+};
+
+export type StackedBarChartProps = {
+  data: StackedBarChartData[];
+  /** Human label per series; index aligns with each datum's `values`. */
+  seriesLabels?: string[];
+  tickLabels?: string[];
+  tooltip?: Snippet<[StackedTooltipArgs]>;
+  /** Pixel gap between bars. Defaults to 2px. */
+  barSpacing?: number;
+  /** Accessible chart summary; rendered as a screen-reader figcaption. */
+  label?: string;
+  /** CSS height for the plot. Defaults to `var(--height-bar-chart)`. */
+  height?: string;
+};

--- a/projects/client/src/lib/components/charts/models/VizPoint.ts
+++ b/projects/client/src/lib/components/charts/models/VizPoint.ts
@@ -1,0 +1,10 @@
+/**
+ * The atomic unit of every value-over-category visualization: a single
+ * labelled value. Bar, line, area, sparkline and distribution primitives all
+ * speak `VizPoint[]`, so a dataset is interchangeable across them - swap a
+ * `<BarChart>` for a `<LineChart>` without reshaping the data.
+ */
+export type VizPoint = {
+  value: number;
+  label: string;
+};

--- a/projects/client/src/lib/components/charts/models/VizSeries.ts
+++ b/projects/client/src/lib/components/charts/models/VizSeries.ts
@@ -1,0 +1,16 @@
+import type { VizPoint } from './VizPoint.ts';
+
+/**
+ * A named collection of {@link VizPoint}s - the multi-series shape consumed by
+ * stacked/grouped primitives. `seriesIndex` ties the series to a `--viz-{slot}`
+ * color so the same series reads consistently across every chart it appears in.
+ */
+export type VizSeries = {
+  /** Stable identity for keyed rendering; falls back to `label`. */
+  id?: string;
+  /** Human-readable series name (legend, tooltip, a11y). */
+  label?: string;
+  /** Zero-based palette slot driving color + hatch pattern. */
+  seriesIndex?: number;
+  points: VizPoint[];
+};

--- a/projects/client/src/lib/components/charts/models/VizTooltipArgs.ts
+++ b/projects/client/src/lib/components/charts/models/VizTooltipArgs.ts
@@ -1,0 +1,9 @@
+/**
+ * Payload handed to every primitive's tooltip snippet. Uniform across charts so
+ * a tooltip authored for one viz drops into another unchanged.
+ */
+export type VizTooltipArgs = {
+  value: number;
+  label: string;
+  index: number;
+};

--- a/projects/client/src/lib/components/charts/vizSeriesSlot.spec.ts
+++ b/projects/client/src/lib/components/charts/vizSeriesSlot.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { vizSeriesSlot } from './vizSeriesSlot.ts';
+
+describe('util: vizSeriesSlot', () => {
+  it('should map index 0 to slot 1', () => {
+    expect(vizSeriesSlot(0)).toBe(1);
+  });
+
+  it('should map index 7 to slot 8', () => {
+    expect(vizSeriesSlot(7)).toBe(8);
+  });
+
+  it('should wrap past eight series', () => {
+    expect(vizSeriesSlot(8)).toBe(1);
+    expect(vizSeriesSlot(9)).toBe(2);
+  });
+
+  it('should wrap negative indices', () => {
+    expect(vizSeriesSlot(-1)).toBe(8);
+  });
+
+  it('should always land within 1..8', () => {
+    for (let i = 0; i < 100; i++) {
+      const slot = vizSeriesSlot(i);
+      expect(slot).toBeGreaterThanOrEqual(1);
+      expect(slot).toBeLessThanOrEqual(8);
+    }
+  });
+});

--- a/projects/client/src/lib/components/charts/vizSeriesSlot.ts
+++ b/projects/client/src/lib/components/charts/vizSeriesSlot.ts
@@ -1,0 +1,12 @@
+const VIZ_SLOT_COUNT = 8;
+
+/**
+ * Map a zero-based series index onto a `1..8` viz palette slot, wrapping for
+ * series beyond eight. Both the color token (`var(--viz-{slot})`) and the
+ * high-contrast hatch pattern id derive from this slot, so series colour and
+ * shape stay in lockstep.
+ */
+export function vizSeriesSlot(index: number): number {
+  const wrapped = ((index % VIZ_SLOT_COUNT) + VIZ_SLOT_COUNT) % VIZ_SLOT_COUNT;
+  return wrapped + 1;
+}

--- a/projects/client/src/lib/components/kpi/KpiTile.svelte
+++ b/projects/client/src/lib/components/kpi/KpiTile.svelte
@@ -22,7 +22,7 @@
     <div class="kpi-icon">{@render icon()}</div>
   {/if}
 
-  <p class="kpi-label tag secondary uppercase ellipsis">{label}</p>
+  <p class="kpi-label small secondary ellipsis">{label}</p>
 
   <div class="kpi-value">
     {#if tooltip}
@@ -80,10 +80,15 @@
     flex-wrap: wrap;
     align-items: center;
     gap: var(--gap-xxs);
-    font-size: var(--kpi-value-size);
-    line-height: 1.05;
-    font-weight: 700;
     min-width: 0;
+
+    &,
+    :global(span),
+    :global(p) {
+      font-size: var(--kpi-value-size);
+      line-height: 1.05;
+      font-weight: 700;
+    }
 
     // Split value parts (e.g. "2h" "11m") inherit the headline size.
     :global(.trakt-tooltip-trigger) {

--- a/projects/client/src/lib/components/kpi/KpiTile.svelte
+++ b/projects/client/src/lib/components/kpi/KpiTile.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import type { KpiTileProps } from "./KpiTileProps.ts";
+
+  // SOT KPI tile: the "caption + headline value + optional delta" pattern that
+  // stat cards across stats/profile/yir/rating each re-implemented. Purely
+  // presentational and card-agnostic - wrap in <Card> at the call site when a
+  // surface is needed.
+  const {
+    label,
+    children,
+    delta,
+    icon,
+    tooltip,
+    size = "normal",
+    align = "start",
+  }: KpiTileProps = $props();
+</script>
+
+<div class="trakt-kpi-tile" data-size={size} data-align={align}>
+  {#if icon}
+    <div class="kpi-icon">{@render icon()}</div>
+  {/if}
+
+  <p class="kpi-label tag secondary uppercase ellipsis">{label}</p>
+
+  <div class="kpi-value">
+    {#if tooltip}
+      <Tooltip content={tooltip} side="right">
+        {@render children()}
+      </Tooltip>
+    {:else}
+      {@render children()}
+    {/if}
+  </div>
+
+  {#if delta}
+    <div class="kpi-delta">{@render delta()}</div>
+  {/if}
+</div>
+
+<style lang="scss">
+  .trakt-kpi-tile {
+    --kpi-value-size: var(--ni-24);
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+    justify-content: space-between;
+    min-width: 0;
+    height: 100%;
+    box-sizing: border-box;
+
+    &[data-size="large"] {
+      --kpi-value-size: var(--ni-32);
+    }
+
+    &[data-align="center"] {
+      align-items: center;
+      text-align: center;
+    }
+
+    &[data-align="start"] {
+      align-items: flex-start;
+    }
+  }
+
+  .kpi-label {
+    margin: 0;
+    color: var(--color-text-secondary);
+  }
+
+  .kpi-icon :global(svg) {
+    width: var(--ni-18);
+    height: var(--ni-18);
+  }
+
+  .kpi-value {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--gap-xxs);
+    font-size: var(--kpi-value-size);
+    line-height: 1.05;
+    font-weight: 700;
+    min-width: 0;
+
+    // Split value parts (e.g. "2h" "11m") inherit the headline size.
+    :global(.trakt-tooltip-trigger) {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--gap-xxs);
+      align-items: center;
+    }
+  }
+
+  .kpi-delta {
+    display: flex;
+    align-items: center;
+  }
+</style>

--- a/projects/client/src/lib/components/kpi/KpiTileProps.ts
+++ b/projects/client/src/lib/components/kpi/KpiTileProps.ts
@@ -1,0 +1,18 @@
+import type { Snippet } from 'svelte';
+
+export type KpiTileProps = {
+  /** Small caption above the value (e.g. "Daily Average"). */
+  label: string;
+  /** The headline value content - plain text, or split parts (e.g. 2h 11m). */
+  children: Snippet;
+  /** Optional trend/delta affordance rendered under the value. */
+  delta?: Snippet;
+  /** Optional leading icon. */
+  icon?: Snippet;
+  /** Tooltip shown on the value (passes through to the shared Tooltip). */
+  tooltip?: string;
+  /** Headline size. Defaults to `normal`. */
+  size?: 'normal' | 'large';
+  /** Horizontal alignment of the stack. Defaults to `start`. */
+  align?: 'start' | 'center';
+};

--- a/projects/client/src/lib/sections/settings/_internal/components/SyncProgress.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/components/SyncProgress.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
+  import { ratio } from "$lib/utils/number/ratio.ts";
   import { slide } from "svelte/transition";
 
   type SyncProgressProps = {
@@ -9,8 +11,8 @@
 
   const { processedCount, totalCount, label }: SyncProgressProps = $props();
 
-  const percentage = $derived(
-    totalCount > 0 ? Math.round((processedCount / totalCount) * 100) : 0,
+  const fraction = $derived(
+    ratio({ value: processedCount, total: totalCount }),
   );
 </script>
 
@@ -18,16 +20,12 @@
   <p class="secondary">
     {label}
   </p>
-  <div class="sync-progress-bar-track">
-    <div
-      class="sync-progress-bar-fill"
-      style="width: {percentage}%"
-      role="progressbar"
-      aria-valuenow={processedCount}
-      aria-valuemin={0}
-      aria-valuemax={totalCount}
-    ></div>
-  </div>
+  <DistributionBar
+    {fraction}
+    color="var(--color-background-purple)"
+    label={label}
+    --distribution-bar-track="color-mix(in srgb, var(--color-border) 50%, transparent)"
+  />
 </div>
 
 <style>
@@ -35,19 +33,5 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-s);
-  }
-
-  .sync-progress-bar-track {
-    height: var(--ni-6);
-    border-radius: var(--border-radius-xs);
-    background-color: color-mix(in srgb, var(--color-border) 50%, transparent);
-    overflow: hidden;
-  }
-
-  .sync-progress-bar-fill {
-    height: 100%;
-    border-radius: var(--border-radius-xs);
-    background-color: var(--color-background-purple);
-    transition: width var(--transition-increment) ease-in-out;
   }
 </style>

--- a/projects/client/src/lib/sections/stats/_internal/PulseCell.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseCell.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Card from "$lib/components/card/Card.svelte";
-  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import KpiTile from "$lib/components/kpi/KpiTile.svelte";
   import type { PulseDeltaKind } from "./models/PulseDeltaKind";
   import PulseDeltaTag from "./PulseDeltaTag.svelte";
   import { splitDuration } from "./utils/splitDuration.ts";
@@ -17,7 +17,7 @@
     value: originalValue,
     label,
     tooltip,
-    delta,
+    delta: deltaValue,
     deltaKind,
   }: PulseCellProps = $props();
 
@@ -26,59 +26,28 @@
   );
 </script>
 
-{#snippet valueText()}
-  {#each value as part, index (index)}
-    <span class="trakt-pulse-cell-value bold ellipsis">{part}</span>
-  {/each}
-{/snippet}
-
 <Card
   --width-card="var(--width-pulse-card)"
   --height-card="var(--height-pulse-card)"
 >
   <div class="trakt-pulse-cell">
-    <p>{label}</p>
+    <KpiTile {label} {tooltip}>
+      {#each value as part, index (index)}
+        <span class="ellipsis">{part}</span>
+      {/each}
 
-    <div class="trakt-pulse-cell-body">
-      {#if tooltip}
-        <Tooltip content={tooltip} side="right">
-          {@render valueText()}
-        </Tooltip>
-      {:else}
-        {@render valueText()}
-      {/if}
-    </div>
-
-    <PulseDeltaTag {delta} {deltaKind} />
+      {#snippet delta()}
+        <PulseDeltaTag delta={deltaValue} {deltaKind} />
+      {/snippet}
+    </KpiTile>
   </div>
 </Card>
 
 <style lang="scss">
   .trakt-pulse-cell {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: var(--gap-xs);
-    justify-content: space-between;
-
+    height: 100%;
     padding: var(--ni-16);
     box-sizing: border-box;
-
     overflow: hidden;
-    height: 100%;
-
-    :global(.trakt-tooltip-trigger),
-    .trakt-pulse-cell-body {
-      display: flex;
-      flex-wrap: wrap;
-      gap: var(--gap-xxs);
-      flex: 1;
-      justify-content: flex-start;
-      align-items: center;
-    }
-  }
-
-  .trakt-pulse-cell-value {
-    font-size: var(--ni-24);
   }
 </style>

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraph.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraph.svelte
@@ -21,7 +21,7 @@
   --height-card="var(--height-pulse-card)"
 >
   <div class="trakt-pulse-graph">
-    <p>{title}</p>
+    <p class="small secondary">{title}</p>
 
     {#if item.kind === "peakHours"}
       <PulseGraphPeakHours data={item.data} />

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraphPeakHours.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraphPeakHours.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
+  import { ratio } from "$lib/utils/number/ratio.ts";
   import type { PeakHoursData } from "./models/PeakHoursData";
 
   const { data }: { data: PeakHoursData } = $props();
@@ -7,14 +9,16 @@
 </script>
 
 <div class="trakt-pulse-graph-peak-hours">
-  {#each data.buckets as bucket (bucket.key)}
+  {#each data.buckets as bucket, i (bucket.key)}
     <div class="peak-row">
       <span class="peak-label tag">{bucket.label}</span>
-      <div class="peak-bar-track">
-        <div
-          class="peak-bar-fill"
-          style:width="{(bucket.count / max) * 100}%"
-        ></div>
+      <div class="peak-bar">
+        <DistributionBar
+          fraction={ratio({ value: bucket.count, total: max })}
+          index={i}
+          active={bucket.count === max && bucket.count > 0}
+          label="{bucket.label}: {bucket.count}"
+        />
       </div>
       <span class="peak-count secondary tag">{bucket.count}</span>
     </div>
@@ -42,20 +46,8 @@
     text-align: start;
   }
 
-  .peak-bar-track {
+  .peak-bar {
     flex: 1;
-    height: var(--ni-8);
-    background: color-mix(in srgb, var(--color-foreground) 8%, transparent);
-    border-radius: var(--ni-4);
-    overflow: hidden;
-  }
-
-  .peak-bar-fill {
-    height: 100%;
-    background: var(--purple-500);
-    border-radius: var(--ni-4);
-    min-width: 2px;
-    transition: width var(--transition-increment) ease;
   }
 
   .peak-count {

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
   import { getLocale, languageTag } from "$lib/features/i18n/index.ts";
   import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration.ts";
   import { toPercentage } from "$lib/utils/formatting/number/toPercentage.ts";
+  import { ratio } from "$lib/utils/number/ratio.ts";
   import type { ScreenTimeDailyData } from "./models/ScreenTimeDailyData";
 
   const { data }: { data: ScreenTimeDailyData } = $props();
@@ -19,10 +21,12 @@
     }).format(0),
   );
 
+  // Sequential brand-purple intensity ramp (light -> deep = more screen time),
+  // premium and on-brand rather than a traffic-light rainbow.
   function barColor(pct: number): string {
-    if (pct >= 30) return "var(--orange-500)";
-    if (pct >= 15) return "var(--yellow-500)";
-    return "var(--green-500)";
+    if (pct >= 30) return "var(--viz-5)";
+    if (pct >= 15) return "var(--viz-1)";
+    return "var(--viz-3)";
   }
 </script>
 
@@ -30,25 +34,27 @@
   {#each data.labels as label, i (i)}
     {@const pct = data.percentages[i] ?? 0}
     {@const minutes = data.minutesPerDay[i] ?? 0}
-    {@const normalizedPct = (pct / maxPct) * 100}
+    {@const fraction = ratio({ value: pct, total: maxPct })}
     <div class="screen-time-column">
-      <div class="screen-time-bar-container">
-        <div
-          class="screen-time-fill"
-          style:height="{normalizedPct}%"
-          style:background={barColor(pct)}
-          title="{toHumanDuration({ minutes }, lang)} · {toPercentage(
-            pct / 100,
-            locale,
-          )}"
-        >
-          <span
-            class="screen-time-value tag secondary no-wrap"
-            title={toHumanDuration({ minutes }, lang)}
-          >
-            {toHumanDuration({ minutes, separator: "" }, lang) || zeroMinutes}
-          </span>
-        </div>
+      <span class="screen-time-value tag secondary no-wrap">
+        {toHumanDuration({ minutes, separator: "" }, lang) || zeroMinutes}
+      </span>
+      <div
+        class="screen-time-bar-container"
+        title="{toHumanDuration({ minutes }, lang)} · {toPercentage(
+          pct / 100,
+          locale,
+        )}"
+      >
+        <DistributionBar
+          orientation="vertical"
+          {fraction}
+          color={barColor(pct)}
+          index={i}
+          minVisible={0.03}
+          label="{label}: {toHumanDuration({ minutes }, lang)}"
+          --distribution-bar-thickness="64%"
+        />
       </div>
       <span class="screen-time-label tag ellipsis no-wrap">{label}</span>
     </div>
@@ -77,25 +83,11 @@
   .screen-time-bar-container {
     width: 100%;
     height: var(--ni-80);
-
-    padding-top: var(--ni-16);
     box-sizing: border-box;
 
+    // Center the single vertical bar within the column slot.
     display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-  }
-
-  .screen-time-fill {
-    position: relative;
-
-    width: 100%;
-    min-height: 2px;
-
-    border-radius: var(--ni-4) var(--ni-4) 0 0;
-
-    transition: var(--transition-increment) ease;
-    transition-property: height, background;
+    justify-content: center;
   }
 
   .screen-time-label {
@@ -103,12 +95,9 @@
     text-align: center;
   }
 
+  // Aligned across all columns at the top of the chart, above every bar.
   .screen-time-value {
-    position: absolute;
-
-    bottom: calc(100% + var(--ni-4));
-    inset-inline: 0;
-
+    width: 100%;
     text-align: center;
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaRating } from "$lib/requests/models/MediaRating.ts";
-  import { getLocale } from "$lib/features/i18n";
   import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber";
   import { toTraktRating } from "$lib/utils/formatting/number/toTraktRating";
-  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import { ratio } from "$lib/utils/number/ratio.ts";
   import { STAR_RATINGS } from "../constants/index.ts";
 
   type RatingsDistributionProps = {
@@ -17,28 +19,17 @@
     & keyof NonNullable<typeof trakt.distribution>
     & string;
 
-  const starBuckets = $derived(
+  const buckets = $derived(
     STAR_RATINGS.map((star) => {
       const low = String(star.range.min + 1) as DistributionKey;
       const high = String(star.range.max) as DistributionKey;
       const value = (trakt.distribution?.[low] ?? 0) +
         (trakt.distribution?.[high] ?? 0);
-      return { star: star.index, value };
+      return { value, star: star.index };
     }),
   );
 
-  const maxValue = $derived(
-    Math.max(...starBuckets.map((b) => b.value), 1),
-  );
-
-  function toIntensity(value: number, max: number): 0 | 1 | 2 | 3 | 4 {
-    if (value <= 0) return 0;
-    const ratio = value / max;
-    if (ratio <= 0.25) return 1;
-    if (ratio <= 0.5) return 2;
-    if (ratio <= 0.75) return 3;
-    return 4;
-  }
+  const maxValue = $derived(Math.max(...buckets.map((b) => b.value), 1));
 
   const traktPercent = $derived(toTraktRating(trakt.rating, getLocale()));
   const voteCountText = $derived(toHumanNumber(trakt.votes, getLocale()));
@@ -56,18 +47,24 @@
     </div>
 
     <div class="trakt-histogram">
-      {#each starBuckets as bucket (bucket.star)}
+      {#each buckets as bucket, i (bucket.star)}
         <Tooltip
           content={toHumanNumber(bucket.value, getLocale())}
           variant="compact"
           sideOffset={4}
         >
           <div class="histogram-column">
-            <div
-              class="histogram-bar"
-              data-intensity={toIntensity(bucket.value, maxValue)}
-              style="--bar-fraction: {bucket.value / maxValue}"
-            ></div>
+            <div class="histogram-bar">
+              <DistributionBar
+                orientation="vertical"
+                fraction={ratio({ value: bucket.value, total: maxValue })}
+                active={bucket.value === maxValue && maxValue > 0}
+                minVisible={0.04}
+                index={i}
+                label="{bucket.star}: {toHumanNumber(bucket.value, getLocale())}"
+                --distribution-bar-thickness="100%"
+              />
+            </div>
             <span class="histogram-label tag secondary">{bucket.star}</span>
           </div>
         </Tooltip>
@@ -132,7 +129,7 @@
 
       @include for-mouse {
         &:hover {
-          transform: scale(1.1);
+          transform: scale(1.05);
         }
       }
     }
@@ -142,52 +139,18 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--ni-2);
+    gap: var(--ni-4);
     width: 100%;
-  }
-
-  @include for-mouse {
-    :global(.trakt-tooltip-trigger:hover) .histogram-bar {
-      background: var(--color-text-primary);
-    }
   }
 
   .histogram-bar {
     width: 70%;
-    height: calc(var(--bar-fraction, 0) * var(--ni-48));
-    min-height: var(--ni-2);
-    border-radius: var(--border-radius-xs);
-    transform-origin: bottom;
-    animation: rating-bar-rise 650ms cubic-bezier(0.16, 1, 0.3, 1) 250ms both;
-    transition: background var(--transition-increment) ease-in-out;
-
-    &[data-intensity="0"] {
-      background: var(--color-heatmap-empty);
-    }
-    &[data-intensity="1"] {
-      background: var(--color-heatmap-l1);
-    }
-    &[data-intensity="2"] {
-      background: var(--color-heatmap-l2);
-    }
-    &[data-intensity="3"] {
-      background: var(--color-heatmap-l3);
-    }
-    &[data-intensity="4"] {
-      background: var(--color-heatmap-l4);
-    }
+    height: var(--ni-48);
+    display: flex;
+    justify-content: center;
   }
 
   .histogram-label {
     color: var(--color-text-secondary);
-  }
-
-  @keyframes rating-bar-rise {
-    from {
-      transform: scaleY(0);
-    }
-    to {
-      transform: scaleY(1);
-    }
   }
 </style>

--- a/projects/client/src/lib/sections/toast/_internal/ProgressBar.svelte
+++ b/projects/client/src/lib/sections/toast/_internal/ProgressBar.svelte
@@ -1,37 +1,11 @@
 <script lang="ts">
+  import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
+
   const { progress }: { progress: number } = $props();
 </script>
 
-<div class="trakt-progress-bar" style="--play-progress: {progress}%"></div>
-
-<style>
-  .trakt-progress-bar {
-    --progress-bar-border-radius: var(--border-radius-m);
-
-    width: 100%;
-    height: var(--ni-8);
-
-    border-radius: var(--progress-bar-border-radius);
-
-    position: relative;
-    display: flex;
-    overflow: hidden;
-
-    box-sizing: border-box;
-
-    background-color: var(--color-toast-progress-bar-background);
-    box-shadow: inset 0 0 0 var(--ni-1) var(--color-toast-progress-bar-shadow);
-
-    &::before {
-      content: "";
-      position: absolute;
-      top: 0;
-      inset-inline-start: 0;
-      height: 100%;
-      width: var(--play-progress);
-      background-color: var(--color-toast-progress-bar-progress);
-      border-radius: var(--progress-bar-border-radius);
-      transition: width var(--transition-increment) ease-in-out;
-    }
-  }
-</style>
+<DistributionBar
+  fraction={progress / 100}
+  color="var(--color-toast-progress-bar-progress)"
+  --distribution-bar-track="var(--color-toast-progress-bar-background)"
+/>

--- a/projects/client/src/lib/sections/vip/_internal/UsageBar.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/UsageBar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
   import { languageTag } from "$lib/features/i18n";
   import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber";
   import { calculateLimitProgress } from "./utils/calculateLimitProgress";
@@ -47,12 +48,15 @@
     </div>
   {/if}
 
-  <div
-    class="trakt-progress-bar"
-    class:is-over-limit={isOverLimit}
-    class:is-low-percentage={isLowPercentage}
-    style:--progress="{isLoading ? 0 : progress}%"
-  ></div>
+  <div class="trakt-usage-fill">
+    <DistributionBar
+      track={false}
+      fraction={(isLoading ? 0 : progress) / 100}
+      minVisible={isLowPercentage ? 0.06 : 0}
+      color={isOverLimit ? "var(--viz-negative)" : "var(--color-usage-bar)"}
+      --distribution-bar-thickness="100%"
+    />
+  </div>
 </div>
 
 <style>
@@ -114,27 +118,9 @@
     transform: translateY(-50%);
   }
 
-  .trakt-progress-bar {
+  .trakt-usage-fill {
     z-index: var(--layer-raised);
     position: absolute;
-    top: 0;
-    inset-inline-start: 0;
-    bottom: 0;
-
-    width: var(--progress);
-
-    background-color: var(--color-usage-bar);
-
-    border-radius: var(--border-radius-xxl);
-
-    transition: width var(--transition-increment) ease-in-out;
-
-    &.is-low-percentage {
-      width: var(--ni-14);
-    }
-
-    &.is-over-limit {
-      background-color: var(--red-700);
-    }
+    inset: 0;
   }
 </style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsMonthlySection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsMonthlySection.svelte
@@ -368,7 +368,6 @@
   .yir-2024-stats-summary-chart {
     min-width: 0;
     width: auto;
-    margin: 0 calc(-1 * var(--panel-padding-x));
 
     @include for-tablet-sm-and-below {
       margin-inline-start: 0;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
@@ -395,7 +395,6 @@
   .yir-2024-stats-summary-chart {
     min-width: 0;
     width: auto;
-    margin: 0 calc(-1 * var(--panel-padding-x));
 
     @include for-tablet-sm-and-below {
       margin-inline-start: 0;

--- a/projects/client/src/lib/sections/yir/_internal/YirGenreBars.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirGenreBars.svelte
@@ -1,266 +1,29 @@
 <script lang="ts">
+  import SegmentedBar from "$lib/components/charts/SegmentedBar.svelte";
   import type { YirGenresGroup } from "$lib/requests/models/YirDetail.ts";
 
   type YirGenreBarsProps = {
     type: "shows" | "movies";
     genres: YirGenresGroup;
-    /**
-     * `default` — colored left-border label (legacy template).
-     * `filled` — opaque bar-colored label with uppercase text (2024 template).
-     */
+    /** Retained for call-site compatibility; the segmented bar is shared now. */
     variant?: "default" | "filled";
   };
 
-  const { type, genres, variant = "default" }: YirGenreBarsProps = $props();
+  const { type, genres }: YirGenreBarsProps = $props();
 
-  const typeLabel = $derived(type === "shows" ? "show" : "movie");
+  const unit = $derived(type === "shows" ? "show" : "movie");
 
-  // Top genre drives the relative (mobile) bar widths; computed once rather
-  // than per-row inside the loop.
-  const maxCount = $derived(genres.genres[0]?.count ?? 1);
-
-  // Categorical palette for the stacked segments. These are intentionally
-  // fixed brand-neutral hues (no semantic theme token maps to "genre #3"),
-  // matching the v2 YIR genre bar colors.
-  const chartColors = [
-    "#CC333F",
-    "#00A0B0",
-    "#EB6841",
-    "#6A4A3C",
-    "#EDC951",
-    "#AB3E5B",
-    "#B3CC57",
-    "#EF746F",
-    "#3E4147",
-    "#FFBE40",
-    "#7B3B3B",
-  ];
-
-  function getBarColor(index: number): string {
-    return chartColors[index % chartColors.length] ?? "#222";
-  }
-
-  function unitLabel(count: number): string {
-    return count === 1 ? typeLabel : `${typeLabel}s`;
-  }
-
-  /*
-    FIXME: the horizontal version should deal better with responsiveness,
-    without users having to scroll.
-    */
+  // Compose the shared SegmentedBar SOT so YIR genres render identically to the
+  // design-system primitive (categorical viz palette, gloss, alternating labels).
+  const items = $derived(
+    genres.genres.map((genre) => ({
+      label: genre.name,
+      value: genre.count,
+      sublabel: `${genre.count.toLocaleString()} ${
+        genre.count === 1 ? unit : `${unit}s`
+      }`,
+    })),
+  );
 </script>
 
-<div class="trakt-yir-genre-bars" data-variant={variant}>
-  {#each genres.genres as genre, index (genre.name)}
-    {@const percentage = (genre.count / genres.itemCount) * 100}
-    {@const relativePercentage = (genre.count / maxCount) * 100}
-    <div
-      class="yir-genre-row"
-      data-index={index}
-      style:--genre-color={getBarColor(index)}
-    >
-      <div class="yir-genre-info">
-        <span class="yir-genre-name">{genre.name}</span>
-        <span class="yir-genre-count">
-          {genre.count.toLocaleString()}
-          {unitLabel(genre.count)}
-        </span>
-      </div>
-      <div
-        class="yir-genre-bar"
-        style:--bar-width="{Math.max(percentage, 5)}%"
-        style:--mobile-bar-width="{relativePercentage}%"
-      >
-        <span class="yir-genre-percentage">{Math.round(percentage)}%</span>
-        <span class="yir-genre-label">
-          <span class="yir-genre-name-desktop">{genre.name}</span>
-          <span class="yir-genre-count-desktop">
-            {genre.count.toLocaleString()}
-            {unitLabel(genre.count)}
-          </span>
-        </span>
-      </div>
-    </div>
-  {/each}
-</div>
-
-<style lang="scss">
-  @use "$style/scss/mixins/index" as *;
-
-  .trakt-yir-genre-bars {
-    display: flex;
-    padding: var(--ni-40) var(--ni-16) var(--ni-60) var(--ni-16);
-    overflow-x: auto;
-    overflow-y: hidden;
-    scrollbar-width: none;
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
-
-    &:hover .yir-genre-bar:not(:hover) {
-      opacity: 0.5;
-    }
-
-    &:hover .yir-genre-bar .yir-genre-percentage {
-      opacity: 1;
-    }
-
-    @include for-tablet-sm-and-below {
-      flex-direction: column;
-      padding: 0 var(--ni-16);
-      overflow: visible;
-    }
-  }
-
-  .yir-genre-row {
-    display: contents;
-
-    @include for-tablet-sm-and-below {
-      display: flex;
-      flex-direction: column;
-      margin-bottom: var(--ni-16);
-    }
-  }
-
-  .yir-genre-info {
-    display: none;
-
-    @include for-tablet-sm-and-below {
-      display: flex;
-      flex-direction: column;
-      margin-bottom: var(--ni-2);
-      padding-inline-start: var(--ni-6);
-      border-inline-start: var(--border-thickness-xxs) solid var(--genre-color);
-    }
-  }
-
-  .yir-genre-name {
-    font-size: var(--font-size-text);
-    text-transform: capitalize;
-    color: var(--shade-10);
-    font-weight: 500;
-    line-height: 1.2;
-  }
-
-  .yir-genre-name-desktop {
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-transform: capitalize;
-    font-size: var(--font-size-text);
-  }
-
-  .yir-genre-bar {
-    height: var(--ni-30);
-    margin-inline-start: var(--ni-2);
-    position: relative;
-    min-width: var(--ni-44);
-    width: var(--bar-width);
-    background-color: var(--genre-color);
-    transition: all 0.5s;
-    cursor: pointer;
-
-    @include for-tablet-lg {
-      min-width: var(--ni-32);
-    }
-
-    @include for-tablet-sm-and-below {
-      height: var(--ni-30);
-      min-height: var(--ni-30);
-      width: var(--mobile-bar-width);
-      margin-inline-start: 0;
-      margin-bottom: 0;
-      display: block;
-    }
-  }
-
-  .yir-genre-row:first-child .yir-genre-bar {
-    margin-inline-start: 0;
-  }
-
-  .yir-genre-percentage {
-    color: var(--shade-1000);
-    position: absolute;
-    width: 100%;
-    text-align: center;
-    inset-inline-start: 0;
-    top: var(--ni-8);
-    font-size: var(--font-size-text-small);
-    opacity: 0;
-    transition: opacity 0.5s;
-
-    @include for-tablet-sm-and-below {
-      display: none;
-    }
-  }
-
-  .yir-genre-label {
-    position: absolute;
-    inset-inline-start: 0;
-    bottom: var(--ni-30);
-    width: 200%;
-    box-sizing: border-box;
-    font-size: var(--font-size-text-small);
-    white-space: nowrap;
-    padding: var(--ni-4) var(--ni-6);
-    color: var(--shade-10);
-    border-inline-start: var(--border-thickness-xs) solid var(--genre-color);
-    pointer-events: none;
-
-    @include for-tablet-sm-and-below {
-      display: none;
-    }
-  }
-
-  .yir-genre-row[data-index]:nth-child(even) .yir-genre-label {
-    top: var(--ni-30);
-    bottom: auto;
-  }
-
-  .yir-genre-count {
-    font-size: var(--font-size-text-small);
-    color: var(--shade-400);
-  }
-
-  .yir-genre-count-desktop {
-    display: block;
-    font-size: var(--font-size-tag);
-    color: var(--shade-400);
-  }
-
-  // Filled variant (2024): the label becomes a translucent box tinted with
-  // the bar's color and uppercase text, instead of the transparent
-  // left-border style. ~31% matches v2's `#RRGGBB50` (0x50 alpha) tint so
-  // the panel reads through the label.
-  .trakt-yir-genre-bars[data-variant="filled"] {
-    .yir-genre-label {
-      width: max-content;
-      max-width: 200%;
-      background-color: color-mix(in srgb, var(--genre-color) 31%, transparent);
-      // Full-color 1px left border on top of the translucent fill (matches
-      // v2: solid border-color + `#RRGGBB50` background tint).
-      border-inline-start: var(--border-thickness-xxs) solid var(--genre-color);
-      text-transform: uppercase;
-    }
-
-    .yir-genre-name-desktop,
-    .yir-genre-name {
-      text-transform: uppercase;
-    }
-
-    // v2's label name is normal-weight and only marginally larger than the
-    // count, not a heavier heading — drop the default's larger ni-14 name
-    // down to match the count line and remove the visual weight.
-    .yir-genre-name-desktop {
-      font-size: var(--font-size-tag);
-      font-weight: 400;
-    }
-
-    // Count (line 2) reads as a muted gray — white at 60% opacity over the
-    // tinted box (matches v2's lighter count text).
-    .yir-genre-count-desktop {
-      color: color-mix(in srgb, var(--shade-10) 60%, transparent);
-    }
-  }
-</style>
+<SegmentedBar {items} label="Top genres" />

--- a/projects/client/src/lib/utils/number/clamp.spec.ts
+++ b/projects/client/src/lib/utils/number/clamp.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { clamp } from './clamp.ts';
+
+describe('util: clamp', () => {
+  it('should return the value when inside the range', () => {
+    expect(clamp({ value: 5, min: 0, max: 10 })).toBe(5);
+  });
+
+  it('should pin to the lower bound when below', () => {
+    expect(clamp({ value: -3, min: 0, max: 10 })).toBe(0);
+  });
+
+  it('should pin to the upper bound when above', () => {
+    expect(clamp({ value: 42, min: 0, max: 10 })).toBe(10);
+  });
+
+  it('should return the bound when value equals it', () => {
+    expect(clamp({ value: 0, min: 0, max: 10 })).toBe(0);
+    expect(clamp({ value: 10, min: 0, max: 10 })).toBe(10);
+  });
+
+  it('should tolerate an inverted range', () => {
+    expect(clamp({ value: 5, min: 10, max: 0 })).toBe(5);
+    expect(clamp({ value: 20, min: 10, max: 0 })).toBe(10);
+  });
+});

--- a/projects/client/src/lib/utils/number/clamp.ts
+++ b/projects/client/src/lib/utils/number/clamp.ts
@@ -1,0 +1,22 @@
+type ClampProps = {
+  value: number;
+  min: number;
+  max: number;
+};
+
+/** Constrain `value` to the inclusive `[min, max]` range. */
+export function clamp({ value, min, max }: ClampProps): number {
+  if (min > max) {
+    return clamp({ value, min: max, max: min });
+  }
+
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+}

--- a/projects/client/src/lib/utils/number/netFlowByDay.spec.ts
+++ b/projects/client/src/lib/utils/number/netFlowByDay.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { netFlowByDay } from './netFlowByDay.ts';
+
+describe('util: netFlowByDay', () => {
+  it('should compute net as added minus removed', () => {
+    expect(
+      netFlowByDay([{ day: '2026-01-01', added: 5, removed: 2 }]),
+    ).toEqual([{ day: '2026-01-01', net: 3 }]);
+  });
+
+  it('should merge entries sharing a day', () => {
+    expect(
+      netFlowByDay([
+        { day: '2026-01-01', added: 5, removed: 0 },
+        { day: '2026-01-01', added: 0, removed: 3 },
+      ]),
+    ).toEqual([{ day: '2026-01-01', net: 2 }]);
+  });
+
+  it('should sort ascending by day regardless of input order', () => {
+    expect(
+      netFlowByDay([
+        { day: '2026-01-03', added: 1, removed: 0 },
+        { day: '2026-01-01', added: 2, removed: 0 },
+        { day: '2026-01-02', added: 3, removed: 0 },
+      ]),
+    ).toEqual([
+      { day: '2026-01-01', net: 2 },
+      { day: '2026-01-02', net: 3 },
+      { day: '2026-01-03', net: 1 },
+    ]);
+  });
+
+  it('should yield negative net when removals dominate', () => {
+    expect(
+      netFlowByDay([{ day: '2026-01-01', added: 1, removed: 4 }]),
+    ).toEqual([{ day: '2026-01-01', net: -3 }]);
+  });
+
+  it('should return an empty array for no entries', () => {
+    expect(netFlowByDay([])).toEqual([]);
+  });
+});

--- a/projects/client/src/lib/utils/number/netFlowByDay.ts
+++ b/projects/client/src/lib/utils/number/netFlowByDay.ts
@@ -1,0 +1,32 @@
+type DayFlowEntry = {
+  /** Day bucket key, e.g. `2026-06-27`. Entries sharing a key are merged. */
+  day: string;
+  /** Positive contribution for the day (e.g. items added). */
+  added: number;
+  /** Negative contribution for the day (e.g. items removed). */
+  removed: number;
+};
+
+export type NetFlowDay = {
+  day: string;
+  net: number;
+};
+
+/**
+ * Collapse signed per-day flow entries into one net value per day
+ * (`added - removed`), ascending by day key. Pure: stable output for a given
+ * input regardless of entry order.
+ */
+export function netFlowByDay(
+  entries: ReadonlyArray<DayFlowEntry>,
+): NetFlowDay[] {
+  const byDay = entries.reduce((acc, entry) => {
+    const running = acc.get(entry.day) ?? 0;
+    acc.set(entry.day, running + entry.added - entry.removed);
+    return acc;
+  }, new Map<string, number>());
+
+  return [...byDay.entries()]
+    .map(([day, net]) => ({ day, net }))
+    .sort((a, b) => a.day.localeCompare(b.day));
+}

--- a/projects/client/src/lib/utils/number/ratio.spec.ts
+++ b/projects/client/src/lib/utils/number/ratio.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { ratio } from './ratio.ts';
+
+describe('util: ratio', () => {
+  it('should divide value by total', () => {
+    expect(ratio({ value: 1, total: 4 })).toBe(0.25);
+  });
+
+  it('should return 0 when total is 0', () => {
+    expect(ratio({ value: 5, total: 0 })).toBe(0);
+  });
+
+  it('should never emit Infinity or NaN', () => {
+    expect(Number.isFinite(ratio({ value: 5, total: 0 }))).toBe(true);
+    expect(Number.isNaN(ratio({ value: 0, total: 0 }))).toBe(false);
+  });
+
+  it('should support ratios above 1', () => {
+    expect(ratio({ value: 8, total: 4 })).toBe(2);
+  });
+});

--- a/projects/client/src/lib/utils/number/ratio.ts
+++ b/projects/client/src/lib/utils/number/ratio.ts
@@ -1,0 +1,16 @@
+type RatioProps = {
+  value: number;
+  total: number;
+};
+
+/**
+ * `value / total` guarded against a zero (or absent) total so charts never
+ * emit `NaN`/`Infinity` into SVG geometry. A zero total yields `0`.
+ */
+export function ratio({ value, total }: RatioProps): number {
+  if (total === 0) {
+    return 0;
+  }
+
+  return value / total;
+}

--- a/projects/client/src/lib/utils/number/resampleSeries.spec.ts
+++ b/projects/client/src/lib/utils/number/resampleSeries.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { resampleSeries } from './resampleSeries.ts';
+
+describe('util: resampleSeries', () => {
+  it('should produce exactly targetLength points', () => {
+    const result = resampleSeries({ values: [0, 5, 2, 8], targetLength: 20 });
+    expect(result).toHaveLength(20);
+  });
+
+  it('should preserve the endpoints', () => {
+    const result = resampleSeries({ values: [3, 9, 1, 7], targetLength: 16 });
+    expect(result.at(0)).toBeCloseTo(3);
+    expect(result.at(-1)).toBeCloseTo(7);
+  });
+
+  it('should pass through the original samples at matching positions', () => {
+    const values = [0, 10, 4, 6, 2];
+    const result = resampleSeries({ values, targetLength: values.length });
+    values.forEach((value, index) => expect(result[index]).toBeCloseTo(value));
+  });
+
+  it('should stay exact for linear data (no overshoot)', () => {
+    const result = resampleSeries({ values: [0, 2, 4, 6], targetLength: 7 });
+    [0, 1, 2, 3, 4, 5, 6].forEach((expected, index) =>
+      expect(result[index]).toBeCloseTo(expected)
+    );
+  });
+
+  it('should keep a monotone-increasing series monotone', () => {
+    const result = resampleSeries({
+      values: [0, 1, 3, 7, 12],
+      targetLength: 50,
+    });
+    result.forEach((value, index) => {
+      if (index === 0) return;
+      expect(value).toBeGreaterThanOrEqual(result[index - 1]);
+    });
+  });
+
+  it('should not overshoot a flat-then-rise step', () => {
+    const result = resampleSeries({
+      values: [0, 0, 0, 10],
+      targetLength: 40,
+    });
+    const max = Math.max(...result);
+    const min = Math.min(...result);
+    expect(max).toBeLessThanOrEqual(10 + 1e-9);
+    expect(min).toBeGreaterThanOrEqual(0 - 1e-9);
+  });
+
+  it('should hold a constant series flat', () => {
+    const result = resampleSeries({ values: [4, 4, 4], targetLength: 9 });
+    result.forEach((value) => expect(value).toBeCloseTo(4));
+  });
+
+  it('should fill from a single value', () => {
+    expect(resampleSeries({ values: [5], targetLength: 4 })).toEqual([
+      5,
+      5,
+      5,
+      5,
+    ]);
+  });
+
+  it('should return an empty array for empty input', () => {
+    expect(resampleSeries({ values: [], targetLength: 10 })).toEqual([]);
+  });
+
+  it('should return an empty array for a non-positive target length', () => {
+    expect(resampleSeries({ values: [1, 2, 3], targetLength: 0 })).toEqual([]);
+  });
+
+  it('should collapse to the first value for a target length of 1', () => {
+    expect(resampleSeries({ values: [1, 2, 3], targetLength: 1 })).toEqual([1]);
+  });
+});

--- a/projects/client/src/lib/utils/number/resampleSeries.ts
+++ b/projects/client/src/lib/utils/number/resampleSeries.ts
@@ -1,0 +1,112 @@
+type ResampleSeriesProps = {
+  values: ReadonlyArray<number>;
+  targetLength: number;
+};
+
+/**
+ * Resample a series to `targetLength` points using monotone cubic Hermite
+ * interpolation (Fritsch-Carlson tangents). Keeping the curve monotone between
+ * samples avoids the overshoot a naive cubic adds, so a `<path>` re-sampled to
+ * a new length keeps its bezier roundness and morphs cleanly under
+ * `transition: d` instead of snapping.
+ *
+ * Fritsch, F. N.; Carlson, R. E. (1980), "Monotone Piecewise Cubic
+ * Interpolation", SIAM Journal on Numerical Analysis.
+ */
+export function resampleSeries(
+  { values, targetLength }: ResampleSeriesProps,
+): number[] {
+  const length = values.length;
+
+  if (targetLength <= 0 || length === 0) {
+    return [];
+  }
+
+  if (length === 1) {
+    return new Array(targetLength).fill(values[0]);
+  }
+
+  if (targetLength === 1) {
+    return [values[0] ?? 0];
+  }
+
+  const tangents = monotoneTangents(values);
+
+  return Array.from({ length: targetLength }, (_, index) => {
+    const position = (index * (length - 1)) / (targetLength - 1);
+    const left = Math.min(Math.floor(position), length - 2);
+    const t = position - left;
+
+    return hermite({
+      t,
+      from: values[left] ?? 0,
+      to: values[left + 1] ?? 0,
+      tangentFrom: tangents[left] ?? 0,
+      tangentTo: tangents[left + 1] ?? 0,
+    });
+  });
+}
+
+/** Slopes between adjacent samples (unit x-spacing). */
+function secantSlopes(values: ReadonlyArray<number>): number[] {
+  return values.slice(0, -1).map((value, index) => values[index + 1] - value);
+}
+
+/** Per-point tangents constrained so the interpolant stays monotone. */
+function monotoneTangents(values: ReadonlyArray<number>): number[] {
+  const slopes = secantSlopes(values);
+  const last = values.length - 1;
+
+  const tangents = values.map((_, index) => {
+    if (index === 0) {
+      return slopes[0];
+    }
+    if (index === last) {
+      return slopes[last - 1];
+    }
+    return (slopes[index - 1] + slopes[index]) / 2;
+  });
+
+  slopes.forEach((slope, index) => {
+    if (slope === 0) {
+      tangents[index] = 0;
+      tangents[index + 1] = 0;
+      return;
+    }
+
+    const alpha = tangents[index] / slope;
+    const beta = tangents[index + 1] / slope;
+    const magnitude = alpha * alpha + beta * beta;
+
+    if (magnitude <= 9) {
+      return;
+    }
+
+    const scale = 3 / Math.sqrt(magnitude);
+    tangents[index] = scale * alpha * slope;
+    tangents[index + 1] = scale * beta * slope;
+  });
+
+  return tangents;
+}
+
+type HermiteProps = {
+  t: number;
+  from: number;
+  to: number;
+  tangentFrom: number;
+  tangentTo: number;
+};
+
+/** Cubic Hermite basis evaluation on a unit interval. */
+function hermite(
+  { t, from, to, tangentFrom, tangentTo }: HermiteProps,
+): number {
+  const t2 = t * t;
+  const t3 = t2 * t;
+
+  return (2 * t3 - 3 * t2 + 1) * from +
+    (t3 - 2 * t2 + t) * tangentFrom +
+    (-2 * t3 + 3 * t2) * to +
+    (t3 - t2) * tangentTo;
+}

--- a/projects/client/src/lib/utils/number/sum.spec.ts
+++ b/projects/client/src/lib/utils/number/sum.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { sum } from './sum.ts';
+
+describe('util: sum', () => {
+  it('should total the values', () => {
+    expect(sum([1, 2, 3, 4])).toBe(10);
+  });
+
+  it('should return 0 for an empty array', () => {
+    expect(sum([])).toBe(0);
+  });
+
+  it('should handle negative values', () => {
+    expect(sum([10, -3, -2])).toBe(5);
+  });
+
+  it('should handle a single value', () => {
+    expect(sum([7])).toBe(7);
+  });
+});

--- a/projects/client/src/lib/utils/number/sum.ts
+++ b/projects/client/src/lib/utils/number/sum.ts
@@ -1,0 +1,4 @@
+/** Total of every value. Empty input is `0` (additive identity). */
+export function sum(values: ReadonlyArray<number>): number {
+  return values.reduce((total, value) => total + value, 0);
+}

--- a/projects/client/src/routes/_design_system/_internal/designSystemPages.ts
+++ b/projects/client/src/routes/_design_system/_internal/designSystemPages.ts
@@ -60,6 +60,13 @@ export const DESIGN_SYSTEM_GROUPS: DesignSystemGroup[] = [
         kind: 'Component',
       },
       {
+        title: 'Charts',
+        href: '/_design_system/charts',
+        description:
+          'Data-viz primitives, distribution-bar + KPI-tile bases, and the shared VizPoint contract.',
+        kind: 'Component',
+      },
+      {
         title: 'Drawers',
         href: '/_design_system/drawers',
         description: 'Drawer sizes, overlay headers, and VIP variants.',

--- a/projects/client/src/routes/_design_system/charts/+page.svelte
+++ b/projects/client/src/routes/_design_system/charts/+page.svelte
@@ -1,0 +1,281 @@
+<script lang="ts">
+  import AreaChart from "$lib/components/charts/AreaChart.svelte";
+  import BarChart from "$lib/components/charts/BarChart.svelte";
+  import BubbleChart from "$lib/components/charts/BubbleChart.svelte";
+  import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
+  import KpiTile from "$lib/components/kpi/KpiTile.svelte";
+  import LineChart from "$lib/components/charts/LineChart.svelte";
+  import SegmentedBar from "$lib/components/charts/SegmentedBar.svelte";
+  import Sparkline from "$lib/components/charts/Sparkline.svelte";
+  import StackedBarChart from "$lib/components/charts/StackedBarChart.svelte";
+
+  // One dataset, reshaped per primitive - proof the VizPoint contract is
+  // interchangeable across charts.
+  const series = [4, 8, 6, 12, 9, 16, 13, 20, 18, 24, 21, 27].map(
+    (value, i) => ({ value, label: `D${i + 1}` }),
+  );
+  const distribution = [320, 540, 2100, 6800, 4300].map((value, i) => ({
+    value,
+    label: `${i + 1}`,
+  }));
+  const stacked = Array.from({ length: 7 }, (_, i) => ({
+    label: `W${i + 1}`,
+    values: [4 + i, 7, 9 - (i % 4), 5],
+  }));
+  const spark = [3, 5, 4, 8, 6, 11, 9, 14, 10, 17, 15, 21];
+  const bubbles = [
+    { id: 1, label: "Drama", value: 80, color: "var(--viz-1)" },
+    { id: 2, label: "Comedy", value: 55, color: "var(--viz-2)" },
+    { id: 3, label: "Sci-Fi", value: 40, color: "var(--viz-3)" },
+    { id: 4, label: "Action", value: 30, color: "var(--viz-4)" },
+    { id: 5, label: "Horror", value: 18, color: "var(--viz-5)" },
+  ];
+  const peak = [
+    { label: "Morning", fraction: 0.1 },
+    { label: "Afternoon", fraction: 0.35 },
+    { label: "Evening", fraction: 1 },
+    { label: "Night", fraction: 0.2 },
+  ];
+  const genres = [
+    { label: "Fantasy", value: 15 },
+    { label: "Sci-Fi", value: 14 },
+    { label: "Drama", value: 13 },
+    { label: "Action", value: 12 },
+    { label: "Adventure", value: 12 },
+    { label: "Animation", value: 7 },
+    { label: "Crime", value: 7 },
+    { label: "Comedy", value: 6 },
+    { label: "Mystery", value: 6 },
+    { label: "Anime", value: 4 },
+  ].map((g) => ({ ...g, sublabel: `${g.value} shows` }));
+</script>
+
+<main>
+  <section>
+    <h2>Line</h2>
+    <p class="caption tag secondary">
+      Smooth monotone line, morphs on data change, glow + draw-in.
+    </p>
+    <div class="demo card"><LineChart data={series} /></div>
+  </section>
+
+  <section>
+    <h2>Area</h2>
+    <p class="caption tag secondary">Line primitive with the floor filled.</p>
+    <div class="demo card"><AreaChart data={series} seriesIndex={2} /></div>
+  </section>
+
+  <section>
+    <h2>Bar</h2>
+    <p class="caption tag secondary">
+      Peak-highlighted (left) vs evenly weighted (right).
+    </p>
+    <div class="row">
+      <div class="demo card"><BarChart data={distribution} /></div>
+      <div class="demo card">
+        <BarChart data={distribution} highlightPeak={false} seriesIndex={1} />
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Stacked Bar</h2>
+    <p class="caption tag secondary">Multi-series, one color slot per series.</p>
+    <div class="demo card">
+      <StackedBarChart
+        data={stacked}
+        seriesLabels={["Movies", "Shows", "Episodes", "Other"]}
+      />
+    </div>
+  </section>
+
+  <section>
+    <h2>Sparkline</h2>
+    <p class="caption tag secondary">Minimal trend, no axes or interaction.</p>
+    <div class="row">
+      <div class="demo card short"><Sparkline values={spark} showArea /></div>
+      <div class="demo card short">
+        <Sparkline values={spark} seriesIndex={4} />
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Distribution Bar</h2>
+    <p class="caption tag secondary">
+      SOT meter base - shared by peak-hours, daily, usage. Horizontal + vertical.
+    </p>
+    <div class="card meter-card">
+      {#each peak as row, i (row.label)}
+        <div class="meter-row">
+          <span class="meter-label tag">{row.label}</span>
+          <div class="meter-bar">
+            <DistributionBar
+              fraction={row.fraction}
+              index={i}
+              active={row.fraction === 1}
+            />
+          </div>
+        </div>
+      {/each}
+    </div>
+    <div class="card vbar-card">
+      {#each distribution as point, i (point.label)}
+        <div class="vbar-col">
+          <DistributionBar
+            orientation="vertical"
+            fraction={point.value / 6800}
+            index={i}
+            --distribution-bar-thickness="60%"
+          />
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <section>
+    <h2>Segmented Bar</h2>
+    <p class="caption tag secondary">
+      One proportional bar split by category (e.g. genres) - shared gloss,
+      outer-corner rounding, alternating labels.
+    </p>
+    <div class="card"><SegmentedBar items={genres} label="Genres" /></div>
+  </section>
+
+  <section>
+    <h2>KPI Tile</h2>
+    <p class="caption tag secondary">
+      SOT headline metric - caption + value (+ optional delta/icon). Normal and
+      large.
+    </p>
+    <div class="kpi-row">
+      <div class="card kpi-demo">
+        <KpiTile label="Daily Average">
+          2h 11m
+          {#snippet delta()}
+            <span class="delta-up bold tag">-18h 8m</span>
+          {/snippet}
+        </KpiTile>
+      </div>
+      <div class="card kpi-demo">
+        <KpiTile label="Waking Hours">
+          2%
+          {#snippet delta()}
+            <span class="delta-down bold tag">-34%</span>
+          {/snippet}
+        </KpiTile>
+      </div>
+      <div class="card kpi-demo">
+        <KpiTile label="Trakt Rating" size="large">75%</KpiTile>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Bubble</h2>
+    <p class="caption tag secondary">Circle-pack by value.</p>
+    <div class="demo card bubble"><BubbleChart items={bubbles} /></div>
+  </section>
+</main>
+
+<style lang="scss">
+  main {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xl);
+    padding: var(--ni-32) var(--ni-16);
+    max-width: var(--ni-960);
+  }
+
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+  }
+
+  h2 {
+    margin: 0;
+  }
+
+  .caption {
+    margin: 0;
+  }
+
+  .card {
+    background: var(--color-card-background);
+    border-radius: var(--border-radius-l);
+    padding: var(--ni-16);
+  }
+
+  .demo {
+    height: var(--ni-180);
+  }
+
+  .demo.short {
+    height: var(--ni-56);
+  }
+
+  .demo.bubble {
+    height: var(--ni-320);
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--gap-m);
+  }
+
+  .meter-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-12);
+  }
+
+  .meter-row {
+    display: flex;
+    align-items: center;
+    gap: var(--ni-8);
+  }
+
+  .meter-label {
+    width: var(--ni-80);
+    flex-shrink: 0;
+  }
+
+  .meter-bar {
+    flex: 1;
+  }
+
+  .vbar-card {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-around;
+    gap: var(--ni-8);
+    height: var(--ni-160);
+  }
+
+  .vbar-col {
+    flex: 1;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+  }
+
+  .kpi-row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--gap-m);
+  }
+
+  .kpi-demo {
+    height: var(--ni-120);
+  }
+
+  .delta-up {
+    color: var(--color-background-trend-up-background-tag);
+  }
+
+  .delta-down {
+    color: var(--color-background-trend-down-background-tag);
+  }
+</style>

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -276,6 +276,7 @@
    * Chart dimensions
    */
   --height-bar-chart: var(--ni-180);
+  --height-area-chart: var(--ni-180);
   --height-bubble-chart: var(--ni-640);
   --min-radius-bubble-chart: var(--ni-20);
 

--- a/projects/client/src/style/scss/mixins/index.scss
+++ b/projects/client/src/style/scss/mixins/index.scss
@@ -6,6 +6,35 @@
   }
 }
 
+// Visually hide an element while keeping it available to screen readers
+// (e.g. a chart's <figcaption> summary).
+@mixin visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// Keyboard focus ring for the chart plots; tints to the series colour, falling
+// back to the hero viz slot when no series is set on the element.
+@mixin viz-focus-ring {
+  outline: var(--ni-2) solid var(--viz-series, var(--viz-1));
+  outline-offset: var(--ni-2);
+  border-radius: var(--viz-bar-radius);
+}
+
+// Active/hover treatment for chart marks: a brightness + saturation pop. No
+// shadow (kept per-segment shadows from stacking) and no transform (never fights
+// the bars' entrance animations). Add `transition: filter` for a smooth in/out.
+@mixin viz-hover-active {
+  filter: brightness(1.16) saturate(1.22);
+}
+
 @mixin for-touch {
   @media (hover: none) and (pointer: coarse) {
     @content;

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -110,4 +110,25 @@
    * Card
    */
   --color-card-border-hover: var(--purple-500);
+
+  /**
+   * Data visualization (theme-independent geometry + timing)
+   *
+   * Colors live in modes.scss (--viz-1..8 etc); these are the shape/size/motion
+   * knobs shared across every chart primitive so a tuning change lands in one
+   * place. `--viz-morph-duration` drives the CSS `transition: d` morph on
+   * lines/areas; `--viz-enter-duration`/`--viz-enter-ease` drive the juicy
+   * spring-style entrance.
+   */
+  --viz-line-width: var(--ni-2);
+  --viz-axis-width: 1px;
+  --viz-dot-radius: var(--ni-4);
+  --viz-bar-radius: var(--border-radius-s);
+  --viz-bar-gap: var(--ni-2);
+  --viz-pattern-stroke-width: 1.5;
+  --viz-pattern-size: var(--ni-6);
+  --viz-morph-duration: var(--transition-increment);
+  --viz-enter-duration: 720ms;
+  --viz-enter-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --viz-glow-blur: var(--ni-12);
 }

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -316,6 +316,43 @@
   --color-filter-tablist-background: var(--shade-100);
   --color-filter-tab-background: var(--purple-700);
   --color-filter-tab-active-text: var(--shade-10);
+
+  /*
+   * Data visualization
+   *
+   * Categorical series palette (--viz-1..8) plus structural roles. A restrained
+   * purple<->blue cool duotone (brand-anchored, NOT a rainbow): odd slots ride
+   * the purple ramp, even slots the blue ramp, interleaving hue + lightness so
+   * adjacent series stay distinguishable while the whole set reads premium and
+   * cohesive. The dark mixin lifts every step for dark surfaces. Components
+   * consume only these tokens - never a raw palette step - so a single edit here
+   * re-skins every chart.
+   */
+  --viz-1: var(--purple-500);
+  --viz-2: var(--blue-600);
+  --viz-3: var(--purple-300);
+  --viz-4: var(--blue-400);
+  --viz-5: var(--purple-700);
+  --viz-6: var(--blue-800);
+  --viz-7: var(--purple-200);
+  --viz-8: var(--blue-300);
+
+  --viz-axis: var(--shade-400);
+  --viz-grid: var(--shade-200);
+  --viz-neutral: var(--shade-300);
+  --viz-track: var(--shade-100);
+  --viz-label: var(--color-text-secondary);
+  --viz-positive: var(--green-600);
+  --viz-negative: var(--red-600);
+
+  // Bottom stop opacity for the vertical fade gradients (the "fade to nothing"
+  // floor). Lighter surfaces want a softer floor so fills don't muddy.
+  --viz-fade-floor: 0.08;
+  // Hover/active bloom strength on the glow drop-shadow.
+  --viz-glow-percent: 45%;
+  // Non-color (hatched <pattern>) encoding is off until a high-contrast mode
+  // turns it on. Kept here so components can reference it unconditionally.
+  --viz-pattern-opacity: 0;
 }
 
 // Define theme variables for dark mode
@@ -638,6 +675,36 @@
   --color-filter-tablist-background: var(--shade-910);
   --color-filter-tab-background: var(--purple-700);
   --color-filter-tab-active-text: var(--shade-10);
+
+  /*
+   * Data visualization (dark surfaces)
+   *
+   * Lifted to the 300/400 steps so saturated hues stay vivid against a dark
+   * panel; --viz-8 stays a touch deeper to round out the spread. Fades + glow
+   * read stronger on dark, hence the higher floor + bloom.
+   */
+  --viz-1: var(--purple-300);
+  --viz-2: var(--blue-400);
+  --viz-3: var(--purple-200);
+  --viz-4: var(--blue-300);
+  --viz-5: var(--purple-500);
+  --viz-6: var(--blue-600);
+  --viz-7: var(--purple-100);
+  --viz-8: var(--blue-200);
+
+  --viz-axis: var(--shade-700);
+  --viz-grid: var(--shade-800);
+  --viz-neutral: var(--shade-600);
+  --viz-track: var(--shade-900);
+  // Lighter than text-secondary so axis labels stay legible on very dark viz
+  // backgrounds (e.g. the near-black YIR template).
+  --viz-label: var(--shade-300);
+  --viz-positive: var(--green-400);
+  --viz-negative: var(--red-400);
+
+  --viz-fade-floor: 0.14;
+  --viz-glow-percent: 60%;
+  --viz-pattern-opacity: 0;
 }
 
 // Apply themes to selectors
@@ -647,6 +714,71 @@
 
 [data-theme='dark'] {
   @include dark-theme();
+}
+
+// High-contrast viz variants (the HC light + HC dark "modes" the charts target).
+// Keyed off the OS `prefers-contrast` signal rather than a 4th/5th theme enum,
+// so they layer on top of the existing light/dark surfaces without forking the
+// Theme model. Series snap to pure-saturated extremes, structural lines go to
+// the foreground, fades flatten toward solid, and the hatched <pattern> overlay
+// is switched on (--viz-pattern-opacity: 1) so series stay distinguishable by
+// shape, not hue alone.
+@mixin viz-high-contrast-light {
+  --viz-1: var(--purple-700);
+  --viz-2: var(--blue-800);
+  --viz-3: var(--purple-500);
+  --viz-4: var(--blue-600);
+  --viz-5: var(--purple-900);
+  --viz-6: var(--blue-900);
+  --viz-7: var(--purple-600);
+  --viz-8: var(--blue-700);
+
+  --viz-axis: var(--shade-900);
+  --viz-grid: var(--shade-400);
+  --viz-neutral: var(--shade-500);
+  --viz-label: var(--color-foreground);
+  --viz-fade-floor: 0.35;
+  --viz-glow-percent: 0%;
+  --viz-pattern-opacity: 1;
+}
+
+@mixin viz-high-contrast-dark {
+  --viz-1: var(--purple-100);
+  --viz-2: var(--blue-100);
+  --viz-3: var(--purple-300);
+  --viz-4: var(--blue-300);
+  --viz-5: var(--purple-50);
+  --viz-6: var(--blue-50);
+  --viz-7: var(--purple-200);
+  --viz-8: var(--blue-200);
+
+  --viz-axis: var(--shade-50);
+  --viz-grid: var(--shade-600);
+  --viz-neutral: var(--shade-500);
+  --viz-label: var(--color-foreground);
+  --viz-fade-floor: 0.45;
+  --viz-glow-percent: 0%;
+  --viz-pattern-opacity: 1;
+}
+
+@media (prefers-contrast: more) {
+  [data-theme='light'] {
+    @include viz-high-contrast-light();
+  }
+
+  [data-theme='dark'] {
+    @include viz-high-contrast-dark();
+  }
+
+  [data-theme='system'] {
+    @media (prefers-color-scheme: light) {
+      @include viz-high-contrast-light();
+    }
+
+    @media (prefers-color-scheme: dark) {
+      @include viz-high-contrast-dark();
+    }
+  }
 }
 
 [data-theme='system'] {


### PR DESCRIPTION
Replaces Carbon Charts with a hand-rolled d3-math + Svelte-SVG chart system and consolidates every bespoke viz/meter/KPI in the app onto a single source of truth.

## What's in it
- **Primitives** (`lib/components/charts/`): `LineChart`, `AreaChart`, `BarChart`, `StackedBarChart`, `Sparkline`, `BubbleChart`, plus the `DistributionBar` meter base, `SegmentedBar`, and `KpiTile`. d3 is used for math only (`scaleLinear`/`scaleBand`/`scalePoint`/`line`/`area`); Svelte owns the DOM.
- **Interchangeable data contracts**: `VizPoint` / `VizSeries` / `VizTooltipArgs` - one dataset shape across primitives.
- **Design tokens**: premium purple<->blue `--viz-1..8` categorical palette + structural roles, across light / dark / high-contrast (`prefers-contrast` adds hatch patterns). Opaque glossy fills, brighten-on-hover, morph + entrance animations (all `prefers-reduced-motion` guarded).
- **App-wide adoption**: ratings distribution, screen-time daily + peak-hours, VIP usage bar, toast + settings progress bars -> `DistributionBar`; `PulseCell` -> `KpiTile`; YIR genre bars -> `SegmentedBar`.
- **Design system**: new `/_design_system/charts` page showcasing every primitive.

## Accessibility
- `role="img"` + `aria-label` + sr-only `<figcaption>` on every chart.
- Mouse + touch: tap-to-pin tooltips, drag-scrub, tap-to-dismiss, synthetic-`pointerleave` ignored on touch; `touch-action: pan-y` on plot roots.
- Keyboard: charts are focusable, arrow keys / Home / End scrub, Enter pins, Escape clears, `:focus-visible` ring + an `aria-live` readout of the active point. Bubbles are tabbable.
- RTL: the SOT primitives use logical properties so fills/labels/ticks/rounding mirror.

## Testing
- Pure math + helpers unit-tested (`clamp`, `sum`, `ratio`, `netFlowByDay`, `resampleSeries`, `vizSeriesSlot`, `nearestIndex`).
- `svelte-check`: 0 errors / 0 warnings on the chart surface.
- Visually verified across light/dark/RTL via the DS page.

## Out of scope / follow-ups
- `CountryMap` still wraps Carbon (the only remaining Carbon dep) - separate migration.
- `MatchDrawer` gauge + breakdown bar are pre-existing one-offs on raw `--purple-500`.
- `@carbon/charts*` can be dropped from `package.json` once `CountryMap` migrates.
