### PR TITLE
feat(yir): light theme support for Year & Month in Review

### DIFF
--- a/projects/client/src/lib/sections/banner/month-in-review/MonthInReview.svelte
+++ b/projects/client/src/lib/sections/banner/month-in-review/MonthInReview.svelte
@@ -86,8 +86,8 @@
 
         background: radial-gradient(
           78.23% 78.23% at 0% 100%,
-          var(--purple-500) 0%,
-          var(--shade-900) 100%
+          var(--color-review-accent) 0%,
+          var(--color-review-base) 100%
         );
       }
     }

--- a/projects/client/src/lib/sections/banner/year-in-review/YearInReview.svelte
+++ b/projects/client/src/lib/sections/banner/year-in-review/YearInReview.svelte
@@ -75,8 +75,8 @@
 
       background: linear-gradient(
         178deg,
-        var(--shade-920) 43.39%,
-        color-mix(in srgb, var(--purple-500) 75%, transparent) 145.02%
+        var(--color-review-base-deep) 43.39%,
+        color-mix(in srgb, var(--color-review-accent) 75%, transparent) 145.02%
       );
     }
 
@@ -95,8 +95,8 @@
 
         background: linear-gradient(
           171deg,
-          var(--shade-920) 63.39%,
-          color-mix(in srgb, var(--purple-500) 75%, transparent) 145.02%
+          var(--color-review-base-deep) 63.39%,
+          color-mix(in srgb, var(--color-review-accent) 75%, transparent) 145.02%
         );
       }
     }

--- a/projects/client/src/lib/sections/banner/year-in-review/YirUpsellBanner.svelte
+++ b/projects/client/src/lib/sections/banner/year-in-review/YirUpsellBanner.svelte
@@ -39,7 +39,7 @@
     justify-content: space-between;
     gap: var(--gap-m);
 
-    color: var(--shade-10);
+    color: var(--color-review-foreground);
 
     height: var(--ni-56);
 
@@ -48,8 +48,8 @@
 
     background: linear-gradient(
       178deg,
-      var(--shade-920) 43.39%,
-      color-mix(in srgb, var(--purple-500) 75%, transparent) 145.02%
+      var(--color-review-base-deep) 43.39%,
+      color-mix(in srgb, var(--color-review-accent) 75%, transparent) 145.02%
     );
 
     border-radius: var(--border-radius-l);
@@ -72,8 +72,8 @@
 
       background: linear-gradient(
         135.65deg,
-        var(--shade-920) 43.39%,
-        color-mix(in srgb, var(--purple-500) 75%, transparent) 145.02%
+        var(--color-review-base-deep) 43.39%,
+        color-mix(in srgb, var(--color-review-accent) 75%, transparent) 145.02%
       );
     }
   }

--- a/projects/client/src/lib/sections/banner/year-in-review/_internal/YirBackground.svelte
+++ b/projects/client/src/lib/sections/banner/year-in-review/_internal/YirBackground.svelte
@@ -40,9 +40,9 @@
     opacity: 0.3;
     background: linear-gradient(
       180deg,
-      color-mix(in srgb, var(--purple-500) 64%, transparent) -2.25%,
-      color-mix(in srgb, var(--purple-500) 32%, transparent) 73.62%,
-      color-mix(in srgb, var(--shade-920) 0%, transparent) 105.05%
+      color-mix(in srgb, var(--color-review-accent) 64%, transparent) -2.25%,
+      color-mix(in srgb, var(--color-review-accent) 32%, transparent) 73.62%,
+      color-mix(in srgb, var(--color-review-base-deep) 0%, transparent) 105.05%
     );
     background-clip: text;
 

--- a/projects/client/src/lib/sections/components/ReviewContent.svelte
+++ b/projects/client/src/lib/sections/components/ReviewContent.svelte
@@ -66,8 +66,8 @@
 
     border-radius: var(--border-radius-l);
 
-    color: var(--shade-10);
-    background: var(--shade-900);
+    color: var(--color-review-foreground);
+    background: var(--color-review-base);
 
     transition: var(--transition-increment) ease-in-out;
     transition-property: background, height, padding, gap;
@@ -78,8 +78,8 @@
   .trakt-review-content[data-variant="gradient"] {
     background: radial-gradient(
       60.59% 305.37% at 100% 100%,
-      var(--purple-500) 0%,
-      var(--shade-900) 100%
+      var(--color-review-accent) 0%,
+      var(--color-review-base) 100%
     );
   }
 

--- a/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
+++ b/projects/client/src/lib/sections/yir/2024/Yir2024.svelte
@@ -243,8 +243,8 @@
     display: flex;
     flex-direction: column;
     gap: var(--content-gap);
-    background-color: var(--shade-950);
-    color: var(--shade-10);
+    background-color: var(--color-yir-background);
+    color: var(--color-yir-text-primary);
     // Scoped to the 2024 template so the Spline Sans face only swaps in
     // here and the rest of the app keeps the global Roboto stack.
     font-family: "Spline Sans", Helvetica, Arial, sans-serif;
@@ -259,6 +259,6 @@
     display: flex;
     justify-content: center;
     padding: var(--ni-72) 0;
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
   }
 </style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CompaniesSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CompaniesSection.svelte
@@ -120,7 +120,7 @@
 
   .yir-2024-companies-heading {
     font-size: clamp(var(--ni-32), 5vw, var(--ni-56));
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     @include for-mobile {
       font-size: var(--ni-28);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CountriesSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CountriesSection.svelte
@@ -92,7 +92,7 @@
     width: 100%;
     display: flex;
     flex-direction: column;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
   }
 
   .yir-2024-countries-map {

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024DailyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024DailyPlaysChart.svelte
@@ -57,12 +57,9 @@
 </div>
 
 <style lang="scss">
-  // Matches Yir2024WeeklyPlaysChart's 2024 palette: light gray bars, peak day
-  // in purple-300, hover purple-500.
+  // Bars render through the shared --viz-* palette (theme-aware, peak-weighted
+  // by the BarChart primitive); only the chart height is template-specific.
   .trakt-yir-2024-daily-plays-chart {
-    --color-bar-custom-default: var(--shade-100);
-    --color-bar-custom-highlight: var(--purple-300);
-    --color-bar-custom-hover: var(--purple-500);
     --height-bar-chart: var(--ni-300);
     width: 100%;
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024GenresSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024GenresSection.svelte
@@ -82,11 +82,7 @@
     overflow: hidden;
     padding: var(--panel-padding-y) var(--panel-padding-x);
     border-radius: var(--panel-radius);
-    background: radial-gradient(
-      50% 39.27% at 50% 0%,
-      color-mix(in srgb, var(--shade-950) 90%, var(--blue-500) 10%) 0%,
-      color-mix(in srgb, var(--shade-950) 70%, var(--shade-900) 30%) 100%
-    );
+    background: var(--color-yir-panel-background);
 
     @include for-mobile {
       --panel-padding-x: var(--ni-20);
@@ -107,7 +103,7 @@
     line-height: 1;
     white-space: nowrap;
     text-transform: lowercase;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
     opacity: 0.04;
     pointer-events: none;
     user-select: none;
@@ -138,7 +134,7 @@
     min-width: 0;
     font-size: clamp(var(--ni-32), 5vw, var(--ni-56));
     line-height: 1.05;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     @include for-mobile {
       font-size: var(--ni-28);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Hero.svelte
@@ -117,23 +117,42 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-yir-2024-hero {
+    position: relative;
+    // Own stacking context so the z-index:-1 watermark below is scoped to this
+    // element and can't slip behind the page background.
+    isolation: isolate;
     display: flex;
     flex-direction: column;
     align-items: center;
     text-align: center;
     gap: var(--gap-xl);
-    // Stylized "trakt" wordmark + fanart cutout sits behind the hero text.
-    // Pushed down a bit so the "2024" stars row sits above it cleanly.
-    background-image: url("/yir/2024/trakt-fanart-logo.svg");
-    background-position: center top var(--ni-72);
-    background-repeat: no-repeat;
-    background-size: contain;
+
+    // Stylized "trakt" wordmark + fanart cutout sits behind the hero text as a
+    // watermark. Rendered on a ::before so its opacity is theme-driven (full
+    // in dark, faint in light) without fading the hero's text, and so the page
+    // background shows through instead of a flat veil rectangle.
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      background-image: url("/yir/2024/trakt-fanart-logo.svg");
+      // Pushed down a bit so the "2024" stars row sits above it cleanly.
+      background-position: center top var(--ni-72);
+      background-repeat: no-repeat;
+      background-size: contain;
+      opacity: var(--yir-hero-watermark-opacity);
+      pointer-events: none;
+    }
 
     @include for-mobile {
-      // Less vertical breathing between rows on small screens, and pull the
-      // backdrop SVG up so it isn't hovering near the middle of the hero.
+      // Less vertical breathing between rows on small screens.
       gap: var(--gap-xs);
-      background-position: center top;
+
+      // Pull the backdrop SVG up so it isn't hovering near the middle.
+      &::before {
+        background-position: center top;
+      }
     }
   }
 
@@ -141,13 +160,13 @@
     display: flex;
     align-items: center;
     gap: var(--gap-m);
-    color: var(--purple-300);
+    color: var(--color-yir-text-accent);
     text-transform: uppercase;
   }
 
   .yir-2024-current-year {
     font-size: var(--ni-52);
-    color: var(--purple-300);
+    color: var(--color-yir-text-accent);
 
     @include for-mobile {
       font-size: var(--ni-24);
@@ -168,12 +187,12 @@
     letter-spacing: -0.04em;
     font-weight: 700;
     padding: 0 var(--ni-12);
-    color: var(--purple-700);
+    color: var(--color-yir-hero-gradient-end);
     white-space: nowrap;
     background: radial-gradient(
       59% 73% at 50% 119%,
-      color-mix(in srgb, var(--purple-300) 80%, white),
-      var(--purple-700)
+      var(--color-yir-hero-gradient-start),
+      var(--color-yir-hero-gradient-end)
     );
     background-clip: text;
     -webkit-background-clip: text;
@@ -219,11 +238,11 @@
   // "Directed By" matches the muted gray of the Trakt Worldwide / Member
   // Since labels; the username pops in the brighter shade-10.
   .yir-2024-by-label {
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
   }
 
   .yir-2024-name-label {
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     :global(.trakt-link) {
       text-decoration: none;
@@ -242,8 +261,8 @@
     width: var(--ni-64);
     height: var(--ni-64);
     border-radius: 50%;
-    border: var(--border-thickness-s) solid var(--shade-10);
-    background: var(--shade-800);
+    border: var(--border-thickness-s) solid var(--color-yir-border);
+    background: var(--color-yir-surface-chip);
     overflow: hidden;
     box-sizing: content-box;
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024LineChart.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024LineChart.svelte
@@ -6,21 +6,9 @@
 </script>
 
 <div class="trakt-yir-2024-line-chart">
-  <!--
-    2024 palette: white line, dark fill (~v2's #222 → shade-920), and a
-    purple-500 hover pin with a faint white halo. Colors are passed as props
-    (rather than via CSS vars on the wrapper) because Carbon resolves
-    `color.scale.value` at chart-init context, where Svelte-scoped wrapper
-    vars aren't accessible.
-  -->
-  <AreaChart
-    {data}
-    {tooltip}
-    lineColor="var(--shade-10)"
-    fillColor="var(--shade-920)"
-    dotColor="var(--purple-500)"
-    dotHaloColor="var(--shade-10)"
-  />
+  <!-- Renders through the shared --viz-* palette (theme-aware) like the rest
+       of the chart SOT. -->
+  <AreaChart {data} {tooltip} />
 </div>
 
 <style lang="scss">

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Membership.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Membership.svelte
@@ -39,7 +39,7 @@
     column-gap: var(--gap-m);
     width: 100%;
     margin-top: var(--ni-neg-24);
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
     box-sizing: border-box;
 
     // Tablet-sm-and-below: collapse to a centered flex row so the two
@@ -105,7 +105,7 @@
     :global(svg) {
       width: var(--ni-44);
       height: var(--ni-44);
-      color: var(--shade-300);
+      color: var(--color-yir-text-secondary);
     }
 
     @include for-mobile {
@@ -118,7 +118,7 @@
 
   .yir-2024-member-year {
     font-size: var(--ni-44);
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
     text-align: end;
 
     @include for-mobile {

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024MostPlayedSection.svelte
@@ -52,7 +52,7 @@
   .yir-2024-most-played-heading {
     margin: 0;
     font-size: clamp(var(--ni-28), 3.5vw, var(--ni-44));
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     @include for-mobile {
       font-size: var(--ni-22);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PeopleColumn.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PeopleColumn.svelte
@@ -52,14 +52,14 @@
     display: block;
     font-size: var(--font-size-text);
     letter-spacing: 2px;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
   }
 
   .yir-2024-people-column-title {
     margin: var(--ni-2) 0 0;
     font-size: var(--ni-32);
     line-height: 1.1;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
   }
 
   /* Capped height with its own scroll, so each of the four columns scrolls
@@ -77,6 +77,6 @@
   .yir-2024-people-column-loading {
     margin: 0;
     padding: var(--ni-20) 0;
-    color: var(--shade-500);
+    color: var(--color-yir-text-muted);
   }
 </style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PeopleSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PeopleSection.svelte
@@ -52,18 +52,14 @@
 
   // Same radial-gradient wrapper as the stats graph panels.
   .trakt-yir-2024-people {
-    --people-divider: var(--shade-1000);
+    --people-divider: var(--color-yir-separator);
 
     box-sizing: border-box;
     width: 100%;
     overflow: hidden;
     border-radius: var(--ni-64);
     padding: var(--ni-44);
-    background: radial-gradient(
-      50% 39.27% at 50% 0%,
-      color-mix(in srgb, var(--shade-950) 90%, var(--blue-500) 10%) 0%,
-      color-mix(in srgb, var(--shade-950) 70%, var(--shade-900) 30%) 100%
-    );
+    background: var(--color-yir-panel-background);
 
     @include for-mobile {
       border-radius: var(--ni-32);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PersonRow.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PersonRow.svelte
@@ -131,8 +131,7 @@
   @use "$style/scss/mixins/index" as *;
 
   .yir-2024-person {
-    border-bottom: var(--border-thickness-xxs) solid
-      color-mix(in srgb, var(--shade-700) 60%, transparent);
+    border-bottom: var(--border-thickness-xxs) solid var(--color-yir-separator);
 
     &:last-child {
       border-bottom: none;
@@ -150,7 +149,7 @@
     flex: none;
     min-width: var(--ni-24);
     font-size: var(--ni-16);
-    color: var(--shade-500);
+    color: var(--color-yir-text-muted);
   }
 
   // Name on line 1, watched counts stacked beneath it on line 2. Flexes to
@@ -177,7 +176,7 @@
     height: var(--ni-40);
     border-radius: 50%;
     object-fit: cover;
-    background-color: var(--shade-800);
+    background-color: var(--color-yir-surface-chip);
   }
 
   .yir-2024-person-name {
@@ -193,7 +192,7 @@
     // `.yir-2024-person-name` is scoped to this component, so the global
     // `.trakt-link` hover only matches names rendered here.
     :global(.trakt-link:hover) .yir-2024-person-name {
-      color: var(--purple-300);
+      color: var(--color-yir-text-accent);
     }
   }
 
@@ -209,7 +208,7 @@
     font-family: inherit;
     text-transform: uppercase;
     letter-spacing: 1px;
-    color: var(--shade-500);
+    color: var(--color-yir-text-muted);
     white-space: nowrap;
     cursor: pointer;
     transition: color 0.2s;
@@ -227,7 +226,7 @@
   }
 
   .yir-2024-person-counts:hover {
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
   }
 
   // Text dropped — a purple circle around the chevron keeps the button
@@ -286,20 +285,20 @@
     align-items: center;
     gap: var(--ni-8);
     text-decoration: none;
-    color: var(--shade-100);
+    color: var(--color-yir-text-primary);
     transition: color 0.2s;
   }
 
   @include for-mouse {
     .yir-2024-person-title :global(.trakt-link):hover {
-      color: var(--purple-300);
+      color: var(--color-yir-text-accent);
     }
   }
 
   .yir-2024-person-title-icon {
     flex: none;
     display: inline-flex;
-    color: var(--shade-400);
+    color: var(--color-yir-text-secondary);
 
     :global(svg) {
       width: var(--ni-16);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PostersRow.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PostersRow.svelte
@@ -89,7 +89,7 @@
     border-radius: var(--border-radius-m);
     overflow: hidden;
     transition: transform 0.3s;
-    background-color: var(--shade-800);
+    background-color: var(--color-yir-surface-chip);
 
     &:hover {
       transform: scale(1.05);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024SectionHeader.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024SectionHeader.svelte
@@ -30,7 +30,7 @@
     font-size: var(--ni-24);
     text-transform: uppercase;
     letter-spacing: 1px;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     @include for-mobile {
       font-size: var(--ni-12);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Stars.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024Stars.svelte
@@ -15,7 +15,7 @@
     display: inline-flex;
     align-items: center;
     gap: var(--gap-xs);
-    color: var(--purple-300);
+    color: var(--color-yir-text-accent);
 
     :global(svg) {
       width: var(--ni-28);

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatSummary.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatSummary.svelte
@@ -61,7 +61,7 @@
     align-items: center;
     gap: var(--ni-32);
     padding: var(--ni-16) 0;
-    border-bottom: var(--border-thickness-xxs) solid var(--shade-800);
+    border-bottom: var(--border-thickness-xxs) solid var(--color-yir-separator);
 
     &:last-child {
       border-bottom: none;
@@ -73,7 +73,7 @@
 
     dt {
       font-size: var(--font-size-title);
-      color: var(--shade-10);
+      color: var(--color-yir-text-primary);
     }
 
     dd {
@@ -81,7 +81,7 @@
       align-items: center;
       gap: var(--gap-xs);
       font-size: var(--font-size-title);
-      color: var(--shade-10);
+      color: var(--color-yir-text-primary);
       min-width: 0;
     }
   }
@@ -90,21 +90,21 @@
   // chart's highlight color (matches v2's link styling). Truncation handled
   // by the `.ellipsis` utility class on the markup.
   .yir-2024-stat-name {
-    color: var(--purple-300);
+    color: var(--color-yir-text-accent);
   }
 
   // Pill-shaped count badge with white background + dark text — matches the
   // v2 design. `--border-radius-xxl` is the established v3 token for
   // pill-shaped tags; `.tag` utility class handles font sizing.
   .yir-2024-stat-count {
-    background: var(--shade-10);
-    color: var(--shade-900);
+    background: var(--color-yir-badge-background);
+    color: var(--color-yir-badge-foreground);
     border-radius: var(--border-radius-xxl);
     padding: var(--ni-4) var(--ni-10);
     white-space: nowrap;
   }
 
   .yir-2024-stat-total {
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
   }
 </style>

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsMonthlySection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsMonthlySection.svelte
@@ -290,11 +290,7 @@
     overflow: visible;
     padding: var(--panel-padding-top) var(--panel-padding-x)
       var(--panel-padding-bottom);
-    background: radial-gradient(
-      50% 39.27% at 50% 0%,
-      color-mix(in srgb, var(--shade-950) 90%, var(--blue-500) 10%) 0%,
-      color-mix(in srgb, var(--shade-950) 70%, var(--shade-900) 30%) 100%
-    );
+    background: var(--color-yir-panel-background);
 
     @include for-mobile {
       --panel-padding-x: var(--ni-20);
@@ -351,7 +347,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-xxs);
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
 
     p {
       margin: 0;
@@ -360,7 +356,7 @@
     }
 
     :global(b) {
-      color: var(--purple-300);
+      color: var(--color-yir-text-accent);
       font-weight: 700;
     }
   }
@@ -407,7 +403,7 @@
 
   .yir-2024-stats-card-icon {
     display: inline-flex;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     :global(svg) {
       width: var(--ni-28);
@@ -430,7 +426,7 @@
     justify-content: space-between;
     align-items: baseline;
     padding: var(--ni-10) var(--panel-padding-x);
-    border-bottom: var(--border-thickness-xxs) solid var(--shade-800);
+    border-bottom: var(--border-thickness-xxs) solid var(--color-yir-separator);
 
     &:last-child {
       border-bottom: none;
@@ -439,7 +435,7 @@
     dt {
       margin: 0;
       font-size: var(--font-size-title);
-      color: var(--shade-300);
+      color: var(--color-yir-text-secondary);
 
       @include for-mobile {
         font-size: var(--font-size-text);
@@ -449,7 +445,7 @@
     dd {
       margin: 0;
       font-size: var(--font-size-title);
-      color: var(--shade-10);
+      color: var(--color-yir-text-primary);
 
       @include for-mobile {
         font-size: var(--font-size-text);
@@ -482,7 +478,7 @@
     font-size: var(--watermark-font-size);
     line-height: 1;
     letter-spacing: -0.02em;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
     opacity: 0.05;
     pointer-events: none;
     user-select: none;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StatsSection.svelte
@@ -303,11 +303,7 @@
       var(--panel-padding-bottom);
     // Approximates v2's #112836 → #191C1E radial: a faint blue-tinged
     // center at the top fading out to a darker charcoal everywhere else.
-    background: radial-gradient(
-      50% 39.27% at 50% 0%,
-      color-mix(in srgb, var(--shade-950) 90%, var(--blue-500) 10%) 0%,
-      color-mix(in srgb, var(--shade-950) 70%, var(--shade-900) 30%) 100%
-    );
+    background: var(--color-yir-panel-background);
 
     @include for-mobile {
       --panel-padding-x: var(--ni-20);
@@ -373,7 +369,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-xxs);
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
 
     p {
       margin: 0;
@@ -384,7 +380,7 @@
     // The i18n strings embed <b> around dynamic values; render those as
     // bold purple inline highlights.
     :global(b) {
-      color: var(--purple-300);
+      color: var(--color-yir-text-accent);
       font-weight: 700;
     }
   }
@@ -438,7 +434,7 @@
 
   .yir-2024-stats-card-icon {
     display: inline-flex;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     :global(svg) {
       width: var(--ni-28);
@@ -467,7 +463,7 @@
     justify-content: space-between;
     align-items: baseline;
     padding: var(--ni-10) var(--panel-padding-x);
-    border-bottom: var(--border-thickness-xxs) solid var(--shade-800);
+    border-bottom: var(--border-thickness-xxs) solid var(--color-yir-separator);
 
     &:last-child {
       border-bottom: none;
@@ -476,7 +472,7 @@
     dt {
       margin: 0;
       font-size: var(--font-size-title);
-      color: var(--shade-300);
+      color: var(--color-yir-text-secondary);
 
       @include for-mobile {
         font-size: var(--font-size-text);
@@ -486,7 +482,7 @@
     dd {
       margin: 0;
       font-size: var(--font-size-title);
-      color: var(--shade-10);
+      color: var(--color-yir-text-primary);
 
       @include for-mobile {
         font-size: var(--font-size-text);
@@ -522,7 +518,7 @@
     font-size: var(--watermark-font-size);
     line-height: 1;
     letter-spacing: -0.02em;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
     opacity: 0.05;
     pointer-events: none;
     user-select: none;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StreamingSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StreamingSection.svelte
@@ -142,7 +142,7 @@
     font-size: var(--ni-24);
     text-transform: uppercase;
     letter-spacing: 1px;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     @include for-mobile {
       font-size: var(--ni-12);
@@ -153,7 +153,7 @@
     margin: 0;
     font-size: clamp(var(--ni-32), 5vw, var(--ni-56));
     line-height: 1.05;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     @include for-mobile {
       font-size: var(--ni-28);
@@ -174,7 +174,7 @@
     align-items: center;
     gap: var(--ni-32);
     padding: var(--ni-16) 0;
-    border-bottom: var(--border-thickness-xxs) solid var(--shade-800);
+    border-bottom: var(--border-thickness-xxs) solid var(--color-yir-separator);
 
     &:last-child {
       border-bottom: none;
@@ -186,7 +186,7 @@
 
     dt {
       font-size: var(--font-size-title);
-      color: var(--shade-10);
+      color: var(--color-yir-text-primary);
       min-width: 0;
     }
 
@@ -194,13 +194,13 @@
       display: flex;
       align-items: center;
       font-size: var(--font-size-title);
-      color: var(--shade-10);
+      color: var(--color-yir-text-primary);
       white-space: nowrap;
     }
   }
 
   .yir-2024-streaming-name {
-    color: var(--purple-300);
+    color: var(--color-yir-text-accent);
   }
 
   // Shows and movies each get their own pill, laid out side by side.
@@ -211,8 +211,8 @@
   // Pill-shaped count badge matching Yir2024StatSummary's stat-count pill so
   // the streaming rows read like the genres / networks stat lists.
   .yir-2024-streaming-count-pill {
-    background: var(--shade-10);
-    color: var(--shade-900);
+    background: var(--color-yir-badge-background);
+    color: var(--color-yir-badge-foreground);
     border-radius: var(--border-radius-xxl);
     padding: var(--ni-4) var(--ni-10);
     white-space: nowrap;

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024ThanksSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024ThanksSection.svelte
@@ -40,7 +40,7 @@
 
   .trakt-yir-2024-thanks-section {
     width: 100%;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
     // Last section on the page — keep a gap below the posters so they don't
     // butt up against the page edge.
     padding-bottom: var(--ni-72);
@@ -91,8 +91,8 @@
     letter-spacing: -0.04em;
     background: linear-gradient(
       180deg,
-      color-mix(in srgb, var(--purple-300) 85%, white) 0%,
-      var(--purple-500) 100%
+      var(--color-yir-hero-gradient-start) 0%,
+      var(--color-yir-hero-gradient-end) 100%
     );
     background-clip: text;
     -webkit-background-clip: text;
@@ -110,7 +110,7 @@
     flex-direction: column;
     gap: var(--ni-20);
     text-align: start;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     // Set on the <p> directly — a global `p { font-size }` rule beats the
     // value the paragraph would otherwise inherit from this container.

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WatchedStats.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WatchedStats.svelte
@@ -122,7 +122,7 @@
     display: inline-flex;
     align-items: center;
     gap: var(--gap-m);
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     @include for-tablet-lg-and-below {
       gap: var(--gap-s);
@@ -141,7 +141,7 @@
   .yir-2024-stat-icon {
     display: inline-flex;
     align-items: center;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
     flex-shrink: 0;
 
     :global(svg) {
@@ -193,7 +193,7 @@
 
   .yir-2024-stat-label {
     font-size: var(--font-size-text);
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
     text-transform: uppercase;
 
     @include for-mobile {

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WeeklyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WeeklyPlaysChart.svelte
@@ -26,13 +26,9 @@
 </div>
 
 <style lang="scss">
-  // 2024 palette: bars use the lightest cool gray (shade-100, exactly
-  // matches v2's #d2d6d9); peak week pops in the lighter purple-300, and
-  // hover lands on purple-500 (#9f42c6, exactly matches v2's hover).
+  // Bars render through the shared --viz-* palette (theme-aware, peak-weighted
+  // by the BarChart primitive); only the chart height is template-specific.
   .trakt-yir-2024-weekly-plays-chart {
-    --color-bar-custom-default: var(--shade-100);
-    --color-bar-custom-highlight: var(--purple-300);
-    --color-bar-custom-hover: var(--purple-500);
     --height-bar-chart: var(--ni-300);
     width: 100%;
 

--- a/projects/client/src/lib/sections/yir/MirPage.svelte
+++ b/projects/client/src/lib/sections/yir/MirPage.svelte
@@ -38,9 +38,13 @@
   .trakt-mir-page {
     display: flex;
     flex-direction: column;
-    background-color: var(--shade-950);
-    color: var(--shade-10);
+    background-color: var(--color-yir-background);
+    color: var(--color-yir-text-primary);
     overflow-x: hidden;
+
+    // MIR renders the theme-aware 2024 template, so the fixed header's text
+    // tracks the theme to stay legible over the light hero.
+    --color-yir-header-foreground: var(--color-yir-text-primary);
 
     // Breathing room below the final section so the last card doesn't sit
     // flush against the bottom of the page.
@@ -49,14 +53,6 @@
     @include for-mobile {
       padding-bottom: var(--ni-72);
     }
-
-    // MIR is rendered with a dark backdrop regardless of user theme.
-    // These overrides force chart colors to stay legible.
-    --color-bar-custom-default: var(--shade-300);
-    --color-bar-custom-highlight: var(--shade-10);
-    --color-bar-custom-hover: var(--red-700);
-    --color-bar-chart-text-primary: var(--shade-10);
-    --color-bar-chart-text-secondary: var(--shade-500);
 
     // Account for the side navbar's outer margin (gap-s on each side) so the
     // visible gap on the right of the navbar matches the gap on the left.

--- a/projects/client/src/lib/sections/yir/YirPage.svelte
+++ b/projects/client/src/lib/sections/yir/YirPage.svelte
@@ -9,7 +9,11 @@
   const Template = $derived(getYirTemplate(year));
 </script>
 
-<div class="trakt-yir-page" id="year-in-review">
+<div
+  class="trakt-yir-page"
+  class:is-2024-template={year === 2024}
+  id="year-in-review"
+>
   <YirHeader {slug} {year} />
   <!-- Always mount the template so its scaffold (header text, hero shell)
        paints immediately; detail-dependent sections inside the template
@@ -28,17 +32,13 @@
   .trakt-yir-page {
     display: flex;
     flex-direction: column;
-    background-color: var(--shade-950);
-    color: var(--shade-10);
+    background-color: var(--color-yir-background);
+    color: var(--color-yir-text-primary);
     overflow-x: hidden;
 
-    // YIR is rendered with a dark backdrop regardless of user theme.
-    // These overrides force chart colors to stay legible.
-    --color-bar-custom-default: var(--shade-300);
-    --color-bar-custom-highlight: var(--shade-10);
-    --color-bar-custom-hover: var(--red-700);
-    --color-bar-chart-text-primary: var(--shade-10);
-    --color-bar-chart-text-secondary: var(--shade-500);
+    // The fixed header floats over the hero. The default template's hero is a
+    // dark poster in both themes, so the header text stays white there.
+    --color-yir-header-foreground: var(--color-yir-poster-foreground);
 
     // YIR-only: account for the side navbar's outer margin (gap-s on each
     // side, see SideNavbar.svelte) so the visible gap on the right of the
@@ -50,5 +50,11 @@
     @include for-tablet-sm-and-below {
       --layout-sidebar-distance: 0;
     }
+  }
+
+  // The 2024 template's hero is theme-aware (not a dark poster), so the
+  // header text must track the theme to stay legible over the light hero.
+  .trakt-yir-page.is-2024-template {
+    --color-yir-header-foreground: var(--color-yir-text-primary);
   }
 </style>

--- a/projects/client/src/lib/sections/yir/_internal/MirHeader.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/MirHeader.svelte
@@ -188,7 +188,7 @@
     padding: var(--ni-20) var(--ni-10);
 
     background: transparent;
-    color: var(--shade-10);
+    color: var(--color-yir-header-foreground, var(--color-yir-poster-foreground));
 
     transition:
       background-color 0.2s,
@@ -231,13 +231,13 @@
     padding: var(--ni-8);
     background: none;
     border: none;
-    color: var(--shade-10);
+    color: var(--color-yir-header-foreground, var(--color-yir-poster-foreground));
     cursor: pointer;
     text-decoration: none;
     transition: color 0.2s;
 
     &:hover:not(.disabled) {
-      color: var(--purple-300);
+      color: var(--color-yir-text-accent);
     }
 
     &.disabled {
@@ -266,7 +266,7 @@
     display: flex;
     align-items: center;
     gap: var(--gap-xs);
-    color: var(--shade-10);
+    color: var(--color-yir-header-foreground, var(--color-yir-poster-foreground));
     text-decoration: none;
     min-width: 0;
   }
@@ -276,7 +276,7 @@
     height: var(--ni-28);
     border-radius: 50%;
     overflow: hidden;
-    background: var(--shade-800);
+    background: var(--color-yir-surface-chip);
     flex-shrink: 0;
 
     :global(img) {
@@ -302,12 +302,12 @@
     padding: var(--ni-8);
     background: none;
     border: none;
-    color: var(--shade-10);
+    color: var(--color-yir-header-foreground, var(--color-yir-poster-foreground));
     cursor: pointer;
     transition: color 0.2s;
 
     &:hover {
-      color: var(--purple-300);
+      color: var(--color-yir-text-accent);
     }
 
     :global(svg) {

--- a/projects/client/src/lib/sections/yir/_internal/YirCompaniesBubbleChart.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirCompaniesBubbleChart.svelte
@@ -24,9 +24,10 @@
 
   // Companies with no brand color or with a pure-black brand color would
   // collapse onto the panel background; fall back to a neutral semantic
-  // gray so the bubble still reads. Carbon writes the value as an inline
-  // SVG fill, so `var(...)` strings resolve at render time at the SVG node.
-  const fallbackColor = "var(--shade-800)";
+  // gray that reads on both the light and dark YIR surface. Carbon writes
+  // the value as an inline SVG fill, so `var(...)` strings resolve at
+  // render time at the SVG node.
+  const fallbackColor = "var(--color-yir-text-muted)";
   const blackPattern = /^#0{3}(?:0{3})?$/i;
 
   function colorFor(company: YirCompany): string {

--- a/projects/client/src/lib/sections/yir/_internal/YirCountriesMap.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirCountriesMap.svelte
@@ -33,7 +33,7 @@
 
 <CountryMap
   {data}
-  --color-map-chart-background="var(--shade-900)"
+  --color-map-chart-background="var(--color-yir-surface-raised)"
   --color-map-chart-highlight="var(--red-500)"
 >
   {#snippet tooltip({ code })}

--- a/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirHeader.svelte
@@ -161,7 +161,7 @@
     padding: var(--ni-20) var(--ni-10);
 
     background: transparent;
-    color: var(--shade-10);
+    color: var(--color-yir-header-foreground, var(--color-yir-poster-foreground));
 
     transition:
       background-color 0.2s,
@@ -206,13 +206,13 @@
     padding: var(--ni-8);
     background: none;
     border: none;
-    color: var(--shade-10);
+    color: var(--color-yir-header-foreground, var(--color-yir-poster-foreground));
     cursor: pointer;
     text-decoration: none;
     transition: color 0.2s;
 
     &:hover:not(.disabled) {
-      color: var(--purple-300);
+      color: var(--color-yir-text-accent);
     }
 
     &.disabled {
@@ -241,7 +241,7 @@
     display: flex;
     align-items: center;
     gap: var(--gap-xs);
-    color: var(--shade-10);
+    color: var(--color-yir-header-foreground, var(--color-yir-poster-foreground));
     text-decoration: none;
     min-width: 0;
   }
@@ -251,7 +251,7 @@
     height: var(--ni-28);
     border-radius: 50%;
     overflow: hidden;
-    background: var(--shade-800);
+    background: var(--color-yir-surface-chip);
     flex-shrink: 0;
 
     :global(img) {
@@ -277,12 +277,12 @@
     padding: var(--ni-8);
     background: none;
     border: none;
-    color: var(--shade-10);
+    color: var(--color-yir-header-foreground, var(--color-yir-poster-foreground));
     cursor: pointer;
     transition: color 0.2s;
 
     &:hover {
-      color: var(--purple-300);
+      color: var(--color-yir-text-accent);
     }
 
     :global(svg) {

--- a/projects/client/src/lib/sections/yir/_internal/YirStreamingBubbleChart.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirStreamingBubbleChart.svelte
@@ -23,9 +23,9 @@
     tooltip: tooltipSnippet,
   }: YirStreamingBubbleChartProps = $props();
 
-  // Services without a brand color fall back to a neutral semantic gray so the
-  // bubble still reads against the dark panel.
-  const fallbackColor = "var(--shade-800)";
+  // Services without a brand color fall back to a neutral semantic gray that
+  // reads on both the light and dark YIR surface.
+  const fallbackColor = "var(--color-yir-text-muted)";
 
   const sourcesQuery = useQuery(streamingSourcesQuery({}));
   const sources = sourcesQuery.pipe(map(($query) => $query.data));

--- a/projects/client/src/lib/sections/yir/_internal/YirTooltip.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirTooltip.svelte
@@ -25,14 +25,13 @@
   // tooltip customHTML callback (see yirTooltipHTML.ts), which renders
   // outside this component's DOM.
   :global(.trakt-yir-tooltip) {
-    background: color-mix(in srgb, var(--shade-1000) 92%, transparent);
-    border: var(--border-thickness-xxs) solid var(--shade-800);
+    background: var(--color-yir-tooltip-background);
+    border: var(--border-thickness-xxs) solid var(--color-yir-separator);
     border-radius: var(--border-radius-xs);
     padding: var(--ni-8) var(--ni-12);
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
     font-family: inherit;
-    box-shadow: 0 var(--ni-2) var(--ni-8)
-      color-mix(in srgb, var(--shade-1000) 60%, transparent);
+    box-shadow: 0 var(--ni-2) var(--ni-8) var(--color-yir-scrim);
     text-align: center;
     white-space: nowrap;
   }
@@ -40,7 +39,7 @@
   :global(.yir-tooltip-main) {
     font-size: var(--font-size-text);
     font-weight: 600;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     &:not(:last-child) {
       margin-bottom: var(--ni-4);
@@ -50,6 +49,6 @@
   :global(.yir-tooltip-sub),
   :global(.yir-tooltip-extra) {
     font-size: var(--ni-12);
-    color: var(--shade-500);
+    color: var(--color-yir-text-muted);
   }
 </style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirCalendarSection.svelte
@@ -82,9 +82,16 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-yir-calendar-section {
+    // Poster hero: keep the overlay dark/white in both themes (see
+    // YirTitleSection for the token-pinning rationale).
+    --color-yir-text-primary: var(--color-yir-poster-foreground);
+    --color-yir-border: var(--color-yir-poster-foreground);
+    --color-yir-title-chip-background: var(--color-yir-scrim);
+
     position: relative;
     text-align: center;
-    background-color: var(--shade-950);
+    background-color: var(--color-yir-poster-background);
+    color: var(--color-yir-poster-foreground);
   }
 
   .yir-calendar-bg {
@@ -99,10 +106,7 @@
   .yir-calendar-shade {
     position: absolute;
     inset: 0;
-    background: radial-gradient(
-      color-mix(in srgb, var(--shade-1000) 80%, transparent),
-      transparent
-    );
+    background: radial-gradient(var(--color-yir-scrim), transparent);
   }
 
   .yir-calendar-inner {
@@ -115,7 +119,7 @@
     :global(.trakt-link) {
       display: block;
       text-decoration: none;
-      color: var(--shade-10);
+      color: var(--color-yir-poster-foreground);
     }
   }
 
@@ -128,8 +132,7 @@
 
   .yir-calendar-title {
     font-size: var(--ni-40);
-    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2)
-      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2) var(--color-yir-scrim);
     margin: 0;
 
     @include for-mobile {
@@ -139,8 +142,7 @@
   }
 
   .yir-calendar-episode {
-    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2)
-      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2) var(--color-yir-scrim);
     margin: var(--ni-10) 0 0 0;
     font-size: var(--ni-22);
 
@@ -164,7 +166,7 @@
     grid-row: 1 / 3;
     display: flex;
     align-items: center;
-    color: var(--shade-10);
+    color: var(--color-yir-poster-foreground);
     opacity: 0.7;
 
     :global(svg) {

--- a/projects/client/src/lib/sections/yir/default/_internal/YirGenresSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirGenresSection.svelte
@@ -33,7 +33,7 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-yir-genres-section {
-    background-color: var(--shade-1000);
+    background-color: var(--color-yir-surface);
     padding-bottom: var(--ni-72);
 
     @include for-mobile {

--- a/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
@@ -106,7 +106,17 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-yir-most-watched-section {
-    background-color: var(--shade-950);
+    // Poster hero: fanart + dark strip + white text in both themes. Pin the
+    // shared chrome tokens (incl. the ranked section-header pill) to their
+    // always-dark poster values (see YirTitleSection for the rationale).
+    --color-yir-text-primary: var(--color-yir-poster-foreground);
+    --color-yir-border: var(--color-yir-poster-foreground);
+    --color-yir-title-chip-background: var(--color-yir-scrim);
+    --color-yir-badge-background: var(--color-yir-poster-foreground);
+    --color-yir-badge-foreground: var(--color-yir-poster-surface);
+
+    background-color: var(--color-yir-poster-background);
+    color: var(--color-yir-poster-foreground);
     text-align: center;
     position: relative;
   }
@@ -138,10 +148,7 @@
   .yir-shade {
     position: absolute;
     inset: 0;
-    background: radial-gradient(
-      color-mix(in srgb, var(--shade-1000) 80%, transparent),
-      transparent
-    );
+    background: radial-gradient(var(--color-yir-scrim), transparent);
   }
 
   .yir-featured-card {
@@ -156,7 +163,7 @@
 
   .yir-card-media {
     margin-top: var(--ni-20);
-    color: var(--shade-10);
+    color: var(--color-yir-poster-foreground);
 
     :global(.trakt-link) {
       display: block;
@@ -173,8 +180,7 @@
 
   .yir-card-title {
     font-size: var(--ni-32);
-    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2)
-      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+    text-shadow: var(--ni-1) var(--ni-1) var(--ni-2) var(--color-yir-scrim);
     margin: 0;
 
     @include for-mobile {
@@ -207,14 +213,11 @@
     margin: -2.5% var(--layout-sidebar-distance) 0;
     // Solid backdrop so hover-faded thumbs reveal this dark color instead
     // of bleeding the fanart through.
-    background-color: var(--shade-1000);
+    background-color: var(--color-yir-poster-surface);
     border-radius: var(--border-radius-s);
     // Drop-shadow follows the alpha outline (incl. the first/last thumbs'
     // rounded corners), so the strip reads as floating above the fanart.
-    filter: drop-shadow(
-      0 var(--ni-4) var(--ni-12)
-        color-mix(in srgb, var(--shade-1000) 70%, transparent)
-    );
+    filter: drop-shadow(0 var(--ni-4) var(--ni-12) var(--color-yir-scrim));
 
     &:hover {
       .yir-grid-item {
@@ -299,12 +302,12 @@
   .yir-rank {
     --rank-size: var(--ni-22);
 
-    background-color: var(--shade-800);
-    color: var(--shade-10);
+    background-color: var(--color-yir-poster-chip);
+    color: var(--color-yir-poster-foreground);
     display: inline-block;
     font-size: var(--ni-12);
     font-weight: bold;
-    border: var(--border-thickness-xs) solid var(--shade-10);
+    border: var(--border-thickness-xs) solid var(--color-yir-poster-foreground);
     border-radius: 50%;
     height: var(--rank-size);
     width: var(--rank-size);

--- a/projects/client/src/lib/sections/yir/default/_internal/YirNetworksSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirNetworksSection.svelte
@@ -28,7 +28,7 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-yir-networks-section {
-    background-color: var(--shade-950);
+    background-color: var(--color-yir-background);
   }
 
   .yir-network-bubbles {

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
@@ -197,7 +197,7 @@
   .yir-people-loading {
     text-align: center;
     opacity: 0.5;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
   }
 
   .yir-pager {
@@ -212,11 +212,11 @@
     background: none;
     border: none;
     cursor: pointer;
-    color: var(--shade-500);
+    color: var(--color-yir-text-muted);
     transition: color 0.3s;
 
     &:hover {
-      color: var(--shade-300);
+      color: var(--color-yir-text-secondary);
     }
 
     &.invisible {
@@ -263,25 +263,25 @@
     :global(.trakt-link) {
       display: block;
       text-decoration: none;
-      color: var(--shade-10);
+      color: var(--color-yir-text-primary);
     }
 
     @include for-mouse {
       &:hover {
         .yir-headshot {
-          box-shadow: 0 0 var(--ni-20) var(--purple-500);
+          box-shadow: 0 0 var(--ni-20) var(--color-yir-accent);
 
           &::after {
-            border-color: var(--purple-500);
+            border-color: var(--color-yir-accent);
           }
         }
 
         .yir-person-name {
-          color: var(--purple-500);
+          color: var(--color-yir-accent);
         }
 
         .yir-person-count {
-          color: var(--shade-100);
+          color: var(--color-yir-text-primary);
         }
       }
     }
@@ -299,16 +299,15 @@
     position: absolute;
     top: 0;
     inset-inline-start: var(--ni-14);
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
     font-weight: bold;
     font-size: var(--ni-12);
     z-index: 2;
-    text-shadow: 0 var(--ni-1) var(--ni-2)
-      color-mix(in srgb, var(--shade-1000) 80%, transparent);
+    text-shadow: 0 var(--ni-1) var(--ni-2) var(--color-yir-scrim);
   }
 
   .yir-headshot {
-    background-color: var(--shade-1000);
+    background-color: var(--color-yir-surface);
     position: relative;
     overflow: hidden;
     border-radius: 50%;
@@ -326,10 +325,12 @@
       border-radius: 100%;
       width: 100%;
       height: 100%;
-      box-shadow: 0 0 0 var(--ni-104) var(--shade-1000);
+      // Flood ring that crops the square headshot into a circle - must match
+      // the section surface so the masked corners blend in both themes.
+      box-shadow: 0 0 0 var(--ni-104) var(--color-yir-surface);
       inset-inline-start: 0;
       top: 0;
-      border: var(--border-thickness-xxs) solid var(--shade-600);
+      border: var(--border-thickness-xxs) solid var(--color-yir-border-subtle);
       transition: border-color 0.5s;
     }
   }
@@ -349,7 +350,7 @@
     font-size: var(--ni-16);
     margin-top: var(--ni-12);
     margin-bottom: var(--ni-8);
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
     transition: all 0.5s;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -363,7 +364,7 @@
   .yir-person-count {
     font-size: var(--ni-12);
     text-transform: uppercase;
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
     margin: var(--ni-2) 0 0 0;
     transition: all 0.5s;
 

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPeopleSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPeopleSection.svelte
@@ -23,6 +23,6 @@
 
 <style lang="scss">
   .trakt-yir-people-section {
-    background-color: var(--shade-1000);
+    background-color: var(--color-yir-surface);
   }
 </style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirRatedSection.svelte
@@ -78,9 +78,16 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-yir-rated-section {
+    // Poster hero: fanart + posters + white text in both themes (see
+    // YirTitleSection for the token-pinning rationale).
+    --color-yir-text-primary: var(--color-yir-poster-foreground);
+    --color-yir-border: var(--color-yir-poster-foreground);
+    --color-yir-title-chip-background: var(--color-yir-scrim);
+
     text-align: center;
     position: relative;
-    background-color: var(--shade-950);
+    background-color: var(--color-yir-poster-background);
+    color: var(--color-yir-poster-foreground);
   }
 
   .yir-fanart-bg {
@@ -99,7 +106,7 @@
   .yir-rated-inner {
     position: relative;
     z-index: 1;
-    background-color: color-mix(in srgb, var(--shade-1000) 30%, transparent);
+    background-color: var(--color-yir-scrim-soft);
     padding-bottom: var(--ni-72);
 
     @include for-mobile {
@@ -136,8 +143,8 @@
 
   .yir-poster {
     border: none;
-    background-color: var(--shade-1000);
-    box-shadow: 0 0 var(--ni-20) var(--shade-1000);
+    background-color: var(--color-yir-poster-surface);
+    box-shadow: 0 0 var(--ni-20) var(--color-yir-poster-surface);
     position: relative;
 
     .yir-poster-img {
@@ -158,7 +165,7 @@
     justify-content: center;
     align-items: center;
     margin-top: var(--ni-8);
-    color: var(--shade-10);
+    color: var(--color-yir-poster-foreground);
     transition: all 0.5s;
   }
 </style>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirSectionHeader.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirSectionHeader.svelte
@@ -57,8 +57,8 @@
       text-transform: uppercase;
       display: inline-block;
       letter-spacing: 1px;
-      border: var(--border-thickness-xxs) solid var(--shade-10);
-      background-color: color-mix(in srgb, var(--shade-1000) 50%, transparent);
+      border: var(--border-thickness-xxs) solid var(--color-yir-border);
+      background-color: var(--color-yir-title-chip-background);
       font-size: var(--ni-16);
       line-height: 1;
       text-align: center;
@@ -67,8 +67,8 @@
 
     .yir-header-number {
       display: inline-block;
-      background-color: var(--shade-10);
-      color: var(--shade-1000);
+      background-color: var(--color-yir-badge-background);
+      color: var(--color-yir-badge-foreground);
       padding: var(--ni-6) var(--ni-8);
       margin-inline-end: var(--ni-neg-4);
     }

--- a/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
@@ -142,7 +142,7 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-yir-stats-section {
-    background-color: var(--shade-950);
+    background-color: var(--color-yir-background);
     padding-bottom: var(--ni-72);
 
     @include for-mobile {
@@ -185,7 +185,7 @@
   .yir-stat-arrow {
     display: flex;
     align-items: center;
-    color: var(--shade-700);
+    color: var(--color-yir-arrow);
     flex-shrink: 0;
     // Vertical offset = (number font-size − svg size) / 2, so the arrow
     // centers on the big number rather than on the row's flex-start baseline.
@@ -216,7 +216,7 @@
     font-size: var(--ni-48);
     font-weight: bold;
     line-height: 1;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     @include for-tablet-sm-and-below {
       font-size: var(--ni-40);
@@ -234,7 +234,7 @@
     gap: var(--gap-xxs);
     font-size: var(--font-size-text);
     text-transform: uppercase;
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
     margin-top: 0;
 
     @include for-mobile {
@@ -243,14 +243,14 @@
   }
 
   .yir-separator {
-    border-bottom: var(--border-thickness-xxs) dashed var(--shade-800);
+    border-bottom: var(--border-thickness-xxs) dashed var(--color-yir-separator);
     margin: var(--ni-40) 0;
   }
 
   .yir-under-chart {
     font-size: var(--font-size-text);
     text-transform: uppercase;
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
     margin: var(--ni-16) 0 0 0;
     text-align: center;
   }
@@ -289,7 +289,7 @@
     overflow-y: hidden;
     /* Hide scrollbar but keep functionality */
     scrollbar-width: thin;
-    scrollbar-color: var(--shade-800) transparent;
+    scrollbar-color: var(--color-yir-separator) transparent;
 
     // Extra horizontal breathing room around the charts on smaller
     // screens so the bars don't hug the viewport edges.
@@ -311,7 +311,7 @@
     }
 
     &::-webkit-scrollbar-thumb {
-      background: var(--shade-800);
+      background: var(--color-yir-separator);
       border-radius: var(--border-radius-xs);
     }
   }

--- a/projects/client/src/lib/sections/yir/default/_internal/YirStudiosSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirStudiosSection.svelte
@@ -28,7 +28,7 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-yir-studios-section {
-    background-color: var(--shade-950);
+    background-color: var(--color-yir-background);
   }
 
   .yir-studio-bubbles {

--- a/projects/client/src/lib/sections/yir/default/_internal/YirTitleSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirTitleSection.svelte
@@ -69,12 +69,21 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-yir-title-section {
+    // Poster hero: cover image + dark panel + white text in both themes.
+    // Pin the shared chrome tokens (consumed by YirSectionHeader and the
+    // text below) to their always-dark poster values so the overlay stays
+    // legible regardless of the active theme.
+    --color-yir-text-primary: var(--color-yir-poster-foreground);
+    --color-yir-border: var(--color-yir-poster-foreground);
+    --color-yir-title-chip-background: var(--color-yir-scrim);
+
     display: flex;
     align-items: center;
     justify-content: center;
     min-height: 100vh;
     min-height: 100dvh;
-    background-color: var(--shade-950);
+    background-color: var(--color-yir-poster-background);
+    color: var(--color-yir-poster-foreground);
     position: relative;
     overflow: hidden;
   }
@@ -102,11 +111,11 @@
     display: inline-block;
     background: radial-gradient(
       circle,
-      var(--shade-900) 20%,
-      var(--shade-950) 80%
+      var(--color-yir-poster-surface-raised) 20%,
+      var(--color-yir-poster-background) 80%
     );
     padding: var(--ni-20);
-    box-shadow: 0 0 var(--ni-52) var(--shade-1000);
+    box-shadow: 0 0 var(--ni-52) var(--color-yir-poster-surface);
 
     @include for-mobile {
       max-width: 80%;
@@ -133,8 +142,8 @@
     width: var(--ni-40);
     height: var(--ni-40);
     border-radius: 50%;
-    border: var(--border-thickness-xs) solid var(--shade-10);
-    background-color: var(--shade-10);
+    border: var(--border-thickness-xs) solid var(--color-yir-poster-foreground);
+    background-color: var(--color-yir-poster-foreground);
     overflow: hidden;
 
     :global(img) {
@@ -155,7 +164,7 @@
     font-size: var(--ni-24);
 
     :global(.trakt-link) {
-      color: var(--shade-10);
+      color: var(--color-yir-poster-foreground);
       text-decoration: none;
     }
 
@@ -167,7 +176,7 @@
   .yir-under-user {
     width: var(--ni-380);
     max-width: 100%;
-    border-bottom: var(--border-thickness-xxs) dashed var(--shade-500);
+    border-bottom: var(--border-thickness-xxs) dashed var(--color-yir-text-muted);
     margin: var(--ni-24) auto var(--ni-6) auto;
 
     @include for-mobile {
@@ -180,7 +189,7 @@
     font-weight: normal;
     margin: 0;
     line-height: 1;
-    color: var(--shade-10);
+    color: var(--color-yir-poster-foreground);
 
     @include for-mobile {
       font-size: var(--ni-104);
@@ -188,8 +197,8 @@
   }
 
   .yir-subtitle {
-    background-color: var(--shade-10);
-    color: var(--shade-950);
+    background-color: var(--color-yir-poster-foreground);
+    color: var(--color-yir-poster-background);
     display: block;
     text-transform: uppercase;
     padding: var(--ni-8) var(--ni-16);

--- a/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
@@ -102,7 +102,7 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-yir-totals-section {
-    background-color: var(--shade-1000);
+    background-color: var(--color-yir-surface);
     padding-bottom: var(--ni-72);
   }
 
@@ -136,7 +136,7 @@
     font-size: var(--ni-60);
     font-weight: bold;
     line-height: 1;
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
 
     @include for-tablet-sm-and-below {
       font-size: var(--ni-44);
@@ -154,7 +154,7 @@
     gap: var(--gap-xxs);
     font-size: var(--font-size-text);
     text-transform: uppercase;
-    color: var(--shade-300);
+    color: var(--color-yir-text-secondary);
     margin-top: 0;
   }
 

--- a/projects/client/src/lib/sections/yir/default/_internal/YirUpgradeSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirUpgradeSection.svelte
@@ -25,7 +25,7 @@
 
   .yir-vip-page {
     position: relative;
-    background-color: var(--shade-950);
+    background-color: var(--color-yir-background);
   }
 
   .yir-upgrade-content {
@@ -35,11 +35,11 @@
 
   .yir-go-vip {
     margin: 0 auto;
-    background: var(--shade-950);
+    background: var(--color-yir-background);
     width: var(--ni-380);
     max-width: 75%;
     font-size: var(--ni-16);
-    box-shadow: 0 0 var(--ni-52) var(--red-800);
+    box-shadow: 0 0 var(--ni-52) var(--color-yir-upgrade-glow);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -48,7 +48,7 @@
     gap: var(--gap-m);
 
     &:hover {
-      background: var(--shade-930);
+      background: var(--color-yir-surface-raised);
     }
 
     @include for-mobile {
@@ -58,6 +58,6 @@
   }
 
   .yir-upgrade-text {
-    color: var(--shade-10);
+    color: var(--color-yir-text-primary);
   }
 </style>

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -353,6 +353,73 @@
   // Non-color (hatched <pattern>) encoding is off until a high-contrast mode
   // turns it on. Kept here so components can reference it unconditionally.
   --viz-pattern-opacity: 0;
+
+  /*
+   * Year / Month in Review
+   *
+   * Two layers. "Chrome" (flat stat/data surfaces) flips with the theme.
+   * "Poster" heroes (cover-image sections with white text over a dark scrim)
+   * stay dark in BOTH themes by design - the scrim keeps overlaid text
+   * legible regardless of the active theme, mirroring the cover-image
+   * treatment above. The review banner is an adaptive purple accent card.
+   */
+  // Chrome
+  --color-yir-background: var(--shade-50);
+  --color-yir-surface: var(--shade-10);
+  --color-yir-surface-raised: var(--shade-100);
+  --color-yir-surface-chip: var(--shade-200);
+  --color-yir-text-primary: var(--shade-920);
+  --color-yir-text-secondary: var(--shade-600);
+  --color-yir-text-muted: var(--shade-500);
+  --color-yir-text-accent: var(--purple-700);
+  --color-yir-accent: var(--purple-500);
+  --color-yir-border: var(--shade-900);
+  --color-yir-border-subtle: var(--shade-300);
+  --color-yir-separator: var(--shade-300);
+  --color-yir-arrow: var(--shade-400);
+  --color-yir-badge-background: var(--shade-900);
+  --color-yir-badge-foreground: var(--shade-10);
+  --color-yir-title-chip-background: color-mix(
+    in srgb,
+    var(--shade-10) 60%,
+    transparent
+  );
+  --color-yir-tooltip-background: color-mix(
+    in srgb,
+    var(--shade-10) 95%,
+    transparent
+  );
+  --color-yir-upgrade-glow: var(--red-300);
+  // Poster heroes (constant across themes)
+  --color-yir-poster-foreground: var(--shade-10);
+  --color-yir-poster-background: var(--shade-950);
+  --color-yir-poster-surface: var(--shade-1000);
+  --color-yir-poster-surface-raised: var(--shade-900);
+  --color-yir-poster-chip: var(--shade-800);
+  --color-yir-scrim: color-mix(in srgb, var(--shade-1000) 80%, transparent);
+  --color-yir-scrim-soft: color-mix(
+    in srgb,
+    var(--shade-1000) 30%,
+    transparent
+  );
+  // Review banner (adaptive accent card)
+  --color-review-foreground: var(--shade-10);
+  --color-review-accent: var(--purple-500);
+  --color-review-base: var(--purple-700);
+  --color-review-base-deep: var(--purple-800);
+  // 2024 template: branded purple hero wordmark and blue-tinged stat panels
+  // (charts themselves render through the shared --viz-* tokens).
+  --color-yir-hero-gradient-start: var(--purple-400);
+  --color-yir-hero-gradient-end: var(--purple-800);
+  --color-yir-panel-background: radial-gradient(
+    50% 39.27% at 50% 0%,
+    color-mix(in srgb, var(--shade-10) 92%, var(--blue-500) 8%) 0%,
+    color-mix(in srgb, var(--shade-50) 70%, var(--shade-100) 30%) 100%
+  );
+  // Opacity of the dark "trakt" fanart wordmark behind the hero. Full in dark
+  // (the SVG reads as designed); knocked back to a faint watermark in light so
+  // the heavy dark wordmark doesn't dominate the light background.
+  --yir-hero-watermark-opacity: 0.12;
 }
 
 // Define theme variables for dark mode
@@ -705,6 +772,67 @@
   --viz-fade-floor: 0.14;
   --viz-glow-percent: 60%;
   --viz-pattern-opacity: 0;
+
+  /*
+   * Year / Month in Review (see light-theme for the layer rationale)
+   */
+  // Chrome
+  --color-yir-background: var(--shade-950);
+  --color-yir-surface: var(--shade-1000);
+  --color-yir-surface-raised: var(--shade-930);
+  --color-yir-surface-chip: var(--shade-800);
+  --color-yir-text-primary: var(--shade-10);
+  --color-yir-text-secondary: var(--shade-300);
+  --color-yir-text-muted: var(--shade-500);
+  --color-yir-text-accent: var(--purple-300);
+  --color-yir-accent: var(--purple-500);
+  --color-yir-border: var(--shade-10);
+  --color-yir-border-subtle: var(--shade-600);
+  --color-yir-separator: var(--shade-800);
+  --color-yir-arrow: var(--shade-700);
+  --color-yir-badge-background: var(--shade-10);
+  --color-yir-badge-foreground: var(--shade-1000);
+  --color-yir-title-chip-background: color-mix(
+    in srgb,
+    var(--shade-1000) 50%,
+    transparent
+  );
+  --color-yir-tooltip-background: color-mix(
+    in srgb,
+    var(--shade-1000) 92%,
+    transparent
+  );
+  --color-yir-upgrade-glow: var(--red-800);
+  // Poster heroes (constant across themes)
+  --color-yir-poster-foreground: var(--shade-10);
+  --color-yir-poster-background: var(--shade-950);
+  --color-yir-poster-surface: var(--shade-1000);
+  --color-yir-poster-surface-raised: var(--shade-900);
+  --color-yir-poster-chip: var(--shade-800);
+  --color-yir-scrim: color-mix(in srgb, var(--shade-1000) 80%, transparent);
+  --color-yir-scrim-soft: color-mix(
+    in srgb,
+    var(--shade-1000) 30%,
+    transparent
+  );
+  // Review banner (adaptive accent card)
+  --color-review-foreground: var(--shade-10);
+  --color-review-accent: var(--purple-500);
+  --color-review-base: var(--shade-900);
+  --color-review-base-deep: var(--shade-920);
+  // 2024 template (see light-theme for the rationale)
+  --color-yir-hero-gradient-start: color-mix(
+    in srgb,
+    var(--purple-300) 80%,
+    white
+  );
+  --color-yir-hero-gradient-end: var(--purple-700);
+  --color-yir-panel-background: radial-gradient(
+    50% 39.27% at 50% 0%,
+    color-mix(in srgb, var(--shade-950) 90%, var(--blue-500) 10%) 0%,
+    color-mix(in srgb, var(--shade-950) 70%, var(--shade-900) 30%) 100%
+  );
+  --yir-hero-watermark-opacity: 1;
 }
 
 // Apply themes to selectors


### PR DESCRIPTION
Year in Review (default + 2024 templates) and Month in Review were hardcoded to a dark aesthetic. This adds full light-theme support without breaking dark, driven entirely by theme CSS variables (no JS theme branching, no hydration flash, no `[data-theme]` selectors in components).

## How it works

A `--color-yir-*` / `--color-review-*` token system in `modes.scss`, defined under both the light and dark mixins. Components consume the tokens unconditionally; the theme decides the value. Three layers:

- **Chrome** (page, stat panels, text, dividers, section headers, tooltips) flips with the theme.
- **Poster heroes** (cover-image sections with white text over a dark scrim) stay dark in both themes by design - the scrim keeps overlaid text legible regardless of theme, mirroring how `modes.scss` already treats cover images.
- **Review banners** become adaptive purple accent cards; branded purple/cover-image cards in the 2024 template stay white-on-dark as self-contained islands.

The fixed YIR/MIR header foreground is parent-driven (`--color-yir-header-foreground`) so it tracks whichever hero sits behind it: white over the default template's dark poster, theme-aware over the 2024 hero (used by year-2024 YIR and all of MIR).

The 2024 hero wordmark is a `::before` watermark with theme-driven opacity, so it reads as a faint backdrop in light mode instead of a heavy dark mass.

## Chart integration

Rebased on top of the new hand-rolled chart SOT (`--viz-*`). The YIR charts now render through the shared viz primitives (theme-aware for free): dropped the obsolete `--color-bar-custom-*` / per-chart color overrides and the matching tokens. `YirGenreBars` adopts the merged `SegmentedBar`. The country map (still Carbon) keeps its `--color-map-chart-*` override, now pointed at theme-aware tokens.

## Commits

- `feat(yir)`: token system + default page + review banners
- `feat(yir)`: 2024 template
- `feat(mir)`: month-in-review page

## Validation

`deno fmt` clean across all touched files; token cross-reference confirms no dangling references. Visual QA done in both themes on the YIR default page, the 2024 archive, and MIR.