### PR TITLE
feat(ds): adapt SegmentedBar to small and mobile containers

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -927,6 +927,19 @@
         }
       }
     },
+    "chart_label_other": {
+      "default": "Other",
+      "description": "Label for the segment that groups the smallest remaining categories in a segmented bar chart."
+    },
+    "chart_label_grouped_categories": {
+      "default": "{count} categories",
+      "description": "Sublabel for the grouped 'Other' segment in a segmented bar chart, stating how many categories it rolls up.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "header_premiered": {
       "default": "Premiered",
       "description": "Header for the premiered section."

--- a/projects/client/src/lib/components/charts/SegmentedBar.svelte
+++ b/projects/client/src/lib/components/charts/SegmentedBar.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
   import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
   import { ratio } from "$lib/utils/number/ratio.ts";
   import { sum } from "$lib/utils/number/sum.ts";
-  import type { SegmentedBarProps } from "./models/SegmentedBarProps.ts";
+  import { collapseToOther } from "./collapseToOther.ts";
+  import type {
+    SegmentedBarItem,
+    SegmentedBarProps,
+  } from "./models/SegmentedBarProps.ts";
   import { vizSeriesSlot } from "./vizSeriesSlot.ts";
 
   // SOT for the single proportional segmented bar (e.g. a genre breakdown):
@@ -10,37 +15,71 @@
   // palette with the shared glossy fill + outer-corner rounding. Labels
   // alternate above/below so adjacent ones don't collide. Hovering a segment
   // dims the rest, lifts it, and reveals its share via the shared tooltip.
+  // When categories exceed `maxSegments`, the smallest collapse into a single
+  // "Other" bucket so the run never degrades into slivers; on mobile the
+  // beside-the-bar labels give way to a legend list under the bar.
   const {
-    items,
+    items = [],
     label = "Segmented distribution",
     minSegment = 0.04,
+    maxSegments = 8,
   }: SegmentedBarProps = $props();
 
-  const total = $derived(sum(items.map((item) => item.value)));
+  type DisplayItem = SegmentedBarItem & { isOther?: boolean };
 
-  const segments = $derived(
-    items.map((item, index) => {
+  const displayItems = $derived.by<DisplayItem[]>(() => {
+    const { visible, other } = collapseToOther(items, maxSegments);
+    if (!other) return visible;
+
+    return [
+      ...visible,
+      {
+        label: m.chart_label_other(),
+        value: other.value,
+        sublabel: m.chart_label_grouped_categories({ count: other.count }),
+        isOther: true,
+      },
+    ];
+  });
+
+  const total = $derived(sum(displayItems.map((item) => item.value)));
+
+  const segments = $derived.by(() => {
+    const base = displayItems.map((item, index) => {
       const share = ratio({ value: item.value, total });
+      const slot = vizSeriesSlot(item.seriesIndex ?? index);
       return {
         ...item,
         index,
-        slot: vizSeriesSlot(item.seriesIndex ?? index),
+        colorVar: item.isOther ? "--viz-neutral" : `--viz-${slot}`,
         percent: Math.round(share * 100),
         grow: item.value > 0 ? Math.max(share, minSegment) : minSegment,
       };
-    }),
-  );
+    });
+
+    // Labels alternate rows, so each only competes with the next same-row
+    // label (two segments over). Let a label span its own slot plus the
+    // opposite-row neighbour beside it, expressed as a multiple of its own
+    // width so the clamp tracks the real gap, not a flat 200%.
+    return base.map((segment, index) => {
+      const nextSameRow = index + 2;
+      const span = nextSameRow < base.length
+        ? segment.grow + (base.at(index + 1)?.grow ?? 0)
+        : sum(base.slice(index).map((s) => s.grow));
+      return { ...segment, labelMax: segment.grow > 0 ? span / segment.grow : 1 };
+    });
+  });
 </script>
 
 <figure class="trakt-segmented-bar" role="img" aria-label={label}>
   <figcaption class="viz-caption">{label}</figcaption>
 
   <div class="segmented-track">
-    {#each segments as segment (segment.label)}
+    {#each segments as segment (segment.index)}
       <div
         class="segment"
         class:is-below={segment.index % 2 === 1}
-        style="--seg-grow: {segment.grow}; --seg-color: var(--viz-{segment.slot}); --viz-series: var(--viz-{segment.slot}); --i: {segment.index};"
+        style="--seg-grow: {segment.grow}; --seg-label-max: {segment.labelMax}; --seg-color: var({segment.colorVar}); --viz-series: var({segment.colorVar}); --i: {segment.index};"
       >
         <span class="segment-label">
           <span class="segment-name bold ellipsis">{segment.label}</span>
@@ -56,6 +95,20 @@
       </div>
     {/each}
   </div>
+
+  <!-- Mobile fallback: beside-the-bar labels can't fit, so list shares here. -->
+  <ul class="segment-legend">
+    {#each segments as segment (segment.index)}
+      <li class="legend-row" style="--seg-color: var({segment.colorVar});">
+        <span class="legend-swatch"></span>
+        <span class="legend-name bold ellipsis">{segment.label}</span>
+        {#if segment.sublabel}
+          <span class="legend-sub tag secondary">{segment.sublabel}</span>
+        {/if}
+        <span class="legend-percent tag secondary">{segment.percent}%</span>
+      </li>
+    {/each}
+  </ul>
 </figure>
 
 <style lang="scss">
@@ -112,6 +165,15 @@
     .segment:hover .segment-fill {
       @include viz-hover-active;
     }
+
+    // Reveal the focused segment's full label over the dimmed neighbours.
+    .segment:hover {
+      z-index: 1;
+    }
+
+    .segment:hover .segment-label {
+      max-width: none;
+    }
   }
 
   // Round only the run's outer corners (logical, so they mirror under RTL).
@@ -131,7 +193,9 @@
     display: flex;
     flex-direction: column;
     gap: var(--ni-1);
-    max-width: 200%;
+    // Span own slot + opposite-row neighbour (see --seg-label-max), less a gap
+    // so the name only clips when it reaches the next same-row label.
+    max-width: calc(var(--seg-label-max, 2) * 100% - var(--ni-12));
     white-space: nowrap;
     // Colored tick tying the label to its segment (inline-start so it mirrors).
     padding-inline-start: var(--ni-6);
@@ -161,5 +225,64 @@
 
   .viz-caption {
     @include visually-hidden;
+  }
+
+  // Legend is the mobile-only fallback for the beside-the-bar labels.
+  .segment-legend {
+    display: none;
+    flex-direction: column;
+    gap: var(--ni-6);
+    margin: 0;
+    margin-block-start: var(--ni-12);
+    padding: 0;
+    list-style: none;
+  }
+
+  .legend-row {
+    display: flex;
+    align-items: center;
+    gap: var(--ni-8);
+  }
+
+  .legend-swatch {
+    flex: none;
+    width: var(--ni-12);
+    height: var(--ni-12);
+    border-radius: var(--border-radius-xs);
+    background: var(--seg-color);
+  }
+
+  .legend-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: var(--font-size-text);
+    color: var(--color-text-primary);
+  }
+
+  .legend-sub {
+    flex: none;
+    color: var(--color-text-secondary);
+  }
+
+  .legend-percent {
+    flex: none;
+    color: var(--color-text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  @include for-mobile {
+    // Beside-the-bar labels need horizontal room there isn't; drop them and
+    // reclaim the vertical padding they reserved, then surface the legend.
+    .trakt-segmented-bar {
+      padding-block: 0;
+    }
+
+    .segment-label {
+      display: none;
+    }
+
+    .segment-legend {
+      display: flex;
+    }
   }
 </style>

--- a/projects/client/src/lib/components/charts/collapseToOther.spec.ts
+++ b/projects/client/src/lib/components/charts/collapseToOther.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { collapseToOther } from './collapseToOther.ts';
+import type { SegmentedBarItem } from './models/SegmentedBarProps.ts';
+
+const item = (label: string, value: number): SegmentedBarItem => ({
+  label,
+  value,
+});
+
+describe('util: collapseToOther', () => {
+  describe('when items fit within the cap', () => {
+    it('should return every item and no Other bucket', () => {
+      const items = [item('a', 5), item('b', 3), item('c', 2)];
+
+      const result = collapseToOther(items, 8);
+
+      expect(result.other).toBeNull();
+      expect(result.visible).toEqual(items);
+    });
+
+    it('should treat an exactly-full bar as a no-op', () => {
+      const items = [item('a', 5), item('b', 3)];
+
+      const result = collapseToOther(items, 2);
+
+      expect(result.other).toBeNull();
+      expect(result.visible).toHaveLength(2);
+    });
+  });
+
+  describe('when items exceed the cap', () => {
+    const items = [
+      item('a', 10),
+      item('b', 8),
+      item('c', 6),
+      item('d', 3),
+      item('e', 2),
+      item('f', 1),
+    ];
+
+    it('should keep the largest categories up to maxSegments - 1', () => {
+      const result = collapseToOther(items, 4);
+
+      expect(result.visible.map((i) => i.label)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should preserve the original order of the kept items', () => {
+      const unsorted = [
+        item('a', 1),
+        item('b', 10),
+        item('c', 5),
+        item('d', 2),
+      ];
+
+      // cap 3 keeps the 2 largest (b, c); a + d collapse into Other.
+      const result = collapseToOther(unsorted, 3);
+
+      // Original order (b before c) is retained, not value order.
+      expect(result.visible.map((i) => i.label)).toEqual(['b', 'c']);
+    });
+
+    it('should roll the smallest categories into Other with summed value', () => {
+      const result = collapseToOther(items, 4);
+
+      expect(result.other).toEqual({ value: 6, count: 3 });
+    });
+
+    it('should collapse everything when the cap is zero or negative', () => {
+      const result = collapseToOther(items, 0);
+
+      expect(result.visible).toHaveLength(0);
+      expect(result.other).toEqual({ value: 30, count: 6 });
+    });
+
+    it('should leave the grand total unchanged across visible + other', () => {
+      const result = collapseToOther(items, 4);
+
+      const visibleTotal = result.visible.reduce((t, i) => t + i.value, 0);
+      expect(visibleTotal + (result.other?.value ?? 0)).toBe(30);
+    });
+  });
+});

--- a/projects/client/src/lib/components/charts/collapseToOther.ts
+++ b/projects/client/src/lib/components/charts/collapseToOther.ts
@@ -1,0 +1,40 @@
+import { sum } from '$lib/utils/number/sum.ts';
+import type { SegmentedBarItem } from './models/SegmentedBarProps.ts';
+
+export type CollapsedSegments = {
+  /** Categories kept as their own segment, in original input order. */
+  visible: SegmentedBarItem[];
+  /** Rolled-up tail, or `null` when nothing was collapsed. */
+  other: { value: number; count: number } | null;
+};
+
+/**
+ * Cap a segmented bar at `maxSegments` by rolling the smallest-by-value
+ * categories past the cap into a single "Other" bucket. Returns the kept
+ * categories (original order preserved) plus the collapsed total + count, so
+ * the bar never degrades into unreadable slivers. Below the cap it is a no-op.
+ */
+export function collapseToOther(
+  items: ReadonlyArray<SegmentedBarItem>,
+  maxSegments: number,
+): CollapsedSegments {
+  if (items.length <= maxSegments) {
+    return { visible: [...items], other: null };
+  }
+
+  const kept = new Set(
+    [...items]
+      .sort((a, b) => b.value - a.value)
+      .slice(0, Math.max(0, maxSegments - 1)),
+  );
+
+  const collapsed = items.filter((item) => !kept.has(item));
+
+  return {
+    visible: items.filter((item) => kept.has(item)),
+    other: {
+      value: sum(collapsed.map((item) => item.value)),
+      count: collapsed.length,
+    },
+  };
+}

--- a/projects/client/src/lib/components/charts/models/SegmentedBarProps.ts
+++ b/projects/client/src/lib/components/charts/models/SegmentedBarProps.ts
@@ -18,4 +18,11 @@ export type SegmentedBarProps = {
    * visible + labelable. Defaults to 0.04.
    */
   minSegment?: number;
+  /**
+   * Cap on rendered segments (including the rolled-up "Other" bucket). When
+   * `items` exceeds this, the smallest-by-value categories collapse into a
+   * single trailing "Other" segment so the bar never degrades into unreadable
+   * slivers. Defaults to 8.
+   */
+  maxSegments?: number;
 };


### PR DESCRIPTION
## What

Makes the shared `SegmentedBar` primitive adapt when it runs out of horizontal room. Previously many-category genre bars collapsed into unreadable slivers, and the alternating beside-the-bar labels collided and truncated ("Mys...", "Anim...", "Co...") even at desktop widths.

## Changes

- **"Other" bucket** - new `maxSegments` prop (default 8). The smallest-by-value categories past the cap roll into a single trailing grey "Other" segment, so the run never degrades into slivers. No-op below the cap. Collapse logic lives in a pure `collapseToOther` helper with a unit spec (ties, exact-cap no-op, original-order preservation, total conservation).
- **Mobile legend** - below the mobile breakpoint the alternating beside-bar labels are dropped (they need horizontal room there isn't) and a legend list surfaces under the bar: swatch + name + sublabel + percent. SSR-safe, no JS measurement.
- **Neighbour-aware label clamp** - labels alternate rows, so each only competes with the next same-row label (two segments over). Each label may now span its own slot plus the opposite-row neighbour beside it (derived from the `grow` values), so a name only ellipsises when it would actually reach its same-row neighbour, not at a flat 200% of its own narrow segment.
- **Hover reveal** - hovering a segment un-clamps its label and lifts it above the dimmed neighbours, so the full name is always legible (mouse only; touch uses the legend).

## Notes

- The breakpoint is viewport-based (`for-mobile` mixin, consistent with the rest of the codebase) rather than a true container query. Fine for the full-width sections that render this today; if `SegmentedBar` later lands in a narrow desktop sidebar we can revisit with `@container`.
- Two new i18n keys: `chart_label_other`, `chart_label_grouped_categories`.

## Verification

- `collapseToOther` spec: 6/6 pass
- `svelte-check`: 0 errors / 0 warnings
- `deno fmt` clean; lint clean for changed files
- Visually verified against the running app at desktop + mobile widths, plus the hover reveal on a narrow truncated segment.
