### PR TITLE
feat(i18n): localize the season ratings chart

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2411,6 +2411,53 @@
       "default": "No ratings yet.",
       "description": "Empty-state text shown in the ratings breakdown drawer when no rating data is available for the title."
     },
+    "header_ratings_quality_over_time": {
+      "default": "Quality Over Time",
+      "description": "Section header above the season-ratings line chart in the ratings breakdown drawer, which plots each season's rating over time."
+    },
+    "label_season_short": {
+      "default": "S{number}",
+      "description": "Compact season label (e.g. S1) used for the season-ratings chart axis, tooltips and peak/low summary.",
+      "variables": {
+        "number": {
+          "type": "string"
+        }
+      }
+    },
+    "label_ratings_season_chart": {
+      "default": "Season ratings over time",
+      "description": "Accessible label for the season-ratings line chart in the ratings breakdown drawer."
+    },
+    "text_ratings_season_extremes": {
+      "default": "Peak {peak} · {peakRating}% · Low {low} · {lowRating}%",
+      "description": "Summary line above the season-ratings chart calling out the highest- and lowest-rated seasons. {peak}/{low} are compact season labels (e.g. S4); {peakRating}/{lowRating} are whole-number percentages.",
+      "variables": {
+        "peak": {
+          "type": "string"
+        },
+        "peakRating": {
+          "type": "string"
+        },
+        "low": {
+          "type": "string"
+        },
+        "lowRating": {
+          "type": "string"
+        }
+      }
+    },
+    "text_ratings_season_point": {
+      "default": "{season} · {rating}%",
+      "description": "Tooltip for a point on the season-ratings chart. {season} is a compact season label (e.g. S3); {rating} is a whole-number percentage.",
+      "variables": {
+        "season": {
+          "type": "string"
+        },
+        "rating": {
+          "type": "string"
+        }
+      }
+    },
     "button_label_view_ratings_breakdown": {
       "default": "View ratings breakdown",
       "description": "Aria-label for the Trakt rating in the summary header that opens the ratings breakdown drawer."

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/SeasonRatingsChart.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/SeasonRatingsChart.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import LineChart from "$lib/components/charts/LineChart.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
   import type { Season } from "$lib/requests/models/Season.ts";
 
   type SeasonPoint = { season: number; rating: number };
@@ -9,6 +10,9 @@
   };
 
   const { seasons }: Props = $props();
+
+  const seasonLabel = (season: number) =>
+    m.label_season_short({ number: String(season) });
 
   const points: SeasonPoint[] = $derived.by(() => {
     const now = new Date();
@@ -22,9 +26,9 @@
   });
 
   const data = $derived(
-    points.map((p) => ({ value: p.rating, label: `S${p.season}` })),
+    points.map((p) => ({ value: p.rating, label: seasonLabel(p.season) })),
   );
-  const tickLabels = $derived(points.map((p) => `S${p.season}`));
+  const tickLabels = $derived(points.map((p) => seasonLabel(p.season)));
 
   // Zoom the line into its meaningful band rather than anchoring at 0.
   const baseline = $derived(Math.min(...points.map((p) => p.rating), 60));
@@ -44,11 +48,17 @@
 {#if points.length >= 2}
   <section class="trakt-season-ratings-chart">
     <div class="header">
-      <h3 class="card-title bold secondary">Quality Over Time</h3>
+      <h3 class="card-title bold secondary">
+        {m.header_ratings_quality_over_time()}
+      </h3>
       {#if peak && trough}
         <span class="meta tag secondary">
-          Peak S{peak.season} · {peak.rating}% &nbsp;·&nbsp; Low S{trough
-            .season} · {trough.rating}%
+          {m.text_ratings_season_extremes({
+            peak: seasonLabel(peak.season),
+            peakRating: String(peak.rating),
+            low: seasonLabel(trough.season),
+            lowRating: String(trough.rating),
+          })}
         </span>
       {/if}
     </div>
@@ -60,11 +70,16 @@
         {baseline}
         showArea
         showDots
-        label="Season ratings over time"
+        label={m.label_ratings_season_chart()}
         height="var(--ni-160)"
       >
         {#snippet tooltip({ label, value })}
-          <span class="season-tooltip">{label} · {value}%</span>
+          <span class="season-tooltip">
+            {m.text_ratings_season_point({
+              season: label,
+              rating: String(value),
+            })}
+          </span>
         {/snippet}
       </LineChart>
     </div>


### PR DESCRIPTION
Follow-up to #2570. The season-ratings line chart shipped with hardcoded English copy (deferred as prototype copy during review); this localizes it.

## What
- Adds Paraglide messages (`i18n/meta/en.json`):
  - `header_ratings_quality_over_time` - card title
  - `label_season_short` - compact `S{n}` label, reused for axis ticks, tooltip, and the peak/low summary
  - `label_ratings_season_chart` - chart aria-label
  - `text_ratings_season_extremes` - peak/low summary line
  - `text_ratings_season_point` - point tooltip
- Replaces the literals in `SeasonRatingsChart.svelte` with `m.*` calls.

## Notes
- Per-locale translations follow via the normal Crowdin sync; new keys fall back to the English default until then.
- `deno task i18n:check` clean; `svelte-check` 0 errors.
