### PR TITLE
feat(yir): localize Year/Month in Review

### DIFF
--- a/projects/client/i18n/messages/bg-BG.json
+++ b/projects/client/i18n/messages/bg-BG.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Зареждане...",
   "yir_title_year_in_review": "Годишен преглед",
   "yir_title_year_to_date": "От началото на годината",
-  "yir_unit_comment": "{count, plural, one {коментар} other {коментара}}",
-  "yir_unit_episode": "{count, plural, one {епизод} other {епизода}}",
-  "yir_unit_hour": "{count, plural, one {час} other {часа}}",
-  "yir_unit_list": "{count, plural, one {списък} other {списъка}}",
-  "yir_unit_movie": "{count, plural, one {филм} other {филма}}",
-  "yir_unit_play": "{count, plural, one {гледане} other {гледания}}",
-  "yir_unit_rating": "{count, plural, one {оценка} other {оценки}}",
-  "yir_unit_show": "{count, plural, one {сериал} other {сериала}}",
   "yir_upgrade_message": "Надстройте до VIP и получете свои собствени страници за годишен преглед за всички времена и за годината, плюс много други страхотни функции!"
 }

--- a/projects/client/i18n/messages/ca-ES.json
+++ b/projects/client/i18n/messages/ca-ES.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Carregant...",
   "yir_title_year_in_review": "Resum de l'Any",
   "yir_title_year_to_date": "Acumulat de l'any",
-  "yir_unit_comment": "{count, plural, one {comentari} other {comentaris}}",
-  "yir_unit_episode": "{count, plural, one {episodi} other {episodis}}",
-  "yir_unit_hour": "{count, plural, one {hora} other {hores}}",
-  "yir_unit_list": "{count, plural, one {llista} other {llistes}}",
-  "yir_unit_movie": "{count, plural, one {pel·lícula} other {pel·lícules}}",
-  "yir_unit_play": "{count, plural, one {reproducció} other {reproduccions}}",
-  "yir_unit_rating": "{count, plural, one {valoració} other {valoracions}}",
-  "yir_unit_show": "{count, plural, one {sèrie} other {sèries}}",
   "yir_upgrade_message": "Actualitza a VIP i obtén les teves pròpies pàgines de resum de l'any de tots els temps i anuals, a més de moltes més funcions fantàstiques!"
 }

--- a/projects/client/i18n/messages/da-DK.json
+++ b/projects/client/i18n/messages/da-DK.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Indlæser...",
   "yir_title_year_in_review": "Årsresumé",
   "yir_title_year_to_date": "År til dato",
-  "yir_unit_comment": "{count, plural, one {kommentar} other {kommentarer}}",
-  "yir_unit_episode": "{count, plural, one {episode} other {episoder}}",
-  "yir_unit_hour": "{count, plural, one {time} other {timer}}",
-  "yir_unit_list": "{count, plural, one {liste} other {lister}}",
-  "yir_unit_movie": "{count, plural, one {film} other {film}}",
-  "yir_unit_play": "{count, plural, one {afspilning} other {afspilninger}}",
-  "yir_unit_rating": "{count, plural, one {bedømmelse} other {bedømmelser}}",
-  "yir_unit_show": "{count, plural, one {serie} other {serier}}",
   "yir_upgrade_message": "Opgrader til VIP og få dine egne 'Årsresume'-sider for al tid og hvert år, plus mange flere fantastiske funktioner!"
 }

--- a/projects/client/i18n/messages/de-DE.json
+++ b/projects/client/i18n/messages/de-DE.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Wird geladen...",
   "yir_title_year_in_review": "Jahresrückblick",
   "yir_title_year_to_date": "Jahresstatistik",
-  "yir_unit_comment": "{count, plural, one {Kommentar} other {Kommentare}}",
-  "yir_unit_episode": "{count, plural, one {Episode} other {Episoden}}",
-  "yir_unit_hour": "{count, plural, one {Stunde} other {Stunden}}",
-  "yir_unit_list": "{count, plural, one {Liste} other {Listen}}",
-  "yir_unit_movie": "{count, plural, one {Film} other {Filme}}",
-  "yir_unit_play": "{count, plural, one {Wiedergabe} other {Wiedergaben}}",
-  "yir_unit_rating": "{count, plural, one {Bewertung} other {Bewertungen}}",
-  "yir_unit_show": "{count, plural, one {Serie} other {Serien}}",
   "yir_upgrade_message": "Upgrade auf VIP und erhalte deine eigenen Jahresrückblicke für alle Zeiten und Jahre, plus viele weitere tolle Funktionen!"
 }

--- a/projects/client/i18n/messages/el-GR.json
+++ b/projects/client/i18n/messages/el-GR.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Φόρτωση...",
   "yir_title_year_in_review": "Ετήσια Ανασκόπηση",
   "yir_title_year_to_date": "Έτος μέχρι σήμερα",
-  "yir_unit_comment": "{count, plural, one {σχόλιο} other {σχόλια}}",
-  "yir_unit_episode": "{count, plural, one {επεισόδιο} other {επεισόδια}}",
-  "yir_unit_hour": "{count, plural, one {ώρα} other {ώρες}}",
-  "yir_unit_list": "{count, plural, one {λίστα} other {λίστες}}",
-  "yir_unit_movie": "{count, plural, one {ταινία} other {ταινίες}}",
-  "yir_unit_play": "{count, plural, one {προβολή} other {προβολές}}",
-  "yir_unit_rating": "{count, plural, one {βαθμολογία} other {βαθμολογίες}}",
-  "yir_unit_show": "{count, plural, one {σειρά} other {σειρές}}",
   "yir_upgrade_message": "Αναβαθμίστε σε VIP και αποκτήστε τις δικές σας σελίδες Ετήσιας Ανασκόπησης για όλο το χρόνο και ανά έτος, καθώς και πολλές ακόμα εξαιρετικές λειτουργίες!"
 }

--- a/projects/client/i18n/messages/en-AU.json
+++ b/projects/client/i18n/messages/en-AU.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Loading...",
   "yir_title_year_in_review": "Year in Review",
   "yir_title_year_to_date": "Year to date",
-  "yir_unit_comment": "{count, plural, one {comment} other {comments}}",
-  "yir_unit_episode": "{count, plural, one {episode} other {episodes}}",
-  "yir_unit_hour": "{count, plural, one {hour} other {hours}}",
-  "yir_unit_list": "{count, plural, one {list} other {lists}}",
-  "yir_unit_movie": "{count, plural, one {movie} other {movies}}",
-  "yir_unit_play": "{count, plural, one {play} other {plays}}",
-  "yir_unit_rating": "{count, plural, one {rating} other {ratings}}",
-  "yir_unit_show": "{count, plural, one {show} other {shows}}",
   "yir_upgrade_message": "Upgrade to VIP and get your own all time and yearly Year in Review pages, plus a lot more great features!"
 }

--- a/projects/client/i18n/messages/es-ES.json
+++ b/projects/client/i18n/messages/es-ES.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Cargando...",
   "yir_title_year_in_review": "Tu año en Trakt",
   "yir_title_year_to_date": "En lo que va del año",
-  "yir_unit_comment": "{count, plural, one {comentario} other {comentarios}}",
-  "yir_unit_episode": "{count, plural, one {episodio} other {episodios}}",
-  "yir_unit_hour": "{count, plural, one {hora} other {horas}}",
-  "yir_unit_list": "{count, plural, one {lista} other {listas}}",
-  "yir_unit_movie": "{count, plural, one {película} other {películas}}",
-  "yir_unit_play": "{count, plural, one {reproducción} other {reproducciones}}",
-  "yir_unit_rating": "{count, plural, one {valoración} other {valoraciones}}",
-  "yir_unit_show": "{count, plural, one {serie} other {series}}",
   "yir_upgrade_message": "¡Actualiza a VIP y obtén tus propias páginas de Resumen del Año totales y anuales, además de muchas más funciones geniales!"
 }

--- a/projects/client/i18n/messages/es-MX.json
+++ b/projects/client/i18n/messages/es-MX.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Cargando...",
   "yir_title_year_in_review": "Resumen Anual",
   "yir_title_year_to_date": "Año hasta la fecha",
-  "yir_unit_comment": "{count, plural, one {comentario} other {comentarios}}",
-  "yir_unit_episode": "{count, plural, one {episodio} other {episodios}}",
-  "yir_unit_hour": "{count, plural, one {hora} other {horas}}",
-  "yir_unit_list": "{count, plural, one {lista} other {listas}}",
-  "yir_unit_movie": "{count, plural, one {película} other {películas}}",
-  "yir_unit_play": "{count, plural, one {reproducción} other {reproducciones}}",
-  "yir_unit_rating": "{count, plural, one {calificación} other {calificaciones}}",
-  "yir_unit_show": "{count, plural, one {serie} other {series}}",
   "yir_upgrade_message": "¡Actualízate a VIP y obtén tus propias páginas de Resumen Anual de todos los tiempos y anuales, además de muchas más funciones geniales!"
 }

--- a/projects/client/i18n/messages/fa-IR.json
+++ b/projects/client/i18n/messages/fa-IR.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "در حال بارگذاری...",
   "yir_title_year_in_review": "مرور سال",
   "yir_title_year_to_date": "سال تا به امروز",
-  "yir_unit_comment": "{count, plural, one {نظر} other {نظر}}",
-  "yir_unit_episode": "{count, plural, one {قسمت} other {قسمت}}",
-  "yir_unit_hour": "{count, plural, one {ساعت} other {ساعت}}",
-  "yir_unit_list": "{count, plural, one {لیست} other {لیست}}",
-  "yir_unit_movie": "{count, plural, one {فیلم} other {فیلم}}",
-  "yir_unit_play": "{count, plural, one {بازدید} other {بازدید}}",
-  "yir_unit_rating": "{count, plural, one {امتیاز} other {امتیاز}}",
-  "yir_unit_show": "{count, plural, one {برنامه} other {برنامه}}",
   "yir_upgrade_message": "به VIP ارتقا دهید و صفحات مرور سالانه و تمام دوران خود را، به همراه بسیاری از ویژگی‌های عالی دیگر، دریافت کنید!"
 }

--- a/projects/client/i18n/messages/fr-CA.json
+++ b/projects/client/i18n/messages/fr-CA.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Chargement...",
   "yir_title_year_in_review": "Rétrospective annuelle",
   "yir_title_year_to_date": "Année à ce jour",
-  "yir_unit_comment": "{count, plural, one {commentaire} other {commentaires}}",
-  "yir_unit_episode": "{count, plural, one {épisode} other {épisodes}}",
-  "yir_unit_hour": "{count, plural, one {heure} other {heures}}",
-  "yir_unit_list": "{count, plural, one {liste} other {listes}}",
-  "yir_unit_movie": "{count, plural, one {film} other {films}}",
-  "yir_unit_play": "{count, plural, one {lecture} other {lectures}}",
-  "yir_unit_rating": "{count, plural, one {évaluation} other {évaluations}}",
-  "yir_unit_show": "{count, plural, one {série} other {séries}}",
   "yir_upgrade_message": "Passez au statut VIP et obtenez vos propres pages de bilan annuel et de tous les temps, ainsi que de nombreuses autres fonctionnalités géniales!"
 }

--- a/projects/client/i18n/messages/fr-FR.json
+++ b/projects/client/i18n/messages/fr-FR.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Chargement...",
   "yir_title_year_in_review": "Bilan annuel",
   "yir_title_year_to_date": "Année à ce jour",
-  "yir_unit_comment": "{count, plural, one {commentaire} other {commentaires}}",
-  "yir_unit_episode": "{count, plural, one {épisode} other {épisodes}}",
-  "yir_unit_hour": "{count, plural, one {heure} other {heures}}",
-  "yir_unit_list": "{count, plural, one {liste} other {listes}}",
-  "yir_unit_movie": "{count, plural, one {film} other {films}}",
-  "yir_unit_play": "{count, plural, one {visionnage} other {visionnages}}",
-  "yir_unit_rating": "{count, plural, one {note} other {notes}}",
-  "yir_unit_show": "{count, plural, one {série} other {séries}}",
   "yir_upgrade_message": "Passez au statut VIP et accédez à vos pages de bilan annuel et de tous les temps, ainsi qu'à de nombreuses autres fonctionnalités exceptionnelles!"
 }

--- a/projects/client/i18n/messages/hu-HU.json
+++ b/projects/client/i18n/messages/hu-HU.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Betöltés...",
   "yir_title_year_in_review": "Éves összefoglaló",
   "yir_title_year_to_date": "Éves összesítés",
-  "yir_unit_comment": "{count, plural, one {hozzászólás} other {hozzászólás}}",
-  "yir_unit_episode": "{count, plural, one {epizód} other {epizód}}",
-  "yir_unit_hour": "{count, plural, one {óra} other {óra}}",
-  "yir_unit_list": "{count, plural, one {lista} other {lista}}",
-  "yir_unit_movie": "{count, plural, one {film} other {film}}",
-  "yir_unit_play": "{count, plural, one {lejátszás} other {lejátszás}}",
-  "yir_unit_rating": "{count, plural, one {értékelés} other {értékelés}}",
-  "yir_unit_show": "{count, plural, one {sorozat} other {sorozat}}",
   "yir_upgrade_message": "Válts VIP-re az örökranglistás és az éves évértékelő oldalaidért, plusz rengeteg más nagyszerű funkcióért!"
 }

--- a/projects/client/i18n/messages/id-ID.json
+++ b/projects/client/i18n/messages/id-ID.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Memuat...",
   "yir_title_year_in_review": "Kilas Balik Tahunan",
   "yir_title_year_to_date": "Tahun Berjalan",
-  "yir_unit_comment": "{count, plural, one {komentar} other {komentar}}",
-  "yir_unit_episode": "{count, plural, one {episode} other {episode}}",
-  "yir_unit_hour": "{count, plural, one {jam} other {jam}}",
-  "yir_unit_list": "{count, plural, one {daftar} other {daftar}}",
-  "yir_unit_movie": "{count, plural, one {film} other {film}}",
-  "yir_unit_play": "{count, plural, one {tontonan} other {tontonan}}",
-  "yir_unit_rating": "{count, plural, one {penilaian} other {penilaian}}",
-  "yir_unit_show": "{count, plural, one {acara} other {acara}}",
   "yir_upgrade_message": "Tingkatkan ke VIP dan dapatkan halaman Kilas Balik Sepanjang Masa dan Tahunan Anda sendiri, ditambah banyak fitur hebat lainnya!"
 }

--- a/projects/client/i18n/messages/it-IT.json
+++ b/projects/client/i18n/messages/it-IT.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Caricamento...",
   "yir_title_year_in_review": "Riepilogo dell'anno",
   "yir_title_year_to_date": "Dall'inizio dell'anno",
-  "yir_unit_comment": "{count, plural, one {commento} other {commenti}}",
-  "yir_unit_episode": "{count, plural, one {episodio} other {episodi}}",
-  "yir_unit_hour": "{count, plural, one {ora} other {ore}}",
-  "yir_unit_list": "{count, plural, one {lista} other {liste}}",
-  "yir_unit_movie": "{count, plural, one {film} other {film}}",
-  "yir_unit_play": "{count, plural, one {riproduzione} other {riproduzioni}}",
-  "yir_unit_rating": "{count, plural, one {valutazione} other {valutazioni}}",
-  "yir_unit_show": "{count, plural, one {serie} other {serie}}",
   "yir_upgrade_message": "Passa a VIP e ottieni le tue pagine di riepilogo dell'anno e di tutti i tempi, oltre a molte altre fantastiche funzionalità!"
 }

--- a/projects/client/i18n/messages/ja-JP.json
+++ b/projects/client/i18n/messages/ja-JP.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "読み込み中...",
   "yir_title_year_in_review": "年間レビュー",
   "yir_title_year_to_date": "今年これまでの統計",
-  "yir_unit_comment": "{count, plural, one {コメント} other {コメント}}",
-  "yir_unit_episode": "{count, plural, one {エピソード} other {エピソード}}",
-  "yir_unit_hour": "{count, plural, one {時間} other {時間}}",
-  "yir_unit_list": "{count, plural, one {リスト} other {リスト}}",
-  "yir_unit_movie": "{count, plural, one {映画} other {映画}}",
-  "yir_unit_play": "{count, plural, one {再生} other {再生}}",
-  "yir_unit_rating": "{count, plural, one {評価} other {評価}}",
-  "yir_unit_show": "{count, plural, one {番組} other {番組}}",
   "yir_upgrade_message": "VIPにアップグレードして、通算および年間の年次レビューページ、さらに多くの素晴らしい機能を手に入れましょう！"
 }

--- a/projects/client/i18n/messages/nb-NO.json
+++ b/projects/client/i18n/messages/nb-NO.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Laster inn...",
   "yir_title_year_in_review": "Året i retrospekt",
   "yir_title_year_to_date": "År til dato",
-  "yir_unit_comment": "{count, plural, one {kommentar} other {kommentarer}}",
-  "yir_unit_episode": "{count, plural, one {episode} other {episoder}}",
-  "yir_unit_hour": "{count, plural, one {time} other {timer}}",
-  "yir_unit_list": "{count, plural, one {liste} other {lister}}",
-  "yir_unit_movie": "{count, plural, one {film} other {filmer}}",
-  "yir_unit_play": "{count, plural, one {avspilling} other {avspillinger}}",
-  "yir_unit_rating": "{count, plural, one {vurdering} other {vurderinger}}",
-  "yir_unit_show": "{count, plural, one {serie} other {serier}}",
   "yir_upgrade_message": "Oppgrader til VIP og få dine egne tilbakeblikkssider for alle tider og årlige, pluss mange flere flotte funksjoner!"
 }

--- a/projects/client/i18n/messages/nl-NL.json
+++ b/projects/client/i18n/messages/nl-NL.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Laden...",
   "yir_title_year_in_review": "Jaaroverzicht",
   "yir_title_year_to_date": "Jaar tot nu toe",
-  "yir_unit_comment": "{count, plural, one {opmerking} other {opmerkingen}}",
-  "yir_unit_episode": "{count, plural, one {aflevering} other {afleveringen}}",
-  "yir_unit_hour": "{count, plural, one {uur} other {uren}}",
-  "yir_unit_list": "{count, plural, one {lijst} other {lijsten}}",
-  "yir_unit_movie": "{count, plural, one {film} other {films}}",
-  "yir_unit_play": "{count, plural, one {weergave} other {weergaven}}",
-  "yir_unit_rating": "{count, plural, one {beoordeling} other {beoordelingen}}",
-  "yir_unit_show": "{count, plural, one {serie} other {series}}",
   "yir_upgrade_message": "Upgrade naar VIP en krijg je eigen all-time en jaarlijkse Jaaroverzicht pagina's, plus nog veel meer geweldige functies!"
 }

--- a/projects/client/i18n/messages/pl-PL.json
+++ b/projects/client/i18n/messages/pl-PL.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Ładowanie...",
   "yir_title_year_in_review": "Podsumowanie roku",
   "yir_title_year_to_date": "Od początku roku",
-  "yir_unit_comment": "{count, plural, one {komentarz} few {komentarze} many {komentarzy} other {komentarze}}",
-  "yir_unit_episode": "{count, plural, one {odcinek} few {odcinki} many {odcinków} other {odcinki}}",
-  "yir_unit_hour": "{count, plural, one {godzina} few {godziny} many {godzin} other {godziny}}",
-  "yir_unit_list": "{count, plural, one {lista} few {listy} many {list} other {listy}}",
-  "yir_unit_movie": "{count, plural, one {film} few {filmy} many {filmów} other {filmy}}",
-  "yir_unit_play": "{count, plural, one {odtworzenie} few {odtworzenia} many {odtworzeń} other {odtworzenia}}",
-  "yir_unit_rating": "{count, plural, one {ocena} few {oceny} many {ocen} other {oceny}}",
-  "yir_unit_show": "{count, plural, one {serial} few {seriale} many {seriali} other {seriale}}",
   "yir_upgrade_message": "Zostań VIP i zyskaj dostęp do corocznych podsumowań, a także wielu innych wspaniałych funkcji!"
 }

--- a/projects/client/i18n/messages/pt-BR.json
+++ b/projects/client/i18n/messages/pt-BR.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Carregando...",
   "yir_title_year_in_review": "Retrospectiva do Ano",
   "yir_title_year_to_date": "Acumulado do Ano",
-  "yir_unit_comment": "{count, plural, one {comentário} other {comentários}}",
-  "yir_unit_episode": "{count, plural, one {episódio} other {episódios}}",
-  "yir_unit_hour": "{count, plural, one {hora} other {horas}}",
-  "yir_unit_list": "{count, plural, one {lista} other {listas}}",
-  "yir_unit_movie": "{count, plural, one {filme} other {filmes}}",
-  "yir_unit_play": "{count, plural, one {exibição} other {exibições}}",
-  "yir_unit_rating": "{count, plural, one {avaliação} other {avaliações}}",
-  "yir_unit_show": "{count, plural, one {série} other {séries}}",
   "yir_upgrade_message": "Faça upgrade para VIP e tenha suas próprias páginas de Retrospectiva anual e de todos os tempos, além de muitos outros recursos excelentes!"
 }

--- a/projects/client/i18n/messages/pt-PT.json
+++ b/projects/client/i18n/messages/pt-PT.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Carregando...",
   "yir_title_year_in_review": "Retrospectiva do Ano",
   "yir_title_year_to_date": "Acumulado do ano",
-  "yir_unit_comment": "{count, plural, one {comentário} other {comentários}}",
-  "yir_unit_episode": "{count, plural, one {episódio} other {episódios}}",
-  "yir_unit_hour": "{count, plural, one {hora} other {horas}}",
-  "yir_unit_list": "{count, plural, one {lista} other {listas}}",
-  "yir_unit_movie": "{count, plural, one {filme} other {filmes}}",
-  "yir_unit_play": "{count, plural, one {reprodução} other {reproduções}}",
-  "yir_unit_rating": "{count, plural, one {avaliação} other {avaliações}}",
-  "yir_unit_show": "{count, plural, one {série} other {séries}}",
   "yir_upgrade_message": "Atualize para VIP e tenha suas próprias páginas de Retrospectiva do Ano e de todos os tempos, além de muitos outros recursos excelentes!"
 }

--- a/projects/client/i18n/messages/ro-RO.json
+++ b/projects/client/i18n/messages/ro-RO.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Se încarcă...",
   "yir_title_year_in_review": "Retrospectiva Anului",
   "yir_title_year_to_date": "Anul curent",
-  "yir_unit_comment": "{count, plural, one {comentariu} other {comentarii}}",
-  "yir_unit_episode": "{count, plural, one {episod} other {episoade}}",
-  "yir_unit_hour": "{count, plural, one {oră} other {ore}}",
-  "yir_unit_list": "{count, plural, one {listă} other {liste}}",
-  "yir_unit_movie": "{count, plural, one {film} other {filme}}",
-  "yir_unit_play": "{count, plural, one {vizionare} other {vizionări}}",
-  "yir_unit_rating": "{count, plural, one {evaluare} other {evaluări}}",
-  "yir_unit_show": "{count, plural, one {serial} other {seriale}}",
   "yir_upgrade_message": "Fă upgrade la VIP și obține propriile pagini Anul în Revistă pentru toate timpurile și anual, plus multe alte funcții grozave!"
 }

--- a/projects/client/i18n/messages/ru-RU.json
+++ b/projects/client/i18n/messages/ru-RU.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Загрузка...",
   "yir_title_year_in_review": "Обзор года",
   "yir_title_year_to_date": "С начала года",
-  "yir_unit_comment": "{count, plural, one {комментарий} few {комментария} many {комментариев} other {комментариев}}",
-  "yir_unit_episode": "{count, plural, one {эпизод} few {эпизода} many {эпизодов} other {эпизодов}}",
-  "yir_unit_hour": "{count, plural, one {час} few {часа} many {часов} other {часов}}",
-  "yir_unit_list": "{count, plural, one {список} few {списка} many {списков} other {списков}}",
-  "yir_unit_movie": "{count, plural, one {фильм} few {фильма} many {фильмов} other {фильмов}}",
-  "yir_unit_play": "{count, plural, one {просмотр} few {просмотра} many {просмотров} other {просмотров}}",
-  "yir_unit_rating": "{count, plural, one {оценка} few {оценки} many {оценок} other {оценок}}",
-  "yir_unit_show": "{count, plural, one {сериал} few {сериала} many {сериалов} other {сериалов}}",
   "yir_upgrade_message": "Перейдите на VIP-подписку и получите доступ к своим страницам «Обзор года» за все время и за каждый год, а также к множеству других замечательных функций!"
 }

--- a/projects/client/i18n/messages/sv-SE.json
+++ b/projects/client/i18n/messages/sv-SE.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Laddar...",
   "yir_title_year_in_review": "Årsöversikt",
   "yir_title_year_to_date": "År hittills",
-  "yir_unit_comment": "{count, plural, one {kommentar} other {kommentarer}}",
-  "yir_unit_episode": "{count, plural, one {avsnitt} other {avsnitt}}",
-  "yir_unit_hour": "{count, plural, one {timme} other {timmar}}",
-  "yir_unit_list": "{count, plural, one {lista} other {listor}}",
-  "yir_unit_movie": "{count, plural, one {film} other {filmer}}",
-  "yir_unit_play": "{count, plural, one {uppspelning} other {uppspelningar}}",
-  "yir_unit_rating": "{count, plural, one {betyg} other {betyg}}",
-  "yir_unit_show": "{count, plural, one {serie} other {serier}}",
   "yir_upgrade_message": "Uppgradera till VIP och få dina egna årsöversikter för alla tider och år, plus många fler fantastiska funktioner!"
 }

--- a/projects/client/i18n/messages/tr-TR.json
+++ b/projects/client/i18n/messages/tr-TR.json
@@ -1770,13 +1770,5 @@
   "yir_state_loading": "Yükleniyor...",
   "yir_title_year_in_review": "Yılın İncelemesi",
   "yir_title_year_to_date": "Yıl Başından Bugüne",
-  "yir_unit_comment": "{count, plural, one {yorum} other {yorum}}",
-  "yir_unit_episode": "{count, plural, one {bölüm} other {bölüm}}",
-  "yir_unit_hour": "{count, plural, one {saat} other {saat}}",
-  "yir_unit_list": "{count, plural, one {liste} other {liste}}",
-  "yir_unit_movie": "{count, plural, one {film} other {film}}",
-  "yir_unit_play": "{count, plural, one {izleme} other {izleme}}",
-  "yir_unit_rating": "{count, plural, one {oy} other {oy}}",
-  "yir_unit_show": "{count, plural, one {dizi} other {dizi}}",
   "yir_upgrade_message": "VIP'ye yükseltin ve tüm zamanların ve yıllık Yılın Özeti sayfalarınıza ek olarak çok daha fazla harika özelliğe sahip olun!"
 }

--- a/projects/client/i18n/messages/uk-UA.json
+++ b/projects/client/i18n/messages/uk-UA.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "Завантаження...",
   "yir_title_year_in_review": "Рік у Підсумках",
   "yir_title_year_to_date": "Рік до сьогодні",
-  "yir_unit_comment": "{count, plural, one {коментар} few {коментарі} other {коментарів}}",
-  "yir_unit_episode": "{count, plural, one {епізод} few {епізоди} other {епізодів}}",
-  "yir_unit_hour": "{count, plural, one {година} few {години} other {годин}}",
-  "yir_unit_list": "{count, plural, one {список} few {списки} other {списків}}",
-  "yir_unit_movie": "{count, plural, one {фільм} few {фільми} other {фільмів}}",
-  "yir_unit_play": "{count, plural, one {перегляд} few {перегляди} other {переглядів}}",
-  "yir_unit_rating": "{count, plural, one {оцінка} few {оцінки} other {оцінок}}",
-  "yir_unit_show": "{count, plural, one {серіал} few {серіали} other {серіалів}}",
   "yir_upgrade_message": "Оновіться до VIP і отримайте власні сторінки підсумків року за весь час та за рік, а також багато інших чудових функцій!"
 }

--- a/projects/client/i18n/messages/zh-CN.json
+++ b/projects/client/i18n/messages/zh-CN.json
@@ -1772,13 +1772,5 @@
   "yir_state_loading": "正在加载...",
   "yir_title_year_in_review": "年度回顾",
   "yir_title_year_to_date": "年至今",
-  "yir_unit_comment": "{count, plural, one {评论} other {评论}}",
-  "yir_unit_episode": "{count, plural, one {集} other {集}}",
-  "yir_unit_hour": "{count, plural, one {小时} other {小时}}",
-  "yir_unit_list": "{count, plural, one {列表} other {列表}}",
-  "yir_unit_movie": "{count, plural, one {电影} other {电影}}",
-  "yir_unit_play": "{count, plural, one {播放} other {播放}}",
-  "yir_unit_rating": "{count, plural, one {评分} other {评分}}",
-  "yir_unit_show": "{count, plural, one {剧集} other {剧集}}",
   "yir_upgrade_message": "升级到 VIP，即可获得您专属的全部时间及年度回顾页面，以及更多精彩功能！"
 }

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5138,77 +5138,73 @@
         }
       }
     },
+    "yir_label_top_genres": {
+      "default": "Top genres",
+      "description": "Label for the top-genres segmented bar chart in the Year in Review genres section."
+    },
     "yir_unit_play": {
-      "default": "{count, plural, one {play} other {plays}}",
-      "description": "Unit for plays (singular/plural).",
-      "variables": {
-        "count": {
-          "type": "number"
-        }
-      }
+      "default": "play",
+      "description": "Singular unit noun for a play, shown next to a count in Year/Month in Review."
+    },
+    "yir_unit_plays": {
+      "default": "plays",
+      "description": "Plural unit noun for plays, shown next to a count in Year/Month in Review."
     },
     "yir_unit_hour": {
-      "default": "{count, plural, one {hour} other {hours}}",
-      "description": "Unit for hours (singular/plural).",
-      "variables": {
-        "count": {
-          "type": "number"
-        }
-      }
+      "default": "hour",
+      "description": "Singular unit noun for an hour, shown next to a count in Year/Month in Review."
+    },
+    "yir_unit_hours": {
+      "default": "hours",
+      "description": "Plural unit noun for hours, shown next to a count in Year/Month in Review."
     },
     "yir_unit_rating": {
-      "default": "{count, plural, one {rating} other {ratings}}",
-      "description": "Unit for ratings (singular/plural).",
-      "variables": {
-        "count": {
-          "type": "number"
-        }
-      }
+      "default": "rating",
+      "description": "Singular unit noun for a rating, shown next to a count in Year/Month in Review."
+    },
+    "yir_unit_ratings": {
+      "default": "ratings",
+      "description": "Plural unit noun for ratings, shown next to a count in Year/Month in Review."
     },
     "yir_unit_comment": {
-      "default": "{count, plural, one {comment} other {comments}}",
-      "description": "Unit for comments (singular/plural).",
-      "variables": {
-        "count": {
-          "type": "number"
-        }
-      }
+      "default": "comment",
+      "description": "Singular unit noun for a comment, shown next to a count in Year/Month in Review."
+    },
+    "yir_unit_comments": {
+      "default": "comments",
+      "description": "Plural unit noun for comments, shown next to a count in Year/Month in Review."
     },
     "yir_unit_list": {
-      "default": "{count, plural, one {list} other {lists}}",
-      "description": "Unit for lists (singular/plural).",
-      "variables": {
-        "count": {
-          "type": "number"
-        }
-      }
+      "default": "list",
+      "description": "Singular unit noun for a list, shown next to a count in Year/Month in Review."
+    },
+    "yir_unit_lists": {
+      "default": "lists",
+      "description": "Plural unit noun for lists, shown next to a count in Year/Month in Review."
     },
     "yir_unit_movie": {
-      "default": "{count, plural, one {movie} other {movies}}",
-      "description": "Unit for movies (singular/plural).",
-      "variables": {
-        "count": {
-          "type": "number"
-        }
-      }
+      "default": "movie",
+      "description": "Singular unit noun for a movie, shown next to a count in Year/Month in Review."
+    },
+    "yir_unit_movies": {
+      "default": "movies",
+      "description": "Plural unit noun for movies, shown next to a count in Year/Month in Review."
     },
     "yir_unit_show": {
-      "default": "{count, plural, one {show} other {shows}}",
-      "description": "Unit for shows (singular/plural).",
-      "variables": {
-        "count": {
-          "type": "number"
-        }
-      }
+      "default": "show",
+      "description": "Singular unit noun for a show, shown next to a count in Year/Month in Review."
+    },
+    "yir_unit_shows": {
+      "default": "shows",
+      "description": "Plural unit noun for shows, shown next to a count in Year/Month in Review."
     },
     "yir_unit_episode": {
-      "default": "{count, plural, one {episode} other {episodes}}",
-      "description": "Unit for episodes (singular/plural).",
-      "variables": {
-        "count": {
-          "type": "number"
-        }
-      }
+      "default": "episode",
+      "description": "Singular unit noun for an episode, shown next to a count in Year/Month in Review."
+    },
+    "yir_unit_episodes": {
+      "default": "episodes",
+      "description": "Plural unit noun for episodes, shown next to a count in Year/Month in Review."
     },
     "yir_button_previous": {
       "default": "Previous",

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CompaniesSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CompaniesSection.svelte
@@ -4,6 +4,7 @@
   import { formatNumber } from "$lib/utils/format/formatNumber.ts";
   import YirCompaniesBubbleChart from "../../_internal/YirCompaniesBubbleChart.svelte";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
+  import { yirMediaUnit } from "../../_internal/yirMediaUnit.ts";
   import Yir2024StatSummary from "./Yir2024StatSummary.svelte";
 
   type Yir2024CompaniesSectionProps = {
@@ -28,13 +29,8 @@
     companies.length > 1 ? companies[companies.length - 1] : undefined,
   );
 
-  // FIXME(i18n): hardcoded English plurals match the existing convention
-  // across the YIR module (default template uses the same pattern in
-  // YirStatsSection, YirTotalsSection, YirMostWatchedSection, etc.).
-  // Migrate holistically when i18n keys are added across all YIR sections.
   function itemUnit(count: number): string {
-    if (type === "movies") return count === 1 ? "movie" : "movies";
-    return count === 1 ? "show" : "shows";
+    return yirMediaUnit(type, count);
   }
 </script>
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CountriesSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024CountriesSection.svelte
@@ -6,6 +6,7 @@
   import { toCountryName } from "$lib/utils/formatting/intl/toCountryName.ts";
   import YirCountriesMap from "../../_internal/YirCountriesMap.svelte";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
+  import { yirMediaUnit } from "../../_internal/yirMediaUnit.ts";
   import Yir2024StatSummary from "./Yir2024StatSummary.svelte";
 
   type Yir2024CountriesSectionProps = {
@@ -25,12 +26,8 @@
     return toCountryName(code, languageTag());
   }
 
-  // FIXME(i18n): hardcoded English plurals match the existing convention
-  // across the YIR module (see Yir2024CompaniesSection and the default
-  // template). Migrate holistically when YIR i18n unit keys are added.
   function itemUnit(count: number): string {
-    if (type === "movies") return count === 1 ? "movie" : "movies";
-    return count === 1 ? "show" : "shows";
+    return yirMediaUnit(type, count);
   }
 
   // API returns the list sorted by count desc, so first = most, last = least.

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024GenresSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024GenresSection.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { GenreIntlProvider } from "$lib/components/summary/GenreIntlProvider.ts";
   import { m } from "$lib/paraglide/messages";
-  import type { YirGenresGroup } from "$lib/requests/models/YirDetail.ts";
+  import type { YirGenre, YirGenresGroup } from "$lib/requests/models/YirDetail.ts";
   import YirGenreBars from "../../_internal/YirGenreBars.svelte";
+  import { yirMediaUnit } from "../../_internal/yirMediaUnit.ts";
   import Yir2024StatSummary from "./Yir2024StatSummary.svelte";
 
   type Yir2024GenresSectionProps = {
@@ -23,19 +25,23 @@
       : m.yir_2024_genres_watermark_movie(),
   );
 
-  const mostWatched = $derived(genres.genres[0]);
+  // Localize the genre name for the stat rows (the bars localize their own
+  // labels). Falls back to the raw API name for genres without a translation.
+  function toStatEntry(genre: YirGenre) {
+    return { name: GenreIntlProvider.genre(genre.name), count: genre.count };
+  }
+
+  const mostWatched = $derived(
+    genres.genres[0] ? toStatEntry(genres.genres[0]) : undefined,
+  );
   const leastWatched = $derived(
     genres.genres.length > 1
-      ? genres.genres[genres.genres.length - 1]
+      ? toStatEntry(genres.genres[genres.genres.length - 1])
       : undefined,
   );
 
-  // FIXME(i18n): hardcoded English plurals match the existing convention
-  // across the YIR module. Migrate holistically when i18n keys are added
-  // across all YIR sections.
   function itemUnit(count: number): string {
-    if (type === "movies") return count === 1 ? "movie" : "movies";
-    return count === 1 ? "show" : "shows";
+    return yirMediaUnit(type, count);
   }
 </script>
 

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StreamingSection.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024StreamingSection.svelte
@@ -4,6 +4,7 @@
   import { formatNumber } from "$lib/utils/format/formatNumber.ts";
   import YirStreamingBubbleChart from "../../_internal/YirStreamingBubbleChart.svelte";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
+  import { yirMediaUnit } from "../../_internal/yirMediaUnit.ts";
 
   type Yir2024StreamingSectionProps = {
     services: YirStreamingService[];
@@ -18,14 +19,11 @@
     [...services].sort((a, b) => b.all - a.all).slice(0, 3),
   );
 
-  // FIXME(i18n): hardcoded English plurals match the existing convention
-  // across the YIR module (see Yir2024CompaniesSection). Migrate holistically
-  // when i18n keys are added across all YIR sections.
   function showsUnit(count: number): string {
-    return count === 1 ? "show" : "shows";
+    return yirMediaUnit("shows", count);
   }
   function moviesUnit(count: number): string {
-    return count === 1 ? "movie" : "movies";
+    return yirMediaUnit("movies", count);
   }
 
   // Per-service count lines, each on its own row in the tooltip. Zero counts

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WatchedStats.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024WatchedStats.svelte
@@ -5,9 +5,11 @@
   import StarIcon from "$lib/components/icons/StarIcon.svelte";
   import ListIcon from "$lib/components/icons/mobile/ListIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
+  import { m } from "$lib/paraglide/messages";
   import type { YirStatsCategory } from "$lib/requests/models/YirDetail";
   import { formatNumber } from "$lib/utils/format/formatNumber";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { yirUnit } from "../../_internal/yirUnit.ts";
 
   type AllStats = YirStatsCategory & {
     listsCounts: { total: number };
@@ -37,7 +39,7 @@
             {formatNumber(stats.playCounts.total)}
           </span>
           <span class="bold yir-2024-stat-label">
-            {stats.playCounts.total === 1 ? "play" : "plays"}
+            {yirUnit(stats.playCounts.total, m.yir_unit_play, m.yir_unit_plays)}
           </span>
         </span>
       </span>
@@ -49,7 +51,7 @@
     <span class="yir-2024-stat-display">
       <span class="bold yir-2024-stat-value">{formatNumber(hours)}</span>
       <span class="bold yir-2024-stat-label">
-        {hours === 1 ? "hour" : "hours"}
+        {yirUnit(hours, m.yir_unit_hour, m.yir_unit_hours)}
       </span>
     </span>
   </span>
@@ -61,7 +63,7 @@
         {formatNumber(stats.ratingsCounts.total)}
       </span>
       <span class="bold yir-2024-stat-label">
-        {stats.ratingsCounts.total === 1 ? "rating" : "ratings"}
+        {yirUnit(stats.ratingsCounts.total, m.yir_unit_rating, m.yir_unit_ratings)}
       </span>
     </span>
   </span>
@@ -73,7 +75,7 @@
         {formatNumber(stats.commentsCounts.total)}
       </span>
       <span class="bold yir-2024-stat-label">
-        {stats.commentsCounts.total === 1 ? "comment" : "comments"}
+        {yirUnit(stats.commentsCounts.total, m.yir_unit_comment, m.yir_unit_comments)}
       </span>
     </span>
   </span>
@@ -85,7 +87,7 @@
         {formatNumber(stats.listsCounts.total)}
       </span>
       <span class="bold yir-2024-stat-label">
-        {stats.listsCounts.total === 1 ? "list" : "lists"}
+        {yirUnit(stats.listsCounts.total, m.yir_unit_list, m.yir_unit_lists)}
       </span>
     </span>
   </span>

--- a/projects/client/src/lib/sections/yir/_internal/YirGenreBars.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirGenreBars.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import SegmentedBar from "$lib/components/charts/SegmentedBar.svelte";
+  import { GenreIntlProvider } from "$lib/components/summary/GenreIntlProvider.ts";
+  import { m } from "$lib/paraglide/messages";
   import type { YirGenresGroup } from "$lib/requests/models/YirDetail.ts";
+  import { yirMediaUnit } from "./yirMediaUnit.ts";
 
   type YirGenreBarsProps = {
     type: "shows" | "movies";
@@ -11,19 +14,17 @@
 
   const { type, genres }: YirGenreBarsProps = $props();
 
-  const unit = $derived(type === "shows" ? "show" : "movie");
-
   // Compose the shared SegmentedBar SOT so YIR genres render identically to the
   // design-system primitive (categorical viz palette, gloss, alternating labels).
   const items = $derived(
     genres.genres.map((genre) => ({
-      label: genre.name,
+      label: GenreIntlProvider.genre(genre.name),
       value: genre.count,
       sublabel: `${genre.count.toLocaleString()} ${
-        genre.count === 1 ? unit : `${unit}s`
+        yirMediaUnit(type, genre.count)
       }`,
     })),
   );
 </script>
 
-<SegmentedBar {items} label="Top genres" />
+<SegmentedBar {items} label={m.yir_label_top_genres()} />

--- a/projects/client/src/lib/sections/yir/_internal/useMirDetail.ts
+++ b/projects/client/src/lib/sections/yir/_internal/useMirDetail.ts
@@ -2,6 +2,7 @@ import { useQuery } from '$lib/features/query/useQuery.ts';
 import { mirDetailQuery } from '$lib/requests/queries/users/mirDetailQuery.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { map } from 'rxjs';
+import { withYirIntlOverlay } from './withYirIntlOverlay.ts';
 
 type UseMirDetailProps = {
   slug: string;
@@ -12,8 +13,8 @@ type UseMirDetailProps = {
 export function useMirDetail(props: UseMirDetailProps) {
   const query = useQuery(mirDetailQuery(props));
 
-  return {
-    detail: query.pipe(map(($query) => $query.data)),
-    isLoading: query.pipe(map(toLoadingState)),
-  };
+  return withYirIntlOverlay(
+    query.pipe(map(($query) => $query.data)),
+    query.pipe(map(toLoadingState)),
+  );
 }

--- a/projects/client/src/lib/sections/yir/_internal/useYirDetail.ts
+++ b/projects/client/src/lib/sections/yir/_internal/useYirDetail.ts
@@ -2,6 +2,7 @@ import { useQuery } from '$lib/features/query/useQuery.ts';
 import { yirDetailQuery } from '$lib/requests/queries/users/yirDetailQuery.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { map } from 'rxjs';
+import { withYirIntlOverlay } from './withYirIntlOverlay.ts';
 
 type UseYirDetailProps = {
   slug: string;
@@ -11,8 +12,8 @@ type UseYirDetailProps = {
 export function useYirDetail(props: UseYirDetailProps) {
   const query = useQuery(yirDetailQuery(props));
 
-  return {
-    detail: query.pipe(map(($query) => $query.data)),
-    isLoading: query.pipe(map(toLoadingState)),
-  };
+  return withYirIntlOverlay(
+    query.pipe(map(($query) => $query.data)),
+    query.pipe(map(toLoadingState)),
+  );
 }

--- a/projects/client/src/lib/sections/yir/_internal/withYirIntlOverlay.ts
+++ b/projects/client/src/lib/sections/yir/_internal/withYirIntlOverlay.ts
@@ -1,0 +1,35 @@
+import { createBulkIntlOverlay } from '$lib/features/intl-overlay/createBulkIntlOverlay.ts';
+import { withOverlayLoading } from '$lib/features/intl-overlay/withOverlayLoading.ts';
+import type { YirDetail } from '$lib/requests/models/YirDetail.ts';
+import { map, type Observable } from 'rxjs';
+import { yirDetailTargets } from './yirDetailTargets.ts';
+
+type YirIntlOverlay = {
+  detail: Observable<YirDetail | undefined>;
+  isLoading: Observable<boolean>;
+};
+
+/**
+ * Overlays localized media titles onto a Year/Month in Review detail by
+ * driving the whole `YirDetail` through the shared bulk intl overlay (wrapped
+ * as a single-element list). No-ops for English. The `isLoading` stream stays
+ * truthy until both the base query and the localization fetch settle so the
+ * page never flashes English titles before the overlay swaps them in.
+ */
+export function withYirIntlOverlay(
+  detail$: Observable<YirDetail | Nil>,
+  baseLoading$: Observable<boolean>,
+): YirIntlOverlay {
+  const overlay = createBulkIntlOverlay<YirDetail>({
+    getTargets: yirDetailTargets,
+  });
+
+  return {
+    detail: detail$.pipe(
+      map((detail) => (detail ? [detail] : [])),
+      overlay.operator,
+      map((entries) => entries.at(0)),
+    ),
+    isLoading: withOverlayLoading(baseLoading$, overlay.intlLoading$),
+  };
+}

--- a/projects/client/src/lib/sections/yir/_internal/yirDetailTargets.ts
+++ b/projects/client/src/lib/sections/yir/_internal/yirDetailTargets.ts
@@ -1,0 +1,106 @@
+import type { BulkIntlTarget } from '$lib/features/intl-overlay/BulkIntlTarget.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type {
+  YirDetail,
+  YirWatchedItem,
+} from '$lib/requests/models/YirDetail.ts';
+
+type EntryMapper = (entry: MediaEntry) => MediaEntry;
+type EntryVisitor = (entry: MediaEntry) => void;
+
+/**
+ * Read-only traversal that visits every localizable media entry the detail
+ * carries (most-watched, top-rated, trends, first/last play and the closing
+ * recommendations) without allocating. Used to enumerate the overlay targets.
+ */
+function forEachYirEntry(detail: YirDetail, visit: EntryVisitor): void {
+  const visitItems = (items: ReadonlyArray<{ entry: MediaEntry }>) => {
+    for (const item of items) visit(item.entry);
+  };
+
+  visitItems(detail.mostWatched.shows);
+  visitItems(detail.mostWatched.movies);
+  visitItems(detail.topRated.shows);
+  visitItems(detail.topRated.movies);
+  if (detail.trends) {
+    visitItems(detail.trends.shows);
+    visitItems(detail.trends.movies);
+  }
+  if (detail.firstWatched) visit(detail.firstWatched.entry);
+  if (detail.lastWatched) visit(detail.lastWatched.entry);
+  if (detail.thanks) {
+    detail.thanks.shows.forEach(visit);
+    detail.thanks.movies.forEach(visit);
+  }
+}
+
+/**
+ * Rebuilds an immutable copy of `detail` with `mapEntry` applied to every
+ * localizable media entry it carries. Used by each target's `apply` to rewrite
+ * a single title across the detail.
+ */
+function mapYirEntries(detail: YirDetail, mapEntry: EntryMapper): YirDetail {
+  const mapItems = <T extends { entry: MediaEntry }>(items: ReadonlyArray<T>) =>
+    items.map((item) => ({ ...item, entry: mapEntry(item.entry) }));
+
+  const mapWatched = (watched: YirWatchedItem | Nil) =>
+    watched ? { ...watched, entry: mapEntry(watched.entry) } : watched;
+
+  return {
+    ...detail,
+    mostWatched: {
+      shows: mapItems(detail.mostWatched.shows),
+      movies: mapItems(detail.mostWatched.movies),
+    },
+    topRated: {
+      shows: mapItems(detail.topRated.shows),
+      movies: mapItems(detail.topRated.movies),
+    },
+    trends: detail.trends
+      ? {
+        shows: mapItems(detail.trends.shows),
+        movies: mapItems(detail.trends.movies),
+      }
+      : detail.trends,
+    firstWatched: mapWatched(detail.firstWatched),
+    lastWatched: mapWatched(detail.lastWatched),
+    thanks: detail.thanks
+      ? {
+        shows: detail.thanks.shows.map(mapEntry),
+        movies: detail.thanks.movies.map(mapEntry),
+      }
+      : detail.thanks,
+  };
+}
+
+/**
+ * `getTargets` for the bulk intl overlay over a whole `YirDetail`. Collects one
+ * target per distinct (type, id) media entry; each target's `apply` rewrites
+ * the title of every matching entry across the detail so a single fetched
+ * localization lands everywhere the title appears.
+ */
+export function yirDetailTargets(
+  detail: YirDetail,
+): ReadonlyArray<BulkIntlTarget<YirDetail>> {
+  const targets = new Map<string, BulkIntlTarget<YirDetail>>();
+
+  forEachYirEntry(detail, (entry) => {
+    const key = `${entry.type}:${entry.id}`;
+    if (targets.has(key)) return;
+
+    targets.set(key, {
+      id: entry.id,
+      type: entry.type,
+      apply: (target, title) =>
+        mapYirEntries(
+          target,
+          (candidate) =>
+            candidate.id === entry.id && candidate.type === entry.type
+              ? { ...candidate, title }
+              : candidate,
+        ),
+    });
+  });
+
+  return [...targets.values()];
+}

--- a/projects/client/src/lib/sections/yir/_internal/yirMediaUnit.ts
+++ b/projects/client/src/lib/sections/yir/_internal/yirMediaUnit.ts
@@ -1,0 +1,14 @@
+import { m } from '$lib/paraglide/messages';
+import { yirUnit } from './yirUnit.ts';
+
+/**
+ * Singular/plural unit noun for a media-typed list, e.g. "1 movie" / "3 shows".
+ */
+export function yirMediaUnit(
+  type: 'shows' | 'movies',
+  count: number,
+): string {
+  return type === 'movies'
+    ? yirUnit(count, m.yir_unit_movie, m.yir_unit_movies)
+    : yirUnit(count, m.yir_unit_show, m.yir_unit_shows);
+}

--- a/projects/client/src/lib/sections/yir/_internal/yirUnit.ts
+++ b/projects/client/src/lib/sections/yir/_internal/yirUnit.ts
@@ -1,0 +1,15 @@
+type UnitMessage = () => string;
+
+/**
+ * Picks the singular or plural unit noun for a count. The project's Paraglide
+ * setup does not compile ICU `plural` syntax, so each unit is authored as a
+ * singular/plural key pair (`yir_unit_show` / `yir_unit_shows`) and selected
+ * here by count.
+ */
+export function yirUnit(
+  count: number,
+  one: UnitMessage,
+  other: UnitMessage,
+): string {
+  return count === 1 ? one() : other();
+}

--- a/projects/client/src/lib/sections/yir/default/_internal/YirDailyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirDailyPlaysChart.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import BarChart from "$lib/components/charts/BarChart.svelte";
   import { getLocale } from "$lib/features/i18n";
+  import { m } from "$lib/paraglide/messages";
   import { toHumanDayOfWeek } from "$lib/utils/formatting/date/toHumanDayOfWeek";
+  import { yirUnit } from "../../_internal/yirUnit.ts";
   import { setDay } from "date-fns/setDay";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
 
@@ -18,6 +20,9 @@
 
 <BarChart data={chartData}>
   {#snippet tooltip({ value, label })}
-    <YirTooltip main="{value} {value === 1 ? 'play' : 'plays'}" sub={label} />
+    <YirTooltip
+      main="{value} {yirUnit(value, m.yir_unit_play, m.yir_unit_plays)}"
+      sub={label}
+    />
   {/snippet}
 </BarChart>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirHourlyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirHourlyPlaysChart.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import BarChart from "$lib/components/charts/BarChart.svelte";
   import { languageTag } from "$lib/features/i18n";
+  import { m } from "$lib/paraglide/messages";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { toHumanClockTime } from "$lib/utils/formatting/date/toHumanClockTime";
   import { toHumanHour } from "$lib/utils/formatting/date/toHumanHour";
+  import { yirUnit } from "../../_internal/yirUnit.ts";
   import { setHours } from "date-fns/setHours";
   import { setMinutes } from "date-fns/setMinutes";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
@@ -35,7 +37,7 @@
       locale,
     )}
     <YirTooltip
-      main="{value} {value === 1 ? 'play' : 'plays'}"
+      main="{value} {yirUnit(value, m.yir_unit_play, m.yir_unit_plays)}"
       sub="{start} - {end}"
     />
   {/snippet}

--- a/projects/client/src/lib/sections/yir/default/_internal/YirMonthlyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirMonthlyPlaysChart.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import BarChart from "$lib/components/charts/BarChart.svelte";
   import { languageTag } from "$lib/features/i18n";
+  import { m } from "$lib/paraglide/messages";
   import { toHumanMonth } from "$lib/utils/formatting/date/toHumanMonth";
+  import { yirUnit } from "../../_internal/yirUnit.ts";
   import { setMonth } from "date-fns/setMonth";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
 
@@ -18,6 +20,9 @@
 
 <BarChart data={chartData}>
   {#snippet tooltip({ value, label })}
-    <YirTooltip main="{value} {value === 1 ? 'play' : 'plays'}" sub={label} />
+    <YirTooltip
+      main="{value} {yirUnit(value, m.yir_unit_play, m.yir_unit_plays)}"
+      sub={label}
+    />
   {/snippet}
 </BarChart>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirMostWatchedSection.svelte
@@ -6,6 +6,7 @@
   import { PLACEHOLDERS } from "$lib/utils/assets";
   import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { yirUnit } from "../../_internal/yirUnit.ts";
   import YirSectionHeader from "./YirSectionHeader.svelte";
 
   const {
@@ -16,7 +17,10 @@
     items: YirMostWatchedItem[];
   } = $props();
 
-  const typeLabel = $derived(type === "shows" ? "show" : "movie");
+  // Localized singular noun fed into the "most watched {type}" label.
+  const typeLabel = $derived(
+    type === "shows" ? m.yir_unit_show() : m.yir_unit_movie(),
+  );
 
   let activeIndex = $state(0);
 
@@ -69,7 +73,7 @@
             </div>
             <div class="yir-stat-line">
               {item.plays.toLocaleString()}
-              {item.plays === 1 ? "play" : "plays"}
+              {yirUnit(item.plays, m.yir_unit_play, m.yir_unit_plays)}
             </div>
           </div>
         </div>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirNetworksChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirNetworksChart.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import YirTooltip from "../../_internal/YirTooltip.svelte";
   import YirCompaniesBubbleChart from "../../_internal/YirCompaniesBubbleChart.svelte";
+  import { yirMediaUnit } from "../../_internal/yirMediaUnit.ts";
   import type { YirCompany } from "$lib/requests/models/YirDetail.ts";
 
   type YirNetworksChartProps = {
@@ -11,8 +12,7 @@
   const { companies, type = "shows" }: YirNetworksChartProps = $props();
 
   function itemLabelFor(count: number): string {
-    if (type === "movies") return count === 1 ? "movie" : "movies";
-    return count === 1 ? "show" : "shows";
+    return yirMediaUnit(type, count);
   }
 </script>
 

--- a/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirPeopleGroup.svelte
@@ -10,6 +10,7 @@
   import { DEFAULT_AVATAR } from "$lib/utils/constants";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import { useYirPeople } from "../../_internal/useYirPeople";
+  import { yirUnit } from "../../_internal/yirUnit.ts";
   import YirSectionHeader from "./YirSectionHeader.svelte";
 
   const {
@@ -125,7 +126,11 @@
                     <span>{title.title} —</span>
                     <span class="yir-episode-count">
                       {title.episodeCount}
-                      {title.episodeCount === 1 ? "episode" : "episodes"}
+                      {yirUnit(
+                        title.episodeCount,
+                        m.yir_unit_episode,
+                        m.yir_unit_episodes,
+                      )}
                     </span>
                   {:else}
                     <span>{title.title}</span>
@@ -151,7 +156,11 @@
                   <h3 class="yir-person-count">
                     {#if person.count.movies > 0}
                       {person.count.movies}
-                      {person.count.movies === 1 ? "movie" : "movies"}
+                      {yirUnit(
+                        person.count.movies,
+                        m.yir_unit_movie,
+                        m.yir_unit_movies,
+                      )}
                     {:else}
                       &nbsp;
                     {/if}
@@ -159,7 +168,11 @@
                   <h3 class="yir-person-count">
                     {#if person.count.shows > 0}
                       {person.count.shows}
-                      {person.count.shows === 1 ? "show" : "shows"}
+                      {yirUnit(
+                        person.count.shows,
+                        m.yir_unit_show,
+                        m.yir_unit_shows,
+                      )}
                     {:else}
                       &nbsp;
                     {/if}

--- a/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirStatsSection.svelte
@@ -3,6 +3,7 @@
   import { m } from "$lib/paraglide/messages";
   import type { YirStatsCategory } from "$lib/requests/models/YirDetail";
   import { formatNumber } from "$lib/utils/format/formatNumber";
+  import { yirUnit } from "../../_internal/yirUnit.ts";
   import YirDailyPlaysChart from "./YirDailyPlaysChart.svelte";
   import YirHourlyPlaysChart from "./YirHourlyPlaysChart.svelte";
   import YirMonthlyPlaysChart from "./YirMonthlyPlaysChart.svelte";
@@ -25,7 +26,11 @@
       ? m.yir_section_title_tv_shows()
       : m.yir_section_title_movies(),
   );
-  const specificType = $derived(type === "shows" ? "episode" : "movie");
+  // Localized singular noun ("episode"/"movie") used both as standalone text
+  // and injected into the chart labels via the message {type} variable.
+  const specificType = $derived(
+    type === "shows" ? m.yir_unit_episode() : m.yir_unit_movie(),
+  );
 
   function formatDecimal(value: number): string {
     return value.toFixed(1);
@@ -75,7 +80,7 @@
         </span>
         <span class="yir-stat-unit">
           {specificType}
-          {stats.playCounts.total === 1 ? "play" : "plays"}
+          {yirUnit(stats.playCounts.total, m.yir_unit_play, m.yir_unit_plays)}
         </span>
       </div>
       <span class="yir-stat-arrow"><ArrowRightIcon /></span>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirTotalsSection.svelte
@@ -8,6 +8,7 @@
   import { m } from "$lib/paraglide/messages";
   import type { YirStatsCategory } from "$lib/requests/models/YirDetail";
   import { formatNumber } from "$lib/utils/format/formatNumber";
+  import { yirUnit } from "../../_internal/yirUnit.ts";
   import YirPageInner from "./YirPageInner.svelte";
   import YirSectionHeader from "./YirSectionHeader.svelte";
 
@@ -41,7 +42,7 @@
           <span class="yir-stat-icon">
             <TrackIcon state="unwatched" />
           </span>
-          {stats.playCounts.total === 1 ? "play" : "plays"}
+          {yirUnit(stats.playCounts.total, m.yir_unit_play, m.yir_unit_plays)}
         </span>
       </div>
 
@@ -49,7 +50,7 @@
         <span class="yir-stat-number">{formatNumber(hoursWatched)}</span>
         <span class="yir-stat-unit">
           <span class="yir-stat-icon"><ClockIcon /></span>
-          {hoursWatched === 1 ? "hour" : "hours"}
+          {yirUnit(hoursWatched, m.yir_unit_hour, m.yir_unit_hours)}
         </span>
       </div>
 
@@ -59,7 +60,7 @@
         </span>
         <span class="yir-stat-unit">
           <span class="yir-stat-icon"><BookmarkIcon state="added" /></span>
-          collected
+          {m.yir_label_collected()}
         </span>
       </div>
     </div>
@@ -71,7 +72,7 @@
         </span>
         <span class="yir-stat-unit">
           <span class="yir-stat-icon"><FavoriteIcon state="filled" /></span>
-          {stats.ratingsCounts.total === 1 ? "rating" : "ratings"}
+          {yirUnit(stats.ratingsCounts.total, m.yir_unit_rating, m.yir_unit_ratings)}
         </span>
       </div>
 
@@ -81,7 +82,7 @@
         </span>
         <span class="yir-stat-unit">
           <span class="yir-stat-icon"><CommentIcon style="filled" /></span>
-          {stats.commentsCounts.total === 1 ? "comment" : "comments"}
+          {yirUnit(stats.commentsCounts.total, m.yir_unit_comment, m.yir_unit_comments)}
         </span>
       </div>
 
@@ -91,7 +92,7 @@
         </span>
         <span class="yir-stat-unit">
           <span class="yir-stat-icon"><ListIcon /></span>
-          {stats.listsCounts.total === 1 ? "list" : "lists"}
+          {yirUnit(stats.listsCounts.total, m.yir_unit_list, m.yir_unit_lists)}
         </span>
       </div>
     </div>

--- a/projects/client/src/lib/sections/yir/default/_internal/YirWeeklyPlaysChart.svelte
+++ b/projects/client/src/lib/sections/yir/default/_internal/YirWeeklyPlaysChart.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { m } from "$lib/paraglide/messages";
   import YirTooltip from "../../_internal/YirTooltip.svelte";
   import YirWeeklyPlaysChart from "../../_internal/YirWeeklyPlaysChart.svelte";
+  import { yirUnit } from "../../_internal/yirUnit.ts";
 
   const {
     data,
@@ -14,8 +16,8 @@
 <YirWeeklyPlaysChart {data} {year}>
   {#snippet tooltip({ value, week, dateRange })}
     <YirTooltip
-      main="{value} {value === 1 ? 'play' : 'plays'}"
-      sub="Week {week}"
+      main="{value} {yirUnit(value, m.yir_unit_play, m.yir_unit_plays)}"
+      sub={m.yir_label_week_number({ weekNumber: week })}
       extra={dateRange}
     />
   {/snippet}


### PR DESCRIPTION
Localizes the Year in Review and Month in Review surfaces end to end.

## What

- **i18n keys**: the existing `yir_unit_*` keys were authored as ICU plurals (`{count, plural, one {x} other {xs}}`), which this Paraglide setup does not compile (they rendered as garbage). Split each into a singular/plural pair (`yir_unit_show` / `yir_unit_shows`, etc.) and added `yir_label_top_genres`. Dropped the obsolete ICU entries from the locale files so Crowdin re-translates the new pairs.
- **Static strings**: replaced every hardcoded English plural ternary and injected noun across the 2024 and default templates (units, chart tooltips, top-genres label, per-week label) with Paraglide messages, selected via a small `yirUnit(count, one, other)` helper.
- **Genres**: genre names now go through `GenreIntlProvider.genre()` in the genre bars and the 2024 genre stat summary, falling back to the API name when a genre has no translation.
- **Media titles** (bonus): the whole `YirDetail` is driven through the shared bulk intl overlay so movie/show titles (most-watched, top-rated, trends, first/last play, recommendations) render localized. `isLoading` stays truthy until the localization fetch settles, so titles never flash English first. No-ops for English.

## Notes

- Translations are intentionally left to Crowdin; only the English source (`meta/en.json`) changes here. Locale files only lose the dead ICU keys.
- Episode titles in first/last-play cards stay as-is (the API gives no episode id to bulk-localize).

## Verification

- `deno task check` (svelte-check): 0 errors
- `deno task i18n:check`: placeholders consistent
- eslint clean on changed files