### PR TITLE
YIR: auto redirect link

### DIFF
--- a/projects/client/src/lib/utils/date/getYearInReviewYear.spec.ts
+++ b/projects/client/src/lib/utils/date/getYearInReviewYear.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getYearInReviewYear } from './getYearInReviewYear.ts';
+
+describe('getYearInReviewYear', () => {
+  it('returns the previous year in January', () => {
+    const date = new Date(2025, 0, 15);
+    expect(getYearInReviewYear(date)).toBe(2024);
+  });
+
+  it('returns the previous year in February', () => {
+    const date = new Date(2025, 1, 28);
+    expect(getYearInReviewYear(date)).toBe(2024);
+  });
+
+  it('returns the current year in March', () => {
+    const date = new Date(2025, 2, 1);
+    expect(getYearInReviewYear(date)).toBe(2025);
+  });
+
+  it('returns the current year for a mid-year date', () => {
+    const date = new Date(2025, 5, 15);
+    expect(getYearInReviewYear(date)).toBe(2025);
+  });
+
+  it('returns the current year in December', () => {
+    const date = new Date(2025, 11, 31);
+    expect(getYearInReviewYear(date)).toBe(2025);
+  });
+});

--- a/projects/client/src/lib/utils/date/getYearInReviewYear.ts
+++ b/projects/client/src/lib/utils/date/getYearInReviewYear.ts
@@ -1,0 +1,4 @@
+export function getYearInReviewYear(date: Date): number {
+  const isEarlyYear = date.getMonth() <= 1; // January (0) or February (1)
+  return isEarlyYear ? date.getFullYear() - 1 : date.getFullYear();
+}

--- a/projects/client/src/routes/users/[user]/yir/+page.ts
+++ b/projects/client/src/routes/users/[user]/yir/+page.ts
@@ -1,0 +1,16 @@
+import { getYearInReviewYear } from '$lib/utils/date/getYearInReviewYear.ts';
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
+import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+// Short URL: /users/:user/yir redirects to that user's year in review.
+// During January and February the previous year is used, since the current
+// year has barely any data yet.
+// Query params (e.g. ?embedded_mode&slurm=1) are preserved across the redirect.
+export const load: PageLoad = ({ params, url }) => {
+  const year = getYearInReviewYear(new Date());
+
+  const target = UrlBuilder.users(params.user).yearToDate(year);
+
+  return redirect(307, `${target}${url.search}`);
+};


### PR DESCRIPTION
# Add /yir short URL for year in review

Adds a short, memorable URL for a user's year in review that mirrors the existing `/users/:user/mir` month-in-review short URL.

Visiting `/users/:user/yir` (e.g. `/users/me/yir`, `/users/justin/yir`) now redirects to that user's full year-in-review page. The year is resolved automatically so the link never needs updating as the calendar rolls over.

# Behavior

- Redirects `/users/:user/yir` → `/users/:user/year/:year`.
- Defaults to the current year, but falls back to the previous year during January and February, since the current year has barely any data that early.
- Preserves query params (e.g. `?embedded_mode&slurm=1`) across the redirect.
- Uses a `307` temporary redirect so the year rollover is never cached as permanent.

# Notes

This complements the existing `/users/:user/mir` route, which already redirects to the previous month's review — no changes were needed there.
