### PR TITLE
feat(footer): add API docs link

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6497,6 +6497,10 @@
       "default": "About",
       "description": "Text for the about link in the footer."
     },
+    "link_text_api": {
+      "default": "API",
+      "description": "Text for the API documentation link in the footer."
+    },
     "link_text_branding": {
       "default": "Branding",
       "description": "Text for the branding link in the footer."

--- a/projects/client/src/lib/sections/footer/components/PageLinks.svelte
+++ b/projects/client/src/lib/sections/footer/components/PageLinks.svelte
@@ -17,8 +17,12 @@
     <Link href={UrlBuilder.vip()}>
       <span class="bold">VIP</span>
     </Link>
-    <Link href={UrlBuilder.branding()}>
-      <span class="bold">{m.link_text_branding()}</span>
+    <Link
+      href={UrlBuilder.docs.api()}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <span class="bold">{m.link_text_api()}</span>
     </Link>
   </div>
 
@@ -56,6 +60,9 @@
     </Link>
     <Link href={UrlBuilder.privacy()}>
       <span class="bold">{m.link_text_privacy()}</span>
+    </Link>
+    <Link href={UrlBuilder.branding()}>
+      <span class="bold">{m.link_text_branding()}</span>
     </Link>
   </div>
 </div>

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -273,6 +273,9 @@ export const UrlBuilder = {
     android: () => 'https://trakt.tv/a/trakt-android',
     ios: () => 'https://trakt.tv/a/trakt-ios',
   },
+  docs: {
+    api: () => 'https://docs.trakt.tv',
+  },
   github: {
     web: () => 'https://github.com/trakt/trakt-web',
     reportIssue: () => 'https://github.com/trakt/trakt-web/issues/new',


### PR DESCRIPTION
## Summary

Adds the Trakt Public API docs link to the footer. This also as the effect to make the footer more balanced with the same number of links in each section (for VIP).

## Changes

- Adds an external API footer link to `https://docs.trakt.tv`.
- Keeps **Platform** as About, VIP, API.
- Keeps **Community** as Forums, Support, Feedback.
- Moves Branding into **Legal** alongside Terms and Privacy.
- Adds the footer API label to i18n metadata.

## Screenshot

<img width="1535" height="1059" alt="Screenshot 2026-07-01 at 08 45 55" src="https://github.com/user-attachments/assets/66e3b38e-1375-4cec-a9b1-0c89b32d3448" />
