### PR TITLE
feat(watchlist): add watchlist reordering support

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4502,6 +4502,14 @@
       "default": "Sort alphabetically",
       "description": "Aria-label for the button that allows users to sort items alphabetically by title."
     },
+    "button_text_sort_rank": {
+      "default": "Rank",
+      "description": "Text for the button that allows users to sort items by their manual rank."
+    },
+    "button_label_sort_rank": {
+      "default": "Sort by rank",
+      "description": "Aria-label for the button that allows users to sort items by their manual rank."
+    },
     "button_label_sort_list": {
       "default": "Sort list",
       "description": "Aria-label for the button that allows users to sort items in their list."

--- a/projects/client/src/lib/requests/queries/users/_internal/postReorderRequest.ts
+++ b/projects/client/src/lib/requests/queries/users/_internal/postReorderRequest.ts
@@ -1,0 +1,22 @@
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+
+type PostReorderParams = {
+  path: string;
+  rank: number[];
+} & ApiParams;
+
+export function postReorderRequest(
+  { fetch, path, rank }: PostReorderParams,
+): Promise<boolean> {
+  return rawApiFetch({
+    fetch,
+    path,
+    init: {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ rank }),
+    },
+  }).then((response) => response.status === 200);
+}

--- a/projects/client/src/lib/requests/queries/users/reorderListRequest.ts
+++ b/projects/client/src/lib/requests/queries/users/reorderListRequest.ts
@@ -1,4 +1,5 @@
-import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import type { ApiParams } from '$lib/requests/api.ts';
+import { postReorderRequest } from './_internal/postReorderRequest.ts';
 
 type ReorderListParams = {
   userId: string | number;
@@ -6,22 +7,14 @@ type ReorderListParams = {
   rank: number[];
 } & ApiParams;
 
-export async function reorderListRequest(
+export function reorderListRequest(
   { fetch, userId, listId, rank }: ReorderListParams,
 ): Promise<boolean> {
-  const response = await rawApiFetch({
+  return postReorderRequest({
     fetch,
     path: `/users/${encodeURIComponent(`${userId}`)}/lists/${
       encodeURIComponent(`${listId}`)
     }/items/reorder`,
-    init: {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ rank }),
-    },
+    rank,
   });
-
-  return response.status === 200;
 }

--- a/projects/client/src/lib/requests/queries/users/reorderWatchlistRequest.ts
+++ b/projects/client/src/lib/requests/queries/users/reorderWatchlistRequest.ts
@@ -1,0 +1,12 @@
+import type { ApiParams } from '$lib/requests/api.ts';
+import { postReorderRequest } from './_internal/postReorderRequest.ts';
+
+type ReorderWatchlistParams = {
+  rank: number[];
+} & ApiParams;
+
+export function reorderWatchlistRequest(
+  { fetch, rank }: ReorderWatchlistParams,
+): Promise<boolean> {
+  return postReorderRequest({ fetch, path: '/sync/watchlist/reorder', rank });
+}

--- a/projects/client/src/lib/requests/queries/users/useWatchlistQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/users/useWatchlistQuery.spec.ts
@@ -48,4 +48,19 @@ describe('watchlistQuery', () => {
 
     expect(result).to.deep.equal(WatchlistShowsMappedMock);
   });
+
+  it('should query all watchlist items in rank order', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createTestBedInfiniteQuery(
+          watchlistQuery({ limit: 10, sortBy: 'rank', sortHow: 'asc' }),
+        ),
+      mapper: mapToEntries,
+    });
+
+    expect(result).to.deep.equal([
+      ...WatchlistMoviesMappedMock,
+      ...WatchlistShowsMappedMock,
+    ]);
+  });
 });

--- a/projects/client/src/lib/sections/lists/user/ListActions.svelte
+++ b/projects/client/src/lib/sections/lists/user/ListActions.svelte
@@ -14,7 +14,7 @@
   import DeleteListButton from "./_internal/DeleteListButton.svelte";
   import EditListButton from "./_internal/EditListButton.svelte";
   import LikeListAction from "./_internal/LikeListAction.svelte";
-  import ListReorderDrawer from "./_internal/ListReorderDrawer.svelte";
+  import ListReorderDrawer from "./ListReorderDrawer.svelte";
   import SaveListDrawer from "./_internal/SaveListDrawer.svelte";
   import { useDeleteList } from "./_internal/useDeleteList";
   import { useLikeList } from "./_internal/useLikeList";

--- a/projects/client/src/lib/sections/lists/user/ListReorderDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/ListReorderDrawer.svelte
@@ -9,20 +9,21 @@
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import { InvalidateAction } from "$lib/requests/models/InvalidateAction.ts";
   import { reorderListRequest } from "$lib/requests/queries/users/reorderListRequest.ts";
+  import { reorderWatchlistRequest } from "$lib/requests/queries/users/reorderWatchlistRequest.ts";
   import { useInvalidator } from "$lib/stores/useInvalidator.ts";
   import { assertDefined } from "$lib/utils/assert/assertDefined.ts";
   import { MEDIA_POSTER_PLACEHOLDER } from "$lib/utils/assets.ts";
   import { flip } from "svelte/animate";
   import { cubicOut } from "svelte/easing";
-  import type { ReorderListSource } from "../models/ReorderListSource.ts";
-  import type { ReorderableListItem } from "./models/ReorderableListItem.ts";
-  import { type DragGhost, reorderDrag } from "./reorderDrag.ts";
+  import type { ReorderListSource } from "./models/ReorderListSource.ts";
+  import type { ReorderableListItem } from "./_internal/models/ReorderableListItem.ts";
+  import { type DragGhost, reorderDrag } from "./_internal/reorderDrag.ts";
   import {
     itemOrderSignature,
     listItemRankIds,
     sortReorderableItems,
-  } from "./reorderListItems.ts";
-  import { useReorderList } from "./useReorderList.ts";
+  } from "./_internal/reorderListItems.ts";
+  import { useReorderList } from "./_internal/useReorderList.ts";
 
   const {
     source,
@@ -162,6 +163,12 @@
   }
 
   async function requestReorder() {
+    if (source.type === "watchlist") {
+      return reorderWatchlistRequest({
+        rank: listItemRankIds(orderedItems),
+      });
+    }
+
     return reorderListRequest({
       userId: assertDefined(
         source.list.user.slug,
@@ -173,10 +180,17 @@
   }
 
   async function refreshReorderedItems() {
-    await invalidateAll([
-      InvalidateAction.Listed("movie"),
-      InvalidateAction.Listed("show"),
-    ]);
+    const invalidations = source.type === "watchlist"
+      ? [
+        InvalidateAction.Watchlisted("movie"),
+        InvalidateAction.Watchlisted("show"),
+      ]
+      : [
+        InvalidateAction.Listed("movie"),
+        InvalidateAction.Listed("show"),
+      ];
+
+    await invalidateAll(invalidations);
   }
 
   async function handleApply() {

--- a/projects/client/src/lib/sections/lists/user/SortIcon.svelte
+++ b/projects/client/src/lib/sections/lists/user/SortIcon.svelte
@@ -2,6 +2,7 @@
   import CalendarIcon from "$lib/components/icons/CalendarIcon.svelte";
   import ClockIcon from "$lib/components/icons/ClockIcon.svelte";
   import RatingIcon from "$lib/components/icons/RatingIcon.svelte";
+  import ReorderIcon from "$lib/components/icons/ReorderIcon.svelte";
   import RemainingIcon from "$lib/components/icons/RemainingIcon.svelte";
   import SortAlphaIcon from "$lib/components/icons/SortAlphaIcon.svelte";
   import StarIcon from "$lib/components/icons/StarIcon.svelte";
@@ -35,6 +36,10 @@
 
 {#if sortBy === "title"}
   <SortAlphaIcon />
+{/if}
+
+{#if sortBy === "rank"}
+  <ReorderIcon />
 {/if}
 
 {#if sortBy === "remaining"}

--- a/projects/client/src/lib/sections/lists/user/_internal/SortOptionsDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SortOptionsDrawer.svelte
@@ -29,17 +29,28 @@
   const reversedDirection = $derived(
     current.sortHow === "asc" ? "desc" : "asc",
   );
+  const usesWatchlistDirectionDefaults = $derived(
+    options.some((option) => option.value === "rank"),
+  );
 
-  function sortHowFor(optionValue: T | undefined): SortDirection {
-    return optionValue === current.sorting.value
-      ? reversedDirection
-      : current.sortHow;
+  function sortHowForOption(optionValue: T | undefined): SortDirection {
+    if (optionValue === current.sorting.value) {
+      return reversedDirection;
+    }
+
+    if (!usesWatchlistDirectionDefaults) {
+      return current.sortHow;
+    }
+
+    return optionValue === "rank" || optionValue === "title"
+      ? "asc"
+      : "desc";
   }
 </script>
 
 <Drawer {onClose} size="auto" title={m.drawer_title_sort()}>
   <div class="sort-buttons">
-    {#each options as option}
+    {#each options as option (option.value ?? "default")}
       {#snippet icon()}
         {#if option.value}
           <SortIcon sortBy={option.value} />
@@ -54,7 +65,7 @@
         replacestate
         style="flat"
         color="default"
-        href={`${urlBuilder({ sortHow: sortHowFor(option.value), sortBy: option.value })}`}
+        href={`${urlBuilder({ sortHow: sortHowForOption(option.value), sortBy: option.value })}`}
         label={option.label()}
         selected={option.value === current.sorting.value}
         icon={option.value ? icon : undefined}
@@ -62,7 +73,7 @@
         onclick={() => {
           track({
             sortBy: option.value ?? "default",
-            sortHow: sortHowFor(option.value),
+            sortHow: sortHowForOption(option.value),
           });
         }}
       >

--- a/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.spec.ts
@@ -137,4 +137,14 @@ describe('formatSortValue', () => {
       expect(formatSortValue(seasonItem, 'title')).toBe('T');
     });
   });
+
+  describe('sortBy: rank', () => {
+    it('should return formatted rank', () => {
+      const listItem = {
+        rank: 3,
+      } as unknown as ListItem;
+
+      expect(formatSortValue(listItem, 'rank')).toBe('#3');
+    });
+  });
 });

--- a/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
@@ -93,6 +93,10 @@ function getRating(item: SortInput): number | null | undefined {
   return getListItemEntry(item).rating;
 }
 
+function getRank(item: SortInput): number | undefined {
+  return 'rank' in item ? item.rank : undefined;
+}
+
 export function formatSortValue(
   item: SortInput,
   sortBy?: SortBy,
@@ -133,6 +137,10 @@ export function formatSortValue(
         : undefined;
     case 'title':
       return getTitle(item)[0]?.toUpperCase();
+    case 'rank': {
+      const rank = getRank(item);
+      return rank == null ? undefined : `#${rank}`;
+    }
   }
 }
 

--- a/projects/client/src/lib/sections/lists/user/_internal/useListSorting.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useListSorting.ts
@@ -5,7 +5,10 @@ import { assertDefined } from '../../../../utils/assert/assertDefined.ts';
 import {
   getListUrl,
 } from '../../components/list-summary/_internal/getListUrl.ts';
-import { LIST_SORT_OPTIONS } from '../constants/index.ts';
+import {
+  LIST_SORT_OPTIONS,
+  WATCHLIST_SORT_OPTIONS,
+} from '../constants/index.ts';
 import type {
   ListUrlBuilder,
   ListUrlBuilderParams,
@@ -18,8 +21,11 @@ function mapToDirection(value: string | Nil): SortDirection | undefined {
   return value === 'asc' || value === 'desc' ? value : undefined;
 }
 
-function mapToSortBy(value: string | Nil): SortBy | undefined {
-  const sortBy = LIST_SORT_OPTIONS.find((option) => option.value === value);
+function mapToSortBy(
+  value: string | Nil,
+  options: Sorting[],
+): SortBy | undefined {
+  const sortBy = options.find((option) => option.value === value);
   return sortBy ? sortBy.value : undefined;
 }
 
@@ -55,8 +61,11 @@ function getDefaultSortBy(props: UseListSortingProps): SortBy | undefined {
 }
 
 function getDefaultDirection(props: UseListSortingProps): SortDirection {
+  if (props.type === 'watchlist') {
+    return 'desc';
+  }
+
   if (
-    props.type === 'watchlist' ||
     props.type === 'favorites' ||
     props.type === 'progress' ||
     !props.list
@@ -67,9 +76,22 @@ function getDefaultDirection(props: UseListSortingProps): SortDirection {
   return props.list.sortHow;
 }
 
+function getSortOptions(props: UseListSortingProps) {
+  if (props.type === 'watchlist') {
+    return WATCHLIST_SORT_OPTIONS;
+  }
+
+  if (props.type === 'favorites') {
+    return LIST_SORT_OPTIONS.filter((option) => option.value !== undefined);
+  }
+
+  return LIST_SORT_OPTIONS;
+}
+
 export function useListSorting(
   props: UseListSortingProps,
 ): ListSorting {
+  const options = getSortOptions(props);
   const params = new BehaviorSubject<Record<string, string | null>>({
     sort_by: null,
     sort_how: null,
@@ -81,16 +103,15 @@ export function useListSorting(
 
   return {
     update,
-    options: props.type === 'favorites'
-      ? LIST_SORT_OPTIONS.filter((option) => option.value !== undefined)
-      : LIST_SORT_OPTIONS,
+    options,
     current: params.pipe(
       map(($params) => {
         const defaultDirection = getDefaultDirection(props);
-        const sortBy = mapToSortBy($params.sort_by) ?? getDefaultSortBy(props);
+        const sortBy = mapToSortBy($params.sort_by, options) ??
+          getDefaultSortBy(props);
         const sortHow = mapToDirection($params.sort_how) ?? defaultDirection;
 
-        const sorting = LIST_SORT_OPTIONS.find(
+        const sorting = options.find(
           (option) => option.value === sortBy,
         );
 

--- a/projects/client/src/lib/sections/lists/user/_internal/useReorderList.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useReorderList.ts
@@ -1,6 +1,7 @@
 import { useAllPagesInfiniteQuery } from '$lib/features/query/useQuery.ts';
 import type { ListItem } from '$lib/requests/models/ListItem.ts';
 import { userListItemsQuery } from '$lib/requests/queries/users/userListItemsQuery.ts';
+import { watchlistQuery } from '$lib/requests/queries/users/watchlistQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { map } from 'rxjs';
 import type { ReorderListSource } from '../models/ReorderListSource.ts';
@@ -18,14 +19,22 @@ function uniqueByKey(entries: ListItem[]): ListItem[] {
 }
 
 export function useReorderList(source: ReorderListSource) {
-  const query = useAllPagesInfiniteQuery(userListItemsQuery({
-    userId: assertDefined(
-      source.list.user.slug,
-      'Expected user list to have a user slug',
-    ),
-    listId: source.list.slug,
-    limit: reorderPageSize,
-  }));
+  const query = useAllPagesInfiniteQuery(
+    source.type === 'watchlist'
+      ? watchlistQuery({
+        limit: reorderPageSize,
+        sortBy: 'rank',
+        sortHow: 'asc',
+      })
+      : userListItemsQuery({
+        userId: assertDefined(
+          source.list.user.slug,
+          'Expected user list to have a user slug',
+        ),
+        listId: source.list.slug,
+        limit: reorderPageSize,
+      }),
+  );
 
   const isLoading = query.pipe(
     map(($query) =>

--- a/projects/client/src/lib/sections/lists/user/constants/index.ts
+++ b/projects/client/src/lib/sections/lists/user/constants/index.ts
@@ -38,3 +38,12 @@ export const LIST_SORT_OPTIONS: Sorting[] = [
     label: m.button_label_sort_title,
   },
 ] as const;
+
+export const WATCHLIST_SORT_OPTIONS: Sorting[] = [
+  ...LIST_SORT_OPTIONS,
+  {
+    value: 'rank',
+    text: m.button_text_sort_rank,
+    label: m.button_label_sort_rank,
+  },
+];

--- a/projects/client/src/lib/sections/lists/user/models/ReorderListSource.ts
+++ b/projects/client/src/lib/sections/lists/user/models/ReorderListSource.ts
@@ -1,6 +1,10 @@
 import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
 
-export type ReorderListSource = {
-  type: 'user-list';
-  list: MediaListSummary;
-};
+export type ReorderListSource =
+  | {
+    type: 'user-list';
+    list: MediaListSummary;
+  }
+  | {
+    type: 'watchlist';
+  };

--- a/projects/client/src/lib/sections/lists/user/models/SortBy.ts
+++ b/projects/client/src/lib/sections/lists/user/models/SortBy.ts
@@ -1,4 +1,5 @@
 export type SortBy =
+  | 'rank'
   | 'added'
   | 'runtime'
   | 'percentage'

--- a/projects/client/src/mocks/handlers/users.ts
+++ b/projects/client/src/mocks/handlers/users.ts
@@ -96,6 +96,12 @@ export const users = [
   http.get('http://localhost/users/me/watchlist/shows*', () => {
     return HttpResponse.json(WatchlistShowsResponseMock);
   }),
+  http.get('http://localhost/users/me/watchlist/movie,show*', () => {
+    return HttpResponse.json([
+      ...WatchlistMoviesResponseMock,
+      ...WatchlistShowsResponseMock,
+    ]);
+  }),
   http.get('http://localhost/v3/users/me/watchlist/minimal', () => {
     return HttpResponse.json(WatchlistMinimalResponseMock);
   }),

--- a/projects/client/src/routes/users/[user]/watchlist/+page.svelte
+++ b/projects/client/src/routes/users/[user]/watchlist/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import * as m from "$lib/features/i18n/messages.ts";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import ListReorderDrawer from "$lib/sections/lists/user/ListReorderDrawer.svelte";
   import { useListSorting } from "$lib/sections/lists/user/_internal/useListSorting.ts";
+  import ListReorderButton from "$lib/sections/lists/user/ListReorderButton.svelte";
   import ListSortActions from "$lib/sections/lists/user/ListSortActions.svelte";
   import WatchlistPaginatedList from "$lib/sections/lists/watchlist/WatchlistPaginatedList.svelte";
   import ResponsiveNavbarStateSetter from "$lib/sections/navbar/ResponsiveNavbarStateSetter.svelte";
@@ -15,7 +18,24 @@
     type: "watchlist",
     intent: "default",
   });
+
+  let showReorderList = $state(false);
 </script>
+
+{#snippet listActions()}
+  <PopupMenu
+    label={m.button_label_popup_menu({ title: m.list_title_watchlist() })}
+    mode="standalone"
+    title={m.list_title_watchlist()}
+  >
+    {#snippet items()}
+      <ListReorderButton
+        title={m.list_title_watchlist()}
+        onclick={() => (showReorderList = true)}
+      />
+    {/snippet}
+  </PopupMenu>
+{/snippet}
 
 <TraktPage
   audience="authenticated"
@@ -29,6 +49,7 @@
     header={{
       title: m.list_title_watchlist(),
       metaInfo: $currentDiscoverMode.text(),
+      actions: listActions,
     }}
   >
     {#snippet headerActions()}
@@ -47,3 +68,11 @@
     sortHow={$current.sortHow}
   />
 </TraktPage>
+
+{#if showReorderList}
+  <ListReorderDrawer
+    title={m.list_title_watchlist()}
+    source={{ type: "watchlist" }}
+    onClose={() => (showReorderList = false)}
+  />
+{/if}


### PR DESCRIPTION
## Summary

Adds Watchlist reordering using the existing Lists reorder experience, while keeping `Default` as the Watchlist default sort and exposing `Rank` as an explicit sort option.

Closes https://github.com/trakt/trakt-web/issues/2592

## Changes

- Reuses the Lists reorder drawer for Watchlist and adds the Watchlist popup menu action.
- Loads Watchlist items by rank and saves the updated order through `/sync/watchlist/reorder`.
- Keeps `Default` as the Watchlist default sort option.
- Adds `Rank` after `Title` in the Watchlist sort drawer.
- Defaults Watchlist `Rank` and `Title` sorting to ascending, and other Watchlist sort selections to descending.
- Adds rank display/icon handling plus mock/query/sort-value coverage.

## Screenshots

<img width="1423" height="1017" alt="Screenshot 2026-07-01 at 11 46 53" src="https://github.com/user-attachments/assets/d4082ca0-fb57-4da4-b86c-5e80b230587b" />

<img width="1423" height="1017" alt="Screenshot 2026-07-01 at 11 52 46" src="https://github.com/user-attachments/assets/ef619a63-318c-4a5c-912e-5cd728363d79" />

<img width="1423" height="1017" alt="Screenshot 2026-07-01 at 11 47 10" src="https://github.com/user-attachments/assets/8e6727a2-7ff2-47c9-abda-481ca4a45930" />

<img width="1423" height="1017" alt="Screenshot 2026-07-01 at 11 47 33" src="https://github.com/user-attachments/assets/b2e0744f-1132-4d07-b198-879852f4bbd4" />

