### PR TITLE
fix(summary): prevent rating layout shift on load

### DIFF
--- a/projects/client/src/lib/components/summary/RatingItem.svelte
+++ b/projects/client/src/lib/components/summary/RatingItem.svelte
@@ -1,15 +1,21 @@
 <script lang="ts">
   import { type Snippet } from "svelte";
-  import { fade, slide } from "svelte/transition";
   import Link from "../link/Link.svelte";
 
   type RatingItemProps = {
     rating?: string | number | Nil;
     superscript: Snippet;
     url?: string | Nil;
+    isLoading?: boolean;
   } & ChildrenProps;
 
-  const { children, rating, superscript, url }: RatingItemProps = $props();
+  const {
+    children,
+    rating,
+    superscript,
+    url,
+    isLoading = false,
+  }: RatingItemProps = $props();
 
   const hasValidRating = $derived(rating !== undefined);
   const ratingLink = $derived(hasValidRating ? url : undefined);
@@ -21,20 +27,26 @@
       {@render children()}
       <div class="rating-info">
         <div class="rating-value">
-          {#if !hasValidRating}
-            <p class="bold" out:slide={{ duration: 150, axis: "x" }}>-</p>
+          {#if isLoading}
+            <span class="rating-skeleton" aria-hidden="true"></span>
+          {:else if hasValidRating}
+            <span class="rating-grow">
+              <span class="rating-grow-clip">
+                <p class="bold">{rating}</p>
+              </span>
+            </span>
           {:else}
-            <div in:fade={{ delay: 150, duration: 150 }}>
-              <p class="bold" in:slide={{ duration: 150, axis: "x" }}>
-                {rating}
-              </p>
-            </div>
+            <p class="bold">-</p>
           {/if}
         </div>
-        {#if hasValidRating}
-          <p class="bold uppercase secondary vote-count tag">
-            {@render superscript()}
-          </p>
+        {#if !isLoading && hasValidRating}
+          <span class="rating-grow has-underline">
+            <span class="rating-grow-clip">
+              <p class="bold uppercase secondary vote-count tag">
+                {@render superscript()}
+              </p>
+            </span>
+          </span>
         {/if}
       </div>
     </div>
@@ -43,6 +55,18 @@
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
+
+  @keyframes rating-grow-in {
+    from {
+      grid-template-columns: 0fr;
+      opacity: 0;
+    }
+
+    to {
+      grid-template-columns: 1fr;
+      opacity: 1;
+    }
+  }
 
   rating {
     :global(.trakt-link) {
@@ -110,12 +134,70 @@
     }
 
     .rating-value {
-      position: relative;
-      min-width: var(--ni-6);
+      display: flex;
+      align-items: center;
 
-      :global(p[inert]) {
-        position: absolute;
+      min-height: var(--font-size-text);
+
+      // tabular-nums keeps digit changes (e.g. re-rating) from micro-shifting.
+      font-variant-numeric: tabular-nums;
+
+      // Small screens hide the vote-count and don't animate, so reserve the
+      // full value width up front (skeleton == loaded value) - no load jump.
+      // "100%" is the widest value; with tabular-nums each digit is 1ch.
+      min-width: 4ch;
+
+      @include for-desktop {
+        // desktop animates the grow-in instead of reserving space
+        min-width: 0;
       }
+    }
+
+    // CSS-only width grow-in. The 0fr -> 1fr column animation reflows for real
+    // (siblings glide, no jump). Gated to desktop: small screens hide the
+    // vote-count, so there is little to grow and the motion reads as jitter.
+    .rating-grow {
+      display: inline-grid;
+      grid-template-columns: 1fr;
+
+      @include for-desktop {
+        animation: rating-grow-in var(--transition-increment) ease-in-out;
+      }
+    }
+
+    .rating-grow-clip {
+      min-width: 0;
+
+      // clip the horizontal collapse; margin gives glyphs vertical breathing
+      overflow: clip;
+      overflow-clip-margin: var(--ni-2);
+    }
+
+    // extra clip margin keeps the vote-count underline visible
+    .rating-grow.has-underline .rating-grow-clip {
+      overflow-clip-margin: var(--ni-6);
+    }
+
+    .rating-skeleton {
+      display: block;
+
+      // match the reserved value box on small screens; slimmer bar on desktop
+      width: 4ch;
+      height: var(--font-size-text);
+
+      @include for-desktop {
+        width: var(--ni-24);
+      }
+
+      border-radius: var(--border-radius-xs);
+      background-color: color-mix(
+        in srgb,
+        var(--color-foreground) 20%,
+        transparent
+      );
+
+      animation: pulse calc(var(--transition-increment) * 6) ease-in-out
+        infinite alternate;
     }
   }
 </style>

--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -33,6 +33,7 @@
     entry: MediaEntry | EpisodeEntry;
     drilldown?: TraktRatingDrilldown;
     variant?: "all" | "external";
+    isLoading?: boolean;
   };
 
   const {
@@ -41,6 +42,7 @@
     entry,
     drilldown,
     variant = "all",
+    isLoading = false,
   }: RatingListProps = $props();
 
   const { trakt, imdb, rotten } = $derived(
@@ -55,6 +57,7 @@
 {#snippet traktItem()}
   <RatingItem
     rating={trakt?.rating && toTraktRating(trakt.rating, getLocale())}
+    {isLoading}
   >
     <RatingIcon style={toVotesBasedRating(trakt?.votes)} />
     {#snippet superscript()}
@@ -68,7 +71,7 @@
     {@render traktItem()}
   {/if}
 
-  <RatingItem rating={imdb?.rating} url={imdb?.url}>
+  <RatingItem rating={imdb?.rating} url={imdb?.url} {isLoading}>
     <IMDBIcon style={toVotesBasedRating(imdb?.votes)} />
     {#snippet superscript()}
       {i18n.voteText(imdb?.votes ?? 0)}
@@ -76,14 +79,22 @@
   </RatingItem>
 
   {#if isMediaEntry}
-    <RatingItem rating={toRottenPercentage(rotten?.critic)} url={rotten?.url}>
+    <RatingItem
+      rating={toRottenPercentage(rotten?.critic)}
+      url={rotten?.url}
+      {isLoading}
+    >
       <RottenIcon style={toRottenCriticRating(rotten?.critic)} />
       {#snippet superscript()}
         {toRottenCriticRating(rotten?.critic ?? 0)}
       {/snippet}
     </RatingItem>
 
-    <RatingItem rating={toRottenPercentage(rotten?.audience)} url={rotten?.url}>
+    <RatingItem
+      rating={toRottenPercentage(rotten?.audience)}
+      url={rotten?.url}
+      {isLoading}
+    >
       <PopcornIcon style={toRottenAudienceRating(rotten?.audience)} />
       {#snippet superscript()}
         {toRottenAudienceRating(rotten?.audience ?? 0)}
@@ -112,7 +123,7 @@
   .trakt-summary-ratings {
     display: flex;
     align-items: center;
-    gap: var(--gap-m);
+    gap: var(--gap-s);
 
     :global(.trakt-ratings-drilldown-button) {
       :global(svg) {
@@ -122,7 +133,7 @@
     }
 
     @include for-mobile() {
-      gap: var(--gap-s);
+      gap: var(--gap-xs);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/lists/components/_internal/SummaryCardRating.svelte
+++ b/projects/client/src/lib/sections/lists/components/_internal/SummaryCardRating.svelte
@@ -25,6 +25,10 @@
     align-items: center;
     gap: var(--gap-micro);
 
+    p {
+      font-variant-numeric: tabular-nums;
+    }
+
     :global(svg) {
       width: var(--ni-16);
       height: var(--ni-16);

--- a/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/EpisodeSummary.svelte
@@ -50,7 +50,7 @@
     episode: episode.number,
   });
 
-  const { ratings } = $derived(
+  const { ratings, isLoading } = $derived(
     useMediaMetaInfo({ type, episode, media: show }),
   );
 
@@ -84,6 +84,7 @@
       ratings={$ratings}
       entry={episode}
       drilldown={ratingsDrawerLink}
+      isLoading={$isLoading}
     />
 
     <RenderFor audience="authenticated">

--- a/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeSummary.svelte
@@ -44,7 +44,7 @@
     episode: episode.number,
   });
 
-  const { ratings } = $derived(
+  const { ratings, isLoading } = $derived(
     useMediaMetaInfo({ type, episode, media: show }),
   );
 
@@ -84,6 +84,7 @@
       ratings={$ratings}
       entry={episode}
       drilldown={ratingsDrawerLink}
+      isLoading={$isLoading}
     />
 
     <RenderFor audience="authenticated">

--- a/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/MediaSummary.svelte
@@ -44,7 +44,7 @@
     slug: media.slug,
   });
 
-  const { ratings } = $derived(useMediaMetaInfo(target));
+  const { ratings, isLoading } = $derived(useMediaMetaInfo(target));
   const { isDropped } = $derived(useIsDropped(media));
   const { isStarted } = $derived(useIsStarted(target));
 
@@ -90,6 +90,7 @@
         ratings={$ratings}
         entry={media}
         drilldown={ratingsDrawerLink}
+        isLoading={$isLoading}
       />
 
       <RenderFor audience="authenticated">

--- a/projects/client/src/lib/sections/summary/components/media/useMediaMetaInfo.ts
+++ b/projects/client/src/lib/sections/summary/components/media/useMediaMetaInfo.ts
@@ -46,5 +46,8 @@ export function useMediaMetaInfo(props: MetaInfoProps) {
     ratings: ratings.pipe(
       map(($ratings) => $ratings.data ?? EMPTY_RATINGS),
     ),
+    isLoading: ratings.pipe(
+      map(($ratings) => $ratings.isLoading),
+    ),
   };
 }

--- a/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/media/v2/MediaSummary.svelte
@@ -39,7 +39,7 @@
 
   const media = $derived(target.media);
 
-  const { ratings } = $derived(useMediaMetaInfo(target));
+  const { ratings, isLoading } = $derived(useMediaMetaInfo(target));
   const title = $derived(intl?.title ?? media?.title ?? "");
   const { watchCount } = $derived(useWatchCount(target));
   const postCreditsCount = $derived(media.postCredits?.length ?? 0);
@@ -94,6 +94,7 @@
       ratings={$ratings}
       entry={media}
       drilldown={ratingsDrawerLink}
+      isLoading={$isLoading}
     />
 
     <RenderFor audience="authenticated">

--- a/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
@@ -25,7 +25,9 @@
     props.type === "episode" ? props.episode : props.media,
   );
 
-  const { ratings: rawRatings } = $derived(useMediaMetaInfo(metaInfoTarget));
+  const { ratings: rawRatings, isLoading } = $derived(
+    useMediaMetaInfo(metaInfoTarget),
+  );
 
   const ratings = $derived(
     getDisplayableRatings({ ratings: $rawRatings, entry }),
@@ -65,7 +67,7 @@
             {m.header_ratings_official()}
           </h3>
           <div class="official-row">
-            <RatingList {ratings} {entry} variant="external" />
+            <RatingList {ratings} {entry} variant="external" isLoading={$isLoading} />
           </div>
         </section>
       {/if}


### PR DESCRIPTION
## Problem

The ratings row shifted around as data resolved:

- The value slid in with a width-animating transition, so the row visibly widened after load.
- Sources with no rating (e.g. a show with no Rotten Tomatoes data) stayed stuck in a perpetual skeleton pulse - we couldn't tell "still loading" from "loaded, no rating".
- The skeleton width didn't match the loaded value, so on small screens the row jumped when the numbers landed.

## Changes

- **Loading vs loaded-empty.** Thread the real `isLoading` from the ratings query through `RatingList` into `RatingItem`. Missing IMDb/Rotten entries now render a `-` once loaded instead of pulsing forever; the skeleton only shows while genuinely fetching.
- **Small screens - reserve, don't animate.** The vote-count is hidden and there's little to grow, so reserve the full value width up front (`min-width: 4ch`, and the skeleton matches). Skeleton and loaded value share one width -> no jump.
- **Desktop - animate the grow.** The vote-count (e.g. `302.3K`, `FRESH`) makes the row grow a lot and its width is unpredictable, so instead of reserving we grow the value in with a CSS `grid-template-columns: 0fr -> 1fr` animation, gated behind `@include for-desktop`. Real reflow, siblings glide, no snap. The animation lives entirely in CSS (media-gated), not JS.
- **tabular-nums** on rating values so digit changes (e.g. re-rating) never micro-shift the box.

Reduced-motion falls out for free - the grow duration keys off `--transition-increment`, which is `0ms` under `prefers-reduced-motion`.

## Scope

Only the summary rating surface (`RatingItem`, `RatingList`, `useMediaMetaInfo` + the 5 callers) and the list-card rating (`SummaryCardRating`, tabular-nums). No behavior change to the ratings data pipeline.

## Test plan

- [ ] Movie/show/episode summary: ratings resolve without the row widening.
- [ ] A title missing Rotten/IMDb shows `-`, not a stuck skeleton.
- [ ] Small screen: skeleton -> value swap has no horizontal jump.
- [ ] Desktop: value + vote-count grow in smoothly.
- [ ] `prefers-reduced-motion`: no grow animation.