### PR TITLE
fix(stats): stop screen-time daily labels overlapping in long locales

### DIFF
--- a/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
@@ -2,7 +2,6 @@
   import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
   import { getLocale, languageTag } from "$lib/features/i18n/index.ts";
   import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration.ts";
-  import { toPercentage } from "$lib/utils/formatting/number/toPercentage.ts";
   import { ratio } from "$lib/utils/number/ratio.ts";
   import type { ScreenTimeDailyData } from "./models/ScreenTimeDailyData";
 
@@ -21,6 +20,30 @@
     }).format(0),
   );
 
+  // Index of the day with the most screen time; label defaults to it. -1's
+  // guard is `hasPeak`: nothing watched -> no default label.
+  const peakIndex = $derived(
+    data.minutesPerDay.reduce(
+      (best, minutes, i, all) => (minutes > (all[best] ?? -1) ? i : best),
+      0,
+    ),
+  );
+  const hasPeak = $derived((data.minutesPerDay[peakIndex] ?? 0) > 0);
+
+  // Only one value is ever labelled at a time: the peak by default, or the day
+  // the user hovers / focuses / taps. A single slot keeps long locales (e.g.
+  // pt "8 h 28 min") from overlapping across the narrow columns.
+  let activeIndex = $state<number | null>(null);
+  const shownIndex = $derived(activeIndex ?? (hasPeak ? peakIndex : null));
+
+  // Cache the formatted durations so hover/focus re-renders don't rebuild an
+  // Intl.NumberFormat per column on every tick.
+  const durations = $derived(
+    data.minutesPerDay.map(
+      (minutes) => toHumanDuration({ minutes }, lang) || zeroMinutes,
+    ),
+  );
+
   // Sequential brand-purple intensity ramp (light -> deep = more screen time),
   // premium and on-brand rather than a traffic-light rainbow.
   function barColor(pct: number): string {
@@ -28,40 +51,55 @@
     if (pct >= 15) return "var(--viz-1)";
     return "var(--viz-3)";
   }
+
+  const reveal = (index: number) => (activeIndex = index);
+  // Guard by index so a trailing leave/blur from the previous column can't wipe
+  // the state a fresh enter/focus just set.
+  const clear = (index: number) => {
+    if (activeIndex === index) {
+      activeIndex = null;
+    }
+  };
 </script>
 
 <div class="trakt-pulse-graph-screen-time-daily">
   {#each data.labels as label, i (i)}
     {@const pct = data.percentages[i] ?? 0}
-    {@const minutes = data.minutesPerDay[i] ?? 0}
     {@const fraction = ratio({ value: pct, total: maxPct })}
-    <div class="screen-time-column">
-      <span class="screen-time-value tag secondary no-wrap">
-        {toHumanDuration({ minutes, separator: "" }, lang) || zeroMinutes}
+    {@const duration = durations[i] ?? zeroMinutes}
+    <button
+      type="button"
+      class="screen-time-column"
+      aria-label="{label}: {duration}"
+      onpointerenter={(e) => e.pointerType !== "touch" && reveal(i)}
+      onpointerleave={(e) => e.pointerType !== "touch" && clear(i)}
+      onclick={() => reveal(i)}
+      onfocus={() => reveal(i)}
+      onblur={() => clear(i)}
+    >
+      <span class="screen-time-value tag bold no-wrap">
+        {#if i === shownIndex}{duration}{/if}
       </span>
-      <div
-        class="screen-time-bar-container"
-        title="{toHumanDuration({ minutes }, lang)} · {toPercentage(
-          pct / 100,
-          locale,
-        )}"
-      >
+      <div class="screen-time-bar-container" aria-hidden="true">
         <DistributionBar
           orientation="vertical"
           {fraction}
           color={barColor(pct)}
           index={i}
+          active={i === shownIndex}
           minVisible={0.03}
-          label="{label}: {toHumanDuration({ minutes }, lang)}"
+          label="{label}: {duration}"
           --distribution-bar-thickness="64%"
         />
       </div>
       <span class="screen-time-label tag ellipsis no-wrap">{label}</span>
-    </div>
+    </button>
   {/each}
 </div>
 
 <style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .trakt-pulse-graph-screen-time-daily {
     display: flex;
     gap: var(--ni-8);
@@ -78,6 +116,23 @@
 
     flex: 1;
     min-width: 0;
+
+    // Reset native button chrome; the column stays a plain interactive stack.
+    appearance: none;
+    border: none;
+    background: none;
+    padding: 0;
+    margin: 0;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    // Let vertical page scroll pass through; drop the native tap highlight.
+    touch-action: pan-y;
+    -webkit-tap-highlight-color: transparent;
+
+    &:focus-visible {
+      @include viz-focus-ring;
+    }
   }
 
   .screen-time-bar-container {
@@ -95,9 +150,11 @@
     text-align: center;
   }
 
-  // Aligned across all columns at the top of the chart, above every bar.
+  // Single value slot above the bars: reserves one line so bars stay aligned
+  // whether or not a value is shown, and only one column fills it at a time.
   .screen-time-value {
     width: 100%;
+    min-height: 1lh;
     text-align: center;
   }
 </style>


### PR DESCRIPTION
## Problem
Reported on the Screen Time "Daily Breakdown" graph: in long locales (pt-BR here) the per-day duration labels overlap and become unreadable.

Root cause: every column rendered its own single-line label above the bar. English "8 h 28 min" is already tight in the ~35px columns; longer locale strings overflow into neighbours.

## Fix
Single value slot: only the peak day is labelled by default, and the rest reveal on hover / tap / keyboard focus. The one visible number moves to the active column, so two labels never share the row. A reserved label line keeps the bars aligned whether or not a value is shown.

- Columns are now `<button>`s: mouse hover, touch tap, and keyboard focus all reveal the day's value; each has an `aria-label` ("day: duration") so screen readers get the value without interacting.
- Peak detection falls back to no default label when nothing was watched.

## Trade-off
Non-peak values are no longer all visible at a glance - one at a time via interaction. Chosen over wrapping every label to 2 lines because it reads cleaner and scales to any locale length.

## Verification
- Behaviour prototyped in pt across default / hover-neighbour / edge-column states (no collision, no clipping).
- `deno fmt`, `eslint`, `svelte-check` all clean.
