### PR TITLE
Fixes feature flag content guarding

### DIFF
--- a/projects/client/src/lib/guards/RenderForFeature.svelte
+++ b/projects/client/src/lib/guards/RenderForFeature.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
-  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import RenderForAudience from "$lib/guards/_internal/RenderForAudience.svelte";
   import type { Snippet } from "svelte";
 
   const {
@@ -19,10 +19,13 @@
   const isFlagEnabled = $derived(isEnabled(flag));
 </script>
 
-<RenderFor {audience}>
-  {#if $isFlagEnabled}
+{#if $isFlagEnabled}
+  <RenderForAudience {audience}>
     {@render enabled()}
-  {:else}
-    {@render children?.()}
-  {/if}
-</RenderFor>
+    {#snippet fallback()}
+      {@render children?.()}
+    {/snippet}
+  </RenderForAudience>
+{:else}
+  {@render children?.()}
+{/if}

--- a/projects/client/src/lib/guards/_internal/RenderForAudience.svelte
+++ b/projects/client/src/lib/guards/_internal/RenderForAudience.svelte
@@ -2,8 +2,13 @@
   import { useAuth } from "$lib/features/auth/stores/useAuth";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import { IS_DEV } from "$lib/utils/env";
+  import type { Snippet } from "svelte";
 
-  const { children, audience }: ChildrenProps & AudienceProps = $props();
+  type RenderForAudienceProps = ChildrenProps & AudienceProps & {
+    fallback?: Snippet;
+  };
+
+  const { children, audience, fallback }: RenderForAudienceProps = $props();
 
   const { isAuthorized } = useAuth();
   const { user } = useUser();
@@ -22,4 +27,6 @@
 
 {#if isAvailableForAudience}
   {@render children()}
+{:else}
+  {@render fallback?.()}
 {/if}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes an issue where `RenderForFeature` would incorrectly guard fallback content.
- The `RenderForFeature` component now explicitly renders its `children` (fallback content) when the associated feature flag is disabled, bypassing audience checks.
- When the feature flag is enabled, the `RenderForAudience` component is used to check audience permissions.
- The `RenderForAudience` component has been updated to accept a `fallback` snippet, which now renders the `children` content if the audience check fails.
- This ensures that appropriate fallback content is always displayed, preventing an empty render state when features are off or audience conditions are not met.
