### PR TITLE
feat(settings): default feature flags to on for director accounts

### DIFF
--- a/projects/client/src/lib/features/feature-flag/_internal/FeatureFlagContext.ts
+++ b/projects/client/src/lib/features/feature-flag/_internal/FeatureFlagContext.ts
@@ -1,10 +1,8 @@
 import type { BehaviorSubject } from 'rxjs';
 import type { FeatureFlag } from '../models/FeatureFlag.ts';
 
-type FeatureFlags = {
-  [key in FeatureFlag]: boolean;
-};
+export type FeatureFlagOverrides = Partial<Record<FeatureFlag, boolean>>;
 
 export type FeatureFlagContext = {
-  flags: BehaviorSubject<FeatureFlags>;
+  overrides: BehaviorSubject<FeatureFlagOverrides>;
 };

--- a/projects/client/src/lib/features/feature-flag/_internal/createFeatureFlagContext.ts
+++ b/projects/client/src/lib/features/feature-flag/_internal/createFeatureFlagContext.ts
@@ -1,22 +1,25 @@
 import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
 import { BehaviorSubject } from 'rxjs';
 import { getContext, setContext } from 'svelte';
-import { FeatureFlag } from '../models/FeatureFlag.ts';
-import type { FeatureFlagContext } from './FeatureFlagContext.ts';
+import type {
+  FeatureFlagContext,
+  FeatureFlagOverrides,
+} from './FeatureFlagContext.ts';
 import { FEATURE_FLAG_CONTEXT_KEY } from './FeatureFlagContextKey.ts';
 
 export const FEATURE_FLAG_LOCAL_STORAGE_KEY = 'trakt-feature-flags';
 
-function initializeFlags() {
+function initializeOverrides(): FeatureFlagOverrides {
   const storedFlags = safeLocalStorage.getItem(FEATURE_FLAG_LOCAL_STORAGE_KEY);
-  const parsedFlags = storedFlags
-    ? JSON.parse(storedFlags) as Partial<Record<FeatureFlag, boolean>>
-    : {};
-  const featureFlags = Object.values(FeatureFlag);
+  if (!storedFlags) {
+    return {};
+  }
 
-  return Object.fromEntries(
-    featureFlags.map((flag) => [flag, parsedFlags[flag] ?? false]),
-  ) as Record<FeatureFlag, boolean>;
+  try {
+    return JSON.parse(storedFlags) as FeatureFlagOverrides;
+  } catch {
+    return {};
+  }
 }
 
 export function createFeatureFlagContext() {
@@ -24,7 +27,7 @@ export function createFeatureFlagContext() {
     FEATURE_FLAG_CONTEXT_KEY,
     getContext<FeatureFlagContext>(FEATURE_FLAG_CONTEXT_KEY) ??
       {
-        flags: new BehaviorSubject(initializeFlags()),
+        overrides: new BehaviorSubject(initializeOverrides()),
       },
   );
 

--- a/projects/client/src/lib/features/feature-flag/useFeatureFlag.spec.ts
+++ b/projects/client/src/lib/features/feature-flag/useFeatureFlag.spec.ts
@@ -1,0 +1,88 @@
+import { clone } from '$lib/utils/object/clone.ts';
+import { deepAssign } from '$lib/utils/object/deepAssign.ts';
+import { ExtendedUsersResponseMock } from '$mocks/data/users/response/ExtendedUserSettingsResponseMock.ts';
+import { server } from '$mocks/server.ts';
+import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
+import { waitForValue } from '$test/readable/waitForValue.ts';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { FeatureFlag } from './models/FeatureFlag.ts';
+import { useFeatureFlag } from './useFeatureFlag.ts';
+
+function mockDirector(isDirector: boolean) {
+  const user = deepAssign(
+    clone(ExtendedUsersResponseMock),
+    { user: { director: isDirector } },
+  );
+
+  server.use(
+    http.get(
+      'http://localhost/users/settings',
+      () => HttpResponse.json(user),
+    ),
+  );
+}
+
+describe('store: useFeatureFlag', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should default every flag to enabled for director accounts', async () => {
+    mockDirector(true);
+    setAuthorization(true);
+
+    const { isEnabled } = await renderStore(() => useFeatureFlag());
+
+    expect(await waitForValue(isEnabled(FeatureFlag.EditMode), true)).toBe(
+      true,
+    );
+    expect(await waitForValue(isEnabled(FeatureFlag.SmartRelated), true))
+      .toBe(true);
+  });
+
+  it('should default every flag to disabled for non-director accounts', async () => {
+    mockDirector(false);
+    setAuthorization(true);
+
+    const { isEnabled } = await renderStore(() => useFeatureFlag());
+
+    expect(await waitForValue(isEnabled(FeatureFlag.EditMode), false)).toBe(
+      false,
+    );
+  });
+
+  it('should default every flag to disabled for anonymous visitors', async () => {
+    setAuthorization(false);
+
+    const { isEnabled } = await renderStore(() => useFeatureFlag());
+
+    expect(await waitForValue(isEnabled(FeatureFlag.EditMode), false)).toBe(
+      false,
+    );
+  });
+
+  it('should let a manual override win over the director default', async () => {
+    mockDirector(true);
+    setAuthorization(true);
+
+    const { isEnabled, setFlag } = await renderStore(() => useFeatureFlag());
+    setFlag(FeatureFlag.EditMode, false);
+
+    expect(await waitForValue(isEnabled(FeatureFlag.EditMode), false)).toBe(
+      false,
+    );
+  });
+
+  it('should let a manual override enable a flag for non-director accounts', async () => {
+    mockDirector(false);
+    setAuthorization(true);
+
+    const { isEnabled, setFlag } = await renderStore(() => useFeatureFlag());
+    setFlag(FeatureFlag.EditMode, true);
+
+    expect(await waitForValue(isEnabled(FeatureFlag.EditMode), true)).toBe(
+      true,
+    );
+  });
+});

--- a/projects/client/src/lib/features/feature-flag/useFeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/useFeatureFlag.ts
@@ -1,19 +1,39 @@
-import { map } from 'rxjs';
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { combineLatest, distinctUntilChanged, map } from 'rxjs';
 import { safeLocalStorage } from '../../utils/storage/safeStorage.ts';
 import { FEATURE_FLAG_LOCAL_STORAGE_KEY } from './_internal/createFeatureFlagContext.ts';
 import { getFeatureFlagContext } from './_internal/getFeatureFlagContext.ts';
-import type { FeatureFlag } from './models/FeatureFlag.ts';
+import { FeatureFlag } from './models/FeatureFlag.ts';
 
 export function useFeatureFlag() {
-  const { flags } = getFeatureFlagContext();
+  const { overrides } = getFeatureFlagContext();
+  const { user } = useUser();
+
+  const isDirector = user.pipe(
+    map((currentUser) => currentUser?.isDirector ?? false),
+    distinctUntilChanged(),
+  );
+
+  // Director accounts get every flag defaulted to on; overrides (manual
+  // toggles persisted to localStorage) always win.
+  const flags = combineLatest([overrides, isDirector]).pipe(
+    map(([overrideValues, isDirectorValue]) =>
+      Object.fromEntries(
+        Object.values(FeatureFlag).map((flag) => [
+          flag,
+          overrideValues[flag] ?? isDirectorValue,
+        ]),
+      ) as Record<FeatureFlag, boolean>
+    ),
+  );
 
   const setFlag = (flag: FeatureFlag, value: boolean) => {
-    const updatedFlags = { ...flags.getValue(), [flag]: value };
+    const updatedOverrides = { ...overrides.getValue(), [flag]: value };
     safeLocalStorage.setItem(
       FEATURE_FLAG_LOCAL_STORAGE_KEY,
-      JSON.stringify(updatedFlags),
+      JSON.stringify(updatedOverrides),
     );
-    flags.next(updatedFlags);
+    overrides.next(updatedOverrides);
   };
 
   return {


### PR DESCRIPTION
## Summary
- Director accounts now get every preview feature flag defaulted to on.
- Manual toggles on the settings page still persist to localStorage and take priority over the director default.

## Test plan
- [x] `deno task check`
- [x] `deno task test:unit`
- [x] `useFeatureFlag.spec.ts` covers: director default-on, non-director default-off, anonymous fallback, and manual override winning over the director default in both directions.
- [ ] Manually verify Settings > Preview Features shows all flags on for a director account, and toggling one off/on persists correctly.