### PR TITLE
chore(auth): switch over to auth.trakt.tv

### DIFF
--- a/projects/client/src/lib/features/auth/resolveOidcAuthority.ts
+++ b/projects/client/src/lib/features/auth/resolveOidcAuthority.ts
@@ -1,11 +1,5 @@
-import { isWorkerAuthHost } from '$lib/utils/url/isWorkerAuthHost.ts';
 import { prependHttps } from '$lib/utils/url/prependHttps.ts';
-import { deriveStandardAuthority } from './deriveStandardAuthority.ts';
 
 export function resolveOidcAuthority(): HttpsUrl {
-  if (isWorkerAuthHost(globalThis.window?.location.hostname)) {
-    return prependHttps('auth.trakt.tv');
-  }
-
-  return deriveStandardAuthority();
+  return prependHttps('auth.trakt.tv');
 }

--- a/projects/client/src/lib/features/auth/stores/useAuth.ts
+++ b/projects/client/src/lib/features/auth/stores/useAuth.ts
@@ -1,6 +1,5 @@
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { isWorkerAuthHost } from '$lib/utils/url/isWorkerAuthHost.ts';
 import { WorkerMessage } from '$worker/WorkerMessage.ts';
 import { workerRequest } from '$worker/workerRequest.ts';
 import { setToken } from '../token/index.ts';
@@ -22,20 +21,12 @@ export function useAuth() {
     await invalidate(InvalidateAction.Auth);
     await workerRequest(WorkerMessage.CacheBust);
 
-    // On the worker auth host, end the session at the provider (RP-initiated
-    // logout) so it's a real logout, not just a local token revoke. signoutRedirect
-    // clears the local user and navigates, returning to this origin.
-    if (manager && isWorkerAuthHost(globalThis.window?.location?.hostname)) {
-      await manager.signoutRedirect({
-        post_logout_redirect_uri: globalThis.window?.location?.origin,
-      });
-      return;
-    }
-
-    await manager?.removeUser();
-    // FIXME: legacy logout path. Remove once the new auth host is used
-    // everywhere - then logout is just revokeTokens() + signoutRedirect().
-    globalThis.window.location.href = 'https://trakt.tv/logout';
+    // End the session at the provider (RP-initiated logout) so it's a real
+    // logout, not just a local token revoke. signoutRedirect clears the local
+    // user and navigates, returning to this origin.
+    await manager?.signoutRedirect({
+      post_logout_redirect_uri: globalThis.window?.location?.origin,
+    });
   };
 
   const login = async () => {


### PR DESCRIPTION
## 🎶 Notes 🎶

- Switches over to `auth.trakt.tv` for auth