### PR TITLE
feat(stats): peak-hours breakdown tooltip + shared bar ramp

### DIFF
--- a/projects/client/src/lib/sections/stats/_internal/PulseGraphPeakHours.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraphPeakHours.svelte
@@ -1,27 +1,66 @@
 <script lang="ts">
   import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
   import { ratio } from "$lib/utils/number/ratio.ts";
+  import { STRENGTH_RAMP_COLOR } from "./strengthRampColor.ts";
   import type { PeakHoursData } from "./models/PeakHoursData";
 
   const { data }: { data: PeakHoursData } = $props();
 
   const max = $derived(Math.max(...data.buckets.map((b) => b.count), 1));
+
+  // Row whose movies/episodes breakdown is revealed (hover / focus / tap).
+  let activeIndex = $state<number | null>(null);
+
+  // Cache the breakdown strings so hover/focus re-renders don't rebuild the
+  // per-row messages on every tick.
+  const breakdowns = $derived(
+    data.buckets.map((bucket) =>
+      `${m.text_stats_movies_count({ count: bucket.movies })} · ${
+        m.text_stats_episodes_count({ count: bucket.episodes })
+      }`
+    ),
+  );
+
+  const reveal = (index: number) => (activeIndex = index);
+  // Guard by index so a trailing leave/blur from the previous row can't wipe the
+  // state a fresh enter/focus just set.
+  const clear = (index: number) => {
+    if (activeIndex === index) {
+      activeIndex = null;
+    }
+  };
 </script>
 
 <div class="trakt-pulse-graph-peak-hours">
   {#each data.buckets as bucket, i (bucket.key)}
-    <div class="peak-row">
+    {@const fraction = ratio({ value: bucket.count, total: max })}
+    {@const breakdown = breakdowns.at(i) ?? ""}
+    <button
+      type="button"
+      class="peak-row"
+      class:is-active={i === activeIndex}
+      aria-label="{bucket.label}: {bucket.count} ({breakdown})"
+      onpointerenter={(e) => e.pointerType !== "touch" && reveal(i)}
+      onpointerleave={(e) => e.pointerType !== "touch" && clear(i)}
+      onclick={() => reveal(i)}
+      onfocus={() => reveal(i)}
+      onblur={() => clear(i)}
+    >
+      <span class="peak-tooltip tag">{breakdown}</span>
       <span class="peak-label tag">{bucket.label}</span>
-      <div class="peak-bar">
+      <div class="peak-bar" aria-hidden="true">
         <DistributionBar
-          fraction={ratio({ value: bucket.count, total: max })}
+          {fraction}
+          color={STRENGTH_RAMP_COLOR}
           index={i}
-          active={bucket.count === max && bucket.count > 0}
+          active={i === activeIndex}
           label="{bucket.label}: {bucket.count}"
+          --viz-bar-strength={fraction}
         />
       </div>
       <span class="peak-count secondary tag">{bucket.count}</span>
-    </div>
+    </button>
   {/each}
 </div>
 
@@ -35,9 +74,24 @@
   }
 
   .peak-row {
+    position: relative;
     display: flex;
     align-items: center;
     gap: var(--ni-8);
+
+    // Reset native button chrome; the row stays a plain interactive stack.
+    appearance: none;
+    border: none;
+    background: none;
+    padding: var(--ni-2) 0;
+    margin: 0;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    text-align: start;
+    -webkit-tap-highlight-color: transparent;
+    // The bar ring below is the focus indicator; suppress the native outline.
+    outline: none;
   }
 
   .peak-label {
@@ -46,13 +100,48 @@
     text-align: start;
   }
 
+  // The bar wrapper is the bar's footprint, so the ring hugs the bar rather than
+  // boxing the whole row. Rings on hover / tap (is-active) and keyboard focus.
   .peak-bar {
     flex: 1;
+    border-radius: var(--viz-bar-radius);
+    outline: var(--ni-2) solid transparent;
+    outline-offset: var(--ni-4);
+    transition: outline-color var(--transition-increment) ease;
+  }
+
+  .peak-row.is-active .peak-bar,
+  .peak-row:focus-visible .peak-bar {
+    outline-color: var(--viz-1);
   }
 
   .peak-count {
     width: var(--ni-28);
     text-align: end;
     flex-shrink: 0;
+  }
+
+  // Breakdown popover above the bar; fades in on interaction.
+  .peak-tooltip {
+    position: absolute;
+    inset-block-end: calc(100% - var(--ni-6));
+    inset-inline-start: calc(var(--ni-64) + var(--ni-8));
+    z-index: var(--layer-top);
+
+    white-space: nowrap;
+    background-color: var(--color-tooltip-background);
+    color: var(--color-tooltip-text);
+    font-weight: 500;
+    border-radius: var(--border-radius-xs);
+    padding: var(--ni-6) var(--ni-8);
+    box-shadow: var(--shadow-menu);
+
+    opacity: 0;
+    transition: opacity var(--transition-increment) ease;
+    pointer-events: none;
+  }
+
+  .peak-row.is-active .peak-tooltip {
+    opacity: 1;
   }
 </style>

--- a/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/PulseGraphScreenTimeDaily.svelte
@@ -5,6 +5,7 @@
   import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration.ts";
   import { ratio } from "$lib/utils/number/ratio.ts";
   import { time } from "$lib/utils/timing/time.ts";
+  import { STRENGTH_RAMP_COLOR } from "./strengthRampColor.ts";
   import type { ScreenTimeDailyData } from "./models/ScreenTimeDailyData";
 
   // Grace period before the label glides back to the peak, so crossing the gap
@@ -52,13 +53,6 @@
   const shownDuration = $derived(
     shownIndex == null ? "" : durations[shownIndex] ?? zeroMinutes,
   );
-
-  // Continuous brand-purple ramp: taller day -> deeper purple. The mix is
-  // resolved in CSS from each bar's `--daily-bar-strength` (0-1), so JS only
-  // forwards the numeric fraction. `clamp` keeps the color-mix percentage valid
-  // even if a stray value lands outside [0, 1].
-  const DAILY_BAR_COLOR =
-    "color-mix(in oklab, var(--viz-3), var(--viz-5) clamp(0%, calc(var(--daily-bar-strength) * 100%), 100%))";
 
   let returnTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -108,13 +102,13 @@
         <DistributionBar
           orientation="vertical"
           {fraction}
-          color={DAILY_BAR_COLOR}
+          color={STRENGTH_RAMP_COLOR}
           index={i}
           active={i === activeIndex}
           minVisible={0.03}
           label="{label}: {duration}"
           --distribution-bar-thickness="100%"
-          --daily-bar-strength={fraction}
+          --viz-bar-strength={fraction}
         />
       </div>
       <span class="screen-time-label tag ellipsis no-wrap">{label}</span>

--- a/projects/client/src/lib/sections/stats/_internal/getGraphItems.ts
+++ b/projects/client/src/lib/sections/stats/_internal/getGraphItems.ts
@@ -38,7 +38,10 @@ export function getGraphItems(
       key: 'peakHours',
       kind: 'peakHours',
       data: {
-        buckets: bucketByTimeOfDay(twAll),
+        buckets: bucketByTimeOfDay({
+          movieDates: thisWeek.movieDates,
+          showDates: thisWeek.showDates,
+        }),
       },
     },
   ];

--- a/projects/client/src/lib/sections/stats/_internal/models/PeakHoursBucket.ts
+++ b/projects/client/src/lib/sections/stats/_internal/models/PeakHoursBucket.ts
@@ -3,5 +3,7 @@ type TimeOfDayKey = 'morning' | 'afternoon' | 'evening' | 'night';
 export type PeakHoursBucket = {
   readonly label: string;
   readonly count: number;
+  readonly movies: number;
+  readonly episodes: number;
   readonly key: TimeOfDayKey;
 };

--- a/projects/client/src/lib/sections/stats/_internal/strengthRampColor.ts
+++ b/projects/client/src/lib/sections/stats/_internal/strengthRampColor.ts
@@ -1,0 +1,6 @@
+// Continuous brand-purple ramp shared by the pulse graphs: a bar's colour is
+// mixed from the light and deep viz slots by its `--viz-bar-strength` (0-1),
+// resolved entirely in CSS so callers only forward the numeric strength. `clamp`
+// keeps the color-mix percentage valid even for a stray out-of-range value.
+export const STRENGTH_RAMP_COLOR =
+  'color-mix(in oklab, var(--viz-3), var(--viz-5) clamp(0%, calc(var(--viz-bar-strength) * 100%), 100%))';

--- a/projects/client/src/lib/sections/stats/_internal/utils/bucketByTimeOfDay.spec.ts
+++ b/projects/client/src/lib/sections/stats/_internal/utils/bucketByTimeOfDay.spec.ts
@@ -15,24 +15,32 @@ import { bucketByTimeOfDay } from './bucketByTimeOfDay.ts';
 
 describe('bucketByTimeOfDay', () => {
   it('returns 4 time buckets with zero counts for empty input', () => {
-    const result = bucketByTimeOfDay([]);
+    const result = bucketByTimeOfDay({ movieDates: [], showDates: [] });
     expect(result).toHaveLength(4);
-    result.forEach((bucket) => expect(bucket.count).toBe(0));
+    result.forEach((bucket) => {
+      expect(bucket.count).toBe(0);
+      expect(bucket.movies).toBe(0);
+      expect(bucket.episodes).toBe(0);
+    });
   });
 
-  it('sorts dates into correct time buckets', () => {
-    const dates = [
-      new Date('2024-01-15T06:00:00Z'), // morning (5-12)
-      new Date('2024-01-15T09:00:00Z'), // morning
-      new Date('2024-01-15T14:00:00Z'), // afternoon (12-17)
-      new Date('2024-01-15T19:00:00Z'), // evening (17-22)
-      new Date('2024-01-15T23:00:00Z'), // late night (22+)
-      new Date('2024-01-15T02:00:00Z'), // late night (<5)
+  it('sorts movies and episodes into their time buckets and totals them', () => {
+    const movieDates = [
+      new Date('2024-01-15T06:00:00'), // morning (5-12)
+      new Date('2024-01-15T09:00:00'), // morning
+      new Date('2024-01-15T14:00:00'), // afternoon (12-17)
     ];
-    const result = bucketByTimeOfDay(dates);
-    expect(result[0]!.count).toBe(2); // morning
-    expect(result[1]!.count).toBe(1); // afternoon
-    expect(result[2]!.count).toBe(1); // evening
-    expect(result[3]!.count).toBe(2); // late night
+    const showDates = [
+      new Date('2024-01-15T19:00:00'), // evening (17-22)
+      new Date('2024-01-15T23:00:00'), // late night (22+)
+      new Date('2024-01-15T02:00:00'), // late night (<5)
+    ];
+
+    const result = bucketByTimeOfDay({ movieDates, showDates });
+
+    expect(result[0]!).toMatchObject({ movies: 2, episodes: 0, count: 2 }); // morning
+    expect(result[1]!).toMatchObject({ movies: 1, episodes: 0, count: 1 }); // afternoon
+    expect(result[2]!).toMatchObject({ movies: 0, episodes: 1, count: 1 }); // evening
+    expect(result[3]!).toMatchObject({ movies: 0, episodes: 2, count: 2 }); // late night
   });
 });

--- a/projects/client/src/lib/sections/stats/_internal/utils/bucketByTimeOfDay.ts
+++ b/projects/client/src/lib/sections/stats/_internal/utils/bucketByTimeOfDay.ts
@@ -6,6 +6,11 @@ const afternoonStartHour = 12;
 const eveningStartHour = 17;
 const lateNightStartHour = 22;
 
+type BucketByTimeOfDayParams = {
+  readonly movieDates: ReadonlyArray<Date>;
+  readonly showDates: ReadonlyArray<Date>;
+};
+
 function timeBucketIndex(hour: number): number {
   if (hour >= morningStartHour && hour < afternoonStartHour) return 0;
   if (hour >= afternoonStartHour && hour < eveningStartHour) return 1;
@@ -13,34 +18,36 @@ function timeBucketIndex(hour: number): number {
   return 3;
 }
 
-export function bucketByTimeOfDay(
-  dates: ReadonlyArray<Date>,
-): ReadonlyArray<PeakHoursBucket> {
-  const counts = Array.from(
+function countPerBucket(dates: ReadonlyArray<Date>): ReadonlyArray<number> {
+  return Array.from(
     { length: 4 },
     (_, i) => dates.filter((d) => timeBucketIndex(d.getHours()) === i).length,
   );
+}
 
-  return [
-    {
-      label: m.text_stats_time_morning(),
-      count: counts[0] ?? 0,
-      key: 'morning',
-    },
-    {
-      label: m.text_stats_time_afternoon(),
-      count: counts[1] ?? 0,
-      key: 'afternoon',
-    },
-    {
-      label: m.text_stats_time_evening(),
-      count: counts[2] ?? 0,
-      key: 'evening',
-    },
-    {
-      label: m.text_stats_time_late_night(),
-      count: counts[3] ?? 0,
-      key: 'night',
-    },
+export function bucketByTimeOfDay(
+  { movieDates, showDates }: BucketByTimeOfDayParams,
+): ReadonlyArray<PeakHoursBucket> {
+  const movies = countPerBucket(movieDates);
+  const episodes = countPerBucket(showDates);
+
+  const buckets: ReadonlyArray<
+    Omit<PeakHoursBucket, 'movies' | 'episodes' | 'count'>
+  > = [
+    { label: m.text_stats_time_morning(), key: 'morning' },
+    { label: m.text_stats_time_afternoon(), key: 'afternoon' },
+    { label: m.text_stats_time_evening(), key: 'evening' },
+    { label: m.text_stats_time_late_night(), key: 'night' },
   ];
+
+  return buckets.map((bucket, i) => {
+    const movieCount = movies.at(i) ?? 0;
+    const episodeCount = episodes.at(i) ?? 0;
+    return {
+      ...bucket,
+      movies: movieCount,
+      episodes: episodeCount,
+      count: movieCount + episodeCount,
+    };
+  });
 }


### PR DESCRIPTION
Adds an interactive breakdown to the Peak Hours ("Ore de vârf") graph, matching the daily graph's treatment.

## What
- **Breakdown tooltip**: hover / keyboard-focus / tap a row to reveal a tooltip splitting that time-of-day's total into movies vs episodes (`{n} movies · {m} episodes`, reusing `text_stats_movies_count` / `text_stats_episodes_count`).
- **Bar ring + brightness** on the active row (interaction feedback), native focus outline suppressed so the ring is the single focus indicator.
- **Matching palette**: rows use the same continuous purple ramp as the daily graph (deeper = more plays).

## Data
- `bucketByTimeOfDay` now buckets `movieDates` and `showDates` separately, so each `PeakHoursBucket` carries `movies` + `episodes` next to the total `count`.
- `getGraphItems` passes both date arrays.

## Refactor
- Extracted the ramp colour into a shared `strengthRampColor` const (CSS-resolved via `--viz-bar-strength`); the daily graph now imports it too. Behaviour-preserving.

## Verification
- `bucketByTimeOfDay` spec updated (movies/episodes/total) - passing.
- `deno fmt` + `eslint` + `svelte-check` clean. UI prototyped in light theme (matches the screenshot).
