### PR TITLE
fix(lists): tighten list title spacing

### DIFF
--- a/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListHeader.svelte
@@ -90,7 +90,17 @@
       align-items: center;
     }
 
-    .trakt-list-title,
+    .trakt-list-title {
+      display: flex;
+      align-items: center;
+      gap: var(--gap-xxs);
+      min-width: 0;
+
+      .trakt-list-actions {
+        margin-inline-start: calc(var(--gap-s) - var(--gap-xxs));
+      }
+    }
+
     .trakt-list-header-content {
       display: flex;
       align-items: center;

--- a/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
+++ b/projects/client/src/lib/components/lists/_internal/ListTitle.svelte
@@ -84,7 +84,7 @@
     :global(.trakt-link) {
       display: flex;
       align-items: center;
-      gap: var(--gap-xs);
+      gap: var(--gap-xxs);
       min-width: 0;
     }
 


### PR DESCRIPTION
## Screenshot
<img width="455" height="558" alt="Screenshot 2026-07-01 at 19 55 35" src="https://github.com/user-attachments/assets/d82f4946-51e2-41aa-a9bb-15856b578338" />


## Summary

Tightens the spacing between collapsible list header elements for a more compact, precise layout.

- Reduces the gap between the collapse chevron and the list title text (`ListHeader`) from `--gap-s` to `--gap-xxs`
- Reduces the gap between the title and subtitle spans (`ListTitle`) from `--gap-xs` to `--gap-xxs`

Closes #2767

🤖 Generated with [Claude Code](https://claude.com/claude-code)