### PR TITLE
feat: landing page styling upgrades

### DIFF
--- a/projects/client/src/lib/sections/landing/Landing.svelte
+++ b/projects/client/src/lib/sections/landing/Landing.svelte
@@ -96,11 +96,24 @@
     padding: var(--landing-padding);
     padding-bottom: var(--popcorn-safe-area);
 
-    background: radial-gradient(
-      1000px 1000px at 50% 100%,
-      color-mix(in srgb, var(--purple-500) 30%, transparent) 0%,
-      transparent 100%
-    );
+    background-color: #14111b;
+    background-image:
+      radial-gradient(
+        72% 78% at 50% 110%,
+        rgba(159, 66, 198, 0.42),
+        transparent 70%
+      ),
+      radial-gradient(
+        110% 90% at 50% 42%,
+        rgba(20, 17, 27, 0.25),
+        rgba(20, 17, 27, 0.8)
+      ),
+      linear-gradient(
+        180deg,
+        #221f2b 0%,
+        #2a2336 45%,
+        #3a2352 100%
+      );
 
     transition: var(--transition-increment) ease-in-out;
     transition-property: padding;

--- a/projects/client/src/lib/sections/landing/Landing.svelte
+++ b/projects/client/src/lib/sections/landing/Landing.svelte
@@ -96,23 +96,23 @@
     padding: var(--landing-padding);
     padding-bottom: var(--popcorn-safe-area);
 
-    background-color: #14111b;
+    background-color: var(--shade-920);
     background-image:
       radial-gradient(
         72% 78% at 50% 110%,
-        rgba(159, 66, 198, 0.42),
+        color-mix(in srgb, var(--purple-500) 42%, transparent),
         transparent 70%
       ),
       radial-gradient(
         110% 90% at 50% 42%,
-        rgba(20, 17, 27, 0.25),
-        rgba(20, 17, 27, 0.8)
+        color-mix(in srgb, var(--shade-920) 25%, transparent),
+        color-mix(in srgb, var(--shade-920) 80%, transparent)
       ),
       linear-gradient(
         180deg,
-        #221f2b 0%,
-        #2a2336 45%,
-        #3a2352 100%
+        var(--shade-900) 0%,
+        var(--shade-800) 45%,
+        var(--purple-900) 100%
       );
 
     transition: var(--transition-increment) ease-in-out;

--- a/projects/client/src/lib/sections/landing/MobileLanding.svelte
+++ b/projects/client/src/lib/sections/landing/MobileLanding.svelte
@@ -41,23 +41,23 @@
 
     overflow-x: hidden;
 
-    background-color: #14111b;
+    background-color: var(--shade-920);
     background-image:
       linear-gradient(
         0deg,
-        rgba(159, 66, 198, 0.3) 0%,
+        color-mix(in srgb, var(--purple-500) 30%, transparent) 0%,
         transparent 70%
       ),
       radial-gradient(
         110% 90% at 50% 42%,
-        rgba(20, 17, 27, 0.45),
-        rgba(20, 17, 27, 0.95)
+        color-mix(in srgb, var(--shade-920) 45%, transparent),
+        color-mix(in srgb, var(--shade-920) 95%, transparent)
       ),
       linear-gradient(
         180deg,
-        #221f2b 0%,
-        #2a2336 45%,
-        #3a2352 100%
+        var(--shade-900) 0%,
+        var(--shade-800) 45%,
+        var(--purple-900) 100%
       );
   }
 

--- a/projects/client/src/lib/sections/landing/MobileLanding.svelte
+++ b/projects/client/src/lib/sections/landing/MobileLanding.svelte
@@ -41,11 +41,24 @@
 
     overflow-x: hidden;
 
-    background: radial-gradient(
-      200dvw 200dvw at 50% 100%,
-      color-mix(in srgb, var(--purple-500) 50%, transparent) 0%,
-      transparent 100%
-    );
+    background-color: #14111b;
+    background-image:
+      linear-gradient(
+        0deg,
+        rgba(159, 66, 198, 0.3) 0%,
+        transparent 70%
+      ),
+      radial-gradient(
+        110% 90% at 50% 42%,
+        rgba(20, 17, 27, 0.45),
+        rgba(20, 17, 27, 0.95)
+      ),
+      linear-gradient(
+        180deg,
+        #221f2b 0%,
+        #2a2336 45%,
+        #3a2352 100%
+      );
   }
 
   .trakt-landing-content {

--- a/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
+++ b/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
@@ -48,11 +48,13 @@
     gap: var(--gap-l);
 
     padding: var(--ni-24);
-    border: var(--ni-1) solid rgba(255, 255, 255, 0.09);
+    border: var(--ni-1) solid
+      color-mix(in srgb, var(--shade-10) 9%, transparent);
     border-radius: var(--ni-24);
 
-    background: rgba(20, 16, 28, 0.72);
-    box-shadow: 0 var(--ni-30) var(--ni-80) rgba(0, 0, 0, 0.5);
+    background: color-mix(in srgb, var(--shade-920) 72%, transparent);
+    box-shadow: 0 var(--ni-30) var(--ni-80)
+      color-mix(in srgb, var(--color-shadow) 50%, transparent);
     backdrop-filter: blur(var(--ni-20));
     -webkit-backdrop-filter: blur(var(--ni-20));
 
@@ -60,7 +62,7 @@
       gap: var(--gap-m);
       padding: var(--ni-24) var(--ni-22);
       border-radius: var(--ni-22);
-      background: rgba(16, 12, 22, 0.78);
+      background: color-mix(in srgb, var(--shade-930) 78%, transparent);
     }
   }
 

--- a/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
+++ b/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LogoMarkCircle from "$lib/components/logo/LogoMarkCircle.svelte";
   import { useTraktTeam } from "$lib/features/team/useTraktTeam";
   import UserAvatar from "$lib/sections/lists/components/UserAvatar.svelte";
   import JoinForFreeButton from "./JoinForFreeButton.svelte";
@@ -10,18 +11,15 @@
 
 <div class="trakt-join-for-free">
   <div class="trakt-landing-social-proof">
-    <div class="trakt-social-proof-stats">
-      <span class="bold trakt-social-proof-count">15</span>
-      <div class="trakt-social-proof-lines">
-        <p>years of watching together</p>
-        <p>mil. shows & movie lovers</p>
-        <p>mil. titles tracked weekly</p>
-      </div>
+    <div class="trakt-social-proof-copy">
+      <span class="bold title welcome-title">
+        Welcome to Trakt <LogoMarkCircle />
+      </span>
+      <p class="secondary">
+        Your new home, where your shows and movies are all in one place.
+      </p>
     </div>
-    <div
-      class="trakt-landing-profiles"
-      style="--profile-count: {profileCount}"
-    >
+    <div class="trakt-landing-profiles" style="--profile-count: {profileCount}">
       {#if !$isLoading}
         {#each $team as member, index (member.username)}
           <div class="trakt-team-member" style="--user-index: {index}">
@@ -66,6 +64,17 @@
     }
   }
 
+  .welcome-title {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    :global(svg) {
+      width: var(--ni-18);
+      height: var(--ni-18);
+    }
+  }
+
   .trakt-landing-social-proof {
     display: flex;
     align-items: center;
@@ -74,28 +83,17 @@
     gap: var(--gap-s);
   }
 
-  .trakt-social-proof-stats {
+  .trakt-social-proof-copy {
     display: flex;
-    gap: var(--gap-xs);
+    flex-direction: column;
+    gap: var(--gap-xxs);
 
-    flex-shrink: 0;
-
-    .trakt-social-proof-count {
-      display: flex;
-      align-items: center;
-      font-size: var(--ni-52);
-      line-height: var(--ni-52);
-    }
-
-    .trakt-social-proof-lines {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-    }
+    flex: 1;
+    min-width: 0;
   }
 
   .trakt-landing-profiles {
-    --avatars-width: 100%;
+    --avatars-width: var(--ni-120);
     --avatar-size: var(--ni-52);
     --avatar-offset: calc(
       (var(--avatars-width) - var(--avatar-size)) / (var(--profile-count) - 1)
@@ -104,7 +102,7 @@
 
     display: flex;
     align-items: center;
-    flex: 1;
+    flex: 0 0 var(--avatars-width);
 
     height: 100%;
     width: var(--avatars-width);

--- a/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
+++ b/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
@@ -56,9 +56,9 @@
     @include backdrop-filter-blur(var(--ni-20));
 
     @include for-tablet-lg-and-below() {
-      gap: var(--gap-m);
-      padding: var(--ni-24) var(--ni-22);
-      border-radius: var(--ni-22);
+      gap: var(--gap-s);
+      padding: var(--ni-14) var(--ni-18);
+      border-radius: var(--ni-18);
       background: color-mix(in srgb, var(--shade-930) 78%, transparent);
     }
   }

--- a/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
+++ b/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
@@ -45,20 +45,22 @@
   .trakt-join-for-free {
     display: flex;
     flex-direction: column;
-    gap: var(--gap-m);
+    gap: var(--gap-l);
 
     padding: var(--ni-24);
-    border-radius: var(--border-radius-xxl);
+    border: var(--ni-1) solid rgba(255, 255, 255, 0.09);
+    border-radius: var(--ni-24);
 
-    background-color: color-mix(
-      in srgb,
-      var(--purple-400) 10%,
-      transparent 90%
-    );
+    background: rgba(20, 16, 28, 0.72);
+    box-shadow: 0 var(--ni-30) var(--ni-80) rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(var(--ni-20));
+    -webkit-backdrop-filter: blur(var(--ni-20));
 
     @include for-tablet-lg-and-below() {
-      gap: var(--gap-s);
-      padding: var(--ni-12);
+      gap: var(--gap-m);
+      padding: var(--ni-24) var(--ni-22);
+      border-radius: var(--ni-22);
+      background: rgba(16, 12, 22, 0.78);
     }
   }
 
@@ -126,7 +128,7 @@
     }
 
     @include for-tablet-lg-and-below() {
-      gap: var(--gap-xxs);
+      gap: var(--gap-xs);
     }
   }
 </style>

--- a/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
+++ b/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
@@ -53,8 +53,7 @@
     background: color-mix(in srgb, var(--shade-920) 72%, transparent);
     box-shadow: 0 var(--ni-30) var(--ni-80)
       color-mix(in srgb, var(--color-shadow) 50%, transparent);
-    backdrop-filter: blur(var(--ni-20));
-    -webkit-backdrop-filter: blur(var(--ni-20));
+    @include backdrop-filter-blur(var(--ni-20));
 
     @include for-tablet-lg-and-below() {
       gap: var(--gap-m);

--- a/projects/client/src/lib/sections/landing/components/LoginButton.svelte
+++ b/projects/client/src/lib/sections/landing/components/LoginButton.svelte
@@ -28,14 +28,15 @@
   .trakt-login-button :global(.trakt-button[data-size=small]) {
     gap: var(--ni-12);
     padding: var(--ni-14) var(--ni-18);
-    border: var(--ni-1) solid rgba(255, 255, 255, 0.14);
+    border: var(--ni-1) solid
+      color-mix(in srgb, var(--shade-10) 14%, transparent);
     border-radius: var(--ni-12);
-    background: rgba(255, 255, 255, 0.07);
+    background: color-mix(in srgb, var(--shade-10) 7%, transparent);
   }
 
   .trakt-login-button :global(.trakt-button[data-size=small]:hover) {
     --color-foreground-button: var(--color-foreground-default);
-    background: rgba(255, 255, 255, 0.12);
-    border-color: rgba(255, 255, 255, 0.24);
+    background: color-mix(in srgb, var(--shade-10) 12%, transparent);
+    border-color: color-mix(in srgb, var(--shade-10) 24%, transparent);
   }
 </style>

--- a/projects/client/src/lib/sections/landing/components/LoginButton.svelte
+++ b/projects/client/src/lib/sections/landing/components/LoginButton.svelte
@@ -8,16 +8,34 @@
   const { login } = useAuth();
 </script>
 
-<Button
-  label={m.button_label_login()}
-  style="flat"
-  size="small"
-  color="default"
-  navigationType={DpadNavigationType.Item}
-  onclick={login}
->
-  {m.button_text_login()}
-  {#snippet icon()}
-    <LockIcon />
-  {/snippet}
-</Button>
+<div class="trakt-login-button">
+  <Button
+    label={m.button_label_login()}
+    style="flat"
+    size="small"
+    color="default"
+    navigationType={DpadNavigationType.Item}
+    onclick={login}
+  >
+    {m.button_text_login()}
+    {#snippet icon()}
+      <LockIcon />
+    {/snippet}
+  </Button>
+</div>
+
+<style lang="scss">
+  .trakt-login-button :global(.trakt-button[data-size=small]) {
+    gap: var(--ni-12);
+    padding: var(--ni-14) var(--ni-18);
+    border: var(--ni-1) solid rgba(255, 255, 255, 0.14);
+    border-radius: var(--ni-12);
+    background: rgba(255, 255, 255, 0.07);
+  }
+
+  .trakt-login-button :global(.trakt-button[data-size=small]:hover) {
+    --color-foreground-button: var(--color-foreground-default);
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.24);
+  }
+</style>

--- a/projects/client/src/lib/sections/landing/components/LoginButton.svelte
+++ b/projects/client/src/lib/sections/landing/components/LoginButton.svelte
@@ -25,6 +25,8 @@
 </div>
 
 <style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
   .trakt-login-button :global(.trakt-button[data-size=small]) {
     gap: var(--ni-12);
     padding: var(--ni-14) var(--ni-18);
@@ -34,9 +36,11 @@
     background: color-mix(in srgb, var(--shade-10) 7%, transparent);
   }
 
-  .trakt-login-button :global(.trakt-button[data-size=small]:hover) {
-    --color-foreground-button: var(--color-foreground-default);
-    background: color-mix(in srgb, var(--shade-10) 12%, transparent);
-    border-color: color-mix(in srgb, var(--shade-10) 24%, transparent);
+  @include for-mouse {
+    .trakt-login-button :global(.trakt-button[data-size=small]:hover) {
+      --color-foreground-button: var(--color-foreground-default);
+      background: color-mix(in srgb, var(--shade-10) 12%, transparent);
+      border-color: color-mix(in srgb, var(--shade-10) 24%, transparent);
+    }
   }
 </style>

--- a/projects/client/src/lib/sections/landing/components/TrendingItems.svelte
+++ b/projects/client/src/lib/sections/landing/components/TrendingItems.svelte
@@ -91,7 +91,11 @@
     height: calc(2 * var(--height-portrait-card) + var(--gap-l));
   }
 
-  .trakt-item-wrapper.has-offset {
-    transform: translateY(var(--ni-32));
+  .trakt-item-wrapper {
+    pointer-events: none;
+
+    &.has-offset {
+      transform: translateY(var(--ni-32));
+    }
   }
 </style>


### PR DESCRIPTION
- this PR proposes some styling changes for landing page to better match the new auth page which always follows up landing actions.
- also makes media items posters decorative (disable pointer actions as they are not links here)

**Auth:**
<img width="3456" height="1942" alt="image" src="https://github.com/user-attachments/assets/4751712f-8f4d-44c8-a0c8-c0684312c35d" />

**After:**
<img width="3426" height="1942" alt="image" src="https://github.com/user-attachments/assets/a926f0e4-9e5e-48fe-9887-791649134bd2" />

**Before:**
<img width="3426" height="1942" alt="image" src="https://github.com/user-attachments/assets/9d9a53a7-c956-4922-ba2a-9217719fa335" />




