### PR TITLE
fix: harden error-prone browser + parsing paths from Sentry & Observability

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -1,6 +1,7 @@
 import '$lib/polyfills/mapGroupBy.ts';
 import '$lib/polyfills/toSorted.ts';
 import { SENTRY_DSN } from '$lib/utils/constants.ts';
+import { safeSessionStorage } from '$lib/utils/storage/safeStorage.ts';
 import * as Sentry from '@sentry/sveltekit';
 import { handleErrorWithSentry } from '@sentry/sveltekit';
 
@@ -150,9 +151,9 @@ function buildReloadUrl() {
 }
 
 function triggerReloadOnce(): void {
-  if (sessionStorage.getItem(DYNAMIC_IMPORT_RELOAD_KEY)) return;
+  if (safeSessionStorage.getItem(DYNAMIC_IMPORT_RELOAD_KEY)) return;
 
-  sessionStorage.setItem(DYNAMIC_IMPORT_RELOAD_KEY, '1');
+  safeSessionStorage.setItem(DYNAMIC_IMPORT_RELOAD_KEY, '1');
   window.location.replace(buildReloadUrl());
 }
 

--- a/projects/client/src/lib/features/auth/getOidcConfig.ts
+++ b/projects/client/src/lib/features/auth/getOidcConfig.ts
@@ -1,4 +1,5 @@
 import { getReferrer } from '$lib/utils/requests/getReferrer.ts';
+import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
 import { type UserManagerSettings, WebStorageStateStore } from 'oidc-client-ts';
 import { resolveOidcAuthority } from './resolveOidcAuthority.ts';
 
@@ -14,7 +15,7 @@ export function getOidcConfig(): UserManagerSettings {
     scope: 'public openid profile email',
     automaticSilentRenew: true,
     userStore: new WebStorageStateStore({
-      store: globalThis.window.localStorage,
+      store: safeLocalStorage,
     }),
   };
 }

--- a/projects/client/src/lib/features/cookie-consent/handle.ts
+++ b/projects/client/src/lib/features/cookie-consent/handle.ts
@@ -1,3 +1,4 @@
+import { safeJsonParse } from '$lib/utils/json/safeJsonParse.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { Handle } from '@sveltejs/kit';
 import { IS_PROD } from '../../utils/env/index.ts';
@@ -17,12 +18,12 @@ function coerceLegacyCookieConsent(
     return;
   }
 
-  const hasConsent = JSON.parse(cookieConsent ?? 'false');
+  const hasConsent = safeJsonParse<boolean>(cookieConsent, false);
   return hasConsent ? 'all' : 'none';
 }
 
 function coerceCookieConsent(cookieConsent: string | undefined): CookieConsent {
-  const cookie = JSON.parse(cookieConsent ?? '{}');
+  const cookie = safeJsonParse<{ categories?: unknown }>(cookieConsent, {});
   if (!Array.isArray(cookie.categories)) return 'none';
 
   const categories = cookie.categories;
@@ -43,9 +44,15 @@ export const handle: Handle = async ({ event, resolve }) => {
   setCookieConsent(legacyConsent ?? consent);
 
   if (event.url.pathname.startsWith(CookieConsentEndpoint.Consent)) {
-    const { consent } = await event.request.json() as {
-      consent: CookieConsent;
-    };
+    const payload = await event.request
+      .json()
+      .catch(() => null) as { consent?: CookieConsent } | null;
+
+    if (!payload?.consent) {
+      return new Response(null, { status: 400 });
+    }
+
+    const { consent } = payload;
     setCookieConsent(consent);
 
     const host = event.url.hostname;

--- a/projects/client/src/lib/utils/assets.ts
+++ b/projects/client/src/lib/utils/assets.ts
@@ -23,9 +23,11 @@ export const PLACEHOLDERS: string[] = [
 
 const generateShareCover = (type: 'show' | 'movie') =>
   assertDefined(
+    // Bracket access instead of .at(): this runs at module-eval on the boot
+    // path and Array.prototype.at throws on old/spoofed WebView engines.
     shuffle(
       [1, 2, 3, 4, 5].map((n) => `${assets}/trakt_share_${type}_${n}.webp`),
-    ).at(0),
+    )[0],
     `${type} share cover is required`,
   );
 
@@ -36,6 +38,6 @@ export const DEFAULT_SHARE_COVER = assertDefined(
   shuffle([
     DEFAULT_SHARE_SHOW_COVER,
     DEFAULT_SHARE_MOVIE_COVER,
-  ]).at(0),
+  ])[0],
   'Default share cover is required',
 );

--- a/projects/client/src/lib/utils/devices/isPWA.ts
+++ b/projects/client/src/lib/utils/devices/isPWA.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import { safeSessionStorage } from '$lib/utils/storage/safeStorage.ts';
 
 export function isPWA() {
   if (!browser) {
@@ -6,7 +7,7 @@ export function isPWA() {
   }
 
   return (
-    sessionStorage.getItem('__trakt_pwa_simulator') === 'true' ||
+    safeSessionStorage.getItem('__trakt_pwa_simulator') === 'true' ||
     globalThis.matchMedia('(display-mode: standalone)').matches ||
     globalThis.matchMedia('(display-mode: fullscreen)').matches ||
     globalThis.matchMedia('(display-mode: minimal-ui)').matches

--- a/projects/client/src/lib/utils/json/safeJsonParse.ts
+++ b/projects/client/src/lib/utils/json/safeJsonParse.ts
@@ -1,0 +1,18 @@
+/**
+ * Parses a JSON string, returning `fallback` when the value is absent
+ * (null/undefined/empty string) or not valid JSON. Never throws - safe for
+ * user-controlled input like cookies and request bodies.
+ */
+export function safeJsonParse<T>(value: string | Nil, fallback: T): T {
+  if (!value) {
+    return fallback;
+  }
+
+  try {
+    // JSON.parse('null') returns null and skips the catch, so coalesce to
+    // keep the fallback for callers expecting a non-nullable value.
+    return (JSON.parse(value) ?? fallback) as T;
+  } catch {
+    return fallback;
+  }
+}

--- a/projects/client/src/routes/+layout.ts
+++ b/projects/client/src/routes/+layout.ts
@@ -5,7 +5,13 @@ import { retryDelay } from '$lib/utils/retry/retryDelay.ts';
 import type { LayoutLoad } from '$types/$types.d.ts';
 import { QueryClient } from '@tanstack/query-core';
 
-const persister = browser ? createIdbPersister() : undefined;
+// IDB and structuredClone are missing on some restricted engines (PS4,
+// in-app WebViews); guard before touching idb-keyval so query init doesn't
+// crash. The query client falls back to an in-memory cache when unset.
+const canPersist = browser &&
+  typeof indexedDB !== 'undefined' &&
+  typeof structuredClone !== 'undefined';
+const persister = canPersist ? createIdbPersister() : undefined;
 
 export const load: LayoutLoad = ({ data }) => {
   const queryClient = new QueryClient({

--- a/projects/client/src/routes/lists/official/[list]/+page.svelte
+++ b/projects/client/src/routes/lists/official/[list]/+page.svelte
@@ -61,9 +61,9 @@
     {/snippet}
   </ResponsiveNavbarStateSetter>
 
-  {#if !$isLoading}
+  {#if !$isLoading && $list}
     <UserListPaginatedList
-      list={$list!}
+      list={$list}
       type={$mode}
       sortBy={$current.sorting.value}
       sortHow={$current.sortHow}

--- a/projects/client/src/routes/people/[slug]/+page.svelte
+++ b/projects/client/src/routes/people/[slug]/+page.svelte
@@ -42,8 +42,8 @@
     <NavbarStateSetter mode={navbarMode} hasFilters />
   </RenderFor>
 
-  {#if !$isLoading}
-    <PeopleSummary person={$person!} {positions} />
+  {#if !$isLoading && $person}
+    <PeopleSummary person={$person} {positions} />
   {:else}
     <!-- TODO: remove this when we have empty state, currently prevents content jumps -->
     <RenderFor audience="all" device={["tablet-sm", "tablet-lg", "desktop"]}>


### PR DESCRIPTION
## 🎶 Notes 🎶

Went over the top Sentry issues and the Cloudflare worker logs, and knocked out the ones with a clear root cause. Seven fixes, one commit each.

### Client-side (Sentry)

- Fixes TRAKT-WEB-A4F & TRAKT-WEB-R2 — cookie consent parsing. Malformed/empty cookies (and empty POST bodies) hit `JSON.parse` unguarded and threw in the handler. Empty strings slipped past the `??` fallback. Now routed through a `safeJsonParse` helper + bad bodies get a 400. Biggest one by volume (~15.5k events, 784 users). Also showed up as `/_features/cookie/consent` 500s in the worker logs.
- Fixes TRAKT-WEB-9G5 & TRAKT-WEB-9YN — oidc was handed raw `window.localStorage`, which is null or throws on access in private mode / in-app WebViews / PS4 / sandboxed iframes. Uses `safeLocalStorage` now.
- Fixes TRAKT-WEB-9V6 & TRAKT-WEB-9WA — idb persister touched `indexedDB` on engines that don't have it. Feature-detect `indexedDB` + `structuredClone` before creating it; falls back to the in-memory cache.
- Fixes TRAKT-WEB-9FY — `.at()` at module-eval on the boot path, took the whole page down on old/spoofed WebViews. Swapped for bracket access (still guarded by `assertDefined`).
- Fixes TRAKT-WEB-9G2 — direct `sessionStorage` access threw in embedded contexts. Routed through `safeSessionStorage`.
- Fixes TRAKT-WEB-773 — `/lists/official/[list]` passed a nullable `$list` down with a `!`, and `useListItems` read `.user` off null. Guarded the render, dropped the assertion.

### Server-side (worker observability)

- `/people/[slug]` was the single largest error anywhere — ~9.5k 500s/day. Same shape as the list fix: `$person` is nullable (summary query resolves empty for slugs the API 404s, which bots crawl heavily), but was passed down with a `!`. `PeopleSummary` then read `person.slug` in the credits blocks that render for the default `mode=media` and threw during SSR. Guarded the render on `$person`, dropped the assertion.

### Left out for now

- `state_unsafe_mutation` (9XG/9XV/A2N/9XH, ~4k events) — it's a synchronous tanstack invalidation cascade racing a Svelte derivation, surfacing at 3 different frames. Not a one-liner and I don't want to change invalidation timing blindly. Needs a local repro — will tackle separately.
- `/favicon.ico` 404 noise (~5.5k/week) — we ship `favicon.svg` but no `.ico`, so legacy requests 404. Trivial to add, but it's log noise not a crash — separate cleanup.
- ⚠️ Server/browser-compat fixes are hard to verify locally; the parsing + storage + null guards are low-risk, but I'll keep an eye on the dashboards after deploy.

## 👀 Example 👀

No visual — all crash/hardening fixes. Verified by root-cause + stacktrace against Sentry and the worker logs; each closes its issue on merge.