### PR TITLE
fix(settings): normalize scheme-less poster urls from the match endpoint

### DIFF
--- a/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
@@ -86,6 +86,21 @@
         {m.import_complete_errors({ count: errorCount })}
       </p>
     {/if}
+    {#if unresolved.length > 0}
+      <p class="secondary">
+        {m.import_complete_unresolved({ count: unresolved.length })}
+      </p>
+      <ul class="import-complete-unresolved">
+        {#each unresolved as item (item)}
+          <li>
+            <span class="ellipsis item-title">{item.title}</span>
+            {#if item.year != null}
+              <span class="tag secondary">{item.year}</span>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
     {#if ambiguous.length > 0}
       <p class="secondary">
         {m.import_complete_ambiguous({ count: ambiguous.length })}
@@ -94,7 +109,7 @@
         {#each ambiguous as entry, index (entry)}
           <li>
             <div class="ambiguous-title">
-              <span class="ellipsis">{entry.item.title}</span>
+              <span class="ellipsis item-title">{entry.item.title}</span>
               {#if entry.item.year != null}
                 <span class="tag secondary">{entry.item.year}</span>
               {/if}
@@ -129,21 +144,6 @@
                 <span class="tag">{m.import_ambiguous_skip()}</span>
               </button>
             </div>
-          </li>
-        {/each}
-      </ul>
-    {/if}
-    {#if unresolved.length > 0}
-      <p class="secondary">
-        {m.import_complete_unresolved({ count: unresolved.length })}
-      </p>
-      <ul class="import-complete-unresolved">
-        {#each unresolved as item (item)}
-          <li>
-            <span class="ellipsis">{item.title}</span>
-            {#if item.year != null}
-              <span class="tag secondary">{item.year}</span>
-            {/if}
           </li>
         {/each}
       </ul>
@@ -234,6 +234,11 @@
     gap: var(--gap-xs);
   }
 
+  /* Parsed titles are de-slugged lowercase; capitalize for display only. */
+  .item-title {
+    text-transform: capitalize;
+  }
+
   .ambiguous-candidates {
     display: flex;
     flex-wrap: wrap;
@@ -254,6 +259,10 @@
     border: var(--border-thickness-xs) solid transparent;
     border-radius: var(--border-radius-m);
     cursor: pointer;
+
+    /* Buttons default to UA colors, not the theme foreground. */
+    color: var(--color-foreground);
+    font-family: inherit;
   }
 
   .ambiguous-candidate.is-selected {

--- a/projects/client/src/lib/sections/settings/import/engine/resolveMovieIds.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/engine/resolveMovieIds.spec.ts
@@ -62,12 +62,15 @@ describe('engine: resolveMovieIds', () => {
               title: 'Split',
               year: 2017,
               score: 21573,
+              poster:
+                'media.trakt.tv/images/movies/000/254/263/posters/medium/aaa0f03e5e.jpg.webp',
               ids: { trakt: 254263, imdb: 'tt4972582', tmdb: 381288 },
             },
             {
               title: 'Split',
               year: 2016,
               score: 2582,
+              poster: null,
               ids: { trakt: 247643, imdb: 'tt3315656', tmdb: 358364 },
             },
           ],
@@ -87,11 +90,14 @@ describe('engine: resolveMovieIds', () => {
       {
         title: 'Split',
         year: 2017,
+        poster:
+          'https://media.trakt.tv/images/movies/000/254/263/posters/medium/aaa0f03e5e.jpg.webp',
         ids: { trakt: 254263, imdb: 'tt4972582', tmdb: 381288 },
       },
       {
         title: 'Split',
         year: 2016,
+        poster: undefined,
         ids: { trakt: 247643, imdb: 'tt3315656', tmdb: 358364 },
       },
     ]);

--- a/projects/client/src/lib/sections/settings/import/engine/resolveMovieIds.ts
+++ b/projects/client/src/lib/sections/settings/import/engine/resolveMovieIds.ts
@@ -49,13 +49,19 @@ function toImportIds(result: MovieMatchResult): ImportIds | undefined {
   };
 }
 
+// The match endpoint returns scheme-less poster paths (media.trakt.tv/...).
+function toPosterUrl(poster?: string | null): string | undefined {
+  if (!poster) return undefined;
+  return poster.startsWith('http') ? poster : `https://${poster}`;
+}
+
 function toCandidates(
   result: MovieMatchResult,
 ): AmbiguousImportItem['candidates'] {
   return (result.candidates ?? []).map((candidate) => ({
     title: candidate.title,
     year: candidate.year ?? undefined,
-    poster: candidate.poster ?? undefined,
+    poster: toPosterUrl(candidate.poster),
     ids: {
       trakt: candidate.ids.trakt,
       imdb: candidate.ids.imdb ?? undefined,


### PR DESCRIPTION
The new `/v3/search/match/movies` endpoint returns poster paths without a scheme (`media.trakt.tv/images/...`). Dropped into `<img src>` as-is, the browser treats them as relative paths and every candidate poster in the ambiguous-match picker 404s.

The resolver now prefixes `https://` when the scheme is missing; full URLs pass through untouched, so a server-side fix later is a no-op for the client.

Verified against the live endpoint - `split` (2016) returns three candidates whose normalized poster URLs all serve `200 image/webp`.

Also includes a picker polish pass from live testing:

- year tags / don't-import chip were near-black on dark theme (UA button color, now theme foreground)
- de-slugged lowercase titles now display title-cased (`text-transform: capitalize`, display only)
- skipped-movies list moved above the picker so it isn't buried under a long candidate grid

NOTE: the rest of the TV Time GDPR import work (parser, bulk match resolver, poster picker, skip report) is already on `main`; these are the stragglers from that stack.