### PR TITLE
fix(lists): flip sort direction from the option row

### DIFF
--- a/projects/client/src/lib/components/dropdown/DropdownItem.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.svelte
@@ -8,6 +8,7 @@
     color?: "red" | "purple" | "blue" | "orange" | "default";
     tabindex?: number;
     icon?: Snippet;
+    end?: Snippet;
     style?: "ghost" | "flat";
     variant?: "primary" | "secondary";
     selected?: boolean;
@@ -23,6 +24,7 @@
     selected = false,
     children,
     icon,
+    end,
     ...props
   }: DropdownItemProps | DropdownItemAnchorProps = $props();
 
@@ -65,6 +67,11 @@
         </div>
       {/if}
       {@render text()}
+      {#if end}
+        <div class="item-end">
+          {@render end()}
+        </div>
+      {/if}
     </Link>
   {:else}
     {#if icon}
@@ -73,6 +80,11 @@
       </div>
     {/if}
     {@render text()}
+    {#if end}
+      <div class="item-end">
+        {@render end()}
+      </div>
+    {/if}
   {/if}
 </li>
 
@@ -107,6 +119,16 @@
 
     .item-icon {
       display: flex;
+
+      :global(svg) {
+        width: var(--ni-20);
+        height: var(--ni-20);
+      }
+    }
+
+    .item-end {
+      display: flex;
+      margin-inline-start: auto;
 
       :global(svg) {
         width: var(--ni-20);

--- a/projects/client/src/lib/components/dropdown/DropdownItem.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.svelte
@@ -10,6 +10,7 @@
     icon?: Snippet;
     style?: "ghost" | "flat";
     variant?: "primary" | "secondary";
+    selected?: boolean;
   } & ChildrenProps &
     HTMLElementProps;
 
@@ -19,6 +20,7 @@
     color = "purple",
     style = "ghost",
     variant = "primary",
+    selected = false,
     children,
     icon,
     ...props
@@ -52,6 +54,7 @@
   data-color={color}
   data-style={style}
   data-variant={variant}
+  class:is-selected={selected}
   {...props}
 >
   {#if href}
@@ -154,6 +157,11 @@
       }
 
       &[disabled="true"] {
+        background: var(--color-foreground-button-disabled);
+        color: var(--color-surface-button-disabled);
+      }
+
+      &.is-selected {
         background: var(--color-foreground-button-disabled);
         color: var(--color-surface-button-disabled);
       }

--- a/projects/client/src/lib/sections/lists/user/_internal/SortOptionsDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SortOptionsDrawer.svelte
@@ -41,11 +41,13 @@
   <div class="sort-buttons">
     {#each options as option}
       {#snippet icon()}
-        {#if option.value === current.sorting.value}
-          <SortDirectionIcon direction={current.sortHow} />
-        {:else if option.value}
+        {#if option.value}
           <SortIcon sortBy={option.value} />
         {/if}
+      {/snippet}
+
+      {#snippet end()}
+        <SortDirectionIcon direction={current.sortHow} />
       {/snippet}
 
       <DropdownItem
@@ -55,9 +57,8 @@
         href={`${urlBuilder({ sortHow: sortHowFor(option.value), sortBy: option.value })}`}
         label={option.label()}
         selected={option.value === current.sorting.value}
-        icon={Boolean(option.value) || option.value === current.sorting.value
-          ? icon
-          : undefined}
+        icon={option.value ? icon : undefined}
+        end={option.value === current.sorting.value ? end : undefined}
         onclick={() => {
           track({
             sortBy: option.value ?? "default",

--- a/projects/client/src/lib/sections/lists/user/_internal/SortOptionsDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/SortOptionsDrawer.svelte
@@ -1,8 +1,6 @@
 <script lang="ts" generics="T extends SortBy | UpNextSortBy">
-  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
   import Drawer from "$lib/components/drawer/Drawer.svelte";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
-  import CheckIcon from "$lib/components/icons/CheckIcon.svelte";
   import SortDirectionIcon from "$lib/components/icons/SortDirectionIcon.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
@@ -31,35 +29,20 @@
   const reversedDirection = $derived(
     current.sortHow === "asc" ? "desc" : "asc",
   );
+
+  function sortHowFor(optionValue: T | undefined): SortDirection {
+    return optionValue === current.sorting.value
+      ? reversedDirection
+      : current.sortHow;
+  }
 </script>
 
-{#snippet badge()}
-  <ActionButton
-    replacestate
-    style="ghost"
-    color="default"
-    size="small"
-    label={reversedDirection === "asc"
-      ? m.button_label_sort_ascending()
-      : m.button_label_sort_descending()}
-    href={`${urlBuilder({ sortHow: reversedDirection, sortBy: current.sorting.value })}`}
-    onclick={() => {
-      track({
-        sortBy: current.sorting.value ?? "default",
-        sortHow: reversedDirection,
-      });
-    }}
-  >
-    <SortDirectionIcon direction={current.sortHow} />
-  </ActionButton>
-{/snippet}
-
-<Drawer {onClose} {badge} size="auto" title={m.drawer_title_sort()}>
+<Drawer {onClose} size="auto" title={m.drawer_title_sort()}>
   <div class="sort-buttons">
     {#each options as option}
       {#snippet icon()}
         {#if option.value === current.sorting.value}
-          <CheckIcon />
+          <SortDirectionIcon direction={current.sortHow} />
         {:else if option.value}
           <SortIcon sortBy={option.value} />
         {/if}
@@ -69,16 +52,16 @@
         replacestate
         style="flat"
         color="default"
-        href={`${urlBuilder({ sortHow: current.sortHow, sortBy: option.value })}`}
+        href={`${urlBuilder({ sortHow: sortHowFor(option.value), sortBy: option.value })}`}
         label={option.label()}
-        disabled={option.value === current.sorting.value}
+        selected={option.value === current.sorting.value}
         icon={Boolean(option.value) || option.value === current.sorting.value
           ? icon
           : undefined}
         onclick={() => {
           track({
             sortBy: option.value ?? "default",
-            sortHow: current.sortHow,
+            sortHow: sortHowFor(option.value),
           });
         }}
       >


### PR DESCRIPTION
## Summary
- Sort direction is now shown per option and toggled by clicking the already-selected option, instead of a separate header arrow toggle
- Direction icon sits at the end of the row (start still holds the category icon), so the label reads first
- `DropdownItem` gains a `selected` state independent of `disabled`, plus an `end` snippet slot for trailing content

## Test plan
- [x] `deno task check` passes
- [ ] Manual: open Sort By drawer, pick an option, click it again, confirm direction flips and list re-sorts