### PR TITLE
feat(settings): show progress while resolving movie matches

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4807,6 +4807,18 @@
         }
       }
     },
+    "import_status_matching": {
+      "default": "Matching movies {processed} / {total}…",
+      "description": "Status text shown while id-less movies are being resolved through the match endpoint, before syncing starts.",
+      "variables": {
+        "processed": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        }
+      }
+    },
     "import_status_parsing": {
       "default": "Parsing your data…",
       "description": "Status text shown while the import file is being parsed."

--- a/projects/client/src/lib/sections/settings/_internal/RawImport.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/RawImport.svelte
@@ -52,6 +52,8 @@
     unresolved: ReadonlyArray<UniversalImportItem>;
     ambiguous: ReadonlyArray<AmbiguousImportItem>;
     parseError: string | null;
+    matchProcessedCount: number;
+    matchTotalCount: number;
   };
 
   const state = $state<ImportUIState>({
@@ -64,6 +66,8 @@
     ambiguous: [],
     parseError: null,
     totalCount: 0,
+    matchProcessedCount: 0,
+    matchTotalCount: 0,
   });
 
   const counts = $derived<ImportCounts>({
@@ -121,6 +125,8 @@
     const startTime = Date.now();
     state.processedCount = 0;
     state.errorCount = 0;
+    state.matchProcessedCount = 0;
+    state.matchTotalCount = 0;
     state.status = "syncing";
 
     try {
@@ -128,7 +134,13 @@
         state.parsedItems,
         {
           signal: abortController.signal,
+          onMatchProgress: (processed, total) => {
+            state.matchProcessedCount = processed;
+            state.matchTotalCount = total;
+            state.status = total > 0 ? "matching" : "syncing";
+          },
           onProgress: (count) => {
+            state.status = "syncing";
             state.processedCount = count;
           },
           onError: (message) => {
@@ -211,6 +223,8 @@
     state.unresolved = [];
     state.ambiguous = [];
     state.parseError = null;
+    state.matchProcessedCount = 0;
+    state.matchTotalCount = 0;
   }
 
   $effect(() => {
@@ -243,7 +257,7 @@
 
 {#snippet importRow()}
   <NavigationGuard
-    isActive={state.status === "syncing"}
+    isActive={state.status === "matching" || state.status === "syncing"}
     confirmationParams={{ type: ConfirmationType.CancelImport }}
     onreset={reset}
   >
@@ -268,6 +282,15 @@
             source={state.selectedSource}
             onstart={startImport}
             onreset={reset}
+          />
+        {:else if state.status === "matching"}
+          <SyncProgress
+            processedCount={state.matchProcessedCount}
+            totalCount={state.matchTotalCount}
+            label={m.import_status_matching({
+              processed: state.matchProcessedCount,
+              total: state.matchTotalCount,
+            })}
           />
         {:else if state.status === "syncing"}
           <SyncProgress

--- a/projects/client/src/lib/sections/settings/import/ImportTypes.ts
+++ b/projects/client/src/lib/sections/settings/import/ImportTypes.ts
@@ -14,6 +14,7 @@ export type ImportStatus =
   | 'reading'
   | 'parsing'
   | 'review'
+  | 'matching'
   | 'syncing'
   | 'complete'
   | 'error';

--- a/projects/client/src/lib/sections/settings/import/engine/resolveMovieIds.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/engine/resolveMovieIds.spec.ts
@@ -184,6 +184,37 @@ describe('engine: resolveMovieIds', () => {
     expect(items[2]?.ids.trakt).toBe(1968);
   });
 
+  it('should report progress per batch resolved', async () => {
+    const match = vi.fn().mockResolvedValue([
+      matched(0, {
+        title: 'Split',
+        year: 2016,
+        score: 2582,
+        ids: { trakt: 247643, imdb: 'tt3315656', tmdb: 358364 },
+      }),
+    ]);
+    const onProgress = vi.fn();
+
+    await resolveMovieIds({ items: [movie()], match, onProgress });
+
+    expect(onProgress).toHaveBeenNthCalledWith(1, 0, 1);
+    expect(onProgress).toHaveBeenNthCalledWith(2, 1, 1);
+  });
+
+  it('should report a total of 0 when nothing needs resolution', async () => {
+    const match = vi.fn().mockResolvedValue([]);
+    const onProgress = vi.fn();
+
+    await resolveMovieIds({
+      items: [movie({ ids: { imdb: 'tt4972582' } })],
+      match,
+      onProgress,
+    });
+
+    expect(onProgress).toHaveBeenCalledWith(0, 0);
+    expect(onProgress).toHaveBeenCalledTimes(1);
+  });
+
   it('should not call match when the signal is already aborted', async () => {
     const match = vi.fn();
     const controller = new AbortController();

--- a/projects/client/src/lib/sections/settings/import/engine/resolveMovieIds.ts
+++ b/projects/client/src/lib/sections/settings/import/engine/resolveMovieIds.ts
@@ -16,6 +16,7 @@ export type MatchMovies = (
 type ResolveMovieIdsParams = {
   items: ReadonlyArray<UniversalImportItem>;
   match: MatchMovies;
+  onProgress?: (processed: number, total: number) => void;
   signal?: AbortSignal;
 };
 
@@ -67,7 +68,7 @@ function toCandidates(
 }
 
 export async function resolveMovieIds(
-  { items, match, signal }: ResolveMovieIdsParams,
+  { items, match, onProgress, signal }: ResolveMovieIdsParams,
 ): Promise<ResolvedMovies> {
   const queries = new Map<string, MovieMatchQuery>();
 
@@ -82,13 +83,20 @@ export async function resolveMovieIds(
     });
   });
 
+  const total = queries.size;
+  onProgress?.(0, total);
+
   const resultsByIndex = new Map<number, MovieMatchResult>();
+  let processed = 0;
 
   for (const batch of chunk([...queries.values()], MATCH_BATCH_SIZE)) {
     if (signal?.aborted) break;
 
     const results = await match(batch).catch(() => []);
     results.forEach((result) => resultsByIndex.set(result.index, result));
+
+    processed += batch.length;
+    onProgress?.(processed, total);
   }
 
   const resultFor = (item: UniversalImportItem) => {

--- a/projects/client/src/lib/sections/settings/import/syncToTrakt.ts
+++ b/projects/client/src/lib/sections/settings/import/syncToTrakt.ts
@@ -11,9 +11,20 @@ import { MOVIE_IDS, pickIds } from './engine/pickIds.ts';
 import { resolveMovieIds } from './engine/resolveMovieIds.ts';
 import type { ImportSyncResult, UniversalImportItem } from './ImportTypes.ts';
 
+type SyncToTraktCallbacks = SyncEngineCallbacks & {
+  onMatchProgress?: (processed: number, total: number) => void;
+};
+
 export async function syncToTrakt(
   items: ReadonlyArray<UniversalImportItem>,
-  { onProgress, onError, onStart, onComplete, signal }: SyncEngineCallbacks,
+  {
+    onProgress,
+    onError,
+    onStart,
+    onComplete,
+    onMatchProgress,
+    signal,
+  }: SyncToTraktCallbacks,
 ): Promise<ImportSyncResult> {
   onStart?.();
 
@@ -21,6 +32,7 @@ export async function syncToTrakt(
     const { items: resolvedItems, ambiguous } = await resolveMovieIds({
       items,
       match: matchMovies,
+      onProgress: onMatchProgress,
       signal,
     });
 


### PR DESCRIPTION
## What

While TV Time (and other id-less) imports resolve movies through the bulk `/v3/search/match/movies` endpoint, the import screen showed no feedback: the sync progress bar stayed frozen at 0 until matching finished, since only the history/watchlist/ratings sync steps reported progress.

`resolveMovieIds` now reports progress per batch (100 movies/call), surfaced as a distinct "matching" phase with its own progress bar and label before the "syncing" phase kicks in.

Also polishes the post-import review screen:

- The "Import More" action is hidden while ambiguous matches still need resolving, since "Import Selected" is already the primary action in that state.
- The multiple-matches grid gets a scroll-shadow cue (reusing `ShadowScroller`) on mouse input, so it reads as scrollable instead of looking cut off. Fixed a bug in `ShadowScroller` itself along the way: its inner scroller used `height: 100%`, which can't resolve against a wrapper whose only height comes from `max-height` (the spec treats it as `auto`), so the scroll listener never fired and the mask never showed up. The panel is also sized to its content width now instead of stretching full-width, so there's no empty gutter that reads as page background but silently captures scroll.
- On touch input the grid no longer gets its own internal scroll box at all - it flows inline with the page, so there's a single scroll surface instead of getting stuck inside the grid before reaching the rest of the page.
- Poster candidates in the multiple-matches grid get a proper styled tooltip on hover (the app's `Tooltip` component) instead of the native browser title tooltip.
- The source guide collapses to a single line once an import is underway (parsing onward) and can be re-expanded on demand, since by then the user has already read it and uploaded their file.
- TV Time is now the first tab and the default selected source instead of IMDb, since it's the most requested import source.

## Why

Large libraries can take a while to resolve through the match endpoint, and a frozen screen with no indication of what's happening reads as a hang. The review screen fixes clear up UI ambiguity/clutter and a touch/mouse scroll trap reported after using the flow.

## Testing

- Added unit tests for `resolveMovieIds`' new `onProgress` callback (per-batch progress, and 0/0 when nothing needs resolution).
- `deno task check` clean (0 errors, 0 warnings).
- Full unit suite passes.
- The ambiguous-matches and mid-import guide states require live mismatched import data to reach, so verify visually against a real import when reviewing.