### PR TITLE
Streaming: tighten colorized watch now logos

### DIFF
--- a/projects/client/src/lib/components/media/streaming-service/_internal/constants/index.ts
+++ b/projects/client/src/lib/components/media/streaming-service/_internal/constants/index.ts
@@ -4,7 +4,6 @@ type WellKnownServices = {
 
 export const WELL_KNOWN_SERVICES: WellKnownServices = {
   amazon: [
-    'amazon_video',
     'amazon_prime',
     'amazon_prime_video',
     'amazon_prime_video_with_ads',

--- a/projects/client/src/lib/components/media/streaming-service/isWellKnownSource.ts
+++ b/projects/client/src/lib/components/media/streaming-service/isWellKnownSource.ts
@@ -15,12 +15,7 @@ export function matchesServiceSlug(
     return false;
   }
 
-  return serviceKeys.some((key) =>
-    source === key ||
-    source.startsWith(`${key}_`) ||
-    source.endsWith(`_${key}`) ||
-    source.includes(`_${key}_`)
-  );
+  return serviceKeys.some((key) => source === key);
 }
 
 export function isWellKnownSource(source: string): boolean {


### PR DESCRIPTION
# Summary

Watch-now service logos render from a curated set of hand-built branded SVG marks (Netflix, Prime Video, Disney+, Hulu, Paramount+, Peacock, and so on) whenever a source slug is recognized as "well known"; every other source falls back to the raw logo image the API ships for it. This PR tightens how a source slug is matched against that curated set so a branded mark is only substituted in when the slug is an exact match, rather than whenever it merely contained a known service name as an underscore-delimited segment.

# What changed

`matchesServiceSlug` previously treated each service key as a whole segment and matched on `source === key`, `source.startsWith(`key_`)`, `source.endsWith(`_key`)`, or `source.includes(`_key_`)`. It now matches on exact equality only (`source === key`), so composite and channel-variant slugs no longer resolve to a base service's branded logo. Separately, `amazon_video` was dropped from the `amazon` key list so it no longer forces the Prime Video mark.

# Why

The segment matching over-matched. Any slug that happened to contain a known service name as a segment — channel add-ons, ad-supported spinoffs, bundled variants, buy/rent stores — picked up that service's branded logo even when it wasn't actually that service, producing mismatched or misleading branding. Restricting to exact matches means only the precisely known slugs get the curated branded SVG, and every other source falls back to its own provided logo. The upshot is that the logo shown always corresponds to the actual source, so the branding reads more clearly and accurately.

# Screenshots

Before the changes, you would just see multiple of the same logo for Prime Video, Apple, Paramount, etc.

<img width="728" height="341" alt="image" src="https://github.com/user-attachments/assets/37aecc1d-b24b-4073-a2ae-5cb407cd04ab" />

<img width="736" height="345" alt="image" src="https://github.com/user-attachments/assets/c4e631b3-05df-4944-b705-9874cd15b866" />

<img width="729" height="341" alt="image" src="https://github.com/user-attachments/assets/1bacbbe4-49e4-43a1-ab6c-086610ede52a" />

<img width="727" height="344" alt="image" src="https://github.com/user-attachments/assets/05d324f7-0208-45c1-a6ca-10e348475aa6" />

# Risk

Low. The change only narrows which sources render a branded SVG. Any source that no longer matches simply falls back to the existing `CrossOriginImage` logo path, which is already the default for every unrecognized source, so there is no blank-logo state introduced.
