### PR TITLE
fix: follow-up crash fixes from post-deploy Sentry

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -1,3 +1,4 @@
+import '$lib/polyfills/at.ts';
 import '$lib/polyfills/mapGroupBy.ts';
 import '$lib/polyfills/toSorted.ts';
 import { SENTRY_DSN } from '$lib/utils/constants.ts';

--- a/projects/client/src/lib/features/auth/getOidcConfig.ts
+++ b/projects/client/src/lib/features/auth/getOidcConfig.ts
@@ -17,5 +17,10 @@ export function getOidcConfig(): UserManagerSettings {
     userStore: new WebStorageStateStore({
       store: safeLocalStorage,
     }),
+    // Set stateStore explicitly too: oidc-client-ts otherwise defaults it to
+    // raw window.localStorage, which throws SecurityError in sandboxed contexts.
+    stateStore: new WebStorageStateStore({
+      store: safeLocalStorage,
+    }),
   };
 }

--- a/projects/client/src/lib/polyfills/at.spec.ts
+++ b/projects/client/src/lib/polyfills/at.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import './at.ts';
+
+describe('Array.prototype.at polyfill', () => {
+  it('returns the element at a positive index', () => {
+    expect(['a', 'b', 'c'].at(0)).toBe('a');
+    expect(['a', 'b', 'c'].at(2)).toBe('c');
+  });
+
+  it('supports negative indices', () => {
+    expect(['a', 'b', 'c'].at(-1)).toBe('c');
+  });
+
+  it('returns undefined when out of range', () => {
+    expect(['a'].at(5)).toBeUndefined();
+    expect(['a'].at(-5)).toBeUndefined();
+  });
+});

--- a/projects/client/src/lib/polyfills/at.ts
+++ b/projects/client/src/lib/polyfills/at.ts
@@ -1,0 +1,23 @@
+// Polyfill for Array.prototype.at (ES2022).
+// Sentry: TRAKT-WEB-AE4, TRAKT-WEB-AEE — older iOS/Safari/Chrome builds reach
+// the app and crash on uses like `parts.at(0)`. Because `.at` is used during
+// locale resolution at module-eval, the failure cascades and leaves dependent
+// singletons (e.g. rxjs Subjects) undefined.
+if (typeof Array.prototype.at !== 'function') {
+  // skipcq: JS-0061
+  Object.defineProperty(Array.prototype, 'at', {
+    value<T>(this: ArrayLike<T>, index: number): T | undefined {
+      const length = this.length;
+      const relativeIndex = Math.trunc(index) || 0;
+      const resolvedIndex = relativeIndex < 0
+        ? length + relativeIndex
+        : relativeIndex;
+
+      return resolvedIndex < 0 || resolvedIndex >= length
+        ? undefined
+        : this[resolvedIndex];
+    },
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

Follow-up to #2777. Re-checked Sentry + the worker logs now that those fixes are live - the big ones (`/people` 500s, indexedDB) have stopped, but two follow-ons of the same classes showed up. One commit each.

- Fixes TRAKT-WEB-AE4 & TRAKT-WEB-AEE — `.at()` polyfill. `splitLanguageTag` calls `parts.at(0)` during locale resolution at module-eval, so on old engines (iOS <15.4, old Chrome) the whole boot chain throws. AEE is the same thing cascading: a module in the import graph fails init and leaves `persistDebounced`'s `writes$` subject undefined. Added an `at` polyfill next to the existing `toSorted`/`mapGroupBy` ones, loaded first in `hooks.client`. Covers all `.at` call sites, not just the one I patched in #2777.
- Fixes TRAKT-WEB-AE3 — oidc `stateStore`. #2777 set `userStore` to `safeLocalStorage` but oidc-client-ts defaults `stateStore` to raw `window.localStorage`, so the SecurityError still fired at `new UserManager()`. Pass `safeLocalStorage` for `stateStore` too.

### Verified live
- `/people` 500s (was ~9.5k/day) dropped to zero after the #2777 deploy landed.
- indexedDB (`Can't find variable: indexedDB`) stragglers were on the pre-deploy build and stopped.

### Left as-is
- `state_unsafe_mutation` still recurring - same deferred one from #2777, needs a repro.
- `Failed to fetch data: query:*` and stale-chunk import errors - expected noise, not crashes.

## 👀 Example 👀

No visual - compat/crash fixes. Verified against Sentry + worker observability; each closes its issue on merge.