### PR TITLE
feat(settings): polish TV Time import review flow

### DIFF
--- a/projects/client/src/lib/sections/components/ShadowScroller.svelte
+++ b/projects/client/src/lib/sections/components/ShadowScroller.svelte
@@ -53,6 +53,8 @@
   .trakt-shadow-scroller {
     height: 100%;
     min-height: var(--mask-size);
+    /* height:100% can't resolve against an auto-height wrapper; max-height inherits as a literal length instead. */
+    max-height: inherit;
 
     overflow-y: auto;
     overflow-x: hidden;

--- a/projects/client/src/lib/sections/settings/_internal/RawImport.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/RawImport.svelte
@@ -36,7 +36,7 @@
 
   function toImportSource(value: string | null): ImportSource {
     if (value && value in IMPORT_SOURCE_CONFIGS) return value as ImportSource;
-    return "imdb";
+    return "tvtime";
   }
 
   const { importInProgress } = useImportInProgress();
@@ -57,7 +57,7 @@
   };
 
   const state = $state<ImportUIState>({
-    selectedSource: "imdb",
+    selectedSource: "tvtime",
     status: "idle",
     parsedItems: [],
     processedCount: 0,

--- a/projects/client/src/lib/sections/settings/_internal/RawImport.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/RawImport.svelte
@@ -77,6 +77,10 @@
   });
 
   const sourceConfig = $derived(IMPORT_SOURCE_CONFIGS[state.selectedSource]);
+  const isGuideCollapsed = $derived(
+    state.status !== "idle" && state.status !== "reading" &&
+      state.status !== "error",
+  );
 
   function getDropPrompt(): string {
     if (sourceConfig.accept.includes(".zip")) return m.import_drop_zip();
@@ -262,7 +266,7 @@
     onreset={reset}
   >
     <div class="trakt-import-row">
-      <ImportGuide config={sourceConfig} />
+      <ImportGuide config={sourceConfig} collapsed={isGuideCollapsed} />
       <div class="import-body">
         {#if state.status === "parsing"}
           <p class="secondary" transition:slide={{ duration: 150, axis: "y" }}>

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
@@ -2,6 +2,7 @@
   import Button from "$lib/components/buttons/Button.svelte";
   import TabView from "$lib/components/tabs/TabView.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
+  import ShadowScroller from "$lib/sections/components/ShadowScroller.svelte";
   import { downloadFile } from "$lib/sections/settings/export/downloadFile.ts";
   import type {
     AmbiguousImportItem,
@@ -87,49 +88,51 @@
     <p class="secondary">
       {m.import_complete_ambiguous({ count: ambiguous.length })}
     </p>
-    <ul class="import-complete-ambiguous">
-      {#each ambiguous as entry, index (entry)}
-        <li>
-          <div class="ambiguous-title">
-            <span class="ellipsis item-title">{entry.item.title}</span>
-            {#if entry.item.year != null}
-              <span class="tag secondary">{entry.item.year}</span>
-            {/if}
-          </div>
-          <div class="ambiguous-candidates">
-            {#each entry.candidates as candidate, candidateIndex (candidate)}
+    <ShadowScroller>
+      <ul class="import-complete-ambiguous">
+        {#each ambiguous as entry, index (entry)}
+          <li>
+            <div class="ambiguous-title">
+              <span class="ellipsis item-title">{entry.item.title}</span>
+              {#if entry.item.year != null}
+                <span class="tag secondary">{entry.item.year}</span>
+              {/if}
+            </div>
+            <div class="ambiguous-candidates">
+              {#each entry.candidates as candidate, candidateIndex (candidate)}
+                <button
+                  class="ambiguous-candidate"
+                  class:is-selected={(picks[index] ?? 0) === candidateIndex}
+                  aria-label={m.button_label_pick_match({
+                    option: toCandidateLabel(candidate),
+                  })}
+                  title={toCandidateLabel(candidate)}
+                  onclick={() => (picks[index] = candidateIndex)}
+                >
+                  <span class="candidate-poster">
+                    {#if candidate.poster}
+                      <img src={candidate.poster} alt="" loading="lazy" />
+                    {/if}
+                    <span class="tag candidate-year">{candidate.year ?? "?"}</span>
+                  </span>
+                  <span class="ellipsis candidate-title">{candidate.title}</span>
+                </button>
+              {/each}
               <button
-                class="ambiguous-candidate"
-                class:is-selected={(picks[index] ?? 0) === candidateIndex}
-                aria-label={m.button_label_pick_match({
-                  option: toCandidateLabel(candidate),
-                })}
-                title={toCandidateLabel(candidate)}
-                onclick={() => (picks[index] = candidateIndex)}
+                class="ambiguous-candidate is-skip"
+                class:is-selected={picks[index] === SKIP}
+                aria-label={m.import_ambiguous_skip()}
+                onclick={() => (picks[index] = SKIP)}
               >
                 <span class="candidate-poster">
-                  {#if candidate.poster}
-                    <img src={candidate.poster} alt="" loading="lazy" />
-                  {/if}
-                  <span class="tag candidate-year">{candidate.year ?? "?"}</span>
+                  <span class="tag">{m.import_ambiguous_skip()}</span>
                 </span>
-                <span class="ellipsis candidate-title">{candidate.title}</span>
               </button>
-            {/each}
-            <button
-              class="ambiguous-candidate is-skip"
-              class:is-selected={picks[index] === SKIP}
-              aria-label={m.import_ambiguous_skip()}
-              onclick={() => (picks[index] = SKIP)}
-            >
-              <span class="candidate-poster">
-                <span class="tag">{m.import_ambiguous_skip()}</span>
-              </span>
-            </button>
-          </div>
-        </li>
-      {/each}
-    </ul>
+            </div>
+          </li>
+        {/each}
+      </ul>
+    </ShadowScroller>
     <div class="import-complete-actions">
       <Button
         label={m.button_label_import_selected()}
@@ -210,16 +213,18 @@
     {@render unresolvedSection()}
   {/if}
 
-  <div class="import-complete-actions">
-    <Button
-      label={m.button_label_import_more()}
-      onclick={onreset}
-      color="default"
-      size="small"
-    >
-      {m.button_text_import_more()}
-    </Button>
-  </div>
+  {#if ambiguous.length === 0}
+    <div class="import-complete-actions">
+      <Button
+        label={m.button_label_import_more()}
+        onclick={onreset}
+        color="default"
+        size="small"
+      >
+        {m.button_text_import_more()}
+      </Button>
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -247,11 +252,13 @@
     flex-direction: column;
     gap: var(--gap-xs);
 
-    max-height: var(--ni-160);
-    overflow-y: auto;
-
     margin: 0;
     padding-inline-start: var(--gap-m);
+  }
+
+  .import-complete-unresolved {
+    max-height: var(--ni-160);
+    overflow-y: auto;
   }
 
   .import-complete-unresolved li {
@@ -262,10 +269,13 @@
   }
 
   .import-complete-ambiguous {
-    max-height: var(--ni-480);
     list-style: none;
     padding-inline-start: 0;
     gap: var(--gap-m);
+  }
+
+  .import-complete-section :global(.trakt-shadow-wrapper) {
+    max-height: var(--ni-480);
   }
 
   .import-complete-ambiguous li {

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
   import TabView from "$lib/components/tabs/TabView.svelte";
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import ShadowScroller from "$lib/sections/components/ShadowScroller.svelte";
   import { downloadFile } from "$lib/sections/settings/export/downloadFile.ts";
@@ -100,23 +101,24 @@
             </div>
             <div class="ambiguous-candidates">
               {#each entry.candidates as candidate, candidateIndex (candidate)}
-                <button
-                  class="ambiguous-candidate"
-                  class:is-selected={(picks[index] ?? 0) === candidateIndex}
-                  aria-label={m.button_label_pick_match({
-                    option: toCandidateLabel(candidate),
-                  })}
-                  title={toCandidateLabel(candidate)}
-                  onclick={() => (picks[index] = candidateIndex)}
-                >
-                  <span class="candidate-poster">
-                    {#if candidate.poster}
-                      <img src={candidate.poster} alt="" loading="lazy" />
-                    {/if}
-                    <span class="tag candidate-year">{candidate.year ?? "?"}</span>
-                  </span>
-                  <span class="ellipsis candidate-title">{candidate.title}</span>
-                </button>
+                <Tooltip content={toCandidateLabel(candidate)} variant="compact">
+                  <button
+                    class="ambiguous-candidate"
+                    class:is-selected={(picks[index] ?? 0) === candidateIndex}
+                    aria-label={m.button_label_pick_match({
+                      option: toCandidateLabel(candidate),
+                    })}
+                    onclick={() => (picks[index] = candidateIndex)}
+                  >
+                    <span class="candidate-poster">
+                      {#if candidate.poster}
+                        <img src={candidate.poster} alt="" loading="lazy" />
+                      {/if}
+                      <span class="tag candidate-year">{candidate.year ?? "?"}</span>
+                    </span>
+                    <span class="ellipsis candidate-title">{candidate.title}</span>
+                  </button>
+                </Tooltip>
               {/each}
               <button
                 class="ambiguous-candidate is-skip"

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
@@ -10,6 +10,7 @@
     UniversalImportItem,
   } from "$lib/sections/settings/import/ImportTypes.ts";
   import { toUnresolvedCsv } from "$lib/sections/settings/import/toUnresolvedCsv.ts";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { slide } from "svelte/transition";
 
   type ImportCompleteProps = {
@@ -40,6 +41,8 @@
   const hasBothSections = $derived(
     ambiguous.length > 0 && unresolved.length > 0,
   );
+
+  const isMouse = useMedia(WellKnownMediaQuery.mouse);
 
   const SKIP = -1;
   const picks = $state<Record<number, number>>({});
@@ -84,57 +87,63 @@
   }
 </script>
 
+{#snippet candidateGrid()}
+  <ul class="import-complete-ambiguous">
+    {#each ambiguous as entry, index (entry)}
+      <li>
+        <div class="ambiguous-title">
+          <span class="ellipsis item-title">{entry.item.title}</span>
+          {#if entry.item.year != null}
+            <span class="tag secondary">{entry.item.year}</span>
+          {/if}
+        </div>
+        <div class="ambiguous-candidates">
+          {#each entry.candidates as candidate, candidateIndex (candidate)}
+            <Tooltip content={toCandidateLabel(candidate)} variant="compact">
+              <button
+                class="ambiguous-candidate"
+                class:is-selected={(picks[index] ?? 0) === candidateIndex}
+                aria-label={m.button_label_pick_match({
+                  option: toCandidateLabel(candidate),
+                })}
+                onclick={() => (picks[index] = candidateIndex)}
+              >
+                <span class="candidate-poster">
+                  {#if candidate.poster}
+                    <img src={candidate.poster} alt="" loading="lazy" />
+                  {/if}
+                  <span class="tag candidate-year">{candidate.year ?? "?"}</span>
+                </span>
+                <span class="ellipsis candidate-title">{candidate.title}</span>
+              </button>
+            </Tooltip>
+          {/each}
+          <button
+            class="ambiguous-candidate is-skip"
+            class:is-selected={picks[index] === SKIP}
+            aria-label={m.import_ambiguous_skip()}
+            onclick={() => (picks[index] = SKIP)}
+          >
+            <span class="candidate-poster">
+              <span class="tag">{m.import_ambiguous_skip()}</span>
+            </span>
+          </button>
+        </div>
+      </li>
+    {/each}
+  </ul>
+{/snippet}
+
 {#snippet ambiguousSection()}
   <div class="import-complete-section">
     <p class="secondary">
       {m.import_complete_ambiguous({ count: ambiguous.length })}
     </p>
-    <ShadowScroller>
-      <ul class="import-complete-ambiguous">
-        {#each ambiguous as entry, index (entry)}
-          <li>
-            <div class="ambiguous-title">
-              <span class="ellipsis item-title">{entry.item.title}</span>
-              {#if entry.item.year != null}
-                <span class="tag secondary">{entry.item.year}</span>
-              {/if}
-            </div>
-            <div class="ambiguous-candidates">
-              {#each entry.candidates as candidate, candidateIndex (candidate)}
-                <Tooltip content={toCandidateLabel(candidate)} variant="compact">
-                  <button
-                    class="ambiguous-candidate"
-                    class:is-selected={(picks[index] ?? 0) === candidateIndex}
-                    aria-label={m.button_label_pick_match({
-                      option: toCandidateLabel(candidate),
-                    })}
-                    onclick={() => (picks[index] = candidateIndex)}
-                  >
-                    <span class="candidate-poster">
-                      {#if candidate.poster}
-                        <img src={candidate.poster} alt="" loading="lazy" />
-                      {/if}
-                      <span class="tag candidate-year">{candidate.year ?? "?"}</span>
-                    </span>
-                    <span class="ellipsis candidate-title">{candidate.title}</span>
-                  </button>
-                </Tooltip>
-              {/each}
-              <button
-                class="ambiguous-candidate is-skip"
-                class:is-selected={picks[index] === SKIP}
-                aria-label={m.import_ambiguous_skip()}
-                onclick={() => (picks[index] = SKIP)}
-              >
-                <span class="candidate-poster">
-                  <span class="tag">{m.import_ambiguous_skip()}</span>
-                </span>
-              </button>
-            </div>
-          </li>
-        {/each}
-      </ul>
-    </ShadowScroller>
+    {#if $isMouse}
+      <ShadowScroller>{@render candidateGrid()}</ShadowScroller>
+    {:else}
+      {@render candidateGrid()}
+    {/if}
     <div class="import-complete-actions">
       <Button
         label={m.button_label_import_selected()}

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
@@ -287,10 +287,8 @@
 
   .import-complete-section :global(.trakt-shadow-wrapper) {
     max-height: var(--ni-480);
-    padding: var(--ni-16);
-
-    background-color: var(--color-card-background);
-    border-radius: var(--border-radius-m);
+    max-width: 100%;
+    align-self: flex-start;
   }
 
   .import-complete-ambiguous li {

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportComplete.svelte
@@ -287,6 +287,10 @@
 
   .import-complete-section :global(.trakt-shadow-wrapper) {
     max-height: var(--ni-480);
+    padding: var(--ni-16);
+
+    background-color: var(--color-card-background);
+    border-radius: var(--border-radius-m);
   }
 
   .import-complete-ambiguous li {

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import { m } from "$lib/features/i18n/messages.ts";
+  import { slide } from "svelte/transition";
   import type {
     ImportSourceConfig,
     StepSegment,
@@ -11,9 +13,15 @@
     importDrawerNavigation,
   } from "./importDrawerNavigation.ts";
 
-  const { config }: { config: ImportSourceConfig } = $props();
+  const { config, collapsed = false }: {
+    config: ImportSourceConfig;
+    collapsed?: boolean;
+  } = $props();
 
   const { buildDrawerLink } = importDrawerNavigation();
+
+  let expanded = $state(false);
+  const isCollapsed = $derived(collapsed && !expanded);
 
   const guidelinesLink = $derived.by(() => {
     switch (config.id) {
@@ -35,39 +43,62 @@
   {/if}
 {/snippet}
 
-<div class="trakt-import-guide">
-  <p class="import-guide-title bold">{config.guide.title}</p>
-
-  {#if config.guide.description != null}
-    <p class="secondary">{config.guide.description}</p>
+<div class="trakt-import-guide" class:is-collapsed={isCollapsed}>
+  {#if collapsed}
+    <button
+      type="button"
+      class="import-guide-toggle"
+      aria-expanded={!isCollapsed}
+      aria-controls="import-guide-body"
+      onclick={() => (expanded = !expanded)}
+    >
+      <span class="import-guide-title bold ellipsis">{config.guide.title}</span>
+      <span class="import-guide-caret" class:is-open={!isCollapsed}>
+        <CaretRightIcon />
+      </span>
+    </button>
+  {:else}
+    <p class="import-guide-title bold">{config.guide.title}</p>
   {/if}
 
-  {#if config.guide.steps != null}
-    <ol class="import-guide-steps">
-      {#each config.guide.steps as step, i (i)}
-        <li>
-          <p class="secondary">
-            {#each step as stepSegment, j (j)}
-              {#if j > 0}" "{/if}
-              {@render segment(stepSegment)}
-            {/each}
-          </p>
-        </li>
-      {/each}
-    </ol>
-  {/if}
+  {#if !isCollapsed}
+    <div
+      id="import-guide-body"
+      class="import-guide-body"
+      transition:slide={{ duration: 150, axis: "y" }}
+    >
+      {#if config.guide.description != null}
+        <p class="secondary">{config.guide.description}</p>
+      {/if}
 
-  {#if guidelinesLink}
-    <div class="import-guide-action">
-      <Button
-        {...guidelinesLink}
-        variant="primary"
-        color="default"
-        size="small"
-        label={m.button_label_view_import_guidelines()}
-      >
-        {m.button_text_view_import_guidelines()}
-      </Button>
+      {#if config.guide.steps != null}
+        <ol class="import-guide-steps">
+          {#each config.guide.steps as step, i (i)}
+            <li>
+              <p class="secondary">
+                {#each step as stepSegment, j (j)}
+                  {#if j > 0}" "{/if}
+                  {@render segment(stepSegment)}
+                {/each}
+              </p>
+            </li>
+          {/each}
+        </ol>
+      {/if}
+
+      {#if guidelinesLink}
+        <div class="import-guide-action">
+          <Button
+            {...guidelinesLink}
+            variant="primary"
+            color="default"
+            size="small"
+            label={m.button_label_view_import_guidelines()}
+          >
+            {m.button_text_view_import_guidelines()}
+          </Button>
+        </div>
+      {/if}
     </div>
   {/if}
 </div>
@@ -82,6 +113,49 @@
     border-radius: var(--border-radius-m);
     background-color: var(--color-card-background);
     box-shadow: var(--shadow-base);
+
+    &.is-collapsed {
+      padding: var(--ni-12) var(--ni-16);
+    }
+  }
+
+  .import-guide-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gap-s);
+
+    width: 100%;
+    padding: 0;
+
+    background: none;
+    border: none;
+    cursor: pointer;
+
+    color: inherit;
+    font-family: inherit;
+    text-align: start;
+
+    .import-guide-title {
+      min-width: 0;
+    }
+  }
+
+  .import-guide-caret {
+    display: inline-flex;
+    flex-shrink: 0;
+    transition: transform var(--transition-increment) ease-in-out;
+    transform: rotate(90deg);
+
+    &.is-open {
+      transform: rotate(-90deg);
+    }
+  }
+
+  .import-guide-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
   }
 
   .import-guide-steps {

--- a/projects/client/src/lib/sections/settings/import/ImportTypes.ts
+++ b/projects/client/src/lib/sections/settings/import/ImportTypes.ts
@@ -100,6 +100,30 @@ export const IMPORT_SOURCE_CONFIGS: Record<
   ImportSource,
   ImportSourceConfig
 > = {
+  tvtime: {
+    id: 'tvtime',
+    name: 'TV Time',
+    accept: '.csv,.zip',
+    maxFiles: 5,
+    guide: {
+      title: "Your TV Time isn't lost in space! 🚀",
+      description:
+        'Two ways to get your data out. Pick whichever suits you and import one export at a time:',
+      steps: [
+        ['Fastest: export your data with the', {
+          text: 'TV Time Liberator extension',
+          href:
+            'https://chromewebstore.google.com/detail/tv-time-liberator-extensi/pohobkcjhigehafgnhehkanhjakajhpm',
+        }, 'while your TV Time login still works, then upload the .csv here'],
+        ['Official: request your GDPR data export on the', {
+          text: 'TV Time privacy portal',
+          href: 'https://gdpr.tvtime.com/gdpr/self-service',
+        }],
+        ["Once the export is ready you'll get two emails: one with a .zip file and another with a password to unlock it."],
+        ['Upload the unlocked .zip here. If the .zip is not accepted, extract it and upload the two tracking-prod-records .csv files instead.'],
+      ],
+    },
+  },
   imdb: {
     id: 'imdb',
     name: 'IMDb',
@@ -141,30 +165,6 @@ export const IMPORT_SOURCE_CONFIGS: Record<
           href: 'https://letterboxd.com/data/export/',
         }],
         ['Download your Letterboxd export data in a zip file and upload it here'],
-      ],
-    },
-  },
-  tvtime: {
-    id: 'tvtime',
-    name: 'TV Time',
-    accept: '.csv,.zip',
-    maxFiles: 5,
-    guide: {
-      title: "Your TV Time isn't lost in space! 🚀",
-      description:
-        'Two ways to get your data out. Pick whichever suits you and import one export at a time:',
-      steps: [
-        ['Fastest: export your data with the', {
-          text: 'TV Time Liberator extension',
-          href:
-            'https://chromewebstore.google.com/detail/tv-time-liberator-extensi/pohobkcjhigehafgnhehkanhjakajhpm',
-        }, 'while your TV Time login still works, then upload the .csv here'],
-        ['Official: request your GDPR data export on the', {
-          text: 'TV Time privacy portal',
-          href: 'https://gdpr.tvtime.com/gdpr/self-service',
-        }],
-        ["Once the export is ready you'll get two emails: one with a .zip file and another with a password to unlock it."],
-        ['Upload the unlocked .zip here. If the .zip is not accepted, extract it and upload the two tracking-prod-records .csv files instead.'],
       ],
     },
   },


### PR DESCRIPTION
## What

Follow-up polish to the TV Time import review screen (multiple-matches picker and skipped-items list) after the initial match-progress work merged in #2782.

- The "Import More" action is hidden while ambiguous matches still need resolving, since "Import Selected" is already the primary action in that state.
- The multiple-matches grid gets a scroll-shadow cue (reusing `ShadowScroller`) on mouse input, so it reads as scrollable instead of looking cut off. Fixed a bug in `ShadowScroller` itself along the way: its inner scroller used `height: 100%`, which can't resolve against a wrapper whose only height comes from `max-height` (the spec treats it as `auto`), so the scroll listener never fired and the mask never showed up.
- The panel is sized to its content width instead of stretching full-width, so there's no empty gutter that reads as page background but silently captures scroll.
- On touch input the grid no longer gets its own internal scroll box at all - it flows inline with the page, so there's a single scroll surface instead of getting stuck inside the grid before reaching the rest of the page.
- Poster candidates in the multiple-matches grid get a proper styled tooltip on hover (the app's `Tooltip` component) instead of the native browser title tooltip.
- The source guide collapses to a single line once an import is underway (parsing onward) and can be re-expanded on demand, since by then the user has already read it and uploaded their file.
- TV Time is now the first tab and the default selected source instead of IMDb, since it's the most requested import source.

## Why

The review screen had a few rough edges once real imports came back with dozens of ambiguous matches: a redundant CTA, an unclear scroll boundary, a touch scroll trap, and a native tooltip that looked out of place. TV Time being the primary use case for this flow, it makes sense as the default tab too.

## Testing

- `deno task check` clean (0 errors, 0 warnings).
- Full unit suite passes.
- The ambiguous-matches and mid-import guide states require live mismatched import data to reach, so verify visually against a real import when reviewing.