### PR TITLE
fix(settings): close the TV Time import gaps

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6965,6 +6965,10 @@
       "default": "Get TV Time Liberator",
       "description": "Call-to-action linking to the TV Time Liberator browser extension."
     },
+    "welcome_tvtime_gdpr_cta": {
+      "default": "Request GDPR export",
+      "description": "Call-to-action linking to TV Time's privacy portal where users request their official GDPR data export."
+    },
     "welcome_tvtime_import_cta": {
       "default": "Import from TV Time",
       "description": "Call-to-action on the TV Time notice that opens the TV Time importer."

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
@@ -3,6 +3,7 @@
   import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import { m } from "$lib/features/i18n/messages.ts";
+  import { EMPTY_SPACE } from "$lib/utils/constants.ts";
   import { slide } from "svelte/transition";
   import type {
     ImportSourceConfig,
@@ -77,7 +78,7 @@
             <li>
               <p class="secondary">
                 {#each step as stepSegment, j (j)}
-                  {#if j > 0}" "{/if}
+                  {#if j > 0}{EMPTY_SPACE}{/if}
                   {@render segment(stepSegment)}
                 {/each}
               </p>

--- a/projects/client/src/lib/sections/settings/import/ImportTypes.ts
+++ b/projects/client/src/lib/sections/settings/import/ImportTypes.ts
@@ -106,7 +106,9 @@ export const IMPORT_SOURCE_CONFIGS: Record<
     id: 'tvtime',
     name: 'TV Time',
     accept: '.csv,.zip',
-    maxFiles: 5,
+    // High enough to swallow a whole extracted GDPR folder (41 files);
+    // unrecognized files are filtered out by the parser.
+    maxFiles: 50,
     guide: {
       title: "Your TV Time isn't lost in space! 🚀",
       description:

--- a/projects/client/src/lib/sections/settings/import/ImportTypes.ts
+++ b/projects/client/src/lib/sections/settings/import/ImportTypes.ts
@@ -126,7 +126,7 @@ export const IMPORT_SOURCE_CONFIGS: Record<
           href: 'https://gdpr.tvtime.com/gdpr/self-service',
         }],
         ["Once the export is ready you'll get two emails: one with a .zip file and another with a password to unlock it."],
-        ['Upload the unlocked .zip here. If the .zip is not accepted, extract it and upload the two tracking-prod-records .csv files (plus followed_tv_show.csv for your watchlist) instead.'],
+        ['Upload the unlocked .zip here. If the .zip is not accepted, extract it and upload the two tracking-prod-records .csv files (plus followed_tv_show.csv and ratings-live-votes.csv for your watchlist and ratings) instead.'],
       ],
     },
   },

--- a/projects/client/src/lib/sections/settings/import/ImportTypes.ts
+++ b/projects/client/src/lib/sections/settings/import/ImportTypes.ts
@@ -126,7 +126,7 @@ export const IMPORT_SOURCE_CONFIGS: Record<
           href: 'https://gdpr.tvtime.com/gdpr/self-service',
         }],
         ["Once the export is ready you'll get two emails: one with a .zip file and another with a password to unlock it."],
-        ['Upload the unlocked .zip here. If the .zip is not accepted, extract it and upload the two tracking-prod-records .csv files instead.'],
+        ['Upload the unlocked .zip here. If the .zip is not accepted, extract it and upload the two tracking-prod-records .csv files (plus followed_tv_show.csv for your watchlist) instead.'],
       ],
     },
   },

--- a/projects/client/src/lib/sections/settings/import/ImportTypes.ts
+++ b/projects/client/src/lib/sections/settings/import/ImportTypes.ts
@@ -112,11 +112,15 @@ export const IMPORT_SOURCE_CONFIGS: Record<
       description:
         'Two ways to get your data out. Pick whichever suits you and import one export at a time:',
       steps: [
-        ['Fastest: export your data with the', {
-          text: 'TV Time Liberator extension',
-          href:
-            'https://chromewebstore.google.com/detail/tv-time-liberator-extensi/pohobkcjhigehafgnhehkanhjakajhpm',
-        }, 'while your TV Time login still works, then upload the .csv here'],
+        [
+          'Fastest: export your data with the',
+          {
+            text: 'TV Time Liberator extension',
+            href:
+              'https://chromewebstore.google.com/detail/tv-time-liberator-extensi/pohobkcjhigehafgnhehkanhjakajhpm',
+          },
+          'while your TV Time login still works, then upload the export .zip (or the activity_history.csv inside it) here',
+        ],
         ['Official: request your GDPR data export on the', {
           text: 'TV Time privacy portal',
           href: 'https://gdpr.tvtime.com/gdpr/self-service',

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.spec.ts
@@ -86,6 +86,24 @@ describe('TvTimeCsvParser', () => {
       });
     });
 
+    it('should route followed show files by their notification_offset column', async () => {
+      const followedCsv = [
+        'user_id,tv_show_id,notification_type,notification_offset,created_at,updated_at,active,diffusion,folder_id,archived,tv_show_name',
+        '1,357864,2,1440,2021-03-15 20:42:59,2021-03-15 20:42:59,0,original,,0,Lovecraft Country',
+      ].join('\n');
+
+      const result = await TvTimeCsvParser.parse([
+        csvFile(followedCsv, 'followed_tv_show.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'watchlist',
+        type: 'show',
+        ids: { tvdb: 357864 },
+      });
+    });
+
     it('should route remaining csv files to the native parser', async () => {
       const result = await TvTimeCsvParser.parse([
         csvFile(NATIVE_CSV, 'seen_episode.csv'),

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.spec.ts
@@ -1,3 +1,4 @@
+import { zipSync } from 'fflate';
 import { describe, expect, it } from 'vitest';
 import { TvTimeCsvParser } from './TvTimeCsvParser.ts';
 
@@ -18,6 +19,19 @@ const GDPR_V2_CSV = [
 
 function csvFile(content: string, name: string): File {
   return new File([content], name, { type: 'text/csv' });
+}
+
+function zipFile(entries: Record<string, string>, name: string): File {
+  const encoder = new TextEncoder();
+  const zipped = zipSync(
+    Object.fromEntries(
+      Object.entries(entries).map(([path, content]) => [
+        path,
+        encoder.encode(content),
+      ]),
+    ),
+  );
+  return new File([zipped as BlobPart], name);
 }
 
 describe('TvTimeCsvParser', () => {
@@ -89,6 +103,64 @@ describe('TvTimeCsvParser', () => {
     it('should return an empty array when no files are provided', async () => {
       const result = await TvTimeCsvParser.parse([]);
       expect(result).toHaveLength(0);
+    });
+
+    it('should route liberator zips by their activity_history.csv entry', async () => {
+      const file = zipFile(
+        { 'activity_history.csv': LIBERATOR_CSV },
+        'tv-time-export.zip',
+      );
+
+      const result = await TvTimeCsvParser.parse([file]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'history',
+        type: 'episode',
+        ids: { imdb: 'tt0903747', tvdb: 3859781 },
+        title: 'Breaking Bad',
+      });
+    });
+
+    it('should route gdpr zips by their tracking-prod-records entries', async () => {
+      const file = zipFile(
+        {
+          'gdpr-data/tracking-prod-records-v2.csv': GDPR_V2_CSV,
+          'gdpr-data/ip_address.csv': 'ip\n127.0.0.1',
+        },
+        'gdpr-data.zip',
+      );
+
+      const result = await TvTimeCsvParser.parse([file]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'history',
+        type: 'episode',
+        ids: { tvdb: 1331151 },
+      });
+    });
+
+    it('should reject zips that match no known TV Time export', async () => {
+      const file = zipFile(
+        { 'random.csv': 'a,b\n1,2' },
+        'unknown.zip',
+      );
+
+      await expect(TvTimeCsvParser.parse([file])).rejects.toThrow(
+        /does not look like a TV Time export/,
+      );
+    });
+
+    it('should raise a helpful error for unreadable zips', async () => {
+      const file = new File(
+        [new Uint8Array([1, 2, 3, 4]) as BlobPart],
+        'gdpr-data.zip',
+      );
+
+      await expect(TvTimeCsvParser.parse([file])).rejects.toThrow(
+        /Could not read the .zip file/,
+      );
     });
   });
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.spec.ts
@@ -182,6 +182,47 @@ describe('TvTimeCsvParser', () => {
     });
   });
 
+  describe('whole-folder drops', () => {
+    it('should ignore unrecognized noise files next to gdpr data', async () => {
+      const result = await TvTimeCsvParser.parse([
+        csvFile('device_id,device_type\nabc,ios', 'device_data.csv'),
+        csvFile(
+          'user_id,tv_show_id,episode_id,created_at,updated_at,tv_show_name\n1,82066,1331151,2021-10-10,2021-10-10,Fringe',
+          'show_seen_episode_latest.csv',
+        ),
+        csvFile(GDPR_V2_CSV, 'tracking-prod-records-v2.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'history',
+        type: 'episode',
+        ids: { tvdb: 1331151 },
+      });
+    });
+
+    it('should ignore json sidecars next to liberator csv files', async () => {
+      const result = await TvTimeCsvParser.parse([
+        new File(['[{"title":"Inception"}]'], 'movies.json'),
+        csvFile(LIBERATOR_CSV, 'activity_history.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'history',
+        type: 'episode',
+        ids: { imdb: 'tt0903747' },
+      });
+    });
+
+    it('should reject uploads with no recognizable TV Time files', async () => {
+      await expect(TvTimeCsvParser.parse([
+        csvFile('device_id,device_type\nabc,ios', 'device_data.csv'),
+        csvFile('', 'empty.csv'),
+      ])).rejects.toThrow(/look like a TV Time export/);
+    });
+  });
+
   describe('mixed uploads', () => {
     it('should reject files from different export formats', async () => {
       await expect(TvTimeCsvParser.parse([

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
@@ -3,11 +3,37 @@ import { TvTimeGdprParser } from './TvTimeGdprParser.ts';
 import { TvTimeLiberatorParser } from './TvTimeLiberatorParser.ts';
 import { TvTimeNativeParser } from './TvTimeNativeParser.ts';
 import { parseCsvFile } from './utils/parseCsvFile.ts';
+import { zipEntryBasenames } from './utils/zipEntryBasenames.ts';
 
 type TvTimeFormat = 'gdpr' | 'liberator' | 'native';
 
+const GDPR_ZIP_MARKER = 'tracking-prod-records';
+const LIBERATOR_ZIP_MARKER = 'activity_history.csv';
+
+async function detectZipFormat(file: File): Promise<TvTimeFormat> {
+  const buffer = await file.arrayBuffer();
+  const basenames = (() => {
+    try {
+      return zipEntryBasenames(buffer);
+    } catch {
+      throw new Error(
+        'Could not read the .zip file. If it is password protected, extract it first and upload the CSV files inside instead.',
+      );
+    }
+  })();
+
+  if (basenames.some((name) => name.startsWith(GDPR_ZIP_MARKER))) {
+    return 'gdpr';
+  }
+  if (basenames.includes(LIBERATOR_ZIP_MARKER)) return 'liberator';
+
+  throw new Error(
+    'This .zip file does not look like a TV Time export. Upload the GDPR data export .zip or the Liberator export .zip.',
+  );
+}
+
 async function detectFormat(file: File): Promise<TvTimeFormat> {
-  if (file.name.endsWith('.zip')) return 'gdpr';
+  if (file.name.endsWith('.zip')) return detectZipFormat(file);
 
   const [first] = await parseCsvFile(file) as Record<string, unknown>[];
   if (!first) return 'native';

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
@@ -40,7 +40,7 @@ async function detectFormat(file: File): Promise<TvTimeFormat> {
   if ('imdb_id' in first) return 'liberator';
   if (
     'type-uuid-n' in first || 'ep_id' in first ||
-    'notification_offset' in first
+    'notification_offset' in first || 'vote_key' in first
   ) {
     return 'gdpr';
   }

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
@@ -5,10 +5,21 @@ import { TvTimeNativeParser } from './TvTimeNativeParser.ts';
 import { parseCsvFile } from './utils/parseCsvFile.ts';
 import { zipEntryBasenames } from './utils/zipEntryBasenames.ts';
 
-type TvTimeFormat = 'gdpr' | 'liberator' | 'native';
+type TvTimeFormat = 'gdpr' | 'liberator' | 'native' | 'unknown';
 
 const GDPR_ZIP_MARKER = 'tracking-prod-records';
 const LIBERATOR_ZIP_MARKER = 'activity_history.csv';
+
+// Columns that accompany episode_id in TV Time's native export. GDPR noise
+// files (show_seen_episode_latest.csv, where-to-watch-prod-table.csv) also
+// carry episode_id, so it alone is not enough to claim the native format.
+const NATIVE_COMPANION_COLUMNS = [
+  'ts',
+  'show_name',
+  'episode_name',
+  'episode_season_number',
+  'episode_number',
+];
 
 async function detectZipFormat(file: File): Promise<TvTimeFormat> {
   const buffer = await file.arrayBuffer();
@@ -36,7 +47,7 @@ async function detectFormat(file: File): Promise<TvTimeFormat> {
   if (file.name.endsWith('.zip')) return detectZipFormat(file);
 
   const [first] = await parseCsvFile(file) as Record<string, unknown>[];
-  if (!first) return 'native';
+  if (!first) return 'unknown';
   if ('imdb_id' in first) return 'liberator';
   if (
     'type-uuid-n' in first || 'ep_id' in first ||
@@ -44,7 +55,10 @@ async function detectFormat(file: File): Promise<TvTimeFormat> {
   ) {
     return 'gdpr';
   }
-  return 'native';
+
+  const isNative = 'episode_id' in first &&
+    NATIVE_COMPANION_COLUMNS.some((column) => column in first);
+  return isNative ? 'native' : 'unknown';
 }
 
 function parsePerFile(parser: FileParser, files: ReadonlyArray<File>) {
@@ -63,8 +77,24 @@ export const TvTimeCsvParser: FileParser = {
   },
 
   async parse(files) {
+    if (files.length === 0) return [];
+
+    // Whole-folder drops include noise files (device_data.csv, JSON
+    // sidecars); unrecognized files are ignored instead of breaking the
+    // import.
     const formats = await Promise.all(files.map(detectFormat));
-    const distinct = new Set(formats);
+    const recognized = files.filter(
+      (_, index) => formats[index] !== 'unknown',
+    );
+    const distinct = new Set(
+      formats.filter((format) => format !== 'unknown'),
+    );
+
+    if (distinct.size === 0) {
+      throw new Error(
+        'None of these files look like a TV Time export. Upload the Liberator export or the GDPR data export.',
+      );
+    }
 
     if (distinct.size > 1) {
       throw new Error(
@@ -76,11 +106,11 @@ export const TvTimeCsvParser: FileParser = {
 
     switch (format) {
       case 'liberator':
-        return parsePerFile(TvTimeLiberatorParser, files);
+        return parsePerFile(TvTimeLiberatorParser, recognized);
       case 'gdpr':
-        return TvTimeGdprParser.parse(files);
+        return TvTimeGdprParser.parse(recognized);
       default:
-        return parsePerFile(TvTimeNativeParser, files);
+        return parsePerFile(TvTimeNativeParser, recognized);
     }
   },
 };

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
@@ -38,7 +38,12 @@ async function detectFormat(file: File): Promise<TvTimeFormat> {
   const [first] = await parseCsvFile(file) as Record<string, unknown>[];
   if (!first) return 'native';
   if ('imdb_id' in first) return 'liberator';
-  if ('type-uuid-n' in first || 'ep_id' in first) return 'gdpr';
+  if (
+    'type-uuid-n' in first || 'ep_id' in first ||
+    'notification_offset' in first
+  ) {
+    return 'gdpr';
+  }
   return 'native';
 }
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
@@ -124,6 +124,36 @@ function v2UserSeries(
   };
 }
 
+const FOLLOWED_HEADER = [
+  'user_id',
+  'tv_show_id',
+  'notification_type',
+  'notification_offset',
+  'created_at',
+  'updated_at',
+  'active',
+  'diffusion',
+  'folder_id',
+  'archived',
+  'tv_show_name',
+];
+
+function followedShow(
+  overrides: Record<string, string> = {},
+): Record<string, string> {
+  return {
+    user_id: '1',
+    tv_show_id: '357864',
+    notification_type: '2',
+    notification_offset: '1440',
+    created_at: '2021-03-15 20:42:59',
+    active: '0',
+    archived: '0',
+    tv_show_name: 'Lovecraft Country',
+    ...overrides,
+  };
+}
+
 function csvFile(content: string, name = 'tracking.csv'): File {
   return new File([content], name, { type: 'text/csv' });
 }
@@ -389,6 +419,64 @@ describe('TvTimeGdprParser', () => {
     });
   });
 
+  describe('followed shows file', () => {
+    it('should watchlist followed shows without watched episodes', async () => {
+      const csv = toCsv(FOLLOWED_HEADER, [followedShow()]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(csv, 'followed_tv_show.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'watchlist',
+        type: 'show',
+        ids: { tvdb: 357864 },
+        title: 'Lovecraft Country',
+      });
+    });
+
+    it('should not watchlist followed shows with watched episodes', async () => {
+      const followedCsv = toCsv(FOLLOWED_HEADER, [
+        followedShow({ tv_show_id: '82066' }),
+      ]);
+      const v2Csv = toCsv(V2_HEADER, [v2EpisodeWatch()]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(followedCsv, 'followed_tv_show.csv'),
+        csvFile(v2Csv, 'tracking-prod-records-v2.csv'),
+      ]);
+
+      expect(result.filter((item) => item.action === 'watchlist'))
+        .toHaveLength(0);
+    });
+
+    it('should not watchlist archived follows', async () => {
+      const csv = toCsv(FOLLOWED_HEADER, [followedShow({ archived: '1' })]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(csv, 'followed_tv_show.csv'),
+      ]);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should not duplicate shows already watchlisted via tracking flags', async () => {
+      const followedCsv = toCsv(FOLLOWED_HEADER, [
+        followedShow({ tv_show_id: '353309', tv_show_name: 'Haunted' }),
+      ]);
+      const v2Csv = toCsv(V2_HEADER, [v2UserSeries({ is_for_later: 'true' })]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(followedCsv, 'followed_tv_show.csv'),
+        csvFile(v2Csv, 'tracking-prod-records-v2.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.ids.tvdb).toBe(353309);
+    });
+  });
+
   describe('zip archives', () => {
     it('should parse tracking files from a gdpr zip', async () => {
       const encoder = new TextEncoder();
@@ -399,6 +487,9 @@ describe('TvTimeGdprParser', () => {
         'gdpr-data/tracking-prod-records-v2.csv': encoder.encode(
           toCsv(V2_HEADER, [v2EpisodeWatch()]),
         ),
+        'gdpr-data/followed_tv_show.csv': encoder.encode(
+          toCsv(FOLLOWED_HEADER, [followedShow()]),
+        ),
         'gdpr-data/ip_address.csv': encoder.encode('ip\n127.0.0.1'),
       });
       const file = new File([zipped as BlobPart], 'gdpr-data.zip');
@@ -407,6 +498,8 @@ describe('TvTimeGdprParser', () => {
 
       expect(result.filter((item) => item.type === 'movie')).toHaveLength(1);
       expect(result.filter((item) => item.type === 'episode')).toHaveLength(1);
+      expect(result.filter((item) => item.action === 'watchlist'))
+        .toHaveLength(1);
     });
 
     it('should raise a helpful error for unreadable zips', async () => {

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
@@ -154,6 +154,27 @@ function followedShow(
   };
 }
 
+const RATINGS_HEADER = [
+  'episode_id',
+  'movie_name',
+  'uuid',
+  'vote_key',
+  'user_id',
+];
+
+function ratingVote(
+  overrides: Record<string, string> = {},
+): Record<string, string> {
+  return {
+    episode_id: '0',
+    movie_name: 'What Happened to Monday',
+    uuid: '002e2d8f-aee0-40ce-aa39-1be952e2952a',
+    vote_key: '002e2d8f-aee0-40ce-aa39-1be952e2952a-36089951-3',
+    user_id: '36089951',
+    ...overrides,
+  };
+}
+
 function csvFile(content: string, name = 'tracking.csv'): File {
   return new File([content], name, { type: 'text/csv' });
 }
@@ -477,6 +498,100 @@ describe('TvTimeGdprParser', () => {
     });
   });
 
+  describe('ratings file', () => {
+    it('should map rating votes to 1-10 movie ratings', async () => {
+      const csv = toCsv(RATINGS_HEADER, [ratingVote()]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(csv, 'ratings-live-votes.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'ratings',
+        type: 'movie',
+        ids: {},
+        title: 'What Happened to Monday',
+        rating: 10,
+      });
+    });
+
+    it('should recover the english title and year from the v1 tracking rows', async () => {
+      const ratingsCsv = toCsv(RATINGS_HEADER, [
+        ratingVote({ movie_name: '승리호' }),
+      ]);
+      const v1Csv = toCsv(V1_HEADER, [v1MovieWatch({
+        movie_name: '승리호',
+        alpha_range_key: 'watch-alpha-space-sweepers',
+        release_date: '2021-02-05',
+      })]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(ratingsCsv, 'ratings-live-votes.csv'),
+        csvFile(v1Csv, 'tracking-prod-records.csv'),
+      ]);
+
+      const rating = result.find((item) => item.action === 'ratings');
+      expect(rating).toMatchObject({
+        title: 'space sweepers',
+        year: 2021,
+        rating: 10,
+      });
+    });
+
+    it('should skip votes with unknown rating ids', async () => {
+      const csv = toCsv(RATINGS_HEADER, [ratingVote({
+        vote_key: '002e2d8f-aee0-40ce-aa39-1be952e2952a-36089951-39',
+      })]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(csv, 'ratings-live-votes.csv'),
+      ]);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should skip episode rating votes', async () => {
+      const csv = toCsv(RATINGS_HEADER, [ratingVote({
+        episode_id: '1331151',
+        movie_name: '',
+      })]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(csv, 'ratings-live-votes.csv'),
+      ]);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should keep a single rating per movie', async () => {
+      const csv = toCsv(RATINGS_HEADER, [
+        ratingVote(),
+        ratingVote({
+          vote_key: '002e2d8f-aee0-40ce-aa39-1be952e2952a-36089951-27',
+        }),
+      ]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(csv, 'ratings-live-votes.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('should ignore emotion votes despite the shared header', async () => {
+      const csv = toCsv(RATINGS_HEADER, [ratingVote({
+        vote_key: '002e2d8f-aee0-40ce-aa39-1be952e2952a-36089951-33',
+      })]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(csv, 'emotions-live-votes.csv'),
+      ]);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
   describe('zip archives', () => {
     it('should parse tracking files from a gdpr zip', async () => {
       const encoder = new TextEncoder();
@@ -490,16 +605,23 @@ describe('TvTimeGdprParser', () => {
         'gdpr-data/followed_tv_show.csv': encoder.encode(
           toCsv(FOLLOWED_HEADER, [followedShow()]),
         ),
+        'gdpr-data/ratings-live-votes.csv': encoder.encode(
+          toCsv(RATINGS_HEADER, [ratingVote()]),
+        ),
         'gdpr-data/ip_address.csv': encoder.encode('ip\n127.0.0.1'),
       });
       const file = new File([zipped as BlobPart], 'gdpr-data.zip');
 
       const result = await TvTimeGdprParser.parse([file]);
 
-      expect(result.filter((item) => item.type === 'movie')).toHaveLength(1);
-      expect(result.filter((item) => item.type === 'episode')).toHaveLength(1);
+      expect(result.filter((item) => item.action === 'history')).toHaveLength(
+        2,
+      );
       expect(result.filter((item) => item.action === 'watchlist'))
         .toHaveLength(1);
+      expect(result.filter((item) => item.action === 'ratings')).toHaveLength(
+        1,
+      );
     });
 
     it('should raise a helpful error for unreadable zips', async () => {

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
@@ -5,6 +5,7 @@ import { toISOString } from './utils/toISOString.ts';
 import { unzipCsvTexts } from './utils/unzipCsvTexts.ts';
 
 type TrackingV1Row = {
+  uuid?: string;
   type?: string;
   entity_type?: string;
   series_name?: string;
@@ -37,9 +38,31 @@ type FollowedShowRow = {
   archived?: string;
 };
 
+type RatingVoteRow = {
+  uuid?: string;
+  episode_id?: string;
+  movie_name?: string;
+  vote_key?: string;
+};
+
 const TRACKING_V1_MARKER = 'type-uuid-n';
 const TRACKING_V2_MARKER = 'ep_id';
 const FOLLOWED_SHOW_MARKER = 'notification_offset';
+
+// emotions-live-votes.csv shares this header, so rating votes are routed
+// by file name instead of a column marker.
+const RATINGS_CSV = 'ratings-live-votes.csv';
+
+// TV Time's stars_wording_scalev2 rating set: id -> star position, doubled
+// to Trakt's 1-10 scale. Stable since 2018 and frozen by the July 2026
+// shutdown; verified against msapi.tvtime.com/live/v1/ratings/sets.
+const RATING_ID_TO_SCORE: Record<number, number> = {
+  1: 2, // bad
+  27: 4, // ok
+  28: 6, // good
+  29: 8, // great
+  3: 10, // wow
+};
 
 function toInt(value?: string): number | undefined {
   if (!value) return undefined;
@@ -173,11 +196,53 @@ function parseFollowedShowWatchlist(
     });
 }
 
+// Vote rows only carry the localized movie_name; joining on uuid against
+// the v1 tracking rows recovers the English slug and release year.
+function parseRatingVotes(
+  ratingRows: RatingVoteRow[],
+  v1Rows: TrackingV1Row[],
+): UniversalImportItem[] {
+  const moviesByUuid = new Map(
+    v1Rows
+      .filter((row) => row.entity_type === 'movie' && row.uuid)
+      .map((row) => [row.uuid, row]),
+  );
+
+  const byUuid = new Map<string, UniversalImportItem>();
+
+  for (const row of ratingRows) {
+    if (!row.uuid) continue;
+    // Episode ratings are skipped: the ratings sync payload only carries
+    // movies and shows.
+    if (row.episode_id && row.episode_id !== '0') continue;
+
+    const ratingId = toInt(row.vote_key?.split('-').at(-1));
+    const rating = ratingId != null ? RATING_ID_TO_SCORE[ratingId] : undefined;
+    if (rating == null) continue;
+
+    const tracked = moviesByUuid.get(row.uuid);
+    const title = tracked ? toMovieTitle(tracked) : row.movie_name || undefined;
+    if (!title) continue;
+
+    byUuid.set(row.uuid, {
+      action: 'ratings',
+      type: 'movie',
+      ids: {},
+      title,
+      year: toYear(tracked?.release_date),
+      rating,
+    });
+  }
+
+  return [...byUuid.values()];
+}
+
 function parseGdprRows(
-  { v1Rows, v2Rows, followedRows }: {
+  { v1Rows, v2Rows, followedRows, ratingRows }: {
     v1Rows: TrackingV1Row[];
     v2Rows: TrackingV2Row[];
     followedRows: FollowedShowRow[];
+    ratingRows: RatingVoteRow[];
   },
 ): UniversalImportItem[] {
   const episodes = v2Rows.length > 0
@@ -213,7 +278,15 @@ function parseGdprRows(
     watchlistedShowIds,
   );
 
-  return [...episodes, ...movies, ...showWatchlist, ...followedWatchlist];
+  const ratings = parseRatingVotes(ratingRows, v1Rows);
+
+  return [
+    ...episodes,
+    ...movies,
+    ...showWatchlist,
+    ...followedWatchlist,
+    ...ratings,
+  ];
 }
 
 function isV1Row(row: Record<string, unknown>): boolean {
@@ -228,11 +301,12 @@ function isFollowedShowRow(row: Record<string, unknown>): boolean {
   return FOLLOWED_SHOW_MARKER in row;
 }
 
-function unzipGdprCsvTexts(buffer: ArrayBuffer): string[] {
+function unzipGdprCsvTexts(buffer: ArrayBuffer) {
   const isGdprCsv = (basename: string) =>
     (basename.startsWith('tracking-prod-records') &&
       basename.endsWith('.csv')) ||
-    basename === 'followed_tv_show.csv';
+    basename === 'followed_tv_show.csv' ||
+    basename === RATINGS_CSV;
 
   try {
     return unzipCsvTexts({ buffer, isMatch: isGdprCsv });
@@ -243,15 +317,15 @@ function unzipGdprCsvTexts(buffer: ArrayBuffer): string[] {
   }
 }
 
-async function collectCsvTexts(files: ReadonlyArray<File>): Promise<string[]> {
-  const texts = await Promise.all(files.map(async (file) => {
+async function collectCsvTexts(files: ReadonlyArray<File>) {
+  const entries = await Promise.all(files.map(async (file) => {
     if (file.name.endsWith('.zip')) {
       return unzipGdprCsvTexts(await file.arrayBuffer());
     }
-    return [await file.text()];
+    return [{ basename: file.name, text: await file.text() }];
   }));
 
-  return texts.flat();
+  return entries.flat();
 }
 
 export const TvTimeGdprParser: FileParser = {
@@ -265,23 +339,31 @@ export const TvTimeGdprParser: FileParser = {
   },
 
   async parse(files) {
-    const texts = await collectCsvTexts(files);
-    const parsed = await Promise.all(texts.map(parseCsvText));
+    const entries = await collectCsvTexts(files);
+    const parsed = await Promise.all(
+      entries.map(async (entry) => ({
+        basename: entry.basename,
+        rows: await parseCsvText(entry.text) as Record<string, unknown>[],
+      })),
+    );
 
     const v1Rows: TrackingV1Row[] = [];
     const v2Rows: TrackingV2Row[] = [];
     const followedRows: FollowedShowRow[] = [];
+    const ratingRows: RatingVoteRow[] = [];
 
-    for (const rows of parsed as Record<string, unknown>[][]) {
+    for (const { basename, rows } of parsed) {
       const [first] = rows;
       if (!first) continue;
-      if (isV2Row(first)) v2Rows.push(...(rows as TrackingV2Row[]));
+      if (basename === RATINGS_CSV) {
+        ratingRows.push(...(rows as RatingVoteRow[]));
+      } else if (isV2Row(first)) v2Rows.push(...(rows as TrackingV2Row[]));
       else if (isV1Row(first)) v1Rows.push(...(rows as TrackingV1Row[]));
       else if (isFollowedShowRow(first)) {
         followedRows.push(...(rows as FollowedShowRow[]));
       }
     }
 
-    return parseGdprRows({ v1Rows, v2Rows, followedRows });
+    return parseGdprRows({ v1Rows, v2Rows, followedRows, ratingRows });
   },
 };

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
@@ -1,8 +1,8 @@
-import { unzipSync } from 'fflate';
 import type { UniversalImportItem } from '../ImportTypes.ts';
 import type { FileParser } from './ParserInterface.ts';
 import { parseCsvText } from './utils/parseCsvText.ts';
 import { toISOString } from './utils/toISOString.ts';
+import { unzipCsvTexts } from './utils/unzipCsvTexts.ts';
 
 type TrackingV1Row = {
   type?: string;
@@ -181,26 +181,16 @@ function isV2Row(row: Record<string, unknown>): boolean {
 }
 
 function unzipTrackingCsvTexts(buffer: ArrayBuffer): string[] {
-  const isTrackingCsv = (filename: string) => {
-    const basename = filename.split('/').at(-1) ?? '';
-    return basename.startsWith('tracking-prod-records') &&
-      basename.endsWith('.csv');
-  };
+  const isTrackingCsv = (basename: string) =>
+    basename.startsWith('tracking-prod-records') && basename.endsWith('.csv');
 
-  const unzipped = (() => {
-    try {
-      return unzipSync(new Uint8Array(buffer), {
-        filter: (file) => isTrackingCsv(file.name),
-      });
-    } catch {
-      throw new Error(
-        'Could not read the .zip file. If it is password protected, extract it first and upload the tracking-prod-records CSV files instead.',
-      );
-    }
-  })();
-
-  const decoder = new TextDecoder('utf-8');
-  return Object.values(unzipped).map((data) => decoder.decode(data));
+  try {
+    return unzipCsvTexts({ buffer, isMatch: isTrackingCsv });
+  } catch {
+    throw new Error(
+      'Could not read the .zip file. If it is password protected, extract it first and upload the tracking-prod-records CSV files instead.',
+    );
+  }
 }
 
 async function collectCsvTexts(files: ReadonlyArray<File>): Promise<string[]> {

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
@@ -31,8 +31,15 @@ type TrackingV2Row = {
   is_archived?: string;
 };
 
+type FollowedShowRow = {
+  tv_show_id?: string;
+  tv_show_name?: string;
+  archived?: string;
+};
+
 const TRACKING_V1_MARKER = 'type-uuid-n';
 const TRACKING_V2_MARKER = 'ep_id';
+const FOLLOWED_SHOW_MARKER = 'notification_offset';
 
 function toInt(value?: string): number | undefined {
   if (!value) return undefined;
@@ -143,8 +150,35 @@ function parseV2ShowWatchlist(
     });
 }
 
+// The v2 tracking flags miss follows that predate them, so
+// followed_tv_show.csv backfills the rest of the watchlist.
+function parseFollowedShowWatchlist(
+  rows: FollowedShowRow[],
+  watchedShowIds: ReadonlySet<number>,
+  seenShowIds: ReadonlySet<number>,
+): UniversalImportItem[] {
+  return rows
+    .filter((row) => row.archived !== '1')
+    .flatMap((row) => {
+      const tvdbId = toInt(row.tv_show_id);
+      if (tvdbId == null) return [];
+      if (watchedShowIds.has(tvdbId) || seenShowIds.has(tvdbId)) return [];
+
+      return [{
+        action: 'watchlist' as const,
+        type: 'show' as const,
+        ids: { tvdb: tvdbId },
+        title: row.tv_show_name || undefined,
+      }];
+    });
+}
+
 function parseGdprRows(
-  { v1Rows, v2Rows }: { v1Rows: TrackingV1Row[]; v2Rows: TrackingV2Row[] },
+  { v1Rows, v2Rows, followedRows }: {
+    v1Rows: TrackingV1Row[];
+    v2Rows: TrackingV2Row[];
+    followedRows: FollowedShowRow[];
+  },
 ): UniversalImportItem[] {
   const episodes = v2Rows.length > 0
     ? v2Rows
@@ -168,8 +202,18 @@ function parseGdprRows(
   );
 
   const showWatchlist = parseV2ShowWatchlist(v2Rows, watchedShowIds);
+  const watchlistedShowIds = new Set(
+    showWatchlist
+      .map((item) => item.ids.tvdb)
+      .filter((id): id is number => id != null),
+  );
+  const followedWatchlist = parseFollowedShowWatchlist(
+    followedRows,
+    watchedShowIds,
+    watchlistedShowIds,
+  );
 
-  return [...episodes, ...movies, ...showWatchlist];
+  return [...episodes, ...movies, ...showWatchlist, ...followedWatchlist];
 }
 
 function isV1Row(row: Record<string, unknown>): boolean {
@@ -180,12 +224,18 @@ function isV2Row(row: Record<string, unknown>): boolean {
   return TRACKING_V2_MARKER in row;
 }
 
-function unzipTrackingCsvTexts(buffer: ArrayBuffer): string[] {
-  const isTrackingCsv = (basename: string) =>
-    basename.startsWith('tracking-prod-records') && basename.endsWith('.csv');
+function isFollowedShowRow(row: Record<string, unknown>): boolean {
+  return FOLLOWED_SHOW_MARKER in row;
+}
+
+function unzipGdprCsvTexts(buffer: ArrayBuffer): string[] {
+  const isGdprCsv = (basename: string) =>
+    (basename.startsWith('tracking-prod-records') &&
+      basename.endsWith('.csv')) ||
+    basename === 'followed_tv_show.csv';
 
   try {
-    return unzipCsvTexts({ buffer, isMatch: isTrackingCsv });
+    return unzipCsvTexts({ buffer, isMatch: isGdprCsv });
   } catch {
     throw new Error(
       'Could not read the .zip file. If it is password protected, extract it first and upload the tracking-prod-records CSV files instead.',
@@ -196,7 +246,7 @@ function unzipTrackingCsvTexts(buffer: ArrayBuffer): string[] {
 async function collectCsvTexts(files: ReadonlyArray<File>): Promise<string[]> {
   const texts = await Promise.all(files.map(async (file) => {
     if (file.name.endsWith('.zip')) {
-      return unzipTrackingCsvTexts(await file.arrayBuffer());
+      return unzipGdprCsvTexts(await file.arrayBuffer());
     }
     return [await file.text()];
   }));
@@ -220,14 +270,18 @@ export const TvTimeGdprParser: FileParser = {
 
     const v1Rows: TrackingV1Row[] = [];
     const v2Rows: TrackingV2Row[] = [];
+    const followedRows: FollowedShowRow[] = [];
 
     for (const rows of parsed as Record<string, unknown>[][]) {
       const [first] = rows;
       if (!first) continue;
       if (isV2Row(first)) v2Rows.push(...(rows as TrackingV2Row[]));
       else if (isV1Row(first)) v1Rows.push(...(rows as TrackingV1Row[]));
+      else if (isFollowedShowRow(first)) {
+        followedRows.push(...(rows as FollowedShowRow[]));
+      }
     }
 
-    return parseGdprRows({ v1Rows, v2Rows });
+    return parseGdprRows({ v1Rows, v2Rows, followedRows });
   },
 };

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.spec.ts
@@ -1,3 +1,4 @@
+import { zipSync } from 'fflate';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TvTimeLiberatorParser } from './TvTimeLiberatorParser.ts';
 import { parseCsvFile } from './utils/parseCsvFile.ts';
@@ -18,13 +19,19 @@ describe('TvTimeLiberatorParser', () => {
       expect(TvTimeLiberatorParser.canParse([dummyFile])).toBe(true);
     });
 
+    it('accepts a single zip file', () => {
+      expect(
+        TvTimeLiberatorParser.canParse([new File([''], 'tv-time-export.zip')]),
+      ).toBe(true);
+    });
+
     it('rejects multiple files', () => {
       expect(TvTimeLiberatorParser.canParse([dummyFile, dummyFile])).toBe(
         false,
       );
     });
 
-    it('rejects non-csv files', () => {
+    it('rejects unsupported file types', () => {
       expect(
         TvTimeLiberatorParser.canParse([new File([''], 'data.json')]),
       ).toBe(false);
@@ -179,6 +186,42 @@ describe('TvTimeLiberatorParser', () => {
     it('returns empty array when no files provided', async () => {
       const result = await TvTimeLiberatorParser.parse([]);
       expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('zip archives', () => {
+    it('parses activity_history.csv from a liberator zip', async () => {
+      const encoder = new TextEncoder();
+      const csv = [
+        'imdb_id,tvdb_id,type,title,season,episode,is_special,is_watched,watched_at,status,is_watchlisted,rating',
+        'tt1375666,113,movie,Inception,,,false,true,2023-01-01T00:00:00Z,,false,',
+      ].join('\n');
+      const zipped = zipSync({
+        'activity_history.csv': encoder.encode(csv),
+        'movies.json': encoder.encode('[]'),
+      });
+      const file = new File([zipped as BlobPart], 'tv-time-export.zip');
+
+      const result = await TvTimeLiberatorParser.parse([file]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'history',
+        type: 'movie',
+        ids: { imdb: 'tt1375666', tvdb: 113 },
+        title: 'Inception',
+      });
+    });
+
+    it('raises a helpful error for unreadable zips', async () => {
+      const file = new File(
+        [new Uint8Array([1, 2, 3, 4]) as BlobPart],
+        'tv-time-export.zip',
+      );
+
+      await expect(TvTimeLiberatorParser.parse([file])).rejects.toThrow(
+        /activity_history.csv/,
+      );
     });
   });
 });

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.spec.ts
@@ -177,6 +177,67 @@ describe('TvTimeLiberatorParser', () => {
       });
     });
 
+    it('emits a rating alongside history for rated movies', async () => {
+      mockParseCsvFile.mockResolvedValue([{
+        imdb_id: 'tt1375666',
+        tvdb_id: '113',
+        type: 'movie',
+        title: 'Inception',
+        is_watched: 'true',
+        watched_at: '2023-01-01T00:00:00Z',
+        is_watchlisted: 'false',
+        rating: '8',
+      }]);
+
+      const result = await TvTimeLiberatorParser.parse([dummyFile]);
+
+      expect(result).toHaveLength(2);
+      expect(result[1]).toMatchObject({
+        action: 'ratings',
+        type: 'movie',
+        ids: { imdb: 'tt1375666', tvdb: 113 },
+        rating: 8,
+      });
+    });
+
+    it('skips episode ratings', async () => {
+      mockParseCsvFile.mockResolvedValue([{
+        imdb_id: 'tt0903747',
+        tvdb_id: '81189',
+        type: 'episode',
+        title: 'Breaking Bad',
+        season: '3',
+        episode: '7',
+        is_watched: 'true',
+        watched_at: '2023-06-01T00:00:00Z',
+        is_watchlisted: 'false',
+        rating: '9',
+      }]);
+
+      const result = await TvTimeLiberatorParser.parse([dummyFile]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.action).toBe('history');
+    });
+
+    it('ignores empty and invalid ratings', async () => {
+      mockParseCsvFile.mockResolvedValue([{
+        imdb_id: 'tt1375666',
+        tvdb_id: '113',
+        type: 'movie',
+        title: 'Inception',
+        is_watched: 'true',
+        watched_at: '2023-01-01T00:00:00Z',
+        is_watchlisted: 'false',
+        rating: '',
+      }]);
+
+      const result = await TvTimeLiberatorParser.parse([dummyFile]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.action).toBe('history');
+    });
+
     it('returns empty array for empty file', async () => {
       mockParseCsvFile.mockResolvedValue([]);
       const result = await TvTimeLiberatorParser.parse([dummyFile]);

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.ts
@@ -82,7 +82,7 @@ async function unzipActivityHistoryRows(file: File): Promise<unknown[]> {
       return unzipCsvTexts({
         buffer,
         isMatch: (basename) => basename === ACTIVITY_HISTORY_CSV,
-      });
+      }).map((entry) => entry.text);
     } catch {
       throw new Error(
         `Could not read the .zip file. Extract it and upload ${ACTIVITY_HISTORY_CSV} instead.`,

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.ts
@@ -1,7 +1,11 @@
 import type { ImportType, UniversalImportItem } from '../ImportTypes.ts';
 import type { FileParser } from './ParserInterface.ts';
 import { parseCsvFile } from './utils/parseCsvFile.ts';
+import { parseCsvText } from './utils/parseCsvText.ts';
 import { toISOString } from './utils/toISOString.ts';
+import { unzipCsvTexts } from './utils/unzipCsvTexts.ts';
+
+const ACTIVITY_HISTORY_CSV = 'activity_history.csv';
 
 type TvTimeLiberatorRow = {
   imdb_id?: string;
@@ -61,19 +65,45 @@ function parseLiberatorRow(row: TvTimeLiberatorRow): UniversalImportItem[] {
   return items;
 }
 
+// The Liberator zip also holds movies.json/shows.json, but
+// activity_history.csv carries the same data plus watchlist flags.
+async function unzipActivityHistoryRows(file: File): Promise<unknown[]> {
+  const buffer = await file.arrayBuffer();
+  const texts = (() => {
+    try {
+      return unzipCsvTexts({
+        buffer,
+        isMatch: (basename) => basename === ACTIVITY_HISTORY_CSV,
+      });
+    } catch {
+      throw new Error(
+        `Could not read the .zip file. Extract it and upload ${ACTIVITY_HISTORY_CSV} instead.`,
+      );
+    }
+  })();
+
+  const parsed = await Promise.all(texts.map(parseCsvText));
+  return parsed.flat();
+}
+
 export const TvTimeLiberatorParser: FileParser = {
   name: 'TV Time Liberator',
 
   canParse(files) {
     const [file] = files;
-    return files.length === 1 && file?.name.endsWith('.csv') === true;
+    return files.length === 1 &&
+      (file?.name.endsWith('.csv') === true ||
+        file?.name.endsWith('.zip') === true);
   },
 
   async parse(files) {
     const [file] = files;
     if (!file) return [];
 
-    const rows = await parseCsvFile(file);
+    const rows = file.name.endsWith('.zip')
+      ? await unzipActivityHistoryRows(file)
+      : await parseCsvFile(file);
+
     return (rows as TvTimeLiberatorRow[]).flatMap(parseLiberatorRow);
   },
 };

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.ts
@@ -19,6 +19,7 @@ type TvTimeLiberatorRow = {
   watched_at?: string;
   status?: string;
   is_watchlisted?: string;
+  rating?: string;
 };
 
 function toInt(value?: string): number | undefined {
@@ -60,6 +61,13 @@ function parseLiberatorRow(row: TvTimeLiberatorRow): UniversalImportItem[] {
 
   if (row.is_watchlisted === 'true') {
     items.push({ ...base, action: 'watchlist' });
+  }
+
+  // Episode ratings are skipped: the ratings sync payload only carries
+  // movies and shows.
+  const rating = toInt(row.rating);
+  if (rating != null && base.type !== 'episode') {
+    items.push({ ...base, action: 'ratings', rating });
   }
 
   return items;

--- a/projects/client/src/lib/sections/settings/import/parsers/utils/unzipCsvTexts.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/utils/unzipCsvTexts.ts
@@ -5,13 +5,21 @@ interface UnzipCsvTextsParams {
   isMatch: (basename: string) => boolean;
 }
 
+interface CsvText {
+  basename: string;
+  text: string;
+}
+
 export function unzipCsvTexts(
   { buffer, isMatch }: UnzipCsvTextsParams,
-): string[] {
+): CsvText[] {
   const unzipped = unzipSync(new Uint8Array(buffer), {
     filter: (file) => isMatch(file.name.split('/').at(-1) ?? ''),
   });
 
   const decoder = new TextDecoder('utf-8');
-  return Object.values(unzipped).map((data) => decoder.decode(data));
+  return Object.entries(unzipped).map(([name, data]) => ({
+    basename: name.split('/').at(-1) ?? '',
+    text: decoder.decode(data),
+  }));
 }

--- a/projects/client/src/lib/sections/settings/import/parsers/utils/unzipCsvTexts.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/utils/unzipCsvTexts.ts
@@ -1,0 +1,17 @@
+import { unzipSync } from 'fflate';
+
+interface UnzipCsvTextsParams {
+  buffer: ArrayBuffer;
+  isMatch: (basename: string) => boolean;
+}
+
+export function unzipCsvTexts(
+  { buffer, isMatch }: UnzipCsvTextsParams,
+): string[] {
+  const unzipped = unzipSync(new Uint8Array(buffer), {
+    filter: (file) => isMatch(file.name.split('/').at(-1) ?? ''),
+  });
+
+  const decoder = new TextDecoder('utf-8');
+  return Object.values(unzipped).map((data) => decoder.decode(data));
+}

--- a/projects/client/src/lib/sections/settings/import/parsers/utils/zipEntryBasenames.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/utils/zipEntryBasenames.ts
@@ -1,0 +1,15 @@
+import { unzipSync } from 'fflate';
+
+// Collects entry names without inflating any data (filter always rejects).
+export function zipEntryBasenames(buffer: ArrayBuffer): string[] {
+  const basenames: string[] = [];
+
+  unzipSync(new Uint8Array(buffer), {
+    filter: (file) => {
+      basenames.push(file.name.split('/').at(-1) ?? '');
+      return false;
+    },
+  });
+
+  return basenames;
+}

--- a/projects/client/src/lib/sections/welcome/components/_internal/TvTimeNotice.svelte
+++ b/projects/client/src/lib/sections/welcome/components/_internal/TvTimeNotice.svelte
@@ -6,6 +6,7 @@
 
   const TV_TIME_LIBERATOR_URL =
     "https://chromewebstore.google.com/detail/tv-time-liberator-extensi/pohobkcjhigehafgnhehkanhjakajhpm";
+  const TV_TIME_GDPR_URL = "https://gdpr.tvtime.com/gdpr/self-service";
 
   const importHref = importSourceHref("tvtime");
 </script>
@@ -46,6 +47,21 @@
         label={m.welcome_tvtime_liberator_cta()}
       >
         {m.welcome_tvtime_liberator_cta()}
+        {#snippet icon()}
+          <ExternalLinkIcon size="small" />
+        {/snippet}
+      </Button>
+
+      <Button
+        href={TV_TIME_GDPR_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        color="default"
+        variant="secondary"
+        style="flat"
+        label={m.welcome_tvtime_gdpr_cta()}
+      >
+        {m.welcome_tvtime_gdpr_cta()}
         {#snippet icon()}
           <ExternalLinkIcon size="small" />
         {/snippet}

--- a/projects/client/src/lib/utils/constants.ts
+++ b/projects/client/src/lib/utils/constants.ts
@@ -14,6 +14,12 @@ export const NOOP_FN = () => {
   // noop
 };
 
+/**
+ * Explicit space for template text joins, where a raw ' ' literal is
+ * easy to misquote and stray whitespace is collapsed by the compiler.
+ */
+export const EMPTY_SPACE = ' ';
+
 export const DEFAULT_PAGE_SIZE = 10;
 
 export const DEFAULT_DRILL_SIZE = 100;


### PR DESCRIPTION
Validated both TV Time export flows (Liberator + GDPR) against real exports after [this Reddit report](https://www.reddit.com/r/trakt/comments/1ulivm9/need_some_help_importing_tv_time_data_to_trakt/) and fixed everything that surfaced.

## Fixes

- **Liberator .zip parsed to zero items.** Every .zip was routed to the GDPR parser, whose tracking-prod-records filter matched nothing inside a Liberator export, ending on a dead review screen. Format is now detected from the zip entry names and activity_history.csv is parsed out of Liberator zips. Unrecognized zips get an actionable error.
- **Liberator ratings were dropped.** The 1-10 rating column now emits ratings items for movies and shows.
- **GDPR imports lost most of the show watchlist** (13 of 77 shows on the reference export). The v2 tracking flags miss follows that predate them; followed_tv_show.csv now backfills the rest (54 of 77, the remainder being in-progress shows we exclude by design).
- **GDPR ratings were not imported at all.** ratings-live-votes.csv encodes each vote as a rating_id from TV Time's stars_wording_scalev2 set; the five ids map to Trakt's 1-10 scale and votes join on uuid against the v1 tracking rows to recover the English title slug and release year for resolution. 10/10 ratings on the reference export match the Liberator ground truth.
- **Whole-folder drops now work.** Drag events bypass the accept filter and maxFiles sliced off the useful files, so dropping the extracted contents of an export errored out. Unrecognized files are now skipped, native detection requires episode_id plus a companion column (so GDPR noise files cannot masquerade as the native format), and maxFiles fits a full extracted GDPR folder.
- **Floating double quotes in the import guide steps.** The segment separator was a literal `" "` string; it is now an explicit `EMPTY_SPACE` constant so the intent cannot be misquoted again.

## QOL

- The welcome page TV Time notice now links the GDPR self-service portal next to the Liberator extension.

## Validation

Every commit was verified end to end against a real Liberator export and a real GDPR export (zipped, unzipped, and whole-folder drops), with identical output across upload shapes. 208 unit specs in the import module cover the new paths.
