### PR TITLE
feat(cta): add empty-state CTA for recommended list

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -3621,6 +3621,10 @@
       "default": "Your timeline. See what's dropping next with a full list of upcoming movies you care about.",
       "description": "Call to action text shown in the Upcoming list, encouraging users to follow movies for upcoming releases."
     },
+    "text_cta_recommended": {
+      "default": "Made for you. Watch, rate, and favorite - picks here sharpen the more you track.",
+      "description": "Call to action text shown in the Recommended list, encouraging users to watch, rate, and favorite media to improve their recommendations."
+    },
     "text_cta_watchlist_unreleased": {
       "default": "Lights, camera… nothing? Add titles to your watchlist and let the binge begin.",
       "description": "Call to action text shown in the Watchlist Unreleased list, encouraging users to add unreleased movies to their watchlist."

--- a/projects/client/src/lib/sections/lists/components/cta/CtaItemIntlProvider.ts
+++ b/projects/client/src/lib/sections/lists/components/cta/CtaItemIntlProvider.ts
@@ -57,6 +57,8 @@ export const CtaItemIntlProvider: CtaItemIntl = {
       }
       case 'smart-list':
         return m.text_cta_smart_lists();
+      case 'recommended':
+        return m.text_cta_recommended();
       case 'personal-list': {
         return m.text_cta_personal_lists();
       }

--- a/projects/client/src/lib/sections/lists/components/cta/_internal/usePlaceholderCover.ts
+++ b/projects/client/src/lib/sections/lists/components/cta/_internal/usePlaceholderCover.ts
@@ -70,6 +70,7 @@ function ctaToQuery(cta: MediaCta | ListCta) {
     case 'personal-list':
     case 'upcoming':
     case 'smart-list':
+    case 'recommended':
       return mediaTypeToQuery(cta.mediaType ?? 'show', cta.type === 'upcoming');
   }
 }

--- a/projects/client/src/lib/sections/lists/components/cta/models/Cta.ts
+++ b/projects/client/src/lib/sections/lists/components/cta/models/Cta.ts
@@ -12,7 +12,8 @@ export type CtaType =
   | 'social'
   | 'personal-list'
   | 'smart-list'
-  | 'progress';
+  | 'progress'
+  | 'recommended';
 
 type CtaAction = {
   disabled: boolean;
@@ -29,6 +30,7 @@ type MediaTypeCta = Extract<
   | 'personal-activity'
   | 'smart-list'
   | 'progress'
+  | 'recommended'
 >;
 
 type CtaMap = {

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedList.svelte
@@ -4,6 +4,7 @@
   import { useFilter } from "$lib/features/filters/useFilter";
   import type { FilterOverrideParams } from "$lib/requests/models/FilterParams";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import CtaItem from "../components/cta/CtaItem.svelte";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
   import { extractWatchWindowParam } from "./extractWatchWindowParam";
   import RecommendedListItem from "./RecommendedListItem.svelte";
@@ -23,6 +24,11 @@
     filterOverride,
   }: RecommendationListProps = $props();
   const { filterMap } = useFilter();
+
+  const cta = $derived({
+    type: "recommended" as const,
+    mediaType: type === "media" ? undefined : type,
+  });
 </script>
 
 <DrillableMediaList
@@ -50,5 +56,13 @@
       {media}
       mode={type === "media" ? "mixed" : "standalone"}
     />
+  {/snippet}
+
+  {#snippet ctaItem()}
+    <CtaItem {cta} variant="card" />
+  {/snippet}
+
+  {#snippet empty()}
+    <CtaItem {cta} variant="placeholder" />
   {/snippet}
 </DrillableMediaList>


### PR DESCRIPTION
## Summary
- Adds a `recommended` CTA type, shown when the Recommended list has no items and as a persistent card in the list otherwise.
- Copy nudges users to watch, rate, and favorite to sharpen their picks over time.

## Test plan
- [x] `deno task check` - 0 errors
- [x] `deno task test:unit` - green (pre-existing unrelated failure in `toMeasurement.test.ts`)
- [x] Manual check on `/` with a fresh/low-history account to confirm the CTA card and empty-state placeholder render