### PR TITLE
fix(i18n): translates data importer steps and guides

### DIFF
--- a/.github/workflows/supply_chain.yml
+++ b/.github/workflows/supply_chain.yml
@@ -29,6 +29,7 @@ jobs:
             api.github.com:443
             codeload.github.com:443
             deno.com:443
+            dl.deno.land:443
             github.com:443
             jsr.io:443
             npm.jsr.io:443
@@ -115,6 +116,7 @@ jobs:
             api.github.com:443
             codeload.github.com:443
             deno.com:443
+            dl.deno.land:443
             github.com:443
             jsr.io:443
             npm.jsr.io:443

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4822,6 +4822,154 @@
       "default": "CSV File",
       "description": "Import source label for a generic Trakt CSV export file."
     },
+    "import_guide_tvtime_title": {
+      "default": "Your TV Time isn't lost in space! 🚀",
+      "description": "Title of the TV Time import guide."
+    },
+    "import_guide_tvtime_description": {
+      "default": "Two ways to get your data out. Pick whichever suits you and import one export at a time:",
+      "description": "Intro paragraph of the TV Time import guide, shown above the steps."
+    },
+    "import_guide_tvtime_step_1": {
+      "default": "Fastest: export your data with the <a>TV Time Liberator extension</a> while your TV Time login still works, then upload the export .zip (or the activity_history.csv inside it) here",
+      "description": "TV Time import guide, step 1. The <a></a> wraps the link text to the browser extension; keep the tag around the same words."
+    },
+    "import_guide_tvtime_step_2": {
+      "default": "Official: request your GDPR data export on the <a>TV Time privacy portal</a>",
+      "description": "TV Time import guide, step 2. The <a></a> wraps the link text to the privacy portal; keep the tag."
+    },
+    "import_guide_tvtime_step_3": {
+      "default": "Once the export is ready you'll get two emails: one with a .zip file and another with a password to unlock it.",
+      "description": "TV Time import guide, step 3."
+    },
+    "import_guide_tvtime_step_4": {
+      "default": "Upload the unlocked .zip here. If the .zip is not accepted, extract it and upload the two tracking-prod-records .csv files (plus followed_tv_show.csv and ratings-live-votes.csv for your watchlist and ratings) instead.",
+      "description": "TV Time import guide, step 4. Filenames stay verbatim."
+    },
+    "import_guide_imdb_title": {
+      "default": "IMDb on Trakt? Lights, camera, action! ✨",
+      "description": "Title of the IMDb import guide."
+    },
+    "import_guide_imdb_description": {
+      "default": "Download your IMDb watchlist as a .csv and import it here in seconds. It's as easy as 1, 2, Trakt! Here's how to get your .csv file:",
+      "description": "Intro paragraph of the IMDb import guide, shown above the steps."
+    },
+    "import_guide_imdb_step_1": {
+      "default": "Go to IMDb and login",
+      "description": "IMDb import guide, step 1."
+    },
+    "import_guide_imdb_step_2": {
+      "default": "Visit your <a>watchlist</a>",
+      "description": "IMDb import guide, step 2. The <a></a> wraps the link text to the IMDb watchlist page; keep the tag."
+    },
+    "import_guide_imdb_step_3": {
+      "default": "Click on Export",
+      "description": "IMDb import guide, step 3 (export the watchlist)."
+    },
+    "import_guide_imdb_step_4": {
+      "default": "Visit your <a>ratings</a>",
+      "description": "IMDb import guide, step 4. The <a></a> wraps the link text to the IMDb ratings page; keep the tag."
+    },
+    "import_guide_imdb_step_5": {
+      "default": "Click on Export",
+      "description": "IMDb import guide, step 5 (export the ratings)."
+    },
+    "import_guide_imdb_step_6": {
+      "default": "Upload the .csv files here",
+      "description": "IMDb import guide, final step."
+    },
+    "import_guide_letterboxd_title": {
+      "default": "Bring your Letterboxd diary to Trakt! 🎬",
+      "description": "Title of the Letterboxd import guide."
+    },
+    "import_guide_letterboxd_description": {
+      "default": "It's just a hop, skip, and a .zip away! Download your Letterboxd data and import it here. Here's the lowdown on getting that .zip:",
+      "description": "Intro paragraph of the Letterboxd import guide, shown above the steps."
+    },
+    "import_guide_letterboxd_step_1": {
+      "default": "Go to Letterboxd and login",
+      "description": "Letterboxd import guide, step 1."
+    },
+    "import_guide_letterboxd_step_2": {
+      "default": "Open your <a>Letterboxd Export settings</a>",
+      "description": "Letterboxd import guide, step 2. The <a></a> wraps the link text to the Letterboxd export settings page; keep the tag."
+    },
+    "import_guide_letterboxd_step_3": {
+      "default": "Download your Letterboxd export data in a zip file and upload it here",
+      "description": "Letterboxd import guide, final step."
+    },
+    "import_guide_json_title": {
+      "default": "JSON aficionado? Perfect!",
+      "description": "Title of the JSON import guide."
+    },
+    "import_guide_json_description": {
+      "default": "Trakt welcomes your structured data with open arms. Upload your JSON file, making sure it follows our guidelines for a smooth and successful import.",
+      "description": "Intro paragraph of the JSON import guide."
+    },
+    "import_guide_json_intro": {
+      "default": "Your JSON file should contain an array of objects. Each object represents an item to import.",
+      "description": "Intro line of the JSON import guidelines drawer, above the field list."
+    },
+    "import_guide_csv_title": {
+      "default": "Data in a grid? We've got you covered!",
+      "description": "Title of the CSV import guide."
+    },
+    "import_guide_csv_description": {
+      "default": "Upload your CSV file and let Trakt organize your movie and TV show universe. Make sure your CSV is properly formatted with the fields described in the guidelines.",
+      "description": "Intro paragraph of the CSV import guide."
+    },
+    "import_guide_csv_intro": {
+      "default": "Your CSV file should contain a header row followed by one row per item to import.",
+      "description": "Intro line of the CSV import guidelines drawer, above the field list."
+    },
+    "import_guide_field_id_description": {
+      "default": "The ID can be a Trakt ID, IMDB ID, or TMDB ID. For TV shows it can also be a TVDB ID.",
+      "description": "Import guidelines: description of the id field. Shared by the JSON and CSV guides."
+    },
+    "import_guide_field_id_note": {
+      "default": "Prefix with the service name:",
+      "description": "Import guidelines: note before the list of id prefix values (trakt_id, imdb_id, …). Shared by the JSON and CSV guides."
+    },
+    "import_guide_field_type_description": {
+      "default": "Specifies what the ID refers to. Optional but recommended.",
+      "description": "Import guidelines: description of the type field. Shared by the JSON and CSV guides."
+    },
+    "import_guide_field_type_note": {
+      "default": "Values:",
+      "description": "Import guidelines: note before the list of allowed type values (movie, episode, …). Shared by the JSON and CSV guides."
+    },
+    "import_guide_field_watched_at_description": {
+      "default": "Date and time the item was watched. ISO 8601 format.",
+      "description": "Import guidelines: description of the watched_at field. Shared by the JSON and CSV guides."
+    },
+    "import_guide_field_watched_at_note": {
+      "default": "Can be \"unknown\" to import with an unknown watch date. Omit if only adding to watchlist.",
+      "description": "Import guidelines: note for the watched_at field. Shared by the JSON and CSV guides."
+    },
+    "import_guide_field_watchlisted_at_description": {
+      "default": "Date and time the item was added to your watchlist. ISO 8601 format.",
+      "description": "Import guidelines: description of the watchlisted_at field. Shared by the JSON and CSV guides."
+    },
+    "import_guide_field_watchlisted_at_note": {
+      "default": "Omit if only marking as watched.",
+      "description": "Import guidelines: note for the watchlisted_at field. Shared by the JSON and CSV guides."
+    },
+    "import_guide_field_rating_description": {
+      "default": "Rating for the item. Must be a value from 1 to 10.",
+      "description": "Import guidelines: description of the rating field. Shared by the JSON and CSV guides."
+    },
+    "import_guide_field_rated_at_description": {
+      "default": "Date and time the item was rated. ISO 8601 format.",
+      "description": "Import guidelines: description of the rated_at field. Shared by the JSON and CSV guides."
+    },
+    "import_guide_field_rated_at_note": {
+      "default": "Only parsed if a rating is also present.",
+      "description": "Import guidelines: note for the rated_at field. Shared by the JSON and CSV guides."
+    },
+    "import_guide_field_optional": {
+      "default": "optional",
+      "description": "Badge shown next to an import guideline field that is not required."
+    },
     "import_drop_csv": {
       "default": "Drop CSV files here or click to upload.",
       "description": "Prompt shown in the dropzone to upload CSV files for import."

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
   import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
-  import Link from "$lib/components/link/Link.svelte";
+  import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
   import { m } from "$lib/features/i18n/messages.ts";
-  import { EMPTY_SPACE } from "$lib/utils/constants.ts";
   import { slide } from "svelte/transition";
-  import type {
-    ImportSourceConfig,
-    StepSegment,
-  } from "../../import/ImportTypes.ts";
+  import type { ImportSourceConfig } from "../../import/ImportTypes.ts";
   import {
     ImportDrawers,
     importDrawerNavigation,
@@ -34,16 +30,6 @@
   });
 </script>
 
-{#snippet segment(stepSegment: StepSegment)}
-  {#if typeof stepSegment === "string"}
-    {stepSegment}
-  {:else}
-    <Link href={stepSegment.href} target="_blank" rel="noopener noreferrer">
-      {stepSegment.text}
-    </Link>
-  {/if}
-{/snippet}
-
 <div class="trakt-import-guide" class:is-collapsed={isCollapsed}>
   {#if collapsed}
     <button
@@ -53,13 +39,13 @@
       aria-controls="import-guide-body"
       onclick={() => (expanded = !expanded)}
     >
-      <span class="import-guide-title bold ellipsis">{config.guide.title}</span>
+      <span class="import-guide-title bold ellipsis">{config.guide.title()}</span>
       <span class="import-guide-caret" class:is-open={!isCollapsed}>
         <CaretRightIcon />
       </span>
     </button>
   {:else}
-    <p class="import-guide-title bold">{config.guide.title}</p>
+    <p class="import-guide-title bold">{config.guide.title()}</p>
   {/if}
 
   {#if !isCollapsed}
@@ -69,7 +55,7 @@
       transition:slide={{ duration: 150, axis: "y" }}
     >
       {#if config.guide.description != null}
-        <p class="secondary">{config.guide.description}</p>
+        <p class="secondary">{config.guide.description()}</p>
       {/if}
 
       {#if config.guide.steps != null}
@@ -77,10 +63,15 @@
           {#each config.guide.steps as step, i (i)}
             <li>
               <p class="secondary">
-                {#each step as stepSegment, j (j)}
-                  {#if j > 0}{EMPTY_SPACE}{/if}
-                  {@render segment(stepSegment)}
-                {/each}
+                {#if step.href != null}
+                  <MessageWithLink
+                    message={step.text()}
+                    href={step.href}
+                    target="_blank"
+                  />
+                {:else}
+                  {step.text()}
+                {/if}
               </p>
             </li>
           {/each}

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportGuidelinesDrawer.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportGuidelinesDrawer.svelte
@@ -5,11 +5,12 @@
     ImportGuidelineField,
     ImportGuidelines,
     ImportNote,
+    StructuredImportNote,
   } from "../../import/ImportTypes.ts";
 
   function isStructuredNote(
     note: ImportNote,
-  ): note is { text: string; values: string[] } {
+  ): note is StructuredImportNote {
     return typeof note === "object";
   }
 
@@ -28,23 +29,25 @@
     <div class="field-header">
       <code class="field-name bold">{field.name}</code>
       {#if field.optional}
-        <span class="field-badge secondary">optional</span>
+        <span class="field-badge secondary">
+          {m.import_guide_field_optional()}
+        </span>
       {/if}
     </div>
 
-    <p class="field-description">{field.description}</p>
+    <p class="field-description">{field.description()}</p>
 
     {#if field.note}
       {#if isStructuredNote(field.note)}
         <p class="italic secondary">
-          {field.note.text}
+          {field.note.text()}
           {#each field.note.values as value, i (i)}
             <code class="field-value">{value}</code>
             {#if i < field.note.values.length - 1},{/if}
           {/each}
         </p>
       {:else}
-        <p class="italic secondary">{field.note}</p>
+        <p class="italic secondary">{field.note()}</p>
       {/if}
     {/if}
   </div>
@@ -54,7 +57,7 @@
   {#if isOpen}
     <div class="guidelines-content">
       <section class="guidelines-section">
-        <p class="guidelines-intro">{guidelines.intro}</p>
+        <p class="guidelines-intro">{guidelines.intro()}</p>
       </section>
 
       <section class="guidelines-section">

--- a/projects/client/src/lib/sections/settings/import/ImportTypes.ts
+++ b/projects/client/src/lib/sections/settings/import/ImportTypes.ts
@@ -1,3 +1,5 @@
+import * as m from '$lib/features/i18n/messages.ts';
+
 export type ImportSource =
   | 'imdb'
   | 'letterboxd'
@@ -65,28 +67,41 @@ export interface ImportSyncResult {
   ambiguous: AmbiguousImportItem[];
 }
 
-export type StepSegment = string | { text: string; href: string };
-export type ImportStep = StepSegment[];
+/**
+ * Resolves a translatable message at render time. Stored as a reference (never
+ * called at module load) so the guide reacts to locale changes.
+ */
+type MessageGetter = () => string;
 
-export type ImportNote = string | { text: string; values: string[] };
+export interface GuideStep {
+  text: MessageGetter;
+  href?: string;
+}
+
+export interface StructuredImportNote {
+  text: MessageGetter;
+  values: string[];
+}
+
+export type ImportNote = MessageGetter | StructuredImportNote;
 
 export interface ImportGuidelineField {
   name: string;
-  description: string;
+  description: MessageGetter;
   note?: ImportNote;
   optional?: boolean;
 }
 
 export interface ImportGuidelines {
-  intro: string;
+  intro: MessageGetter;
   fields: ImportGuidelineField[];
   example: string;
 }
 
 export interface ImportSourceGuide {
-  title: string;
-  description?: string;
-  steps?: ImportStep[];
+  title: MessageGetter;
+  description?: MessageGetter;
+  steps?: GuideStep[];
   guidelines?: ImportGuidelines;
 }
 
@@ -97,6 +112,64 @@ export interface ImportSourceConfig {
   maxFiles: number;
   guide: ImportSourceGuide;
 }
+
+interface TraktFieldNames {
+  id: string;
+  type: string;
+  watchedAt: string;
+  watchlistedAt: string;
+  rating: string;
+  ratedAt: string;
+}
+
+/**
+ * JSON and CSV share identical field descriptions/notes - only the code field
+ * names and the example block differ. Build the field list from the shared
+ * messages, injecting the format-specific names.
+ */
+const buildTraktGuidelineFields = (
+  names: TraktFieldNames,
+): ImportGuidelineField[] => [
+  {
+    name: names.id,
+    description: m.import_guide_field_id_description,
+    note: {
+      text: m.import_guide_field_id_note,
+      values: ['trakt_id', 'imdb_id', 'tmdb_id', 'tvdb_id'],
+    },
+  },
+  {
+    name: names.type,
+    description: m.import_guide_field_type_description,
+    note: {
+      text: m.import_guide_field_type_note,
+      values: ['movie', 'episode', 'show', 'season'],
+    },
+  },
+  {
+    name: names.watchedAt,
+    description: m.import_guide_field_watched_at_description,
+    note: m.import_guide_field_watched_at_note,
+    optional: true,
+  },
+  {
+    name: names.watchlistedAt,
+    description: m.import_guide_field_watchlisted_at_description,
+    note: m.import_guide_field_watchlisted_at_note,
+    optional: true,
+  },
+  {
+    name: names.rating,
+    description: m.import_guide_field_rating_description,
+    optional: true,
+  },
+  {
+    name: names.ratedAt,
+    description: m.import_guide_field_rated_at_description,
+    note: m.import_guide_field_rated_at_note,
+    optional: true,
+  },
+];
 
 export const IMPORT_SOURCE_CONFIGS: Record<
   ImportSource,
@@ -110,25 +183,20 @@ export const IMPORT_SOURCE_CONFIGS: Record<
     // unrecognized files are filtered out by the parser.
     maxFiles: 50,
     guide: {
-      title: "Your TV Time isn't lost in space! 🚀",
-      description:
-        'Two ways to get your data out. Pick whichever suits you and import one export at a time:',
+      title: m.import_guide_tvtime_title,
+      description: m.import_guide_tvtime_description,
       steps: [
-        [
-          'Fastest: export your data with the',
-          {
-            text: 'TV Time Liberator extension',
-            href:
-              'https://chromewebstore.google.com/detail/tv-time-liberator-extensi/pohobkcjhigehafgnhehkanhjakajhpm',
-          },
-          'while your TV Time login still works, then upload the export .zip (or the activity_history.csv inside it) here',
-        ],
-        ['Official: request your GDPR data export on the', {
-          text: 'TV Time privacy portal',
+        {
+          text: m.import_guide_tvtime_step_1,
+          href:
+            'https://chromewebstore.google.com/detail/tv-time-liberator-extensi/pohobkcjhigehafgnhehkanhjakajhpm',
+        },
+        {
+          text: m.import_guide_tvtime_step_2,
           href: 'https://gdpr.tvtime.com/gdpr/self-service',
-        }],
-        ["Once the export is ready you'll get two emails: one with a .zip file and another with a password to unlock it."],
-        ['Upload the unlocked .zip here. If the .zip is not accepted, extract it and upload the two tracking-prod-records .csv files (plus followed_tv_show.csv and ratings-live-votes.csv for your watchlist and ratings) instead.'],
+        },
+        { text: m.import_guide_tvtime_step_3 },
+        { text: m.import_guide_tvtime_step_4 },
       ],
     },
   },
@@ -138,22 +206,21 @@ export const IMPORT_SOURCE_CONFIGS: Record<
     accept: '.csv',
     maxFiles: 2,
     guide: {
-      title: 'IMDb on Trakt? Lights, camera, action! ✨',
-      description:
-        "Download your IMDb watchlist as a .csv and import it here in seconds. It's as easy as 1, 2, Trakt! Here's how to get your .csv file:",
+      title: m.import_guide_imdb_title,
+      description: m.import_guide_imdb_description,
       steps: [
-        ['Go to IMDb and login'],
-        ['Visit your', {
-          text: 'watchlist',
+        { text: m.import_guide_imdb_step_1 },
+        {
+          text: m.import_guide_imdb_step_2,
           href: 'https://www.imdb.com/list/watchlist',
-        }],
-        ['Click on Export'],
-        ['Visit your', {
-          text: 'ratings',
+        },
+        { text: m.import_guide_imdb_step_3 },
+        {
+          text: m.import_guide_imdb_step_4,
           href: 'https://www.imdb.com/list/ratings',
-        }],
-        ['Click on Export'],
-        ['Upload the .csv files here'],
+        },
+        { text: m.import_guide_imdb_step_5 },
+        { text: m.import_guide_imdb_step_6 },
       ],
     },
   },
@@ -163,16 +230,15 @@ export const IMPORT_SOURCE_CONFIGS: Record<
     accept: '.zip',
     maxFiles: 1,
     guide: {
-      title: 'Bring your Letterboxd diary to Trakt! 🎬',
-      description:
-        "It's just a hop, skip, and a .zip away! Download your Letterboxd data and import it here. Here's the lowdown on getting that .zip:",
+      title: m.import_guide_letterboxd_title,
+      description: m.import_guide_letterboxd_description,
       steps: [
-        ['Go to Letterboxd and login'],
-        ['Open your', {
-          text: 'Letterboxd Export settings',
+        { text: m.import_guide_letterboxd_step_1 },
+        {
+          text: m.import_guide_letterboxd_step_2,
           href: 'https://letterboxd.com/data/export/',
-        }],
-        ['Download your Letterboxd export data in a zip file and upload it here'],
+        },
+        { text: m.import_guide_letterboxd_step_3 },
       ],
     },
   },
@@ -182,57 +248,18 @@ export const IMPORT_SOURCE_CONFIGS: Record<
     accept: '.json,.zip',
     maxFiles: 1,
     guide: {
-      title: 'JSON aficionado? Perfect!',
-      description:
-        'Trakt welcomes your structured data with open arms. Upload your JSON file, making sure it follows our guidelines for a smooth and successful import.',
+      title: m.import_guide_json_title,
+      description: m.import_guide_json_description,
       guidelines: {
-        intro:
-          'Your JSON file should contain an array of objects. Each object represents an item to import.',
-        fields: [
-          {
-            name: '"id": "string"',
-            description:
-              'The ID can be a Trakt ID, IMDB ID, or TMDB ID. For TV shows it can also be a TVDB ID.',
-            note: {
-              text: 'Prefix with the service name:',
-              values: ['trakt_id', 'imdb_id', 'tmdb_id', 'tvdb_id'],
-            },
-          },
-          {
-            name: '"type": "string"',
-            description:
-              'Specifies what the ID refers to. Optional but recommended.',
-            note: {
-              text: 'Values:',
-              values: ['movie', 'episode', 'show', 'season'],
-            },
-          },
-          {
-            name: '"watched_at": "string"',
-            description: 'Date and time the item was watched. ISO 8601 format.',
-            note:
-              'Can be "unknown" to import with an unknown watch date. Omit if only adding to watchlist.',
-            optional: true,
-          },
-          {
-            name: '"watchlisted_at": "string"',
-            description:
-              'Date and time the item was added to your watchlist. ISO 8601 format.',
-            note: 'Omit if only marking as watched.',
-            optional: true,
-          },
-          {
-            name: '"rating": "number"',
-            description: 'Rating for the item. Must be a value from 1 to 10.',
-            optional: true,
-          },
-          {
-            name: '"rated_at": "string"',
-            description: 'Date and time the item was rated. ISO 8601 format.',
-            note: 'Only parsed if a rating is also present.',
-            optional: true,
-          },
-        ],
+        intro: m.import_guide_json_intro,
+        fields: buildTraktGuidelineFields({
+          id: '"id": "string"',
+          type: '"type": "string"',
+          watchedAt: '"watched_at": "string"',
+          watchlistedAt: '"watchlisted_at": "string"',
+          rating: '"rating": "number"',
+          ratedAt: '"rated_at": "string"',
+        }),
         example: `[
   {
     "imdb_id": "tt0068646",
@@ -264,57 +291,18 @@ export const IMPORT_SOURCE_CONFIGS: Record<
     accept: '.csv',
     maxFiles: 1,
     guide: {
-      title: "Data in a grid? We've got you covered!",
-      description:
-        'Upload your CSV file and let Trakt organize your movie and TV show universe. Make sure your CSV is properly formatted with the fields described in the guidelines.',
+      title: m.import_guide_csv_title,
+      description: m.import_guide_csv_description,
       guidelines: {
-        intro:
-          'Your CSV file should contain a header row followed by one row per item to import.',
-        fields: [
-          {
-            name: 'id',
-            description:
-              'The ID can be a Trakt ID, IMDB ID, or TMDB ID. For TV shows it can also be a TVDB ID.',
-            note: {
-              text: 'Prefix with the service name:',
-              values: ['trakt_id', 'imdb_id', 'tmdb_id', 'tvdb_id'],
-            },
-          },
-          {
-            name: 'type',
-            description:
-              'Specifies what the ID refers to. Optional but recommended.',
-            note: {
-              text: 'Values:',
-              values: ['movie', 'episode', 'show', 'season'],
-            },
-          },
-          {
-            name: 'watched_at',
-            description: 'Date and time the item was watched. ISO 8601 format.',
-            note:
-              'Can be "unknown" to import with an unknown watch date. Omit if only adding to watchlist.',
-            optional: true,
-          },
-          {
-            name: 'watchlisted_at',
-            description:
-              'Date and time the item was added to your watchlist. ISO 8601 format.',
-            note: 'Omit if only marking as watched.',
-            optional: true,
-          },
-          {
-            name: 'rating',
-            description: 'Rating for the item. Must be a value from 1 to 10.',
-            optional: true,
-          },
-          {
-            name: 'rated_at',
-            description: 'Date and time the item was rated. ISO 8601 format.',
-            note: 'Only parsed if a rating is also present.',
-            optional: true,
-          },
-        ],
+        intro: m.import_guide_csv_intro,
+        fields: buildTraktGuidelineFields({
+          id: 'id',
+          type: 'type',
+          watchedAt: 'watched_at',
+          watchlistedAt: 'watchlisted_at',
+          rating: 'rating',
+          ratedAt: 'rated_at',
+        }),
         example: `imdb_id,type,watched_at,watchlisted_at,rating,rated_at
 tt0068646,movie,2024-10-25T20:00:00Z,2024-10-01T10:00:00Z,7,2024-10-25T21:00:00Z
 tt15239678,movie,,2024-04-30T11:00:00Z,,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Introduces comprehensive internationalization (i18n) for all data import guides, including TV Time, IMDb, Letterboxd, JSON, and CSV.
- Refactors import guide components to dynamically retrieve localized strings using message getter functions, allowing for future locale changes without code modification.
- Centralizes the definition of common guideline fields for JSON and CSV imports into a shared helper, improving maintainability and reducing code duplication.
- Updates all import source configurations to utilize the new i18n-ready structure for guide titles, descriptions, and individual steps, ensuring consistent localization.
- And a small update to allow `dl.deno.land` in the supply chain check. [They changed it recently.](https://github.com/denoland/setup-deno/pull/130)