### PR TITLE
feat(auth): pass user locale as lang param on login redirect

### DIFF
--- a/projects/client/src/lib/features/auth/stores/useAuth.ts
+++ b/projects/client/src/lib/features/auth/stores/useAuth.ts
@@ -1,3 +1,4 @@
+import { getLocale } from '$lib/features/i18n/index.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { WorkerMessage } from '$worker/WorkerMessage.ts';
@@ -31,9 +32,13 @@ export function useAuth() {
 
   const login = async () => {
     const manager = getUserManager();
+    const [language, region] = getLocale().split('-');
+    const lang = region ? `${language}-${region.toUpperCase()}` : language;
+
     await manager?.signinRedirect({
       extraQueryParams: {
         hide_email_form: 'true',
+        lang,
       },
     });
   };


### PR DESCRIPTION
## Summary
- Auth redirect now sends the user's current locale as a `lang` extraQueryParam so the auth flow proceeds in their language.
- Format: bare language code for English (`en`), `language-REGION` otherwise (e.g. `fr-FR`).

## Test plan
- [x] Switch app locale to French, trigger login, confirm `lang=fr-FR` on the auth.trakt.tv redirect URL
- [x] Switch to English, confirm `lang=en`