### PR TITLE
fix(landing): adds missing translations

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -733,6 +733,18 @@
       "default": "mil. titles tracked weekly",
       "description": "Part of the promotion text for welcoming a new user. Example: 15 mil. titles tracked weekly"
     },
+    "header_landing_welcome": {
+      "default": "Welcome to Trakt",
+      "description": "Heading welcoming a new user on the landing page. This should be short and concise."
+    },
+    "text_landing_welcome": {
+      "default": "Your new home, where your shows and movies are all in one place.",
+      "description": "Subheading on the landing page describing Trakt as a home for the user's shows and movies."
+    },
+    "text_landing_join": {
+      "default": "Track everything you watch, wherever you stream it.",
+      "description": "Supporting text under the join for free button on the landing page, encouraging users to track what they watch."
+    },
     "list_title_trending": {
       "default": "Trending",
       "description": "Title for lists containing trending movies or shows. This title should be as short and concise as possible."

--- a/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
+++ b/projects/client/src/lib/sections/landing/components/JoinForFree.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import LogoMarkCircle from "$lib/components/logo/LogoMarkCircle.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
   import { useTraktTeam } from "$lib/features/team/useTraktTeam";
   import UserAvatar from "$lib/sections/lists/components/UserAvatar.svelte";
   import JoinForFreeButton from "./JoinForFreeButton.svelte";
@@ -13,10 +14,11 @@
   <div class="trakt-landing-social-proof">
     <div class="trakt-social-proof-copy">
       <span class="bold title welcome-title">
-        Welcome to Trakt <LogoMarkCircle />
+        {m.header_landing_welcome()}
+        <LogoMarkCircle />
       </span>
       <p class="secondary">
-        Your new home, where your shows and movies are all in one place.
+        {m.text_landing_welcome()}
       </p>
     </div>
     <div class="trakt-landing-profiles" style="--profile-count: {profileCount}">
@@ -32,7 +34,7 @@
   <div class="trakt-join-for-free-button">
     <JoinForFreeButton />
     <span class="secondary">
-      Track everything you watch, wherever you stream it.
+      {m.text_landing_join()}
     </span>
   </div>
 </div>


### PR DESCRIPTION
## 🎶 Notes 🎶
- Adds internationalization keys for the landing page welcome header, welcome subheading, and join for free call-to-action text.
- Replaces hardcoded strings in the `JoinForFree.svelte` component with the newly added i18n messages.