### PR TITLE
fix(crypto): polyfill crypto.randomUUID for old browsers

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -1,5 +1,6 @@
 import '$lib/polyfills/at.ts';
 import '$lib/polyfills/mapGroupBy.ts';
+import '$lib/polyfills/randomUUID.ts';
 import '$lib/polyfills/toSorted.ts';
 import { SENTRY_DSN } from '$lib/utils/constants.ts';
 import { safeSessionStorage } from '$lib/utils/storage/safeStorage.ts';

--- a/projects/client/src/lib/polyfills/randomUUID.spec.ts
+++ b/projects/client/src/lib/polyfills/randomUUID.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { randomUUIDPolyfill } from './randomUUID.ts';
+
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('crypto.randomUUID polyfill', () => {
+  it('returns a v4-shaped UUID', () => {
+    expect(randomUUIDPolyfill()).toMatch(UUID_V4);
+  });
+
+  it('returns unique values', () => {
+    const ids = new Set(
+      Array.from({ length: 1000 }, () => randomUUIDPolyfill()),
+    );
+    expect(ids.size).toBe(1000);
+  });
+});

--- a/projects/client/src/lib/polyfills/randomUUID.ts
+++ b/projects/client/src/lib/polyfills/randomUUID.ts
@@ -1,0 +1,31 @@
+// Polyfill for crypto.randomUUID (added Chrome 92 / Safari 15.4 / Firefox 95).
+// Sentry: TRAKT-WEB-9J7, TRAKT-WEB-9J8, TRAKT-WEB-AH1, TRAKT-WEB-AGV,
+// TRAKT-WEB-AGT — older mobile browsers (e.g. Chrome Mobile 90 / Android 10)
+// reach the app and crash on `crypto.randomUUID()`, used in SVG icon `<defs>`
+// ids, form element ids and the cookie-consent id. `crypto.getRandomValues` is
+// universally supported, so build an RFC4122 v4 UUID from it.
+
+type UUID = `${string}-${string}-${string}-${string}-${string}`;
+
+export function randomUUIDPolyfill(): UUID {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+
+  // Per RFC4122 v4: set the version (4) and variant (10xx) bits.
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${
+    hex.slice(6, 8).join('')
+  }-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}` as UUID;
+}
+
+if (typeof crypto !== 'undefined' && typeof crypto.randomUUID !== 'function') {
+  // Defined non-enumerable to mirror the native method, matching the `at` polyfill.
+  Object.defineProperty(crypto, 'randomUUID', {
+    value: randomUUIDPolyfill,
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

Same class as the `.at()` polyfill in #2784 — another API missing on old mobile engines. `crypto.randomUUID` only landed in Chrome 92 / Safari 15.4 / Firefox 95, so Chrome Mobile 90 (Android 10) and friends throw the moment we call it.

- Fixes TRAKT-WEB-9J7, TRAKT-WEB-9J8, TRAKT-WEB-AH1, TRAKT-WEB-AGV, TRAKT-WEB-AGT — all `crypto.randomUUID is not a function`, ~150 events in half a day across `/settings`, `/profile/me` and `/`. Culprits are the SVG icon `<defs>` ids (`StarIcon`, `StreakIcon`), form element ids and the cookie-consent id.
- Polyfilled `crypto.randomUUID` from `crypto.getRandomValues` (universally supported), only installing when the native API is missing. Sits next to the existing `at`/`mapGroupBy`/`toSorted` polyfills, loaded in `hooks.client`.
- No call-site changes — all 8 usages work as-is.

## 👀 Example 👀

No visual — compat/crash fix. Verified by root-cause against the Sentry stacks + a unit test on the fallback path; each closes its issue on merge.