### PR TITLE
feat(settings): add import action toggles

### DIFF
--- a/projects/client/src/lib/sections/settings/_internal/RawImport.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/RawImport.svelte
@@ -18,12 +18,15 @@
     type AmbiguousImportItem,
     DEFAULT_IMPORT_SOURCE,
     IMPORT_SOURCE_CONFIGS,
+    type ImportAction,
+    type ImportActionSelection,
     type ImportCounts,
     type ImportSource,
     type ImportSourceConfig,
     type ImportStatus,
     type UniversalImportItem,
   } from "../import/ImportTypes.ts";
+  import { filterImportItemsByActionSelection } from "../import/filterImportItemsByActionSelection.ts";
   import { getParser } from "../import/parsers/getParser.ts";
   import { syncToTrakt } from "../import/syncToTrakt.ts";
   import type { SyncState } from "../sync/models/SyncState.ts";
@@ -40,6 +43,14 @@
     return DEFAULT_IMPORT_SOURCE;
   }
 
+  function defaultSelectedActions(): ImportActionSelection {
+    return {
+      history: true,
+      watchlist: true,
+      ratings: true,
+    };
+  }
+
   const { importInProgress } = useImportInProgress();
   const { invalidate } = useInvalidator();
   const { record } = useAnalytics();
@@ -48,6 +59,7 @@
 
   type ImportUIState = SyncState<ImportStatus> & {
     selectedSource: ImportSource;
+    selectedActions: ImportActionSelection;
     parsedItems: ReadonlyArray<UniversalImportItem>;
     errorCount: number;
     unresolved: ReadonlyArray<UniversalImportItem>;
@@ -59,6 +71,7 @@
 
   const state = $state<ImportUIState>({
     selectedSource: DEFAULT_IMPORT_SOURCE,
+    selectedActions: defaultSelectedActions(),
     status: "idle",
     parsedItems: [],
     processedCount: 0,
@@ -76,6 +89,18 @@
     watchlist: state.parsedItems.filter((i) => i.action === "watchlist").length,
     ratings: state.parsedItems.filter((i) => i.action === "ratings").length,
   });
+  const selectedItems = $derived(
+    filterImportItemsByActionSelection({
+      items: state.parsedItems,
+      selectedActions: state.selectedActions,
+    }),
+  );
+  const selectedCounts = $derived<ImportCounts>({
+    history: state.selectedActions.history ? counts.history : 0,
+    watchlist: state.selectedActions.watchlist ? counts.watchlist : 0,
+    ratings: state.selectedActions.ratings ? counts.ratings : 0,
+  });
+  const selectedTotalCount = $derived(selectedItems.length);
 
   const sourceConfig = $derived(IMPORT_SOURCE_CONFIGS[state.selectedSource]);
   const isGuideCollapsed = $derived(
@@ -94,6 +119,7 @@
     const parser = getParser(state.selectedSource);
 
     state.parseError = null;
+    state.selectedActions = defaultSelectedActions();
     state.status = "parsing";
 
     try {
@@ -126,6 +152,11 @@
   }
 
   async function startImport() {
+    const itemsToImport = selectedItems;
+    const countsToImport = selectedCounts;
+    const totalToImport = selectedTotalCount;
+    if (totalToImport === 0) return;
+
     abortController = new AbortController();
     const startTime = Date.now();
     state.processedCount = 0;
@@ -136,7 +167,7 @@
 
     try {
       const { errorCount, unresolved, ambiguous } = await syncToTrakt(
-        state.parsedItems,
+        itemsToImport,
         {
           signal: abortController.signal,
           onMatchProgress: (processed, total) => {
@@ -160,7 +191,7 @@
       );
 
       const duration = Date.now() - startTime;
-      const successCount = state.totalCount - errorCount - unresolved.length -
+      const successCount = totalToImport - errorCount - unresolved.length -
         ambiguous.length;
 
       state.errorCount = errorCount;
@@ -169,10 +200,10 @@
 
       record(AnalyticsEvent.ImportCompleted, {
         source: state.selectedSource,
-        totalItems: state.totalCount,
-        historyCount: counts.history,
-        watchlistCount: counts.watchlist,
-        ratingsCount: counts.ratings,
+        totalItems: totalToImport,
+        historyCount: countsToImport.history,
+        watchlistCount: countsToImport.watchlist,
+        ratingsCount: countsToImport.ratings,
         successCount,
         failedCount: errorCount,
         unresolvedCount: unresolved.length,
@@ -222,6 +253,7 @@
   function reset() {
     abortController?.abort();
     state.status = "idle";
+    state.selectedActions = defaultSelectedActions();
     state.parsedItems = [];
     state.processedCount = 0;
     state.errorCount = 0;
@@ -258,6 +290,13 @@
         return config.name;
     }
   };
+
+  function onActionChange(action: ImportAction, isIncluded: boolean) {
+    state.selectedActions = {
+      ...state.selectedActions,
+      [action]: isIncluded,
+    };
+  }
 </script>
 
 {#snippet importRow()}
@@ -283,8 +322,9 @@
         {:else if state.status === "review"}
           <ImportSummary
             {counts}
-            totalItems={state.totalCount}
+            selectedActions={state.selectedActions}
             source={state.selectedSource}
+            onactionchange={onActionChange}
             onstart={startImport}
             onreset={reset}
           />
@@ -300,10 +340,10 @@
         {:else if state.status === "syncing"}
           <SyncProgress
             processedCount={state.processedCount}
-            totalCount={state.totalCount}
+            totalCount={selectedTotalCount}
             label={m.import_status_syncing({
               processed: state.processedCount,
-              total: state.totalCount,
+              total: selectedTotalCount,
             })}
           />
         {:else if state.status === "complete"}

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportSummary.spec.ts
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportSummary.spec.ts
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { of } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import ImportSummary from './ImportSummary.svelte';
+
+vi.mock('$lib/features/auth/stores/useUser.ts', () => ({
+  useUser: () => ({
+    user: of({ isVip: true }),
+    limits: of(null),
+  }),
+}));
+
+describe('ImportSummary', () => {
+  const counts = {
+    history: 2,
+    watchlist: 3,
+    ratings: 1,
+  };
+
+  it('should show an enabled switch for every import action with items', () => {
+    render(ImportSummary, {
+      counts,
+      selectedActions: {
+        history: true,
+        watchlist: true,
+        ratings: true,
+      },
+      source: 'tvtime',
+      onactionchange: vi.fn(),
+      onstart: vi.fn(),
+      onreset: vi.fn(),
+    });
+
+    expect(screen.getByRole('switch', { name: '2 items for History' }))
+      .toBeChecked();
+    expect(screen.getByRole('switch', { name: '3 items for Watchlist' }))
+      .toBeChecked();
+    expect(screen.getByRole('switch', { name: '1 ratings' })).toBeChecked();
+  });
+
+  it('should request skipping an import action when its switch is clicked', async () => {
+    const onactionchange = vi.fn();
+
+    render(ImportSummary, {
+      counts,
+      selectedActions: {
+        history: true,
+        watchlist: true,
+        ratings: true,
+      },
+      source: 'tvtime',
+      onactionchange,
+      onstart: vi.fn(),
+      onreset: vi.fn(),
+    });
+
+    await fireEvent.click(
+      screen.getByRole('switch', { name: '3 items for Watchlist' }),
+    );
+
+    expect(onactionchange).toHaveBeenCalledWith('watchlist', false);
+  });
+
+  it('should disable start import when all import actions are skipped', () => {
+    render(ImportSummary, {
+      counts,
+      selectedActions: {
+        history: false,
+        watchlist: false,
+        ratings: false,
+      },
+      source: 'tvtime',
+      onactionchange: vi.fn(),
+      onstart: vi.fn(),
+      onreset: vi.fn(),
+    });
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Start importing your data into Trakt.',
+      }),
+    ).toBeDisabled();
+  });
+});

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportSummary.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportSummary.svelte
@@ -1,23 +1,61 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
+  import Switch from "$lib/components/toggles/Switch.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import UpsellCta from "$lib/features/upsell/UpsellCta.svelte";
   import { slide } from "svelte/transition";
-  import type { ImportCounts, ImportSource } from "../../import/ImportTypes.ts";
+  import type {
+    ImportAction,
+    ImportActionSelection,
+    ImportCounts,
+    ImportSource,
+  } from "../../import/ImportTypes.ts";
 
   type ImportSummaryProps = {
     counts: ImportCounts;
-    totalItems: number;
+    selectedActions: ImportActionSelection;
     source: ImportSource;
+    onactionchange: (action: ImportAction, isIncluded: boolean) => void;
     onstart: () => void;
     onreset: () => void;
   };
 
-  const { counts, totalItems, source, onstart, onreset }: ImportSummaryProps =
-    $props();
+  const {
+    counts,
+    selectedActions,
+    source,
+    onactionchange,
+    onstart,
+    onreset,
+  }: ImportSummaryProps = $props();
 
   const { user, limits } = useUser();
+
+  const selectedCounts = $derived<ImportCounts>({
+    history: selectedActions.history ? counts.history : 0,
+    watchlist: selectedActions.watchlist ? counts.watchlist : 0,
+    ratings: selectedActions.ratings ? counts.ratings : 0,
+  });
+  const selectedTotalItems = $derived(
+    selectedCounts.history + selectedCounts.watchlist + selectedCounts.ratings,
+  );
+
+  const actionRows = $derived<
+    ReadonlyArray<{
+      action: ImportAction;
+      count: number;
+      label: (inputs: { count: number }) => string;
+    }>
+  >([
+    { action: "history", count: counts.history, label: m.import_summary_history },
+    {
+      action: "watchlist",
+      count: counts.watchlist,
+      label: m.import_summary_watchlist,
+    },
+    { action: "ratings", count: counts.ratings, label: m.import_summary_ratings },
+  ]);
 
   const isVipLimitExceeded = $derived.by(() => {
     if ($user?.isVip) return false;
@@ -29,7 +67,8 @@
     const historyFreeLimit = $limits.history.free * limitMultiplier;
 
     return (
-      counts.watchlist > watchlistFreeLimit || counts.history > historyFreeLimit
+      selectedCounts.watchlist > watchlistFreeLimit ||
+      selectedCounts.history > historyFreeLimit
     );
   });
 </script>
@@ -39,33 +78,37 @@
   transition:slide={{ duration: 150, axis: "y" }}
 >
   <div class="import-summary-counts">
-    {#if counts.history > 0}
-      <p class="secondary">
-        {m.import_summary_history({ count: counts.history })}
-      </p>
-    {/if}
-    {#if counts.watchlist > 0}
-      <p class="secondary">
-        {m.import_summary_watchlist({ count: counts.watchlist })}
-      </p>
-    {/if}
-    {#if counts.ratings > 0}
-      <p class="secondary">
-        {m.import_summary_ratings({ count: counts.ratings })}
-      </p>
-    {/if}
+    {#each actionRows as { action, count, label } (action)}
+      {#if count > 0}
+        <div
+          class="import-summary-action"
+          data-included={selectedActions[action] ? "true" : "false"}
+        >
+          <span class="import-summary-switch">
+            <Switch
+              label={label({ count })}
+              checked={selectedActions[action]}
+              onclick={() => onactionchange(action, !selectedActions[action])}
+            />
+          </span>
+          <p class="secondary" aria-hidden="true">
+            {label({ count })}
+          </p>
+        </div>
+      {/if}
+    {/each}
   </div>
 
   {#if isVipLimitExceeded}
     <UpsellCta source="import" variant="small">
-      {m.import_vip_limit_exceeded({ count: totalItems })}
+      {m.import_vip_limit_exceeded({ count: selectedTotalItems })}
     </UpsellCta>
   {/if}
 
   <div class="import-summary-actions">
     <Button
       label={m.button_label_start_import()}
-      disabled={isVipLimitExceeded || totalItems === 0}
+      disabled={isVipLimitExceeded || selectedTotalItems === 0}
       onclick={onstart}
       color="purple"
       size="small"
@@ -94,6 +137,40 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-xs);
+  }
+
+  .import-summary-action {
+    display: grid;
+    grid-template-columns: var(--ni-44) minmax(0, 1fr);
+    align-items: center;
+    gap: var(--gap-xs);
+
+    p {
+      transition:
+        opacity var(--transition-increment) ease-in-out,
+        text-decoration-color var(--transition-increment) ease-in-out;
+    }
+
+    &[data-included="false"] {
+      p {
+        opacity: 0.55;
+        text-decoration: line-through;
+        text-decoration-color: currentColor;
+      }
+    }
+  }
+
+  .import-summary-switch {
+    display: flex;
+    align-items: center;
+    inline-size: var(--ni-44);
+
+    :global(.trakt-switch) {
+      --button-width: var(--ni-44);
+      --button-height: var(--ni-20);
+      --tick-size: var(--ni-14);
+      --tick-offset: var(--ni-3);
+    }
   }
 
   .import-summary-actions {

--- a/projects/client/src/lib/sections/settings/import/ImportTypes.ts
+++ b/projects/client/src/lib/sections/settings/import/ImportTypes.ts
@@ -11,6 +11,8 @@ export const DEFAULT_IMPORT_SOURCE: ImportSource = 'tvtime';
 
 export type ImportAction = 'history' | 'watchlist' | 'ratings';
 
+export type ImportActionSelection = Record<ImportAction, boolean>;
+
 export type ImportType = 'movie' | 'show' | 'episode';
 
 export type ImportStatus =

--- a/projects/client/src/lib/sections/settings/import/filterImportItemsByActionSelection.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/filterImportItemsByActionSelection.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { filterImportItemsByActionSelection } from './filterImportItemsByActionSelection.ts';
+import type { UniversalImportItem } from './ImportTypes.ts';
+
+const items: UniversalImportItem[] = [
+  {
+    action: 'history',
+    type: 'episode',
+    ids: { tvdb: 1 },
+  },
+  {
+    action: 'watchlist',
+    type: 'show',
+    ids: { tvdb: 2 },
+  },
+  {
+    action: 'ratings',
+    type: 'movie',
+    ids: { trakt: 3 },
+    rating: 10,
+  },
+];
+
+describe('filterImportItemsByActionSelection', () => {
+  it('should keep only items whose import action is selected', () => {
+    const result = filterImportItemsByActionSelection({
+      items,
+      selectedActions: {
+        history: false,
+        watchlist: true,
+        ratings: true,
+      },
+    });
+
+    expect(result.map((item) => item.action)).toEqual([
+      'watchlist',
+      'ratings',
+    ]);
+  });
+
+  it('should return an empty array when every import action is skipped', () => {
+    const result = filterImportItemsByActionSelection({
+      items,
+      selectedActions: {
+        history: false,
+        watchlist: false,
+        ratings: false,
+      },
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/projects/client/src/lib/sections/settings/import/filterImportItemsByActionSelection.ts
+++ b/projects/client/src/lib/sections/settings/import/filterImportItemsByActionSelection.ts
@@ -1,0 +1,15 @@
+import type {
+  ImportActionSelection,
+  UniversalImportItem,
+} from './ImportTypes.ts';
+
+interface FilterImportItemsByActionSelectionParams {
+  items: ReadonlyArray<UniversalImportItem>;
+  selectedActions: ImportActionSelection;
+}
+
+export function filterImportItemsByActionSelection(
+  { items, selectedActions }: FilterImportItemsByActionSelectionParams,
+): UniversalImportItem[] {
+  return items.filter((item) => selectedActions[item.action]);
+}


### PR DESCRIPTION
## Summary

Adds category toggles to the import review screen so users can choose whether to import History, Watchlist, and Ratings before starting an import.

## Changes

- Adds compact, left-aligned switches beside each import category count.
- Filters parsed import items by the selected categories before syncing to Trakt.
- Updates progress totals, analytics counts, success counts, and VIP limit checks to use the selected import categories.
- Adds focused tests for import action filtering and review-screen toggle behavior.

## Screenshot

<img width="2940" height="1914" alt="Screenshot 2026-07-03 at 18 11 12" src="https://github.com/user-attachments/assets/bba8fc6f-2776-4abc-8f22-b6bb092f4d98" />
