### PR TITLE
fix(settings): detect TV Time gdpr v2 files by key column

### DIFF
--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
@@ -50,7 +50,7 @@ async function detectFormat(file: File): Promise<TvTimeFormat> {
   if (!first) return 'unknown';
   if ('imdb_id' in first) return 'liberator';
   if (
-    'type-uuid-n' in first || 'ep_id' in first ||
+    'type-uuid-n' in first || 'key' in first ||
     'notification_offset' in first || 'vote_key' in first
   ) {
     return 'gdpr';

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
@@ -67,6 +67,27 @@ const V2_HEADER = [
   'is_special',
 ];
 
+// TV Time prunes every episode-level column (ep_id, episode_id, ...) when
+// the account has no watch history, leaving this series-only header.
+const V2_SLIM_HEADER = [
+  'movie_watch_count',
+  'series_follow_count',
+  'key',
+  'total_series_runtime',
+  'user_id',
+  'updated_at',
+  'ep_watch_count',
+  'total_movies_runtime',
+  'created_at',
+  'uuid',
+  's_id',
+  'followed_at',
+  'is_archived',
+  'series_name',
+  'is_for_later',
+  'is_followed',
+];
+
 function toCsv(
   header: string[],
   rows: Record<string, string>[],
@@ -286,6 +307,40 @@ describe('TvTimeGdprParser', () => {
       const result = await TvTimeGdprParser.parse([csvFile(csv)]);
 
       expect(result).toHaveLength(0);
+    });
+  });
+
+  // Accounts with no watch history export a series-only header with none of
+  // the episode columns, so the v2 format must be detected off s_id.
+  describe('v2 tracking file: slim header (no watch history)', () => {
+    it('should watchlist followed shows', async () => {
+      const csv = toCsv(V2_SLIM_HEADER, [
+        v2UserSeries({ is_followed: 'true' }),
+      ]);
+
+      const result = await TvTimeGdprParser.parse([csvFile(csv)]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'watchlist',
+        type: 'show',
+        ids: { tvdb: 353309 },
+      });
+    });
+
+    it('should watchlist shows marked for later', async () => {
+      const csv = toCsv(V2_SLIM_HEADER, [
+        v2UserSeries({ is_for_later: 'true' }),
+      ]);
+
+      const result = await TvTimeGdprParser.parse([csvFile(csv)]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'watchlist',
+        type: 'show',
+        ids: { tvdb: 353309 },
+      });
     });
   });
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
@@ -46,7 +46,11 @@ type RatingVoteRow = {
 };
 
 const TRACKING_V1_MARKER = 'type-uuid-n';
-const TRACKING_V2_MARKER = 'ep_id';
+// Every v2 row is identified by its `key` (watch-episode-*, user-series-*,
+// tracking-stats) — it's the field the parser branches on. The episode
+// columns (ep_id, episode_id, ...) are pruned by TV Time when the account
+// has no watch history, so they can't be relied on to detect the format.
+const TRACKING_V2_MARKER = 'key';
 const FOLLOWED_SHOW_MARKER = 'notification_offset';
 
 // emotions-live-votes.csv shares this header, so rating votes are routed


### PR DESCRIPTION
## 🎶 Notes 🎶

- TV Time exports `tracking-prod-records-v2.csv`, but its columns aren't stable: when an account has no watch history, TV Time prunes every episode-level column (`ep_id`, `episode_id`, …), leaving a series-only header.
- We were detecting the v2 format off `ep_id`, so those slim exports slipped through:
  - whole-zip import → the rows fell through every bucket and got silently dropped. The watchlist only survived via the `followed_tv_show.csv` backfill.
  - loose CSV upload → the file was rejected outright as *"not a TV Time export"*.
- Keyed detection off the always-present `key` column instead (`watch-episode-*` / `user-series-*` / `tracking-stats`). It's the field the parser already branches on, and it's exclusive to v2 — v1 uses `type-uuid-n`, followed uses `notification_offset`, ratings/emotions use `vote_key`.
- Added a slim-header fixture + regression tests.
- Verified header-only against real exports (history + no-history, v1-only, mixed v1+v2): no misrouting, full exports behave exactly as before — the fix only rescues the slim variant.