### PR TITLE
fix(episode): media card links

### DIFF
--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -138,7 +138,7 @@
   });
 
   const href = $derived(
-    isShowContext && rest.type === "episode"
+    rest.type === "episode"
       ? UrlBuilder.episode(media.slug, rest.episode.season, rest.episode.number)
       : UrlBuilder.media(media.type, media.slug),
   );


### PR DESCRIPTION
## Summary

- Episode cards in `MediaSummaryCard` were navigating to the show page instead of the episode page outside of a show context (e.g. history page, recommended list)
- The `isShowContext` guard belonged on card display logic only (episode title vs show title + episode number), not on the `href`

## Background

Recurring regression of f7d91834. Re-introduced by 555575ebd (`feat(recommended)`) which was developed on a branch predating that fix — when merged, the `href` line resolved to the old code and lost the fix.

## Test plan

- [x] Go to `/history` and click an episode — should navigate to `/shows/{slug}/seasons/{s}/episodes/{e}`, not `/shows/{slug}`
- [x] Open a show's seasons drawer and click an episode — should still navigate to the episode page