### PR TITLE
feat(rating): Enhances removal and UI for ratings

### DIFF
--- a/projects/client/src/lib/requests/sync/toRemoveRatingsPayload.ts
+++ b/projects/client/src/lib/requests/sync/toRemoveRatingsPayload.ts
@@ -1,0 +1,15 @@
+import type { RemoveRatingsParams } from '@trakt/api';
+
+type RatingMediaType = 'movie' | 'show' | 'episode';
+
+// Builds the sync/ratings/remove body for a set of trakt ids of a single media
+// type. The computed `${type}s` key can't be verified against the union, hence
+// the cast at the boundary.
+export function toRemoveRatingsPayload(
+  type: RatingMediaType,
+  traktIds: ReadonlyArray<number>,
+): RemoveRatingsParams {
+  return {
+    [`${type}s`]: traktIds.map((trakt) => ({ ids: { trakt } })),
+  } as RemoveRatingsParams;
+}

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.spec.ts
@@ -14,12 +14,21 @@ import {
 
 vi.mock('$lib/stores/useInvalidator.ts');
 
+const removeRatingSpy = vi.fn((_body?: unknown) => Promise.resolve(true));
+vi.mock('$lib/requests/sync/removeRatingRequest.ts', () => ({
+  removeRatingRequest: (body: unknown) => removeRatingSpy(body),
+}));
+vi.mock('$lib/requests/sync/removeWatchedRequest.ts', () => ({
+  removeWatchedRequest: () => Promise.resolve(true),
+}));
+
 describe('useMarkAsWatched', () => {
   const invalidate = vi.fn(function () {});
 
   beforeEach(() => {
     setAuthorization(true);
     invalidate.mockReset();
+    removeRatingSpy.mockClear();
 
     (useInvalidator as Mock)
       .mockReturnValueOnce({ invalidate }) // 1: useMarkAsWatched
@@ -115,6 +124,53 @@ describe('useMarkAsWatched', () => {
       );
 
       expect(await waitForEmission(isWatched, 2)).toBe(true);
+    });
+  });
+
+  describe('orphaned ratings on remove', () => {
+    it('should remove the rating when removing the last watch of a rated movie', async () => {
+      const { removeWatched } = await renderStore(() =>
+        useMarkAsWatched({
+          type: 'movie' as const,
+          // Heretic (916302): single play in history, carries a rating.
+          media: { id: 916302, effectiveReleaseDate: new Date('2020-01-01') },
+        })
+      );
+
+      await removeWatched();
+
+      expect(removeRatingSpy).toHaveBeenCalledWith({
+        body: { movies: [{ ids: { trakt: 916302 } }] },
+      });
+    });
+
+    it('should NOT remove a rating for an unrated movie', async () => {
+      const { removeWatched } = await renderStore(() =>
+        useMarkAsWatched({
+          type: 'movie' as const,
+          media: { id: 1, effectiveReleaseDate: new Date('2020-01-01') },
+        })
+      );
+
+      await removeWatched();
+
+      expect(removeRatingSpy).not.toHaveBeenCalled();
+    });
+
+    it('should remove the rating of a rated, watched show (all plays removed)', async () => {
+      const { removeWatched } = await renderStore(() =>
+        useMarkAsWatched({
+          type: 'show' as const,
+          // Silo (180770): watched + rated; the main action wipes all plays.
+          media: { id: 180770, effectiveReleaseDate: new Date('2020-01-01') },
+        })
+      );
+
+      await removeWatched();
+
+      expect(removeRatingSpy).toHaveBeenCalledWith({
+        body: { shows: [{ ids: { trakt: 180770 } }] },
+      });
     });
   });
 

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
@@ -5,11 +5,13 @@ import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
 import { markAsWatchedRequest } from '$lib/requests/sync/markAsWatchedRequest.ts';
+import { removeRatingRequest } from '$lib/requests/sync/removeRatingRequest.ts';
 import { removeWatchedRequest } from '$lib/requests/sync/removeWatchedRequest.ts';
+import { toRemoveRatingsPayload } from '$lib/requests/sync/toRemoveRatingsPayload.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { hasAired } from '$lib/utils/media/hasAired.ts';
 import { resolve } from '$lib/utils/store/resolve.ts';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, filter } from 'rxjs';
 import type { MarkAsWatchedAt } from '../../../models/MarkAsWatchedAt.ts';
 import { toMarkAsWatchedPayload } from './toMarkAsWatchedPayload.ts';
 import { useIsWatched } from './useIsWatched.ts';
@@ -24,7 +26,7 @@ export function useMarkAsWatched(
   const { type } = props;
   const media = Array.isArray(props.media) ? props.media : [props.media];
   const isMarkingAsWatched = new BehaviorSubject(false);
-  const { user } = useUser();
+  const { user, history, ratings } = useUser();
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.MarkAsWatched);
 
@@ -51,13 +53,60 @@ export function useMarkAsWatched(
     isMarkingAsWatched.next(false);
   };
 
+  // Ids whose rating this removal orphans. The main action removes *every*
+  // play of the target, so history goes empty regardless of play count - a
+  // rated item that's currently watched always qualifies (a rewatch does not
+  // preserve the rating here). Gating on "currently watched" keeps us from
+  // touching ratings on items that weren't in the history to begin with. Read
+  // pre-removal, hence before the request below.
+  const getOrphanedRatingIds = async (): Promise<number[]> => {
+    // `history` emits `null` while unsettled; resolve() only skips `undefined`,
+    // so gate on a settled (non-null) value or we'd read an empty history and
+    // never orphan the rating.
+    const [currentHistory, currentRatings] = await Promise.all([
+      resolve(history.pipe(filter((value) => value !== null))),
+      resolve(ratings),
+    ]);
+
+    if (!currentHistory || !currentRatings) {
+      return [];
+    }
+
+    const isOrphanedRating = (item: { id: number }): boolean => {
+      switch (props.type) {
+        case 'movie':
+          return currentRatings.movies.has(item.id) &&
+            currentHistory.movies.has(item.id);
+        case 'show':
+          return currentRatings.shows.has(item.id) &&
+            currentHistory.shows.has(item.id);
+        case 'episode': {
+          const isWatched = currentHistory.shows.get(props.show.id)
+            ?.episodes.some((entry) => entry.episodeId === item.id);
+          return currentRatings.episodes.has(item.id) && Boolean(isWatched);
+        }
+      }
+    };
+
+    return media.filter(isOrphanedRating).map((item) => item.id);
+  };
+
   const removeWatched = async () => {
     isMarkingAsWatched.next(true);
     track({ action: 'remove' });
 
+    const orphanedRatingIds = await getOrphanedRatingIds();
+
     await removeWatchedRequest({
       body: toMarkAsWatchedPayload(props),
     });
+
+    if (orphanedRatingIds.length > 0) {
+      await removeRatingRequest({
+        body: toRemoveRatingsPayload(type, orphanedRatingIds),
+      });
+      await invalidate(InvalidateAction.Rated(type));
+    }
 
     await invalidate(InvalidateAction.MarkAsWatched(type));
 

--- a/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.spec.ts
@@ -4,21 +4,29 @@ import {
   type UseRemoveFromHistoryProps,
 } from '$lib/sections/media-actions/remove-from-history/useRemoveFromHistory.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { renderStore } from '$test/beds/store/renderStore.ts';
+import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
 import { firstValueFrom } from 'rxjs';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
 vi.mock('$lib/stores/useInvalidator.ts');
 
+const removeRatingSpy = vi.fn((_body?: unknown) => Promise.resolve(true));
+vi.mock('$lib/requests/sync/removeRatingRequest.ts', () => ({
+  removeRatingRequest: (body: unknown) => removeRatingSpy(body),
+}));
+vi.mock('$lib/requests/sync/removeWatchedRequest.ts', () => ({
+  removeWatchedRequest: () => Promise.resolve(true),
+}));
+
 describe('useRemoveFromHistory', () => {
   const invalidate = vi.fn(function () {});
 
   beforeEach(() => {
+    setAuthorization(true);
     invalidate.mockReset();
+    removeRatingSpy.mockClear();
 
-    (useInvalidator as Mock)
-      .mockReturnValueOnce({ invalidate }) // 1: useRemoveFromHistory
-      .mockReturnValueOnce({ invalidate }); // 2: useRemoveFromHistory -> useTrack -> useUser
+    (useInvalidator as Mock).mockReturnValue({ invalidate });
   });
 
   const runCommonTests = (
@@ -56,15 +64,45 @@ describe('useRemoveFromHistory', () => {
     const props = {
       type: 'movie' as const,
       id: 1,
+      movie: { id: 1 },
     };
 
     runCommonTests(props, InvalidateAction.MarkAsWatched('movie'));
+
+    it('should remove the orphaned rating when removing the last watch', async () => {
+      const { removeFromHistory } = await renderStore(() =>
+        useRemoveFromHistory({
+          type: 'movie' as const,
+          id: 42,
+          // Heretic (916302): single play in history, carries a rating.
+          movie: { id: 916302 },
+        })
+      );
+
+      await removeFromHistory();
+
+      expect(removeRatingSpy).toHaveBeenCalledWith({
+        body: { movies: [{ ids: { trakt: 916302 } }] },
+      });
+    });
+
+    it('should NOT remove a rating for an unrated movie', async () => {
+      const { removeFromHistory } = await renderStore(() =>
+        useRemoveFromHistory(props)
+      );
+
+      await removeFromHistory();
+
+      expect(removeRatingSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('media type: episode', () => {
     const props = {
       type: 'episode' as const,
       id: 1,
+      episode: { id: 1 },
+      show: { id: 1 },
     };
 
     runCommonTests(props, InvalidateAction.MarkAsWatched('episode'));

--- a/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.ts
+++ b/projects/client/src/lib/sections/media-actions/remove-from-history/useRemoveFromHistory.ts
@@ -1,25 +1,76 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { removeRatingRequest } from '$lib/requests/sync/removeRatingRequest.ts';
 import { removeWatchedRequest } from '$lib/requests/sync/removeWatchedRequest.ts';
+import { toRemoveRatingsPayload } from '$lib/requests/sync/toRemoveRatingsPayload.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, filter } from 'rxjs';
+import { resolve } from '$lib/utils/store/resolve.ts';
 
-export type UseRemoveFromHistoryProps = {
-  id: number;
-  type: 'movie' | 'episode';
-};
+export type UseRemoveFromHistoryProps =
+  | { type: 'movie'; id: number; movie: { id: number } }
+  | {
+    type: 'episode';
+    id: number;
+    episode: { id: number };
+    show: { id: number };
+  };
 
-export function useRemoveFromHistory({ id, type }: UseRemoveFromHistoryProps) {
+export function useRemoveFromHistory(props: UseRemoveFromHistoryProps) {
+  const { id, type } = props;
+  // Trakt id of the media itself; `id` above is the history entry (play) id.
+  const traktId = props.type === 'movie' ? props.movie.id : props.episode.id;
+
   const isRemoving = new BehaviorSubject(false);
+  const { history, ratings } = useUser();
   const { invalidate } = useInvalidator();
   const { track } = useTrack(AnalyticsEvent.RemoveFromHistory);
+
+  // Whether this removal empties the item's watch history *and* it still
+  // carries a rating - i.e. the rating is about to be orphaned. Only a single
+  // remaining play counts as "last", so a rewatched item keeps its rating.
+  // `history` emits `null` while unsettled and resolve() only skips
+  // `undefined`, so gate on a settled value or we'd read an empty history.
+  const isLastRatedPlay = async (): Promise<boolean> => {
+    const [currentHistory, currentRatings] = await Promise.all([
+      resolve(history.pipe(filter((value) => value !== null))),
+      resolve(ratings),
+    ]);
+
+    if (!currentHistory || !currentRatings) {
+      return false;
+    }
+
+    switch (props.type) {
+      case 'movie':
+        return currentRatings.movies.has(traktId) &&
+          currentHistory.movies.get(traktId)?.plays === 1;
+      case 'episode': {
+        const episode = currentHistory.shows.get(props.show.id)
+          ?.episodes.find((entry) => entry.episodeId === traktId);
+        return currentRatings.episodes.has(traktId) &&
+          episode?.plays === 1;
+      }
+    }
+  };
 
   const removeFromHistory = async () => {
     isRemoving.next(true);
     track();
 
+    const shouldRemoveRating = await isLastRatedPlay();
+
     await removeWatchedRequest({ body: { ids: [id] } });
+
+    if (shouldRemoveRating) {
+      await removeRatingRequest({
+        body: toRemoveRatingsPayload(type, [traktId]),
+      });
+      await invalidate(InvalidateAction.Rated(type));
+    }
+
     await invalidate(InvalidateAction.MarkAsWatched(type));
 
     isRemoving.next(false);

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -74,10 +74,6 @@
           removeRating();
         }}
         onAddRating={(rating: number, ev?: MouseEvent) => {
-          if (rating === $current?.rating) {
-            return;
-          }
-
           onclick?.();
           setConfettiPosition(rating, ev);
           addRating(rating);

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte
@@ -64,6 +64,8 @@
 
   const displayStars = $derived(previewStars ?? committedStars);
   const isPreviewing = $derived(previewStars !== null);
+  // Previewing the "no rating" state - tint the row red to signal removal.
+  const isClearing = $derived(isPreviewing && displayStars <= 0);
   const highlightIndex = $derived(Math.ceil(displayStars) - 1);
 
   // Layout measured once per interaction and reused across pointermoves; reading
@@ -240,6 +242,7 @@
   class="trakt-rating-stars"
   data-variant={variant}
   class:is-previewing={isPreviewing}
+  class:is-clearing={isClearing}
   class:is-touch-scrub={isTouchScrub && isPreviewing}
   bind:this={rootEl}
 >
@@ -369,6 +372,11 @@
       :global(.star-item:not([data-highlighted])) {
         opacity: 0.75;
       }
+    }
+
+    // Hovering the "no rating" zone: recolor the row red to flag removal.
+    &.is-clearing :global(.star-item) {
+      color: var(--red-500);
     }
 
     // Touch scrub: the thumb sits on the active star, so lift it and the

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte
@@ -128,6 +128,8 @@
     previewStars = null;
     clearLayout();
 
+    // Scrubbing (or clicking) to the leading edge yields 0, which clears the
+    // rating.
     if (stars <= 0) {
       onRemoveRating();
       return;
@@ -235,7 +237,7 @@
     aria-hidden="true"
     style={previewX !== null ? `--preview-x: ${previewX}px` : undefined}
   >
-    {displayStars.toFixed(1)}
+    {displayStars <= 0 ? m.text_no_rating() : displayStars.toFixed(1)}
   </span>
 
   <RatingGroup.Root

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RatingStars.svelte
@@ -57,6 +57,11 @@
   // double-committing the pointer ones.
   let lastInputWasPointer = false;
 
+  // True only while a touch gesture is actively scrubbing. Mouse hover never
+  // sets it. Drives lifting the active star + tooltip clear of the thumb, which
+  // would otherwise sit right on top of them.
+  let isTouchScrub = $state(false);
+
   const displayStars = $derived(previewStars ?? committedStars);
   const isPreviewing = $derived(previewStars !== null);
   const highlightIndex = $derived(Math.ceil(displayStars) - 1);
@@ -186,17 +191,22 @@
     const down$ = fromEvent<PointerEvent>(el, "pointerdown", { capture: true });
     const key$ = fromEvent<KeyboardEvent>(el, "keydown", { capture: true });
 
+    const up$ = fromEvent<PointerEvent>(el, "pointerup");
+    const cancel$ = fromEvent<PointerEvent>(el, "pointercancel");
+    const leave$ = fromEvent<PointerEvent>(el, "pointerleave");
+
     const { preview$, commit$ } = createScrubInteraction({
       down$,
       move$: fromEvent<PointerEvent>(el, "pointermove"),
-      up$: fromEvent<PointerEvent>(el, "pointerup"),
-      cancel$: fromEvent<PointerEvent>(el, "pointercancel"),
-      leave$: fromEvent<PointerEvent>(el, "pointerleave"),
+      up$,
+      cancel$,
+      leave$,
     });
 
     merge(
       down$.pipe(tap((event) => {
         lastInputWasPointer = true;
+        isTouchScrub = event.pointerType === "touch";
         // Capture so a drag keeps scrubbing even if the pointer drifts off the
         // row. setPointerCapture can throw where unsupported (e.g. jsdom).
         try {
@@ -207,6 +217,7 @@
       })),
       preview$.pipe(tap(syncPreview)),
       commit$.pipe(tap(({ down, up }) => commitGesture(down, up))),
+      merge(up$, cancel$, leave$).pipe(tap(() => (isTouchScrub = false))),
       key$.pipe(tap(() => (lastInputWasPointer = false))),
     )
       .pipe(takeUntil(destroy$))
@@ -229,6 +240,7 @@
   class="trakt-rating-stars"
   data-variant={variant}
   class:is-previewing={isPreviewing}
+  class:is-touch-scrub={isTouchScrub && isPreviewing}
   bind:this={rootEl}
 >
   <span
@@ -279,6 +291,8 @@
     align-items: center;
     position: relative;
     touch-action: none;
+    // Suppress the grey flash the mobile browser paints on tap.
+    -webkit-tap-highlight-color: transparent;
 
     // Premium easing curves shared across the interaction.
     --ease-glide: cubic-bezier(0.16, 1, 0.3, 1);
@@ -354,6 +368,18 @@
 
       :global(.star-item:not([data-highlighted])) {
         opacity: 0.75;
+      }
+    }
+
+    // Touch scrub: the thumb sits on the active star, so lift it and the
+    // tooltip clear of the finger to keep both legible.
+    &.is-touch-scrub {
+      .rating-preview {
+        bottom: calc(100% + var(--gap-l));
+      }
+
+      :global(.star-item[data-highlighted]) {
+        transform: translateY(-0.75rem) scale(1.3);
       }
     }
 

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/starsFromRects.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/starsFromRects.spec.ts
@@ -27,8 +27,8 @@ describe('util: starsFromRects', () => {
   });
 
   describe('half ratings (LTR)', () => {
-    it('should clamp to a half star before the first star', () => {
-      expect(measure(-5)).toBe(0.5);
+    it('should clear (0) before the first star', () => {
+      expect(measure(-5)).toBe(0);
     });
 
     it('should clamp to the max past the last star', () => {
@@ -36,24 +36,40 @@ describe('util: starsFromRects', () => {
     });
 
     it('should return a half when the pointer is over a star left half', () => {
-      expect(measure(5)).toBe(0.5);
       expect(measure(25)).toBe(1.5);
     });
 
     it('should return a whole when the pointer is over a star right half', () => {
-      expect(measure(15)).toBe(1);
       expect(measure(38)).toBe(2);
+    });
+
+    describe('first star', () => {
+      it('should clear (0) over its leading third', () => {
+        expect(measure(2)).toBe(0);
+      });
+
+      it('should return a half over its middle third', () => {
+        expect(measure(10)).toBe(0.5);
+      });
+
+      it('should return a whole over its trailing third', () => {
+        expect(measure(18)).toBe(1);
+      });
     });
   });
 
   describe('whole-only ratings', () => {
     it('should never return a half when allowHalf is false', () => {
-      expect(measure(5, { allowHalf: false })).toBe(1);
+      expect(measure(15, { allowHalf: false })).toBe(1);
       expect(measure(25, { allowHalf: false })).toBe(2);
     });
 
-    it('should clamp to a whole star before the first star', () => {
-      expect(measure(-5, { allowHalf: false })).toBe(1);
+    it('should clear (0) before the first star', () => {
+      expect(measure(-5, { allowHalf: false })).toBe(0);
+    });
+
+    it('should clear (0) over the first star leading half', () => {
+      expect(measure(5, { allowHalf: false })).toBe(0);
     });
   });
 
@@ -97,14 +113,20 @@ describe('util: starsFromRects', () => {
   describe('RTL', () => {
     it('should flip the clamp ends', () => {
       expect(measure(-5, { isRtl: true })).toBe(5);
-      expect(measure(150, { isRtl: true })).toBe(0.5);
+      expect(measure(150, { isRtl: true })).toBe(0);
     });
 
     it('should read the half from the opposite side of the star', () => {
-      // clientX 15 sits in the right 25% of star 0; in RTL that is its near
+      // clientX 35 sits in the right 25% of star 1; in RTL that is its near
       // (low) half.
-      expect(measure(15, { isRtl: true })).toBe(0.5);
-      expect(measure(5, { isRtl: true })).toBe(1);
+      expect(measure(35, { isRtl: true })).toBe(1.5);
+      expect(measure(25, { isRtl: true })).toBe(2);
+    });
+
+    it('should clear (0) over the first star leading side in RTL', () => {
+      // In RTL the first star's leading side is its right; clientX 18 sits
+      // there, in the leading third.
+      expect(measure(18, { isRtl: true })).toBe(0);
     });
   });
 });

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/starsFromRects.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/starsFromRects.ts
@@ -19,12 +19,14 @@ export function starsFromRects(
 ): number | null {
   if (rects.length === 0) return null;
 
-  const minStars = allowHalf ? 0.5 : 1;
   const inlineStart = Math.min(...rects.map((rect) => rect.left));
   const inlineEnd = Math.max(...rects.map((rect) => rect.right));
 
-  if (clientX <= inlineStart) return isRtl ? max : minStars;
-  if (clientX >= inlineEnd) return isRtl ? minStars : max;
+  // Past the leading edge clears the rating (0 stars); the trailing edge is
+  // the max. 0 is only reachable here - within the stars the fraction floors
+  // at a half (or whole) star.
+  if (clientX <= inlineStart) return isRtl ? max : 0;
+  if (clientX >= inlineEnd) return isRtl ? 0 : max;
 
   const hitIndex = rects
     .map((rect, index) => ({
@@ -43,7 +45,22 @@ export function starsFromRects(
     ? (rect.right - clientX) / rect.width
     : (clientX - rect.left) / rect.width;
   const whole = hitIndex + 1;
+  const isFirstStar = hitIndex === 0;
 
-  if (!allowHalf) return whole;
+  if (!allowHalf) {
+    // The first star clears to 0 on its leading half; the rest stay whole.
+    if (isFirstStar && fraction < 0.5) return 0;
+    return whole;
+  }
+
+  // The first star is split three ways so its leading region can clear the
+  // rating (0 | 0.5 | 1) without having to reach past the row's edge. Every
+  // other star keeps the standard near-half / far-whole split.
+  if (isFirstStar) {
+    if (fraction < 1 / 3) return 0;
+    if (fraction < 2 / 3) return 0.5;
+    return 1;
+  }
+
   return fraction < 0.5 ? whole - 0.5 : whole;
 }


### PR DESCRIPTION
## 🎶 Notes 🎶
- Automatically removes user ratings when the last watch entry for a rated item (movie, show, or episode) is removed, preventing orphaned ratings.
- Introduces the ability to explicitly clear a rating from the star component by scrubbing or selecting the "no rating" zone (zero stars).
- Provides clearer visual feedback in the rating component, including a red highlight when clearing a rating and an adjusted display for touch-based scrubbing.

## 👀 Examples 👀
Hovering over the left side of the first star:

<img width="310" height="120" alt="Screenshot 2026-07-06 at 10 50 16" src="https://github.com/user-attachments/assets/9dcc0b78-b016-4702-a4cc-038abe93b9ae" />

When swiping, also lifts the stars higher:

https://github.com/user-attachments/assets/0598c3f7-0f8c-4052-af3b-3e45c054bc42

