### PR TITLE
feat(settings): add CSV to raw export option

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4788,6 +4788,14 @@
       "default": "Export a ZIP file containing your raw data.",
       "description": "Aria-label for the button that allows users to export their raw data."
     },
+    "export_format_json_files": {
+      "default": "JSON files",
+      "description": "Text for the raw export menu option that exports JSON files."
+    },
+    "export_format_csv_files": {
+      "default": "CSV files",
+      "description": "Text for the raw export menu option that exports CSV files."
+    },
     "text_exporting": {
       "default": "Exporting… {progress}",
       "description": "Text shown to indicate that the user's data export is in progress.",

--- a/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
@@ -54,9 +54,13 @@ type ImportCompletedType = {
   duration: number;
 };
 type ImportFailedType = { source: string; error: string };
-type ExportInitiatedType = { isVip: string };
-type ExportCompletedType = { duration: number; endpointCount: number };
-type ExportFailedType = { error: string };
+type ExportFormatType = { format: 'json' | 'csv' };
+type ExportInitiatedType = { isVip: string } & ExportFormatType;
+type ExportCompletedType = {
+  duration: number;
+  endpointCount: number;
+} & ExportFormatType;
+type ExportFailedType = { error: string } & ExportFormatType;
 
 type ClearInitiatedType = { source: string };
 type ClearCompletedType = {

--- a/projects/client/src/lib/sections/settings/_internal/RawExport.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/RawExport.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-  import Button from "$lib/components/buttons/Button.svelte";
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import DropdownList from "$lib/components/dropdown/DropdownList.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent.ts";
   import { useAnalytics } from "$lib/features/analytics/useAnalytics";
   import { useUser } from "$lib/features/auth/stores/useUser";
   import * as m from "$lib/features/i18n/messages.ts";
   import { time } from "$lib/utils/timing/time.ts";
   import { slide } from "svelte/transition";
+  import type { RawExportFormat } from "../export/RawExportFormat.ts";
   import { runRawExport } from "../export/runRawExport.ts";
   import SettingsRow from "./SettingsRow.svelte";
   import SettingsSection from "./SettingsSection.svelte";
@@ -27,8 +29,17 @@
     endpointCount: 0,
   });
 
-  async function startExport() {
+  const exportFormats: ReadonlyArray<{
+    format: RawExportFormat;
+    label: () => string;
+  }> = [
+    { format: "json", label: m.export_format_json_files },
+    { format: "csv", label: m.export_format_csv_files },
+  ];
+
+  async function startExport(format: RawExportFormat) {
     if (!$user) return;
+    if (state.isExporting) return;
 
     const startTime = Date.now();
     state.isExporting = true;
@@ -36,10 +47,12 @@
 
     record(AnalyticsEvent.ExportInitiated, {
       isVip: $user.isVip ? "true" : "false",
+      format,
     });
 
     await runRawExport({
       user: { slug: $user.slug, isVip: $user.isVip },
+      format,
       onStatus: (status) => {
         switch (status.type) {
           case "complete":
@@ -62,6 +75,7 @@
         record(AnalyticsEvent.ExportCompleted, {
           duration: exportDuration,
           endpointCount: state.endpointCount,
+          format,
         });
 
         setTimeout(() => {
@@ -72,7 +86,7 @@
       },
       onError: (err) => {
         const errorMessage = err instanceof Error ? err.message : String(err);
-        record(AnalyticsEvent.ExportFailed, { error: errorMessage });
+        record(AnalyticsEvent.ExportFailed, { error: errorMessage, format });
 
         state.statusText = m.text_export_status_fail();
         state.isExporting = false;
@@ -93,15 +107,22 @@
 >
   <SettingsRow title={m.text_raw_export()}>
     <div class="trakt-raw-export">
-      <Button
+      <DropdownList
         label={m.button_label_raw_export()}
         disabled={state.isExporting}
-        onclick={startExport}
         color="default"
         size="small"
+        preferNative
       >
         {m.button_text_raw_export()}
-      </Button>
+        {#snippet items()}
+          {#each exportFormats as option (option.format)}
+            <DropdownItem onclick={() => startExport(option.format)}>
+              {option.label()}
+            </DropdownItem>
+          {/each}
+        {/snippet}
+      </DropdownList>
       <div>
         {#if state.isExporting}
           {@render exportLabel(m.text_exporting({ progress: state.progress }))}

--- a/projects/client/src/lib/sections/settings/export/RawExportFormat.ts
+++ b/projects/client/src/lib/sections/settings/export/RawExportFormat.ts
@@ -1,0 +1,1 @@
+export type RawExportFormat = 'json' | 'csv';

--- a/projects/client/src/lib/sections/settings/export/jsonToCsv.spec.ts
+++ b/projects/client/src/lib/sections/settings/export/jsonToCsv.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { jsonToCsv } from './jsonToCsv.ts';
+
+describe('jsonToCsv', () => {
+  it('flattens nested objects into dotted columns', async () => {
+    const result = await jsonToCsv([
+      {
+        type: 'movie',
+        watched_at: '2024-01-15T12:00:00.000Z',
+        movie: {
+          title: 'Inception',
+          year: 2010,
+          ids: { trakt: 16662, imdb: 'tt1375666' },
+        },
+      },
+    ]);
+
+    expect(result).toBe(
+      [
+        'type,watched_at,movie.title,movie.year,movie.ids.trakt,movie.ids.imdb',
+        'movie,2024-01-15T12:00:00.000Z,Inception,2010,16662,tt1375666',
+      ].join('\r\n'),
+    );
+  });
+
+  it('uses a union of columns across rows', async () => {
+    const result = await jsonToCsv([
+      { title: 'Inception', watched_at: '2024-01-15T12:00:00.000Z' },
+      { title: 'Dune', rating: 9 },
+    ]);
+
+    expect(result).toBe(
+      [
+        'title,watched_at,rating',
+        'Inception,2024-01-15T12:00:00.000Z,',
+        'Dune,,9',
+      ].join('\r\n'),
+    );
+  });
+
+  it('keeps arrays as JSON cells', async () => {
+    const result = await jsonToCsv({
+      slug: 'me',
+      genres: ['action', 'sci-fi'],
+      stats: { plays: [1, 2] },
+    });
+
+    expect(result).toBe(
+      [
+        'slug,genres,stats.plays',
+        'me,"[""action"",""sci-fi""]","[1,2]"',
+      ].join('\r\n'),
+    );
+  });
+
+  it('returns an empty CSV for empty arrays and objects', async () => {
+    await expect(jsonToCsv([])).resolves.toBe('');
+    await expect(jsonToCsv({})).resolves.toBe('');
+  });
+
+  it('escapes formula-like values for Excel', async () => {
+    const result = await jsonToCsv([{
+      title: '=IMPORTXML("https://example.com")',
+    }]);
+
+    expect(result).toBe('title\r\n"\'=IMPORTXML(""https://example.com"")"');
+  });
+});

--- a/projects/client/src/lib/sections/settings/export/jsonToCsv.ts
+++ b/projects/client/src/lib/sections/settings/export/jsonToCsv.ts
@@ -1,0 +1,71 @@
+type CsvCell = string | number | boolean | null;
+type CsvRow = Record<string, CsvCell>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toJsonCell(value: unknown): string {
+  return JSON.stringify(value) ?? '';
+}
+
+function toCsvCell(value: unknown): CsvCell {
+  if (value == null) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return value;
+  if (typeof value === 'boolean') return value;
+
+  return toJsonCell(value);
+}
+
+function flattenRecord(
+  record: Record<string, unknown>,
+  parentKey = '',
+): CsvRow {
+  return Object.entries(record).reduce<CsvRow>((row, [key, value]) => {
+    const field = parentKey ? `${parentKey}.${key}` : key;
+    if (!isRecord(value)) return { ...row, [field]: toCsvCell(value) };
+
+    const nestedRow = flattenRecord(value, field);
+    if (Object.keys(nestedRow).length === 0) {
+      return { ...row, [field]: toJsonCell(value) };
+    }
+
+    return { ...row, ...nestedRow };
+  }, {});
+}
+
+function toCsvRow(value: unknown): CsvRow {
+  if (!isRecord(value)) return { value: toCsvCell(value) };
+
+  const row = flattenRecord(value);
+  if (Object.keys(row).length > 0) return row;
+
+  return { value: toJsonCell(value) };
+}
+
+function collectFields(rows: ReadonlyArray<CsvRow>): string[] {
+  return rows.reduce<string[]>((fields, row) => {
+    const newFields = Object.keys(row).filter((field) =>
+      !fields.includes(field)
+    );
+
+    return [...fields, ...newFields];
+  }, []);
+}
+
+export async function jsonToCsv(json: unknown): Promise<string> {
+  if (isRecord(json) && Object.keys(json).length === 0) return '';
+
+  const rows = Array.isArray(json) ? json.map(toCsvRow) : [toCsvRow(json)];
+  const fields = collectFields(rows);
+  if (fields.length === 0) return '';
+
+  const Papa = await import('papaparse');
+  return Papa.default.unparse(rows, {
+    columns: fields,
+    escapeFormulae: true,
+    header: true,
+    newline: '\r\n',
+  });
+}

--- a/projects/client/src/lib/sections/settings/export/runRawExport.ts
+++ b/projects/client/src/lib/sections/settings/export/runRawExport.ts
@@ -1,7 +1,9 @@
 import { error } from '$lib/utils/console/print.ts';
 import { strToU8, zip, type Zippable } from 'fflate';
+import type { RawExportFormat } from './RawExportFormat.ts';
 import { downloadFile } from './downloadFile.ts';
 import { processEndpoint } from './processEndpoint.ts';
+import { toRawExportFileContent } from './toRawExportFileContent.ts';
 
 type UserLike = {
   slug: string;
@@ -22,6 +24,7 @@ type ExportStatus =
 
 interface ExportOptions {
   user: UserLike;
+  format: RawExportFormat;
   onStatus: (status: ExportStatus) => void;
   onProgress: (msg: string) => void;
   onComplete: () => void;
@@ -30,6 +33,7 @@ interface ExportOptions {
 
 export async function runRawExport({
   user,
+  format,
   onStatus,
   onProgress,
   onComplete,
@@ -187,11 +191,16 @@ export async function runRawExport({
       onProgress(`(${count}/${endpoints.length})`);
       onStatus({ type: 'fetch', item: endpoint.file });
 
-      await processEndpoint(endpoint.path, (data, { page, pageCount }) => {
-        const suffix = page > 1 || pageCount > 1 ? `-${page}` : '';
-        const filename = `${endpoint.file}${suffix}.json`;
-        files[filename] = strToU8(JSON.stringify(data, null, 2));
-      });
+      await processEndpoint(
+        endpoint.path,
+        async (data, { page, pageCount }) => {
+          const suffix = page > 1 || pageCount > 1 ? `-${page}` : '';
+          const filename = `${endpoint.file}${suffix}.${format}`;
+          files[filename] = strToU8(
+            await toRawExportFileContent(data, format),
+          );
+        },
+      );
     }
 
     onStatus({ type: 'zip' });
@@ -205,7 +214,8 @@ export async function runRawExport({
         type: 'application/zip',
       });
 
-      downloadFile(blob, `trakt-export-${slug}.zip`);
+      const archiveSuffix = format === 'csv' ? '-csv' : '';
+      downloadFile(blob, `trakt-export-${slug}${archiveSuffix}.zip`);
       onStatus({ type: 'complete' });
       onComplete();
     });

--- a/projects/client/src/lib/sections/settings/export/toRawExportFileContent.spec.ts
+++ b/projects/client/src/lib/sections/settings/export/toRawExportFileContent.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { toRawExportFileContent } from './toRawExportFileContent.ts';
+
+describe('toRawExportFileContent', () => {
+  it('returns an empty CSV file for empty arrays and objects', async () => {
+    await expect(toRawExportFileContent([], 'csv')).resolves.toBe('');
+    await expect(toRawExportFileContent({}, 'csv')).resolves.toBe('');
+  });
+
+  it('adds a byte order mark to non-empty CSV files', async () => {
+    const result = await toRawExportFileContent(
+      [{ title: 'Inception' }],
+      'csv',
+    );
+
+    expect(result).toBe('\uFEFFtitle\r\nInception');
+  });
+
+  it('keeps JSON exports unchanged', async () => {
+    const result = await toRawExportFileContent([], 'json');
+
+    expect(result).toBe('[]');
+  });
+});

--- a/projects/client/src/lib/sections/settings/export/toRawExportFileContent.ts
+++ b/projects/client/src/lib/sections/settings/export/toRawExportFileContent.ts
@@ -1,0 +1,16 @@
+import type { RawExportFormat } from './RawExportFormat.ts';
+import { jsonToCsv } from './jsonToCsv.ts';
+
+const CSV_BYTE_ORDER_MARK = '\uFEFF';
+
+export async function toRawExportFileContent(
+  data: unknown,
+  format: RawExportFormat,
+): Promise<string> {
+  if (format === 'csv') {
+    const csv = await jsonToCsv(data);
+    return csv ? `${CSV_BYTE_ORDER_MARK}${csv}` : '';
+  }
+
+  return JSON.stringify(data, null, 2) ?? '';
+}


### PR DESCRIPTION
## Summary

- Adds JSON/CSV choices to the raw export button on data settings.
- Converts raw API response payloads to CSV files before creating the export ZIP.
- Keeps empty `[]` and `{}` responses as empty CSV files.
- Tracks the selected export format in data export analytics.

## Screenshots

<img width="1331" height="886" alt="Screenshot 2026-07-06 at 11 01 47" src="https://github.com/user-attachments/assets/c8a6d122-d324-4262-94f0-fecd651c37d0" />
