### PR TITLE
fix(routing): resolve user profile redirects in load, not onMount

### DIFF
--- a/projects/client/src/routes/users/[user]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/+page.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-  import Redirect from "$lib/components/router/Redirect.svelte";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
-  import type { PageProps } from "./$types";
-
-  const { params }: PageProps = $props();
-</script>
-
-<Redirect to={UrlBuilder.profile.user(params.user)} />

--- a/projects/client/src/routes/users/[user]/+page.ts
+++ b/projects/client/src/routes/users/[user]/+page.ts
@@ -1,0 +1,14 @@
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
+import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+// Short URL: /users/:user redirects to that user's profile.
+// Done in load (not a client-side <Redirect> onMount) so the redirect
+// resolves before mount. A client goto here races the goto FilterProvider
+// fires on first load, which aborts it and leaves a blank page.
+// Query params are preserved across the redirect.
+export const load: PageLoad = ({ params, url }) => {
+  const target = UrlBuilder.profile.user(params.user);
+
+  return redirect(307, `${target}${url.search}`);
+};

--- a/projects/client/src/routes/users/[user]/library/+page.svelte
+++ b/projects/client/src/routes/users/[user]/library/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import Redirect from "$lib/components/router/Redirect.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
@@ -10,40 +9,30 @@
   import ResponsiveNavbarStateSetter from "$lib/sections/navbar/ResponsiveNavbarStateSetter.svelte";
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
   import { toTranslatedLibrary } from "$lib/utils/formatting/string/toTranslatedLibrary";
-  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
-  import type { PageProps } from "./$types";
-
-  const { params }: PageProps = $props();
 
   const library: Library = $derived(
     page.url.searchParams.get("library") === "other" ? "other" : "plex",
   );
-
-  const isMe = $derived(params.user === "me");
 </script>
 
 {#snippet actions()}
   <LibraryToggler value={library} withLinks />
 {/snippet}
 
-{#if !isMe}
-  <Redirect to={UrlBuilder.home()} />
-{:else}
-  <TraktPage
-    audience="authenticated"
-    image={DEFAULT_SHARE_MOVIE_COVER}
-    title={m.page_title_library()}
-  >
-    <ResponsiveNavbarStateSetter
-      header={{
-        title: m.list_title_library(),
-        metaInfo: toTranslatedLibrary(library),
-        actions,
-      }}
-    />
+<TraktPage
+  audience="authenticated"
+  image={DEFAULT_SHARE_MOVIE_COVER}
+  title={m.page_title_library()}
+>
+  <ResponsiveNavbarStateSetter
+    header={{
+      title: m.list_title_library(),
+      metaInfo: toTranslatedLibrary(library),
+      actions,
+    }}
+  />
 
-    <TraktPageCoverSetter />
+  <TraktPageCoverSetter />
 
-    <LibraryListPaginated {library} />
-  </TraktPage>
-{/if}
+  <LibraryListPaginated {library} />
+</TraktPage>

--- a/projects/client/src/routes/users/[user]/library/+page.ts
+++ b/projects/client/src/routes/users/[user]/library/+page.ts
@@ -1,0 +1,13 @@
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
+import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+// The library is only viewable for the authenticated user's own account
+// (the `me` alias). Guard in load so the redirect resolves before mount — a
+// client-side <Redirect> here races the goto FilterProvider fires on first
+// load, which aborts it and leaves a blank page.
+export const load: PageLoad = ({ params }) => {
+  if (params.user !== 'me') {
+    return redirect(307, UrlBuilder.home());
+  }
+};


### PR DESCRIPTION
## 🎶 Notes 🎶

- Visiting a user profile link directly (e.g. `/users/seftur`) rendered a blank body — only worked after a refresh.
- Cause: the page redirected client-side via `<Redirect>` in `onMount`, racing the `goto` that `FilterProvider` fires on first load (appending its `discover` param). FilterProvider's `goto` lands second and aborts the redirect, leaving an aborted navigation on a `<Redirect>` stub → blank body.
  - Refresh worked because the URL then already had the `discover` param, so FilterProvider skipped its `goto` and the redirect ran unopposed.
- Fix: moved `/users/:user` (and `/users/:user/library`) redirects from client-side `<Redirect>` `onMount` to server-side `load` redirects, so they resolve before mount. Matches the existing `yir`/`mir` pattern.
