### PR TITLE
feat(settings): Adds support for deleting user account

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5164,6 +5164,30 @@
       "default": "Permanently delete data from your Trakt account.",
       "description": "Description for the clear data settings section."
     },
+    "header_delete_account": {
+      "default": "Delete Account",
+      "description": "Header for the settings section that lets users permanently delete their Trakt account."
+    },
+    "description_delete_account": {
+      "default": "Your personal information will be removed and your statistical data will be anonymized.",
+      "description": "Description for the delete account settings section, warning that the action is irreversible."
+    },
+    "button_label_delete_account": {
+      "default": "Delete your Trakt account",
+      "description": "Aria-label for the delete account button."
+    },
+    "confirmation_title_delete_account": {
+      "default": "Delete account?",
+      "description": "Title of the confirmation dialog shown before permanently deleting the user's account."
+    },
+    "warning_prompt_delete_account": {
+      "default": "Are you sure you want to permanently delete your account? This will remove all of your data and cannot be undone.",
+      "description": "Confirmation prompt shown when a user attempts to permanently delete their account."
+    },
+    "error_text_delete_account": {
+      "default": "Something went wrong deleting your account. Please try again.",
+      "description": "Error message shown when permanent account deletion fails."
+    },
     "text_clear_watchlist": {
       "default": "Clear watchlist",
       "description": "Label for the row in clear data settings that allows users to clear their entire watchlist."
@@ -6834,53 +6858,75 @@
       "default": "Charged <b>{amount}</b> via <b>{method}</b> for <b>{term}</b>",
       "description": "Payment-history sentence for a charge. The <b> tags wrap the amount, payment method, and term as bold highlights - keep them when translating. amount is a formatted price (e.g. $30), method is the payment provider, term is the plan length (e.g. 1 Year).",
       "variables": {
-        "amount": { "type": "string" },
-        "method": { "type": "string" },
-        "term": { "type": "string" }
+        "amount": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "term": {
+          "type": "string"
+        }
       }
     },
     "text_vip_transaction_charged_short": {
       "default": "Charged <b>{amount}</b> via <b>{method}</b>",
       "description": "Payment-history sentence for a charge with no known term. The <b> tags wrap the amount and payment method as bold highlights - keep them when translating.",
       "variables": {
-        "amount": { "type": "string" },
-        "method": { "type": "string" }
+        "amount": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        }
       }
     },
     "text_vip_transaction_created": {
       "default": "Created a new <b>{method}</b> subscription",
       "description": "Payment-history sentence for a new subscription. The <b> tags wrap the payment method as a bold highlight - keep them when translating.",
       "variables": {
-        "method": { "type": "string" }
+        "method": {
+          "type": "string"
+        }
       }
     },
     "text_vip_transaction_cancelled": {
       "default": "Cancelled a <b>{method}</b> subscription",
       "description": "Payment-history sentence for a cancellation. The <b> tags wrap the payment method as a bold highlight - keep them when translating.",
       "variables": {
-        "method": { "type": "string" }
+        "method": {
+          "type": "string"
+        }
       }
     },
     "text_vip_transaction_refunded": {
       "default": "Refunded <b>{amount}</b> via <b>{method}</b>",
       "description": "Payment-history sentence for a refund. The <b> tags wrap the amount and payment method as bold highlights - keep them when translating.",
       "variables": {
-        "amount": { "type": "string" },
-        "method": { "type": "string" }
+        "amount": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        }
       }
     },
     "text_vip_transaction_disputed": {
       "default": "Disputed a <b>{method}</b> charge",
       "description": "Payment-history sentence for a disputed charge. The <b> tags wrap the payment method as a bold highlight - keep them when translating.",
       "variables": {
-        "method": { "type": "string" }
+        "method": {
+          "type": "string"
+        }
       }
     },
     "text_vip_transaction_plan_changed": {
       "default": "Changed your <b>{method}</b> plan",
       "description": "Payment-history sentence for a plan change. The <b> tags wrap the payment method as a bold highlight - keep them when translating.",
       "variables": {
-        "method": { "type": "string" }
+        "method": {
+          "type": "string"
+        }
       }
     },
     "text_vip_transaction_complimentary": {
@@ -9285,6 +9331,19 @@
           "type": "string"
         }
       }
+    },
+    "confirmation_challenge_delete_account": {
+      "default": "To confirm, type your username {username} below.",
+      "description": "Instruction shown in the delete-account confirmation dialog telling the user to type their username to enable the delete button. {username} is the account's username.",
+      "variables": {
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "notice_delete_account_vip": {
+      "default": "Since you're an active Trakt VIP, please <a>cancel your VIP membership</a> before deleting your account.",
+      "description": "Info banner shown in the delete-account settings section when the user still has an active, cancellable VIP subscription. The <a> tag wraps the link to the VIP management page."
     }
   }
 }

--- a/projects/client/src/lib/components/dialogs/ConfirmationDialog.svelte
+++ b/projects/client/src/lib/components/dialogs/ConfirmationDialog.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import Button from "$lib/components/buttons/Button.svelte";
+  import FormInput from "$lib/components/form/FormInput.svelte";
   import type { ConfirmationAction } from "$lib/features/confirmation/models/ConfirmationAction";
+  import type { ConfirmationChallenge } from "$lib/features/confirmation/models/ConfirmationChallenge";
   import type { ConfirmationOperation } from "$lib/features/confirmation/models/ConfirmationOperation";
   import * as m from "$lib/features/i18n/messages.ts";
   import Modal from "./Modal.svelte";
@@ -13,6 +15,7 @@
     cancelText: externalCancelText,
     onAction,
     operation,
+    challenge,
   }: {
     title: string;
     message: string;
@@ -21,11 +24,18 @@
     cancelText?: string;
     operation: ConfirmationOperation;
     onAction: (action: ConfirmationAction) => void;
+    challenge?: ConfirmationChallenge;
   } = $props();
 
   const isDestructive = $derived(operation === "destructive");
   const isPreventative = $derived(operation === "preventative");
   const cancelText = $derived(externalCancelText ?? m.button_text_cancel());
+
+  let challengeInput = $state("");
+  const isConfirmDisabled = $derived(
+    challenge != null &&
+      challengeInput.trim().toLowerCase() !== challenge.value.toLowerCase(),
+  );
 </script>
 
 <Modal onClose={() => onAction("cancel")}>
@@ -34,6 +44,18 @@
     <p class="trakt-confirmation-message secondary">{message}</p>
     {#if detail}
       <p class="trakt-confirmation-message secondary">{detail}</p>
+    {/if}
+
+    {#if challenge}
+      <label class="trakt-confirmation-challenge">
+        <span class="small secondary">{challenge.label}</span>
+        <FormInput
+          placeholder={challenge.placeholder ?? ""}
+          onChange={(value) => (challengeInput = value)}
+          disabled={false}
+          autofocus
+        />
+      </label>
     {/if}
   </div>
 
@@ -54,6 +76,7 @@
         variant="primary"
         color="custom"
         label={buttonText}
+        disabled={isConfirmDisabled}
         onclick={() => onAction("confirm")}
       >
         {buttonText}
@@ -69,6 +92,14 @@
     display: flex;
     flex-direction: column;
     gap: var(--ni-8);
+  }
+
+  .trakt-confirmation-challenge {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-8);
+
+    margin-top: var(--ni-8);
   }
 
   .trakt-confirmation-actions {

--- a/projects/client/src/lib/components/link/MessageWithLink.svelte
+++ b/projects/client/src/lib/components/link/MessageWithLink.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
   import Link from "./Link.svelte";
 
-  const { message, href, target } = $props();
+  const { message, href, target, color }: {
+    message: string;
+    href: string;
+    target?: "_blank" | "_self" | "_parent" | "_top";
+    color?: "default" | "classic" | "inherit";
+  } = $props();
 
   const [beforeText, linkText, afterText] = $derived(
     message.split(/<a[^>]*>|<\/a>/),
   );
 </script>
 
-{beforeText}<Link {href} {target}>{linkText}</Link>{afterText}
+{beforeText}<Link {href} {target} {color}>{linkText}</Link>{afterText}

--- a/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
+++ b/projects/client/src/lib/features/confirmation/ConfirmationProvider.svelte
@@ -17,6 +17,7 @@
     buttonText={$activeConfirmation.buttonText}
     cancelText={$activeConfirmation.cancelText}
     operation={$activeConfirmation.operation}
+    challenge={$activeConfirmation.challenge}
     onAction={(action) => {
       if (action === "confirm") {
         $activeConfirmation.onConfirm();

--- a/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/ConfirmationContext.ts
@@ -1,4 +1,5 @@
 import { BehaviorSubject } from 'rxjs';
+import type { ConfirmationChallenge } from '../models/ConfirmationChallenge.ts';
 import type { ConfirmationOperation } from '../models/ConfirmationOperation.ts';
 
 export type ConfirmationRequest = {
@@ -10,6 +11,7 @@ export type ConfirmationRequest = {
   buttonText: string;
   cancelText?: string;
   operation: ConfirmationOperation;
+  challenge?: ConfirmationChallenge;
 };
 
 export type ConfirmationContext = {

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
@@ -1,4 +1,5 @@
 import * as m from '$lib/features/i18n/messages.ts';
+import type { ConfirmationChallenge } from '../models/ConfirmationChallenge.ts';
 import type { ConfirmationOperation } from '../models/ConfirmationOperation.ts';
 import type { ConfirmationParams } from '../models/ConfirmationParams.ts';
 import { ConfirmationType } from '../models/ConfirmationType.ts';
@@ -11,6 +12,7 @@ type Confirmation = {
   buttonText: string;
   cancelText?: string;
   operation: ConfirmationOperation;
+  challenge?: ConfirmationChallenge;
 };
 
 type ConfirmationBuilder<T extends ConfirmationType> = (
@@ -133,6 +135,19 @@ const CONFIRMATION_BUILDERS: ConfirmationBuilders = {
     buttonText: m.button_text_logout(),
     message: m.warning_prompt_log_out(),
     operation: 'destructive',
+  }),
+  [ConfirmationType.DeleteAccount]: (props) => ({
+    title: m.confirmation_title_delete_account(),
+    buttonText: m.button_text_delete_account(),
+    message: m.warning_prompt_delete_account(),
+    operation: 'destructive',
+    challenge: {
+      label: m.confirmation_challenge_delete_account({
+        username: props.username,
+      }),
+      value: props.username,
+      placeholder: props.username,
+    },
   }),
   [ConfirmationType.SimpleFilters]: () => ({
     title: m.confirmation_title_reset_filters(),

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationChallenge.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationChallenge.ts
@@ -1,0 +1,7 @@
+export type ConfirmationChallenge = {
+  /** Instruction shown above the input (e.g. "Type your username to confirm"). */
+  label: string;
+  /** The exact text the user must type before the confirm action is enabled. */
+  value: string;
+  placeholder?: string;
+};

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
@@ -118,6 +118,10 @@ interface ConfirmationParamsMap {
     type: ConfirmationType.DeleteApiApp;
     name: string;
   };
+  [ConfirmationType.DeleteAccount]: {
+    type: ConfirmationType.DeleteAccount;
+    username: string;
+  };
 }
 
 export type ConfirmationParams<T extends ConfirmationType> =

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationType.ts
@@ -30,4 +30,5 @@ export enum ConfirmationType {
   DisconnectPlex = 'disconnect-plex',
   RevokeApp = 'revoke-app',
   DeleteApiApp = 'delete-api-app',
+  DeleteAccount = 'delete-account',
 }

--- a/projects/client/src/lib/requests/queries/users/deleteAccountRequest.ts
+++ b/projects/client/src/lib/requests/queries/users/deleteAccountRequest.ts
@@ -1,0 +1,12 @@
+import { rawApiFetch } from '$lib/requests/api.ts';
+
+export async function deleteAccountRequest(): Promise<boolean> {
+  const response = await rawApiFetch({
+    path: '/users/settings',
+    init: {
+      method: 'DELETE',
+    },
+  });
+
+  return response?.ok ?? false;
+}

--- a/projects/client/src/lib/sections/settings/AdvancedSettings.svelte
+++ b/projects/client/src/lib/sections/settings/AdvancedSettings.svelte
@@ -1,11 +1,27 @@
 <script lang="ts">
   import { page } from "$app/state";
   import SettingsFrame from "$lib/components/frame/SettingsFrame.svelte";
+  import DeleteAccount from "./_internal/DeleteAccount.svelte";
   import SettingsGroupCard from "./_internal/SettingsGroupCard.svelte";
 
   const section = $derived(page.url.searchParams.get("section") ?? "");
 </script>
 
-<SettingsGroupCard>
-  <SettingsFrame {section} />
-</SettingsGroupCard>
+<div class="trakt-advanced-settings-page">
+  <SettingsGroupCard>
+    <SettingsFrame {section} />
+  </SettingsGroupCard>
+
+  <DeleteAccount />
+</div>
+
+<style>
+  .trakt-advanced-settings-page {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xxl);
+
+    width: 100%;
+    max-width: var(--ni-640);
+  }
+</style>

--- a/projects/client/src/lib/sections/settings/_internal/DeleteAccount.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/DeleteAccount.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import Button from "$lib/components/buttons/Button.svelte";
+  import DeleteIcon from "$lib/components/icons/DeleteIcon.svelte";
+  import InfoIcon from "$lib/components/icons/InfoIcon.svelte";
+  import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
+  import { useAuth } from "$lib/features/auth/stores/useAuth.ts";
+  import { useUser } from "$lib/features/auth/stores/useUser.ts";
+  import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType.ts";
+  import { useConfirm } from "$lib/features/confirmation/useConfirm.ts";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { useQuery } from "$lib/features/query/useQuery.ts";
+  import { deleteAccountRequest } from "$lib/requests/queries/users/deleteAccountRequest.ts";
+  import { vipSubscriptionQuery } from "$lib/requests/vip/vipSubscriptionQuery.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+  import { map } from "rxjs";
+  import { slide } from "svelte/transition";
+  import SettingsGroupCard from "./SettingsGroupCard.svelte";
+  import SettingsGroupRow from "./SettingsGroupRow.svelte";
+
+  const { confirm } = useConfirm();
+  const { logout } = useAuth();
+  const { user } = useUser();
+
+  const vipSubscription = useQuery(vipSubscriptionQuery()).pipe(
+    map(($subscription) => $subscription.data),
+  );
+
+  // A lifetime membership has nothing to cancel, and an already-cancelled one
+  // will lapse on its own, only a live recurring subscription blocks deletion.
+  const hasActiveVip = $derived(
+    $vipSubscription != null &&
+      !$vipSubscription.isCancelled &&
+      $vipSubscription.type !== "life",
+  );
+
+  let isDeleting = $state(false);
+  let hasError = $state(false);
+
+  async function deleteAccount() {
+    isDeleting = true;
+    hasError = false;
+
+    try {
+      const success = await deleteAccountRequest();
+
+      if (!success) {
+        isDeleting = false;
+        hasError = true;
+        return;
+      }
+
+      // Deletion revokes the account's authorizations server-side, so the
+      // current token is already dead. Log out to clear local state and end the
+      // session.
+      await logout();
+    } catch {
+      isDeleting = false;
+      hasError = true;
+    }
+  }
+</script>
+
+<SettingsGroupCard title={m.header_delete_account()}>
+  {#if hasActiveVip}
+    <div
+      class="trakt-delete-account-vip-notice"
+      transition:slide={{ duration: 150, axis: "y" }}
+    >
+      <span class="vip-notice-icon"><InfoIcon /></span>
+      <p class="vip-notice-text">
+        <MessageWithLink
+          message={m.notice_delete_account_vip()}
+          href={UrlBuilder.vip()}
+          target="_self"
+          color="inherit"
+        />
+      </p>
+    </div>
+  {/if}
+
+  <SettingsGroupRow
+    title={m.button_label_delete_account()}
+    description={m.description_delete_account()}
+    variant="custom"
+  >
+    {#snippet icon()}<DeleteIcon />{/snippet}
+
+    <Button
+      label={m.button_label_delete_account()}
+      color="red"
+      size="small"
+      disabled={isDeleting || $vipSubscription === undefined || hasActiveVip}
+      onclick={confirm({
+        type: ConfirmationType.DeleteAccount,
+        username: $user?.username ?? "",
+        onConfirm: deleteAccount,
+      })}
+    >
+      {m.button_text_delete_account()}
+    </Button>
+  </SettingsGroupRow>
+
+  {#if hasError}
+    <p
+      class="trakt-delete-account-error small"
+      transition:slide={{ duration: 150, axis: "y" }}
+    >
+      {m.error_text_delete_account()}
+    </p>
+  {/if}
+</SettingsGroupCard>
+
+<style lang="scss">
+  .trakt-delete-account-error {
+    margin: 0;
+    padding: var(--gap-s) var(--gap-m);
+    color: var(--red-500);
+  }
+
+  .trakt-delete-account-vip-notice {
+    display: flex;
+    align-items: center;
+    /* Match SettingsGroupRow's inline padding + icon gap so the icon and text
+       line up vertically with the delete row below. */
+    gap: var(--gap-m);
+
+    padding: var(--gap-m);
+
+    color: var(--color-foreground-blue);
+    background: var(--color-background-blue);
+  }
+
+  .vip-notice-icon {
+    flex-shrink: 0;
+
+    /* Same footprint as the row icon container so the text starts at the same
+       horizontal position as the row title. */
+    width: var(--ni-36);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    :global(svg) {
+      width: var(--ni-20);
+      height: var(--ni-20);
+    }
+  }
+
+  .vip-notice-text {
+    margin: 0;
+  }
+</style>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2315
- Introduces a dedicated section in Advanced Settings for account deletion.
- Implements a security challenge in the confirmation dialog, requiring users to type their username before proceeding with account deletion.
- Displays a warning and prevents account deletion for users with active VIP subscriptions, guiding them to cancel first.
- Adds all necessary internationalization keys for the account deletion flow.
- Includes the API endpoint for account deletion and ensures the user is logged out upon successful removal of their account.
- Extends the `MessageWithLink` component to support custom link colors.

## 👀 Examples 👀
With active VIP:
<img width="668" height="204" alt="Screenshot 2026-07-06 at 16 26 25" src="https://github.com/user-attachments/assets/19bba964-c847-48ed-9852-89b761cc5736" />

Deleting:

https://github.com/user-attachments/assets/289fd637-2321-41ff-87c9-e395f9d436db

