### PR TITLE
fix(image): keeps cached avatars visible after list re-renders

### DIFF
--- a/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
+++ b/projects/client/src/lib/features/image/components/CrossOriginImage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { appendClassList } from "$lib/utils/actions/appendClassList";
+  import { trackImageLoaded } from "$lib/utils/actions/trackImageLoaded.ts";
   import { PLACEHOLDERS } from "$lib/utils/assets";
   import { iffy } from "$lib/utils/function/iffy";
   import type { ImageProps } from "./ImageProps";
@@ -21,7 +22,6 @@
 
   $effect(() => {
     uri = src;
-    isImageLoaded = false;
   });
 
   const isPlaceholder = $derived(PLACEHOLDERS.includes(src));
@@ -34,16 +34,14 @@
   class:image-animation-enabled={animate}
   class:image-placeholder={isPlaceholder}
   use:appendClassList={classList}
+  use:trackImageLoaded={{ src: uri, onLoaded: (loaded) => (isImageLoaded = loaded) }}
   src={uri}
   {alt}
   onerror={(ev) => {
     resolveEnvironmentUri(src).then((next) => (uri = next.uri));
     _onerror?.(ev);
   }}
-  onload={(ev) => {
-    isImageLoaded = true;
-    _onload?.(ev);
-  }}
+  onload={_onload}
   {...rest}
 />
 

--- a/projects/client/src/lib/utils/actions/trackImageLoaded.ts
+++ b/projects/client/src/lib/utils/actions/trackImageLoaded.ts
@@ -1,0 +1,33 @@
+export type TrackImageLoadedProps = {
+  src: string;
+  onLoaded: (loaded: boolean) => void;
+};
+
+export function trackImageLoaded(
+  node: HTMLImageElement,
+  { onLoaded }: TrackImageLoadedProps,
+) {
+  let notify = onLoaded;
+
+  // The browser does not refire `load` when a cached or unchanged src is
+  // assigned, so reading `complete` is the only reliable signal. `naturalWidth`
+  // guards against a completed-but-broken image.
+  const sync = () => notify(node.complete && node.naturalWidth > 0);
+
+  node.addEventListener('load', sync);
+  node.addEventListener('error', sync);
+  sync();
+
+  return {
+    update({ onLoaded }: TrackImageLoadedProps) {
+      notify = onLoaded;
+      // Runs after Svelte has flushed the new src to the element, so
+      // `complete` reflects the current src.
+      sync();
+    },
+    destroy() {
+      node.removeEventListener('load', sync);
+      node.removeEventListener('error', sync);
+    },
+  };
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes the social activity avatars silently disappearing after actions (mark as watched, rate, etc.)
- `CrossOriginImage` gated its opacity on an `isImageLoaded` flag that only flipped `true` from the `<img>` `load` event.
  - The mount effect resets that flag to `false` on every `src` change.
  - But the browser doesn't refire `load` when a cached/unchanged `src` is assigned to a reused element — so the flag stayed `false` and the image sat at `opacity: 0`.
- Small avatars are basically always cache-resident, and the social list re-renders in place on user actions, so all the conditions lined up there. Latent everywhere `animate` is on, just never visible until now.
- Now reads `img.complete` directly via a `use:trackImageLoaded` action, which is the reliable signal. `load`/`error` still handled, non-animated usages unaffected.
