### PR TITLE
feat(related): default to smart related, version 2, open flag to VIPs

### DIFF
--- a/projects/client/src/lib/components/toggles/_internal/constants.ts
+++ b/projects/client/src/lib/components/toggles/_internal/constants.ts
@@ -177,17 +177,17 @@ const library: ToggleDefinition<'library'> = {
 
 const related: ToggleDefinition<'related'> = {
   id: 'related',
-  default: 'standard',
+  default: 'smart',
   options: [
-    {
-      value: 'standard',
-      text: m.button_text_related_standard,
-      label: m.button_label_related_standard,
-    },
     {
       value: 'smart',
       text: m.button_text_related_smart,
       label: m.button_label_related_smart,
+    },
+    {
+      value: 'standard',
+      text: m.button_text_related_standard,
+      label: m.button_label_related_standard,
     },
   ],
 };

--- a/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
+++ b/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
@@ -98,7 +98,6 @@ export const featureFlagDefinitions: FeatureFlagDefinitions = {
     icon: BrainIcon,
     title: () => m.preview_feature_title_smart_related(),
     description: () => m.preview_feature_description_smart_related(),
-    audience: 'director',
   },
   [FeatureFlag.Rewatching]: {
     icon: FastRewindIcon,

--- a/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieRelatedQuery.ts
@@ -22,7 +22,7 @@ const movieRelatedRequest = async (
     const response = await rawApiFetch({
       fetch,
       path:
-        `/movies/${slug}/related/nn?extended=full,images,colors&limit=${limit}&page=${page}`,
+        `/movies/${slug}/related/nn?extended=full,images,colors&limit=${limit}&page=${page}&version=2`,
     });
     return response.ok
       ? {

--- a/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showRelatedQuery.ts
@@ -26,7 +26,7 @@ const showRelatedRequest = async (
     const response = await rawApiFetch({
       fetch,
       path:
-        `/shows/${slug}/related/nn?extended=full,images,colors&limit=${limit}&page=${page}`,
+        `/shows/${slug}/related/nn?extended=full,images,colors&limit=${limit}&page=${page}&version=2`,
     });
     return response.ok
       ? {

--- a/projects/client/src/lib/sections/lists/RelatedList.svelte
+++ b/projects/client/src/lib/sections/lists/RelatedList.svelte
@@ -2,6 +2,7 @@
   import Toggler from "$lib/components/toggles/Toggler.svelte";
   import { useToggler } from "$lib/components/toggles/useToggler";
   import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
@@ -20,11 +21,13 @@
   const { title, type, slug, drilldownLink }: RelatedListProps = $props();
 
   const { current, set, options } = useToggler("related");
-  const isSmart = $derived($current.value === "smart");
+  const { isEnabled } = useFeatureFlag();
+  const isSmartEnabled = isEnabled(FeatureFlag.SmartRelated);
+  const isSmart = $derived($isSmartEnabled && $current.value === "smart");
 </script>
 
 {#snippet metaInfo()}
-  <RenderForFeature flag={FeatureFlag.SmartRelated} audience="director">
+  <RenderForFeature flag={FeatureFlag.SmartRelated}>
     {#snippet enabled()}
       <ListMetaInfo text={$current.text()} />
     {/snippet}
@@ -32,7 +35,7 @@
 {/snippet}
 
 {#snippet actions()}
-  <RenderForFeature flag={FeatureFlag.SmartRelated} audience="director">
+  <RenderForFeature flag={FeatureFlag.SmartRelated}>
     {#snippet enabled()}
       <Toggler value={$current.value} onChange={set} {options} variant="icon" />
     {/snippet}

--- a/projects/client/src/routes/movies/[slug]/related/+page.svelte
+++ b/projects/client/src/routes/movies/[slug]/related/+page.svelte
@@ -2,6 +2,7 @@
   import Toggler from "$lib/components/toggles/Toggler.svelte";
   import { useToggler } from "$lib/components/toggles/useToggler";
   import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
   import * as m from "$lib/features/i18n/messages";
   import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
@@ -14,11 +15,13 @@
   const { params }: PageProps = $props();
 
   const { current, set, options } = useToggler("related");
-  const isSmart = $derived($current.value === "smart");
+  const { isEnabled } = useFeatureFlag();
+  const isSmartEnabled = isEnabled(FeatureFlag.SmartRelated);
+  const isSmart = $derived($isSmartEnabled && $current.value === "smart");
 </script>
 
 {#snippet metaInfo()}
-  <RenderForFeature flag={FeatureFlag.SmartRelated} audience="director">
+  <RenderForFeature flag={FeatureFlag.SmartRelated}>
     {#snippet enabled()}
       <ListMetaInfo text={$current.text()} />
     {/snippet}
@@ -26,7 +29,7 @@
 {/snippet}
 
 {#snippet actions()}
-  <RenderForFeature flag={FeatureFlag.SmartRelated} audience="director">
+  <RenderForFeature flag={FeatureFlag.SmartRelated}>
     {#snippet enabled()}
       <Toggler value={$current.value} onChange={set} {options} variant="icon" />
     {/snippet}

--- a/projects/client/src/routes/shows/[slug]/related/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/related/+page.svelte
@@ -2,6 +2,7 @@
   import Toggler from "$lib/components/toggles/Toggler.svelte";
   import { useToggler } from "$lib/components/toggles/useToggler";
   import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
   import * as m from "$lib/features/i18n/messages";
   import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
@@ -14,11 +15,13 @@
   const { params }: PageProps = $props();
 
   const { current, set, options } = useToggler("related");
-  const isSmart = $derived($current.value === "smart");
+  const { isEnabled } = useFeatureFlag();
+  const isSmartEnabled = isEnabled(FeatureFlag.SmartRelated);
+  const isSmart = $derived($isSmartEnabled && $current.value === "smart");
 </script>
 
 {#snippet metaInfo()}
-  <RenderForFeature flag={FeatureFlag.SmartRelated} audience="director">
+  <RenderForFeature flag={FeatureFlag.SmartRelated}>
     {#snippet enabled()}
       <ListMetaInfo text={$current.text()} />
     {/snippet}
@@ -26,7 +29,7 @@
 {/snippet}
 
 {#snippet actions()}
-  <RenderForFeature flag={FeatureFlag.SmartRelated} audience="director">
+  <RenderForFeature flag={FeatureFlag.SmartRelated}>
     {#snippet enabled()}
       <Toggler value={$current.value} onChange={set} {options} variant="icon" />
     {/snippet}

--- a/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/related/+page.svelte
+++ b/projects/client/src/routes/shows/[slug]/seasons/[season]/episodes/[episode]/related/+page.svelte
@@ -2,6 +2,7 @@
   import Toggler from "$lib/components/toggles/Toggler.svelte";
   import { useToggler } from "$lib/components/toggles/useToggler";
   import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
   import * as m from "$lib/features/i18n/messages";
   import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
@@ -14,11 +15,13 @@
   const { params }: PageProps = $props();
 
   const { current, set, options } = useToggler("related");
-  const isSmart = $derived($current.value === "smart");
+  const { isEnabled } = useFeatureFlag();
+  const isSmartEnabled = isEnabled(FeatureFlag.SmartRelated);
+  const isSmart = $derived($isSmartEnabled && $current.value === "smart");
 </script>
 
 {#snippet metaInfo()}
-  <RenderForFeature flag={FeatureFlag.SmartRelated} audience="director">
+  <RenderForFeature flag={FeatureFlag.SmartRelated}>
     {#snippet enabled()}
       <ListMetaInfo text={$current.text()} />
     {/snippet}
@@ -26,7 +29,7 @@
 {/snippet}
 
 {#snippet actions()}
-  <RenderForFeature flag={FeatureFlag.SmartRelated} audience="director">
+  <RenderForFeature flag={FeatureFlag.SmartRelated}>
     {#snippet enabled()}
       <Toggler value={$current.value} onChange={set} {options} variant="icon" />
     {/snippet}


### PR DESCRIPTION
## What

- Smart related is now the first and default option in the related toggler when the `smart-related` flag is on.
- `isSmart` is gated by the flag in all four related surfaces (movie/show/episode related lists + paginated pages), so flag-off users still get standard related and never hit the `/related/nn` endpoint.
- Smart related now requests the `version=2` nearest-neighbour endpoint directly (no version chip/toggle - dropped after review).
- Opened the `smart-related` preview flag to VIPs (was director-only): removed `audience: 'director'` from the flag definition and the render guards, both falling back to the `vip` default.

## Notes

- VIPs still opt in via the preview-features UI - only director accounts get flags defaulted on. This just makes the flag visible/toggleable and renders the toggler for VIPs once enabled.
- Generic `Toggler`/`Toggle` components are untouched (an earlier chip prototype was reverted; it regressed the active-pill color).