### PR TITLE
List: allow unlisting even if over the limit

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5258,9 +5258,9 @@
       "default": "Enable or disable multiple watches",
       "description": "Aria-label for the switch that allows users to enable or disable multiple watches."
     },
-    "header_add_to_list": {
-      "default": "Add to list",
-      "description": "Header for the section that allows users to add/remove a movie or show to/from a list."
+    "header_manage_lists": {
+      "default": "Manage lists",
+      "description": "Header for the drawer that allows users to add/remove a movie or show to/from their lists."
     },
     "header_sentiment_highlight": {
       "default": "Highlight",

--- a/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItem.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListDropdownItem.svelte
@@ -67,7 +67,7 @@
     color: $color,
     variant: isListed ? variant : "primary",
     onclick: handler,
-    disabled: $isListUpdating || !isBelowLimit,
+    disabled: $isListUpdating || (!isListed && !isBelowLimit),
     ...events,
   });
 </script>

--- a/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.svelte
+++ b/projects/client/src/lib/sections/components/lists-drawer/ListsDrawer.svelte
@@ -64,7 +64,7 @@
   });
 </script>
 
-<Drawer {onClose} title={m.header_add_to_list()} {metaInfo}>
+<Drawer {onClose} title={m.header_manage_lists()} {metaInfo}>
   <ul>
     <WatchlistButton
       title={title ?? media.title}


### PR DESCRIPTION
# Summary

Fixes #1870. On a detail page, the "Manage lists" drawer disabled the row for any list that had reached the account's item limit, which also blocked removing an item from a full list. The limit check now only applies to lists that don't already contain the item, so removal is always available.

# Changes

- `ListDropdownItem.svelte`: the row is now disabled only while updating or when the list is at its limit **and** the item isn't already on it (`$isListUpdating || (!isListed && !isBelowLimit)`).
- `ListsDrawer.svelte`: the drawer title now reads "Manage lists" (matching the trigger button) instead of "Add to list", since the drawer both adds and removes.
- `i18n/meta/en.json`: replaced the now-unused `header_add_to_list` key with `header_manage_lists` — a new key rather than a text change on the existing one, to keep the locale baseline at zero mismatches.

# Testing

- Verified in the drawer that a full list containing the item is enabled and tapping it shows the remove confirmation, while a full list not containing the item stays disabled.
- Drawer header renders "Manage lists".