### PR TITLE
feat(settings): add TV Time FAQ link to import guide

### DIFF
--- a/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportGuide.svelte
@@ -3,6 +3,7 @@
   import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
   import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
   import { m } from "$lib/features/i18n/messages.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
   import { slide } from "svelte/transition";
   import type { ImportSourceConfig } from "../../import/ImportTypes.ts";
   import {
@@ -31,6 +32,10 @@
         return buildDrawerLink(ImportDrawers.CsvGuidelines);
     }
   });
+
+  const faqHref = $derived(
+    config.id === "tvtime" ? UrlBuilder.faq.tvTime() : undefined,
+  );
 </script>
 
 <div class="trakt-import-guide" class:is-collapsed={isCollapsed}>
@@ -93,6 +98,20 @@
             label={m.button_label_view_import_guidelines()}
           >
             {m.button_text_view_import_guidelines()}
+          </Button>
+        </div>
+      {/if}
+
+      {#if faqHref}
+        <div class="import-guide-action">
+          <Button
+            href={faqHref}
+            variant="primary"
+            color="default"
+            size="small"
+            label={m.button_label_tv_time_faq()}
+          >
+            {m.button_text_tv_time_faq()}
           </Button>
         </div>
       {/if}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds link to FAQ in TV Time importer guide
- Follow up to https://github.com/trakt/trakt-web/pull/2827
  - FAQ page also allows for submitting reports with data attachments.

## 👀 Examples 👀
<img width="1048" height="890" alt="Screenshot 2026-07-06 at 23 12 28" src="https://github.com/user-attachments/assets/3e433448-5d9b-41fe-b6e1-8e38c8bc11d1" />

https://github.com/user-attachments/assets/9d460293-b91f-475d-9174-bc76a004e366

