### PR TITLE
feat(rating): add season rating prompt

### DIFF
--- a/projects/client/src/lib/features/auth/queries/currentUserRatingsQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserRatingsQuery.ts
@@ -1,5 +1,5 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
-import { api, type ApiParams } from '$lib/requests/api.ts';
+import { api, type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { toMap } from '$lib/utils/array/toMap.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
@@ -13,6 +13,19 @@ export const RatedMediaSchema = z.object({
   id: z.number(),
 });
 export type RatedEntry = z.infer<typeof RatedMediaSchema>;
+
+const RatedSeasonResponseSchema = z.object({
+  rated_at: z.string().datetime(),
+  rating: z.number().int().min(1).max(10),
+  type: z.literal('season'),
+  season: z.object({
+    ids: z.object({
+      trakt: z.number().int(),
+    }).passthrough(),
+  }).passthrough().nullish(),
+}).passthrough();
+const RatedSeasonsResponseSchema = z.array(RatedSeasonResponseSchema);
+type RatedSeasonResponse = z.infer<typeof RatedSeasonResponseSchema>;
 
 function mapRatedItemResponse(response: RatedItemResponse): RatedEntry {
   const common = {
@@ -43,8 +56,25 @@ function mapRatedItemResponse(response: RatedItemResponse): RatedEntry {
         ).ids.trakt,
       };
     case 'season':
-      throw new Error('Season ratings are not supported');
+      return {
+        ...common,
+        id: assertDefined(
+          response.season,
+          'Expected season in RatedItemResponse',
+        ).ids.trakt,
+      };
   }
+}
+
+function mapRatedSeasonResponse(response: RatedSeasonResponse): RatedEntry {
+  return {
+    rating: response.rating,
+    ratedAt: new Date(response.rated_at),
+    id: assertDefined(
+      response.season,
+      'Expected season in RatedSeasonResponse',
+    ).ids.trakt,
+  };
 }
 
 const currentUserRatedMoviesRequest = ({ fetch }: ApiParams) =>
@@ -71,9 +101,24 @@ const currentUserRatedEpisodesRequest = ({ fetch }: ApiParams) =>
       params: { id: 'me' },
     });
 
+const currentUserRatedSeasonsRequest = async ({ fetch }: ApiParams) => {
+  const response = await rawApiFetch({
+    fetch,
+    path: '/users/me/ratings/seasons',
+  });
+
+  return response.ok
+    ? {
+      body: RatedSeasonsResponseSchema.parse(await response.json()),
+      status: 200,
+    }
+    : { body: [], status: 200 };
+};
+
 const UserRatingsSchema = z.object({
   movies: z.map(z.number(), RatedMediaSchema),
   shows: z.map(z.number(), RatedMediaSchema),
+  seasons: z.map(z.number(), RatedMediaSchema),
   episodes: z.map(z.number(), RatedMediaSchema),
 });
 export type UserRatings = z.infer<typeof UserRatingsSchema>;
@@ -84,21 +129,30 @@ export const currentUserRatingsQuery = defineQuery({
     Promise.all([
       currentUserRatedMoviesRequest(params),
       currentUserRatedShowsRequest(params),
+      currentUserRatedSeasonsRequest(params),
       currentUserRatedEpisodesRequest(params),
     ]),
   invalidations: [
     InvalidateAction.Rated('episode'),
+    InvalidateAction.Rated('season'),
     InvalidateAction.Rated('show'),
     InvalidateAction.Rated('movie'),
   ],
   dependencies: [],
-  mapper: ([moviesResponse, showsResponse, episodesResponse]) => ({
+  mapper: (
+    [moviesResponse, showsResponse, seasonsResponse, episodesResponse],
+  ) => ({
     movies: toMap(
       moviesResponse.body,
       mapRatedItemResponse,
       (entry) => entry.id,
     ),
     shows: toMap(showsResponse.body, mapRatedItemResponse, (entry) => entry.id),
+    seasons: toMap(
+      seasonsResponse.body,
+      mapRatedSeasonResponse,
+      (entry) => entry.id,
+    ),
     episodes: toMap(
       episodesResponse.body,
       mapRatedItemResponse,

--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -163,6 +163,7 @@ function createUseUserInstance() {
           ratings: of<UserRatings>({
             episodes: new Map(),
             movies: new Map(),
+            seasons: new Map(),
             shows: new Map(),
           }),
           reactions: of<UserReactions>(new Map()),

--- a/projects/client/src/lib/features/intl-overlay/profileActivityTargets.ts
+++ b/projects/client/src/lib/features/intl-overlay/profileActivityTargets.ts
@@ -19,6 +19,12 @@ type RatingEpisode = {
   episode: { id: number; title: string };
 };
 
+type RatingSeason = {
+  activityType: 'ratings';
+  type: 'season';
+  show: { id: number; title: string };
+};
+
 type ReviewMovieOrShow = {
   activityType: 'reviews';
   type: 'movie' | 'show';
@@ -36,13 +42,14 @@ type ProfileActivity =
   | RatingMovie
   | RatingShow
   | RatingEpisode
+  | RatingSeason
   | ReviewMovieOrShow
   | ReviewEpisode;
 
 /**
  * Targets for profile activity entries (ratings + reviews).
  * Discriminates on `activityType` first, then `type`:
- * - ratings carry titles in `movie`, `show`, or `episode` fields.
+ * - ratings carry titles in `movie`, `show`, `season`, or `episode` fields.
  * - reviews carry the main entity title in `media` and optionally `episode`.
  */
 export const profileActivityTargets = <T extends ProfileActivity>(entry: T) =>
@@ -85,6 +92,16 @@ export const profileActivityTargets = <T extends ProfileActivity>(entry: T) =>
       patch: (e, title) =>
         e.activityType === 'ratings' && e.type === 'episode'
           ? ({ ...e, episode: { ...e.episode, title } } as T)
+          : e,
+    },
+    {
+      get: (e) =>
+        e.activityType === 'ratings' && e.type === 'season'
+          ? { id: e.show.id, type: 'show' }
+          : null,
+      patch: (e, title) =>
+        e.activityType === 'ratings' && e.type === 'season'
+          ? ({ ...e, show: { ...e.show, title } } as T)
           : e,
     },
     {

--- a/projects/client/src/lib/requests/_internal/mapToListItem.ts
+++ b/projects/client/src/lib/requests/_internal/mapToListItem.ts
@@ -1,7 +1,7 @@
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import type { ListedAllResponse } from '@trakt/api';
 import type { ListItem } from '../models/ListItem.ts';
-import { mapToSeason } from '../queries/shows/showSeasonsQuery.ts';
+import { mapToSeason } from './mapToSeason.ts';
 import { mapToEpisodeEntry } from './mapToEpisodeEntry.ts';
 import { mapToMovieEntry } from './mapToMovieEntry.ts';
 import { mapToShowEntry } from './mapToShowEntry.ts';

--- a/projects/client/src/lib/requests/_internal/mapToSeason.ts
+++ b/projects/client/src/lib/requests/_internal/mapToSeason.ts
@@ -1,0 +1,27 @@
+import { mapToPoster } from '$lib/requests/_internal/mapToPoster.ts';
+import { mapToTraktRating } from '$lib/requests/_internal/mapToTraktRating.ts';
+import { MAX_DATE } from '$lib/utils/constants.ts';
+import { findDefined } from '$lib/utils/string/findDefined.ts';
+import type { SeasonsResponse } from '@trakt/api';
+import type { Season } from '../models/Season.ts';
+
+export const mapToSeason = (item: SeasonsResponse[0]): Season => {
+  const poster = findDefined(
+    ...(item.images?.poster ?? []),
+  );
+
+  return {
+    id: item.ids.trakt,
+    key: `season-${item.ids.trakt}`,
+    number: item.number,
+    episodes: {
+      count: item.episode_count ?? 0,
+    },
+    poster: poster ? mapToPoster(item.images) : undefined,
+    airDate: new Date(item.first_aired ?? MAX_DATE),
+    overview: item.overview ?? null,
+    rating: mapToTraktRating(item.rating),
+    network: item.network,
+    totalRuntime: item.total_runtime ?? NaN,
+  };
+};

--- a/projects/client/src/lib/requests/models/InvalidateAction.ts
+++ b/projects/client/src/lib/requests/models/InvalidateAction.ts
@@ -2,6 +2,8 @@ import type { CommentableMediaType } from './CommentableMediaType.ts';
 import type { ExtendedMediaType } from './ExtendedMediaType.ts';
 import type { MediaType } from './MediaType.ts';
 
+export type RatedMediaType = ExtendedMediaType | 'season';
+
 type UserType = 'avatar' | 'settings' | 'follow' | 'cover' | 'block';
 type ListType = 'edited' | 'deleted' | 'created' | 'like';
 type VipType = 'canceled' | 'updated';
@@ -12,7 +14,7 @@ const INVALIDATION_ID = 'invalidate' as const;
 
 export type InvalidateActionOptions =
   | `${typeof INVALIDATION_ID}:auth`
-  | `${typeof INVALIDATION_ID}:rated:${ExtendedMediaType}`
+  | `${typeof INVALIDATION_ID}:rated:${RatedMediaType}`
   | `${typeof INVALIDATION_ID}:mark_as_watched:${ExtendedMediaType}`
   | `${typeof INVALIDATION_ID}:collected:${ExtendedMediaType}`
   | `${typeof INVALIDATION_ID}:watchlisted:${MediaType}`
@@ -41,7 +43,7 @@ export type InvalidateActionOptions =
 
 type TypeDataMap = {
   'auth': null;
-  'rated': ExtendedMediaType;
+  'rated': RatedMediaType;
   'mark_as_watched': ExtendedMediaType;
   'collected': ExtendedMediaType;
   'watchlisted': MediaType;
@@ -90,7 +92,7 @@ function buildInvalidationKey<T extends keyof TypeDataMap>(
 export const InvalidateAction = {
   Auth: buildInvalidationKey('auth'),
 
-  Rated: (type: ExtendedMediaType) => buildInvalidationKey('rated', type),
+  Rated: (type: RatedMediaType) => buildInvalidationKey('rated', type),
 
   MarkAsWatched: (type: ExtendedMediaType) =>
     buildInvalidationKey('mark_as_watched', type),

--- a/projects/client/src/lib/requests/queries/shows/showSeasonsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSeasonsQuery.ts
@@ -1,13 +1,9 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { mapToSeason } from '$lib/requests/_internal/mapToSeason.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import type { SeasonsResponse } from '@trakt/api';
 import { z } from 'zod';
-import { MAX_DATE } from '../../../utils/constants.ts';
-import { findDefined } from '../../../utils/string/findDefined.ts';
-import { mapToPoster } from '../../_internal/mapToPoster.ts';
-import { mapToTraktRating } from '../../_internal/mapToTraktRating.ts';
-import { type Season, SeasonSchema } from '../../models/Season.ts';
+import { SeasonSchema } from '../../models/Season.ts';
 
 type ShowSeasonsParams = {
   slug: string;
@@ -26,27 +22,6 @@ const showSeasonsRequest = (
         extended: 'full,images',
       },
     });
-
-export const mapToSeason = (item: SeasonsResponse[0]): Season => {
-  const poster = findDefined(
-    ...(item.images?.poster ?? []),
-  );
-
-  return {
-    id: item.ids.trakt,
-    key: `season-${item.ids.trakt}`,
-    number: item.number,
-    episodes: {
-      count: item.episode_count ?? 0,
-    },
-    poster: poster ? mapToPoster(item.images) : undefined,
-    airDate: new Date(item.first_aired ?? MAX_DATE),
-    overview: item.overview ?? null,
-    rating: mapToTraktRating(item.rating),
-    network: item.network,
-    totalRuntime: item.total_runtime ?? NaN,
-  };
-};
 
 export const showSeasonsQuery = defineQuery({
   key: 'showSeasons',

--- a/projects/client/src/lib/requests/queries/users/userRatingsQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/userRatingsQuery.ts
@@ -2,16 +2,18 @@ import { defineInfiniteQuery } from '$lib/features/query/defineQuery.ts';
 import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
 import { mapToEpisodeEntry } from '$lib/requests/_internal/mapToEpisodeEntry.ts';
 import { mapToMovieEntry } from '$lib/requests/_internal/mapToMovieEntry.ts';
+import { mapToSeason } from '$lib/requests/_internal/mapToSeason.ts';
 import { mapToShowEntry } from '$lib/requests/_internal/mapToShowEntry.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { EpisodeEntrySchema } from '$lib/requests/models/EpisodeEntry.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { MovieEntrySchema } from '$lib/requests/models/MovieEntry.ts';
 import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import { SeasonSchema } from '$lib/requests/models/Season.ts';
 import { ShowEntrySchema } from '$lib/requests/models/ShowEntry.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import type { RatedItemResponse } from '@trakt/api';
+import { type RatedItemResponse, seasonResponseSchema } from '@trakt/api';
 import { z } from 'zod';
 import type { PaginationParams } from '../../models/PaginationParams.ts';
 
@@ -43,15 +45,26 @@ const EpisodeRatingEntrySchema = z.object({
   episode: EpisodeEntrySchema,
 });
 
+const SeasonRatingEntrySchema = z.object({
+  key: z.string(),
+  activityType: z.literal('ratings'),
+  ratedAt: z.date(),
+  rating: z.number(),
+  type: z.literal('season'),
+  show: ShowEntrySchema,
+  season: SeasonSchema,
+});
+
 export const UserRatingEntrySchema = z.discriminatedUnion('type', [
   MovieRatingEntrySchema,
   ShowRatingEntrySchema,
   EpisodeRatingEntrySchema,
+  SeasonRatingEntrySchema,
 ]);
 
 export type UserRatingEntry = z.infer<typeof UserRatingEntrySchema>;
 
-const SUPPORTED_RATING_TYPES = ['movie', 'show', 'episode'] as const;
+const SUPPORTED_RATING_TYPES = ['movie', 'show', 'episode', 'season'] as const;
 type SupportedRatingType = typeof SUPPORTED_RATING_TYPES[number];
 type SupportedRatingResponse = Extract<
   RatedItemResponse,
@@ -111,6 +124,23 @@ const mapToRatingEntry = (item: SupportedRatingResponse): UserRatingEntry => {
         episode,
       };
     }
+    case 'season': {
+      const show = mapToShowEntry(
+        assertDefined(item.show, 'Expected show in season rating'),
+      );
+      const season = mapToSeason(
+        seasonResponseSchema.parse(
+          assertDefined(item.season, 'Expected season in season rating'),
+        ),
+      );
+      return {
+        ...common,
+        key: `rating-season-${show.id}-${season.number}`,
+        type: 'season',
+        show,
+        season,
+      };
+    }
   }
 };
 
@@ -139,6 +169,7 @@ export const userRatingsQuery = defineInfiniteQuery({
   key: 'userRatings',
   invalidations: [
     InvalidateAction.Rated('episode'),
+    InvalidateAction.Rated('season'),
     InvalidateAction.Rated('show'),
     InvalidateAction.Rated('movie'),
   ],

--- a/projects/client/src/lib/sections/lists/components/MediaCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaCard.svelte
@@ -36,6 +36,10 @@
 
   const defaultVariant = $derived(useDefaultCardVariant(type));
   const variant = $derived(rest.variant ?? $defaultVariant);
+
+  const activitySubtitle = $derived(
+    "subtitle" in rest ? rest.subtitle : undefined,
+  );
 </script>
 
 {#snippet content(mediaCoverImageUrl: string, mediaCoverOverlay?: string)}
@@ -121,7 +125,7 @@
       </Link>
       <p class="trakt-card-subtitle ellipsis">
         {#if variant === "activity"}
-          {toTranslatedType(media.type)}
+          {activitySubtitle ?? toTranslatedType(media.type)}
         {:else}
           {toHumanDuration({ minutes: media.runtime }, languageTag())}
         {/if}

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -88,9 +88,13 @@
       };
     }
 
+    const seasonPoster = rest.type === "season"
+      ? rest.season.poster?.url.thumb
+      : undefined;
+
     return {
       background: media.cover.url.thumb,
-      poster: media.poster.url.thumb,
+      poster: seasonPoster ?? media.poster.url.thumb,
       title: media.title,
     };
   });

--- a/projects/client/src/lib/sections/lists/components/models/MediaCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/MediaCardProps.ts
@@ -6,8 +6,12 @@ import type { BaseItemProps } from './BaseItemProps.ts';
 
 export type MediaItemVariant<T> =
   | { variant?: Nil } & MediaInput<T>
-  | { variant: 'activity'; date: Date; activityType: ActivityType }
-    & MediaInput<T>
+  | {
+    variant: 'activity';
+    date: Date;
+    activityType: ActivityType;
+    subtitle?: string;
+  } & MediaInput<T>
   | { variant: 'next'; progress: number; minutesLeft: number } & MediaInput<T>
   | { variant: 'start' } & MediaInput<T>
   | { variant: 'progress' } & MediaInput<T>

--- a/projects/client/src/lib/sections/lists/user/_internal/getUserRatingForItem.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/getUserRatingForItem.ts
@@ -33,6 +33,8 @@ export function getUserRatingForItem(
       return ratings.shows.get(item.entry.id)?.rating;
     case 'episode':
       return ratings.episodes.get(item.entry.episode.id)?.rating;
+    case 'season':
+      return ratings.seasons.get(item.entry.season.id)?.rating;
     default:
       return undefined;
   }

--- a/projects/client/src/lib/sections/profile/components/_internal/ActivityRatingItem.svelte
+++ b/projects/client/src/lib/sections/profile/components/_internal/ActivityRatingItem.svelte
@@ -3,49 +3,51 @@
   import UserRating from "$lib/sections/components/UserRating.svelte";
   import EpisodeItem from "$lib/sections/lists/components/EpisodeItem.svelte";
   import MediaItem from "$lib/sections/lists/components/MediaItem.svelte";
+  import MediaSummaryCard from "$lib/sections/lists/components/MediaSummaryCard.svelte";
+  import { seasonLabel } from "$lib/utils/intl/seasonLabel";
 
   const {
     entry,
     style = "cover",
   }: { entry: UserRatingEntry; style?: "summary" | "cover" | "compact" } =
     $props();
+
+  const shared = $derived({
+    variant: "activity" as const,
+    activityType: "personal" as const,
+    date: entry.ratedAt,
+    source: "ratings" as const,
+    style,
+  });
+
+  const mediaProps = $derived(
+    entry.type === "movie"
+      ? { type: "movie" as const, media: entry.movie }
+      : {
+        type: "show" as const,
+        media: entry.show,
+        subtitle: entry.type === "season"
+          ? seasonLabel(entry.season.number)
+          : undefined,
+      },
+  );
 </script>
 
 {#snippet action()}
   <UserRating rating={entry.rating} />
 {/snippet}
 
-{#if entry.type === "episode"}
-  <EpisodeItem
-    episode={entry.episode}
-    media={entry.show}
-    variant="activity"
-    activityType="personal"
-    date={entry.ratedAt}
-    source="ratings"
-    {style}
-    {action}
-  />
-{:else if entry.type === "show"}
-  <MediaItem
-    type="show"
+{#if entry.type === "season" && style !== "cover"}
+  <MediaSummaryCard
+    type="season"
+    season={entry.season}
     media={entry.show}
     source="ratings"
-    variant="activity"
-    activityType="personal"
-    date={entry.ratedAt}
-    {style}
-    {action}
+    layout={style === "compact" ? "compact" : "default"}
+    badge={action}
   />
+{:else if entry.type === "episode"}
+  <EpisodeItem episode={entry.episode} media={entry.show} {...shared} {action} />
 {:else}
-  <MediaItem
-    type="movie"
-    media={entry.movie}
-    source="ratings"
-    variant="activity"
-    activityType="personal"
-    date={entry.ratedAt}
-    {style}
-    {action}
-  />
+  <MediaItem {...mediaProps} {...shared} {action} />
 {/if}

--- a/projects/client/src/lib/sections/profile/components/_internal/useMyActivityList.ts
+++ b/projects/client/src/lib/sections/profile/components/_internal/useMyActivityList.ts
@@ -59,7 +59,8 @@ export function useMyActivityList(props: UseMyActivityListProps) {
 
       return $list.filter((entry) => {
         if (props.mode === 'show') {
-          return entry.type === 'show' || entry.type === 'episode';
+          return entry.type === 'show' || entry.type === 'episode' ||
+            entry.type === 'season';
         }
 
         return entry.type === 'movie';

--- a/projects/client/src/lib/sections/settings/sync/clearRatings.ts
+++ b/projects/client/src/lib/sections/settings/sync/clearRatings.ts
@@ -18,6 +18,9 @@ export async function clearRatings(
     const shows = Array.from(ratings.shows.keys()).map((id) => ({
       ids: { trakt: id },
     }));
+    const seasons = Array.from(ratings.seasons.keys()).map((id) => ({
+      ids: { trakt: id },
+    }));
     const episodes = Array.from(ratings.episodes.keys()).map((id) => ({
       ids: { trakt: id },
     }));
@@ -38,6 +41,15 @@ export async function clearRatings(
         chunk(shows, SYNC_CHUNK_SIZE),
         (batch) => batch,
         (batch) => client.sync.ratings.remove({ body: { shows: [...batch] } }),
+      );
+    }
+
+    if (seasons.length > 0) {
+      await run(
+        chunk(seasons, SYNC_CHUNK_SIZE),
+        (batch) => batch,
+        (batch) =>
+          client.sync.ratings.remove({ body: { seasons: [...batch] } }),
       );
     }
 

--- a/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
+++ b/projects/client/src/lib/sections/stats/_internal/useWeeklyPulse.ts
@@ -47,6 +47,7 @@ function getRatingsInRange(
   return [
     ...data.movies.values(),
     ...data.shows.values(),
+    ...data.seasons.values(),
     ...data.episodes.values(),
   ].filter((e) => e.ratedAt >= range.start && e.ratedAt < range.end);
 }

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -80,7 +80,7 @@
         }}
       />
 
-      {#if props.type !== "episode"}
+      {#if props.type !== "episode" && props.type !== "season"}
         <div
           class="trakt-favorite-action"
           transition:slideFade={{ duration: 300, axis: "x" }}

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/useIsRateable.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/useIsRateable.ts
@@ -1,9 +1,9 @@
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
-import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
+import type { ExtendedMediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { map } from 'rxjs';
 import { useIsWatched } from '../../../../media-actions/mark-as-watched/useIsWatched.ts';
 
-export type IsRateableProps = MediaStoreProps;
+export type IsRateableProps = ExtendedMediaStoreProps;
 
 export function useIsRateable(props: IsRateableProps) {
   const { type } = props;

--- a/projects/client/src/lib/sections/summary/components/rating/models/RateNowProps.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/models/RateNowProps.ts
@@ -1,6 +1,7 @@
 import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
 import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import type { Season } from '$lib/requests/models/Season.ts';
 import type { ShowEntry } from '$lib/requests/models/ShowEntry.ts';
 
 type RateableEpisode = {
@@ -9,12 +10,20 @@ type RateableEpisode = {
   show: ShowEntry;
 };
 
+type RateableSeason = {
+  type: 'season';
+  media: Season;
+  show: ShowEntry;
+};
+
 type RateableMedia = {
   type: MediaType;
   media: MediaEntry;
 };
 
-export type RateNowProps = (RateableEpisode | RateableMedia) & {
-  onclick?: () => void;
-  style?: 'default' | 'minimal';
-};
+export type RateNowProps =
+  & (RateableEpisode | RateableSeason | RateableMedia)
+  & {
+    onclick?: () => void;
+    style?: 'default' | 'minimal';
+  };

--- a/projects/client/src/lib/sections/summary/components/rating/useRatings.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/useRatings.spec.ts
@@ -1,7 +1,9 @@
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
 import { MovieMatrixMappedMock } from '$mocks/data/summary/movies/matrix/MovieMatrixMappedMock.ts';
+import { ShowSiloSeasonsMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts';
 import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
 import { waitForEmission } from '$test/readable/waitForEmission.ts';
 import { waitForValue } from '$test/readable/waitForValue.ts';
@@ -62,6 +64,23 @@ describe('useRatings', () => {
     expect(value?.rating).toBe(10);
   });
 
+  it('should return the current season rating', async () => {
+    const season = assertDefined(ShowSiloSeasonsMappedMock.at(0));
+
+    const { current } = await renderStore(() =>
+      useRatings({
+        type: 'season',
+        id: season.id,
+      })
+    );
+
+    const value = await waitForValue(current, {
+      rating: 8,
+      isFavorited: false,
+    });
+    expect(value?.rating).toBe(8);
+  });
+
   it('should return undefined if there is no current rating', async () => {
     const { current } = await renderStore(() =>
       useRatings({
@@ -91,5 +110,24 @@ describe('useRatings', () => {
       .toHaveBeenCalledWith(InvalidateAction.Rated('movie'));
     expect(invalidate)
       .not.toHaveBeenNthCalledWith(2, InvalidateAction.Favorited('movie'));
+  });
+
+  it('should call invalidate after rating a season', async () => {
+    const season = assertDefined(ShowSiloSeasonsMappedMock.at(1));
+
+    const { addRating } = await renderStore(() =>
+      useRatings({
+        type: 'season',
+        id: season.id,
+      })
+    );
+
+    vi.useFakeTimers();
+    addRating(6);
+    await vi.advanceTimersByTimeAsync(500);
+    vi.useRealTimers();
+
+    expect(invalidate)
+      .toHaveBeenCalledWith(InvalidateAction.Rated('season'));
   });
 });

--- a/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
@@ -2,8 +2,10 @@ import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { useLastWatched } from '$lib/features/toast/useLastWatched.ts';
-import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
-import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import {
+  InvalidateAction,
+  type RatedMediaType,
+} from '$lib/requests/models/InvalidateAction.ts';
 import { addRatingRequest } from '$lib/requests/sync/addRatingRequest.ts';
 import { removeRatingRequest } from '$lib/requests/sync/removeRatingRequest.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
@@ -21,7 +23,7 @@ import {
 
 const postDelay = time.seconds(0.5);
 
-type RateableType = ExtendedMediaType;
+type RateableType = RatedMediaType;
 
 export type WatchlistStoreProps = {
   type: RateableType;
@@ -65,6 +67,8 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
           return $ratings.movies.get(id);
         case 'show':
           return $ratings.shows.get(id);
+        case 'season':
+          return $ratings.seasons.get(id);
         case 'episode':
           return $ratings.episodes.get(id);
       }
@@ -82,6 +86,8 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
           return $favorites.movies.has(id);
         case 'show':
           return $favorites.shows.has(id);
+        case 'season':
+          return false;
         case 'episode':
           return false;
       }
@@ -122,6 +128,9 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
         case 'show':
           hasRating = currentRatings.shows.has(id);
           break;
+        case 'season':
+          hasRating = currentRatings.seasons.has(id);
+          break;
         case 'episode':
           hasRating = currentRatings.episodes.has(id);
           break;
@@ -135,7 +144,9 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
 
     pendingRating.next(null);
     isSubmitting.next(false);
-    dismiss(id, type, 'rating');
+    if (type !== 'season') {
+      dismiss(id, type, 'rating');
+    }
   });
 
   const addRating = (newRating: number) => {

--- a/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonInfoSection.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonInfoSection.svelte
@@ -4,14 +4,16 @@
   import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { Season } from "$lib/requests/models/Season";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
+  import RateNow from "$lib/sections/summary/components/rating/RateNow.svelte";
   import { toTraktRating } from "$lib/utils/formatting/number/toTraktRating.ts";
 
   type SeasonInfoSectionProps = {
     season: Season;
-    showTitle: string;
+    show: ShowEntry;
   };
 
-  const { season, showTitle }: SeasonInfoSectionProps = $props();
+  const { season, show }: SeasonInfoSectionProps = $props();
 
   const traktRating = $derived(
     season.rating != null
@@ -21,16 +23,20 @@
 </script>
 
 <div class="season-info-section">
-  {#if traktRating}
-    <div class="season-rating">
-      <RatingIcon style="rated" />
-      <p class="bold">{traktRating}</p>
-    </div>
-  {/if}
+  <div class="season-rating-row">
+    {#if traktRating}
+      <div class="season-rating">
+        <RatingIcon style="rated" />
+        <p class="bold">{traktRating}</p>
+      </div>
+    {/if}
+
+    <RateNow type="season" media={season} {show} />
+  </div>
 
   {#if season.overview}
     <ClampedText
-      label={m.button_label_expand_media_overview({ title: showTitle })}
+      label={m.button_label_expand_media_overview({ title: show.title })}
       lineCount={6}
     >
       {season.overview}
@@ -43,6 +49,19 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-m);
+  }
+
+  .season-rating-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--gap-m);
+    min-height: var(--ni-40);
+
+    :global(.trakt-rate-now) {
+      margin-inline-start: auto;
+    }
   }
 
   .season-rating {

--- a/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonOverviewTab.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonOverviewTab.svelte
@@ -23,7 +23,7 @@
 <div class="season-overview-tab">
   <div class="season-overview-block">
     <SeasonTabTitle title={m.section_title_seasons_overview()} />
-    <SeasonInfoSection {season} showTitle={show.title} />
+    <SeasonInfoSection {season} {show} />
   </div>
 
   <SeasonCastSection crew={$crew} type="show" isLoading={$isLoading} />

--- a/projects/client/src/mocks/data/users/mapped/UserRatedMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/UserRatedMappedMock.ts
@@ -3,6 +3,7 @@ import type { RatedEntry } from '$lib/features/auth/queries/currentUserRatingsQu
 export const UserRatedMappedMock: {
   movies: Map<number, RatedEntry>;
   shows: Map<number, RatedEntry>;
+  seasons: Map<number, RatedEntry>;
   episodes: Map<number, RatedEntry>;
 } = {
   movies: new Map([
@@ -17,6 +18,13 @@ export const UserRatedMappedMock: {
       'id': 180770,
       'ratedAt': new Date('2025-01-16T17:39:23.000Z'),
       'rating': 9,
+    }],
+  ]),
+  seasons: new Map([
+    [257490, {
+      'id': 257490,
+      'ratedAt': new Date('2025-01-16T17:41:12.000Z'),
+      'rating': 8,
     }],
   ]),
   episodes: new Map([

--- a/projects/client/src/mocks/data/users/response/RatedSeasonsResponseMock.ts
+++ b/projects/client/src/mocks/data/users/response/RatedSeasonsResponseMock.ts
@@ -1,0 +1,20 @@
+import { ShowSiloMinimalResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloMinimalResponseMock.ts';
+import type { RatedItemResponse } from '@trakt/api';
+
+export const RatedSeasonsResponseMock: RatedItemResponse[] = [
+  {
+    'rated_at': '2025-01-16T17:41:12.000Z',
+    'rating': 8,
+    'type': 'season',
+    'season': {
+      'number': 1,
+      'ids': {
+        'trakt': 257490,
+        'tvdb': 1928276,
+        'tmdb': 196076,
+      },
+      'aired_episodes': 10,
+    },
+    'show': ShowSiloMinimalResponseMock,
+  },
+];

--- a/projects/client/src/mocks/handlers/users.ts
+++ b/projects/client/src/mocks/handlers/users.ts
@@ -22,6 +22,7 @@ import { MinimalLikedListsResponseMock } from '../data/users/response/MinimalLik
 import { MovieActivityHistoryResponseMock } from '../data/users/response/MovieActivityHistoryResponseMock.ts';
 import { RatedEpisodesResponseMock } from '../data/users/response/RatedEpisodesResponseMock.ts';
 import { RatedMoviesResponseMock } from '../data/users/response/RatedMoviesResponseMock.ts';
+import { RatedSeasonsResponseMock } from '../data/users/response/RatedSeasonsResponseMock.ts';
 import { RewatchingShowsResponseMock } from '../data/users/response/RewatchingShowsResponseMock.ts';
 import { ShowActivityHistoryResponseMock } from '../data/users/response/ShowActivityHistoryResponseMock.ts';
 import { SocialActivityResponseMock } from '../data/users/response/SocialActivityResponseMock.ts';
@@ -110,6 +111,9 @@ export const users = [
   }),
   http.get('http://localhost/users/me/ratings/shows', () => {
     return HttpResponse.json(RatedShowsResponseMock);
+  }),
+  http.get('http://localhost/users/me/ratings/seasons*', () => {
+    return HttpResponse.json(RatedSeasonsResponseMock);
   }),
   http.get('http://localhost/users/me/ratings/episodes', () => {
     return HttpResponse.json(RatedEpisodesResponseMock);


### PR DESCRIPTION
Follow-up to #1606.

## Summary

Adds a season rating prompt to the season drawer info tab, next to the overall Trakt season rating. The prompt uses the existing rating UI and only appears when the current user has watched the full season.

## Changes

- Extend current-user ratings to include season ratings.
- Allow `RateNow` / `useRatings` to handle `season` targets without showing favorite actions.
- Render the season rating prompt beside the overall rating in the season info section.
- Include season ratings in supporting user-rating flows such as clear ratings, list display, and weekly pulse stats.

## Screenshots

<img width="1340" height="1044" alt="Screenshot 2026-07-07 at 10 03 44" src="https://github.com/user-attachments/assets/ded1ea1e-c096-45ab-a18f-c35dbda41dda" />
