### PR TITLE
fix(summary): format IMDb ratings to a single decimal place

### DIFF
--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -5,6 +5,7 @@
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import type { MediaRating } from "$lib/requests/models/MediaRating";
+  import { toIMDBRating } from "$lib/utils/formatting/number/toIMDBRating";
   import {
     toRottenAudienceRating,
     toRottenCriticRating,
@@ -71,7 +72,11 @@
     {@render traktItem()}
   {/if}
 
-  <RatingItem rating={imdb?.rating} url={imdb?.url} {isLoading}>
+  <RatingItem
+    rating={imdb?.rating && toIMDBRating(imdb.rating, getLocale())}
+    url={imdb?.url}
+    {isLoading}
+  >
     <IMDBIcon style={toVotesBasedRating(imdb?.votes)} />
     {#snippet superscript()}
       {i18n.voteText(imdb?.votes ?? 0)}

--- a/projects/client/src/lib/features/share/_internal/RatingsList.svelte
+++ b/projects/client/src/lib/features/share/_internal/RatingsList.svelte
@@ -6,6 +6,7 @@
   import RottenIcon from "$lib/components/icons/RottenIcon.svelte";
   import StarIcon from "$lib/components/icons/StarIcon.svelte";
   import type { MediaRating } from "$lib/requests/models/MediaRating";
+  import { toIMDBRating } from "$lib/utils/formatting/number/toIMDBRating";
   import {
     toRottenAudienceRating,
     toRottenCriticRating,
@@ -20,7 +21,9 @@
   const traktRating = $derived(
     trakt?.rating ? toTraktRating(trakt.rating, "en") : undefined,
   );
-  const imdbRating = $derived(imdb?.rating);
+  const imdbRating = $derived(
+    imdb?.rating ? toIMDBRating(imdb.rating, "en") : undefined,
+  );
   const rottenCriticRating = $derived(
     rotten?.critic ? toTraktRating(rotten.critic, "en") : undefined,
   );

--- a/projects/client/src/lib/utils/formatting/number/toIMDBRating.spec.ts
+++ b/projects/client/src/lib/utils/formatting/number/toIMDBRating.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { toIMDBRating } from './toIMDBRating.ts';
+
+describe('toIMDBRating', () => {
+  it('rounds up to a single decimal place', () => {
+    // Replicates the specific IMDb bug
+    expect(toIMDBRating(9.0888, 'en-US')).toBe('9.1');
+    expect(toIMDBRating(8.16, 'en-US')).toBe('8.2');
+  });
+
+  it('rounds down to a single decimal place', () => {
+    expect(toIMDBRating(8.14, 'en-US')).toBe('8.1');
+  });
+
+  it('pads exact integers with a trailing zero', () => {
+    expect(toIMDBRating(9, 'en-US')).toBe('9.0');
+    expect(toIMDBRating(8.0, 'en-US')).toBe('8.0');
+  });
+
+  it('respects locale-specific decimal separators', () => {
+    // Many European locales use a comma instead of a period for decimals
+    expect(toIMDBRating(9.0888, 'de-DE')).toBe('9,1');
+    expect(toIMDBRating(9, 'de-DE')).toBe('9,0');
+    expect(toIMDBRating(8.14, 'fr-FR')).toBe('8,1');
+  });
+});

--- a/projects/client/src/lib/utils/formatting/number/toIMDBRating.ts
+++ b/projects/client/src/lib/utils/formatting/number/toIMDBRating.ts
@@ -1,6 +1,18 @@
-export function toIMDBRating(rating: number, locale: string): string {
-  return new Intl.NumberFormat(locale, {
+const formatterCache = new Map<string, Intl.NumberFormat>();
+
+function getFormatter(locale: string): Intl.NumberFormat {
+  const cached = formatterCache.get(locale);
+  if (cached) return cached;
+
+  const formatter = new Intl.NumberFormat(locale, {
     minimumFractionDigits: 1,
     maximumFractionDigits: 1,
-  }).format(rating);
+  });
+  formatterCache.set(locale, formatter);
+
+  return formatter;
+}
+
+export function toIMDBRating(rating: number, locale: string): string {
+  return getFormatter(locale).format(rating);
 }

--- a/projects/client/src/lib/utils/formatting/number/toIMDBRating.ts
+++ b/projects/client/src/lib/utils/formatting/number/toIMDBRating.ts
@@ -1,0 +1,6 @@
+export function toIMDBRating(rating: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(rating);
+}


### PR DESCRIPTION
## Summary
- IMDb ratings from Trakt can carry extra decimal precision (e.g. `9.0888`), which rendered raw instead of a clean single-decimal display.
- Adds `toIMDBRating`, a locale-aware `Intl.NumberFormat` wrapper that rounds to one decimal and pads whole numbers (`9` -> `9.0`).
- Applies it everywhere the IMDb rating is displayed: the summary `RatingList` and the share feature's `RatingsList`.

## Test plan
- [x] `toIMDBRating.spec.ts` covers rounding up/down, whole-number padding, and locale-specific separators (`de-DE`, `fr-FR`)
- [x] Manually verify IMDb rating renders as `X.X` on a movie/show summary page

@seferturan is there a way we can test the share image? 
- [x] Manually verify IMDb rating renders as `X.X` on the share image 

Before
<img width="433" height="296" alt="Screenshot 2026-07-07 at 6 14 05 pm" src="https://github.com/user-attachments/assets/f3aeb668-ef85-4c0c-8d56-6888c08a3c89" />

After
<img width="473" height="269" alt="Screenshot 2026-07-07 at 6 13 40 pm" src="https://github.com/user-attachments/assets/50dd669b-3ef7-4ed7-91f8-1a2af5fd39da" />
