### PR TITLE
feat(banner): add TV Time migration companion banner

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7354,6 +7354,18 @@
       "default": "Import your data",
       "description": "Call-to-action on the welcome banner that takes the user to the data import settings page."
     },
+    "tv_time_banner_heading": {
+      "default": "Coming from TV Time?",
+      "description": "Heading on the banner shown to users who joined Trakt around the TV Time shutdown announcement, promoting the TV Time-style companion app."
+    },
+    "tv_time_banner_description": {
+      "default": "TV Time is shutting down on July 15. Feel right at home with our familiar companion app, powered by your Trakt account.",
+      "description": "Description on the TV Time migration banner explaining that tvtime.trakt.tv is a familiar companion app backed by Trakt."
+    },
+    "tv_time_banner_action": {
+      "default": "Open tvtime.trakt.tv",
+      "description": "Call-to-action link on the TV Time migration banner that opens the tvtime.trakt.tv companion app in a new tab."
+    },
     "welcome_greeting": {
       "default": "Welcome to Trakt, {name}",
       "description": "Main heading on the Welcome page, greeting the signed-in user by name."

--- a/projects/client/src/lib/sections/banner/Banner.svelte
+++ b/projects/client/src/lib/sections/banner/Banner.svelte
@@ -4,6 +4,7 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import PromotionBanners from "./_internal/PromotionBanners.svelte";
   import ReviewBanners from "./_internal/ReviewBanners.svelte";
+  import TvTimeBanner from "./tv-time/TvTimeBanner.svelte";
   import WelcomeBanner from "./welcome/WelcomeBanner.svelte";
 
   $effect.pre(() => initializePromotions());
@@ -12,6 +13,7 @@
 
 <RenderFor audience="authenticated">
   <WelcomeBanner />
+  <TvTimeBanner />
 </RenderFor>
 
 <RenderFor audience="vip">

--- a/projects/client/src/lib/sections/banner/_internal/BannerLink.svelte
+++ b/projects/client/src/lib/sections/banner/_internal/BannerLink.svelte
@@ -27,6 +27,7 @@
   <Link
     {href}
     {target}
+    color="inherit"
     onclick={() => track({ source, target: href ?? "banner-link" })}
   >
     <ExternalLinkIcon size="small" />
@@ -51,6 +52,7 @@
       border-radius: var(--border-radius-l);
       padding: var(--ni-8) var(--ni-12);
 
+      color: var(--shade-10);
       text-decoration: none;
 
       transition: padding var(--transition-increment) ease-in-out;

--- a/projects/client/src/lib/sections/banner/tv-time/TvTimeBanner.svelte
+++ b/projects/client/src/lib/sections/banner/tv-time/TvTimeBanner.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import LogoMarkCircle from "$lib/components/logo/LogoMarkCircle.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+  import BannerContainer from "../_internal/BannerContainer.svelte";
+  import BannerLink from "../_internal/BannerLink.svelte";
+  import DismissButton from "../_internal/DismissButton.svelte";
+  import { useTvTimeBanner } from "./_internal/useTvTimeBanner.ts";
+  import { TV_TIME_BANNER_ID } from "./constants/index.ts";
+
+  const { isVisible, dismiss } = useTvTimeBanner();
+</script>
+
+{#if $isVisible}
+  <BannerContainer>
+    <section class="trakt-tv-time-banner">
+      <div class="tv-time-banner-dismiss">
+        <DismissButton onDismiss={dismiss} />
+      </div>
+
+      <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
+        <div class="tv-time-banner-icon" aria-hidden="true">
+          <LogoMarkCircle />
+        </div>
+      </RenderFor>
+
+      <div class="tv-time-banner-content">
+        <h2 class="bold tv-time-banner-title">
+          {m.tv_time_banner_heading()}
+          <RenderFor audience="all" device={["tablet-sm", "mobile"]}>
+            <LogoMarkCircle />
+          </RenderFor>
+        </h2>
+        <p class="secondary">{m.tv_time_banner_description()}</p>
+      </div>
+
+      <BannerLink
+        href={UrlBuilder.app.tvTime()}
+        target="_blank"
+        source={TV_TIME_BANNER_ID}
+      >
+        {m.tv_time_banner_action()}
+      </BannerLink>
+    </section>
+  </BannerContainer>
+{/if}
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-tv-time-banner {
+    position: relative;
+    overflow: hidden;
+
+    display: flex;
+    align-items: center;
+    gap: var(--gap-l);
+
+    width: 100%;
+    box-sizing: border-box;
+
+    padding: var(--gap-l) var(--gap-xl);
+    padding-inline-end: var(--ni-48);
+
+    background: color-mix(
+      in srgb,
+      var(--color-card-background) 80%,
+      transparent
+    );
+    border: var(--border-thickness-xxs) solid
+      color-mix(in srgb, var(--color-border) 50%, transparent);
+    border-radius: var(--border-radius-xl);
+
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: padding, gap;
+
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+
+      background: radial-gradient(
+        85% 130% at 100% 0%,
+        color-mix(in srgb, var(--purple-500) 12%, transparent),
+        transparent 60%
+      );
+    }
+
+    @include for-tablet-sm-and-below {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--gap-m);
+
+      padding: var(--gap-l);
+      padding-inline-end: var(--ni-48);
+    }
+  }
+
+  .tv-time-banner-dismiss {
+    position: absolute;
+    z-index: 1;
+
+    top: var(--ni-8);
+    inset-inline-end: var(--ni-8);
+  }
+
+  .tv-time-banner-icon {
+    position: relative;
+    flex-shrink: 0;
+
+    display: grid;
+    place-items: center;
+
+    width: var(--ni-48);
+    height: var(--ni-48);
+
+    :global(svg) {
+      width: var(--ni-24);
+      height: var(--ni-24);
+    }
+  }
+
+  .tv-time-banner-content {
+    position: relative;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xxs);
+
+    flex: 1 1 auto;
+
+    @include for-tablet-sm-and-below {
+      gap: var(--gap-s);
+    }
+  }
+
+  .tv-time-banner-title {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    :global(svg) {
+      width: var(--ni-18);
+      height: var(--ni-18);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/banner/tv-time/_internal/useTvTimeBanner.ts
+++ b/projects/client/src/lib/sections/banner/tv-time/_internal/useTvTimeBanner.ts
@@ -1,0 +1,34 @@
+import type { UserSettings } from '$lib/features/auth/queries/currentUserSettingsQuery.ts';
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { combineLatest, map } from 'rxjs';
+import { useBannerDismissal } from '../../_internal/useBannerDismissal.ts';
+import {
+  TV_TIME_ANNOUNCEMENT_DATE,
+  TV_TIME_BANNER_END,
+  TV_TIME_BANNER_ID,
+} from '../constants/index.ts';
+
+const DISMISSAL_VALUE = 'dismissed';
+
+function joinedAfterAnnouncement(user: UserSettings | undefined): boolean {
+  const joinedAt = user?.joinedAt;
+  return joinedAt != null && joinedAt >= TV_TIME_ANNOUNCEMENT_DATE;
+}
+
+export function useTvTimeBanner() {
+  const { user } = useUser();
+  const { isDismissed, dismiss } = useBannerDismissal(
+    TV_TIME_BANNER_ID,
+    DISMISSAL_VALUE,
+  );
+
+  const hasExpired = new Date() >= TV_TIME_BANNER_END;
+
+  const isVisible = combineLatest([user, isDismissed]).pipe(
+    map(([$user, $isDismissed]) =>
+      !hasExpired && !$isDismissed && joinedAfterAnnouncement($user)
+    ),
+  );
+
+  return { isVisible, dismiss };
+}

--- a/projects/client/src/lib/sections/banner/tv-time/constants/index.ts
+++ b/projects/client/src/lib/sections/banner/tv-time/constants/index.ts
@@ -1,0 +1,10 @@
+export const TV_TIME_BANNER_ID = 'tv-time';
+
+// TV Time announced its shutdown in-app on 2026-07-01 (TechCrunch reported it
+// 2026-07-02). Users who joined on/after this date are treated as migrating
+// from TV Time and shown the companion-app banner.
+export const TV_TIME_ANNOUNCEMENT_DATE = new Date('2026-07-01T00:00:00.000Z');
+
+// Hard cutoff - the banner stops showing at the end of the shutdown month
+// (July 2026) regardless of join date. Exclusive upper bound.
+export const TV_TIME_BANNER_END = new Date('2026-08-01T00:00:00.000Z');

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -274,6 +274,7 @@ export const UrlBuilder = {
   app: {
     android: () => 'https://trakt.tv/a/trakt-android',
     ios: () => 'https://trakt.tv/a/trakt-ios',
+    tvTime: () => 'https://tvtime.trakt.tv',
   },
   docs: {
     api: () => 'https://docs.trakt.tv',


### PR DESCRIPTION
## What

Adds a dismissible banner shown to authenticated users who joined on or after the TV Time shutdown announcement (2026-07-01), pointing them at the `tvtime.trakt.tv` companion app (our TV Time-style UI over the Trakt API).

TV Time announced its shutdown in-app on 2026-07-01 (TechCrunch reported 2026-07-02); the service goes offline July 15. Users who signed up around that window are almost certainly TV Time refugees, so we surface the familiar companion app to them.

## How

- New `sections/banner/tv-time/` module mirroring the welcome banner:
  - `constants/` - `TV_TIME_ANNOUNCEMENT_DATE` (lower cutoff) + `TV_TIME_BANNER_END` (hard upper cutoff)
  - `_internal/useTvTimeBanner.ts` - visible when `useUser().user.joinedAt >= announcement`, not dismissed (localStorage via `useBannerDismissal`), and before the end cutoff
  - `TvTimeBanner.svelte` - `BannerContainer` + copy + external `BannerLink` + `DismissButton`
- Mounted in `Banner.svelte` under `RenderFor audience="authenticated"`
- `UrlBuilder.app.tvTime()` -> `https://tvtime.trakt.tv`
- `BannerLink` pill now owns its text color (`--shade-10`) via `color="inherit"` on the inner `Link`, so the label stays readable regardless of the parent banner's color. Black Friday banner unaffected (already light-on-dark).
- 3 new i18n keys (`tv_time_banner_heading` / `_description` / `_action`)

Slots into the existing TV Time migration work (`/faq/tv-time`, `tv_time_report_*`).

## Notes

- Join-date lower bound is `>=` the announcement date. The banner also hard-stops at the end of the shutdown month (`TV_TIME_BANNER_END` = 2026-08-01, exclusive), regardless of join date.
- A brand-new migrant with zero activity could briefly see both the welcome and TV Time banners; each is independently dismissible. Left as-is.