### PR TITLE
fix(settings): repair TV Time import for GDPR v2 + support the current export format

### DIFF
--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.spec.ts
@@ -223,7 +223,69 @@ describe('TvTimeCsvParser', () => {
     });
   });
 
+  describe('current export format (tvtime-*.csv / tvtime-export.zip)', () => {
+    const EPISODES_CSV = [
+      'series_tvdb_id,series_imdb_id,series_uuid,title,season,episode,tvdb_id,is_watched,watched_at,rewatch_count,special',
+      '346328,,uuid,Elite,1,1,6671792,true,2019-10-04 03:43:42,0,false',
+    ].join('\n');
+
+    it('should route tvtime-series-episodes csv to the export parser', async () => {
+      const result = await TvTimeCsvParser.parse([
+        csvFile(EPISODES_CSV, 'tvtime-series-episodes-2026-07-05.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'history',
+        type: 'episode',
+        ids: { tvdb: 6671792 },
+        title: 'Elite',
+        season: 1,
+        episode: 1,
+      });
+    });
+
+    it('should route a tvtime-export zip to the export parser', async () => {
+      const file = zipFile(
+        {
+          'tvtime-series-episodes-2026-07-07.csv': EPISODES_CSV,
+          'tvtime-summary-2026-07-07.html': '<html></html>',
+        },
+        'tvtime-export-2026-07-07.zip',
+      );
+
+      const result = await TvTimeCsvParser.parse([file]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        type: 'episode',
+        ids: { tvdb: 6671792 },
+      });
+    });
+  });
+
   describe('mixed uploads', () => {
+    // A GDPR noise file (where-to-watch-prod-table.csv) carries episode_id +
+    // episode_number, which used to trip the native heuristic and reject the
+    // whole batch as "different exports". It must be ignored, not misdetected.
+    it('should not misdetect gdpr noise carrying episode_id as native', async () => {
+      const whereToWatch = [
+        'vote_type,hash_key,episode_id,type,id,created_at,range_key,user_id,network_platform,series_name,episode_number,season_number',
+        'watch,hk,1331151,ep,1,2021-10-10,rk,1,Netflix,Fringe,10,2',
+      ].join('\n');
+
+      const result = await TvTimeCsvParser.parse([
+        csvFile(whereToWatch, 'where-to-watch-prod-table.csv'),
+        csvFile(GDPR_V2_CSV, 'tracking-prod-records-v2.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        type: 'episode',
+        ids: { tvdb: 1331151 },
+      });
+    });
+
     it('should reject files from different export formats', async () => {
       await expect(TvTimeCsvParser.parse([
         csvFile(LIBERATOR_CSV, 'tv-time-liberator.csv'),

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeCsvParser.ts
@@ -1,25 +1,32 @@
 import type { FileParser } from './ParserInterface.ts';
+import { TvTimeExportParser } from './TvTimeExportParser.ts';
 import { TvTimeGdprParser } from './TvTimeGdprParser.ts';
 import { TvTimeLiberatorParser } from './TvTimeLiberatorParser.ts';
 import { TvTimeNativeParser } from './TvTimeNativeParser.ts';
 import { parseCsvFile } from './utils/parseCsvFile.ts';
 import { zipEntryBasenames } from './utils/zipEntryBasenames.ts';
 
-type TvTimeFormat = 'gdpr' | 'liberator' | 'native' | 'unknown';
+type TvTimeFormat = 'gdpr' | 'liberator' | 'native' | 'export' | 'unknown';
 
 const GDPR_ZIP_MARKER = 'tracking-prod-records';
 const LIBERATOR_ZIP_MARKER = 'activity_history.csv';
 
-// Columns that accompany episode_id in TV Time's native export. GDPR noise
-// files (show_seen_episode_latest.csv, where-to-watch-prod-table.csv) also
-// carry episode_id, so it alone is not enough to claim the native format.
+// Columns unique to TV Time's native export. GDPR noise files
+// (show_seen_episode_latest.csv, where-to-watch-prod-table.csv) also carry
+// episode_id + episode_number, so those generic columns can't be used to
+// claim the native format — only the show_name/ts/episode_name family is.
 const NATIVE_COMPANION_COLUMNS = [
   'ts',
   'show_name',
   'episode_name',
   'episode_season_number',
-  'episode_number',
 ];
+
+// The current "export my data" tool emits tvtime-*.csv files (loose or zipped
+// as tvtime-export-*.zip); series-episodes carries a series_tvdb_id column.
+function isExportCsv(file: File, first: Record<string, unknown>): boolean {
+  return file.name.startsWith('tvtime-') || 'series_tvdb_id' in first;
+}
 
 async function detectZipFormat(file: File): Promise<TvTimeFormat> {
   const buffer = await file.arrayBuffer();
@@ -37,6 +44,14 @@ async function detectZipFormat(file: File): Promise<TvTimeFormat> {
     return 'gdpr';
   }
   if (basenames.includes(LIBERATOR_ZIP_MARKER)) return 'liberator';
+  if (
+    basenames.some((name) =>
+      name.startsWith('tvtime-') &&
+      (name.endsWith('.csv') || name.endsWith('.json'))
+    )
+  ) {
+    return 'export';
+  }
 
   throw new Error(
     'This .zip file does not look like a TV Time export. Upload the GDPR data export .zip or the Liberator export .zip.',
@@ -48,6 +63,7 @@ async function detectFormat(file: File): Promise<TvTimeFormat> {
 
   const [first] = await parseCsvFile(file) as Record<string, unknown>[];
   if (!first) return 'unknown';
+  if (isExportCsv(file, first)) return 'export';
   if ('imdb_id' in first) return 'liberator';
   if (
     'type-uuid-n' in first || 'key' in first ||
@@ -109,6 +125,8 @@ export const TvTimeCsvParser: FileParser = {
         return parsePerFile(TvTimeLiberatorParser, recognized);
       case 'gdpr':
         return TvTimeGdprParser.parse(recognized);
+      case 'export':
+        return TvTimeExportParser.parse(recognized);
       default:
         return parsePerFile(TvTimeNativeParser, recognized);
     }

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.spec.ts
@@ -1,0 +1,273 @@
+import { zipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { TvTimeExportParser } from './TvTimeExportParser.ts';
+
+const EPISODES_HEADER = [
+  'series_tvdb_id',
+  'series_imdb_id',
+  'series_uuid',
+  'title',
+  'season',
+  'episode',
+  'tvdb_id',
+  'is_watched',
+  'watched_at',
+  'rewatch_count',
+  'special',
+];
+
+const MOVIES_HEADER = [
+  'uuid',
+  'tvdb_id',
+  'imdb_id',
+  'title',
+  'year',
+  'created_at',
+  'watched_at',
+  'is_watched',
+  'rewatch_count',
+];
+
+const SERIES_HEADER = [
+  'uuid',
+  'tvdb_id',
+  'imdb_id',
+  'title',
+  'status',
+  'created_at',
+];
+
+function toCsv(header: string[], rows: Record<string, string>[]): string {
+  const lines = rows.map(
+    (row) => header.map((column) => row[column] ?? '').join(','),
+  );
+  return [header.join(','), ...lines].join('\n');
+}
+
+function csvFile(content: string, name: string): File {
+  return new File([content], name, { type: 'text/csv' });
+}
+
+const episodeRow = (overrides: Record<string, string> = {}) => ({
+  series_tvdb_id: '346328',
+  title: 'Elite',
+  season: '1',
+  episode: '1',
+  tvdb_id: '6671792',
+  is_watched: 'true',
+  watched_at: '2019-10-04 03:43:42',
+  ...overrides,
+});
+
+const movieRow = (overrides: Record<string, string> = {}) => ({
+  tvdb_id: '1435',
+  imdb_id: 'tt1396484',
+  title: 'It',
+  year: '2017',
+  watched_at: '2019-09-10T08:01:29Z',
+  is_watched: 'true',
+  ...overrides,
+});
+
+describe('TvTimeExportParser', () => {
+  describe('csv', () => {
+    it('should import watched episodes with tvdb ids', async () => {
+      const csv = toCsv(EPISODES_HEADER, [episodeRow()]);
+
+      const result = await TvTimeExportParser.parse([
+        csvFile(csv, 'tvtime-series-episodes-2026-07-05.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'history',
+        type: 'episode',
+        ids: { tvdb: 6671792 },
+        title: 'Elite',
+        season: 1,
+        episode: 1,
+      });
+      expect(result[0]?.watched_at).toBeDefined();
+    });
+
+    it('should skip unwatched episodes', async () => {
+      const csv = toCsv(EPISODES_HEADER, [episodeRow({ is_watched: 'false' })]);
+
+      const result = await TvTimeExportParser.parse([
+        csvFile(csv, 'tvtime-series-episodes-2026-07-05.csv'),
+      ]);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should import watched movies with tvdb and imdb ids', async () => {
+      const csv = toCsv(MOVIES_HEADER, [movieRow()]);
+
+      const result = await TvTimeExportParser.parse([
+        csvFile(csv, 'tvtime-movies-2026-07-05.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'history',
+        type: 'movie',
+        ids: { tvdb: 1435, imdb: 'tt1396484' },
+        title: 'It',
+        year: 2017,
+      });
+    });
+
+    it('should watchlist only not-started-yet series', async () => {
+      const csv = toCsv(SERIES_HEADER, [
+        {
+          tvdb_id: '111',
+          imdb_id: '',
+          title: 'Wanted',
+          status: 'not_started_yet',
+        },
+        {
+          tvdb_id: '222',
+          imdb_id: '',
+          title: 'Watching',
+          status: 'continuing',
+        },
+        { tvdb_id: '333', imdb_id: '', title: 'Done', status: 'up_to_date' },
+      ]);
+
+      const result = await TvTimeExportParser.parse([
+        csvFile(csv, 'tvtime-series-2026-07-05.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'watchlist',
+        type: 'show',
+        ids: { tvdb: 111 },
+        title: 'Wanted',
+      });
+    });
+
+    it('should ignore custom list files', async () => {
+      const csv =
+        'list_id,list_name,item_type,tvdb_id,uuid,name,custom_order\n' +
+        '1,Favs,series,346328,uuid,Elite,0';
+
+      const result = await TvTimeExportParser.parse([
+        csvFile(csv, 'tvtime-lists-2026-07-05.csv'),
+      ]);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('zip', () => {
+    it('should parse tvtime csv files from a zip', async () => {
+      const encoder = new TextEncoder();
+      const zipped = zipSync({
+        'tvtime-series-episodes-2026-07-07.csv': encoder.encode(
+          toCsv(EPISODES_HEADER, [episodeRow()]),
+        ),
+        'tvtime-movies-2026-07-07.csv': encoder.encode(
+          toCsv(MOVIES_HEADER, [movieRow()]),
+        ),
+        'tvtime-summary-2026-07-07.html': encoder.encode('<html></html>'),
+      });
+
+      const result = await TvTimeExportParser.parse([
+        new File([zipped as BlobPart], 'tvtime-export-2026-07-07.zip'),
+      ]);
+
+      expect(result.filter((item) => item.type === 'episode')).toHaveLength(1);
+      expect(result.filter((item) => item.type === 'movie')).toHaveLength(1);
+    });
+  });
+
+  describe('json', () => {
+    it('should import watched episodes nested in the series json', async () => {
+      const shows = [{
+        id: { tvdb: 346328, imdb: null },
+        title: 'Elite',
+        status: 'continuing',
+        seasons: [{
+          number: 1,
+          episodes: [
+            {
+              id: { tvdb: 6671792 },
+              number: 1,
+              is_watched: true,
+              watched_at: '2019-10-04T03:43:42Z',
+            },
+            { id: { tvdb: 6671793 }, number: 2, is_watched: false },
+          ],
+        }],
+      }];
+
+      const result = await TvTimeExportParser.parse([
+        new File([JSON.stringify(shows)], 'tvtime-series-2026-07-07.json'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'history',
+        type: 'episode',
+        ids: { tvdb: 6671792 },
+        title: 'Elite',
+        season: 1,
+        episode: 1,
+      });
+    });
+
+    it('should import watched movies from the movies json', async () => {
+      const movies = [
+        {
+          id: { tvdb: 1435, imdb: 'tt1396484' },
+          title: 'It',
+          year: 2017,
+          is_watched: true,
+          watched_at: '2019-09-10T08:01:29Z',
+        },
+        { id: { tvdb: 99 }, title: 'Unwatched', is_watched: false },
+      ];
+
+      const result = await TvTimeExportParser.parse([
+        new File([JSON.stringify(movies)], 'tvtime-movies-2026-07-07.json'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        type: 'movie',
+        ids: { tvdb: 1435, imdb: 'tt1396484' },
+      });
+    });
+  });
+
+  describe('mixed csv + json upload', () => {
+    it('should prefer csv and not double-count watches', async () => {
+      const encoder = new TextEncoder();
+      const csvZip = zipSync({
+        'tvtime-series-episodes-2026-07-07.csv': encoder.encode(
+          toCsv(EPISODES_HEADER, [episodeRow()]),
+        ),
+      });
+      const shows = [{
+        id: { tvdb: 346328 },
+        title: 'Elite',
+        status: 'continuing',
+        seasons: [{
+          number: 1,
+          episodes: [{ id: { tvdb: 6671792 }, number: 1, is_watched: true }],
+        }],
+      }];
+      const jsonZip = zipSync({
+        'tvtime-series-2026-07-07.json': encoder.encode(JSON.stringify(shows)),
+      });
+
+      const result = await TvTimeExportParser.parse([
+        new File([csvZip as BlobPart], 'tvtime-export-2026-07-07 (1).zip'),
+        new File([jsonZip as BlobPart], 'tvtime-export-2026-07-07 (2).zip'),
+      ]);
+
+      expect(result.filter((item) => item.type === 'episode')).toHaveLength(1);
+    });
+  });
+});

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.ts
@@ -1,0 +1,285 @@
+import type { UniversalImportItem } from '../ImportTypes.ts';
+import type { FileParser } from './ParserInterface.ts';
+import { parseCsvText } from './utils/parseCsvText.ts';
+import { toISOString } from './utils/toISOString.ts';
+import { unzipCsvTexts } from './utils/unzipCsvTexts.ts';
+
+// The current TV Time "export my data" tool emits a set of tvtime-*.* files
+// (loose or zipped as tvtime-export-*.zip) in either a CSV or a JSON
+// serialization: a per-episode watch log, a movie watch log, a series-status
+// list, and custom lists. Columns/fields carry TVDB ids directly, so no id
+// resolution is needed. When both serializations are uploaded together we
+// prefer the CSV to avoid importing every watch twice.
+
+type EpisodeRow = {
+  series_tvdb_id?: string;
+  title?: string;
+  season?: string;
+  episode?: string;
+  tvdb_id?: string;
+  is_watched?: string;
+  watched_at?: string;
+};
+
+type MovieRow = {
+  tvdb_id?: string;
+  imdb_id?: string;
+  title?: string;
+  year?: string;
+  watched_at?: string;
+  is_watched?: string;
+};
+
+type SeriesRow = {
+  tvdb_id?: string;
+  imdb_id?: string;
+  title?: string;
+  status?: string;
+};
+
+type JsonId = { tvdb?: number | null; imdb?: string | null };
+type JsonEpisode = {
+  id?: JsonId;
+  number?: number;
+  is_watched?: boolean;
+  watched_at?: string;
+};
+type JsonSeason = { number?: number; episodes?: JsonEpisode[] };
+type JsonShow = {
+  id?: JsonId;
+  title?: string;
+  status?: string;
+  seasons?: JsonSeason[];
+};
+type JsonMovie = {
+  id?: JsonId;
+  title?: string;
+  year?: number;
+  watched_at?: string;
+  is_watched?: boolean;
+};
+
+// Only shows the user has not started yet belong on the watchlist; the rest
+// (up_to_date, continuing, stopped) either already have episode history or
+// were dropped.
+const WATCHLIST_SERIES_STATUS = 'not_started_yet';
+
+function toInt(value?: string): number | undefined {
+  if (!value) return undefined;
+  const n = parseInt(value, 10);
+  return isNaN(n) ? undefined : n;
+}
+
+function toImdb(value?: string | null): string | undefined {
+  return value && value !== '-1' ? value : undefined;
+}
+
+function toTvdb(value?: number | null): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function parseEpisodeRow(row: EpisodeRow): UniversalImportItem | null {
+  if (row.is_watched !== 'true') return null;
+
+  const tvdbId = toInt(row.tvdb_id);
+  if (tvdbId == null) return null;
+
+  return {
+    action: 'history',
+    type: 'episode',
+    ids: { tvdb: tvdbId },
+    title: row.title || undefined,
+    season: toInt(row.season),
+    episode: toInt(row.episode),
+    watched_at: toISOString(row.watched_at),
+  };
+}
+
+function parseMovieRow(row: MovieRow): UniversalImportItem | null {
+  if (row.is_watched !== 'true') return null;
+
+  const tvdbId = toInt(row.tvdb_id);
+  const imdbId = toImdb(row.imdb_id);
+  if (tvdbId == null && !imdbId) return null;
+
+  return {
+    action: 'history',
+    type: 'movie',
+    ids: { tvdb: tvdbId, imdb: imdbId },
+    title: row.title || undefined,
+    year: toInt(row.year),
+    watched_at: toISOString(row.watched_at),
+  };
+}
+
+function parseSeriesRow(row: SeriesRow): UniversalImportItem | null {
+  if (row.status !== WATCHLIST_SERIES_STATUS) return null;
+
+  const tvdbId = toInt(row.tvdb_id);
+  const imdbId = toImdb(row.imdb_id);
+  if (tvdbId == null && !imdbId) return null;
+
+  return {
+    action: 'watchlist',
+    type: 'show',
+    ids: { tvdb: tvdbId, imdb: imdbId },
+    title: row.title || undefined,
+  };
+}
+
+function parseCsvRows(
+  basename: string,
+  rows: Record<string, unknown>[],
+): UniversalImportItem[] {
+  // series-episodes must be checked before series (both start "tvtime-series").
+  if (
+    basename.includes('series-episodes') || 'series_tvdb_id' in (rows[0] ?? {})
+  ) {
+    return rows
+      .map((row) => parseEpisodeRow(row as EpisodeRow))
+      .filter((item): item is UniversalImportItem => item !== null);
+  }
+  if (basename.includes('movies')) {
+    return rows
+      .map((row) => parseMovieRow(row as MovieRow))
+      .filter((item): item is UniversalImportItem => item !== null);
+  }
+  if (basename.includes('series')) {
+    return rows
+      .map((row) => parseSeriesRow(row as SeriesRow))
+      .filter((item): item is UniversalImportItem => item !== null);
+  }
+  // tvtime-lists (custom lists) has no home in the import model — ignored.
+  return [];
+}
+
+// The JSON series export nests every watch inside show -> seasons -> episodes.
+function parseJsonShows(shows: JsonShow[]): UniversalImportItem[] {
+  return shows.flatMap((show) => {
+    const episodes = (show.seasons ?? []).flatMap((season) =>
+      (season.episodes ?? [])
+        .filter((episode) => episode.is_watched === true)
+        .flatMap((episode): UniversalImportItem[] => {
+          const tvdbId = toTvdb(episode.id?.tvdb);
+          if (tvdbId == null) return [];
+          return [{
+            action: 'history',
+            type: 'episode',
+            ids: { tvdb: tvdbId },
+            title: show.title || undefined,
+            season: season.number,
+            episode: episode.number,
+            watched_at: toISOString(episode.watched_at),
+          }];
+        })
+    );
+
+    if (show.status !== WATCHLIST_SERIES_STATUS) return episodes;
+
+    const tvdbId = toTvdb(show.id?.tvdb);
+    const imdbId = toImdb(show.id?.imdb);
+    if (tvdbId == null && !imdbId) return episodes;
+
+    return [...episodes, {
+      action: 'watchlist',
+      type: 'show',
+      ids: { tvdb: tvdbId, imdb: imdbId },
+      title: show.title || undefined,
+    }];
+  });
+}
+
+function parseJsonMovies(movies: JsonMovie[]): UniversalImportItem[] {
+  return movies
+    .filter((movie) => movie.is_watched === true)
+    .flatMap((movie): UniversalImportItem[] => {
+      const tvdbId = toTvdb(movie.id?.tvdb);
+      const imdbId = toImdb(movie.id?.imdb);
+      if (tvdbId == null && !imdbId) return [];
+      return [{
+        action: 'history',
+        type: 'movie',
+        ids: { tvdb: tvdbId, imdb: imdbId },
+        title: movie.title || undefined,
+        year: movie.year,
+        watched_at: toISOString(movie.watched_at),
+      }];
+    });
+}
+
+function parseJson(basename: string, text: string): UniversalImportItem[] {
+  const data = (() => {
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      return null;
+    }
+  })();
+  if (!Array.isArray(data)) return [];
+
+  if (basename.includes('movies')) return parseJsonMovies(data as JsonMovie[]);
+  if (basename.includes('series')) return parseJsonShows(data as JsonShow[]);
+  return [];
+}
+
+type Entry = { basename: string; text: string };
+
+function unzipExportTexts(buffer: ArrayBuffer): Entry[] {
+  const isExportFile = (basename: string) =>
+    basename.startsWith('tvtime-') &&
+    (basename.endsWith('.csv') || basename.endsWith('.json'));
+
+  try {
+    return unzipCsvTexts({ buffer, isMatch: isExportFile });
+  } catch {
+    throw new Error(
+      'Could not read the .zip file. If it is password protected, extract it first and upload the tvtime-*.csv files inside instead.',
+    );
+  }
+}
+
+async function collectEntries(files: ReadonlyArray<File>): Promise<Entry[]> {
+  const entries = await Promise.all(files.map(async (file) => {
+    if (file.name.endsWith('.zip')) {
+      return unzipExportTexts(await file.arrayBuffer());
+    }
+    return [{ basename: file.name, text: await file.text() }];
+  }));
+
+  return entries.flat();
+}
+
+export const TvTimeExportParser: FileParser = {
+  name: 'TV Time export',
+
+  canParse(files) {
+    return files.length > 0 &&
+      files.every(
+        (file) => file.name.endsWith('.csv') || file.name.endsWith('.zip'),
+      );
+  },
+
+  async parse(files) {
+    const entries = await collectEntries(files);
+
+    // Both serializations carry the same watches; prefer CSV when present so a
+    // combined CSV+JSON upload doesn't import everything twice.
+    const hasCsv = entries.some((entry) => entry.basename.endsWith('.csv'));
+    const useCsv = hasCsv;
+
+    const results = await Promise.all(entries.map(async (entry) => {
+      const isCsv = entry.basename.endsWith('.csv');
+      if (isCsv !== useCsv) return [];
+      if (isCsv) {
+        const rows = await parseCsvText(entry.text) as Record<
+          string,
+          unknown
+        >[];
+        return parseCsvRows(entry.basename, rows);
+      }
+      return parseJson(entry.basename, entry.text);
+    }));
+
+    return results.flat();
+  },
+};

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
@@ -59,7 +59,6 @@ const V2_HEADER = [
   'rewatch_count',
   's_no',
   'is_unitary',
-  'episode_id',
   'season_number',
   'gsi',
   'runtime',
@@ -123,9 +122,9 @@ function v2EpisodeWatch(
     created_at: '2021-10-10 11:49:11',
     s_id: '82066',
     series_name: 'Fringe',
-    episode_id: '1331151',
-    season_number: '2',
-    episode_number: '10',
+    ep_id: '1331151',
+    s_no: '2',
+    ep_no: '10',
     ...overrides,
   };
 }
@@ -238,7 +237,7 @@ describe('TvTimeGdprParser', () => {
     });
 
     it('should skip episode rows without an episode id', async () => {
-      const csv = toCsv(V2_HEADER, [v2EpisodeWatch({ episode_id: '' })]);
+      const csv = toCsv(V2_HEADER, [v2EpisodeWatch({ ep_id: '' })]);
 
       const result = await TvTimeGdprParser.parse([csvFile(csv)]);
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
@@ -24,9 +24,9 @@ type TrackingV2Row = {
   created_at?: string;
   s_id?: string;
   series_name?: string;
-  season_number?: string;
-  episode_number?: string;
-  episode_id?: string;
+  s_no?: string;
+  ep_no?: string;
+  ep_id?: string;
   is_followed?: string;
   is_for_later?: string;
   is_archived?: string;
@@ -138,7 +138,9 @@ function parseV1Episode(row: TrackingV1Row): UniversalImportItem | null {
 function parseV2Episode(row: TrackingV2Row): UniversalImportItem | null {
   if (!row.key?.startsWith('watch-episode-')) return null;
 
-  const tvdbId = toInt(row.episode_id);
+  // ep_id is the TVDB episode id (verified against the Trakt search API);
+  // there is no `episode_id` column in the real v2 export.
+  const tvdbId = toInt(row.ep_id);
   if (tvdbId == null) return null;
 
   return {
@@ -146,8 +148,8 @@ function parseV2Episode(row: TrackingV2Row): UniversalImportItem | null {
     type: 'episode',
     ids: { tvdb: tvdbId },
     title: row.series_name || undefined,
-    season: toInt(row.season_number),
-    episode: toInt(row.episode_number),
+    season: toInt(row.s_no),
+    episode: toInt(row.ep_no),
     watched_at: toISOString(row.created_at),
   };
 }


### PR DESCRIPTION
## Why

Triaged all 81 open reports in `trakt/import-reports` (all TV Time). Pulled each user's uploaded files from the private `import-reports` R2 bucket and ran the **real** `TvTimeCsvParser` against them. **73 of 81 produced no history (or were rejected) before this branch; all 73 import after it.**

## Root causes

**1. GDPR v2 episode column mismatch (61 reports)**
`parseV2Episode` read `episode_id` / `season_number` / `episode_number`. The real `tracking-prod-records-v2.csv` rows use **`ep_id`** (TVDB episode id), `s_no`, `ep_no` - there is no `episode_id` column. Every watched episode resolved to `null`, so users imported only movies + watchlist, never their episode history (often thousands of episodes). Confirmed `ep_id` is the TVDB episode id via the Trakt search API. The spec passed because its mock fabricated an `episode_id` column that does not exist in real exports - corrected to the real columns.

**2. Current `tvtime-export` format unsupported (7 reports)**
TV Time's "export my data" tool emits `tvtime-series-episodes/movies/series/lists` files (loose or zipped as `tvtime-export-*.zip`) in **CSV or JSON**. The movie file matched the Liberator parser while the episode log fell through as `unknown` and was silently dropped; the zips were rejected outright. Added `TvTimeExportParser` handling both serializations (prefers CSV when both are present so combined uploads don't double-count).

**3. Detection collision (1 report)**
`where-to-watch-prod-table.csv` (a GDPR noise file) carries `episode_id` + `episode_number` and tripped the `native` heuristic, so mixed loose GDPR uploads were rejected as "different exports". Dropped `episode_number` from the native signature (kept `ts`/`show_name`/`episode_name`/`episode_season_number`), which the real native export always has.

## Impact (parser output, real report data)

| Bucket | Reports | Result |
| --- | --- | --- |
| GDPR v2 fix | 61 | 0 episodes → full history (e.g. #50 `136 → 40,589` items, #28 `→ 26,342`) |
| New export format | 7 | rejected/movies-only → full history+movies (#10 `→ 15,942` episodes) |
| Detection collision | 1 | rejected → `2,026` items (#24) |

## Not addressed here (data / out of scope)

- `tv-time-export.csv` (id-less third-party exporter, only title+season+episode) - #43,82,83. Needs title→id search resolution; deferred.
- Incomplete GDPR exports with no `tracking-prod-records` file - #39,52,55 (TV Time-side).
- Empty/wrong uploads - #70 (empty Liberator), #6 (a Trakt export).

## Tests

- Corrected the fabricated v2 spec mock to real columns.
- New `TvTimeExportParser.spec.ts` (CSV, JSON nested episodes, zip, mixed CSV+JSON dedup).
- Added export-routing + detection-collision cases to `TvTimeCsvParser.spec.ts`.
- 178 import-parser specs pass; `deno fmt` clean; eslint clean.