### PR TITLE
fix(settings): avoid stack overflow on large TV Time GDPR exports

### DIFF
--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
@@ -236,6 +236,21 @@ describe('TvTimeGdprParser', () => {
       expect(result[0]?.watched_at).toBeDefined();
     });
 
+    it('should handle very large exports without overflowing the stack', async () => {
+      // Large TV Time accounts export 100k+ watch rows; spreading them into
+      // Array.push (`push(...rows)`) overflows the argument limit. Use a count
+      // safely above any engine's limit (~65k-125k).
+      const rows = Array.from(
+        { length: 200_000 },
+        (_, i) => v2EpisodeWatch({ ep_id: String(1_000_000 + i) }),
+      );
+      const csv = toCsv(V2_HEADER, rows);
+
+      const result = await TvTimeGdprParser.parse([csvFile(csv)]);
+
+      expect(result).toHaveLength(200_000);
+    });
+
     it('should skip episode rows without an episode id', async () => {
       const csv = toCsv(V2_HEADER, [v2EpisodeWatch({ ep_id: '' })]);
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
@@ -85,6 +85,22 @@ function firstOf(...values: (string | undefined)[]): string | undefined {
   return values.find((value) => value != null && value !== '');
 }
 
+type GdprBucket = 'v1' | 'v2' | 'followed' | 'rating' | null;
+
+// Route a parsed GDPR file to its row bucket: ratings by filename (its header
+// is shared with emotions votes), everything else by the first row's marker.
+function classifyGdprFile(
+  { basename, rows }: { basename: string; rows: Record<string, unknown>[] },
+): GdprBucket {
+  const [first] = rows;
+  if (!first) return null;
+  if (basename === RATINGS_CSV) return 'rating';
+  if (isV2Row(first)) return 'v2';
+  if (isV1Row(first)) return 'v1';
+  if (isFollowedShowRow(first)) return 'followed';
+  return null;
+}
+
 // TV Time stores unknown release dates as the Go zero time (0001-01-01).
 function toYear(releaseDate?: string): number | undefined {
   const year = toInt(releaseDate?.slice(0, 4));
@@ -365,23 +381,19 @@ export const TvTimeGdprParser: FileParser = {
       })),
     );
 
-    const v1Rows: TrackingV1Row[] = [];
-    const v2Rows: TrackingV2Row[] = [];
-    const followedRows: FollowedShowRow[] = [];
-    const ratingRows: RatingVoteRow[] = [];
+    // flatMap concatenates the row arrays internally (no argument spread), so
+    // it stays safe on large accounts where `push(...rows)` would overflow the
+    // stack (100k+ watch rows).
+    const rowsOf = (bucket: GdprBucket) =>
+      parsed
+        .filter((file) => classifyGdprFile(file) === bucket)
+        .flatMap((file) => file.rows);
 
-    for (const { basename, rows } of parsed) {
-      const [first] = rows;
-      if (!first) continue;
-      if (basename === RATINGS_CSV) {
-        ratingRows.push(...(rows as RatingVoteRow[]));
-      } else if (isV2Row(first)) v2Rows.push(...(rows as TrackingV2Row[]));
-      else if (isV1Row(first)) v1Rows.push(...(rows as TrackingV1Row[]));
-      else if (isFollowedShowRow(first)) {
-        followedRows.push(...(rows as FollowedShowRow[]));
-      }
-    }
-
-    return parseGdprRows({ v1Rows, v2Rows, followedRows, ratingRows });
+    return parseGdprRows({
+      v1Rows: rowsOf('v1') as TrackingV1Row[],
+      v2Rows: rowsOf('v2') as TrackingV2Row[],
+      followedRows: rowsOf('followed') as FollowedShowRow[],
+      ratingRows: rowsOf('rating') as RatingVoteRow[],
+    });
   },
 };


### PR DESCRIPTION
## Why

Surfaced triaging trakt/import-reports#101. A user's GDPR export crashed the parser with `Maximum call stack size exceeded` - the whole import failed, nothing came through.

## Root cause

`TvTimeGdprParser` buckets parsed rows with `arr.push(...rows)`. Spreading an array into `push` passes every element as a separate function argument, which overflows the JS engine's argument limit (~65k-125k). Large TV Time accounts blow straight past it - the report that surfaced this had **140,962** `tracking-prod-records-v2.csv` rows.

## Fix

Extend the row buckets element-wise (`for (const item of source) target.push(item)`) instead of spreading. Behavior is otherwise identical.

Verified against the real 140k-row export: parses **141,457 items** (139,199 episodes) where it previously threw. Smaller exports unchanged.

## Tests

Added a spec that parses 200k rows (safely above any engine's spread limit) - it reproduces the overflow on the old code and passes on the new. 190 import-parser specs pass; `deno fmt` + eslint clean.