### PR TITLE
feat(settings): import TV Time custom lists

### DIFF
--- a/.agents/scripts/anonymize-tvtime-export.py
+++ b/.agents/scripts/anonymize-tvtime-export.py
@@ -75,6 +75,15 @@ def anon_export_csv(text, kind):
         for r in rows:
             by_status.setdefault(r.get("status"), r)
         sample = list(by_status.values())
+    elif kind == "lists":
+        # a few items from up to two distinct lists
+        names, sample = set(), []
+        for r in rows:
+            names.add(r.get("list_name"))
+            if len(names) > 2:
+                break
+            sample.append(r)
+        sample = sample[:10]
     else:  # movies
         watched = [r for r in rows if r.get("is_watched") == "true"][:4]
         unwatched = [r for r in rows if r.get("is_watched") != "true"][:1]
@@ -122,11 +131,40 @@ def anon_json_movies(data):
     return json.dumps(out, ensure_ascii=False, indent=1)
 
 
+import re as _re
+
+
+# GDPR lists-prod-lists.csv: one row per list, items embedded in a Go-printed
+# `objects` field. Keep name/is_public/objects (public catalog ids), scrub the
+# per-user uuid tokens + user_id, and trim objects to a few items each.
+def anon_gdpr_lists(text):
+    rows = list(csv.DictReader(io.StringIO(text)))
+    header = list(rows[0].keys()) if rows else []
+    named = [r for r in rows if (r.get("name") or "").strip()][:2]
+    out = io.StringIO()
+    w = csv.DictWriter(out, fieldnames=header)
+    w.writeheader()
+    for i, r in enumerate(named):
+        row = dict(r)
+        if "user_id" in row:
+            row["user_id"] = "0"
+        if "s_key" in row:
+            row["s_key"] = SYNTH_UUID.format(i)
+        objects = row.get("objects", "")
+        maps = _re.findall(r"map\[[^\]]*\]", objects)[:4]
+        maps = [_re.sub(r"\s*uuid:[^\s\]]+", "", m) for m in maps]
+        row["objects"] = "[" + " ".join(maps) + "]"
+        w.writerow(row)
+    return out.getvalue().strip() + "\n"
+
+
 if __name__ == "__main__":
     mode, src, dst = sys.argv[1], sys.argv[2], sys.argv[3]
     text = open(src, encoding="utf-8", errors="replace").read()
     if mode == "v2":
         res = anon_v2(text)
+    elif mode == "gdpr-lists":
+        res = anon_gdpr_lists(text)
     elif mode.startswith("export-"):
         res = anon_export_csv(text, mode.split("-", 1)[1])
     elif mode == "json-series":

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5159,6 +5159,15 @@
         }
       }
     },
+    "import_summary_list": {
+      "default": "{count} list items",
+      "description": "Summary line showing the number of custom-list items found in the import file.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "import_complete_synced": {
       "default": "{count} items synced successfully.",
       "description": "Text shown at the end of a successful import showing the count of synced items.",

--- a/projects/client/src/lib/sections/settings/_internal/RawImport.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/RawImport.svelte
@@ -48,6 +48,7 @@
       history: true,
       watchlist: true,
       ratings: true,
+      list: true,
     };
   }
 
@@ -88,6 +89,7 @@
     history: state.parsedItems.filter((i) => i.action === "history").length,
     watchlist: state.parsedItems.filter((i) => i.action === "watchlist").length,
     ratings: state.parsedItems.filter((i) => i.action === "ratings").length,
+    list: state.parsedItems.filter((i) => i.action === "list").length,
   });
   const selectedItems = $derived(
     filterImportItemsByActionSelection({
@@ -99,6 +101,7 @@
     history: state.selectedActions.history ? counts.history : 0,
     watchlist: state.selectedActions.watchlist ? counts.watchlist : 0,
     ratings: state.selectedActions.ratings ? counts.ratings : 0,
+    list: state.selectedActions.list ? counts.list : 0,
   });
   const selectedTotalCount = $derived(selectedItems.length);
 

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportSummary.spec.ts
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportSummary.spec.ts
@@ -15,6 +15,7 @@ describe('ImportSummary', () => {
     history: 2,
     watchlist: 3,
     ratings: 1,
+    list: 1,
   };
 
   it('should show an enabled switch for every import action with items', () => {
@@ -24,6 +25,7 @@ describe('ImportSummary', () => {
         history: true,
         watchlist: true,
         ratings: true,
+        list: true,
       },
       source: 'tvtime',
       onactionchange: vi.fn(),
@@ -36,6 +38,8 @@ describe('ImportSummary', () => {
     expect(screen.getByRole('switch', { name: '3 items for Watchlist' }))
       .toBeChecked();
     expect(screen.getByRole('switch', { name: '1 ratings' })).toBeChecked();
+    expect(screen.getByRole('switch', { name: '1 list items' }))
+      .toBeChecked();
   });
 
   it('should request skipping an import action when its switch is clicked', async () => {
@@ -47,6 +51,7 @@ describe('ImportSummary', () => {
         history: true,
         watchlist: true,
         ratings: true,
+        list: true,
       },
       source: 'tvtime',
       onactionchange,
@@ -68,6 +73,7 @@ describe('ImportSummary', () => {
         history: false,
         watchlist: false,
         ratings: false,
+        list: false,
       },
       source: 'tvtime',
       onactionchange: vi.fn(),

--- a/projects/client/src/lib/sections/settings/_internal/import/ImportSummary.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/import/ImportSummary.svelte
@@ -36,9 +36,11 @@
     history: selectedActions.history ? counts.history : 0,
     watchlist: selectedActions.watchlist ? counts.watchlist : 0,
     ratings: selectedActions.ratings ? counts.ratings : 0,
+    list: selectedActions.list ? counts.list : 0,
   });
   const selectedTotalItems = $derived(
-    selectedCounts.history + selectedCounts.watchlist + selectedCounts.ratings,
+    selectedCounts.history + selectedCounts.watchlist +
+      selectedCounts.ratings + selectedCounts.list,
   );
 
   const actionRows = $derived<
@@ -55,6 +57,7 @@
       label: m.import_summary_watchlist,
     },
     { action: "ratings", count: counts.ratings, label: m.import_summary_ratings },
+    { action: "list", count: counts.list, label: m.import_summary_list },
   ]);
 
   const isVipLimitExceeded = $derived.by(() => {
@@ -65,10 +68,12 @@
     const limitMultiplier = source === "tvtime" ? 2 : 1;
     const watchlistFreeLimit = $limits.watchlistItems.free * limitMultiplier;
     const historyFreeLimit = $limits.history.free * limitMultiplier;
+    const listItemsFreeLimit = $limits.totalListItems.free * limitMultiplier;
 
     return (
       selectedCounts.watchlist > watchlistFreeLimit ||
-      selectedCounts.history > historyFreeLimit
+      selectedCounts.history > historyFreeLimit ||
+      selectedCounts.list > listItemsFreeLimit
     );
   });
 </script>

--- a/projects/client/src/lib/sections/settings/import/ImportTypes.ts
+++ b/projects/client/src/lib/sections/settings/import/ImportTypes.ts
@@ -9,7 +9,7 @@ export type ImportSource =
 
 export const DEFAULT_IMPORT_SOURCE: ImportSource = 'tvtime';
 
-export type ImportAction = 'history' | 'watchlist' | 'ratings';
+export type ImportAction = 'history' | 'watchlist' | 'ratings' | 'list';
 
 export type ImportActionSelection = Record<ImportAction, boolean>;
 
@@ -43,12 +43,17 @@ export interface UniversalImportItem {
   rated_at?: string;
   season?: number;
   episode?: number;
+  // For action 'list': the source list this item belongs to. Items are grouped
+  // by listName at sync time; listIsPublic maps to the created list's privacy.
+  listName?: string;
+  listIsPublic?: boolean;
 }
 
 export interface ImportCounts {
   history: number;
   watchlist: number;
   ratings: number;
+  list: number;
 }
 
 export interface MovieMatchCandidate {

--- a/projects/client/src/lib/sections/settings/import/filterImportItemsByActionSelection.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/filterImportItemsByActionSelection.spec.ts
@@ -29,6 +29,7 @@ describe('filterImportItemsByActionSelection', () => {
         history: false,
         watchlist: true,
         ratings: true,
+        list: true,
       },
     });
 
@@ -45,6 +46,7 @@ describe('filterImportItemsByActionSelection', () => {
         history: false,
         watchlist: false,
         ratings: false,
+        list: false,
       },
     });
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.spec.ts
@@ -147,10 +147,33 @@ describe('TvTimeExportParser', () => {
       });
     });
 
-    it('should ignore custom list files', async () => {
+    it('should import custom list items as list entries', async () => {
       const csv =
         'list_id,list_name,item_type,tvdb_id,uuid,name,custom_order\n' +
-        '1,Favs,series,346328,uuid,Elite,0';
+        '1,Favs,series,346328,uuid,Elite,0\n' +
+        '1,Favs,movie,1435,uuid,It,1';
+
+      const result = await TvTimeExportParser.parse([
+        csvFile(csv, 'tvtime-lists-2026-07-05.csv'),
+      ]);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        action: 'list',
+        type: 'show',
+        ids: { tvdb: 346328 },
+        title: 'Elite',
+        listName: 'Favs',
+        listIsPublic: false,
+      });
+      expect(result[1]).toMatchObject({ action: 'list', type: 'movie' });
+    });
+
+    it('should skip list rows without a list name or tvdb id', async () => {
+      const csv =
+        'list_id,list_name,item_type,tvdb_id,uuid,name,custom_order\n' +
+        '1,,series,346328,uuid,Elite,0\n' +
+        '1,Favs,series,,uuid,NoId,1';
 
       const result = await TvTimeExportParser.parse([
         csvFile(csv, 'tvtime-lists-2026-07-05.csv'),

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.ts
@@ -39,6 +39,13 @@ type SeriesRow = {
   status?: string;
 };
 
+type ListRow = {
+  list_name?: string;
+  item_type?: string;
+  tvdb_id?: string;
+  name?: string;
+};
+
 type JsonId = { tvdb?: number | null; imdb?: string | null };
 type JsonEpisode = {
   id?: JsonId;
@@ -129,10 +136,31 @@ function parseSeriesRow(row: SeriesRow): UniversalImportItem | null {
   };
 }
 
+// Custom lists carry no privacy flag in this export, so they import as private.
+function parseListRow(row: ListRow): UniversalImportItem | null {
+  const listName = row.list_name?.trim();
+  const tvdbId = toInt(row.tvdb_id);
+  if (!listName || tvdbId == null) return null;
+
+  return {
+    action: 'list',
+    type: row.item_type === 'movie' ? 'movie' : 'show',
+    ids: { tvdb: tvdbId },
+    title: row.name || undefined,
+    listName,
+    listIsPublic: false,
+  };
+}
+
 function parseCsvRows(
   basename: string,
   rows: Record<string, unknown>[],
 ): UniversalImportItem[] {
+  if (basename.includes('lists')) {
+    return rows
+      .map((row) => parseListRow(row as ListRow))
+      .filter((item): item is UniversalImportItem => item !== null);
+  }
   // series-episodes must be checked before series (both start "tvtime-series").
   if (
     basename.includes('series-episodes') || 'series_tvdb_id' in (rows[0] ?? {})
@@ -151,7 +179,6 @@ function parseCsvRows(
       .map((row) => parseSeriesRow(row as SeriesRow))
       .filter((item): item is UniversalImportItem => item !== null);
   }
-  // tvtime-lists (custom lists) has no home in the import model — ignored.
   return [];
 }
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
@@ -727,6 +727,51 @@ describe('TvTimeGdprParser', () => {
     });
   });
 
+  describe('custom lists file', () => {
+    const LISTS_HEADER = ['name', 'is_public', 'objects'];
+
+    it('should import list items from the go-map objects column', async () => {
+      const objects =
+        '[map[created_at:1.7e+09 id:253463 type:series uuid:abc] ' +
+        'map[created_at:1.7e+09 id:1435 type:movie uuid:def]]';
+      const csv = toCsv(LISTS_HEADER, [
+        { name: 'Favs', is_public: 'true', objects },
+      ]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(csv, 'lists-prod-lists.csv'),
+      ]);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        action: 'list',
+        type: 'show',
+        ids: { tvdb: 253463 },
+        listName: 'Favs',
+        listIsPublic: true,
+      });
+      expect(result[1]).toMatchObject({ type: 'movie', ids: { tvdb: 1435 } });
+    });
+
+    it('should map is_public false to a private list and skip unnamed lists', async () => {
+      const objects = '[map[created_at:1.7e+09 id:253463 type:series]]';
+      const csv = toCsv(LISTS_HEADER, [
+        { name: 'Private', is_public: 'false', objects },
+        { name: '', is_public: 'true', objects },
+      ]);
+
+      const result = await TvTimeGdprParser.parse([
+        csvFile(csv, 'lists-prod-lists.csv'),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        listName: 'Private',
+        listIsPublic: false,
+      });
+    });
+  });
+
   describe('zip archives', () => {
     it('should parse tracking files from a gdpr zip', async () => {
       const encoder = new TextEncoder();

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
@@ -50,6 +50,12 @@ type RatingVoteRow = {
   vote_key?: string;
 };
 
+type ListRow = {
+  name?: string;
+  is_public?: string;
+  objects?: string;
+};
+
 const TRACKING_V1_MARKER = 'type-uuid-n';
 // Every v2 row is identified by its `key` (watch-episode-*, user-series-*,
 // tracking-stats) — it's the field the parser branches on. The episode
@@ -61,6 +67,10 @@ const FOLLOWED_SHOW_MARKER = 'notification_offset';
 // emotions-live-votes.csv shares this header, so rating votes are routed
 // by file name instead of a column marker.
 const RATINGS_CSV = 'ratings-live-votes.csv';
+
+// Custom lists: one row per list, items embedded in the `objects` column as
+// Go-printed maps. Routed by filename.
+const LISTS_CSV = 'lists-prod-lists.csv';
 
 // TV Time's stars_wording_scalev2 rating set: id -> star position, doubled
 // to Trakt's 1-10 scale. Stable since 2018 and frozen by the July 2026
@@ -85,16 +95,17 @@ function firstOf(...values: (string | undefined)[]): string | undefined {
   return values.find((value) => value != null && value !== '');
 }
 
-type GdprBucket = 'v1' | 'v2' | 'followed' | 'rating' | null;
+type GdprBucket = 'v1' | 'v2' | 'followed' | 'rating' | 'list' | null;
 
-// Route a parsed GDPR file to its row bucket: ratings by filename (its header
-// is shared with emotions votes), everything else by the first row's marker.
+// Route a parsed GDPR file to its row bucket: ratings/lists by filename (their
+// headers are shared/ambiguous), everything else by the first row's marker.
 function classifyGdprFile(
   { basename, rows }: { basename: string; rows: Record<string, unknown>[] },
 ): GdprBucket {
   const [first] = rows;
   if (!first) return null;
   if (basename === RATINGS_CSV) return 'rating';
+  if (basename === LISTS_CSV) return 'list';
   if (isV2Row(first)) return 'v2';
   if (isV1Row(first)) return 'v1';
   if (isFollowedShowRow(first)) return 'followed';
@@ -271,12 +282,40 @@ function parseRatingVotes(
   return [...byUuid.values()];
 }
 
+// The `objects` column is a Go-printed map array:
+// `[map[created_at:.. id:75675 type:series uuid:..] map[.. id:367118 ..]]`.
+// Keys print alphabetically, so `id:<n> type:<t>` are always adjacent.
+const LIST_OBJECT_RE = /id:(\d+)\s+type:(\w+)/g;
+
+function parseListRows(listRows: ListRow[]): UniversalImportItem[] {
+  return listRows.flatMap((row) => {
+    const listName = row.name?.trim();
+    if (!listName || !row.objects) return [];
+
+    const listIsPublic = row.is_public === 'true';
+    return [...row.objects.matchAll(LIST_OBJECT_RE)].flatMap(
+      ([, id, type]): UniversalImportItem[] => {
+        const tvdbId = toInt(id);
+        if (tvdbId == null) return [];
+        return [{
+          action: 'list',
+          type: type === 'movie' ? 'movie' : 'show',
+          ids: { tvdb: tvdbId },
+          listName,
+          listIsPublic,
+        }];
+      },
+    );
+  });
+}
+
 function parseGdprRows(
-  { v1Rows, v2Rows, followedRows, ratingRows }: {
+  { v1Rows, v2Rows, followedRows, ratingRows, listRows }: {
     v1Rows: TrackingV1Row[];
     v2Rows: TrackingV2Row[];
     followedRows: FollowedShowRow[];
     ratingRows: RatingVoteRow[];
+    listRows: ListRow[];
   },
 ): UniversalImportItem[] {
   const episodes = v2Rows.length > 0
@@ -313,6 +352,7 @@ function parseGdprRows(
   );
 
   const ratings = parseRatingVotes(ratingRows, v1Rows);
+  const lists = parseListRows(listRows);
 
   return [
     ...episodes,
@@ -320,6 +360,7 @@ function parseGdprRows(
     ...showWatchlist,
     ...followedWatchlist,
     ...ratings,
+    ...lists,
   ];
 }
 
@@ -340,7 +381,8 @@ function unzipGdprCsvTexts(buffer: ArrayBuffer) {
     (basename.startsWith('tracking-prod-records') &&
       basename.endsWith('.csv')) ||
     basename === 'followed_tv_show.csv' ||
-    basename === RATINGS_CSV;
+    basename === RATINGS_CSV ||
+    basename === LISTS_CSV;
 
   try {
     return unzipCsvTexts({ buffer, isMatch: isGdprCsv });
@@ -394,6 +436,7 @@ export const TvTimeGdprParser: FileParser = {
       v2Rows: rowsOf('v2') as TrackingV2Row[],
       followedRows: rowsOf('followed') as FollowedShowRow[],
       ratingRows: rowsOf('rating') as RatingVoteRow[],
+      listRows: rowsOf('list') as ListRow[],
     });
   },
 };

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeRealExports.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeRealExports.spec.ts
@@ -46,6 +46,19 @@ function zipFixtures(names: string[], zipName: string): File {
   return new File([zipSync(entries) as BlobPart], zipName);
 }
 
+// Zip fixtures under explicit archive names (prefixed fixtures whose real
+// upload name differs, e.g. gdpr-v2-*.csv -> tracking-prod-records-v2.csv).
+function zipNamed(
+  pairs: ReadonlyArray<[fixtureName: string, entryName: string]>,
+  zipName: string,
+): File {
+  const encoder = new TextEncoder();
+  const entries = Object.fromEntries(
+    pairs.map(([name, entry]) => [entry, encoder.encode(fixture(name))]),
+  );
+  return new File([zipSync(entries) as BlobPart], zipName);
+}
+
 describe('TvTimeCsvParser: real anonymized exports', () => {
   it('imports a real GDPR v2 tracking file (ep_id episodes + watchlist)', async () => {
     const result = await TvTimeCsvParser.parse([
@@ -128,5 +141,32 @@ describe('TvTimeCsvParser: real anonymized exports', () => {
       'history:movie': 7,
     });
     expect(result.every((item) => item.ids.tvdb != null)).toBe(true);
+  });
+
+  it('imports custom lists from a real tvtime-lists export', async () => {
+    const result = await TvTimeCsvParser.parse([csvFile('tvtime-lists.csv')]);
+
+    expect(tally(result)).toEqual({ 'list:show': 10 });
+    expect(result.every((item) => item.listName === 'LIKE')).toBe(true);
+    expect(result.every((item) => item.ids.tvdb != null)).toBe(true);
+  });
+
+  it('imports custom lists from a real GDPR zip alongside tracking data', async () => {
+    const zip = zipNamed([
+      ['gdpr-v2-tracking-prod-records-v2.csv', 'tracking-prod-records-v2.csv'],
+      ['gdpr-lists-prod-lists.csv', 'lists-prod-lists.csv'],
+    ], 'gdpr-data.zip');
+
+    const result = await TvTimeCsvParser.parse([zip]);
+
+    const t = tally(result);
+    // 8 v2 episodes + 1 watchlist (the v2 fixture) plus the list items.
+    expect(t['history:episode']).toBe(8);
+    expect(t['list:show']).toBe(8);
+    expect(
+      result.filter((i) => i.action === 'list').every((i) =>
+        i.listName != null && i.ids.tvdb != null
+      ),
+    ).toBe(true);
   });
 });

--- a/projects/client/src/lib/sections/settings/import/parsers/__fixtures__/tvtime/README.md
+++ b/projects/client/src/lib/sections/settings/import/parsers/__fixtures__/tvtime/README.md
@@ -16,6 +16,8 @@ Consumed by `../../TvTimeRealExports.spec.ts`.
 | `gdpr-v2-tracking-prod-records-v2.csv`                                   | GDPR v2 tracking (episodes via `ep_id`, watchlist via `user-series-*`) | `TvTimeGdprParser`   |
 | `tvtime-series-episodes.csv` / `tvtime-movies.csv` / `tvtime-series.csv` | current "export my data" CSV                                           | `TvTimeExportParser` |
 | `tvtime-series.json` / `tvtime-movies.json`                              | current "export my data" JSON                                          | `TvTimeExportParser` |
+| `tvtime-lists.csv`                                                       | current export custom lists                                            | `TvTimeExportParser` |
+| `gdpr-lists-prod-lists.csv`                                              | GDPR custom lists (Go-map `objects` column)                            | `TvTimeGdprParser`   |
 
 ## Anonymization
 

--- a/projects/client/src/lib/sections/settings/import/parsers/__fixtures__/tvtime/gdpr-lists-prod-lists.csv
+++ b/projects/client/src/lib/sections/settings/import/parsers/__fixtures__/tvtime/gdpr-lists-prod-lists.csv
@@ -1,0 +1,3 @@
+ordering,s_key,name,type,description,is_public,user_id,objects,created_at,lists,list_count
+0,00000000-0000-0000-0000-000000000000,Slice of life,list,,true,0,[map[created_at:1.707766149e+09 id:422981 type:series] map[created_at:1.707766174e+09 id:80644 type:series] map[created_at:1.707766194e+09 id:402412 type:series] map[created_at:1.707766216e+09 id:354198 type:series]],2024-02-12 19:28:40,,
+0,00000000-0000-0000-0000-000000000001,Kdrama,list,,true,0,[map[created_at:1.710781645e+09 id:317220 type:series] map[created_at:1.710781665e+09 id:305327 type:series] map[created_at:1.710781688e+09 id:311297 type:series] map[created_at:1.71078178e+09 id:354403 type:series]],2024-03-18 17:07:05,,

--- a/projects/client/src/lib/sections/settings/import/parsers/__fixtures__/tvtime/tvtime-lists.csv
+++ b/projects/client/src/lib/sections/settings/import/parsers/__fixtures__/tvtime/tvtime-lists.csv
@@ -1,0 +1,11 @@
+list_id,list_name,item_type,tvdb_id,uuid,name,custom_order
+a8393dd9-e654-4890-ab8c-734d2c7ce337,LIKE,series,253463,,Black Mirror,0
+a8393dd9-e654-4890-ab8c-734d2c7ce337,LIKE,series,318366,,Brave Heart,1
+a8393dd9-e654-4890-ab8c-734d2c7ce337,LIKE,series,334824,,Dark,2
+a8393dd9-e654-4890-ab8c-734d2c7ce337,LIKE,series,121361,,Game of Thrones,3
+a8393dd9-e654-4890-ab8c-734d2c7ce337,LIKE,series,360295,,His Dark Materials,4
+a8393dd9-e654-4890-ab8c-734d2c7ce337,LIKE,series,270408,,Outlander,5
+a8393dd9-e654-4890-ab8c-734d2c7ce337,LIKE,series,270915,,Peaky Blinders,6
+a8393dd9-e654-4890-ab8c-734d2c7ce337,LIKE,series,265766,,Penny Dreadful,7
+a8393dd9-e654-4890-ab8c-734d2c7ce337,LIKE,series,343391,,,8
+a8393dd9-e654-4890-ab8c-734d2c7ce337,LIKE,series,176941,,Sherlock,9

--- a/projects/client/src/lib/sections/settings/import/syncToTrakt.ts
+++ b/projects/client/src/lib/sections/settings/import/syncToTrakt.ts
@@ -15,6 +15,93 @@ type SyncToTraktCallbacks = SyncEngineCallbacks & {
   onMatchProgress?: (processed: number, total: number) => void;
 };
 
+type TraktClient = ReturnType<typeof api>;
+type SyncRunner = ReturnType<typeof createSyncRunner>['run'];
+
+// Personal lists are few; one large page covers reuse-by-name lookup.
+const ALL_LISTS_PAGE_SIZE = 1000;
+
+interface ListGroup {
+  isPublic: boolean;
+  items: UniversalImportItem[];
+}
+
+function groupByList(
+  listItems: ReadonlyArray<UniversalImportItem>,
+): Map<string, ListGroup> {
+  return listItems.reduce((groups, item) => {
+    if (!item.listName) return groups;
+    const group = groups.get(item.listName) ??
+      { isPublic: item.listIsPublic === true, items: [] };
+    return groups.set(item.listName, {
+      ...group,
+      items: [...group.items, item],
+    });
+  }, new Map<string, ListGroup>());
+}
+
+// TV Time custom lists -> Trakt personal lists. Reuse an existing list with the
+// same name so re-importing doesn't duplicate it; otherwise create it. Items
+// are added with the watchlist (bulk media) payload shape.
+async function syncLists(
+  listItems: ReadonlyArray<UniversalImportItem>,
+  client: TraktClient,
+  run: SyncRunner,
+  onError?: (message: string) => void,
+): Promise<void> {
+  const groups = groupByList(listItems);
+  if (groups.size === 0) return;
+
+  const slugByName = new Map<string, string>();
+  try {
+    const existing = await client.users.lists.personal({
+      params: { id: 'me' },
+      query: { limit: ALL_LISTS_PAGE_SIZE, page: 1 },
+    });
+    if (existing.status === 200 && existing.body) {
+      for (const list of existing.body) {
+        slugByName.set(list.name, list.ids.slug);
+      }
+    } else {
+      onError?.(`Failed to fetch existing lists (status ${existing.status})`);
+    }
+  } catch (error) {
+    onError?.(error instanceof Error ? error.message : String(error));
+  }
+
+  for (const [name, { isPublic, items }] of groups) {
+    let slug = slugByName.get(name);
+
+    if (!slug) {
+      try {
+        const created = await client.users.lists.create({
+          params: { id: 'me' },
+          body: { name, privacy: isPublic ? 'public' : 'private' },
+        });
+        if (created.status !== 201 || !created.body?.ids?.slug) {
+          onError?.(`Failed to create list "${name}"`);
+          continue;
+        }
+        slug = created.body.ids.slug;
+      } catch (error) {
+        onError?.(error instanceof Error ? error.message : String(error));
+        continue;
+      }
+    }
+
+    const listSlug = slug;
+    await run(
+      chunk(items, SYNC_CHUNK_SIZE),
+      (batch) => buildWatchlistPayload([...batch]),
+      (payload) =>
+        client.users.lists.list.add({
+          params: { id: 'me', list_id: listSlug },
+          body: payload,
+        }),
+    );
+  }
+}
+
 export async function syncToTrakt(
   items: ReadonlyArray<UniversalImportItem>,
   {
@@ -49,6 +136,7 @@ export async function syncToTrakt(
       i.action === 'watchlist'
     );
     const ratingItems = resolvedItems.filter((i) => i.action === 'ratings');
+    const listItems = resolvedItems.filter((i) => i.action === 'list');
 
     const client = api();
     const { run, getErrorCount } = createSyncRunner({
@@ -79,6 +167,10 @@ export async function syncToTrakt(
         (batch) => buildRatingsPayload([...batch]),
         (payload) => client.sync.ratings.add({ body: payload }),
       );
+    }
+
+    if (listItems.length > 0) {
+      await syncLists(listItems, client, run, onError);
     }
 
     onComplete?.(!signal?.aborted);


### PR DESCRIPTION
## Why

Follow-up to the TV Time import work (#2839/#2841/#2842). Custom lists were silently dropped - the current export's `tvtime-lists.csv` was ignored and the GDPR export's `lists-prod-lists.csv` was never even extracted from the zip. Reported in trakt/import-reports#99.

## What

Adds a `list` import action end to end.

**Parsing** (both real shapes):
- Current export `tvtime-lists.csv` - flat `list_id,list_name,item_type,tvdb_id,...,name` rows.
- GDPR `lists-prod-lists.csv` - one row per list, items embedded in the Go-printed `objects` column (`map[... id:75675 type:series uuid:...]`), parsed by regex. Now extracted from the GDPR zip.

**Sync** (`syncToTrakt`): groups items by list name, then per list **reuses an existing Trakt personal list with the same name** (so re-importing doesn't duplicate lists - matches the "re-import is safe" guarantee) or creates it. Privacy honors the GDPR `is_public` flag; current-export lists (no privacy field) default to private. Items are added with the existing watchlist bulk-media payload.

**UI**: a "list items" toggle + count in the import summary (`ImportSummary`), on by default. Free-account users whose selected list items exceed the free `totalListItems` limit get the same VIP-upsell warning as history/watchlist.

## Design decisions (confirmed)

- Idempotency: reuse-by-name (not create-always or skip).
- Scope: both export formats.
- Privacy: honor source `is_public`, default private.

## Tests

- Parser unit specs for both shapes (`TvTimeExportParser`, `TvTimeGdprParser`).
- Real anonymized fixtures added (`tvtime-lists.csv`, `gdpr-lists-prod-lists.csv`) + assertions in the shared `TvTimeRealExports` suite (new-export lists = 10 items; GDPR zip parses lists alongside tracking data). Anonymizer gained `export-lists` / `gdpr-lists` modes.
- 244 import specs pass; `deno fmt` + eslint clean; `svelte-check` clean for all touched files.

> [!NOTE]
> `svelte-check` reports 3 pre-existing errors in unrelated settings files (`currentUserSettingsQuery.ts`, `ExtendedUserSettingsResponseMock.ts`, `useSettings.ts` - a `browsing.locale` mismatch) that exist on `main` and are untouched here.