### PR TITLE
Feat/social activities sorting

### DIFF
--- a/projects/client/src/lib/requests/models/MediaSocial.ts
+++ b/projects/client/src/lib/requests/models/MediaSocial.ts
@@ -18,6 +18,7 @@ const MediaSocialCommentSchema = z.object({
 
 const MediaSocialWatchedSchema = z.object({
   plays: z.number(),
+  minutesWatched: z.number().nullish(),
   lastWatchedAt: z.date().nullish(),
   lastUpdatedAt: z.date().nullish(),
   rating: MediaSocialRatingSchema.optional(),

--- a/projects/client/src/lib/requests/queries/media/mediaSocialQuery.ts
+++ b/projects/client/src/lib/requests/queries/media/mediaSocialQuery.ts
@@ -80,6 +80,7 @@ const MediaSocialCommentResponseSchema = z.object({
 
 const MediaSocialWatchedResponseSchema = z.object({
   plays: z.number(),
+  minutes_watched: z.number().nullish(),
   last_watched_at: z.string().nullish(),
   last_updated_at: z.string().nullish(),
   rating: MediaSocialRatingResponseSchema.optional(),
@@ -198,6 +199,7 @@ function mapToSocialWatched(
 
   return {
     plays: watched.plays,
+    minutesWatched: watched.minutes_watched ?? null,
     lastWatchedAt: toDate(watched.last_watched_at),
     lastUpdatedAt: toDate(watched.last_updated_at),
     ...(rating && { rating }),

--- a/projects/client/src/lib/sections/summary/components/_internal/sortMediaSocialEntries.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/sortMediaSocialEntries.spec.ts
@@ -22,7 +22,7 @@ function socialEntry(
 }
 
 describe('sortMediaSocialEntries', () => {
-  it('sorts by rating, play count, watchlist, and latest activity date', () => {
+  it('falls back to play count, then watchlist, then latest activity date', () => {
     const ratedLowPlays = socialEntry('rated-low-plays', {
       watched: {
         plays: 1,
@@ -66,12 +66,120 @@ describe('sortMediaSocialEntries', () => {
     const sorted = sortMediaSocialEntries(entries);
 
     expect(sorted.map((entry) => entry.key)).toEqual([
-      'rated-low-plays',
       'watched-high-plays',
       'watched-low-plays',
+      'rated-low-plays',
       'watchlisted-recent',
       'watchlisted-old',
     ]);
     expect(entries.at(0)?.key).toBe('watchlisted-old');
+  });
+
+  it('ranks entries with plays on top, by watch time descending', () => {
+    const lowMinutes = socialEntry('low-minutes', {
+      watched: { plays: 2, minutesWatched: 100 },
+    });
+    const highMinutes = socialEntry('high-minutes', {
+      watched: { plays: 1, minutesWatched: 300 },
+    });
+    const ratedMidMinutes = socialEntry('rated-mid-minutes', {
+      watched: {
+        plays: 5,
+        minutesWatched: 200,
+        rating: { rating: 9, ratedAt: new Date('2026-01-01T00:00:00.000Z') },
+      },
+    });
+    const watchlisted = socialEntry('watchlisted', {
+      watchlisted: { listedAt: new Date('2026-06-01T00:00:00.000Z') },
+    });
+
+    const sorted = sortMediaSocialEntries([
+      lowMinutes,
+      watchlisted,
+      ratedMidMinutes,
+      highMinutes,
+    ]);
+
+    expect(sorted.map((entry) => entry.key)).toEqual([
+      'high-minutes',
+      'rated-mid-minutes',
+      'low-minutes',
+      'watchlisted',
+    ]);
+  });
+
+  it('ranks a review above a watchlist add at equal watch time', () => {
+    const ratedAt = new Date('2026-01-01T00:00:00.000Z');
+    const watchedWatchlisted = socialEntry('watched-watchlisted', {
+      watched: { plays: 1, minutesWatched: 157 },
+      watchlisted: { listedAt: ratedAt },
+    });
+    const watchedReviewed = socialEntry('watched-reviewed', {
+      watched: {
+        plays: 1,
+        minutesWatched: 157,
+        comment: {
+          id: 1,
+          key: 'comment-1',
+          comment: 'nice',
+          isSpoiler: false,
+          isReview: true,
+          createdAt: ratedAt,
+          updatedAt: ratedAt,
+        },
+      },
+    });
+
+    const sorted = sortMediaSocialEntries([
+      watchedWatchlisted,
+      watchedReviewed,
+    ]);
+
+    expect(sorted.map((entry) => entry.key)).toEqual([
+      'watched-reviewed',
+      'watched-watchlisted',
+    ]);
+  });
+
+  it('breaks equal watch time ties by weighted activity score', () => {
+    const ratedAt = new Date('2026-01-01T00:00:00.000Z');
+    const watchedOnly = socialEntry('watched-only', {
+      watched: { plays: 1, minutesWatched: 157 },
+    });
+    const watchedReviewed = socialEntry('watched-reviewed', {
+      watched: {
+        plays: 1,
+        minutesWatched: 157,
+        comment: {
+          id: 1,
+          key: 'comment-1',
+          comment: 'nice',
+          isSpoiler: false,
+          isReview: true,
+          createdAt: ratedAt,
+          updatedAt: ratedAt,
+        },
+      },
+    });
+    const watchedWatchlistedRated = socialEntry('watched-watchlisted-rated', {
+      watched: {
+        plays: 1,
+        minutesWatched: 157,
+        rating: { rating: 5, ratedAt },
+      },
+      watchlisted: { listedAt: ratedAt },
+    });
+
+    const sorted = sortMediaSocialEntries([
+      watchedOnly,
+      watchedReviewed,
+      watchedWatchlistedRated,
+    ]);
+
+    expect(sorted.map((entry) => entry.key)).toEqual([
+      'watched-watchlisted-rated',
+      'watched-reviewed',
+      'watched-only',
+    ]);
   });
 });

--- a/projects/client/src/lib/sections/summary/components/_internal/sortMediaSocialEntries.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/sortMediaSocialEntries.ts
@@ -1,11 +1,28 @@
 import type { MediaSocial } from '$lib/requests/models/MediaSocial.ts';
 
-function hasRating(entry: MediaSocial) {
-  return entry.watched?.rating != null;
+function hasPlays(entry: MediaSocial) {
+  return entry.watched != null;
 }
 
-function watchlistedValue(entry: MediaSocial) {
-  return entry.watchlisted == null ? 0 : 1;
+function minutesWatched(entry: MediaSocial) {
+  return entry.watched?.minutesWatched ?? 0;
+}
+
+// Weighted per activity kind (see mapToSocialActivityEntries for the pills).
+// Rating and reviewing signal more engagement than a watchlist add. A watch
+// isn't scored: every entry ranked here already has one (see hasPlays).
+const ACTIVITY_WEIGHTS = {
+  watchlisted: 1,
+  rating: 2,
+  comment: 2,
+} as const;
+
+function activityScore(entry: MediaSocial) {
+  return (
+    (entry.watchlisted != null ? ACTIVITY_WEIGHTS.watchlisted : 0) +
+    (entry.watched?.rating != null ? ACTIVITY_WEIGHTS.rating : 0) +
+    (entry.watched?.comment != null ? ACTIVITY_WEIGHTS.comment : 0)
+  );
 }
 
 function watchedPlays(entry: MediaSocial) {
@@ -33,9 +50,14 @@ function compareDescending(a: number, b: number) {
 
 function compareSocialEntry(a: MediaSocial, b: MediaSocial) {
   return (
-    compareDescending(Number(hasRating(a)), Number(hasRating(b))) ||
+    // Leaderboard: entries with plays on top, ordered by watch time (falling
+    // back to play count when the endpoint omits minutes), then by a weighted
+    // activity score (rating/review outweigh a watchlist add), then recency,
+    // and finally username for a stable order.
+    compareDescending(Number(hasPlays(a)), Number(hasPlays(b))) ||
+    compareDescending(minutesWatched(a), minutesWatched(b)) ||
     compareDescending(watchedPlays(a), watchedPlays(b)) ||
-    compareDescending(watchlistedValue(a), watchlistedValue(b)) ||
+    compareDescending(activityScore(a), activityScore(b)) ||
     compareDescending(lastActivityDate(a), lastActivityDate(b)) ||
     a.user.username.localeCompare(b.user.username)
   );

--- a/projects/client/src/lib/sections/summary/components/social/_internal/SocialActivityRow.svelte
+++ b/projects/client/src/lib/sections/summary/components/social/_internal/SocialActivityRow.svelte
@@ -18,6 +18,13 @@
   );
 
   const activities = $derived(mapToSocialActivityEntries(entry));
+
+  const ratingActivity = $derived(
+    activities.find((activity) => activity.type === "rating"),
+  );
+  const otherActivities = $derived(
+    activities.filter((activity) => activity.type !== "rating"),
+  );
 </script>
 
 <li class="trakt-social-activity-row">
@@ -34,9 +41,15 @@
       </Link>
 
       <div class="trakt-social-activity-pills">
-        {#each activities as activity (activity.key)}
+        {#each otherActivities as activity (activity.key)}
           <SocialActivityTag {activity} />
         {/each}
+
+        {#if ratingActivity}
+          <span class="trakt-social-activity-rating">
+            <SocialActivityTag activity={ratingActivity} />
+          </span>
+        {/if}
       </div>
     </div>
   </div>
@@ -61,6 +74,12 @@
     align-items: center;
     gap: var(--gap-s);
     min-width: 0;
+  }
+
+  .trakt-social-activity-rating {
+    display: inline-flex;
+    margin-inline-start: auto;
+    flex: 0 0 auto;
   }
 
   .trakt-social-activity-user-copy {

--- a/projects/client/src/lib/sections/summary/components/social/_internal/SocialActivityTag.svelte
+++ b/projects/client/src/lib/sections/summary/components/social/_internal/SocialActivityTag.svelte
@@ -2,8 +2,9 @@
   import StarIcon from "$lib/components/icons/StarIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import StemTag from "$lib/components/tags/StemTag.svelte";
-  import { getLocale } from "$lib/features/i18n";
+  import { getLocale, languageTag } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration";
   import { toUserRating } from "$lib/utils/formatting/number/toUserRating";
   import { summaryDrawerNavigation } from "../../../_internal/summaryDrawerNavigation";
   import type { SocialActivityEntry } from "../models/SocialActivityEntry";
@@ -11,6 +12,12 @@
   const { activity }: { activity: SocialActivityEntry } = $props();
 
   const { buildReviewDrawerLink } = summaryDrawerNavigation();
+
+  const watchTimeLabel = $derived(
+    activity.type === "watch" && activity.minutesWatched
+      ? toHumanDuration({ minutes: activity.minutesWatched }, languageTag())
+      : null,
+  );
 
   const tagText = $derived.by(() => {
     switch (activity.type) {
@@ -30,7 +37,14 @@
 
 {#snippet tag()}
   <StemTag>
-    <p class="bold capitalize no-wrap">{tagText}</p>
+    {#if watchTimeLabel}
+      <p class="bold no-wrap">{watchTimeLabel}</p>
+      <span class="trakt-social-activity-play-count capitalize tag no-wrap">
+        · {tagText}
+      </span>
+    {:else}
+      <p class="bold capitalize no-wrap">{tagText}</p>
+    {/if}
 
     {#if activity.type === "rating"}
       <span class="trakt-social-activity-icon">
@@ -61,6 +75,10 @@
     :global(.trakt-link) {
       text-decoration: none;
     }
+  }
+
+  .trakt-social-activity-play-count {
+    opacity: var(--de-emphasized-opacity);
   }
 
   .trakt-social-activity-icon {

--- a/projects/client/src/lib/sections/summary/components/social/_internal/mapToSocialActivityEntries.ts
+++ b/projects/client/src/lib/sections/summary/components/social/_internal/mapToSocialActivityEntries.ts
@@ -12,6 +12,7 @@ export function mapToSocialActivityEntries(
       key: `${mediaSocial.key}-watched`,
       type: 'watch',
       playCount: mediaSocial.watched.plays,
+      minutesWatched: mediaSocial.watched.minutesWatched ?? null,
     });
   }
 

--- a/projects/client/src/lib/sections/summary/components/social/models/SocialActivityEntry.ts
+++ b/projects/client/src/lib/sections/summary/components/social/models/SocialActivityEntry.ts
@@ -16,6 +16,7 @@ type RatingSocialActivityEntry = CommonSocialActivityEntry & {
 type WatchSocialActivityEntry = CommonSocialActivityEntry & {
   type: 'watch';
   playCount: number;
+  minutesWatched: number | null;
 };
 
 type WatchlistSocialActivityEntry = CommonSocialActivityEntry & {

--- a/projects/client/src/mocks/data/summary/common/mapped/MediaSocialMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/common/mapped/MediaSocialMappedMock.ts
@@ -29,6 +29,7 @@ export const MediaSocialMappedMock: MediaSocial[] = [
     },
     watched: {
       plays: 2,
+      minutesWatched: 210,
       lastWatchedAt: new Date('2026-06-01T20:15:00.000Z'),
       lastUpdatedAt: new Date('2026-06-01T20:16:00.000Z'),
       rating: {

--- a/projects/client/src/mocks/data/summary/common/response/MediaSocialResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/common/response/MediaSocialResponseMock.ts
@@ -41,6 +41,7 @@ export const MediaSocialResponseMock: MediaSocialResponseInput = [
     user: HarryDuBoisResponseMock,
     watched: {
       plays: 2,
+      minutes_watched: 210,
       last_watched_at: '2026-06-01T20:15:00.000Z',
       last_updated_at: '2026-06-01T20:16:00.000Z',
       rating: {


### PR DESCRIPTION
## 🎶 Notes 🎶

- The social activities drawer now also shows (and sorts on) the total watch time on something. Making it clearly visible how much someone can like The Fast and the Furious.
  - On equal plays/time, it's sorted on (weighted) activity. E.g. rating and reviewing count higher than watchlisting.
- Aligns the ratings tag with the average rating at the top.

## 👀 Examples 👀
Before/after:
<img width="401" height="406" alt="Screenshot 2026-07-08 at 16 24 35" src="https://github.com/user-attachments/assets/b772f775-f7e0-443f-b43e-82ec1219dde7" />

<img width="401" height="406" alt="Screenshot 2026-07-08 at 16 42 56" src="https://github.com/user-attachments/assets/152f0f77-e9d2-4083-9092-84ef3c793867" />

Before/after:
<img width="401" height="406" alt="Screenshot 2026-07-08 at 17 11 47" src="https://github.com/user-attachments/assets/f5c359d5-b08d-43b7-95fd-4d0da3d6a2ac" />

<img width="401" height="406" alt="Screenshot 2026-07-08 at 17 13 45" src="https://github.com/user-attachments/assets/59622cc8-fd9e-43f5-9c85-0d1687ea8edf" />
