### PR TITLE
feat(settings): resolve imported episodes by season/episode number

### DIFF
--- a/projects/client/src/lib/sections/settings/import/ImportTypes.ts
+++ b/projects/client/src/lib/sections/settings/import/ImportTypes.ts
@@ -43,6 +43,12 @@ export interface UniversalImportItem {
   rated_at?: string;
   season?: number;
   episode?: number;
+  // For episode items: ids of the parent show. Enable positional history
+  // resolution (show + season + episode number) when Trakt has no TVDB id on
+  // the episode; imdb is a fallback for shows also missing a TVDB id. See
+  // parsers/utils/toEpisodeIds.ts.
+  showTvdb?: number;
+  showImdb?: string;
   // For action 'list': the source list this item belongs to. Items are grouped
   // by listName at sync time; listIsPublic maps to the created list's privacy.
   listName?: string;

--- a/projects/client/src/lib/sections/settings/import/engine/buildHistoryPayload.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/engine/buildHistoryPayload.spec.ts
@@ -80,7 +80,153 @@ describe('buildHistoryPayload', () => {
   });
 
   describe('episodes', () => {
-    it('should add an episode by resolved episode ids', () => {
+    it('should resolve an episode positionally via show + season + number', () => {
+      const item: UniversalImportItem = {
+        action: 'history',
+        type: 'episode',
+        ids: {},
+        showTvdb: 9001,
+        season: 2,
+        episode: 1,
+        watched_at,
+      };
+
+      const result = buildHistoryPayload([item]);
+
+      expect(result.shows).toEqual([{
+        ids: { tvdb: 9001 },
+        seasons: [{ number: 2, episodes: [{ number: 1, watched_at }] }],
+      }]);
+      expect(result.episodes).toHaveLength(0);
+    });
+
+    it('should resolve positionally via show imdb when the show has no tvdb', () => {
+      const item: UniversalImportItem = {
+        action: 'history',
+        type: 'episode',
+        ids: {},
+        showImdb: 'tt1234567',
+        season: 1,
+        episode: 1,
+        watched_at,
+      };
+
+      const result = buildHistoryPayload([item]);
+
+      expect(result.shows).toEqual([{
+        ids: { imdb: 'tt1234567' },
+        seasons: [{ number: 1, episodes: [{ number: 1, watched_at }] }],
+      }]);
+      expect(result.episodes).toHaveLength(0);
+    });
+
+    it('should merge one show when items carry differing show ids', () => {
+      const items: UniversalImportItem[] = [
+        {
+          action: 'history',
+          type: 'episode',
+          ids: {},
+          showTvdb: 9001,
+          season: 1,
+          episode: 1,
+          watched_at,
+        },
+        {
+          action: 'history',
+          type: 'episode',
+          ids: {},
+          showTvdb: 9001,
+          showImdb: 'tt1234567',
+          season: 1,
+          episode: 2,
+          watched_at,
+        },
+      ];
+
+      const result = buildHistoryPayload(items);
+
+      expect(result.shows).toEqual([{
+        ids: { tvdb: 9001, imdb: 'tt1234567' },
+        seasons: [{
+          number: 1,
+          episodes: [
+            { number: 1, watched_at },
+            { number: 2, watched_at },
+          ],
+        }],
+      }]);
+    });
+
+    it('should group positional episodes by show and season', () => {
+      const items: UniversalImportItem[] = [
+        {
+          action: 'history',
+          type: 'episode',
+          ids: {},
+          showTvdb: 9001,
+          season: 1,
+          episode: 1,
+          watched_at,
+        },
+        {
+          action: 'history',
+          type: 'episode',
+          ids: {},
+          showTvdb: 9001,
+          season: 1,
+          episode: 2,
+          watched_at,
+        },
+        {
+          action: 'history',
+          type: 'episode',
+          ids: {},
+          showTvdb: 9001,
+          season: 2,
+          episode: 1,
+          watched_at,
+        },
+      ];
+
+      const result = buildHistoryPayload(items);
+
+      expect(result.shows).toEqual([{
+        ids: { tvdb: 9001 },
+        seasons: [
+          {
+            number: 1,
+            episodes: [
+              { number: 1, watched_at },
+              { number: 2, watched_at },
+            ],
+          },
+          { number: 2, episodes: [{ number: 1, watched_at }] },
+        ],
+      }]);
+      expect(result.episodes).toHaveLength(0);
+    });
+
+    it('should prefer positional resolution over the episode id', () => {
+      const item: UniversalImportItem = {
+        action: 'history',
+        type: 'episode',
+        ids: { tvdb: 4321 },
+        showTvdb: 9001,
+        season: 2,
+        episode: 1,
+        watched_at,
+      };
+
+      const result = buildHistoryPayload([item]);
+
+      expect(result.shows).toEqual([{
+        ids: { tvdb: 9001 },
+        seasons: [{ number: 2, episodes: [{ number: 1, watched_at }] }],
+      }]);
+      expect(result.episodes).toHaveLength(0);
+    });
+
+    it('should add an episode by its id when not positionally resolvable', () => {
       const item: UniversalImportItem = {
         action: 'history',
         type: 'episode',

--- a/projects/client/src/lib/sections/settings/import/engine/buildHistoryPayload.ts
+++ b/projects/client/src/lib/sections/settings/import/engine/buildHistoryPayload.ts
@@ -26,16 +26,72 @@ function toHistoryShow(
   return null;
 }
 
+// Prefer positional resolution (show id + season/episode number) over the
+// episode's own id: many Trakt episodes have no TVDB id, while the show does,
+// and (show, season, number) identifies an episode unambiguously.
+function isPositional(
+  item: UniversalImportItem,
+): item is UniversalImportItem & { season: number; episode: number } {
+  return (item.showTvdb != null || item.showImdb != null) &&
+    item.season != null && item.episode != null;
+}
+
+type PositionalEpisode = { number: number; watched_at?: string };
+type ShowIds = { tvdb?: number; imdb?: string };
+type ShowGroup = { ids: ShowIds; seasons: Map<number, PositionalEpisode[]> };
+
+function toShowIds(item: UniversalImportItem): ShowIds {
+  return {
+    ...(item.showTvdb != null ? { tvdb: item.showTvdb } : {}),
+    ...(item.showImdb != null ? { imdb: item.showImdb } : {}),
+  };
+}
+
+// Fold positional episodes into `shows`: one entry per show carrying its
+// watched seasons -> episodes-by-number, each keeping its own watched_at. The
+// show id block merges tvdb and/or imdb across items so shows missing a TVDB id
+// still resolve. Keyed on tvdb (else imdb) so the same show grouped from two
+// serializations - one carrying imdb, one not - collapses into one entry.
+function toPositionalShows(
+  items: ReadonlyArray<
+    UniversalImportItem & { season: number; episode: number }
+  >,
+): HistoryShow[] {
+  const byShow = items.reduce((shows, item) => {
+    const key = item.showTvdb != null
+      ? `tvdb:${item.showTvdb}`
+      : `imdb:${item.showImdb}`;
+    const group = shows.get(key) ??
+      { ids: {} as ShowIds, seasons: new Map<number, PositionalEpisode[]>() };
+    const episodes = group.seasons.get(item.season) ?? [];
+    group.seasons.set(item.season, [
+      ...episodes,
+      { number: item.episode, watched_at: item.watched_at },
+    ]);
+    return shows.set(key, {
+      ids: { ...group.ids, ...toShowIds(item) },
+      seasons: group.seasons,
+    });
+  }, new Map<string, ShowGroup>());
+
+  return [...byShow.values()].map(({ ids, seasons }) => ({
+    ids,
+    seasons: [...seasons].map(([number, episodes]) => ({ number, episodes })),
+  })) as unknown as HistoryShow[];
+}
+
 export function buildHistoryPayload(
   items: UniversalImportItem[],
 ): HistoryAddRequest {
   const episodeItems = items.filter((item) => item.type === 'episode');
+  const positionalEpisodes = episodeItems.filter(isPositional);
+  const idEpisodes = episodeItems.filter((item) => !isPositional(item));
 
   const movies = items
     .filter((item) => item.type === 'movie')
     .flatMap((item) => toHistoryMovie(item) ?? []);
 
-  const episodes: HistoryEpisode[] = episodeItems.flatMap(
+  const episodes: HistoryEpisode[] = idEpisodes.flatMap(
     ({ ids, watched_at }) => {
       const resolvedIds = pickIds(ids, EPISODE_IDS);
       return resolvedIds ? [{ ids: resolvedIds as never, watched_at }] : [];
@@ -46,7 +102,8 @@ export function buildHistoryPayload(
     ...items
       .filter((item) => item.type === 'show')
       .flatMap((item) => toHistoryShow(item) ?? []),
-    ...episodeItems.flatMap(({ ids, watched_at }) => {
+    ...toPositionalShows(positionalEpisodes),
+    ...idEpisodes.flatMap(({ ids, watched_at }) => {
       const resolvedIds = pickIds(ids, EPISODE_IDS);
       return !resolvedIds && ids.imdb
         ? [{ ids: { imdb: ids.imdb } as never, watched_at }]

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.ts
@@ -2,6 +2,7 @@ import type { UniversalImportItem } from '../ImportTypes.ts';
 import type { FileParser } from './ParserInterface.ts';
 import { parseCsvText } from './utils/parseCsvText.ts';
 import { toISOString } from './utils/toISOString.ts';
+import { toEpisodeIds } from './utils/toEpisodeIds.ts';
 import { unzipCsvTexts } from './utils/unzipCsvTexts.ts';
 
 // The current TV Time "export my data" tool emits a set of tvtime-*.* files
@@ -90,16 +91,25 @@ function toTvdb(value?: number | null): number | undefined {
 function parseEpisodeRow(row: EpisodeRow): UniversalImportItem | null {
   if (row.is_watched !== 'true') return null;
 
-  const tvdbId = toInt(row.tvdb_id);
-  if (tvdbId == null) return null;
+  const showTvdb = toInt(row.series_tvdb_id);
+  const season = toInt(row.season);
+  const episode = toInt(row.episode);
+  const ids = toEpisodeIds({
+    tvdbId: toInt(row.tvdb_id),
+    showTvdb,
+    season,
+    episode,
+  });
+  if (ids == null) return null;
 
   return {
     action: 'history',
     type: 'episode',
-    ids: { tvdb: tvdbId },
+    ids,
+    showTvdb,
     title: row.title || undefined,
-    season: toInt(row.season),
-    episode: toInt(row.episode),
+    season,
+    episode,
     watched_at: toISOString(row.watched_at),
   };
 }
@@ -186,17 +196,27 @@ function parseCsvRows(
 function parseJsonShows(shows: JsonShow[]): UniversalImportItem[] {
   return shows.flatMap((show) => {
     if (!show) return [];
+    const showTvdb = toTvdb(show.id?.tvdb);
+    const showImdb = toImdb(show.id?.imdb);
     const episodes = (show.seasons ?? []).flatMap((season) => {
       if (!season) return [];
       return (season.episodes ?? [])
         .filter((episode) => episode?.is_watched === true)
         .flatMap((episode): UniversalImportItem[] => {
-          const tvdbId = toTvdb(episode?.id?.tvdb);
-          if (tvdbId == null) return [];
+          const ids = toEpisodeIds({
+            tvdbId: toTvdb(episode?.id?.tvdb),
+            showTvdb,
+            showImdb,
+            season: season.number,
+            episode: episode.number,
+          });
+          if (ids == null) return [];
           return [{
             action: 'history',
             type: 'episode',
-            ids: { tvdb: tvdbId },
+            ids,
+            showTvdb,
+            showImdb,
             title: show.title || undefined,
             season: season.number,
             episode: episode.number,
@@ -207,14 +227,12 @@ function parseJsonShows(shows: JsonShow[]): UniversalImportItem[] {
 
     if (show.status !== WATCHLIST_SERIES_STATUS) return episodes;
 
-    const tvdbId = toTvdb(show.id?.tvdb);
-    const imdbId = toImdb(show.id?.imdb);
-    if (tvdbId == null && !imdbId) return episodes;
+    if (showTvdb == null && !showImdb) return episodes;
 
     return [...episodes, {
       action: 'watchlist',
       type: 'show',
-      ids: { tvdb: tvdbId, imdb: imdbId },
+      ids: { tvdb: showTvdb, imdb: showImdb },
       title: show.title || undefined,
     }];
   });
@@ -284,6 +302,22 @@ async function collectEntries(files: ReadonlyArray<File>): Promise<Entry[]> {
 // the same episode/movie present in both the CSV and JSON exports collapses to
 // one item.
 function itemKey(item: UniversalImportItem): string {
+  // A positional episode is identified by show + season + episode alone; its
+  // own id must stay out of the key, or the same watch present in both
+  // serializations (one carrying the episode id, one not) fails to dedupe.
+  if (
+    item.type === 'episode' &&
+    (item.showTvdb != null || item.showImdb != null) &&
+    item.season != null && item.episode != null
+  ) {
+    // Prefer tvdb (else imdb) so a watch present in both serializations, one
+    // carrying imdb and one not, keys the same and dedupes.
+    const showKey = item.showTvdb != null
+      ? `tvdb-${item.showTvdb}`
+      : `imdb-${item.showImdb}`;
+    return [item.action, item.type, showKey, item.season, item.episode]
+      .join('-');
+  }
   return [
     item.action,
     item.type,

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.spec.ts
@@ -251,8 +251,26 @@ describe('TvTimeGdprParser', () => {
       expect(result).toHaveLength(200_000);
     });
 
-    it('should skip episode rows without an episode id', async () => {
+    it('should resolve an episode with no episode id positionally', async () => {
+      // The show id + season/episode number recover the watch when the
+      // episode's own TVDB id is absent (many Trakt episodes have none).
       const csv = toCsv(V2_HEADER, [v2EpisodeWatch({ ep_id: '' })]);
+
+      const result = await TvTimeGdprParser.parse([csvFile(csv)]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        action: 'history',
+        type: 'episode',
+        ids: {},
+        showTvdb: 82066,
+        season: 2,
+        episode: 10,
+      });
+    });
+
+    it('should skip episode rows with neither an episode id nor a show id', async () => {
+      const csv = toCsv(V2_HEADER, [v2EpisodeWatch({ ep_id: '', s_id: '' })]);
 
       const result = await TvTimeGdprParser.parse([csvFile(csv)]);
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
@@ -2,6 +2,7 @@ import type { UniversalImportItem } from '../ImportTypes.ts';
 import type { FileParser } from './ParserInterface.ts';
 import { parseCsvText } from './utils/parseCsvText.ts';
 import { toISOString } from './utils/toISOString.ts';
+import { toEpisodeIds } from './utils/toEpisodeIds.ts';
 import { unzipCsvTexts } from './utils/unzipCsvTexts.ts';
 
 type TrackingV1Row = {
@@ -176,19 +177,28 @@ function parseV1Episode(row: TrackingV1Row): UniversalImportItem | null {
 function parseV2Episode(row: TrackingV2Row): UniversalImportItem | null {
   if (!row.key?.startsWith('watch-episode-')) return null;
 
-  // ep_id is the TVDB episode id (verified against the Trakt search API).
-  // Fall back to the legacy episode_id column for export variants that only
-  // populate that one.
-  const tvdbId = toInt(firstOf(row.ep_id, row.episode_id));
-  if (tvdbId == null) return null;
+  // ep_id is the TVDB episode id (verified against the Trakt search API);
+  // legacy exports carry it under episode_id. s_id/s_no/ep_no back positional
+  // resolution when the episode's own id is absent.
+  const showTvdb = toInt(row.s_id);
+  const season = toInt(firstOf(row.s_no, row.season_number));
+  const episode = toInt(firstOf(row.ep_no, row.episode_number));
+  const ids = toEpisodeIds({
+    tvdbId: toInt(firstOf(row.ep_id, row.episode_id)),
+    showTvdb,
+    season,
+    episode,
+  });
+  if (ids == null) return null;
 
   return {
     action: 'history',
     type: 'episode',
-    ids: { tvdb: tvdbId },
+    ids,
+    showTvdb,
     title: row.series_name || undefined,
-    season: toInt(firstOf(row.s_no, row.season_number)),
-    episode: toInt(firstOf(row.ep_no, row.episode_number)),
+    season,
+    episode,
     watched_at: toISOString(row.created_at),
   };
 }

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeRealExports.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeRealExports.spec.ts
@@ -2,6 +2,7 @@ import { zipSync } from 'fflate';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { buildHistoryPayload } from '../engine/buildHistoryPayload.ts';
 import type { UniversalImportItem } from '../ImportTypes.ts';
 import { TvTimeCsvParser } from './TvTimeCsvParser.ts';
 
@@ -75,6 +76,39 @@ describe('TvTimeCsvParser: real anonymized exports', () => {
     // Every parsed item must resolve to a TVDB id - the v2 bug produced items
     // with no id (or none at all).
     expect(result.every((item) => item.ids.tvdb != null)).toBe(true);
+    // Episodes also carry the show's TVDB id, so history can resolve them
+    // positionally when Trakt has no TVDB id on the episode.
+    expect(
+      result
+        .filter((item) => item.type === 'episode')
+        .every((item) => item.showTvdb != null),
+    ).toBe(true);
+  });
+
+  it('routes real episode watches through positional history resolution', async () => {
+    // TV Time episodes carry a TVDB id, but many Trakt episodes have none, so
+    // id-based history drops them; they must be sent as show + season/episode
+    // number instead. Proven here end-to-end on a real export.
+    const result = await TvTimeCsvParser.parse([
+      csvFile(
+        'gdpr-v2-tracking-prod-records-v2.csv',
+        'tracking-prod-records-v2.csv',
+      ),
+    ]);
+
+    const payload = buildHistoryPayload([...result]);
+
+    // No episode goes out by its own id; all 8 route positionally under shows.
+    expect(payload.episodes).toHaveLength(0);
+    const positionalEpisodes = (payload.shows ?? [])
+      .flatMap((show) => ('seasons' in show ? show.seasons ?? [] : []))
+      .flatMap((season) => season.episodes ?? []);
+    expect(positionalEpisodes).toHaveLength(8);
+    expect(
+      (payload.shows ?? []).every((show) =>
+        'ids' in show && show.ids != null && 'tvdb' in show.ids
+      ),
+    ).toBe(true);
   });
 
   it('imports a real current-format export from loose tvtime-*.csv files', async () => {

--- a/projects/client/src/lib/sections/settings/import/parsers/utils/toEpisodeIds.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/utils/toEpisodeIds.ts
@@ -1,0 +1,21 @@
+import type { ImportIds } from '../../ImportTypes.ts';
+
+type EpisodeKeys = {
+  tvdbId?: number;
+  showTvdb?: number;
+  showImdb?: string;
+  season?: number;
+  episode?: number;
+};
+
+// The id fields for an imported episode, or null when it can't be resolved. An
+// episode resolves by its own TVDB id or, when Trakt has none for it, by a
+// positional key (show id + season + episode number).
+export function toEpisodeIds(
+  { tvdbId, showTvdb, showImdb, season, episode }: EpisodeKeys,
+): ImportIds | null {
+  const hasShow = showTvdb != null || showImdb != null;
+  const hasPositional = hasShow && season != null && episode != null;
+  if (tvdbId == null && !hasPositional) return null;
+  return tvdbId != null ? { tvdb: tvdbId } : {};
+}


### PR DESCRIPTION
## Problem

TV Time exports carry episode **TVDB ids**, and the importer resolved watched episodes solely by that id. But many episodes in Trakt's catalog have no TVDB id stored (they exist, linked by other ids). Whenever a watched episode was one of those, the id-based history path dropped it silently - the root cause behind the recurring "only some seasons imported / half my history is missing" TV Time reports.

## Fix

Resolve episodes **positionally** - by the show's id plus the season/episode number - instead of the episode's own id. Trakt's `/sync/history` already accepts this shape (`shows[].seasons[].episodes[].number`, per-episode `watched_at`). The `(show, season, number)` pair identifies an episode unambiguously and works regardless of whether Trakt has a TVDB id on the episode. This mirrors the approach a standalone community importer used successfully (grouping watches under `show -> seasons -> episodes`).

- `showTvdb`/`showImdb` are carried onto episode items in the GDPR v2 and current-export (CSV + JSON) parsers. An episode is kept when it has **either** its own id **or** a full positional key (show id + season + episode), via a shared `toEpisodeIds` helper - so id-less rows are no longer discarded.
- `buildHistoryPayload` groups positional episodes into `shows -> seasons -> episodes-by-number`. The show id block carries **tvdb and/or imdb**, so a show that itself lacks a TVDB id still resolves via imdb (JSON export carries the show imdb). The episode-id path stays as a fallback for rows without a positional key (e.g. legacy v1 exports, which carry no show id).
- Dedup keys positional episodes on the positional key, so the same watch present in both the CSV and JSON serializations collapses regardless of which one carries the episode id.

## Verification

- `buildHistoryPayload.spec.ts`: positional resolution (via show tvdb and via show imdb), show/season grouping, positional-preferred-over-id, id fallback.
- `TvTimeRealExports.spec.ts`: end-to-end over the real anonymized v2 export - all watches route positionally under `shows`, `episodes` is empty.
- `TvTimeGdprParser.spec.ts`: id-less rows resolve positionally; rows with neither an episode id nor a show id are still skipped.
- Full import suite (247 tests) green; `svelte-check` clean on touched files (pre-existing `browsing.locale` errors on `main` are unrelated).

## Known tradeoff

Positional matching assumes TV Time's season/episode numbers agree with Trakt's. Both derive numbering from TVDB, so they align in the overwhelming majority; where they diverge (rare) the episode's own id could not have rescued it either. Flagging for visibility - happy to add an id-first/positional-fallback toggle if we ever see divergence in the wild.
