### PR TITLE
feat(banner): add TV Time importer-update banner

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7375,6 +7375,18 @@
       "default": "Open tvtime.trakt.tv",
       "description": "Call-to-action link on the TV Time migration banner that opens the tvtime.trakt.tv companion app in a new tab."
     },
+    "tv_time_import_banner_heading": {
+      "default": "Your TV Time import, improved",
+      "description": "Heading on the banner shown to users who joined during the TV Time migration, telling them the importer has been upgraded."
+    },
+    "tv_time_import_banner_description": {
+      "default": "We've upgraded the importer. If some shows or episodes are missing, import your TV Time export again to pull them in. Still missing after that? Delete the old plays first, then import once more.",
+      "description": "Description on the TV Time importer-update banner explaining that re-importing now recovers missing show/episode data, and to delete old plays before re-importing if issues persist."
+    },
+    "tv_time_import_banner_action": {
+      "default": "Import again",
+      "description": "Call-to-action button on the TV Time importer-update banner that opens the data import settings page."
+    },
     "welcome_greeting": {
       "default": "Welcome to Trakt, {name}",
       "description": "Main heading on the Welcome page, greeting the signed-in user by name."

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4886,6 +4886,14 @@
       "default": "Usually the wrong files were uploaded, or the export was empty. Double-check you uploaded the files listed above from a fresh export. If it still comes up empty, send it to us below.",
       "description": "TV Time FAQ answer about an import that imported nothing."
     },
+    "tv_time_faq_missing_episodes_question": {
+      "default": "Some shows or episodes are missing or marked unwatched.",
+      "description": "TV Time FAQ question about shows or episodes missing / marked unwatched after import."
+    },
+    "tv_time_faq_missing_episodes_answer": {
+      "default": "As of July 8, 2026 we've improved how the importer matches episodes, so shows that previously came in incomplete should now import fully. Import your export again to pull in the missing episodes. If some are still missing after that, delete the old plays first, then import once more.",
+      "description": "TV Time FAQ answer explaining the improved importer (released July 8, 2026) recovers missing episodes on re-import, and to delete old plays before re-importing if issues persist. Keep the date aligned with the importer's actual release date."
+    },
     "tv_time_faq_missing_ratings_question": {
       "default": "My ratings didn't come across.",
       "description": "TV Time FAQ question about ratings missing after import."

--- a/projects/client/src/lib/sections/banner/Banner.svelte
+++ b/projects/client/src/lib/sections/banner/Banner.svelte
@@ -4,6 +4,7 @@
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import PromotionBanners from "./_internal/PromotionBanners.svelte";
   import ReviewBanners from "./_internal/ReviewBanners.svelte";
+  import TvTimeImportBanner from "./tv-time-import/TvTimeImportBanner.svelte";
   import TvTimeBanner from "./tv-time/TvTimeBanner.svelte";
   import WelcomeBanner from "./welcome/WelcomeBanner.svelte";
 
@@ -14,6 +15,7 @@
 <RenderFor audience="authenticated">
   <WelcomeBanner />
   <TvTimeBanner />
+  <TvTimeImportBanner />
 </RenderFor>
 
 <RenderFor audience="vip">

--- a/projects/client/src/lib/sections/banner/tv-time-import/TvTimeImportBanner.svelte
+++ b/projects/client/src/lib/sections/banner/tv-time-import/TvTimeImportBanner.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  import Button from "$lib/components/buttons/Button.svelte";
+  import LogoMarkCircle from "$lib/components/logo/LogoMarkCircle.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+  import BannerContainer from "../_internal/BannerContainer.svelte";
+  import DismissButton from "../_internal/DismissButton.svelte";
+  import { useTvTimeImportBanner } from "./_internal/useTvTimeImportBanner.ts";
+
+  const { isVisible, dismiss } = useTvTimeImportBanner();
+</script>
+
+{#if $isVisible}
+  <BannerContainer>
+    <section class="trakt-tv-time-import-banner">
+      <div class="tv-time-import-banner-dismiss">
+        <DismissButton onDismiss={dismiss} />
+      </div>
+
+      <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
+        <div class="tv-time-import-banner-icon" aria-hidden="true">
+          <LogoMarkCircle />
+        </div>
+      </RenderFor>
+
+      <div class="tv-time-import-banner-content">
+        <h2 class="bold tv-time-import-banner-title">
+          {m.tv_time_import_banner_heading()}
+          <RenderFor audience="all" device={["tablet-sm", "mobile"]}>
+            <LogoMarkCircle />
+          </RenderFor>
+        </h2>
+        <p class="secondary">{m.tv_time_import_banner_description()}</p>
+      </div>
+
+      <Button
+        href={UrlBuilder.settings.data()}
+        color="purple"
+        variant="primary"
+        style="flat"
+        size="small"
+        label={m.tv_time_import_banner_action()}
+      >
+        {m.tv_time_import_banner_action()}
+      </Button>
+    </section>
+  </BannerContainer>
+{/if}
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-tv-time-import-banner {
+    position: relative;
+    overflow: hidden;
+
+    display: flex;
+    align-items: center;
+    gap: var(--gap-l);
+
+    width: 100%;
+    box-sizing: border-box;
+
+    padding: var(--gap-l) var(--gap-xl);
+    padding-inline-end: var(--ni-48);
+
+    background: color-mix(
+      in srgb,
+      var(--color-card-background) 80%,
+      transparent
+    );
+    border: var(--border-thickness-xxs) solid
+      color-mix(in srgb, var(--color-border) 50%, transparent);
+    border-radius: var(--border-radius-xl);
+
+    transition: var(--transition-increment) ease-in-out;
+    transition-property: padding, gap;
+
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+
+      background: radial-gradient(
+        85% 130% at 100% 0%,
+        color-mix(in srgb, var(--purple-500) 12%, transparent),
+        transparent 60%
+      );
+    }
+
+    @include for-tablet-sm-and-below {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--gap-m);
+
+      padding: var(--gap-l);
+      padding-inline-end: var(--ni-48);
+    }
+  }
+
+  .tv-time-import-banner-dismiss {
+    position: absolute;
+    z-index: 1;
+
+    top: var(--ni-8);
+    inset-inline-end: var(--ni-8);
+  }
+
+  .tv-time-import-banner-icon {
+    position: relative;
+    flex-shrink: 0;
+
+    display: grid;
+    place-items: center;
+
+    width: var(--ni-48);
+    height: var(--ni-48);
+
+    :global(svg) {
+      width: var(--ni-24);
+      height: var(--ni-24);
+    }
+  }
+
+  .tv-time-import-banner-content {
+    position: relative;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xxs);
+
+    flex: 1 1 auto;
+
+    @include for-tablet-sm-and-below {
+      gap: var(--gap-s);
+    }
+  }
+
+  .tv-time-import-banner-title {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    :global(svg) {
+      width: var(--ni-18);
+      height: var(--ni-18);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/banner/tv-time-import/_internal/useTvTimeImportBanner.ts
+++ b/projects/client/src/lib/sections/banner/tv-time-import/_internal/useTvTimeImportBanner.ts
@@ -1,0 +1,39 @@
+import type { UserSettings } from '$lib/features/auth/queries/currentUserSettingsQuery.ts';
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { combineLatest, map } from 'rxjs';
+import { TV_TIME_ANNOUNCEMENT_DATE } from '../../tv-time/constants/index.ts';
+import { useBannerDismissal } from '../../_internal/useBannerDismissal.ts';
+import {
+  TV_TIME_IMPORT_BANNER_END,
+  TV_TIME_IMPORT_BANNER_ID,
+  TV_TIME_IMPORT_V2_RELEASE_DATE,
+} from '../constants/index.ts';
+
+const DISMISSAL_VALUE = 'dismissed';
+
+// The migration cohort that imported before the v2 importer: joined on/after
+// the shutdown announcement but before the v2 release.
+function joinedBeforeImportV2(user: UserSettings | undefined): boolean {
+  const joinedAt = user?.joinedAt;
+  return joinedAt != null &&
+    joinedAt >= TV_TIME_ANNOUNCEMENT_DATE &&
+    joinedAt < TV_TIME_IMPORT_V2_RELEASE_DATE;
+}
+
+export function useTvTimeImportBanner() {
+  const { user } = useUser();
+  const { isDismissed, dismiss } = useBannerDismissal(
+    TV_TIME_IMPORT_BANNER_ID,
+    DISMISSAL_VALUE,
+  );
+
+  const hasExpired = new Date() >= TV_TIME_IMPORT_BANNER_END;
+
+  const isVisible = combineLatest([user, isDismissed]).pipe(
+    map(([$user, $isDismissed]) =>
+      !hasExpired && !$isDismissed && joinedBeforeImportV2($user)
+    ),
+  );
+
+  return { isVisible, dismiss };
+}

--- a/projects/client/src/lib/sections/banner/tv-time-import/constants/index.ts
+++ b/projects/client/src/lib/sections/banner/tv-time-import/constants/index.ts
@@ -1,0 +1,14 @@
+export const TV_TIME_IMPORT_BANNER_ID = 'tv-time-import-v2';
+
+// The improved TV Time importer (show + season/episode resolution) shipped on
+// this date. Users who joined between the shutdown announcement
+// (TV_TIME_ANNOUNCEMENT_DATE) and this release imported with the previous
+// version and may have missing show/episode data, so they are prompted to
+// re-import. Exclusive upper bound on join date - align with the actual deploy.
+export const TV_TIME_IMPORT_V2_RELEASE_DATE = new Date(
+  '2026-07-08T00:00:00.000Z',
+);
+
+// Hard cutoff - the banner retires at the end of the shutdown month regardless
+// of join date. Exclusive upper bound.
+export const TV_TIME_IMPORT_BANNER_END = new Date('2026-08-01T00:00:00.000Z');

--- a/projects/client/src/lib/sections/faq/_internal/TvTimeFaqList.svelte
+++ b/projects/client/src/lib/sections/faq/_internal/TvTimeFaqList.svelte
@@ -14,6 +14,10 @@
       answer: m.tv_time_faq_nothing_imported_answer,
     },
     {
+      question: m.tv_time_faq_missing_episodes_question,
+      answer: m.tv_time_faq_missing_episodes_answer,
+    },
+    {
       question: m.tv_time_faq_missing_ratings_question,
       answer: m.tv_time_faq_missing_ratings_answer,
     },


### PR DESCRIPTION
## What

TV Time migration UX for the improved importer:

1. **Banner** telling the migration cohort the importer has been improved and they can re-import to recover missing show/episode data.
2. **FAQ entry** covering the same, on the TV Time FAQ page.

### Banner

Shown to **authenticated** users whose `joinedAt` falls between the TV Time shutdown announcement (`TV_TIME_ANNOUNCEMENT_DATE`, reused from the migration banner) and the improved importer's release - i.e. people who imported with the previous version and may have gaps.

- **Heading:** Your TV Time import, improved
- **Description:** We've upgraded the importer. If some shows or episodes are missing, import your TV Time export again to pull them in. Still missing after that? Delete the old plays first, then import once more.
- **CTA:** Import again -> `/settings/data`
- Dismissible (persisted), auto-retires at `TV_TIME_IMPORT_BANNER_END` (end of the shutdown month). Mirrors the migration banner's layout; internal button CTA like the Welcome banner.

### FAQ

New item on the TV Time FAQ page: "Some shows or episodes are missing or marked unwatched." - explains the improved importer recovers them on re-import, and to delete old plays first if issues persist.

## Depends on / relates to

The importer fix this points users at is trakt/trakt-web#2857 (positional episode resolution).

## TODO before merge

`TV_TIME_IMPORT_V2_RELEASE_DATE` (the banner's join-date upper bound) is set to `2026-07-08` as a placeholder - it should equal the actual deploy date of #2857 so the whole affected cohort is covered. Will align once #2857 lands.
