### PR TITLE
feat: adds support for viewing reviews in a specific language

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -13,7 +13,7 @@
     "npm:@ethercorps/sveltekit-og@4.2.1": "4.2.1_@sveltejs+kit@2.69.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@7.1.2___svelte@5.56.4___vite@8.1.3____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.4__typescript@5.8.3__vite@8.1.3___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@7.1.2__svelte@5.56.4__vite@8.1.3___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0_svelte@5.56.4_typescript@5.8.3_vite@8.1.3__esbuild@0.28.1__sass-embedded@1.100.0",
     "npm:@inlang/paraglide-js@2.20.2": "2.20.2_typescript@5.8.3",
     "npm:@jsr/libn__fuzzy@0.4.0": "0.4.0",
-    "npm:@jsr/trakt__api@0.4.20": "0.4.20_openapi3-ts@4.6.0",
+    "npm:@jsr/trakt__api@0.4.21": "0.4.21_openapi3-ts@4.6.0",
     "npm:@playwright/test@1.61.1": "1.61.1",
     "npm:@sentry/sveltekit@10.63.0": "10.63.0_@sveltejs+kit@2.69.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@7.1.2___svelte@5.56.4___vite@8.1.3____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.4__typescript@5.8.3__vite@8.1.3___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_vite@8.1.3__esbuild@0.28.1__sass-embedded@1.100.0_@cloudflare+workers-types@4.20260702.1_@opentelemetry+api@1.9.1_@opentelemetry+core@2.9.0__@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@7.1.2__svelte@5.56.4__vite@8.1.3___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0_svelte@5.56.4_typescript@5.8.3",
     "npm:@svelte-put/shortcut@4.2.0": "4.2.0_svelte@5.56.4",
@@ -2087,14 +2087,14 @@
       "integrity": "sha512-aD9yjW6CMt37S3AMTc95LeuRXcKor69Zkr0aWOhYvinTOEAhEIuaJhP4pQqyQGaAC9HIrQcKh1PtRTK85kkVjA==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/libn__fuzzy/0.4.0.tgz"
     },
-    "@jsr/trakt__api@0.4.20_openapi3-ts@4.6.0": {
-      "integrity": "sha512-SFEF4l6KKcRjtWatVR3X/x01eWADiIolSIodb5vMgBk29JP5LIunVUI3U2n2Z5n7GRiLCtOJ3Hou8XkB74plWw==",
+    "@jsr/trakt__api@0.4.21_openapi3-ts@4.6.0": {
+      "integrity": "sha512-CTb+n4kQAslcetVrxFdWT+7MIX6P4FuYFADhmTlYHB3UNWoDDlzZu/bZuxmxJuUWNx+bjvEPfEoPh374/ZxnPA==",
       "dependencies": [
         "@anatine/zod-openapi",
         "@ts-rest/core",
         "zod"
       ],
-      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.4.20.tgz"
+      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.4.21.tgz"
     },
     "@lix-js/sdk@0.4.10": {
       "integrity": "sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==",
@@ -7616,7 +7616,7 @@
             "npm:@ethercorps/sveltekit-og@4.2.1",
             "npm:@inlang/paraglide-js@2.20.2",
             "npm:@jsr/libn__fuzzy@0.4.0",
-            "npm:@jsr/trakt__api@0.4.20",
+            "npm:@jsr/trakt__api@0.4.21",
             "npm:@playwright/test@1.61.1",
             "npm:@sentry/sveltekit@10.63.0",
             "npm:@svelte-put/shortcut@4.2.0",

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -1809,6 +1809,10 @@
       "default": "No reviews yet.",
       "description": "Placeholder text shown when there are no reviews in a list."
     },
+    "list_placeholder_comments_language": {
+      "default": "No {language} reviews yet.",
+      "description": "Placeholder text shown when there are no reviews in a specific language. {language} is the localized language name, e.g. 'Dutch'."
+    },
     "text_review_by": {
       "default": "Review by",
       "description": "Text used to indicate the author of a review."
@@ -2448,6 +2452,10 @@
     "option_text_all": {
       "default": "All",
       "description": "Text for the 'All' option in dropdowns or filters."
+    },
+    "option_text_comment_language_all": {
+      "default": "All languages",
+      "description": "Option in the comment language filter that shows comments written in any language."
     },
     "header_display": {
       "default": "Display",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -81,7 +81,7 @@
     "@tanstack/query-core": "5.101.2",
     "@tanstack/query-devtools": "5.101.2",
     "@tanstack/query-persist-client-core": "5.101.2",
-    "@trakt/api": "npm:@jsr/trakt__api@0.4.20",
+    "@trakt/api": "npm:@jsr/trakt__api@0.4.21",
     "@ts-rest/core": "3.52.1",
     "@use-gesture/vanilla": "10.3.1",
     "bits-ui": "2.18.1",

--- a/projects/client/src/lib/components/select/SingleSelect.svelte
+++ b/projects/client/src/lib/components/select/SingleSelect.svelte
@@ -10,6 +10,7 @@
     disabled = false,
     autoWidth = false,
     onChange,
+    trigger,
   }: SingleSelectProps = $props();
 
   const selectedLabel = $derived(
@@ -26,6 +27,7 @@
   {placeholder}
   {disabled}
   {autoWidth}
+  {trigger}
   triggerLabel={selectedLabel}
   hasValue={Boolean(value)}
   onValueChange={onChange}

--- a/projects/client/src/lib/components/select/_internal/SelectBase.svelte
+++ b/projects/client/src/lib/components/select/_internal/SelectBase.svelte
@@ -24,6 +24,7 @@
     hasValue: boolean;
     children: Snippet;
     autoWidth?: boolean;
+    trigger?: Snippet<[{ props: Record<string, unknown>; open: boolean }]>;
   } & (SelectSingleProps | SelectMultipleProps);
 
   const {
@@ -33,6 +34,7 @@
     hasValue,
     children,
     autoWidth = false,
+    trigger,
     ...rest
   }: SelectBaseProps = $props();
 
@@ -42,15 +44,19 @@
 {#snippet shell()}
   <Select.Trigger>
     {#snippet child({ props })}
-      <button
-        {...props}
-        class="trakt-select-trigger"
-        aria-label={placeholder}
-        data-has-value={hasValue}
-      >
-        <span class="ellipsis capitalize">{triggerLabel}</span>
-        <DropdownCaretIcon {open} />
-      </button>
+      {#if trigger}
+        {@render trigger({ props, open })}
+      {:else}
+        <button
+          {...props}
+          class="trakt-select-trigger"
+          aria-label={placeholder}
+          data-has-value={hasValue}
+        >
+          <span class="ellipsis capitalize">{triggerLabel}</span>
+          <DropdownCaretIcon {open} />
+        </button>
+      {/if}
     {/snippet}
   </Select.Trigger>
   <Select.Portal>

--- a/projects/client/src/lib/components/select/models/SingleSelectProps.ts
+++ b/projects/client/src/lib/components/select/models/SingleSelectProps.ts
@@ -1,3 +1,4 @@
+import type { Snippet } from 'svelte';
 import type { SelectOption } from './SelectOption.ts';
 
 export type SingleSelectProps = {
@@ -7,4 +8,5 @@ export type SingleSelectProps = {
   disabled?: boolean;
   autoWidth?: boolean;
   onChange: (value: string) => void;
+  trigger?: Snippet<[{ props: Record<string, unknown>; open: boolean }]>;
 };

--- a/projects/client/src/lib/requests/queries/episode/episodeCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/episode/episodeCommentsQuery.ts
@@ -11,12 +11,27 @@ import { PaginatableSchemaFactory } from '../../models/Paginatable.ts';
 import type { PaginationParams } from '../../models/PaginationParams.ts';
 
 type EpisodeCommentsParams =
-  & { slug: string; season: number; episode: number; sort: CommentSortType }
+  & {
+    slug: string;
+    season: number;
+    episode: number;
+    sort: CommentSortType;
+    language?: string;
+  }
   & ApiParams
   & PaginationParams;
 
 const showCommentsRequest = (
-  { fetch, slug, season, episode, limit, page, sort }: EpisodeCommentsParams,
+  {
+    fetch,
+    slug,
+    season,
+    episode,
+    limit,
+    page,
+    sort,
+    language,
+  }: EpisodeCommentsParams,
 ) =>
   api({ fetch })
     .shows
@@ -32,6 +47,7 @@ const showCommentsRequest = (
         extended: 'images',
         limit,
         page,
+        language,
       },
     });
 
@@ -50,6 +66,7 @@ export const episodeCommentsQuery = defineInfiniteQuery({
     params.page,
     params.limit,
     params.sort,
+    params.language,
   ],
   request: showCommentsRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/requests/queries/movies/movieCommentsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieCommentsQuery.spec.ts
@@ -1,8 +1,11 @@
 import { MovieHereticCommentsMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticCommentsMappedMock.ts';
+import { MovieHereticCommentsResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticCommentsResponseMock.ts';
 import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
+import { server } from '$mocks/server.ts';
 import { createTestBedInfiniteQuery } from '$test/beds/query/createTestBedInfiniteQuery.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
 import { mapToEntries } from '$test/utils/mapToEntries.ts';
+import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
 import { movieCommentsQuery } from './movieCommentsQuery.ts';
 
@@ -21,5 +24,34 @@ describe('movieCommentsQuery', () => {
     });
 
     expect(result).to.deep.equal(MovieHereticCommentsMappedMock);
+  });
+
+  it('should forward the language filter to the request', async () => {
+    let requestedLanguage: string | null = null;
+
+    server.use(
+      http.get(
+        `http://localhost/movies/${MovieHereticMappedMock.slug}/comments/likes`,
+        ({ request }) => {
+          requestedLanguage = new URL(request.url).searchParams.get('language');
+          return HttpResponse.json(MovieHereticCommentsResponseMock);
+        },
+      ),
+    );
+
+    await runQuery({
+      factory: () =>
+        createTestBedInfiniteQuery(
+          movieCommentsQuery({
+            slug: MovieHereticMappedMock.slug,
+            limit: 10,
+            sort: 'likes',
+            language: 'fr',
+          }),
+        ),
+      mapper: mapToEntries,
+    });
+
+    expect(requestedLanguage).to.equal('fr');
   });
 });

--- a/projects/client/src/lib/requests/queries/movies/movieCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieCommentsQuery.ts
@@ -10,12 +10,12 @@ import { PaginatableSchemaFactory } from '../../models/Paginatable.ts';
 import type { PaginationParams } from '../../models/PaginationParams.ts';
 
 type MovieCommentsParams =
-  & { slug: string; sort: CommentSortType }
+  & { slug: string; sort: CommentSortType; language?: string }
   & ApiParams
   & PaginationParams;
 
 const movieCommentsRequest = (
-  { fetch, slug, limit, page, sort }: MovieCommentsParams,
+  { fetch, slug, limit, page, sort, language }: MovieCommentsParams,
 ) =>
   api({ fetch })
     .movies
@@ -28,6 +28,7 @@ const movieCommentsRequest = (
         extended: 'images',
         limit,
         page,
+        language,
       },
     });
 
@@ -39,7 +40,7 @@ export const movieCommentsQuery = defineInfiniteQuery({
   ],
   dependencies: (
     params,
-  ) => [params.slug, params.page, params.limit, params.sort],
+  ) => [params.slug, params.page, params.limit, params.sort, params.language],
   request: movieCommentsRequest,
   mapper: (response) => ({
     entries: response.body.map(mapToMediaComment),

--- a/projects/client/src/lib/requests/queries/shows/showCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showCommentsQuery.ts
@@ -10,12 +10,12 @@ import { PaginatableSchemaFactory } from '../../models/Paginatable.ts';
 import type { PaginationParams } from '../../models/PaginationParams.ts';
 
 type ShowCommentsParams =
-  & { slug: string; sort: CommentSortType }
+  & { slug: string; sort: CommentSortType; language?: string }
   & ApiParams
   & PaginationParams;
 
 const showCommentsRequest = (
-  { fetch, slug, limit, page, sort }: ShowCommentsParams,
+  { fetch, slug, limit, page, sort, language }: ShowCommentsParams,
 ) =>
   api({ fetch })
     .shows
@@ -28,6 +28,7 @@ const showCommentsRequest = (
         extended: 'images',
         page,
         limit,
+        language,
       },
     });
 
@@ -39,7 +40,7 @@ export const showCommentsQuery = defineInfiniteQuery({
   ],
   dependencies: (
     params,
-  ) => [params.slug, params.page, params.limit, params.sort],
+  ) => [params.slug, params.page, params.limit, params.sort, params.language],
   request: showCommentsRequest,
   mapper: (response) => ({
     entries: response.body.map(mapToMediaComment),

--- a/projects/client/src/lib/requests/queries/shows/showSeasonCommentsQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSeasonCommentsQuery.ts
@@ -15,12 +15,14 @@ type ShowSeasonCommentsParams =
     slug: string;
     season: number;
     sort: CommentSortType;
+    language?: string;
   }
   & ApiParams
   & PaginationParams;
 
 const showSeasonCommentsRequest = (
-  { fetch, slug, season, limit, page, sort }: ShowSeasonCommentsParams,
+  { fetch, slug, season, limit, page, sort, language }:
+    ShowSeasonCommentsParams,
 ) =>
   api({ fetch })
     .shows
@@ -35,6 +37,7 @@ const showSeasonCommentsRequest = (
         extended: 'images',
         limit,
         page,
+        language,
       },
     });
 
@@ -50,6 +53,7 @@ export const showSeasonCommentsQuery = defineInfiniteQuery({
     params.page,
     params.limit,
     params.sort,
+    params.language,
   ],
   request: showSeasonCommentsRequest,
   mapper: (response) => ({

--- a/projects/client/src/lib/sections/summary/components/comments/Comments.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/Comments.svelte
@@ -9,7 +9,10 @@
   import { summaryDrawerNavigation } from "$lib/sections/summary/_internal/summaryDrawerNavigation";
   import CommentCard from "$lib/sections/summary/components/comments/CommentCard.svelte";
   import { writable } from "$lib/utils/store/WritableSubject.ts";
+  import CommentLanguageSelect from "./_internal/CommentLanguageSelect.svelte";
   import AddCommentAction from "./_internal/comment-actions/AddCommentAction.svelte";
+  import { commentsPlaceholder } from "./_internal/commentsPlaceholder.ts";
+  import { useCommentLanguage } from "./_internal/useCommentLanguage.svelte.ts";
   import type { ActiveComment } from "./_internal/models/ActiveComment";
   import { useComments } from "./_internal/useComments";
   import type { CommentsProps } from "./CommentsProps";
@@ -19,10 +22,13 @@
 
   const { current: sortType, set, options } = useToggler("comment");
 
+  const commentLanguage = useCommentLanguage();
+
   const { isLoading, list: comments } = $derived(
     useComments({
       slug: media.slug,
       sort: $sortType.value,
+      language: commentLanguage.filter,
       ...props,
     }),
   );
@@ -49,7 +55,7 @@
   <SectionList
     id={{
       scope: `comments-list-${props.type}`,
-      key: `${media.slug}-${$sortType.value}`,
+      key: `${media.slug}-${$sortType.value}-${commentLanguage.value}`,
     }}
     items={$comments}
     title={m.list_title_comments()}
@@ -67,7 +73,7 @@
 
     {#snippet empty()}
       {#if !$isLoading}
-        <p>{m.list_placeholder_comments()}</p>
+        <p>{commentsPlaceholder(commentLanguage.value)}</p>
       {/if}
     {/snippet}
 
@@ -78,6 +84,11 @@
           set(value);
         }}
         {options}
+      />
+
+      <CommentLanguageSelect
+        value={commentLanguage.value}
+        onChange={commentLanguage.set}
       />
 
       <AddCommentAction

--- a/projects/client/src/lib/sections/summary/components/comments/InlineComments.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/InlineComments.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   import PaginatedList from "$lib/components/lists/PaginatedList.svelte";
-  import * as m from "$lib/features/i18n/messages.ts";
   import type { CommentSortType } from "$lib/requests/models/CommentSortType.ts";
   import { COMMENTS_DRILL_SIZE } from "$lib/utils/constants";
   import type { CommentsProps } from "./CommentsProps.ts";
+  import { commentsPlaceholder } from "./_internal/commentsPlaceholder.ts";
   import { useComments } from "./_internal/useComments.ts";
   import { useActiveComment } from "./drawers/useActiveComment.ts";
   import CommentThreadCard from "./drawers/CommentThreadCard.svelte";
 
-  const { media, sort, ...props }: CommentsProps & { sort: CommentSortType } =
-    $props();
+  const { media, sort, language, ...props }:
+    & CommentsProps
+    & { sort: CommentSortType; language?: string } = $props();
 
   const { reset, setReplying, activeComment } = useActiveComment();
 
@@ -19,20 +20,21 @@
 
 <div class="trakt-comment-threads-list">
   <PaginatedList
-    type={`inline-comments-${sort}`}
+    type={`inline-comments-${sort}-${language ?? "all"}`}
     target="default"
     useList={() =>
       useComments({
         slug: media.slug,
         limit: COMMENTS_DRILL_SIZE,
         sort,
+        language,
         ...props,
       })}
   >
     {#snippet items(items, isLoading)}
       {#if items.length === 0 && !isLoading}
         <p class="inline-comments-empty">
-          {m.list_placeholder_comments()}
+          {commentsPlaceholder(language)}
         </p>
       {:else}
         {#each items as comment (comment.id)}

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentLanguageSelect.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentLanguageSelect.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import ActionButton from "$lib/components/buttons/ActionButton.svelte";
+  import GlobeIcon from "$lib/components/icons/GlobeIcon.svelte";
+  import SingleSelect from "$lib/components/select/SingleSelect.svelte";
+  import { availableLocales, getLocale } from "$lib/features/i18n/index.ts";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { COMMENT_LANGUAGE_ALL } from "./commentLanguageAll.ts";
+  import type { CommentLanguageSelectProps } from "./CommentLanguageSelectProps.ts";
+
+  const { value, onChange }: CommentLanguageSelectProps = $props();
+
+  const options = $derived.by(() => {
+    const currentLocale = getLocale();
+    const displayNames = new Intl.DisplayNames([currentLocale], {
+      type: "language",
+    });
+    const collator = new Intl.Collator(currentLocale, { sensitivity: "base" });
+
+    const languageOptions = [
+      ...new Set(
+        availableLocales.map((locale) => locale.split("-").at(0) ?? locale),
+      ),
+    ]
+      .map((code) => ({
+        value: code,
+        label: displayNames.of(code) ?? code,
+      }))
+      .sort((a, b) => collator.compare(a.label, b.label));
+
+    return [
+      {
+        value: COMMENT_LANGUAGE_ALL,
+        label: m.option_text_comment_language_all(),
+      },
+      ...languageOptions,
+    ];
+  });
+</script>
+
+<SingleSelect
+  {options}
+  {value}
+  placeholder={m.header_language()}
+  {onChange}
+  autoWidth
+>
+  {#snippet trigger({ props })}
+    <ActionButton {...props} label={m.header_language()} style="ghost">
+      <GlobeIcon />
+    </ActionButton>
+  {/snippet}
+</SingleSelect>

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentLanguageSelectProps.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentLanguageSelectProps.ts
@@ -1,0 +1,4 @@
+export type CommentLanguageSelectProps = {
+  value: string;
+  onChange: (value: string) => void;
+};

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/commentLanguageAll.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/commentLanguageAll.ts
@@ -1,0 +1,1 @@
+export const COMMENT_LANGUAGE_ALL = 'all';

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/commentsPlaceholder.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/commentsPlaceholder.ts
@@ -1,0 +1,39 @@
+import { getLocale } from '$lib/features/i18n/index.ts';
+import * as m from '$lib/features/i18n/messages.ts';
+import { COMMENT_LANGUAGE_ALL } from './commentLanguageAll.ts';
+
+const DEFAULT_LANGUAGE = 'en';
+
+/**
+ * Localized display name for a language code. Falls back to the raw code for a
+ * malformed tag, since the value can come straight from a URL search param and
+ * `Intl.DisplayNames.of()` throws a RangeError on invalid BCP 47 input.
+ */
+function displayLanguageName(language: string): string {
+  try {
+    return new Intl.DisplayNames([getLocale()], { type: 'language' })
+      .of(language) ?? language;
+  } catch {
+    return language;
+  }
+}
+
+/**
+ * Empty-state placeholder for comment lists. Uses the plain message for the
+ * default filters ("all" / English), and a language-specific variant otherwise
+ * (e.g. "No Dutch reviews yet."). `language` is the effective filter value
+ * (nullish means "all").
+ */
+export function commentsPlaceholder(language: string | Nil): string {
+  if (
+    !language ||
+    language === COMMENT_LANGUAGE_ALL ||
+    language === DEFAULT_LANGUAGE
+  ) {
+    return m.list_placeholder_comments();
+  }
+
+  return m.list_placeholder_comments_language({
+    language: displayLanguageName(language),
+  });
+}

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/useCommentLanguage.svelte.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/useCommentLanguage.svelte.ts
@@ -1,0 +1,40 @@
+import { goto } from '$app/navigation';
+import { page } from '$app/state';
+import { languageTag } from '$lib/features/i18n/index.ts';
+import { COMMENT_LANGUAGE_ALL } from './commentLanguageAll.ts';
+
+const REVIEW_LANGUAGE_PARAM = 'review_lang';
+
+/**
+ * Comment language filter, backed by a shareable URL search param. Defaults to
+ * the user's current locale language when the param is absent. Shared across
+ * every comment surface (inline section, drawer, season tab) so a linked URL
+ * reproduces the selection.
+ *
+ * `value` is the picker selection ("all" or a language code); `filter` is the
+ * value to pass to the query (undefined for "all", i.e. no filter).
+ */
+export function useCommentLanguage() {
+  const value = $derived(
+    page.url.searchParams.get(REVIEW_LANGUAGE_PARAM) ?? languageTag(),
+  );
+  const filter = $derived(
+    value === COMMENT_LANGUAGE_ALL ? undefined : value,
+  );
+
+  function set(next: string) {
+    const url = new URL(page.url);
+    url.searchParams.set(REVIEW_LANGUAGE_PARAM, next);
+    goto(url, { replaceState: true, noScroll: true, keepFocus: true });
+  }
+
+  return {
+    get value() {
+      return value;
+    },
+    get filter() {
+      return filter;
+    },
+    set,
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/useComments.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/useComments.ts
@@ -11,6 +11,7 @@ type UseCommentsProps = {
   slug: string;
   limit?: number;
   sort: CommentSortType;
+  language?: string;
 } & CommentTypeProps;
 
 function typeToCommentsQuery(props: UseCommentsProps) {
@@ -18,6 +19,7 @@ function typeToCommentsQuery(props: UseCommentsProps) {
     slug: props.slug,
     limit: props.limit ?? DEFAULT_PAGE_SIZE,
     sort: props.sort,
+    language: props.language,
   };
 
   switch (props.type) {

--- a/projects/client/src/lib/sections/summary/components/comments/drawers/CommentsDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/drawers/CommentsDrawerHost.svelte
@@ -6,6 +6,8 @@
   import { COMMENTS_DRILL_SIZE } from "$lib/utils/constants";
   import { writable } from "svelte/store";
   import type { CommentsProps } from "../CommentsProps";
+  import CommentLanguageSelect from "../_internal/CommentLanguageSelect.svelte";
+  import { useCommentLanguage } from "../_internal/useCommentLanguage.svelte.ts";
   import type { ActiveComment } from "../_internal/models/ActiveComment";
   import { useComments } from "../_internal/useComments";
   import ReviewsDrawerShell from "./_internal/ReviewsDrawerShell.svelte";
@@ -18,6 +20,8 @@
   const { onClose, source, media, ...props }: CommentsDrawerProps = $props();
 
   const { current: sortType, set, options } = useToggler("comment");
+
+  const commentLanguage = useCommentLanguage();
 
   const isOpened = writable(false);
 </script>
@@ -37,6 +41,7 @@
           slug: media.slug,
           limit: COMMENTS_DRILL_SIZE,
           sort: $sortType.value,
+          language: commentLanguage.filter,
           ...props,
         })}
       {media}
@@ -46,5 +51,9 @@
 
   {#snippet badge()}
     <Toggler value={$sortType.value} onChange={set} {options} />
+    <CommentLanguageSelect
+      value={commentLanguage.value}
+      onChange={commentLanguage.set}
+    />
   {/snippet}
 </Drawer>

--- a/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonReviewsTab.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonReviewsTab.svelte
@@ -3,6 +3,8 @@
   import { useToggler } from "$lib/components/toggles/useToggler";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
+  import CommentLanguageSelect from "$lib/sections/summary/components/comments/_internal/CommentLanguageSelect.svelte";
+  import { useCommentLanguage } from "$lib/sections/summary/components/comments/_internal/useCommentLanguage.svelte.ts";
   import AddCommentAction from "$lib/sections/summary/components/comments/_internal/comment-actions/AddCommentAction.svelte";
   import AddReviewDrawerHost from "$lib/sections/summary/components/comments/drawers/AddReviewDrawerHost.svelte";
   import InlineComments from "$lib/sections/summary/components/comments/InlineComments.svelte";
@@ -22,6 +24,8 @@
 
   const { current: sort, set: setSort, options } = useToggler("comment");
 
+  const commentLanguage = useCommentLanguage();
+
   const isPostReviewOpen = writable(false);
 </script>
 
@@ -33,6 +37,10 @@
 
     {#snippet actions()}
       <Toggler value={$sort.value} onChange={setSort} {options} />
+      <CommentLanguageSelect
+        value={commentLanguage.value}
+        onChange={commentLanguage.set}
+      />
       <AddCommentAction onclick={() => isPostReviewOpen.set(true)} />
     {/snippet}
   </SeasonTabTitle>
@@ -44,6 +52,7 @@
       {season}
       id={seasonId}
       sort={$sort.value}
+      language={commentLanguage.filter}
     />
   {/key}
 </div>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds a language picker to the reviews section (movie / show / season / episode)
- Defaults to the user's current locale language, with an "All languages" option to show everything
- Empty state now names the language, e.g. "No Dutch reviews yet." (falls back to plain "No reviews yet." for all / English)
- Adds a custom-trigger snippet to the Select primitive so it can render as an icon button (default text trigger unchanged for existing callers)
- Search param is transient for now, we could do a follow-up to persist it.

## 👀 Example 👀

https://github.com/user-attachments/assets/06cfbc4a-671e-412f-a540-b15f2dd1f9bf

