### PR TITLE
feat(summary): add episode information drawer

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -1597,6 +1597,10 @@
       "default": "People",
       "description": "Title for the drawer containing people related to a movie, show, or episode. This title should be as short and concise as possible."
     },
+    "drawer_title_episode_information": {
+      "default": "Episode Information",
+      "description": "Title for the episode information drawer opened from an episode card on a summary page."
+    },
     "drawer_meta_info_cast": {
       "default": "Cast",
       "description": "Subtitle for the people drawer when cast members are selected. This should be as short and concise as possible."

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -39,6 +39,14 @@
     useEpisodeSpoilerImage({ episode, show, variant: rest.variant }),
   );
 
+  const episodeLink = $derived(
+    rest.urlOverride ?? {
+      href: UrlBuilder.episode(show.slug, episode.season, episode.number),
+      noscroll: undefined,
+      replacestate: undefined,
+    },
+  );
+
   const { track } = useTrack(AnalyticsEvent.SummaryDrilldown);
 </script>
 
@@ -65,7 +73,9 @@
 
     <Link
       focusable={false}
-      href={UrlBuilder.episode(show.slug, episode.season, episode.number)}
+      href={episodeLink.href}
+      noscroll={episodeLink.noscroll}
+      replacestate={episodeLink.replacestate}
       onclick={() => source && track({ source, type: "episode" })}
     >
       <CardCover
@@ -90,7 +100,9 @@
 
     <Link
       focusable={false}
-      href={UrlBuilder.episode(show.slug, episode.season, episode.number)}
+      href={episodeLink.href}
+      noscroll={episodeLink.noscroll}
+      replacestate={episodeLink.replacestate}
       onclick={() => source && track({ source, type: "episode" })}
     >
       <CardCover

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -219,6 +219,7 @@
         },
       }}
       popupActions={props.popupActions}
+      urlOverride={props.urlOverride}
       layout={summaryCardLayout}
       badge={action}
       {sortTag}

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -141,11 +141,17 @@
     };
   });
 
-  const href = $derived(
-    rest.type === "episode"
-      ? UrlBuilder.episode(media.slug, rest.episode.season, rest.episode.number)
-      : UrlBuilder.media(media.type, media.slug),
+  const urlOverride = $derived(
+    rest.type === "episode" ? rest.urlOverride : undefined,
   );
+
+  const href = $derived.by(() => {
+    if (urlOverride) return urlOverride.href;
+
+    return rest.type === "episode"
+      ? UrlBuilder.episode(media.slug, rest.episode.season, rest.episode.number)
+      : UrlBuilder.media(media.type, media.slug);
+  });
 
   const popupMenuTitle = $derived(
     rest.type === "episode" ? rest.episode.title : media.title,
@@ -281,6 +287,8 @@
 
   <Link
     {href}
+    noscroll={urlOverride?.noscroll}
+    replacestate={urlOverride?.replacestate}
     onclick={() => source && track({ source, type: rest.type })}
     color="inherit"
   >

--- a/projects/client/src/lib/sections/lists/components/models/EpisodeCardProps.ts
+++ b/projects/client/src/lib/sections/lists/components/models/EpisodeCardProps.ts
@@ -3,6 +3,7 @@ import type { ShowInput } from '$lib/models/MediaInput.ts';
 import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
 import type { EpisodeProgressEntry } from '$lib/requests/models/EpisodeProgressEntry.ts';
 import type { BaseItemProps } from './BaseItemProps.ts';
+import type { EpisodeUrlOverride } from './EpisodeUrlOverride.ts';
 
 type EpisodeContext = 'show' | 'standalone';
 
@@ -29,6 +30,7 @@ export type EpisodeItemVariant =
 
 export type EpisodeCardProps = BaseItemProps & EpisodeItemVariant & {
   media: ShowInput;
+  urlOverride?: EpisodeUrlOverride;
   /**
    * FIXME: We should migrate these on the backend and remove from the client.
    */

--- a/projects/client/src/lib/sections/lists/components/models/EpisodeUrlOverride.ts
+++ b/projects/client/src/lib/sections/lists/components/models/EpisodeUrlOverride.ts
@@ -1,0 +1,5 @@
+export type EpisodeUrlOverride = {
+  href: string;
+  noscroll?: boolean;
+  replacestate?: boolean;
+};

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeItem.svelte
@@ -10,6 +10,7 @@
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import EpisodeItem from "$lib/sections/lists/components/EpisodeItem.svelte";
   import type { BaseItemProps } from "$lib/sections/lists/components/models/BaseItemProps";
+  import type { EpisodeUrlOverride } from "$lib/sections/lists/components/models/EpisodeUrlOverride";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import WatchedUntilHereDrawer from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/WatchedUntilHereDrawer.svelte";
   import { useWatchUntilHereEpisodes } from "$lib/sections/media-actions/mark-as-watched/_internal/watch-until-here/useWatchUntilHereEpisodes.ts";
@@ -27,6 +28,7 @@
     isCurrentEpisode?: boolean;
     style?: BaseItemProps["style"];
     source: string;
+    urlOverride?: EpisodeUrlOverride;
   };
 
   const {
@@ -40,6 +42,7 @@
     isCurrentEpisode = false,
     style,
     source,
+    urlOverride,
   }: SeasonEpisodeItemProps = $props();
 
   const isFuture = $derived(episode.effectiveReleaseDate > new Date());
@@ -119,6 +122,7 @@
     variant={isFuture ? "upcoming" : "default"}
     context="show"
     {source}
+    {urlOverride}
     coverUrl={$src}
   />
 {/snippet}

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonEpisodeList.svelte
@@ -47,7 +47,7 @@
     useShowWatchedEpisodes({ showId: show.id }),
   );
 
-  const { buildDrawerLink } = summaryDrawerNavigation();
+  const { buildDrawerLink, buildEpisodeDrawerLink } = summaryDrawerNavigation();
   const seasonDrawerLink = $derived(buildDrawerLink(SummaryDrawers.Seasons));
 </script>
 
@@ -76,6 +76,10 @@
       watchedBySeason={$watchedBySeason}
       isWatchedLoading={$isWatchedLoading}
       isCurrentEpisode={episode.number === currentEpisode}
+      urlOverride={buildEpisodeDrawerLink({
+        season: episode.season,
+        episode: episode.number,
+      })}
       source="season-episode-list"
     />
   {/snippet}

--- a/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
@@ -19,6 +19,7 @@
   import CommentsDrawerHost from "./components/comments/drawers/CommentsDrawerHost.svelte";
   import ReviewDrawerHost from "./components/comments/drawers/ReviewDrawerHost.svelte";
   import DetailsDrawer from "./components/details/DetailsDrawer.svelte";
+  import EpisodeDrawerHost from "./components/episode-drawer/EpisodeDrawerHost.svelte";
   import type { MediaDetailsProps } from "./components/details/MediaDetailsProps";
   import HistoryDrawerHost from "./components/history/HistoryDrawerHost.svelte";
   import NotesDrawerHost from "./components/notes/NotesDrawerHost.svelte";
@@ -42,7 +43,7 @@
     currentSeason?: number;
   } & MediaDetailsProps = $props();
 
-  const { drawer, close, sourceCommentId } = $derived(
+  const { drawer, close, sourceCommentId, sourceEpisode } = $derived(
     summaryDrawerNavigation(page.url.searchParams),
   );
 
@@ -141,6 +142,16 @@
     show={showEntry}
     {seasons}
     {currentSeason}
+    onClose={close}
+  />
+{/if}
+
+{#if drawer === SummaryDrawers.Episode && seasons && currentSeason != null && sourceEpisode != null && showEntry}
+  <EpisodeDrawerHost
+    show={showEntry}
+    {seasons}
+    season={currentSeason}
+    episode={sourceEpisode}
     onClose={close}
   />
 {/if}

--- a/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
+++ b/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
@@ -11,6 +11,7 @@ export enum SummaryDrawers {
   Social = 'social',
   WhereToWatch = 'where-to-watch',
   Seasons = 'seasons',
+  Episode = 'episode',
   Notes = 'notes',
   Comments = 'comments',
   Review = 'review',
@@ -19,10 +20,13 @@ export enum SummaryDrawers {
 }
 
 const commentIdParam = 'comment_id';
+const episodeParam = 'episode';
+const seasonParam = 'season';
 
 const summaryDrawerParams = {
   [SummaryDrawers.Comments]: { [commentIdParam]: '' },
   [SummaryDrawers.Review]: { [commentIdParam]: '' },
+  [SummaryDrawers.Episode]: { [episodeParam]: '' },
 } satisfies Partial<Record<SummaryDrawers, Record<string, string>>>;
 
 function mapToDrawer(value: string | Nil) {
@@ -45,6 +49,8 @@ function mapToDrawer(value: string | Nil) {
       return SummaryDrawers.WhereToWatch;
     case SummaryDrawers.Seasons:
       return SummaryDrawers.Seasons;
+    case SummaryDrawers.Episode:
+      return SummaryDrawers.Episode;
     case SummaryDrawers.Notes:
       return SummaryDrawers.Notes;
     case SummaryDrawers.Comments:
@@ -65,12 +71,28 @@ export function summaryDrawerNavigation(searchParams?: URLSearchParams) {
   const drawer = mapToDrawer(searchParams?.get(DRAWER_VIEW_PARAM));
   const commentId = searchParams?.get(commentIdParam);
   const sourceCommentId = commentId != null ? Number(commentId) : undefined;
+  const episodeNumber = searchParams?.get(episodeParam);
+  const sourceEpisode = episodeNumber != null
+    ? Number(episodeNumber)
+    : undefined;
 
   return {
     drawer,
     sourceCommentId,
+    sourceEpisode,
     close,
     buildDrawerLink,
+    buildEpisodeDrawerLink: (
+      { season, episode }: { season: number; episode: number },
+    ) => {
+      const link = buildDrawerLink(
+        SummaryDrawers.Episode,
+        { [episodeParam]: String(episode) },
+      );
+      const url = new URL(link.href);
+      url.searchParams.set(seasonParam, String(season));
+      return { ...link, href: url.toString() };
+    },
     buildCommentsDrawerLink: (id?: number) =>
       buildDrawerLink(
         SummaryDrawers.Comments,

--- a/projects/client/src/lib/sections/summary/components/_internal/DrawerCastSection.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/DrawerCastSection.svelte
@@ -10,7 +10,7 @@
   import CreditMemberItem from "$lib/sections/lists/components/CreditMemberItem.svelte";
   import type { CreditMember } from "$lib/sections/lists/models/CreditMember.ts";
   import { toCreditMembers } from "$lib/sections/lists/toCreditMembers.ts";
-  import SeasonTabTitle from "./SeasonTabTitle.svelte";
+  import DrawerTabTitle from "./DrawerTabTitle.svelte";
 
   type CreditsType = "cast" | "crew";
 
@@ -71,8 +71,8 @@
   );
 </script>
 
-<div class="season-cast-section">
-  <SeasonTabTitle title={m.drawer_title_people()}>
+<div class="drawer-cast-section">
+  <DrawerTabTitle title={m.drawer_title_people()}>
     {#snippet metaInfo()}
       <ListMetaInfo text={creditsMetaInfo} />
     {/snippet}
@@ -86,7 +86,7 @@
         />
       {/if}
     {/snippet}
-  </SeasonTabTitle>
+  </DrawerTabTitle>
 
   {#if isLoading}
     <LoadingIndicator />
@@ -103,7 +103,7 @@
 
     {#if visibleCredits.length > 0}
       <div
-        id={`season-cast-list-${type}-${isSearching ? "search" : creditsType}`}
+        id={`drawer-cast-list-${type}-${isSearching ? "search" : creditsType}`}
         class="credit-list"
         role="list"
       >
@@ -122,7 +122,7 @@
 </div>
 
 <style lang="scss">
-  .season-cast-section {
+  .drawer-cast-section {
     display: flex;
     flex-direction: column;
     gap: var(--gap-m);

--- a/projects/client/src/lib/sections/summary/components/_internal/DrawerTabTitle.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/DrawerTabTitle.svelte
@@ -12,8 +12,8 @@
   } = $props();
 </script>
 
-<div class="season-tab-title">
-  <div class="season-tab-title-main">
+<div class="drawer-tab-title">
+  <div class="drawer-tab-title-main">
     <span class="title ellipsis">{title}</span>
     {#if metaInfo}
       {@render metaInfo()}
@@ -21,21 +21,21 @@
   </div>
 
   {#if actions}
-    <div class="season-tab-title-actions">
+    <div class="drawer-tab-title-actions">
       {@render actions()}
     </div>
   {/if}
 </div>
 
 <style lang="scss">
-  .season-tab-title {
+  .drawer-tab-title {
     display: flex;
     align-items: center;
     gap: var(--gap-s);
     min-height: var(--ni-40);
   }
 
-  .season-tab-title-main {
+  .drawer-tab-title-main {
     display: flex;
     flex-direction: column;
     min-width: 0;
@@ -45,7 +45,7 @@
     }
   }
 
-  .season-tab-title-actions {
+  .drawer-tab-title-actions {
     display: flex;
     align-items: center;
     gap: var(--gap-xs);

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/EpisodeDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/EpisodeDrawerHost.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import CommentIcon from "$lib/components/icons/CommentIcon.svelte";
+  import InfoIcon from "$lib/components/icons/InfoIcon.svelte";
+  import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
+  import PlayIcon from "$lib/components/icons/PlayIcon.svelte";
+  import TabView from "$lib/components/tabs/TabView.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { Season } from "$lib/requests/models/Season";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
+  import SeasonEpisodesTab from "$lib/sections/summary/components/seasons/SeasonEpisodesTab.svelte";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte.ts";
+  import { onMount } from "svelte";
+  import { fade } from "svelte/transition";
+  import EpisodeInfoTab from "./_internal/EpisodeInfoTab.svelte";
+  import EpisodeReviewsTab from "./_internal/EpisodeReviewsTab.svelte";
+  import { useEpisodeSummary } from "./_internal/useEpisodeSummary.ts";
+
+  const {
+    onClose,
+    show,
+    seasons,
+    season,
+    episode,
+  }: {
+    show: ShowEntry;
+    seasons: Season[];
+    season: number;
+    episode: number;
+    onClose: () => void;
+  } = $props();
+
+  let isOpen = $state(false);
+  let activeTab = $state("info");
+
+  const params$ = fromRune(() => ({
+    slug: show.slug,
+    season,
+    episode,
+  }));
+
+  const { episode: episodeEntry, isLoading } = useEpisodeSummary(params$);
+
+  onMount(() => {
+    // The card that opened the drawer keeps focus during the URL
+    // navigation (data-sveltekit-keepfocus), so activeElement at mount
+    // is the originating trigger - return focus to it on close.
+    const trigger = document.activeElement;
+
+    return () => {
+      if (trigger instanceof HTMLElement && trigger.isConnected) {
+        trigger.focus();
+      }
+    };
+  });
+</script>
+
+{#snippet infoIcon()}
+  <InfoIcon />
+{/snippet}
+
+{#snippet reviewsIcon()}
+  <CommentIcon />
+{/snippet}
+
+{#snippet episodesIcon()}
+  <PlayIcon />
+{/snippet}
+
+{#snippet infoContent()}
+  {#if $episodeEntry}
+    <EpisodeInfoTab {show} episode={$episodeEntry} />
+  {:else if $isLoading}
+    <LoadingIndicator />
+  {/if}
+{/snippet}
+
+{#snippet reviewsContent()}
+  {#if $episodeEntry}
+    <EpisodeReviewsTab {show} episode={$episodeEntry} />
+  {:else if $isLoading}
+    <LoadingIndicator />
+  {/if}
+{/snippet}
+
+{#snippet episodesContent()}
+  <SeasonEpisodesTab
+    {show}
+    {seasons}
+    currentSeason={season}
+    currentEpisode={episode}
+  />
+{/snippet}
+
+<Drawer
+  {onClose}
+  onOpened={() => (isOpen = true)}
+  title={m.drawer_title_episode_information()}
+  size="large"
+>
+  {#if isOpen}
+    <div class="episode-drawer-content" transition:fade={{ duration: 150 }}>
+      <TabView
+        value={activeTab}
+        onChange={(value) => (activeTab = value)}
+        tabs={[
+          {
+            value: "info",
+            label: m.tab_text_seasons_info(),
+            icon: infoIcon,
+            content: infoContent,
+          },
+          {
+            value: "reviews",
+            label: m.tab_text_seasons_reviews(),
+            icon: reviewsIcon,
+            content: reviewsContent,
+          },
+          {
+            value: "episodes",
+            label: m.tab_text_seasons_episodes(),
+            icon: episodesIcon,
+            content: episodesContent,
+          },
+        ]}
+      />
+    </div>
+  {/if}
+</Drawer>
+
+<style lang="scss">
+  .episode-drawer-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-l);
+
+    padding-bottom: var(--ni-8);
+
+    :global(.trakt-list-item-container) {
+      padding-inline: 0;
+    }
+
+    :global(.trakt-grid-list-container) {
+      overflow-x: visible;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoSection.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoSection.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import RatingIcon from "$lib/components/icons/RatingIcon.svelte";
+  import ClampedText from "$lib/components/text/ClampedText.svelte";
+  import { getLocale } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry.ts";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
+  import RateNow from "$lib/sections/summary/components/rating/RateNow.svelte";
+  import { toTraktRating } from "$lib/utils/formatting/number/toTraktRating.ts";
+
+  type EpisodeInfoSectionProps = {
+    episode: EpisodeEntry;
+    show: ShowEntry;
+  };
+
+  const { episode, show }: EpisodeInfoSectionProps = $props();
+
+  const traktRating = $derived(
+    episode.rating != null
+      ? toTraktRating(episode.rating, getLocale())
+      : undefined,
+  );
+</script>
+
+<div class="episode-info-section">
+  <div class="episode-rating-row">
+    {#if traktRating}
+      <div class="episode-rating">
+        <RatingIcon style="rated" />
+        <p class="bold">{traktRating}</p>
+      </div>
+    {/if}
+
+    <RateNow type="episode" media={episode} {show} />
+  </div>
+
+  {#if episode.overview}
+    <ClampedText
+      label={m.button_label_expand_media_overview({ title: show.title })}
+      lineCount={6}
+    >
+      {episode.overview}
+    </ClampedText>
+  {/if}
+</div>
+
+<style lang="scss">
+  .episode-info-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-m);
+  }
+
+  .episode-rating-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--gap-m);
+    min-height: var(--ni-40);
+
+    :global(.trakt-rate-now) {
+      margin-inline-start: auto;
+    }
+  }
+
+  .episode-rating {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    :global(svg) {
+      height: var(--font-size-text);
+      width: auto;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoTab.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoTab.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry.ts";
+  import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
+  import DrawerCastSection from "$lib/sections/summary/components/_internal/DrawerCastSection.svelte";
+  import DrawerTabTitle from "$lib/sections/summary/components/_internal/DrawerTabTitle.svelte";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte.ts";
+  import EpisodeInfoSection from "./EpisodeInfoSection.svelte";
+  import { useEpisodePeople } from "./useEpisodePeople.ts";
+
+  const {
+    show,
+    episode,
+  }: {
+    show: ShowEntry;
+    episode: EpisodeEntry;
+  } = $props();
+
+  const params$ = fromRune(() => ({
+    slug: show.slug,
+    season: episode.season,
+    episode: episode.number,
+  }));
+
+  const { crew, isLoading } = useEpisodePeople(params$);
+</script>
+
+<div class="episode-info-tab">
+  <div class="episode-info-block">
+    <DrawerTabTitle title={m.section_title_seasons_overview()} />
+    <EpisodeInfoSection {episode} {show} />
+  </div>
+
+  <DrawerCastSection crew={$crew} type="episode" isLoading={$isLoading} />
+</div>
+
+<style lang="scss">
+  .episode-info-tab {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-l);
+  }
+
+  .episode-info-block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeReviewsTab.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeReviewsTab.svelte
@@ -1,23 +1,22 @@
 <script lang="ts">
   import Toggler from "$lib/components/toggles/Toggler.svelte";
   import { useToggler } from "$lib/components/toggles/useToggler";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry.ts";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
+  import DrawerTabTitle from "$lib/sections/summary/components/_internal/DrawerTabTitle.svelte";
   import AddCommentAction from "$lib/sections/summary/components/comments/_internal/comment-actions/AddCommentAction.svelte";
   import AddReviewDrawerHost from "$lib/sections/summary/components/comments/drawers/AddReviewDrawerHost.svelte";
   import InlineComments from "$lib/sections/summary/components/comments/InlineComments.svelte";
-  import * as m from "$lib/features/i18n/messages.ts";
   import { writable } from "$lib/utils/store/WritableSubject.ts";
-  import DrawerTabTitle from "$lib/sections/summary/components/_internal/DrawerTabTitle.svelte";
 
   const {
     show,
-    season,
-    seasonId,
+    episode,
   }: {
     show: ShowEntry;
-    season: number;
-    seasonId: number;
+    episode: EpisodeEntry;
   } = $props();
 
   const { current: sort, set: setSort, options } = useToggler("comment");
@@ -25,7 +24,7 @@
   const isPostReviewOpen = writable(false);
 </script>
 
-<div class="season-reviews-tab">
+<div class="episode-reviews-tab">
   <DrawerTabTitle title={m.tab_text_seasons_reviews()}>
     {#snippet metaInfo()}
       <ListMetaInfo text={$sort.text()} />
@@ -37,12 +36,13 @@
     {/snippet}
   </DrawerTabTitle>
 
-  {#key season}
+  {#key episode.id}
     <InlineComments
       media={show}
-      type="season"
-      {season}
-      id={seasonId}
+      type="episode"
+      season={episode.season}
+      episode={episode.number}
+      id={episode.id}
       sort={$sort.value}
     />
   {/key}
@@ -54,14 +54,15 @@
     onCommentPost={() => isPostReviewOpen.set(false)}
     mode="post"
     media={show}
-    type="season"
-    {season}
-    id={seasonId}
+    type="episode"
+    season={episode.season}
+    episode={episode.number}
+    id={episode.id}
   />
 {/if}
 
 <style lang="scss">
-  .season-reviews-tab {
+  .episode-reviews-tab {
     display: flex;
     flex-direction: column;
     gap: var(--gap-m);

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/useEpisodePeople.ts
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/useEpisodePeople.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import { EMPTY_CREW } from '$lib/requests/_internal/mapToMediaCrew.ts';
+import { episodePeopleQuery } from '$lib/requests/queries/episode/episodePeopleQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { map, type Observable } from 'rxjs';
+import type { EpisodeSummaryParams } from './useEpisodeSummary.ts';
+
+export function useEpisodePeople(params$: Observable<EpisodeSummaryParams>) {
+  const query = useQuery(
+    params$.pipe(map((params) => episodePeopleQuery(params))),
+  );
+
+  return {
+    crew: query.pipe(map(($query) => $query.data ?? EMPTY_CREW)),
+    isLoading: query.pipe(map(toLoadingState)),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/useEpisodeSummary.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/useEpisodeSummary.spec.ts
@@ -1,0 +1,25 @@
+import { EpisodeSiloMappedMock } from '$mocks/data/summary/episodes/silo/mapped/EpisodeSiloMappedMock.ts';
+import { EpisodeSiloResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloResponseMock.ts';
+import { ShowSiloResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloResponseMock.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { valueObservable } from '$test/beds/store/valueObservable.ts';
+import { describe, expect, it } from 'vitest';
+import { useEpisodeSummary } from './useEpisodeSummary.ts';
+
+describe('store: useEpisodeSummary', () => {
+  it('should fetch the episode summary', async () => {
+    const result = await runQuery({
+      factory: () =>
+        useEpisodeSummary(
+          valueObservable({
+            slug: ShowSiloResponseMock.ids.slug,
+            season: EpisodeSiloResponseMock.season,
+            episode: EpisodeSiloResponseMock.number,
+          }),
+        ).episode,
+      waitFor: (value) => value != null,
+    });
+
+    expect(result).to.deep.equal(EpisodeSiloMappedMock);
+  });
+});

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/useEpisodeSummary.ts
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/useEpisodeSummary.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import { episodeSummaryQuery } from '$lib/requests/queries/episode/episodeSummaryQuery.ts';
+import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
+import { map, type Observable } from 'rxjs';
+
+export type EpisodeSummaryParams = {
+  slug: string;
+  season: number;
+  episode: number;
+};
+
+export function useEpisodeSummary(params$: Observable<EpisodeSummaryParams>) {
+  const query = useQuery(
+    params$.pipe(map((params) => episodeSummaryQuery(params))),
+  );
+
+  return {
+    episode: query.pipe(map(($query) => $query.data)),
+    isLoading: query.pipe(map(toLoadingState)),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonEpisodesTab.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonEpisodesTab.svelte
@@ -11,18 +11,23 @@
   import { useShowWatchedEpisodes } from "$lib/sections/lists/season/_internal/useShowWatchedEpisodes";
   import { useSeasonEpisodes } from "$lib/sections/lists/stores/useSeasonEpisodes";
   import SeasonProgressCard from "$lib/sections/summary/components/seasons/SeasonProgressCard.svelte";
+  import { summaryDrawerNavigation } from "$lib/sections/summary/_internal/summaryDrawerNavigation";
   import { countWatchedEpisodes } from "$lib/utils/media/countWatchedEpisodes";
-  import SeasonTabTitle from "./SeasonTabTitle.svelte";
+  import DrawerTabTitle from "$lib/sections/summary/components/_internal/DrawerTabTitle.svelte";
 
   const {
     show,
     seasons,
     currentSeason,
+    currentEpisode,
   }: {
     show: ShowEntry;
     seasons: Season[];
     currentSeason: number;
+    currentEpisode?: number;
   } = $props();
+
+  const { buildEpisodeDrawerLink } = summaryDrawerNavigation();
 
   const { list: episodes, isLoading } = $derived(
     useSeasonEpisodes(show.slug, currentSeason),
@@ -65,7 +70,7 @@
     {/if}
   </RenderFor>
 
-  <SeasonTabTitle title={m.tab_text_seasons_episodes()}>
+  <DrawerTabTitle title={m.tab_text_seasons_episodes()}>
     {#snippet metaInfo()}
       {#if !$isLoading}
         <ListMetaInfo
@@ -73,7 +78,7 @@
         />
       {/if}
     {/snippet}
-  </SeasonTabTitle>
+  </DrawerTabTitle>
 
   {#if $isLoading}
     <LoadingIndicator />
@@ -92,6 +97,11 @@
           currentSeasonEpisodes={$episodes}
           watchedBySeason={$watchedBySeason}
           isWatchedLoading={$isWatchedLoading}
+          isCurrentEpisode={episode.number === currentEpisode}
+          urlOverride={buildEpisodeDrawerLink({
+            season: episode.season,
+            episode: episode.number,
+          })}
           style="minimal"
           source="seasons-drawer"
         />

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawerHost.svelte
@@ -12,7 +12,7 @@
   import SeasonDropdown from "$lib/sections/lists/season/SeasonDropdown.svelte";
   import { fade } from "svelte/transition";
   import SeasonDrawerItem from "./_internal/SeasonDrawerItem.svelte";
-  import SeasonEpisodesTab from "./_internal/SeasonEpisodesTab.svelte";
+  import SeasonEpisodesTab from "./SeasonEpisodesTab.svelte";
   import SeasonOverviewTab from "./_internal/SeasonOverviewTab.svelte";
   import SeasonReviewsTab from "./_internal/SeasonReviewsTab.svelte";
 

--- a/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonOverviewTab.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/_internal/SeasonOverviewTab.svelte
@@ -2,9 +2,9 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import type { Season } from "$lib/requests/models/Season";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
-  import SeasonCastSection from "./SeasonCastSection.svelte";
+  import DrawerCastSection from "$lib/sections/summary/components/_internal/DrawerCastSection.svelte";
   import SeasonInfoSection from "./SeasonInfoSection.svelte";
-  import SeasonTabTitle from "./SeasonTabTitle.svelte";
+  import DrawerTabTitle from "$lib/sections/summary/components/_internal/DrawerTabTitle.svelte";
   import { useSeasonPeople } from "./useSeasonPeople";
 
   const {
@@ -22,11 +22,11 @@
 
 <div class="season-overview-tab">
   <div class="season-overview-block">
-    <SeasonTabTitle title={m.section_title_seasons_overview()} />
+    <DrawerTabTitle title={m.section_title_seasons_overview()} />
     <SeasonInfoSection {season} {show} />
   </div>
 
-  <SeasonCastSection crew={$crew} type="show" isLoading={$isLoading} />
+  <DrawerCastSection crew={$crew} type="show" isLoading={$isLoading} />
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
##Screenshots

<img width="1893" height="1241" alt="Screenshot 2026-07-08 at 20 09 05" src="https://github.com/user-attachments/assets/1f169967-19bb-4835-95d5-5315bff2dfbc" />
<img width="1893" height="1241" alt="Screenshot 2026-07-08 at 20 09 09" src="https://github.com/user-attachments/assets/47ea097f-3744-4af0-94d0-3702b5874855" />
<img width="1893" height="1241" alt="Screenshot 2026-07-08 at 20 09 12" src="https://github.com/user-attachments/assets/30344a3a-30be-4973-b235-39e08ba949f2" />


## What

Replaces full-page navigation from episode cards on summary pages with an in-context **Episode Information** side drawer. Clicking an episode card now opens the drawer over the current page (`?view=episode&season=S&episode=E`) instead of discarding the summary page state.

## How it works

- **Drawer** uses the base `Drawer` container (`size="large"`), title `"Episode Information"` (new i18n key `drawer_title_episode_information`), and a `TabView` with exactly three tabs in order: **Info → Reviews → Episodes**. The drawer always opens on **Info** (host remounts per open).
- **Info tab**: Trakt rating + `RateNow type="episode"`, 6-line `ClampedText` overview, and the shared cast/crew section with search + toggler — identical components to the season drawer.
- **Reviews tab**: `InlineComments type="episode"` with sort toggler and post-review flow, mirroring `SeasonReviewsTab` 1:1.
- **Episodes tab**: reuses `SeasonEpisodesTab` (season progress card + episode grid). Clicking another episode switches the drawer in place via query params — same-route navigation doesn't trigger the drawer's auto-close.
- **Focus return**: the host captures `document.activeElement` on mount (cards keep focus through the URL navigation via `data-sveltekit-keepfocus`) and restores focus to the originating card when the drawer closes.
- Opening/switching uses `replaceState` + `noscroll`, so navigation history stays clean.

## Refactors along the way

- `SeasonTabTitle` / `SeasonCastSection` uplifted from `seasons/_internal/` to shared `summary/components/_internal/DrawerTabTitle` / `DrawerCastSection` — both drawers now share one implementation, guaranteeing styling/behavior parity.
- `SeasonEpisodesTab` uplifted out of `_internal/` so the episode drawer can reuse it; gained optional `currentEpisode` highlight.
- New optional `urlOverride` prop threaded through `EpisodeCard` / `MediaSummaryCard` / `EpisodeItem` / `SeasonEpisodeItem` so summary lists can point cards at the drawer without touching calendar/history/progress deep links.
- New `useEpisodeSummary` / `useEpisodePeople` hooks (Observable-params pattern) wrapping `episodeSummaryQuery` / `episodePeopleQuery`.

## Deliberate decisions

- **Episode route pages are kept** as the canonical deep-link target (external links, calendar/history cards, SEO). Only summary-context cards were switched to the drawer.
- Tab labels reuse the existing `tab_text_seasons_*` keys — identical strings, already translated in all locales. Only the drawer title key is new.
- The `season` query param persists after close, matching existing seasons-drawer behavior.

## Testing

- `svelte-check`: no new errors (3 pre-existing on `main` in settings/auth)
- Unit suite: all tests pass; new `useEpisodeSummary` spec added against the Silo mocks
- `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)