### PR TITLE
feat(recommended): smart recommendations toggle

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7955,6 +7955,14 @@
       "default": "Use our next-gen engine to surface related movies and shows beyond the obvious.",
       "description": "Description for the Smart Related preview feature."
     },
+    "preview_feature_title_smart_recommendations": {
+      "default": "Smart Recommendations",
+      "description": "Title for the Smart Recommendations preview feature."
+    },
+    "preview_feature_description_smart_recommendations": {
+      "default": "Use our next-gen engine to surface recommended movies and shows beyond the obvious.",
+      "description": "Description for the Smart Recommendations preview feature."
+    },
     "preview_feature_title_rewatch": {
       "default": "Rewatch",
       "description": "Title for the Rewatch preview feature."
@@ -9269,6 +9277,22 @@
     "button_label_related_smart": {
       "default": "Smart related",
       "description": "Aria-label for the related media toggle button to show smart related movies or shows. This should be as short and concise as possible."
+    },
+    "button_text_recommendation_standard": {
+      "default": "Standard",
+      "description": "Text for the recommendations toggle button to show standard recommended movies or shows. This should be as short and concise as possible."
+    },
+    "button_label_recommendation_standard": {
+      "default": "Standard recommendations",
+      "description": "Aria-label for the recommendations toggle button to show standard recommended movies or shows. This should be as short and concise as possible."
+    },
+    "button_text_recommendation_smart": {
+      "default": "Smart",
+      "description": "Text for the recommendations toggle button to show smart recommended movies or shows. This should be as short and concise as possible."
+    },
+    "button_label_recommendation_smart": {
+      "default": "Smart recommendations",
+      "description": "Aria-label for the recommendations toggle button to show smart recommended movies or shows. This should be as short and concise as possible."
     },
     "text_list_private": {
       "default": "Private",

--- a/projects/client/src/lib/components/toggles/_internal/constants.ts
+++ b/projects/client/src/lib/components/toggles/_internal/constants.ts
@@ -11,7 +11,8 @@ export type TogglerId =
   | 'progress'
   | 'activity'
   | 'library'
-  | 'related';
+  | 'related'
+  | 'recommendation';
 
 type DiscoverToggleType = DiscoverMode;
 type SocialToggleType = 'following' | 'followers' | 'requests';
@@ -21,6 +22,7 @@ type ProgressToggleType = 'in-progress' | 'dropped' | 'completed';
 type ActivityToggleType = 'reviews' | 'ratings';
 type LibraryToggleType = 'plex' | 'other';
 type RelatedToggleType = 'standard' | 'smart';
+type RecommendationToggleType = 'standard' | 'smart';
 
 type Toggler<T, K> = {
   id: T;
@@ -37,6 +39,7 @@ export type TogglerValueMap = {
   activity: ActivityToggleType;
   library: LibraryToggleType;
   related: RelatedToggleType;
+  recommendation: RecommendationToggleType;
 };
 
 type ToggleDefinition<K extends TogglerId> = Toggler<K, TogglerValueMap[K]>;
@@ -192,6 +195,23 @@ const related: ToggleDefinition<'related'> = {
   ],
 };
 
+const recommendation: ToggleDefinition<'recommendation'> = {
+  id: 'recommendation',
+  default: 'smart',
+  options: [
+    {
+      value: 'smart',
+      text: m.button_text_recommendation_smart,
+      label: m.button_label_recommendation_smart,
+    },
+    {
+      value: 'standard',
+      text: m.button_text_recommendation_standard,
+      label: m.button_label_recommendation_standard,
+    },
+  ],
+};
+
 export const TOGGLERS: {
   [K in TogglerId]: Toggler<K, TogglerValueMap[K]>;
 } = {
@@ -203,4 +223,5 @@ export const TOGGLERS: {
   activity,
   library,
   related,
+  recommendation,
 } as const;

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -5,5 +5,6 @@ export enum FeatureFlag {
   ScopedFavorites = 'scoped-favorites',
   PlexSync = 'plex-sync',
   SmartRelated = 'smart-related',
+  SmartRecommendations = 'smart-recommendations',
   Rewatching = 'rewatching',
 }

--- a/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
+++ b/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
@@ -88,6 +88,11 @@ export const featureFlagDefinitions: FeatureFlagDefinitions = {
     title: () => m.preview_feature_title_smart_related(),
     description: () => m.preview_feature_description_smart_related(),
   },
+  [FeatureFlag.SmartRecommendations]: {
+    icon: BrainIcon,
+    title: () => m.preview_feature_title_smart_recommendations(),
+    description: () => m.preview_feature_description_smart_recommendations(),
+  },
   [FeatureFlag.Rewatching]: {
     icon: FastRewindIcon,
     title: () => m.preview_feature_title_rewatch(),

--- a/projects/client/src/lib/requests/queries/media/mediaRecommendedQuery.ts
+++ b/projects/client/src/lib/requests/queries/media/mediaRecommendedQuery.ts
@@ -18,7 +18,11 @@ import {
   RecommendedShowSchema,
 } from '../recommendations/recommendedShowsQuery.ts';
 
-type RecommendedMediaParams = LimitParams & ApiParams & FilterParams;
+type RecommendedMediaParams =
+  & { isSmart?: boolean }
+  & LimitParams
+  & ApiParams
+  & FilterParams;
 
 const RecommendedMediaSchema = z.union([
   RecommendedShowSchema,
@@ -26,7 +30,7 @@ const RecommendedMediaSchema = z.union([
 ]);
 
 const recommendedMediaRequest = async (
-  { fetch, limit, filter, filterOverride }: RecommendedMediaParams,
+  { fetch, limit, filter, filterOverride, isSmart }: RecommendedMediaParams,
 ) => {
   const filterParams = filterOverride?.movie ?? filterOverride?.show ?? filter;
   const searchParams = getRecommendedSearchParams({ limit, filterParams });
@@ -34,7 +38,7 @@ const recommendedMediaRequest = async (
   // FIXME: move to @trakt/api when we drop support for legacy recommendations
   const response = await rawApiFetch({
     fetch,
-    path: `/media/recommendations?${searchParams}`,
+    path: `/media/recommendations${isSmart ? '/smart' : ''}?${searchParams}`,
   });
 
   return response.ok
@@ -60,6 +64,7 @@ export const recommendedMediaQuery = defineQuery({
     params: RecommendedMediaParams,
   ) => [
     params.limit,
+    params.isSmart,
     params.filter?.watch_window,
     ...getGlobalFilterDependencies(
       params.filterOverride?.movie ?? params.filter,

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedMoviesQuery.ts
@@ -18,17 +18,21 @@ export const RecommendedMovieSchema = MovieEntrySchema.extend({
 });
 export type RecommendedMovie = z.infer<typeof RecommendedMovieSchema>;
 
-type RecommendedMoviesParams = LimitParams & ApiParams & FilterParams;
+type RecommendedMoviesParams =
+  & { isSmart?: boolean }
+  & LimitParams
+  & ApiParams
+  & FilterParams;
 
 export const recommendedMoviesRequest = async (
-  { fetch, limit, filter, filterOverride }: RecommendedMoviesParams,
+  { fetch, limit, filter, filterOverride, isSmart }: RecommendedMoviesParams,
 ) => {
   const filterParams = filterOverride?.movie ?? filter;
   const searchParams = getRecommendedSearchParams({ limit, filterParams });
 
   const response = await rawApiFetch({
     fetch,
-    path: `/movies/recommendations?${searchParams}`,
+    path: `/movies/recommendations${isSmart ? '/smart' : ''}?${searchParams}`,
   });
 
   return response.ok
@@ -50,6 +54,7 @@ export const recommendedMoviesQuery = defineQuery({
     params,
   ) => [
     params.limit,
+    params.isSmart,
     params.filter?.watch_window,
     ...getGlobalFilterDependencies(
       params.filterOverride?.movie ?? params.filter,

--- a/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
+++ b/projects/client/src/lib/requests/queries/recommendations/recommendedShowsQuery.ts
@@ -18,17 +18,21 @@ export const RecommendedShowSchema = ShowEntrySchema.extend({
 });
 export type RecommendedShow = z.infer<typeof RecommendedShowSchema>;
 
-type RecommendedShowsParams = LimitParams & ApiParams & FilterParams;
+type RecommendedShowsParams =
+  & { isSmart?: boolean }
+  & LimitParams
+  & ApiParams
+  & FilterParams;
 
 export const recommendedShowsRequest = async (
-  { fetch, limit, filter, filterOverride }: RecommendedShowsParams,
+  { fetch, limit, filter, filterOverride, isSmart }: RecommendedShowsParams,
 ) => {
   const filterParams = filterOverride?.show ?? filter;
   const searchParams = getRecommendedSearchParams({ limit, filterParams });
 
   const response = await rawApiFetch({
     fetch,
-    path: `/shows/recommendations?${searchParams}`,
+    path: `/shows/recommendations${isSmart ? '/smart' : ''}?${searchParams}`,
   });
 
   return response.ok
@@ -51,6 +55,7 @@ export const recommendedShowsQuery = defineQuery({
     params,
   ) => [
     params.limit,
+    params.isSmart,
     params.filter?.watch_window,
     ...getGlobalFilterDependencies(
       params.filterOverride?.show ?? params.filter,

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedList.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import Toggler from "$lib/components/toggles/Toggler.svelte";
+  import { useToggler } from "$lib/components/toggles/useToggler";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
   import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import type { FilterOverrideParams } from "$lib/requests/models/FilterParams";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CtaItem from "../components/cta/CtaItem.svelte";
@@ -25,6 +30,11 @@
   }: RecommendationListProps = $props();
   const { filterMap } = useFilter();
 
+  const { current, set, options } = useToggler("recommendation");
+  const { isEnabled } = useFeatureFlag();
+  const isSmartEnabled = isEnabled(FeatureFlag.SmartRecommendations);
+  const isSmart = $derived($isSmartEnabled && $current.value === "smart");
+
   const cta = $derived({
     type: "recommended" as const,
     mediaType: type === "media" ? undefined : type,
@@ -47,9 +57,22 @@
     ...extractWatchWindowParam(page.url.searchParams),
   }}
   {filterOverride}
-  useList={useRecommendedList}
+  useList={(params) => useRecommendedList({ ...params, isSmart })}
   urlBuilder={() => UrlBuilder.recommended()}
 >
+  {#snippet actions()}
+    <RenderForFeature flag={FeatureFlag.SmartRecommendations}>
+      {#snippet enabled()}
+        <Toggler
+          value={$current.value}
+          onChange={set}
+          {options}
+          variant="icon"
+        />
+      {/snippet}
+    </RenderForFeature>
+  {/snippet}
+
   {#snippet item(media)}
     <RecommendedListItem
       type={media.type}

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedPaginatedList.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import { useToggler } from "$lib/components/toggles/useToggler";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
+  import { useFeatureFlag } from "$lib/features/feature-flag/useFeatureFlag";
   import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode";
   import { useFilter } from "$lib/features/filters/useFilter";
   import DrilledMediaList from "../drilldown/DrilledMediaList.svelte";
@@ -13,6 +16,11 @@
 
   const { type }: RecommendedListProps = $props();
   const { filterMap } = useFilter();
+
+  const { current } = useToggler("recommendation");
+  const { isEnabled } = useFeatureFlag();
+  const isSmartEnabled = isEnabled(FeatureFlag.SmartRecommendations);
+  const isSmart = $derived($isSmartEnabled && $current.value === "smart");
 </script>
 
 <DrilledMediaList
@@ -22,7 +30,7 @@
     ...$filterMap,
     ...extractWatchWindowParam(page.url.searchParams),
   }}
-  useList={useRecommendedList}
+  useList={(params) => useRecommendedList({ ...params, isSmart })}
 >
   {#snippet item(media)}
     <RecommendedListItem

--- a/projects/client/src/lib/sections/lists/recommended/useRecommendedList.ts
+++ b/projects/client/src/lib/sections/lists/recommended/useRecommendedList.ts
@@ -26,18 +26,23 @@ export type RecommendedMediaList = Array<RecommendedEntry>;
 type RecommendationListStoreProps =
   & {
     type: DiscoverMode;
+    isSmart?: boolean;
   }
   & PaginationParams
   & FilterParams;
 
 function typeToQuery(
-  { type, filter, filterOverride }: Omit<RecommendationListStoreProps, 'page'>,
+  { type, filter, filterOverride, isSmart }: Omit<
+    RecommendationListStoreProps,
+    'page'
+  >,
 ) {
   /** Recommendations are calculated daily, so we load all of them. */
   const params = {
     limit: RECOMMENDED_UPPER_LIMIT,
     filter,
     filterOverride,
+    isSmart,
   };
 
   switch (type) {
@@ -57,20 +62,24 @@ function typeToQuery(
 }
 
 function getListKey(props: RecommendationListStoreProps) {
+  const suffix = props.isSmart ? '-smart' : '';
+
   if (props.filterOverride) {
-    return `${props.type}-overridden`;
+    return `${props.type}-overridden${suffix}`;
   }
 
   const filters = props.filter ?? {};
   const hasFilters = Object.keys(filters).length > 0;
 
-  return hasFilters
+  const baseKey = hasFilters
     ? `${props.type}-${
       Object.entries(filters)
         .map(([key, value]) => `${key}-${value}`)
         .join('-')
     }`
     : props.type;
+
+  return `${baseKey}${suffix}`;
 }
 
 export const useRecommendedList = (props: RecommendationListStoreProps) => {

--- a/projects/client/src/routes/discover/recommended/+page.svelte
+++ b/projects/client/src/routes/discover/recommended/+page.svelte
@@ -1,6 +1,10 @@
 <script>
+  import Toggler from "$lib/components/toggles/Toggler.svelte";
+  import { useToggler } from "$lib/components/toggles/useToggler";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import * as m from "$lib/features/i18n/messages";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
 
@@ -9,7 +13,26 @@
   import { DEFAULT_SHARE_MOVIE_COVER } from "$lib/utils/assets";
 
   const { mode, current } = useDiscover();
+
+  const {
+    current: recommendation,
+    set: setRecommendation,
+    options: recommendationOptions,
+  } = useToggler("recommendation");
 </script>
+
+{#snippet actions()}
+  <RenderForFeature flag={FeatureFlag.SmartRecommendations}>
+    {#snippet enabled()}
+      <Toggler
+        value={$recommendation.value}
+        onChange={setRecommendation}
+        options={recommendationOptions}
+        variant="icon"
+      />
+    {/snippet}
+  </RenderForFeature>
+{/snippet}
 
 <TraktPage
   audience="authenticated"
@@ -21,6 +44,7 @@
     header={{
       title: m.list_title_recommended(),
       metaInfo: $current.text(),
+      actions,
     }}
   />
   <TraktPageCoverSetter />


### PR DESCRIPTION
## What

Mirrors the smart related feature for recommendations.

- New `SmartRecommendations` preview flag (VIP-accessible, no `audience: director`) in `FeatureFlag.ts` + `featureFlagDefinitions.ts`.
- New `recommendation` toggler in `constants.ts` with `smart` first and default (`standard | smart`), plus i18n keys mirroring the related ones.
- `isSmart` threaded through all three recommendation queries (movies, shows, media): when set, the request hits `/{type}/recommendations/smart` instead of `/{type}/recommendations`. Added to `dependencies` so toggling refetches.
- `RecommendedList` (home section rows) and `RecommendedPaginatedList` (recommended page) derive `isSmart` from the shared `recommendation` toggler, gated by the flag, so both follow the same global choice.
- Toggle control rendered in two places, both gated by `RenderForFeature`: the `discover/recommended` page header, and the home `Recommended` section header (via `DrillableMediaList` actions slot).

## Notes

- Follows the same pattern as the merged smart-related work. VIPs opt in via the preview-features UI; the flag defaults on for directors.
- Pre-existing `typecheck` errors on `main` in the comment-language files are unrelated to this change.