### PR TITLE
feat(progress): add Continue Watching smart sort

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4474,6 +4474,14 @@
       "default": "Sort by default order",
       "description": "Aria-label for the button that allows users to sort items by the default sorting method."
     },
+    "button_text_sort_smart": {
+      "default": "Smart",
+      "description": "Text for the button that allows users to sort up next items by the smart sorting method."
+    },
+    "button_label_sort_smart": {
+      "default": "Sort by smart order",
+      "description": "Aria-label for the button that allows users to sort up next items by the smart sorting method."
+    },
     "button_text_sort_added_date": {
       "default": "Date Added",
       "description": "Text for the button that allows users to sort items by the date they were added."
@@ -8002,6 +8010,14 @@
     "preview_feature_description_smart_recommendations": {
       "default": "Use our next-gen engine to surface recommended movies and shows beyond the obvious.",
       "description": "Description for the Smart Recommendations preview feature."
+    },
+    "preview_feature_title_up_next_smart_sort": {
+      "default": "Continue Watching Smart Sort",
+      "description": "Title for the Up Next Smart Sort preview feature."
+    },
+    "preview_feature_description_up_next_smart_sort": {
+      "default": "Test a smarter way to sort your Continue Watching.",
+      "description": "Description for the Up Next Smart Sort preview feature."
     },
     "preview_feature_title_rewatch": {
       "default": "Rewatch",

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -3,6 +3,7 @@ export enum FeatureFlag {
   ScopedFavorites = 'scoped-favorites',
   SmartRelated = 'smart-related',
   SmartRecommendations = 'smart-recommendations',
+  UpNextSmartSort = 'up-next-smart-sort',
   Rewatching = 'rewatching',
   Leaderboard = 'leaderboard',
 }

--- a/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
+++ b/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
@@ -3,6 +3,7 @@ import EditModeIcon from '$lib/components/icons/EditModeIcon.svelte';
 import FastRewindIcon from '$lib/components/icons/FastRewindIcon.svelte';
 import FavoriteIcon from '$lib/components/icons/FavoriteIcon.svelte';
 import PeopleIcon from '$lib/components/icons/PeopleIcon.svelte';
+import SmartListIcon from '$lib/components/icons/SmartListIcon.svelte';
 import { m } from '$lib/features/i18n/messages.ts';
 import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
 import type { Component } from 'svelte';
@@ -55,6 +56,16 @@ export const featureFlagDefinitions: FeatureFlagDefinitions = {
     icon: BrainIcon,
     title: () => m.preview_feature_title_smart_recommendations(),
     description: () => m.preview_feature_description_smart_recommendations(),
+  },
+  [FeatureFlag.UpNextSmartSort]: {
+    icon: SmartListIcon,
+    title: () => m.preview_feature_title_up_next_smart_sort(),
+    description: () => m.preview_feature_description_up_next_smart_sort(),
+    featureLink: () =>
+      openFeatureLink(
+        UrlBuilder.progress('me', { sort_by: 'smart' }),
+        m.preview_feature_title_up_next_smart_sort(),
+      ),
   },
   [FeatureFlag.Rewatching]: {
     icon: FastRewindIcon,

--- a/projects/client/src/lib/features/feature-flag/useFeatureFlag.spec.ts
+++ b/projects/client/src/lib/features/feature-flag/useFeatureFlag.spec.ts
@@ -39,6 +39,8 @@ describe('store: useFeatureFlag', () => {
     );
     expect(await waitForValue(isEnabled(FeatureFlag.SmartRelated), true))
       .toBe(true);
+    expect(await waitForValue(isEnabled(FeatureFlag.UpNextSmartSort), true))
+      .toBe(true);
   });
 
   it('should default every flag to disabled for non-director accounts', async () => {

--- a/projects/client/src/lib/requests/queries/sync/_internal/getMovieProgressSortValue.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/getMovieProgressSortValue.ts
@@ -1,0 +1,16 @@
+import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts';
+import type { MovieProgressEntry } from '../../../models/MovieProgressEntry.ts';
+
+export function getMovieProgressSortValue(
+  entry: MovieProgressEntry,
+  sortBy: UpNextSortBy | undefined,
+): number {
+  switch (sortBy) {
+    case 'released':
+      return entry.effectiveReleaseDate.getTime();
+    case 'remaining':
+      return 0;
+    default:
+      return entry.lastWatchedAt?.getTime() ?? 0;
+  }
+}

--- a/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.spec.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.spec.ts
@@ -239,4 +239,46 @@ describe('interleaveMediaProgress', () => {
       expect(result[3]!.key).toBe('episode-2');
     });
   });
+
+  describe('sorting by smart', () => {
+    it('should interleave movies by progress date without reordering smart episodes', () => {
+      const episodes = [
+        createContinueEpisode(
+          'episode-smart-first',
+          new Date('2020-01-01'),
+          new Date('2024-01-05'),
+        ),
+        createContinueEpisode(
+          'episode-smart-second',
+          new Date('2020-01-01'),
+          new Date('2024-01-01'),
+        ),
+      ];
+      const movies = [
+        createContinueMovie(
+          'movie-first',
+          new Date('2020-01-01'),
+          new Date('2024-01-07'),
+        ),
+        createContinueMovie(
+          'movie-second',
+          new Date('2020-01-01'),
+          new Date('2024-01-03'),
+        ),
+      ];
+
+      const result = interleaveMediaProgress({
+        episodes,
+        movies,
+        sortBy: 'smart',
+      });
+
+      expect(result.map((e) => e.key)).toEqual([
+        'movie-first',
+        'episode-smart-first',
+        'movie-second',
+        'episode-smart-second',
+      ]);
+    });
+  });
 });

--- a/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/interleaveMediaProgress.ts
@@ -2,6 +2,7 @@ import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts'
 import type { SortDirection } from '$lib/sections/lists/user/models/SortDirection.ts';
 import type { MovieProgressEntry } from '../../../models/MovieProgressEntry.ts';
 import type { UpNextEntry } from '../../../models/UpNextEntry.ts';
+import { getMovieProgressSortValue } from './getMovieProgressSortValue.ts';
 import { sortMovieProgress } from './sortMovieProgress.ts';
 
 type SortMediaProgressProps = {
@@ -11,20 +12,29 @@ type SortMediaProgressProps = {
   sortHow?: SortDirection;
 };
 
+function getEpisodeSortValue(
+  episode: UpNextEntry,
+  sortBy: UpNextSortBy,
+): number {
+  switch (sortBy) {
+    case 'released':
+      return episode.effectiveReleaseDate.getTime();
+    case 'remaining':
+      return episode.remaining;
+    case 'smart':
+      return episode.lastWatchedAt?.getTime() ?? 0;
+  }
+}
+
 function getComparableValues(
   movie: MovieProgressEntry,
   episode: UpNextEntry,
   sortBy: UpNextSortBy,
 ): [number, number] {
-  switch (sortBy) {
-    case 'released':
-      return [
-        movie.effectiveReleaseDate.getTime(),
-        episode.effectiveReleaseDate.getTime(),
-      ];
-    case 'remaining':
-      return [0, episode.remaining];
-  }
+  return [
+    getMovieProgressSortValue(movie, sortBy),
+    getEpisodeSortValue(episode, sortBy),
+  ];
 }
 
 function shouldInsertBefore(

--- a/projects/client/src/lib/requests/queries/sync/_internal/sortMovieProgress.spec.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/sortMovieProgress.spec.ts
@@ -98,4 +98,18 @@ describe('sortMovieProgress', () => {
       expect(result).toHaveLength(2);
     });
   });
+
+  describe('sortBy smart', () => {
+    it('should keep movies on the default progress sort', () => {
+      const entries = [
+        createMovie('a', { lastWatchedAt: new Date('2024-01-01') }),
+        createMovie('b', { lastWatchedAt: new Date('2024-01-03') }),
+        createMovie('c', { lastWatchedAt: new Date('2024-01-02') }),
+      ];
+
+      const result = sortMovieProgress({ entries, sortBy: 'smart' });
+
+      expect(result.map((e) => e.key)).toEqual(['b', 'c', 'a']);
+    });
+  });
 });

--- a/projects/client/src/lib/requests/queries/sync/_internal/sortMovieProgress.ts
+++ b/projects/client/src/lib/requests/queries/sync/_internal/sortMovieProgress.ts
@@ -1,6 +1,7 @@
 import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts';
 import type { SortDirection } from '$lib/sections/lists/user/models/SortDirection.ts';
 import type { MovieProgressEntry } from '../../../models/MovieProgressEntry.ts';
+import { getMovieProgressSortValue } from './getMovieProgressSortValue.ts';
 
 type SortMovieProgressProps = {
   entries: ReadonlyArray<MovieProgressEntry>;
@@ -8,26 +9,14 @@ type SortMovieProgressProps = {
   sortHow?: SortDirection;
 };
 
-function getSortValue(
-  entry: MovieProgressEntry,
-  sortBy: UpNextSortBy | undefined,
-): number {
-  switch (sortBy) {
-    case 'released':
-      return entry.effectiveReleaseDate.getTime();
-    case 'remaining':
-      return 0;
-    default:
-      return entry.lastWatchedAt?.getTime() ?? 0;
-  }
-}
-
 export function sortMovieProgress(
   { entries, sortBy, sortHow = 'desc' }: SortMovieProgressProps,
 ): MovieProgressEntry[] {
   const direction = sortHow === 'asc' ? 1 : -1;
 
   return entries.toSorted(
-    (a, b) => (getSortValue(a, sortBy) - getSortValue(b, sortBy)) * direction,
+    (a, b) =>
+      (getMovieProgressSortValue(a, sortBy) -
+        getMovieProgressSortValue(b, sortBy)) * direction,
   );
 }

--- a/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.spec.ts
@@ -1,7 +1,10 @@
 import { UpNextMappedMock } from '$mocks/data/sync/mapped/UpNextMappedMock.ts';
+import { UpNextResponseMock } from '$mocks/data/sync/response/UpNextResponseMock.ts';
+import { server } from '$mocks/server.ts';
 import { createTestBedInfiniteQuery } from '$test/beds/query/createTestBedInfiniteQuery.ts';
 import { runQuery } from '$test/beds/query/runQuery.ts';
 import { mapToEntries } from '$test/utils/mapToEntries.ts';
+import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
 import { upNextNitroQuery } from './upNextNitroQuery.ts';
 
@@ -16,5 +19,30 @@ describe('upNextNitroQuery', () => {
     });
 
     expect(result).to.deep.equal(UpNextMappedMock);
+  });
+
+  it('should request smart sort for up next', async () => {
+    let requestedUrl: URL | undefined;
+
+    server.use(
+      http.get(
+        'http://localhost/sync/progress/up_next_nitro',
+        ({ request }) => {
+          requestedUrl = new URL(request.url);
+          return HttpResponse.json(UpNextResponseMock);
+        },
+      ),
+    );
+
+    await runQuery({
+      factory: () =>
+        createTestBedInfiniteQuery(
+          upNextNitroQuery({ limit: 10, sortBy: 'smart', sortHow: 'desc' }),
+        ),
+      mapper: mapToEntries,
+    });
+
+    expect(requestedUrl?.searchParams.get('sort_by')).toBe('smart');
+    expect(requestedUrl?.searchParams.get('sort_how')).toBe('desc');
   });
 });

--- a/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
+++ b/projects/client/src/lib/requests/queries/sync/upNextNitroQuery.ts
@@ -27,6 +27,11 @@ type UpNextParams =
     sortHow?: SortDirection;
   };
 
+function mapToNitroSortBy(sortBy: UpNextSortBy): string {
+  if (sortBy === 'released') return 'aired';
+  return sortBy;
+}
+
 export function mapUpNextResponse(item: UpNextResponse): UpNextEntry {
   const show = mapToShowEntry(item.show);
   const episode = mapToEpisodeEntry(item.progress.next_episode);
@@ -66,9 +71,7 @@ export const upNextNitroRequest = (
         limit,
         intent: 'continue',
         ...filter,
-        ...(sortBy
-          ? { sort_by: sortBy === 'released' ? 'aired' : sortBy }
-          : {}),
+        ...(sortBy ? { sort_by: mapToNitroSortBy(sortBy) } : {}),
         ...(sortHow ? { sort_how: sortHow } : {}),
       },
     });

--- a/projects/client/src/lib/sections/lists/progress/UpNextSortBy.ts
+++ b/projects/client/src/lib/sections/lists/progress/UpNextSortBy.ts
@@ -1,1 +1,1 @@
-export type UpNextSortBy = 'released' | 'remaining';
+export type UpNextSortBy = 'released' | 'remaining' | 'smart';

--- a/projects/client/src/lib/sections/lists/progress/useUpNextSorting.spec.ts
+++ b/projects/client/src/lib/sections/lists/progress/useUpNextSorting.spec.ts
@@ -1,0 +1,66 @@
+import { FeatureFlag } from '$lib/features/feature-flag/models/FeatureFlag.ts';
+import { useFeatureFlag } from '$lib/features/feature-flag/useFeatureFlag.ts';
+import { renderStore } from '$test/beds/store/renderStore.ts';
+import { filter, firstValueFrom, map, take } from 'rxjs';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useUpNextSorting } from './useUpNextSorting.ts';
+
+describe('useUpNextSorting', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should hide smart sorting until the preview flag is enabled', async () => {
+    const { sorting, featureFlag } = await renderStore(() => ({
+      sorting: useUpNextSorting('me'),
+      featureFlag: useFeatureFlag(),
+    }));
+    const hasSmartOption = () =>
+      firstValueFrom(
+        sorting.options.pipe(
+          map((options) => options.some((option) => option.value === 'smart')),
+        ),
+      );
+    const waitForSmartOption = () =>
+      firstValueFrom(
+        sorting.options.pipe(
+          map((options) => options.some((option) => option.value === 'smart')),
+          filter(Boolean),
+          take(1),
+        ),
+      );
+
+    expect(await hasSmartOption()).toBe(false);
+
+    featureFlag.setFlag(FeatureFlag.UpNextSmartSort, true);
+
+    expect(await waitForSmartOption()).toBe(true);
+  });
+
+  it('should ignore smart sorting from the URL until the preview flag is enabled', async () => {
+    const { sorting, featureFlag } = await renderStore(() => ({
+      sorting: useUpNextSorting('me'),
+      featureFlag: useFeatureFlag(),
+    }));
+    const currentSortBy = () =>
+      firstValueFrom(
+        sorting.current.pipe(map((current) => current.sorting.value)),
+      );
+
+    sorting.update({ sort_by: 'smart' });
+
+    expect(await currentSortBy()).toBeUndefined();
+
+    featureFlag.setFlag(FeatureFlag.UpNextSmartSort, true);
+
+    expect(
+      await firstValueFrom(
+        sorting.current.pipe(
+          map((current) => current.sorting.value),
+          filter((sortBy) => sortBy === 'smart'),
+          take(1),
+        ),
+      ),
+    ).toBe('smart');
+  });
+});

--- a/projects/client/src/lib/sections/lists/progress/useUpNextSorting.ts
+++ b/projects/client/src/lib/sections/lists/progress/useUpNextSorting.ts
@@ -1,3 +1,5 @@
+import { FeatureFlag } from '$lib/features/feature-flag/models/FeatureFlag.ts';
+import { useFeatureFlag } from '$lib/features/feature-flag/useFeatureFlag.ts';
 import * as m from '$lib/features/i18n/messages.ts';
 import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts';
 import type { ListUrlBuilder } from '$lib/sections/lists/user/models/ListUrlBuilder.ts';
@@ -5,13 +7,24 @@ import type { SortDirection } from '$lib/sections/lists/user/models/SortDirectio
 import type { Sorting } from '$lib/sections/lists/user/models/Sorting.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
-import { BehaviorSubject, map, type Observable } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  map,
+  type Observable,
+  startWith,
+} from 'rxjs';
 
 const upNextSortOptions: Sorting<UpNextSortBy>[] = [
   {
     value: undefined,
     text: m.button_text_sort_default,
     label: m.button_label_sort_default,
+  },
+  {
+    value: 'smart',
+    text: m.button_text_sort_smart,
+    label: m.button_label_sort_smart,
   },
   {
     value: 'released',
@@ -30,7 +43,7 @@ type UpNextSorting = {
     sorting: Sorting<UpNextSortBy>;
     sortHow: SortDirection;
   }>;
-  options: Sorting<UpNextSortBy>[];
+  options: Observable<Sorting<UpNextSortBy>[]>;
   update: (params: Record<string, string>) => void;
   urlBuilder: ListUrlBuilder<UpNextSortBy>;
 };
@@ -39,11 +52,28 @@ function mapToDirection(value: string | Nil): SortDirection | undefined {
   return value === 'asc' || value === 'desc' ? value : undefined;
 }
 
-function mapToSortBy(value: string | Nil): UpNextSortBy | undefined {
-  return upNextSortOptions.find((option) => option.value === value)?.value;
+function getSortOptions(
+  isSmartSortEnabled: boolean,
+): Sorting<UpNextSortBy>[] {
+  return isSmartSortEnabled
+    ? upNextSortOptions
+    : upNextSortOptions.filter((option) => option.value !== 'smart');
+}
+
+function mapToSortBy(
+  value: string | Nil,
+  options: Sorting<UpNextSortBy>[],
+): UpNextSortBy | undefined {
+  return options.find((option) => option.value === value)?.value;
 }
 
 export function useUpNextSorting(user: string): UpNextSorting {
+  const { isEnabled } = useFeatureFlag();
+  const options = isEnabled(FeatureFlag.UpNextSmartSort).pipe(
+    map(getSortOptions),
+    startWith(getSortOptions(false)),
+  );
+
   const params = new BehaviorSubject<Record<string, string | null>>({
     sort_by: null,
     sort_how: null,
@@ -55,13 +85,13 @@ export function useUpNextSorting(user: string): UpNextSorting {
 
   return {
     update,
-    options: upNextSortOptions,
-    current: params.pipe(
-      map(($params) => {
-        const sortBy = mapToSortBy($params.sort_by);
+    options,
+    current: combineLatest([params, options]).pipe(
+      map(([$params, $options]) => {
+        const sortBy = mapToSortBy($params.sort_by, $options);
         const sortHow = mapToDirection($params.sort_how);
 
-        const sorting = upNextSortOptions.find(
+        const sorting = $options.find(
           (option) => option.value === sortBy,
         );
 

--- a/projects/client/src/lib/sections/lists/user/SortIcon.svelte
+++ b/projects/client/src/lib/sections/lists/user/SortIcon.svelte
@@ -4,6 +4,7 @@
   import RatingIcon from "$lib/components/icons/RatingIcon.svelte";
   import ReorderIcon from "$lib/components/icons/ReorderIcon.svelte";
   import RemainingIcon from "$lib/components/icons/RemainingIcon.svelte";
+  import SmartListIcon from "$lib/components/icons/SmartListIcon.svelte";
   import SortAlphaIcon from "$lib/components/icons/SortAlphaIcon.svelte";
   import StarIcon from "$lib/components/icons/StarIcon.svelte";
   import type { UpNextSortBy } from "$lib/sections/lists/progress/UpNextSortBy.ts";
@@ -44,4 +45,8 @@
 
 {#if sortBy === "remaining"}
   <RemainingIcon />
+{/if}
+
+{#if sortBy === "smart"}
+  <SmartListIcon />
 {/if}

--- a/projects/client/src/routes/users/[user]/progress/+page.svelte
+++ b/projects/client/src/routes/users/[user]/progress/+page.svelte
@@ -16,7 +16,7 @@
   const {
     current: currentSort,
     update,
-    options,
+    options: sortOptions,
     urlBuilder,
   } = useUpNextSorting(page.params.user ?? "me");
 </script>
@@ -34,7 +34,7 @@
   >
     {#snippet headerActions()}
       <ListSortActions
-        {options}
+        options={$sortOptions}
         {urlBuilder}
         current={$currentSort}
         onUpdate={update}


### PR DESCRIPTION
## Summary

- Adds a Smart Sort for Continue Watching.
- Adds the Smart option to the Up Next sorting drawer.
- Feature flagged for Preview (VIP).
- Sends `sort_by=smart` to the up next nitro endpoint for the progress page only.
- Keeps the home and default sorting behavior unchanged.

## Context

- Related to trakt/trakt-web#1618
- Related to https://roadmap.trakt.tv/p/smarter-up-next
- Uses the new backend-baked smart sorting from trakt/trakt-workers#1134 that prioritize new season premieres.
- This is intentionally preview-gated while the sorting behavior continues to improve.

## Screenshots

Default:
<img width="1363" height="1100" alt="618815208-f8ec480d-81e7-481c-a167-6a39caeb5e6c" src="https://github.com/user-attachments/assets/9a61906f-b489-4e8f-8b2c-35eb8af82fe8" />

Smart ("Trying" premiered today, last watched ~1 year ago):
<img width="1568" height="1016" alt="Screenshot 2026-07-09 at 08 39 48" src="https://github.com/user-attachments/assets/81798250-1d75-42f6-b536-ec824f94f556" />
