### PR TITLE
feat(settings): mobile grouped-list settings overview

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -75,6 +75,14 @@
       "default": "Streaming Sync",
       "description": "Header for the streaming sync settings section."
     },
+    "header_sync": {
+      "default": "Sync",
+      "description": "Header for the sync group on the mobile settings overview."
+    },
+    "header_more_settings": {
+      "default": "More",
+      "description": "Header for the additional settings group on the mobile settings overview."
+    },
     "description_streaming_sync": {
       "default": "Automatically sync your watched history and ratings.",
       "description": "Description for the streaming sync settings section."

--- a/projects/client/src/lib/sections/settings/GeneralSettings.svelte
+++ b/projects/client/src/lib/sections/settings/GeneralSettings.svelte
@@ -6,11 +6,22 @@
   import BlockedUsers from "./_internal/BlockedUsers.svelte";
   import Genres from "./_internal/Genres.svelte";
   import Profile from "./_internal/Profile.svelte";
+  import SettingsMobileOverview from "./_internal/SettingsMobileOverview.svelte";
 </script>
 
 <div class="trakt-general-settings">
   <Profile />
-  <Behavior />
+
+  <RenderFor audience="authenticated" device={["mobile"]}>
+    <SettingsMobileOverview />
+  </RenderFor>
+  <RenderFor
+    audience="authenticated"
+    device={["tablet-sm", "tablet-lg", "desktop"]}
+  >
+    <Behavior />
+  </RenderFor>
+
   <Genres />
   <BlockedUsers />
   <Appearance />

--- a/projects/client/src/lib/sections/settings/_internal/SettingsGroupRow.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsGroupRow.svelte
@@ -5,7 +5,7 @@
   type CommonRowProps = {
     title: string;
     description?: string;
-    icon: Snippet;
+    icon?: Snippet;
     tag?: Snippet;
   };
 
@@ -34,9 +34,11 @@
 </script>
 
 {#snippet rowContent()}
-  <div class="row-icon-container">
-    {@render icon()}
-  </div>
+  {#if icon}
+    <div class="row-icon-container">
+      {@render icon()}
+    </div>
+  {/if}
 
   <div class="row-body">
     <div class="row-title-line">

--- a/projects/client/src/lib/sections/settings/_internal/SettingsMobileOverview.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsMobileOverview.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import Switch from "$lib/components/toggles/Switch.svelte";
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag.ts";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+  import SettingsGroupCard from "./SettingsGroupCard.svelte";
+  import SettingsGroupRow from "./SettingsGroupRow.svelte";
+  import { useSettings } from "./useSettings.ts";
+
+  const { watchAgain, spoilers, ratingPrompt, isSavingSettings } =
+    useSettings();
+</script>
+
+<div class="trakt-settings-mobile-overview">
+  <SettingsGroupCard title={m.header_behavior()}>
+    <SettingsGroupRow title={m.text_show_spoilers()} variant="custom">
+      <Switch
+        label={m.switch_label_spoilers()}
+        checked={!$spoilers.isHidden}
+        onclick={() => $spoilers.set(!$spoilers.isHidden)}
+        disabled={$isSavingSettings}
+        color="purple"
+      />
+    </SettingsGroupRow>
+
+    <SettingsGroupRow
+      title={m.text_settings_enable_multiple_plays()}
+      variant="custom"
+    >
+      <Switch
+        label={m.switch_label_multiple_watches()}
+        checked={$watchAgain.hasWatchAgain}
+        onclick={() => $watchAgain.set(!$watchAgain.hasWatchAgain)}
+        disabled={$isSavingSettings}
+        color="purple"
+      />
+    </SettingsGroupRow>
+
+    <SettingsGroupRow
+      title={m.text_settings_show_rating_prompt()}
+      variant="custom"
+    >
+      <Switch
+        label={m.switch_label_rating_prompt()}
+        checked={$ratingPrompt.showRatingPrompt}
+        onclick={() => $ratingPrompt.set(!$ratingPrompt.showRatingPrompt)}
+        disabled={$isSavingSettings}
+        color="purple"
+      />
+    </SettingsGroupRow>
+  </SettingsGroupCard>
+
+  <SettingsGroupCard title={m.header_sync()}>
+    <SettingsGroupRow
+      title={m.link_text_streaming_sync_settings()}
+      variant="link"
+      href={UrlBuilder.settings.streamingServices()}
+    />
+
+    <RenderForFeature flag={FeatureFlag.PlexSync}>
+      {#snippet enabled()}
+        <SettingsGroupRow
+          title={m.link_text_plex_settings()}
+          variant="link"
+          href={UrlBuilder.settings.plex()}
+        />
+      {/snippet}
+    </RenderForFeature>
+  </SettingsGroupCard>
+
+  <SettingsGroupCard title={m.link_text_apps_settings()}>
+    <SettingsGroupRow
+      title={m.heading_connected_apps()}
+      variant="link"
+      href={UrlBuilder.settings.appsConnected()}
+    />
+
+    <SettingsGroupRow
+      title={m.heading_api_applications()}
+      variant="link"
+      href={UrlBuilder.settings.appsApi()}
+    />
+  </SettingsGroupCard>
+
+  <SettingsGroupCard title={m.header_more_settings()}>
+    <SettingsGroupRow
+      title={m.link_text_data_settings()}
+      variant="link"
+      href={UrlBuilder.settings.data()}
+    />
+
+    <SettingsGroupRow
+      title={m.link_text_advanced_settings()}
+      variant="link"
+      href={UrlBuilder.settings.advanced()}
+    />
+
+    <SettingsGroupRow
+      title={m.link_text_preview_settings()}
+      variant="link"
+      href={UrlBuilder.settings.preview()}
+    />
+  </SettingsGroupCard>
+</div>
+
+<style lang="scss">
+  .trakt-settings-mobile-overview {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xl);
+  }
+</style>

--- a/projects/client/src/lib/sections/settings/_internal/SettingsNavbar.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsNavbar.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
   import SettingsNavLinks from "./SettingsNavLinks.svelte";
   import SettingsNavMenu from "./SettingsNavMenu.svelte";
+
+  const isGeneralSettings = $derived(
+    page.url.pathname === UrlBuilder.settings.general(),
+  );
 </script>
 
 <RenderFor audience="authenticated" device={["tablet-lg", "desktop"]}>
@@ -10,8 +16,14 @@
   </nav>
 </RenderFor>
 
-<RenderFor audience="authenticated" device={["tablet-sm", "mobile"]}>
+<RenderFor audience="authenticated" device={["tablet-sm"]}>
   <SettingsNavMenu />
+</RenderFor>
+
+<RenderFor audience="authenticated" device={["mobile"]}>
+  {#if !isGeneralSettings}
+    <SettingsNavMenu />
+  {/if}
 </RenderFor>
 
 <style lang="scss">


### PR DESCRIPTION
##Visuals

<img width="400" height="856" alt="Screenshot 2026-07-10 at 12 26 25" src="https://github.com/user-attachments/assets/787f9d29-f025-473a-b5c4-da5d866ed835" />

<img width="402" height="853" alt="Screenshot 2026-07-10 at 12 26 30" src="https://github.com/user-attachments/assets/38f11580-db53-4ad4-8003-3c76600f6894" />

<img width="399" height="851" alt="Screenshot 2026-07-10 at 12 26 37" src="https://github.com/user-attachments/assets/6abed0ec-c4f1-42a2-b49d-30ad08b78776" />




## What

Restructures how the Settings page presents its content on **mobile web only**. The `/settings` landing page now shows a grouped list — category header cards containing toggle rows (label left, switch right) and navigation rows with a disclosure chevron — matching the mobile design reference. Desktop and tablet layouts are untouched.

## Why

On mobile, settings navigation was hidden behind a drawer menu and the Behavior card carried desktop-oriented rows (icons + descriptions). The grouped list surfaces quick toggles and all sub-pages directly on the landing page, one scroll, no drawer.

## How

- **New `SettingsMobileOverview`** (`_internal/`): built entirely from existing `SettingsGroupCard` / `SettingsGroupRow` / `Switch`, so the current Trakt visual system (tokens, cards, dividers, carets, RTL behavior) is reused as-is:
  - **Behavior** — Spoilers / Multiple Plays / Rating Prompts toggles wired through the existing `useSettings` store (same save mutation, disabled while saving).
  - **Sync** — Streaming ›, Plex › (gated by `FeatureFlag.PlexSync` via `RenderForFeature`, same as the nav links).
  - **Apps** — Connected Apps ›, API Applications ›.
  - **More** — Data ›, Advanced ›, Preview ›.
- **`GeneralSettings`** renders the overview instead of the `Behavior` card on `device={["mobile"]}` via `RenderFor`; tablet/desktop branch renders `Behavior` exactly as before. Profile, Genres, Blocked Users, Appearance and Logout are unchanged on all devices.
- **`SettingsNavbar`** hides the drawer nav menu on the mobile landing page only (the overview rows replace it); mobile sub-pages and tablet-sm keep the menu, desktop sidebar untouched.
- **`SettingsGroupRow`**: `icon` snippet is now optional — the icon container only renders when provided, letting overview rows be label-only. No impact on existing callers.
- **i18n**: new meta keys `header_sync` ("Sync") and `header_more_settings` ("More"); all row labels reuse existing messages.

## Verification

- `svelte-check`: 7 errors, identical to the main baseline (pre-existing `@trakt/api` type drift) — zero new.
- ESLint: no findings in changed/new code (the 2 `SettingsGroupRow` errors pre-exist on main).
- Settings unit tests: 283 passing (one `TvTimeGdprParser` timeout reproduced as suite-contention flake; passes in isolation on both main and this branch).
- `deno fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)