### PR TITLE
fix(search): cap per-search compute via embedded scoped-key params

### DIFF
--- a/projects/client/src/lib/features/search/_internal/SearchContext.ts
+++ b/projects/client/src/lib/features/search/_internal/SearchContext.ts
@@ -6,5 +6,5 @@ export type SearchContext = {
   isSearching: BehaviorSubject<boolean>;
   pathName: string;
   query: BehaviorSubject<string>;
-  config: TypesenseConfig;
+  config: BehaviorSubject<TypesenseConfig>;
 };

--- a/projects/client/src/lib/features/search/_internal/createSearchContext.ts
+++ b/projects/client/src/lib/features/search/_internal/createSearchContext.ts
@@ -24,7 +24,7 @@ export function createSearchContext(
         isSearching: new BehaviorSubject(false),
         pathName: UrlBuilder.search(),
         query: new BehaviorSubject(''),
-        config,
+        config: new BehaviorSubject(config),
       },
   );
 

--- a/projects/client/src/lib/features/search/ensureFreshSearchKeys.ts
+++ b/projects/client/src/lib/features/search/ensureFreshSearchKeys.ts
@@ -1,0 +1,52 @@
+import type { BehaviorSubject } from 'rxjs';
+import { fetchSearchKeys } from './fetchSearchKeys.ts';
+import { SEARCH_KEY_LIFETIME } from './searchKeyLifetime.ts';
+
+// Refresh coordination shared across every useSearch() instance. useSearch is
+// mounted by multiple components and its pipeline can run more than once per
+// search, so keeping this state in the hook closure minted a key per run.
+// Hoisting it here means a stale key triggers a single re-mint, reused by all
+// callers, and the staleness clock is shared.
+let activeConfig: BehaviorSubject<TypesenseConfig> | null = null;
+let mintedAt = Date.now();
+let nextAttemptAt = 0;
+let refreshPromise: Promise<TypesenseConfig> | null = null;
+
+export function ensureFreshSearchKeys(
+  config: BehaviorSubject<TypesenseConfig>,
+): Promise<TypesenseConfig> {
+  // A new provider means a freshly minted SSR key: reset the clock to it.
+  if (config !== activeConfig) {
+    activeConfig = config;
+    mintedAt = Date.now();
+    nextAttemptAt = 0;
+    refreshPromise = null;
+  }
+
+  const now = Date.now();
+  const isStale = now - mintedAt >= SEARCH_KEY_LIFETIME.refreshInterval;
+  if (!isStale || now < nextAttemptAt) {
+    return Promise.resolve(config.value);
+  }
+
+  // Reuse the in-flight refresh so concurrent searches share one request.
+  if (!refreshPromise) {
+    refreshPromise = fetchSearchKeys()
+      .then((fresh) => {
+        config.next(fresh);
+        mintedAt = Date.now();
+        return fresh;
+      })
+      .catch(() => {
+        // Back off before retrying so a failing endpoint is not hit on every
+        // subsequent search. Keep serving the current key meanwhile.
+        nextAttemptAt = Date.now() + SEARCH_KEY_LIFETIME.retryCooldown;
+        return config.value;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
+}

--- a/projects/client/src/lib/features/search/fetchSearchKeys.ts
+++ b/projects/client/src/lib/features/search/fetchSearchKeys.ts
@@ -1,0 +1,27 @@
+import { time } from '$lib/utils/timing/time.ts';
+import { z } from 'zod';
+
+// Bound the request so a hung endpoint cannot leave a search pending forever
+// (the refresh sits in the search pipeline and gates the spinner).
+const REQUEST_TIMEOUT = time.seconds(5);
+
+const TypesenseConfigSchema = z.object({
+  keys: z.object({
+    media: z.object({
+      default: z.string(),
+      exact: z.string(),
+    }),
+    people: z.string(),
+  }),
+  server: z.string(),
+});
+
+export async function fetchSearchKeys(): Promise<TypesenseConfig> {
+  const response = await fetch('/api/search-keys', {
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch search keys: ${response.status}`);
+  }
+  return TypesenseConfigSchema.parse(await response.json());
+}

--- a/projects/client/src/lib/features/search/handle.ts
+++ b/projects/client/src/lib/features/search/handle.ts
@@ -1,56 +1,8 @@
-import { env } from '$env/dynamic/private';
 import type { Handle } from '@sveltejs/kit';
-import { createSearcher } from '../../requests/search/createSearcher.ts';
-import { DEFAULT_SEARCH_LIMIT } from '../../utils/constants.ts';
-import { time } from '../../utils/timing/time.ts';
+import { mintSearchKeysFromEnv } from './mintSearchKeysFromEnv.ts';
 
 export const handle: Handle = ({ event, resolve }) => {
-  const typesenseKey = env.TYPESENSE_CLIENT_KEY ?? '';
-  const typesenseServer = env.TYPESENSE_SERVER ?? '';
-
-  const typesense = createSearcher({
-    key: typesenseKey ?? '',
-    server: typesenseServer,
-  });
-
-  const expires_at = Math.floor(
-    (Date.now() + time.hours(6)) / time.seconds(1),
-  );
-
-  const mediaSearchKey = typesense
-    .keys()
-    .generateScopedSearchKey(typesenseKey, {
-      preset: 'search:media',
-      limit_hits: DEFAULT_SEARCH_LIMIT,
-      expires_at,
-    });
-
-  const mediaSearchExactKey = typesense
-    .keys()
-    .generateScopedSearchKey(typesenseKey, {
-      preset: 'search:media:exact',
-      limit_hits: DEFAULT_SEARCH_LIMIT,
-      expires_at,
-    });
-
-  const peopleSearchKey = typesense
-    .keys()
-    .generateScopedSearchKey(typesenseKey, {
-      preset: 'search:people',
-      limit_hits: DEFAULT_SEARCH_LIMIT,
-      expires_at,
-    });
-
-  event.locals.typesense = {
-    keys: {
-      media: {
-        default: mediaSearchKey,
-        exact: mediaSearchExactKey,
-      },
-      people: peopleSearchKey,
-    },
-    server: env.TYPESENSE_SERVER ?? '',
-  };
+  event.locals.typesense = mintSearchKeysFromEnv();
 
   return resolve(event);
 };

--- a/projects/client/src/lib/features/search/mintSearchKeys.ts
+++ b/projects/client/src/lib/features/search/mintSearchKeys.ts
@@ -1,0 +1,45 @@
+import { createSearcher } from '$lib/requests/search/createSearcher.ts';
+import { DEFAULT_SEARCH_LIMIT } from '$lib/utils/constants.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { SEARCH_KEY_LIFETIME } from './searchKeyLifetime.ts';
+
+// Hard caps baked into the scoped key. Typesense applies embedded params
+// itself and the client cannot override them, so these enforce a per-search
+// compute ceiling even if the transient token is replayed directly.
+const SEARCH_CUTOFF_MS = 250; // tune toward 100-150 once p99 search latency is confirmed
+
+type MintSearchKeysParams = {
+  key: string;
+  server: string;
+};
+
+export function mintSearchKeys(
+  { key, server }: MintSearchKeysParams,
+): TypesenseConfig {
+  const typesense = createSearcher({ key, server });
+  const expires_at = Math.floor(
+    (Date.now() + SEARCH_KEY_LIFETIME.ttl) / time.seconds(1),
+  );
+
+  const scope = (preset: string) =>
+    typesense
+      .keys()
+      .generateScopedSearchKey(key, {
+        preset,
+        limit_hits: DEFAULT_SEARCH_LIMIT,
+        per_page: DEFAULT_SEARCH_LIMIT,
+        search_cutoff_ms: SEARCH_CUTOFF_MS,
+        expires_at,
+      });
+
+  return {
+    keys: {
+      media: {
+        default: scope('search:media'),
+        exact: scope('search:media:exact'),
+      },
+      people: scope('search:people'),
+    },
+    server,
+  };
+}

--- a/projects/client/src/lib/features/search/mintSearchKeysFromEnv.ts
+++ b/projects/client/src/lib/features/search/mintSearchKeysFromEnv.ts
@@ -1,0 +1,12 @@
+import { env } from '$env/dynamic/private';
+import { mintSearchKeys } from './mintSearchKeys.ts';
+
+// Boundary wrapper: reads the server-only secrets and delegates to the pure
+// mint. Keeps the secret names in one place across the handle hook and the
+// re-mint endpoint.
+export function mintSearchKeysFromEnv(): TypesenseConfig {
+  return mintSearchKeys({
+    key: env.TYPESENSE_CLIENT_KEY ?? '',
+    server: env.TYPESENSE_SERVER ?? '',
+  });
+}

--- a/projects/client/src/lib/features/search/searchKeyLifetime.ts
+++ b/projects/client/src/lib/features/search/searchKeyLifetime.ts
@@ -1,0 +1,11 @@
+import { time } from '$lib/utils/timing/time.ts';
+
+// Scoped-key lifecycle, shared by the server-side mint and the client refresh.
+// The client must re-mint before the server token expires, so refreshInterval
+// stays safely below ttl. retryCooldown throttles re-minting after a failed
+// refresh so a broken endpoint is not hammered on every keystroke.
+export const SEARCH_KEY_LIFETIME = {
+  ttl: time.minutes(15),
+  refreshInterval: time.minutes(12),
+  retryCooldown: time.minutes(1),
+} as const;

--- a/projects/client/src/lib/features/search/useSearch.ts
+++ b/projects/client/src/lib/features/search/useSearch.ts
@@ -2,8 +2,15 @@ import { browser } from '$app/environment';
 import { useQueryClient } from '$lib/features/query/_internal/queryClientContext.ts';
 import type { CreateQueryOptions } from '$lib/features/query/types.ts';
 import { multicast } from '$lib/utils/store/multicast.ts';
-import { BehaviorSubject, combineLatest, of } from 'rxjs';
-import { debounceTime, map, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, from, of } from 'rxjs';
+import {
+  catchError,
+  debounceTime,
+  map,
+  shareReplay,
+  switchMap,
+  tap,
+} from 'rxjs/operators';
 import type { SearchMode } from '../../requests/queries/search/models/SearchMode.ts';
 import {
   searchListsQuery,
@@ -27,6 +34,7 @@ import { createBulkMediaIntl } from '../intl-overlay/createBulkMediaIntl.ts';
 import { getSearchContext } from './_internal/getSearchContext.ts';
 import { mapToSearchCover } from './_internal/mapToSearchCover.ts';
 import { postRecentSearch } from './_internal/postRecentSearch.ts';
+import { ensureFreshSearchKeys } from './ensureFreshSearchKeys.ts';
 import type { SearchResponse } from './models/SearchResponse.ts';
 
 function modeToQuery(
@@ -92,38 +100,46 @@ export function useSearch() {
     switchMap(([rawTerm, currentMode]) => {
       const term = rawTerm.toLowerCase().trim();
 
-      if (term.trim().length === 0) {
+      if (term.length === 0) {
         return of(null);
       }
 
       isSearching.next(true);
       track({ mode: currentMode });
 
-      const searchQuery = client.fetchQuery(
-        modeToQuery(term, currentMode, config, false),
-      );
+      return from(ensureFreshSearchKeys(config)).pipe(
+        switchMap((freshConfig) => {
+          const searchQuery = client.fetchQuery(
+            modeToQuery(term, currentMode, freshConfig, false),
+          );
 
-      if (currentMode === 'people' || currentMode === 'lists') {
-        return searchQuery;
-      }
+          if (currentMode === 'people' || currentMode === 'lists') {
+            return searchQuery;
+          }
 
-      const trendingQuery = client.fetchQuery(
-        modeToTrendingQuery(term, currentMode),
-      );
+          const trendingQuery = client.fetchQuery(
+            modeToTrendingQuery(term, currentMode),
+          );
 
-      const exactQuery = client.fetchQuery(
-        modeToQuery(term, currentMode, config, true),
-      );
-      return combineLatest([exactQuery, searchQuery, trendingQuery]).pipe(
-        map(([exactResults, searchResults, trendingResults]) => ({
-          type: 'media' as const,
-          items: dedupe(
-            (item) => item.key,
-            (exactResults as MediaSearchResult).items,
-            trendingResults?.items ?? [],
-            (searchResults as MediaSearchResult).items,
-          ),
-        })),
+          const exactQuery = client.fetchQuery(
+            modeToQuery(term, currentMode, freshConfig, true),
+          );
+          return combineLatest([exactQuery, searchQuery, trendingQuery]).pipe(
+            map(([exactResults, searchResults, trendingResults]) => ({
+              type: 'media' as const,
+              items: dedupe(
+                (item) => item.key,
+                (exactResults as MediaSearchResult).items,
+                trendingResults?.items ?? [],
+                (searchResults as MediaSearchResult).items,
+              ),
+            })),
+          );
+        }),
+        // Contain a failed lookup to this search. Without this the error
+        // propagates through switchMap and terminates the whole stream, so
+        // every later search silently returns nothing until remount.
+        catchError(() => of(null)),
       );
     }),
     tap(() => isSearching.next(false)),

--- a/projects/client/src/routes/api/search-keys/+server.ts
+++ b/projects/client/src/routes/api/search-keys/+server.ts
@@ -1,0 +1,8 @@
+import { mintSearchKeysFromEnv } from '$lib/features/search/mintSearchKeysFromEnv.ts';
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+// Re-mints scoped search keys so long-lived tabs can refresh before the
+// short-lived token expires. Mirrors the mint in the root handle hook.
+export const GET: RequestHandler = () => {
+  return json(mintSearchKeysFromEnv());
+};


### PR DESCRIPTION
## Why

Scoped Typesense keys are handed to the browser, so any clamp we apply in client JS is bypassable by calling Typesense directly with the token. Typesense only enforces params that are **baked into the scoped key** - the client cannot override those. So the real enforcement has to move into the key itself.

## What

- **Embed hard caps in the scoped key.** Adds `search_cutoff_ms` and `per_page` alongside the existing `limit_hits`. `search_cutoff_ms` is a per-search time wall: normal short queries finish well under it, so relevance is unchanged, while a pathological large query returns early instead of allocating a huge expansion state.
- **Shorter TTL.** Scoped-key lifetime drops from 6h to 15m to shrink the replay window on a leaked token.
- **Shared mint.** Extracts the logic into `mintSearchKeys()` so the root `handle` hook and the new `/api/search-keys` endpoint use one definition.
- **On-demand re-mint.** The search context now holds keys in a `BehaviorSubject` and refreshes via `/api/search-keys` before the TTL lapses (12m threshold, below the 15m server TTL). A tab left open keeps searching with a live key instead of hitting an expired-token 401.

## Not doing (yet)

`num_typos` / `max_candidates` stay at preset defaults. Lowering them would trim typo tolerance for normal users, and the cutoff already caps compute without that cost. Can revisit if telemetry shows expansion pressure.

## Follow-ups (out of scope)

- Rate-limit `/api/search-keys` per session/IP (it is a public mint surface).
- Edge body-size + rate limit in front of the Typesense host, if it is CF-frontable.
- Tune `search_cutoff_ms` (currently 250ms) toward 100-150ms once p99 search latency is confirmed from logs.

## Test plan

- [x] `deno task check` - no new type errors (7 pre-existing, unrelated)
- [x] `deno task lint` - clean on touched files
- [x] `useSearch.spec.ts` passes
- [x] Manual: search works normally; leave a tab idle past 12m, search again, confirm a fresh key is minted (network tab shows `/api/search-keys`) and results return