### PR TITLE
fix(client): preserve rated_at date in import ratings sync payload

### DIFF
--- a/projects/client/src/lib/sections/settings/import/engine/buildRatingsPayload.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/engine/buildRatingsPayload.spec.ts
@@ -21,6 +21,24 @@ describe('buildRatingsPayload', () => {
       expect(result.shows).toHaveLength(0);
     });
 
+    it('should preserve rated_at date for movies', () => {
+      const item: UniversalImportItem = {
+        action: 'ratings',
+        type: 'movie',
+        ids: { imdb: 'tt1234567' },
+        rating: 8,
+        rated_at: '2022-09-18T00:00:00.000Z',
+      };
+
+      const result = buildRatingsPayload([item]);
+
+      expect(result.movies).toEqual([{
+        rating: 8,
+        ids: { imdb: 'tt1234567' },
+        rated_at: '2022-09-18T00:00:00.000Z',
+      }]);
+    });
+
     it('should skip a movie with no resolvable ids', () => {
       const item: UniversalImportItem = {
         action: 'ratings',
@@ -50,11 +68,16 @@ describe('buildRatingsPayload', () => {
         type: 'show',
         ids: { tvdb: 81189 },
         rating: 10,
+        rated_at: '2022-09-18T00:00:00.000Z',
       };
 
       const result = buildRatingsPayload([item]);
 
-      expect(result.shows).toEqual([{ rating: 10, ids: { tvdb: 81189 } }]);
+      expect(result.shows).toEqual([{
+        rating: 10,
+        ids: { tvdb: 81189 },
+        rated_at: '2022-09-18T00:00:00.000Z',
+      }]);
       expect(result.movies).toHaveLength(0);
     });
   });

--- a/projects/client/src/lib/sections/settings/import/engine/buildRatingsPayload.ts
+++ b/projects/client/src/lib/sections/settings/import/engine/buildRatingsPayload.ts
@@ -10,21 +10,29 @@ function clampRating(rating: number): number {
 }
 
 function toRatingsMovie(
-  { ids, rating }: UniversalImportItem,
+  { ids, rating, rated_at }: UniversalImportItem,
 ): RatingsMovie | null {
   if (rating == null) return null;
   const resolvedIds = pickIds(ids, MOVIE_IDS);
   if (!resolvedIds) return null;
-  return { rating: clampRating(rating), ids: resolvedIds as never };
+  return {
+    rating: clampRating(rating),
+    ids: resolvedIds as never,
+    ...(rated_at ? { rated_at } : {}),
+  };
 }
 
 function toRatingsShow(
-  { ids, rating }: UniversalImportItem,
+  { ids, rating, rated_at }: UniversalImportItem,
 ): RatingsShow | null {
   if (rating == null) return null;
   const resolvedIds = pickIds(ids, SHOW_IDS);
   if (!resolvedIds) return null;
-  return { rating: clampRating(rating), ids: resolvedIds as never };
+  return {
+    rating: clampRating(rating),
+    ids: resolvedIds as never,
+    ...(rated_at ? { rated_at } : {}),
+  };
 }
 
 export function buildRatingsPayload(

--- a/projects/client/src/lib/sections/settings/import/parsers/LetterboxdParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/LetterboxdParser.spec.ts
@@ -157,6 +157,7 @@ describe('LetterboxdParser', () => {
         title: 'Inception',
         year: 2010,
         rating: 8,
+        rated_at: '2024-01-15T00:00:00.000Z',
       });
     });
 


### PR DESCRIPTION
## Scene Setting: A Clear Description

Currently, when importing rating records from import files (such as Letterboxd, IMDb, or Trakt CSV/JSON exports), the payload builder does not map the `rated_at` property from the parsed items. Because of this omission, all imported ratings are submitted to Trakt with the default "today" timestamp (the current import time).

This PR fixes this behavior by extracting and mapping the `rated_at` field inside the `toRatingsMovie` and `toRatingsShow` mapping functions of `buildRatingsPayload.ts`. This ensures that rated movies and shows are imported with their actual rating dates instead of the current import date.

## Show, Don't Tell: Screenshots and Videos

*No visual UI changes were made. This is a logic fix in the background parser payload builder.*

## Testing: The Dress Rehearsal

New test cases have been added to verify that the date is successfully mapped and preserved:
1. Updated `buildRatingsPayload.spec.ts` under the `movies` and `shows` suites to verify that `rated_at` is preserved in the mapped payloads.
2. Updated `LetterboxdParser.spec.ts` to assert that the parsed output contains the correct `rated_at` ISO timestamp.

All client unit tests have been run and are passing.

## Pull Request Checklist

- [x] **Clear and Concise Title:** Followed conventional commit format with scope.
- [x] **Detailed Description:** Described the issue and fix details.
- [x] **Screenshots/Videos:** N/A (background logic fix).
- [x] **Tests:** Added unit test coverage in both `buildRatingsPayload.spec.ts` and `LetterboxdParser.spec.ts`.
- [x] **Coding Standards:** Code is formatted using `deno fmt`.
- [x] **Commit Messages:** Followed Conventional Commits.
- [x] **Documentation:** No documentation updates needed for this logic fix.
- [x] **Code Review:** Ready to address feedback.
