### PR TITLE
feat(pwa): offline mode for tracking actions

### DIFF
--- a/.agents/rules/components.md
+++ b/.agents/rules/components.md
@@ -221,6 +221,10 @@ export function useUser() {
 - Return `$derived` values, not raw observables
 - Do **not** import across feature boundaries - if sharing needed, expose via
   context or shared section
+- Hooks that fire user tracking mutations (history, watchlist, ratings,
+  favorites) route writes through `executeOrEnqueue` and overlay reads with
+  `findPendingOverride` so actions work offline - see "Pattern 5" in
+  `requests.md`
 
 ### Hooks that drive `useQuery` take `Observable<T>`, never a bare value
 
@@ -388,8 +392,12 @@ concatenation.
 ```
 
 ```scss
-button[data-variant='primary'] { … }
-button[data-style='filled'] { … }
+button[data-variant='primary'] {
+  …
+}
+button[data-style='filled'] {
+  …
+}
 ```
 
 Common attributes:
@@ -451,8 +459,12 @@ nests them under the root selector so the global namespace stays clean.
 
 ```scss
 .trakt-card {
-  .card-cover { … }
-  .card-title { … }
+  .card-cover {
+    …
+  }
+  .card-title {
+    …
+  }
 }
 ```
 
@@ -478,9 +490,15 @@ expressed as state classes prefixed `is-` or `has-`, toggled with Svelte's
 
 ```scss
 .trakt-drawer {
-  &.is-open { … }
-  &.is-loading { … }
-  &.has-error { … }
+  &.is-open {
+    …
+  }
+  &.is-loading {
+    …
+  }
+  &.has-error {
+    …
+  }
 }
 ```
 
@@ -504,13 +522,23 @@ components and are forbidden.
 
 ```scss
 // Good
-.trakt-button { … }
-.trakt-button[data-variant='primary'] { … }
-.trakt-button .button-label { … }
+.trakt-button {
+  …
+}
+.trakt-button[data-variant='primary'] {
+  …
+}
+.trakt-button .button-label {
+  …
+}
 
 // Bad
-button { … }                    // leaks globally
-.primary { … }                  // collides with utility
+button {
+  …
+} // leaks globally
+.primary {
+  …
+} // collides with utility
 .button[data-variant='primary'] // unprefixed, fragile
 ```
 

--- a/.agents/rules/requests.md
+++ b/.agents/rules/requests.md
@@ -11,8 +11,10 @@ applyTo: 'projects/client/src/lib/requests/**'
 
 `lib/requests/` integrates with two sources:
 
-- **`@trakt/api`** - Typed SDK for Trakt v2 REST API. Use `api({ fetch })` to call it.
-- **`v3/` endpoints** - Untyped internal endpoints accessed via `rawApiFetch`. Always define a local Zod schema for their response.
+- **`@trakt/api`** - Typed SDK for Trakt v2 REST API. Use `api({ fetch })` to
+  call it.
+- **`v3/` endpoints** - Untyped internal endpoints accessed via `rawApiFetch`.
+  Always define a local Zod schema for their response.
 
 ---
 
@@ -69,8 +71,10 @@ export const someQuery = defineQuery({
 - `request` receives full `params` object - destructure only what you need.
 - `mapper` transforms `response.body` (typed by SDK) into domain model.
 - `schema` is Zod schema for **output** - validates what `mapper` returns.
-- `dependencies` must list every param that, when changed, should refetch. Use spread helpers for filters/search (see below).
-- `invalidations` lists `InvalidateAction.*` tokens that bust this cache when mutations fire.
+- `dependencies` must list every param that, when changed, should refetch. Use
+  spread helpers for filters/search (see below).
+- `invalidations` lists `InvalidateAction.*` tokens that bust this cache when
+  mutations fire.
 
 ---
 
@@ -123,7 +127,9 @@ export const someListQuery = defineInfiniteQuery({
 
 ## Pattern 3 - `v3/` Endpoint Query
 
-`v3/` endpoints not covered by `@trakt/api`'s type system. **Always** define a Zod schema locally for their response, parse with it before returning from request function.
+`v3/` endpoints not covered by `@trakt/api`'s type system. **Always** define a
+Zod schema locally for their response, parse with it before returning from
+request function.
 
 ```ts
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
@@ -174,15 +180,19 @@ export const someV3Query = defineQuery({
 ### Key rules
 
 - **Always** `.parse()` raw JSON - never trust unvalidated `v3/` responses.
-- If endpoint can return empty/error body, guard with `response.ok` and return `{ body: undefined, status: 200 }` as fallback so `mapper` receives `undefined` and handles it gracefully.
+- If endpoint can return empty/error body, guard with `response.ok` and return
+  `{ body: undefined, status: 200 }` as fallback so `mapper` receives
+  `undefined` and handles it gracefully.
 - Export `ResponseSchema` when other files need to reference it.
-- Keep raw response schema (`...ResponseSchema`) and domain schema (`...Schema`) separate.
+- Keep raw response schema (`...ResponseSchema`) and domain schema (`...Schema`)
+  separate.
 
 ---
 
 ## Pattern 4 - Mutation Request
 
-Use for write operations (add, remove, update). Plain async functions - not queries.
+Use for write operations (add, remove, update). Plain async functions - not
+queries.
 
 ```ts
 import { api, type ApiParams } from '$lib/requests/api.ts';
@@ -202,7 +212,60 @@ export function someActionRequest(
 }
 ```
 
-For `v3/` mutations use `rawApiFetch` with `method: 'POST'` / `'DELETE'` and validate with Zod if response body matters.
+For `v3/` mutations use `rawApiFetch` with `method: 'POST'` / `'DELETE'` and
+validate with Zod if response body matters.
+
+---
+
+## Pattern 5 - Offline-Aware Tracking Mutation
+
+User tracking mutations (history, watchlist, ratings, favorites) must survive a
+dead connection: they queue in IndexedDB and replay when connectivity returns.
+The infrastructure lives in `lib/features/offline/`.
+
+**Hooks never call these request functions directly.** They go through
+`executeOrEnqueue`, which runs the request when online and queues it (deduped by
+media key set, latest intent wins) on network failure:
+
+```ts
+import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
+import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
+
+await executeOrEnqueue({
+  endpoint: 'watchlist:add',
+  keys: media.map((item) => toMediaKey(type, item.id)),
+  body,
+  invalidations: [InvalidateAction.Watchlisted(type)],
+});
+await invalidate(InvalidateAction.Watchlisted(type));
+```
+
+The matching read store overlays the pending queue so the UI reflects the action
+while offline (see `useIsWatched` / `useIsWatchlisted`):
+
+```ts
+const pending = findPendingOverride({ actions: $actions, domain, keys });
+if (pending) return isAddEndpoint(pending.endpoint);
+// ...fall through to server state
+```
+
+### Adding a new offline-queueable action
+
+1. Add the endpoint to `OfflineActionEndpointSchema`
+   (`offline/models/OfflineActionEndpoint.ts`) - format `{domain}:{add|remove}`.
+2. Map its body type in `offline/models/OfflineActionBody.ts`.
+3. Register the executor in `offline/_internal/executeOfflineAction.ts`
+   (endpoint -> existing `*Request` function).
+4. Route the hook's write through `executeOrEnqueue` with `toMediaKey` keys and
+   the same `InvalidateAction` tokens the hook already fires.
+5. Overlay the read store with `findPendingOverride` + `isAddEndpoint`.
+6. If replaying the action can duplicate server-side effects (like extra history
+   plays), extend the reconcile step
+   (`offline/_internal/findDuplicateWatch.ts`); idempotent actions (watchlist,
+   ratings, favorites) skip it.
+
+Keep real-time actions (e.g. check-in) out of the queue - replaying them after
+the fact is semantically wrong.
 
 ---
 
@@ -210,8 +273,10 @@ For `v3/` mutations use `rawApiFetch` with `method: 'POST'` / `'DELETE'` and val
 
 - Pure functions - no side effects, no API calls.
 - Named `mapTo{DomainType}(apiResponse): DomainType`.
-- Live in `_internal/` if reused across queries; inline or exported from query file if used only once or twice.
-- When extending existing mapper (e.g., adding a field), prefer `.extend()` on schema rather than duplicating.
+- Live in `_internal/` if reused across queries; inline or exported from query
+  file if used only once or twice.
+- When extending existing mapper (e.g., adding a field), prefer `.extend()` on
+  schema rather than duplicating.
 
 ```ts
 // _internal/mapToEntry.ts
@@ -229,7 +294,8 @@ export function mapToEntry(response: EntryResponse): Entry {
 ## Models
 
 - Define Zod schema first; derive TypeScript type with `z.infer`.
-- Use `.nullish()` for optional nullable fields, `.optional()` for fields that may be absent.
+- Use `.nullish()` for optional nullable fields, `.optional()` for fields that
+  may be absent.
 - Export both schema (`EntitySchema`) and type (`Entity`) from same file.
 
 ```ts
@@ -281,7 +347,8 @@ Leave `invalidations: []` for queries that never need external cache busting.
 
 ## Filter & Search Dependencies
 
-When a query accepts `FilterParams` or `SearchParams`, spread the helper functions in `dependencies`:
+When a query accepts `FilterParams` or `SearchParams`, spread the helper
+functions in `dependencies`:
 
 ```ts
 import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
@@ -335,3 +402,5 @@ Before submitting a new query or request, verify:
 - [ ] `invalidations` lists relevant `InvalidateAction.*` tokens
 - [ ] Mapper is pure function - no side effects
 - [ ] `ttl` is appropriate for data's freshness requirements
+- [ ] Tracking mutation: hook routes through `executeOrEnqueue` (Pattern 5),
+      read store overlays the pending queue via `findPendingOverride`

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -8978,6 +8978,58 @@
       "default": "your streaming service",
       "description": "Generic fallback name used when a streaming service name can't be resolved."
     },
+    "text_offline_queued_title": {
+      "default": "Saved while offline",
+      "description": "Title of the snackbar shown when a tracking action is queued because there is no connection."
+    },
+    "text_offline_queued_message": {
+      "default": "We'll sync your activity with Trakt once you're back online.",
+      "description": "Message of the snackbar shown when a tracking action is queued because there is no connection."
+    },
+    "text_offline_synced_title": {
+      "default": "Back online",
+      "description": "Title of the snackbar shown after queued offline actions were synced."
+    },
+    "text_offline_synced_message_one": {
+      "default": "Your offline action has been synced.",
+      "description": "Message shown after exactly one queued offline action was synced."
+    },
+    "text_offline_synced_message_other": {
+      "default": "{count} offline actions have been synced.",
+      "description": "Message shown after multiple queued offline actions were synced."
+    },
+    "text_offline_sync_failed_title": {
+      "default": "Some actions didn't sync",
+      "description": "Title of the snackbar shown when the server rejected queued offline actions."
+    },
+    "text_offline_sync_failed_message_one": {
+      "default": "An offline action was rejected by the server and removed.",
+      "description": "Message shown when the server rejected exactly one queued offline action."
+    },
+    "text_offline_sync_failed_message_other": {
+      "default": "{count} offline actions were rejected by the server and removed.",
+      "description": "Message shown when the server rejected multiple queued offline actions."
+    },
+    "text_offline_duplicate_title": {
+      "default": "Already synced elsewhere",
+      "description": "Title of the snackbar asking whether to replay offline watches that were already recorded from another device."
+    },
+    "text_offline_duplicate_message_one": {
+      "default": "An item you tracked offline was already marked as watched from another device. Add the extra play?",
+      "description": "Prompt shown when exactly one queued offline watch was already recorded from another device."
+    },
+    "text_offline_duplicate_message_other": {
+      "default": "{count} items you tracked offline were already marked as watched from another device. Add the extra plays?",
+      "description": "Prompt shown when multiple queued offline watches were already recorded from another device."
+    },
+    "button_text_sync_anyway": {
+      "default": "Add anyway",
+      "description": "Button text confirming that duplicate offline watches should be replayed as extra plays."
+    },
+    "button_label_sync_anyway": {
+      "default": "Add the offline plays anyway",
+      "description": "Accessible label for the button confirming that duplicate offline watches should be replayed."
+    },
     "error_text_sync_load_failed": {
       "default": "We couldn't load this right now. Please try again.",
       "description": "Inline error message shown when a streaming sync detail or its items fail to load."

--- a/projects/client/src/lib/features/offline/OfflineSync.svelte
+++ b/projects/client/src/lib/features/offline/OfflineSync.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+  import Snackbar from "$lib/components/snackbar/Snackbar.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { useInvalidator } from "$lib/stores/useInvalidator.ts";
+  import { distinctUntilChanged, filter, pairwise } from "rxjs";
+  import { onMount } from "svelte";
+  import { offlineActionsStore } from "./_internal/offlineActionsStore.ts";
+  import { onlineStatusStore } from "./_internal/onlineStatusStore.ts";
+  import {
+    replayOfflineActions,
+    type ReplayOutcome,
+  } from "./_internal/replayOfflineActions.ts";
+  import type { OfflineAction } from "./models/OfflineAction.ts";
+  import { time } from "$lib/utils/timing/time.ts";
+
+  const NOTICE_DURATION_MS = time.seconds(6);
+  const QUEUED_NOTICE_WINDOW_MS = time.seconds(10);
+
+  type Notice =
+    | { kind: "queued" }
+    | { kind: "synced"; count: number }
+    | { kind: "failed"; count: number };
+
+  const { invalidateAll } = useInvalidator();
+
+  let notice = $state<Notice | null>(null);
+  let duplicates = $state<OfflineAction[]>([]);
+  let isReplaying = false;
+
+  const applyOutcome = async (outcome: ReplayOutcome) => {
+    await offlineActionsStore.remove([
+      ...outcome.executedIds,
+      ...outcome.failedIds,
+    ]);
+
+    if (outcome.invalidations.length > 0) {
+      await invalidateAll(outcome.invalidations);
+    }
+
+    if (outcome.failedIds.length > 0) {
+      notice = { kind: "failed", count: outcome.failedIds.length };
+      return;
+    }
+
+    if (outcome.executedIds.length > 0) {
+      notice = { kind: "synced", count: outcome.executedIds.length };
+    }
+  };
+
+  const replay = async () => {
+    await offlineActionsStore.refresh();
+    const actions = offlineActionsStore.current();
+
+    if (actions.length === 0) {
+      return;
+    }
+
+    const outcome = await replayOfflineActions({ actions });
+    await applyOutcome(outcome);
+    duplicates = outcome.duplicates;
+  };
+
+  // The web lock keeps two tabs from replaying the same queue at once; the
+  // losing tab skips and picks up whatever is left on its next trigger.
+  const withReplayLock = async (task: () => Promise<void>) => {
+    if (!navigator.locks) {
+      await task();
+      return;
+    }
+
+    await navigator.locks.request(
+      "trakt-offline-replay",
+      { ifAvailable: true },
+      async (lock) => {
+        if (lock) {
+          await task();
+        }
+      },
+    );
+  };
+
+  const runReplay = async () => {
+    if (isReplaying) {
+      return;
+    }
+
+    isReplaying = true;
+
+    try {
+      await withReplayLock(replay);
+    } finally {
+      isReplaying = false;
+    }
+  };
+
+  const syncDuplicatesAnyway = async () => {
+    const approved = duplicates;
+    duplicates = [];
+
+    const outcome = await replayOfflineActions({
+      actions: approved,
+      reconcile: false,
+    });
+    await applyOutcome(outcome);
+  };
+
+  const skipDuplicates = async () => {
+    const skipped = duplicates;
+    duplicates = [];
+
+    await offlineActionsStore.remove(skipped.map(({ id }) => id));
+  };
+
+  onMount(() => {
+    const replayTrigger = onlineStatusStore.isOnline$
+      .pipe(distinctUntilChanged(), filter(Boolean))
+      .subscribe(() => void runReplay());
+
+    const queuedNotice = offlineActionsStore.actions$
+      .pipe(pairwise())
+      .subscribe(([previous, next]) => {
+        if (next.length <= previous.length) {
+          return;
+        }
+
+        // IDB hydration also grows the queue; only a just-queued action
+        // should toast, not actions restored from a previous session.
+        const latest = next.at(-1);
+        const isRecent = latest &&
+          Date.now() - latest.queuedAt < QUEUED_NOTICE_WINDOW_MS;
+
+        if (isRecent) {
+          notice = { kind: "queued" };
+        }
+      });
+
+    return () => {
+      replayTrigger.unsubscribe();
+      queuedNotice.unsubscribe();
+    };
+  });
+
+  const noticeContent = $derived.by(() => {
+    if (!notice) {
+      return null;
+    }
+
+    switch (notice.kind) {
+      case "queued":
+        return {
+          title: m.text_offline_queued_title(),
+          message: m.text_offline_queued_message(),
+          variant: "default" as const,
+        };
+      case "synced":
+        return {
+          title: m.text_offline_synced_title(),
+          message:
+            notice.count === 1
+              ? m.text_offline_synced_message_one()
+              : m.text_offline_synced_message_other({ count: notice.count }),
+          variant: "default" as const,
+        };
+      case "failed":
+        return {
+          title: m.text_offline_sync_failed_title(),
+          message:
+            notice.count === 1
+              ? m.text_offline_sync_failed_message_one()
+              : m.text_offline_sync_failed_message_other({
+                  count: notice.count,
+                }),
+          variant: "error" as const,
+        };
+    }
+  });
+</script>
+
+{#if duplicates.length > 0}
+  <Snackbar
+    open
+    title={m.text_offline_duplicate_title()}
+    message={duplicates.length === 1
+      ? m.text_offline_duplicate_message_one()
+      : m.text_offline_duplicate_message_other({ count: duplicates.length })}
+    action={{
+      text: m.button_text_sync_anyway(),
+      label: m.button_label_sync_anyway(),
+      onAction: () => void syncDuplicatesAnyway(),
+    }}
+    onDismiss={() => void skipDuplicates()}
+  />
+{:else if noticeContent}
+  <Snackbar
+    open
+    title={noticeContent.title}
+    message={noticeContent.message}
+    variant={noticeContent.variant}
+    dismissDurationMs={NOTICE_DURATION_MS}
+    onDismiss={() => (notice = null)}
+  />
+{/if}

--- a/projects/client/src/lib/features/offline/_internal/FreshWatchedState.ts
+++ b/projects/client/src/lib/features/offline/_internal/FreshWatchedState.ts
@@ -1,0 +1,5 @@
+export type FreshWatchedState = {
+  movies: Map<number, Date>;
+  shows: Map<number, Date>;
+  episodes: Map<number, Date>;
+};

--- a/projects/client/src/lib/features/offline/_internal/OfflineActionsStorage.ts
+++ b/projects/client/src/lib/features/offline/_internal/OfflineActionsStorage.ts
@@ -1,0 +1,6 @@
+import type { OfflineAction } from '../models/OfflineAction.ts';
+
+export type OfflineActionsStorage = {
+  read: () => Promise<OfflineAction[]>;
+  write: (actions: OfflineAction[]) => Promise<void>;
+};

--- a/projects/client/src/lib/features/offline/_internal/createOfflineActionsStorage.ts
+++ b/projects/client/src/lib/features/offline/_internal/createOfflineActionsStorage.ts
@@ -1,0 +1,35 @@
+import { error } from '$lib/utils/console/print.ts';
+import { createStore, get, set } from 'idb-keyval';
+import { OfflineActionSchema } from '../models/OfflineAction.ts';
+import type { OfflineActionsStorage } from './OfflineActionsStorage.ts';
+
+const DB_NAME = 'trakt-offline';
+const STORE_NAME = 'action-queue';
+const QUEUE_KEY = 'queue';
+
+const handleError = (e: unknown) => {
+  error('Offline actions storage error:', e);
+};
+
+// Entries round-trip through IDB structured clone. Each entry is validated on
+// read so malformed rows from older deploys are dropped instead of breaking
+// the queue.
+export function createOfflineActionsStorage(): OfflineActionsStorage {
+  const store = createStore(DB_NAME, STORE_NAME);
+
+  return {
+    read: () =>
+      get<unknown[]>(QUEUE_KEY, store)
+        .then((stored) =>
+          (stored ?? [])
+            .map((entry) => OfflineActionSchema.safeParse(entry))
+            .filter((result) => result.success)
+            .map((result) => result.data)
+        )
+        .catch((e) => {
+          handleError(e);
+          return [];
+        }),
+    write: (actions) => set(QUEUE_KEY, actions, store).catch(handleError),
+  };
+}

--- a/projects/client/src/lib/features/offline/_internal/createOfflineActionsStore.spec.ts
+++ b/projects/client/src/lib/features/offline/_internal/createOfflineActionsStore.spec.ts
@@ -1,0 +1,129 @@
+import { buildOfflineAction } from '$test/beds/offline/buildOfflineAction.ts';
+import { describe, expect, it, vi } from 'vitest';
+import type { OfflineAction } from '../models/OfflineAction.ts';
+import { createOfflineActionsStore } from './createOfflineActionsStore.ts';
+import type { OfflineActionsStorage } from './OfflineActionsStorage.ts';
+
+function createMemoryStorage(
+  initial: OfflineAction[] = [],
+): OfflineActionsStorage & { stored: () => OfflineAction[] } {
+  let stored = initial;
+
+  return {
+    read: () => Promise.resolve(stored),
+    write: (actions) => {
+      stored = actions;
+      return Promise.resolve();
+    },
+    stored: () => stored,
+  };
+}
+
+describe('store: createOfflineActionsStore', () => {
+  it('should hydrate queued actions from storage', async () => {
+    const action = buildOfflineAction();
+    const store = createOfflineActionsStore(createMemoryStorage([action]));
+
+    await store.refresh();
+
+    expect(store.current()).toEqual([action]);
+  });
+
+  it('should append and persist enqueued actions', async () => {
+    const storage = createMemoryStorage();
+    const store = createOfflineActionsStore(storage);
+
+    const first = buildOfflineAction({ keys: ['movie:1'] });
+    const second = buildOfflineAction({ keys: ['movie:2'] });
+    await store.enqueue(first);
+    await store.enqueue(second);
+
+    expect(store.current()).toEqual([first, second]);
+    expect(storage.stored()).toEqual([first, second]);
+  });
+
+  it('should supersede an action with the same domain and keys', async () => {
+    const store = createOfflineActionsStore(createMemoryStorage());
+
+    const add = buildOfflineAction({ endpoint: 'history:add' });
+    const remove = buildOfflineAction({
+      endpoint: 'history:remove',
+      queuedAt: 2,
+    });
+    await store.enqueue(add);
+    await store.enqueue(remove);
+
+    expect(store.current()).toEqual([remove]);
+  });
+
+  it('should keep actions from other domains for the same keys', async () => {
+    const store = createOfflineActionsStore(createMemoryStorage());
+
+    const watch = buildOfflineAction({ endpoint: 'history:add' });
+    const rate = buildOfflineAction({
+      endpoint: 'rating:add',
+      body: { movies: [{ ids: { trakt: 1 }, rating: 8 }] },
+      invalidations: ['invalidate:rated:movie'],
+    });
+    await store.enqueue(watch);
+    await store.enqueue(rate);
+
+    expect(store.current()).toEqual([watch, rate]);
+  });
+
+  it('should keep actions with a different key set in the same domain', async () => {
+    const store = createOfflineActionsStore(createMemoryStorage());
+
+    const single = buildOfflineAction({ keys: ['movie:1'] });
+    const bulk = buildOfflineAction({ keys: ['movie:1', 'movie:2'] });
+    await store.enqueue(single);
+    await store.enqueue(bulk);
+
+    expect(store.current()).toEqual([single, bulk]);
+  });
+
+  it('should remove actions by id', async () => {
+    const storage = createMemoryStorage();
+    const store = createOfflineActionsStore(storage);
+
+    const first = buildOfflineAction({ keys: ['movie:1'] });
+    const second = buildOfflineAction({ keys: ['movie:2'] });
+    await store.enqueue(first);
+    await store.enqueue(second);
+
+    await store.remove([first.id]);
+
+    expect(store.current()).toEqual([second]);
+    expect(storage.stored()).toEqual([second]);
+  });
+
+  it('should pick up external storage writes on refresh', async () => {
+    const storage = createMemoryStorage();
+    const store = createOfflineActionsStore(storage);
+
+    const external = buildOfflineAction();
+    await storage.write([external]);
+    await store.refresh();
+
+    expect(store.current()).toEqual([external]);
+  });
+
+  it('should keep accepting mutations after a storage failure', async () => {
+    const storage = createMemoryStorage();
+    const failOnce = {
+      ...storage,
+      write: vi.fn()
+        .mockRejectedValueOnce(new Error('quota exceeded'))
+        .mockImplementation(storage.write),
+    };
+    const store = createOfflineActionsStore(failOnce);
+
+    const dropped = buildOfflineAction({ keys: ['movie:1'] });
+    const queued = buildOfflineAction({ keys: ['movie:2'] });
+    await store.enqueue(dropped);
+    await store.enqueue(queued);
+
+    expect(store.current()).toEqual([dropped, queued]);
+    expect(storage.stored()).toEqual([dropped, queued]);
+  });
+});

--- a/projects/client/src/lib/features/offline/_internal/createOfflineActionsStore.ts
+++ b/projects/client/src/lib/features/offline/_internal/createOfflineActionsStore.ts
@@ -1,0 +1,72 @@
+import { BehaviorSubject, type Observable } from 'rxjs';
+import type { OfflineAction } from '../models/OfflineAction.ts';
+import type { OfflineActionsStorage } from './OfflineActionsStorage.ts';
+
+export type OfflineActionsStore = {
+  actions$: Observable<OfflineAction[]>;
+  current: () => OfflineAction[];
+  enqueue: (action: OfflineAction) => Promise<void>;
+  remove: (ids: string[]) => Promise<void>;
+  refresh: () => Promise<void>;
+};
+
+function toDomain(endpoint: OfflineAction['endpoint']) {
+  return endpoint.split(':').at(0);
+}
+
+// Same domain + same key set = the newer action supersedes the older one
+// (e.g. mark watched then unmark while offline leaves only the unmark).
+function isSuperseded(queued: OfflineAction, incoming: OfflineAction): boolean {
+  return toDomain(queued.endpoint) === toDomain(incoming.endpoint) &&
+    queued.keys.length === incoming.keys.length &&
+    queued.keys.every((key) => incoming.keys.includes(key));
+}
+
+export function createOfflineActionsStore(
+  storage: OfflineActionsStorage,
+): OfflineActionsStore {
+  const actions = new BehaviorSubject<OfflineAction[]>([]);
+
+  // A rejected link would brick every later mutation, so each one settles:
+  // persistence is best-effort and the in-memory queue stays authoritative.
+  const settled = (task: Promise<unknown>) => task.catch(() => undefined);
+
+  // Serializes hydration and every mutation so concurrent enqueues never
+  // clobber each other's storage writes.
+  let pending: Promise<unknown> = settled(
+    storage.read().then((stored) => {
+      actions.next([...stored, ...actions.getValue()]);
+    }),
+  );
+
+  const mutate = (updater: (current: OfflineAction[]) => OfflineAction[]) => {
+    pending = settled(
+      pending.then(() => {
+        const next = updater(actions.getValue());
+        actions.next(next);
+        return storage.write(next);
+      }),
+    );
+    return pending.then(() => undefined);
+  };
+
+  return {
+    actions$: actions.asObservable(),
+    current: () => actions.getValue(),
+    enqueue: (action) =>
+      mutate((current) => [
+        ...current.filter((queued) => !isSuperseded(queued, action)),
+        action,
+      ]),
+    remove: (ids) =>
+      mutate((current) => current.filter((queued) => !ids.includes(queued.id))),
+    refresh: () => {
+      pending = settled(
+        pending.then(async () => {
+          actions.next(await storage.read());
+        }),
+      );
+      return pending.then(() => undefined);
+    },
+  };
+}

--- a/projects/client/src/lib/features/offline/_internal/executeOfflineAction.ts
+++ b/projects/client/src/lib/features/offline/_internal/executeOfflineAction.ts
@@ -1,0 +1,37 @@
+import { addRatingRequest } from '$lib/requests/sync/addRatingRequest.ts';
+import { addToFavoritesRequest } from '$lib/requests/sync/addToFavoritesRequest.ts';
+import { addToWatchlistRequest } from '$lib/requests/sync/addToWatchlistRequest.ts';
+import { markAsWatchedRequest } from '$lib/requests/sync/markAsWatchedRequest.ts';
+import { removeFromFavoritesRequest } from '$lib/requests/sync/removeFromFavoritesRequest.ts';
+import { removeFromWatchlistRequest } from '$lib/requests/sync/removeFromWatchlistRequest.ts';
+import { removeRatingRequest } from '$lib/requests/sync/removeRatingRequest.ts';
+import { removeWatchedRequest } from '$lib/requests/sync/removeWatchedRequest.ts';
+import type { OfflineAction } from '../models/OfflineAction.ts';
+import type { OfflineActionBody } from '../models/OfflineActionBody.ts';
+import type { OfflineActionEndpoint } from '../models/OfflineActionEndpoint.ts';
+
+type OfflineActionExecutors = {
+  [TEndpoint in OfflineActionEndpoint]: (
+    body: OfflineActionBody[TEndpoint],
+  ) => Promise<boolean>;
+};
+
+const EXECUTORS: OfflineActionExecutors = {
+  'history:add': (body) => markAsWatchedRequest({ body }),
+  'history:remove': (body) => removeWatchedRequest({ body }),
+  'watchlist:add': (body) => addToWatchlistRequest({ body }),
+  'watchlist:remove': (body) => removeFromWatchlistRequest({ body }),
+  'rating:add': (body) => addRatingRequest({ body }),
+  'rating:remove': (body) => removeRatingRequest({ body }),
+  'favorites:add': (body) => addToFavoritesRequest({ body }),
+  'favorites:remove': (body) => removeFromFavoritesRequest({ body }),
+};
+
+export function executeOfflineAction(action: OfflineAction): Promise<boolean> {
+  // Body typing is enforced at enqueue time (executeOrEnqueue); after an IDB
+  // round-trip it is `unknown`, so the executor takes it back on trust.
+  const execute = EXECUTORS[action.endpoint] as (
+    body: unknown,
+  ) => Promise<boolean>;
+  return execute(action.body);
+}

--- a/projects/client/src/lib/features/offline/_internal/fetchFreshWatchedState.ts
+++ b/projects/client/src/lib/features/offline/_internal/fetchFreshWatchedState.ts
@@ -1,0 +1,51 @@
+import {
+  currentUserWatchedMoviesQuery,
+  type WatchedMovie,
+} from '$lib/features/auth/queries/currentUserWatchedMoviesQuery.ts';
+import {
+  currentUserWatchedShowsQuery,
+  type WatchedShow,
+} from '$lib/features/auth/queries/currentUserWatchedShowsQuery.ts';
+import type { Paginatable } from '$lib/requests/models/Paginatable.ts';
+import type { FreshWatchedState } from './FreshWatchedState.ts';
+
+// Mirrors the page sizes in useCurrentUserHistory - one page covers the full
+// history for reconciliation purposes.
+const MOVIES_LIMIT = 10000;
+const SHOWS_LIMIT = 1000;
+
+type PageFetcher<T> = (context: { pageParam: number }) => Promise<
+  Paginatable<T>
+>;
+
+function fetchFirstPage<T>(queryFn: unknown): Promise<T[]> {
+  const fetchPage = queryFn as PageFetcher<T>;
+  return fetchPage({ pageParam: 1 }).then((page) => page.entries);
+}
+
+/**
+ * Fetches watched state straight from the server (bypasses the query cache)
+ * to detect plays recorded from another device while this one was offline.
+ */
+export async function fetchFreshWatchedState(): Promise<FreshWatchedState> {
+  const [movies, shows] = await Promise.all([
+    fetchFirstPage<WatchedMovie>(
+      currentUserWatchedMoviesQuery({ limit: MOVIES_LIMIT }).queryFn,
+    ),
+    fetchFirstPage<WatchedShow>(
+      currentUserWatchedShowsQuery({ limit: SHOWS_LIMIT }).queryFn,
+    ),
+  ]);
+
+  return {
+    movies: new Map(movies.map((movie) => [movie.id, movie.watchedAt])),
+    shows: new Map(shows.map((show) => [show.id, show.watchedAt])),
+    episodes: new Map(
+      shows.flatMap((show) =>
+        show.episodes.map((episode) =>
+          [episode.episodeId, episode.watchedAt] as const
+        )
+      ),
+    ),
+  };
+}

--- a/projects/client/src/lib/features/offline/_internal/findDuplicateWatch.spec.ts
+++ b/projects/client/src/lib/features/offline/_internal/findDuplicateWatch.spec.ts
@@ -1,0 +1,73 @@
+import { buildOfflineAction } from '$test/beds/offline/buildOfflineAction.ts';
+import { describe, expect, it } from 'vitest';
+import type { OfflineAction } from '../models/OfflineAction.ts';
+import { findDuplicateWatch } from './findDuplicateWatch.ts';
+import type { FreshWatchedState } from './FreshWatchedState.ts';
+
+const QUEUED_AT = new Date('2026-07-01T10:00:00Z').getTime();
+const BEFORE_QUEUE = new Date('2026-06-30T10:00:00Z');
+const AFTER_QUEUE = new Date('2026-07-02T10:00:00Z');
+
+function buildAction(overrides: Partial<OfflineAction> = {}): OfflineAction {
+  return buildOfflineAction({ queuedAt: QUEUED_AT, ...overrides });
+}
+
+function buildWatched(
+  overrides: Partial<FreshWatchedState> = {},
+): FreshWatchedState {
+  return {
+    movies: new Map(),
+    shows: new Map(),
+    episodes: new Map(),
+    ...overrides,
+  };
+}
+
+describe('util: findDuplicateWatch', () => {
+  it('should flag a movie watched elsewhere after it was queued', () => {
+    const watched = buildWatched({ movies: new Map([[1, AFTER_QUEUE]]) });
+
+    expect(findDuplicateWatch({ action: buildAction(), watched })).toBe(true);
+  });
+
+  it('should not flag a movie watched before it was queued', () => {
+    const watched = buildWatched({ movies: new Map([[1, BEFORE_QUEUE]]) });
+
+    expect(findDuplicateWatch({ action: buildAction(), watched })).toBe(false);
+  });
+
+  it('should not flag a movie without any server plays', () => {
+    expect(
+      findDuplicateWatch({ action: buildAction(), watched: buildWatched() }),
+    )
+      .toBe(false);
+  });
+
+  it('should flag an episode watched elsewhere after it was queued', () => {
+    const action = buildAction({ keys: ['episode:42'] });
+    const watched = buildWatched({ episodes: new Map([[42, AFTER_QUEUE]]) });
+
+    expect(findDuplicateWatch({ action, watched })).toBe(true);
+  });
+
+  it('should flag a show with plays recorded after it was queued', () => {
+    const action = buildAction({ keys: ['show:7'] });
+    const watched = buildWatched({ shows: new Map([[7, AFTER_QUEUE]]) });
+
+    expect(findDuplicateWatch({ action, watched })).toBe(true);
+  });
+
+  it('should flag a bulk action when any target is a duplicate', () => {
+    const action = buildAction({ keys: ['movie:1', 'movie:2'] });
+    const watched = buildWatched({ movies: new Map([[2, AFTER_QUEUE]]) });
+
+    expect(findDuplicateWatch({ action, watched })).toBe(true);
+  });
+
+  it('should never flag non-watch actions', () => {
+    const action = buildAction({ endpoint: 'history:remove' });
+    const watched = buildWatched({ movies: new Map([[1, AFTER_QUEUE]]) });
+
+    expect(findDuplicateWatch({ action, watched })).toBe(false);
+  });
+});

--- a/projects/client/src/lib/features/offline/_internal/findDuplicateWatch.ts
+++ b/projects/client/src/lib/features/offline/_internal/findDuplicateWatch.ts
@@ -1,0 +1,43 @@
+import type { OfflineAction } from '../models/OfflineAction.ts';
+import type { FreshWatchedState } from './FreshWatchedState.ts';
+
+type FindDuplicateWatchParams = {
+  action: OfflineAction;
+  watched: FreshWatchedState;
+};
+
+function toWatchedAt(
+  key: string,
+  watched: FreshWatchedState,
+): Date | undefined {
+  const [type, rawId] = key.split(':');
+  const id = Number(rawId);
+
+  switch (type) {
+    case 'movie':
+      return watched.movies.get(id);
+    case 'show':
+      return watched.shows.get(id);
+    case 'episode':
+      return watched.episodes.get(id);
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * A queued watch is a duplicate when the server recorded a play for one of
+ * its targets after it was queued (same thing watched from another device).
+ */
+export function findDuplicateWatch(
+  { action, watched }: FindDuplicateWatchParams,
+): boolean {
+  if (action.endpoint !== 'history:add') {
+    return false;
+  }
+
+  return action.keys.some((key) => {
+    const watchedAt = toWatchedAt(key, watched);
+    return watchedAt != null && watchedAt.getTime() >= action.queuedAt;
+  });
+}

--- a/projects/client/src/lib/features/offline/_internal/isNetworkError.ts
+++ b/projects/client/src/lib/features/offline/_internal/isNetworkError.ts
@@ -1,0 +1,5 @@
+// fetch rejects with a TypeError when the network is unreachable; HTTP error
+// statuses resolve normally, so this only matches true connectivity failures.
+export function isNetworkError(candidate: unknown): boolean {
+  return candidate instanceof TypeError;
+}

--- a/projects/client/src/lib/features/offline/_internal/offlineActionsStore.ts
+++ b/projects/client/src/lib/features/offline/_internal/offlineActionsStore.ts
@@ -1,0 +1,23 @@
+import { browser } from '$app/environment';
+import { createOfflineActionsStorage } from './createOfflineActionsStorage.ts';
+import {
+  createOfflineActionsStore,
+  type OfflineActionsStore,
+} from './createOfflineActionsStore.ts';
+import type { OfflineActionsStorage } from './OfflineActionsStorage.ts';
+
+const memoryStorage: OfflineActionsStorage = {
+  read: () => Promise.resolve([]),
+  write: () => Promise.resolve(),
+};
+
+function resolveStorage(): OfflineActionsStorage {
+  if (!browser || typeof indexedDB === 'undefined') {
+    return memoryStorage;
+  }
+
+  return createOfflineActionsStorage();
+}
+
+export const offlineActionsStore: OfflineActionsStore =
+  createOfflineActionsStore(resolveStorage());

--- a/projects/client/src/lib/features/offline/_internal/onlineStatusStore.ts
+++ b/projects/client/src/lib/features/offline/_internal/onlineStatusStore.ts
@@ -1,0 +1,19 @@
+import { browser } from '$app/environment';
+import { BehaviorSubject, type Observable } from 'rxjs';
+
+const isOnlineSubject = new BehaviorSubject<boolean>(
+  browser ? navigator.onLine : true,
+);
+
+if (browser) {
+  globalThis.addEventListener('online', () => isOnlineSubject.next(true));
+  globalThis.addEventListener('offline', () => isOnlineSubject.next(false));
+}
+
+export const onlineStatusStore: {
+  isOnline$: Observable<boolean>;
+  isOnline: () => boolean;
+} = {
+  isOnline$: isOnlineSubject.asObservable(),
+  isOnline: () => isOnlineSubject.getValue(),
+};

--- a/projects/client/src/lib/features/offline/_internal/replayOfflineActions.spec.ts
+++ b/projects/client/src/lib/features/offline/_internal/replayOfflineActions.spec.ts
@@ -1,0 +1,151 @@
+import { buildOfflineAction } from '$test/beds/offline/buildOfflineAction.ts';
+import { describe, expect, it, vi } from 'vitest';
+import type { OfflineAction } from '../models/OfflineAction.ts';
+import type { FreshWatchedState } from './FreshWatchedState.ts';
+import { replayOfflineActions } from './replayOfflineActions.ts';
+
+const QUEUED_AT = new Date('2026-07-01T10:00:00Z').getTime();
+const AFTER_QUEUE = new Date('2026-07-02T10:00:00Z');
+
+function buildAction(overrides: Partial<OfflineAction> = {}): OfflineAction {
+  return buildOfflineAction({
+    endpoint: 'watchlist:add',
+    invalidations: ['invalidate:watchlisted:movie'],
+    queuedAt: QUEUED_AT,
+    ...overrides,
+  });
+}
+
+const emptyWatched = (): Promise<FreshWatchedState> =>
+  Promise.resolve({
+    movies: new Map(),
+    shows: new Map(),
+    episodes: new Map(),
+  });
+
+describe('util: replayOfflineActions', () => {
+  it('should execute actions in order and collect invalidations', async () => {
+    const executed: string[] = [];
+    const first = buildAction();
+    const second = buildAction({
+      endpoint: 'rating:add',
+      invalidations: ['invalidate:rated:movie'],
+    });
+
+    const outcome = await replayOfflineActions({
+      actions: [first, second],
+      execute: (action) => {
+        executed.push(action.id);
+        return Promise.resolve(true);
+      },
+      fetchWatched: emptyWatched,
+    });
+
+    expect(executed).toEqual([first.id, second.id]);
+    expect(outcome.executedIds).toEqual([first.id, second.id]);
+    expect(outcome.invalidations).toEqual([
+      'invalidate:watchlisted:movie',
+      'invalidate:rated:movie',
+    ]);
+    expect(outcome.aborted).toBe(false);
+  });
+
+  it('should hold back duplicate watches instead of executing them', async () => {
+    const duplicate = buildAction({
+      endpoint: 'history:add',
+      keys: ['movie:1'],
+    });
+    const fresh = buildAction({
+      endpoint: 'history:add',
+      keys: ['movie:2'],
+    });
+
+    const execute = vi.fn(() => Promise.resolve(true));
+    const outcome = await replayOfflineActions({
+      actions: [duplicate, fresh],
+      execute,
+      fetchWatched: () =>
+        Promise.resolve({
+          movies: new Map([[1, AFTER_QUEUE]]),
+          shows: new Map(),
+          episodes: new Map(),
+        }),
+    });
+
+    expect(outcome.duplicates).toEqual([duplicate]);
+    expect(outcome.executedIds).toEqual([fresh.id]);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip reconciliation when disabled', async () => {
+    const action = buildAction({ endpoint: 'history:add' });
+    const fetchWatched = vi.fn(emptyWatched);
+
+    const outcome = await replayOfflineActions({
+      actions: [action],
+      reconcile: false,
+      execute: () => Promise.resolve(true),
+      fetchWatched,
+    });
+
+    expect(fetchWatched).not.toHaveBeenCalled();
+    expect(outcome.executedIds).toEqual([action.id]);
+  });
+
+  it('should not fetch watched state without queued watches', async () => {
+    const fetchWatched = vi.fn(emptyWatched);
+
+    await replayOfflineActions({
+      actions: [buildAction()],
+      execute: () => Promise.resolve(true),
+      fetchWatched,
+    });
+
+    expect(fetchWatched).not.toHaveBeenCalled();
+  });
+
+  it('should abort and keep the rest queued on a network error', async () => {
+    const first = buildAction();
+    const second = buildAction({ keys: ['movie:2'] });
+
+    const outcome = await replayOfflineActions({
+      actions: [first, second],
+      execute: (action) =>
+        action.id === first.id
+          ? Promise.reject(new TypeError('Failed to fetch'))
+          : Promise.resolve(true),
+      fetchWatched: emptyWatched,
+    });
+
+    expect(outcome.aborted).toBe(true);
+    expect(outcome.executedIds).toEqual([]);
+    expect(outcome.failedIds).toEqual([]);
+  });
+
+  it('should abort when the reconcile fetch hits a network error', async () => {
+    const outcome = await replayOfflineActions({
+      actions: [buildAction({ endpoint: 'history:add' })],
+      execute: () => Promise.resolve(true),
+      fetchWatched: () => Promise.reject(new TypeError('Failed to fetch')),
+    });
+
+    expect(outcome.aborted).toBe(true);
+    expect(outcome.executedIds).toEqual([]);
+  });
+
+  it('should drop server-rejected actions as failed', async () => {
+    const rejected = buildAction();
+    const accepted = buildAction({ keys: ['movie:2'] });
+
+    const outcome = await replayOfflineActions({
+      actions: [rejected, accepted],
+      execute: (action) => Promise.resolve(action.id !== rejected.id),
+      fetchWatched: emptyWatched,
+    });
+
+    expect(outcome.failedIds).toEqual([rejected.id]);
+    expect(outcome.executedIds).toEqual([accepted.id]);
+    expect(outcome.invalidations).toEqual(['invalidate:watchlisted:movie']);
+    expect(outcome.aborted).toBe(false);
+  });
+});

--- a/projects/client/src/lib/features/offline/_internal/replayOfflineActions.ts
+++ b/projects/client/src/lib/features/offline/_internal/replayOfflineActions.ts
@@ -1,0 +1,119 @@
+import type { InvalidateActionOptions } from '$lib/requests/models/InvalidateAction.ts';
+import type { OfflineAction } from '../models/OfflineAction.ts';
+import { executeOfflineAction } from './executeOfflineAction.ts';
+import { fetchFreshWatchedState } from './fetchFreshWatchedState.ts';
+import { findDuplicateWatch } from './findDuplicateWatch.ts';
+import type { FreshWatchedState } from './FreshWatchedState.ts';
+import { isNetworkError } from './isNetworkError.ts';
+
+export type ReplayOutcome = {
+  executedIds: string[];
+  failedIds: string[];
+  duplicates: OfflineAction[];
+  invalidations: InvalidateActionOptions[];
+  aborted: boolean;
+};
+
+type ReplayOfflineActionsParams = {
+  actions: OfflineAction[];
+  reconcile?: boolean;
+  execute?: (action: OfflineAction) => Promise<boolean>;
+  fetchWatched?: () => Promise<FreshWatchedState>;
+};
+
+const ABORTED_OUTCOME: ReplayOutcome = {
+  executedIds: [],
+  failedIds: [],
+  duplicates: [],
+  invalidations: [],
+  aborted: true,
+};
+
+async function resolveWatchedState(
+  fetchWatched: () => Promise<FreshWatchedState>,
+): Promise<FreshWatchedState | null | 'unreachable'> {
+  try {
+    return await fetchWatched();
+  } catch (candidate) {
+    if (isNetworkError(candidate)) {
+      return 'unreachable';
+    }
+
+    // Fresh state is unavailable for a non-network reason. Worst case of
+    // replaying without it is an extra play, which the user accepted.
+    return null;
+  }
+}
+
+/**
+ * Replays queued actions in FIFO order. Watches already recorded elsewhere
+ * after queuing come back as `duplicates` for the user to confirm; a network
+ * failure aborts (rest stays queued), a server rejection drops the action.
+ */
+export async function replayOfflineActions({
+  actions,
+  reconcile = true,
+  execute = executeOfflineAction,
+  fetchWatched = fetchFreshWatchedState,
+}: ReplayOfflineActionsParams): Promise<ReplayOutcome> {
+  const needsReconcile = reconcile &&
+    actions.some((action) => action.endpoint === 'history:add');
+
+  const watched = needsReconcile
+    ? await resolveWatchedState(fetchWatched)
+    : null;
+
+  if (watched === 'unreachable') {
+    return ABORTED_OUTCOME;
+  }
+
+  const duplicates = watched === null
+    ? []
+    : actions.filter((action) => findDuplicateWatch({ action, watched }));
+  const duplicateIds = new Set(duplicates.map(({ id }) => id));
+
+  const executedIds: string[] = [];
+  const failedIds: string[] = [];
+  const invalidations = new Set<InvalidateActionOptions>();
+
+  for (const action of actions) {
+    if (duplicateIds.has(action.id)) {
+      continue;
+    }
+
+    try {
+      const isExecuted = await execute(action);
+
+      if (!isExecuted) {
+        failedIds.push(action.id);
+        continue;
+      }
+
+      executedIds.push(action.id);
+      action.invalidations.forEach((invalidation) =>
+        invalidations.add(invalidation)
+      );
+    } catch (candidate) {
+      if (isNetworkError(candidate)) {
+        return {
+          executedIds,
+          failedIds,
+          duplicates,
+          invalidations: [...invalidations],
+          aborted: true,
+        };
+      }
+
+      // Unexpected error: drop the action so it cannot poison future replays.
+      failedIds.push(action.id);
+    }
+  }
+
+  return {
+    executedIds,
+    failedIds,
+    duplicates,
+    invalidations: [...invalidations],
+    aborted: false,
+  };
+}

--- a/projects/client/src/lib/features/offline/executeOrEnqueue.spec.ts
+++ b/projects/client/src/lib/features/offline/executeOrEnqueue.spec.ts
@@ -1,0 +1,66 @@
+import { server } from '$mocks/server.ts';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { offlineActionsStore } from './_internal/offlineActionsStore.ts';
+import { executeOrEnqueue } from './executeOrEnqueue.ts';
+
+const WATCHLIST_BODY = { movies: [{ ids: { trakt: 1 } }] };
+
+function addToWatchlist() {
+  return executeOrEnqueue({
+    endpoint: 'watchlist:add',
+    keys: ['movie:1'],
+    body: WATCHLIST_BODY,
+    invalidations: ['invalidate:watchlisted:movie'],
+  });
+}
+
+async function drainQueue() {
+  const ids = offlineActionsStore.current().map(({ id }) => id);
+  await offlineActionsStore.remove(ids);
+}
+
+describe('util: executeOrEnqueue', () => {
+  it('should execute right away when the request succeeds', async () => {
+    const result = await addToWatchlist();
+
+    expect(result).toBe('executed');
+    expect(offlineActionsStore.current()).toEqual([]);
+  });
+
+  it('should treat an http error as executed (server rejected)', async () => {
+    server.use(
+      http.post(
+        'http://localhost/sync/watchlist',
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+
+    const result = await addToWatchlist();
+
+    expect(result).toBe('executed');
+    expect(offlineActionsStore.current()).toEqual([]);
+  });
+
+  it('should queue the action when the network is unreachable', async () => {
+    server.use(
+      http.post(
+        'http://localhost/sync/watchlist',
+        () => HttpResponse.error(),
+      ),
+    );
+
+    const result = await addToWatchlist();
+
+    expect(result).toBe('queued');
+    expect(offlineActionsStore.current()).toMatchObject([
+      {
+        endpoint: 'watchlist:add',
+        keys: ['movie:1'],
+        body: WATCHLIST_BODY,
+      },
+    ]);
+
+    await drainQueue();
+  });
+});

--- a/projects/client/src/lib/features/offline/executeOrEnqueue.ts
+++ b/projects/client/src/lib/features/offline/executeOrEnqueue.ts
@@ -1,0 +1,51 @@
+import type { InvalidateActionOptions } from '$lib/requests/models/InvalidateAction.ts';
+import { executeOfflineAction } from './_internal/executeOfflineAction.ts';
+import { isNetworkError } from './_internal/isNetworkError.ts';
+import { offlineActionsStore } from './_internal/offlineActionsStore.ts';
+import { onlineStatusStore } from './_internal/onlineStatusStore.ts';
+import type { OfflineAction } from './models/OfflineAction.ts';
+import type { OfflineActionBody } from './models/OfflineActionBody.ts';
+import type { OfflineActionEndpoint } from './models/OfflineActionEndpoint.ts';
+
+type ExecuteOrEnqueueParams<TEndpoint extends OfflineActionEndpoint> = {
+  endpoint: TEndpoint;
+  keys: string[];
+  body: OfflineActionBody[TEndpoint];
+  invalidations: InvalidateActionOptions[];
+};
+
+/**
+ * Runs a tracking mutation right away when online, queues it otherwise.
+ * Queued actions are replayed by `OfflineSync` once connectivity returns.
+ */
+export async function executeOrEnqueue<
+  TEndpoint extends OfflineActionEndpoint,
+>(
+  { endpoint, keys, body, invalidations }: ExecuteOrEnqueueParams<TEndpoint>,
+): Promise<'executed' | 'queued'> {
+  const action: OfflineAction = {
+    id: crypto.randomUUID(),
+    endpoint,
+    keys,
+    body,
+    invalidations,
+    queuedAt: Date.now(),
+  };
+
+  if (!onlineStatusStore.isOnline()) {
+    await offlineActionsStore.enqueue(action);
+    return 'queued';
+  }
+
+  try {
+    await executeOfflineAction(action);
+    return 'executed';
+  } catch (candidate) {
+    if (!isNetworkError(candidate)) {
+      throw candidate;
+    }
+
+    await offlineActionsStore.enqueue(action);
+    return 'queued';
+  }
+}

--- a/projects/client/src/lib/features/offline/findPendingOverride.spec.ts
+++ b/projects/client/src/lib/features/offline/findPendingOverride.spec.ts
@@ -1,0 +1,67 @@
+import { buildOfflineAction } from '$test/beds/offline/buildOfflineAction.ts';
+import { describe, expect, it } from 'vitest';
+import { findPendingOverride } from './findPendingOverride.ts';
+
+describe('util: findPendingOverride', () => {
+  it('should find an action covering all requested keys', () => {
+    const action = buildOfflineAction({ keys: ['movie:1', 'movie:2'] });
+
+    const result = findPendingOverride({
+      actions: [action],
+      domain: 'history',
+      keys: ['movie:1'],
+    });
+
+    expect(result).toBe(action);
+  });
+
+  it('should ignore actions from other domains', () => {
+    const action = buildOfflineAction({ endpoint: 'watchlist:add' });
+
+    const result = findPendingOverride({
+      actions: [action],
+      domain: 'history',
+      keys: ['movie:1'],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('should ignore actions that only cover some keys', () => {
+    const action = buildOfflineAction({ keys: ['movie:1'] });
+
+    const result = findPendingOverride({
+      actions: [action],
+      domain: 'history',
+      keys: ['movie:1', 'movie:2'],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('should return the latest covering action', () => {
+    const add = buildOfflineAction({ endpoint: 'history:add' });
+    const remove = buildOfflineAction({
+      endpoint: 'history:remove',
+      queuedAt: 2,
+    });
+
+    const result = findPendingOverride({
+      actions: [add, remove],
+      domain: 'history',
+      keys: ['movie:1'],
+    });
+
+    expect(result).toBe(remove);
+  });
+
+  it('should return null for empty keys', () => {
+    const result = findPendingOverride({
+      actions: [buildOfflineAction()],
+      domain: 'history',
+      keys: [],
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/projects/client/src/lib/features/offline/findPendingOverride.ts
+++ b/projects/client/src/lib/features/offline/findPendingOverride.ts
@@ -1,0 +1,26 @@
+import type { OfflineAction } from './models/OfflineAction.ts';
+import type { OfflineActionDomain } from './models/OfflineActionEndpoint.ts';
+
+type FindPendingOverrideParams = {
+  actions: OfflineAction[];
+  domain: OfflineActionDomain;
+  keys: string[];
+};
+
+/**
+ * Queued action overriding server state for the given keys - the queue is
+ * FIFO, so the last covering action reflects the user's latest intent.
+ */
+export function findPendingOverride(
+  { actions, domain, keys }: FindPendingOverrideParams,
+): OfflineAction | null {
+  if (keys.length === 0) {
+    return null;
+  }
+
+  const covers = (action: OfflineAction) =>
+    action.endpoint.startsWith(`${domain}:`) &&
+    keys.every((key) => action.keys.includes(key));
+
+  return actions.filter(covers).at(-1) ?? null;
+}

--- a/projects/client/src/lib/features/offline/isAddEndpoint.ts
+++ b/projects/client/src/lib/features/offline/isAddEndpoint.ts
@@ -1,0 +1,5 @@
+import type { OfflineActionEndpoint } from './models/OfflineActionEndpoint.ts';
+
+export function isAddEndpoint(endpoint: OfflineActionEndpoint): boolean {
+  return endpoint.endsWith(':add');
+}

--- a/projects/client/src/lib/features/offline/models/OfflineAction.ts
+++ b/projects/client/src/lib/features/offline/models/OfflineAction.ts
@@ -1,0 +1,19 @@
+import type { InvalidateActionOptions } from '$lib/requests/models/InvalidateAction.ts';
+import { invalidationId } from '$lib/requests/models/InvalidateAction.ts';
+import { z } from 'zod';
+import { OfflineActionEndpointSchema } from './OfflineActionEndpoint.ts';
+
+const InvalidateActionSchema = z.custom<InvalidateActionOptions>(
+  (value) => typeof value === 'string' && value.startsWith(invalidationId()),
+);
+
+export const OfflineActionSchema = z.object({
+  id: z.string(),
+  endpoint: OfflineActionEndpointSchema,
+  keys: z.array(z.string()),
+  body: z.unknown(),
+  invalidations: z.array(InvalidateActionSchema),
+  queuedAt: z.number(),
+});
+
+export type OfflineAction = z.infer<typeof OfflineActionSchema>;

--- a/projects/client/src/lib/features/offline/models/OfflineActionBody.ts
+++ b/projects/client/src/lib/features/offline/models/OfflineActionBody.ts
@@ -1,0 +1,19 @@
+import type {
+  FavoritesRequest,
+  HistoryAddRequest,
+  HistoryRemoveRequest,
+  RatingsSyncRequest,
+  RemoveRatingsParams,
+  WatchlistRequest,
+} from '@trakt/api';
+
+export type OfflineActionBody = {
+  'history:add': HistoryAddRequest;
+  'history:remove': HistoryRemoveRequest;
+  'watchlist:add': WatchlistRequest;
+  'watchlist:remove': WatchlistRequest;
+  'rating:add': RatingsSyncRequest;
+  'rating:remove': RemoveRatingsParams;
+  'favorites:add': FavoritesRequest;
+  'favorites:remove': FavoritesRequest;
+};

--- a/projects/client/src/lib/features/offline/models/OfflineActionEndpoint.ts
+++ b/projects/client/src/lib/features/offline/models/OfflineActionEndpoint.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const OfflineActionEndpointSchema = z.enum([
+  'history:add',
+  'history:remove',
+  'watchlist:add',
+  'watchlist:remove',
+  'rating:add',
+  'rating:remove',
+  'favorites:add',
+  'favorites:remove',
+]);
+
+export type OfflineActionEndpoint = z.infer<typeof OfflineActionEndpointSchema>;
+
+export type OfflineActionDomain = OfflineActionEndpoint extends
+  `${infer TDomain}:${string}` ? TDomain : never;

--- a/projects/client/src/lib/features/offline/toMediaKey.ts
+++ b/projects/client/src/lib/features/offline/toMediaKey.ts
@@ -1,0 +1,9 @@
+import type { RatedMediaType } from '$lib/requests/models/InvalidateAction.ts';
+
+/**
+ * Canonical identity of a media item in the offline queue - enqueue sites
+ * and pending-state overlays must build keys through this helper to agree.
+ */
+export function toMediaKey(type: RatedMediaType, id: number): string {
+  return `${type}:${id}`;
+}

--- a/projects/client/src/lib/features/offline/useOfflineActions.ts
+++ b/projects/client/src/lib/features/offline/useOfflineActions.ts
@@ -1,0 +1,11 @@
+import type { Observable } from 'rxjs';
+import { offlineActionsStore } from './_internal/offlineActionsStore.ts';
+import type { OfflineAction } from './models/OfflineAction.ts';
+
+export function useOfflineActions(): {
+  actions: Observable<OfflineAction[]>;
+} {
+  return {
+    actions: offlineActionsStore.actions$,
+  };
+}

--- a/projects/client/src/lib/sections/media-actions/favorite/useFavorites.ts
+++ b/projects/client/src/lib/sections/media-actions/favorite/useFavorites.ts
@@ -1,10 +1,13 @@
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
+import { findPendingOverride } from '$lib/features/offline/findPendingOverride.ts';
+import { isAddEndpoint } from '$lib/features/offline/isAddEndpoint.ts';
+import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
+import { useOfflineActions } from '$lib/features/offline/useOfflineActions.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
-import { addToFavoritesRequest } from '$lib/requests/sync/addToFavoritesRequest.ts';
-import { removeFromFavoritesRequest } from '$lib/requests/sync/removeFromFavoritesRequest.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
-import { BehaviorSubject, map } from 'rxjs';
+import { BehaviorSubject, combineLatest, map } from 'rxjs';
 
 export type FavoritesStoreProps = {
   type: MediaType;
@@ -27,9 +30,20 @@ export function useFavorites({ type, id }: FavoritesStoreProps) {
   const isUpdatingFavorite = new BehaviorSubject(false);
   const { favorites } = useUser();
   const { invalidate } = useInvalidator();
+  const { actions } = useOfflineActions();
 
-  const isFavorited = favorites.pipe(
-    map(($favorites) => {
+  const isFavorited = combineLatest([favorites, actions]).pipe(
+    map(([$favorites, $actions]) => {
+      const pending = findPendingOverride({
+        actions: $actions,
+        domain: 'favorites',
+        keys: [toMediaKey(type, id)],
+      });
+
+      if (pending) {
+        return isAddEndpoint(pending.endpoint);
+      }
+
       if (!$favorites) {
         return false;
       }
@@ -48,18 +62,17 @@ export function useFavorites({ type, id }: FavoritesStoreProps) {
 
     const payload = getFavoritesPayload({ type, id });
 
-    switch (action) {
-      case 'add':
-        await addToFavoritesRequest({ body: payload });
-        break;
-      case 'remove':
-        await removeFromFavoritesRequest({ body: payload });
-        break;
+    const result = await executeOrEnqueue({
+      endpoint: action === 'add' ? 'favorites:add' : 'favorites:remove',
+      keys: [toMediaKey(type, id)],
+      body: payload,
+      invalidations: [InvalidateAction.Favorited(type)],
+    });
+
+    if (result === 'executed') {
+      await invalidate(InvalidateAction.Favorited(type));
+      isUpdatingFavorite.next(false);
     }
-
-    await invalidate(InvalidateAction.Favorited(type));
-
-    isUpdatingFavorite.next(false);
   };
 
   return {

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.spec.ts
@@ -1,0 +1,62 @@
+import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
+import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
+import { server } from '$mocks/server.ts';
+import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
+import { http, HttpResponse } from 'msw';
+import { firstValueFrom } from 'rxjs';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useIsWatched } from './useIsWatched.ts';
+
+const MOVIE_ID = 999_999;
+
+function failHistorySync() {
+  server.use(
+    http.post('http://localhost/sync/history', () => HttpResponse.error()),
+    http.post(
+      'http://localhost/sync/history/remove',
+      () => HttpResponse.error(),
+    ),
+  );
+}
+
+describe('store: useIsWatched', () => {
+  beforeEach(() => {
+    setAuthorization(true);
+  });
+
+  describe('offline overlay', () => {
+    it('should report a queued offline watch as watched', async () => {
+      failHistorySync();
+
+      await executeOrEnqueue({
+        endpoint: 'history:add',
+        keys: [toMediaKey('movie', MOVIE_ID)],
+        body: { movies: [{ ids: { trakt: MOVIE_ID } }] },
+        invalidations: ['invalidate:mark_as_watched:movie'],
+      });
+
+      const { isWatched } = await renderStore(() =>
+        useIsWatched({ type: 'movie', media: { id: MOVIE_ID } })
+      );
+
+      expect(await firstValueFrom(isWatched)).toBe(true);
+    });
+
+    it('should report a queued offline unwatch as not watched', async () => {
+      failHistorySync();
+
+      await executeOrEnqueue({
+        endpoint: 'history:remove',
+        keys: [toMediaKey('movie', MOVIE_ID)],
+        body: { movies: [{ ids: { trakt: MOVIE_ID } }] },
+        invalidations: ['invalidate:mark_as_watched:movie'],
+      });
+
+      const { isWatched } = await renderStore(() =>
+        useIsWatched({ type: 'movie', media: { id: MOVIE_ID } })
+      );
+
+      expect(await firstValueFrom(isWatched)).toBe(false);
+    });
+  });
+});

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
@@ -1,5 +1,10 @@
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
-import { map, shareReplay } from 'rxjs';
+import { findPendingOverride } from '$lib/features/offline/findPendingOverride.ts';
+import { isAddEndpoint } from '$lib/features/offline/isAddEndpoint.ts';
+import type { OfflineAction } from '$lib/features/offline/models/OfflineAction.ts';
+import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
+import { useOfflineActions } from '$lib/features/offline/useOfflineActions.ts';
+import { combineLatest, map, shareReplay } from 'rxjs';
 import type { ExtendedMediaStoreProps } from '../../../models/MediaStoreProps.ts';
 
 export type IsWatchedProps = ExtendedMediaStoreProps;
@@ -8,6 +13,32 @@ export function useIsWatched(props: IsWatchedProps) {
   const { type } = props;
   const media = Array.isArray(props.media) ? props.media : [props.media];
   const { history } = useUser();
+  const { actions } = useOfflineActions();
+
+  // Offline actions are queued per movie/show/episode; season marks are
+  // enqueued as their show payload, so seasons keep the plain server state.
+  const findPendingWatchState = (
+    $actions: OfflineAction[],
+  ): { isWatched: boolean; isPartiallyWatched: boolean } | null => {
+    if (type === 'season') {
+      return null;
+    }
+
+    const pending = findPendingOverride({
+      actions: $actions,
+      domain: 'history',
+      keys: media.map((item) => toMediaKey(type, item.id)),
+    });
+
+    if (!pending) {
+      return null;
+    }
+
+    return {
+      isWatched: isAddEndpoint(pending.endpoint),
+      isPartiallyWatched: false,
+    };
+  };
 
   const episodes = props.type === 'episode'
     ? Array.isArray(props.media) ? props.media : [props.media]
@@ -20,8 +51,14 @@ export function useIsWatched(props: IsWatchedProps) {
     ? Array.isArray(props.media) ? props.media : [props.media]
     : [];
 
-  const watchState = history.pipe(
-    map(($history) => {
+  const watchState = combineLatest([history, actions]).pipe(
+    map(([$history, $actions]) => {
+      const pendingState = findPendingWatchState($actions);
+
+      if (pendingState) {
+        return pendingState;
+      }
+
       if (!$history) {
         return { isWatched: false, isPartiallyWatched: false };
       }

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
@@ -1,12 +1,11 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
+import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
-import { markAsWatchedRequest } from '$lib/requests/sync/markAsWatchedRequest.ts';
-import { removeRatingRequest } from '$lib/requests/sync/removeRatingRequest.ts';
-import { removeWatchedRequest } from '$lib/requests/sync/removeWatchedRequest.ts';
 import { toRemoveRatingsPayload } from '$lib/requests/sync/toRemoveRatingsPayload.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { hasAired } from '$lib/utils/media/hasAired.ts';
@@ -25,6 +24,7 @@ export function useMarkAsWatched(
 ) {
   const { type } = props;
   const media = Array.isArray(props.media) ? props.media : [props.media];
+  const mediaKeys = media.map((item) => toMediaKey(type, item.id));
   const isMarkingAsWatched = new BehaviorSubject(false);
   const { user, history, ratings } = useUser();
   const { invalidate } = useInvalidator();
@@ -44,13 +44,17 @@ export function useMarkAsWatched(
     isMarkingAsWatched.next(true);
     track({ action: 'add' });
 
-    await markAsWatchedRequest({
+    const result = await executeOrEnqueue({
+      endpoint: 'history:add',
+      keys: mediaKeys,
       body: toMarkAsWatchedPayload(props, watchedAtDate),
+      invalidations: [InvalidateAction.MarkAsWatched(type)],
     });
 
-    await invalidate(InvalidateAction.MarkAsWatched(type));
-
-    isMarkingAsWatched.next(false);
+    if (result === 'executed') {
+      await invalidate(InvalidateAction.MarkAsWatched(type));
+      isMarkingAsWatched.next(false);
+    }
   };
 
   // Ids whose rating this removal orphans. The main action removes *every*
@@ -97,20 +101,29 @@ export function useMarkAsWatched(
 
     const orphanedRatingIds = await getOrphanedRatingIds();
 
-    await removeWatchedRequest({
+    const removeResult = await executeOrEnqueue({
+      endpoint: 'history:remove',
+      keys: mediaKeys,
       body: toMarkAsWatchedPayload(props),
+      invalidations: [InvalidateAction.MarkAsWatched(type)],
     });
 
     if (orphanedRatingIds.length > 0) {
-      await removeRatingRequest({
+      const ratingResult = await executeOrEnqueue({
+        endpoint: 'rating:remove',
+        keys: orphanedRatingIds.map((id) => toMediaKey(type, id)),
         body: toRemoveRatingsPayload(type, orphanedRatingIds),
+        invalidations: [InvalidateAction.Rated(type)],
       });
-      await invalidate(InvalidateAction.Rated(type));
+      if (ratingResult === 'executed') {
+        await invalidate(InvalidateAction.Rated(type));
+      }
     }
 
-    await invalidate(InvalidateAction.MarkAsWatched(type));
-
-    isMarkingAsWatched.next(false);
+    if (removeResult === 'executed') {
+      await invalidate(InvalidateAction.MarkAsWatched(type));
+      isMarkingAsWatched.next(false);
+    }
   };
 
   const isWatchable = media.every((item) => {

--- a/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
+++ b/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
@@ -1,9 +1,9 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
+import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
-import { addToWatchlistRequest } from '$lib/requests/sync/addToWatchlistRequest.ts';
-import { removeFromWatchlistRequest } from '$lib/requests/sync/removeFromWatchlistRequest.ts';
 import { toBulkPayload } from '$lib/sections/media-actions/_internal/toBulkPayload.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { useIsWatchlisted } from '$lib/stores/useIsWatchlisted.ts';
@@ -29,13 +29,17 @@ export function useWatchlist(props: MediaStoreProps) {
     isWatchlistUpdating.next(true);
     track({ action: 'add' });
 
-    await addToWatchlistRequest({
+    const addResult = await executeOrEnqueue({
+      endpoint: 'watchlist:add',
+      keys: ids.map((id) => toMediaKey(type, id)),
       body,
+      invalidations: [InvalidateAction.Watchlisted(type)],
     });
 
-    await invalidate(InvalidateAction.Watchlisted(type));
-
-    isWatchlistUpdating.next(false);
+    if (addResult === 'executed') {
+      await invalidate(InvalidateAction.Watchlisted(type));
+      isWatchlistUpdating.next(false);
+    }
   };
 
   const removeFromWatchlist = async () => {
@@ -46,13 +50,17 @@ export function useWatchlist(props: MediaStoreProps) {
     isWatchlistUpdating.next(true);
     track({ action: 'remove' });
 
-    await removeFromWatchlistRequest({
+    const removeResult = await executeOrEnqueue({
+      endpoint: 'watchlist:remove',
+      keys: ids.map((id) => toMediaKey(type, id)),
       body,
+      invalidations: [InvalidateAction.Watchlisted(type)],
     });
 
-    await invalidate(InvalidateAction.Watchlisted(type));
-
-    isWatchlistUpdating.next(false);
+    if (removeResult === 'executed') {
+      await invalidate(InvalidateAction.Watchlisted(type));
+      isWatchlistUpdating.next(false);
+    }
   };
 
   return {

--- a/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
@@ -1,13 +1,18 @@
 import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts';
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
+import type { RatedEntry } from '$lib/features/auth/queries/currentUserRatingsQuery.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
+import { findPendingOverride } from '$lib/features/offline/findPendingOverride.ts';
+import { isAddEndpoint } from '$lib/features/offline/isAddEndpoint.ts';
+import type { OfflineAction } from '$lib/features/offline/models/OfflineAction.ts';
+import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
+import { useOfflineActions } from '$lib/features/offline/useOfflineActions.ts';
 import { useLastWatched } from '$lib/features/toast/useLastWatched.ts';
 import {
   InvalidateAction,
   type RatedMediaType,
 } from '$lib/requests/models/InvalidateAction.ts';
-import { addRatingRequest } from '$lib/requests/sync/addRatingRequest.ts';
-import { removeRatingRequest } from '$lib/requests/sync/removeRatingRequest.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import type { RatingsSyncRequest, RemoveRatingsParams } from '@trakt/api';
@@ -49,6 +54,25 @@ function toRemovePayload(
   return { [key]: [payload] };
 }
 
+function toPendingRatedEntry(
+  pending: OfflineAction,
+  type: RateableType,
+  id: number,
+): RatedEntry | undefined {
+  if (!isAddEndpoint(pending.endpoint)) {
+    return undefined;
+  }
+
+  const body = pending.body as RatingsSyncRequest;
+  const rating = body[`${type}s`]?.at(0)?.rating;
+
+  if (rating == null) {
+    return undefined;
+  }
+
+  return { id, rating, ratedAt: new Date(pending.queuedAt) };
+}
+
 export function useRatings({ type, id }: WatchlistStoreProps) {
   const pendingRating = new BehaviorSubject<null | number>(null);
   const { ratings, favorites } = useUser();
@@ -56,8 +80,20 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
   const { track } = useTrack(AnalyticsEvent.Rate);
   const { dismiss } = useLastWatched();
 
-  const rating = ratings.pipe(
-    map(($ratings) => {
+  const { actions } = useOfflineActions();
+
+  const rating = combineLatest([ratings, actions]).pipe(
+    map(([$ratings, $actions]) => {
+      const pending = findPendingOverride({
+        actions: $actions,
+        domain: 'rating',
+        keys: [toMediaKey(type, id)],
+      });
+
+      if (pending) {
+        return toPendingRatedEntry(pending, type, id);
+      }
+
       if (!$ratings) {
         return;
       }
@@ -139,13 +175,19 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
 
     track({ action: hasRating ? 'changed' : 'added', rating: newRating });
 
-    await addRatingRequest({ body: toAddPayload(type, id, newRating) });
-    await invalidate(InvalidateAction.Rated(type));
-
-    pendingRating.next(null);
-    isSubmitting.next(false);
-    if (type !== 'season') {
-      dismiss(id, type, 'rating');
+    const addResult = await executeOrEnqueue({
+      endpoint: 'rating:add',
+      keys: [toMediaKey(type, id)],
+      body: toAddPayload(type, id, newRating),
+      invalidations: [InvalidateAction.Rated(type)],
+    });
+    if (addResult === 'executed') {
+      await invalidate(InvalidateAction.Rated(type));
+      pendingRating.next(null);
+      isSubmitting.next(false);
+      if (type !== 'season') {
+        dismiss(id, type, 'rating');
+      }
     }
   });
 
@@ -159,11 +201,16 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
     pendingRating.next(0);
 
     track({ action: 'removed' });
-    await removeRatingRequest({
+    const removeResult = await executeOrEnqueue({
+      endpoint: 'rating:remove',
+      keys: [toMediaKey(type, id)],
       body: toRemovePayload(type, id),
+      invalidations: [InvalidateAction.Rated(type)],
     });
-    await invalidate(InvalidateAction.Rated(type));
-    pendingRating.next(null);
+    if (removeResult === 'executed') {
+      await invalidate(InvalidateAction.Rated(type));
+      pendingRating.next(null);
+    }
   };
 
   return {

--- a/projects/client/src/lib/stores/useIsWatchlisted.ts
+++ b/projects/client/src/lib/stores/useIsWatchlisted.ts
@@ -1,6 +1,10 @@
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { findPendingOverride } from '$lib/features/offline/findPendingOverride.ts';
+import { isAddEndpoint } from '$lib/features/offline/isAddEndpoint.ts';
+import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
+import { useOfflineActions } from '$lib/features/offline/useOfflineActions.ts';
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
-import { map } from 'rxjs';
+import { combineLatest, map } from 'rxjs';
 
 export type IsWatchlistedStoreProps = MediaStoreProps;
 
@@ -8,9 +12,24 @@ export function useIsWatchlisted(props: IsWatchlistedStoreProps) {
   const { type } = props;
   const media = Array.isArray(props.media) ? props.media : [props.media];
   const { watchlist } = useUser();
+  const { actions } = useOfflineActions();
 
-  const isWatchlisted = watchlist.pipe(
-    map(($watchlist) => {
+  const isWatchlisted = combineLatest([watchlist, actions]).pipe(
+    map(([$watchlist, $actions]) => {
+      if (type === 'episode') {
+        return false;
+      }
+
+      const pending = findPendingOverride({
+        actions: $actions,
+        domain: 'watchlist',
+        keys: media.map((m) => toMediaKey(type, m.id)),
+      });
+
+      if (pending) {
+        return isAddEndpoint(pending.endpoint);
+      }
+
       if (!$watchlist) {
         return false;
       }
@@ -20,8 +39,6 @@ export function useIsWatchlisted(props: IsWatchlistedStoreProps) {
           return media.every((m) => $watchlist.movies.has(m.id));
         case 'show':
           return media.every((m) => $watchlist.shows.has(m.id));
-        case 'episode':
-          return false;
       }
     }),
   );

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -21,6 +21,7 @@
   import NavigationHistoryProvider from "$lib/features/navigation-history/NavigationHistoryProvider.svelte";
   import NavigationProvider from "$lib/features/navigation/NavigationProvider.svelte";
   import AddNoteDrawerProvider from "$lib/features/notes/AddNoteDrawerProvider.svelte";
+  import OfflineSync from "$lib/features/offline/OfflineSync.svelte";
   import GlobalParameterProvider from "$lib/features/parameters/GlobalParameterProvider.svelte";
   import PlayerProvider from "$lib/features/player/YoutubePlayerProvider.svelte";
   import QueryClientProvider from "$lib/features/query/QueryClientProvider.svelte";
@@ -207,6 +208,10 @@
 
                                           <RenderFor audience="authenticated">
                                             <NavbarToastContent />
+                                          </RenderFor>
+
+                                          <RenderFor audience="authenticated">
+                                            <OfflineSync />
                                           </RenderFor>
                                           <QueryDevtools
                                             client={data.queryClient}

--- a/projects/client/test/beds/offline/buildOfflineAction.ts
+++ b/projects/client/test/beds/offline/buildOfflineAction.ts
@@ -1,0 +1,15 @@
+import type { OfflineAction } from '$lib/features/offline/models/OfflineAction.ts';
+
+export function buildOfflineAction(
+  overrides: Partial<OfflineAction> = {},
+): OfflineAction {
+  return {
+    id: crypto.randomUUID(),
+    endpoint: 'history:add',
+    keys: ['movie:1'],
+    body: { movies: [{ ids: { trakt: 1 } }] },
+    invalidations: ['invalidate:mark_as_watched:movie'],
+    queuedAt: 1,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
Adds offline support for user tracking actions - track things on a plane or in a low-connectivity region, and everything syncs back when the connection returns.

## What's in here

**Offline action queue** (`lib/features/offline/`)
- History, watchlist, ratings, and favorites mutations route through `executeOrEnqueue`: online -> request runs as before; offline or fetch failure -> action is queued in a dedicated IndexedDB store.
- Queue dedupes by media key set within a domain, latest intent wins (mark then unmark offline leaves only the unmark).

**Pending state overlay**
- `useIsWatched` / `useIsWatchlisted` / `useFavorites` / `useRatings` overlay the queue on top of server state, so buttons flip immediately while offline and you can't double-tap yourself into duplicate plays.

**Replay + reconciliation** (`OfflineSync`, mounted for authenticated users)
- On reconnect: web lock (single tab drains), FIFO replay, original `InvalidateAction` tokens fire after.
- Before replaying queued watches it fetches fresh server history; anything already watched from another device after the action was queued is held back behind a snackbar prompt ("Add anyway?") instead of silently duplicating plays. Dismiss drops them.
- Server-rejected actions are dropped and surfaced; a network failure mid-replay keeps the remainder queued.

**Docs**
- New Pattern 5 in `requests.md` + checklist for making future mutations offline-queueable; cross-linked from the hooks section in `components.md`.

## Deliberate calls

- Check-in is excluded - replaying a stale live check-in is semantically wrong; mark-as-watched covers the offline case.
- Reads were already offline-capable (per-query IDB persistence + SW caching); this PR fills the write side.
- Queue is not live-synced between two open tabs; the web lock prevents double-drain and storage is re-read before replay. BroadcastChannel felt like overkill for now.

## Testing

- 29 new unit tests across the queue store, overlay resolution, duplicate detection, and replay orchestration; full suite green (2269 passed).
- `svelte-check` and eslint report only pre-existing issues (SDK type drift in untouched files).
