### PR TITLE
ci: make fork PRs pass their own checks + document the pipeline

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,6 +37,26 @@ A few guidelines to keep things smooth:
 - Don't worry about getting it perfect on the first try. We'll work through it
   together in the review.
 
+### Commit messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/), enforced by
+`commitlint`. One thing that trips people up: the **scope** (the bit in
+parentheses, e.g. `fix(settings):`) is not free-form - it's a fixed list. If you
+pick a scope that isn't on the list, the `commitlint` check fails.
+
+The full list lives in [`commitlint.config.js`](../commitlint.config.js) under
+`scope-enum`. Pick the closest existing scope to what you touched, or open the
+PR and we'll help you land on the right one - it's an easy fix.
+
+### The red checks on your PR are probably fine 🙂
+
+If you're contributing from a fork, you'll likely see a few checks go red:
+**Enable Auto Merge**, **E2E**, and **DeepSource: Test coverage**. These need
+repository secrets that GitHub - correctly - never shares with fork PRs, so they
+can't pass from a fork no matter how good your change is. They're not caused by
+your diff. A maintainer takes care of them when merging, so don't let them worry
+you.
+
 ## i18n Contributions
 
 Helping make trakt-web available in more languages is a fantastic way to

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -54,6 +54,8 @@ masterpiece.
 - **test:** Adding missing tests or correcting existing tests
 - **chore:** Changes to the build process or auxiliary tools and libraries such as documentation generation
 
+**A note on scope:** the scope in parentheses (e.g. `fix(settings):`) is enforced against a fixed list in [`commitlint.config.js`](../commitlint.config.js) (`scope-enum`). Pick the closest existing scope - an off-list scope fails the `commitlint` check.
+
 By following these guidelines, you'll ensure your pull request is a cinematic
 triumph, a contribution worthy of a place in the trakt-web hall of fame. Now,
 let the show begin!

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -109,7 +109,7 @@ jobs:
       needs.files-changed.outputs.client_source == 'true' ||
       needs.files-changed.outputs.workflows == 'true'
       }}
-    name: "The Interrogation Room (Shard) [${{ matrix.shard }}/4]"
+    name: 'The Interrogation Room (Shard) [${{ matrix.shard }}/4]'
     runs-on: ubuntu-latest
     concurrency:
       group: ci-test-${{ github.ref }}-${{ matrix.shard }}
@@ -267,7 +267,7 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           timeout_seconds: 60
-          max_attempts: 10
+          max_attempts: 2
           command: |
             cd projects/client
             deno task test:e2e
@@ -275,6 +275,9 @@ jobs:
         env:
           E2E_HEADLESS: 'true'
           E2E_BASE_URL: 'http://localhost:4173/'
+          # Forks have no Trakt API secret, so the preview can't load summary
+          # data. Skip @live-data scenarios there; static ones still run.
+          E2E_SKIP_LIVE_DATA: ${{ secrets.TRAKT_CLIENT_ID == '' }}
 
       - name: Witnessing the Premonition's Demise aka Kill Preview
         working-directory: projects/client
@@ -314,7 +317,7 @@ jobs:
           FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
           FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      
+
       # Add this new step to copy the .npmrc file
       - name: The Ancient Scroll of JSR aka Copy .npmrc
         run: |

--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -27,7 +27,9 @@ jobs:
           skip-checkout: true
 
   merge:
-    if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main' && github.head_ref != 'i18n_crowdin_updates'
+    # Skip on fork PRs: they can't read GH_APP_ID/GH_APP_PRIVATE_KEY, so the
+    # token step hard-fails. A maintainer enables auto-merge manually instead.
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main' && github.head_ref != 'i18n_crowdin_updates' && github.event.pull_request.head.repo.full_name == github.repository
     name: The Convergence of Realms (Enable Auto Merge)
     runs-on: ubuntu-latest
     steps:

--- a/projects/client/cucumber.mjs
+++ b/projects/client/cucumber.mjs
@@ -1,6 +1,12 @@
+// Fork PRs can't read the Trakt API secrets, so scenarios that need live
+// summary data are skipped there (E2E_SKIP_LIVE_DATA=true). Static scenarios
+// still run and give external contributors real signal.
+const skipLiveData = process.env.E2E_SKIP_LIVE_DATA === 'true';
+
 export default {
   parallel: 1,
   forceExit: true,
+  ...(skipLiveData ? { tags: 'not @live-data' } : {}),
   format: [
     ['html', 'test-results/e2e/cucumber-report.html'],
     ['junit', 'test-results/e2e/cucumber-report.xml'],

--- a/projects/client/e2e/features/navigate.feature
+++ b/projects/client/e2e/features/navigate.feature
@@ -1,9 +1,7 @@
 Feature: Basic navigation
 
-  Scenario: Public pages
+  Scenario: Public static pages
     When I click on the "consent-button" button
-
-
     Then I should see "Home" in the page title
 
     When I open the shows section
@@ -12,9 +10,12 @@ Feature: Basic navigation
     When I open the movies section
     Then I should see "Movies" in the page title
 
-    When I view the show summary of "silo"
+  @live-data
+  Scenario: Public live-data pages
+    When I click on the "consent-button" button
+    And I view the show summary of "silo"
     Then I should see the "summary-media-title" element on the page
 
     When I view the movie summary of "heretic-2024"
     Then I should see the "summary-media-title" element on the page
-    Then I should not see the "feature-flag-tool-button" element on the page
+    And I should not see the "feature-flag-tool-button" element on the page

--- a/projects/client/e2e/features/seo.feature
+++ b/projects/client/e2e/features/seo.feature
@@ -32,6 +32,7 @@ Feature: SEO meta tags
     And the description should be "Browse trending, popular, and highly anticipated movies on Trakt Web. Find your next watch and keep track of everything you've seen."
     And the canonical path should be "/discover"
 
+  @live-data
   Scenario: Show summary page has complete SEO meta tags
     When I view the show summary of "silo"
     Then the page should meet core SEO requirements
@@ -46,6 +47,7 @@ Feature: SEO meta tags
     And the JSON-LD name should match the og:title
     And the JSON-LD should include genre and year
 
+  @live-data
   Scenario: Movie summary page has complete SEO meta tags
     When I view the movie summary of "heretic-2024"
     Then the page should meet core SEO requirements


### PR DESCRIPTION
While reviewing an external contribution (#2877) I noticed every fork PR lands with the same three checks red, none of them the contributor's fault. Root cause is the same for all three: GitHub never shares repository secrets with fork PRs on `pull_request` (correct, secure behavior - we deliberately avoid `pull_request_target`). Verified the identical red set across #2877, #2876, #2832, #2594.

This makes the checks that _can_ pass on a fork actually pass, and tells contributors what's going on.

## What changed

**CI (`ci` commit)**
- **Auto Merge job** skips fork PRs. It needs the GitHub App token secrets, so on forks the token step hard-fails before doing anything. Guarded on `head.repo.full_name == github.repository`; a maintainer enables auto-merge manually for fork PRs (same as we already do).
- **E2E** summary scenarios tagged `@live-data` and skipped when the Trakt API secret is absent. These hit the real API for summary data, which forks can't reach. The 3 static SEO scenarios still run, so external contributors get real E2E signal on their changes. 3 of 6 scenarios are `@live-data` - exactly the set that was failing.
- **E2E retry** dropped from `max_attempts: 10` to `2`. The summary failures were deterministic (missing data, not flake), so 10 retries only burned ~10x runtime and framed a hard failure as flakiness.

**Docs (`docs` commit)**
- `CONTRIBUTING.md` + PR template now say the commit scope is enum-restricted (`commitlint.config.js`), which was silently tripping people up.
- One note that the remaining red checks on fork PRs are environmental and maintainer-handled, so they don't read as "your PR is broken".

## Still on you (dashboard, not code)
**DeepSource: Test coverage** fails on forks because the coverage upload needs `DEEPSOURCE_DSN`. That's a DeepSource settings toggle (exempt fork PRs / drop it as a required check), not something fixable in this repo.

## Testing
- Confirmed `tags` is a valid cucumber config option and the `@live-data` filter selects the right 3 scenarios (6 total, 3 tagged).
- `deno fmt` clean.
- Full CI runs on this PR (same-repo, so all checks including E2E execute normally).