### PR TITLE
Fix/yir title

### DIFF
--- a/projects/client/src/lib/sections/yir/_internal/YirTitleSection.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirTitleSection.svelte
@@ -6,19 +6,17 @@
   import type { YirYear } from "$lib/requests/models/YirYear";
   import { userProfileQuery } from "$lib/requests/queries/users/userProfileQuery";
   import UserAvatar from "$lib/sections/lists/components/UserAvatar.svelte";
-  import { DEFAULT_COVER } from "$lib/utils/constants";
+  import { toLoadingState } from "$lib/utils/requests/toLoadingState";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import { map } from "rxjs";
 
   const {
     slug,
     year,
-    coverImage,
     subtitleOverride,
   }: {
     slug: string;
     year: YirYear;
-    coverImage: string | Nil;
     /** Replaces the computed subtitle (e.g. the all-time year range). */
     subtitleOverride?: string;
   } = $props();
@@ -38,15 +36,17 @@
           : m.yir_title_year_in_review()),
   );
 
-  const hasCover = $derived(!!$profile?.cover?.url || !!coverImage);
-  const coverSrc = $derived(
-    $profile?.cover?.url || coverImage || DEFAULT_COVER,
+  const isProfilePending = $derived(
+    profileQuery.pipe(map(($q) => toLoadingState($q))),
   );
+
+  const hasGradient = $derived(!$isProfilePending && !$profile?.cover?.url);
+  const coverSrc = $derived($profile?.cover?.url);
 </script>
 
 <section class="trakt-yir-title-section" class:is-all-time={isAllTime}>
-  <div class="yir-cover-bg" class:has-cover={hasCover}>
-    {#if hasCover}
+  <div class="yir-cover-bg" class:has-gradient={hasGradient}>
+    {#if coverSrc}
       <CrossOriginImage src={coverSrc} alt="" />
     {/if}
   </div>
@@ -100,23 +100,25 @@
   .yir-cover-bg {
     position: absolute;
     inset: 0;
-    // Default (no cover image): gradient background.
-    background:
-      radial-gradient(
-        ellipse 70% 65% at 25% 52%,
-        var(--purple-700) 0%,
-        transparent 65%
-      ),
-      radial-gradient(
-        ellipse 50% 45% at 72% 50%,
-        var(--blue-800) 0%,
-        transparent 65%
-      ),
-      var(--color-yir-poster-background);
+
+    // When explicitly set (no cover, not loading): gradient background.
+    &.has-gradient {
+      background:
+        radial-gradient(
+          ellipse 70% 65% at 25% 52%,
+          var(--purple-700) 0%,
+          transparent 65%
+        ),
+        radial-gradient(
+          ellipse 50% 45% at 72% 50%,
+          var(--blue-800) 0%,
+          transparent 65%
+        ),
+        var(--color-yir-poster-background);
+    }
 
     // When a cover image is present, render it and add the top scrim.
-    &.has-cover {
-      background: none;
+    &:not(.has-gradient) {
       // Own stacking context so the top scrim below can layer above the image
       // (the image is a stacking context via `contain`, so a plain positioned
       // ::before would otherwise paint under it). Stays below the titles.

--- a/projects/client/src/lib/sections/yir/_internal/YirTitleSection.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirTitleSection.svelte
@@ -8,7 +8,6 @@
   import UserAvatar from "$lib/sections/lists/components/UserAvatar.svelte";
   import { toLoadingState } from "$lib/utils/requests/toLoadingState";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
-  import { map } from "rxjs";
 
   const {
     slug,
@@ -22,7 +21,7 @@
   } = $props();
 
   const profileQuery = $derived(useQuery(userProfileQuery({ slug })));
-  const profile = $derived(profileQuery.pipe(map(($q) => $q.data)));
+  const profile = $derived($profileQuery.data);
 
   const now = new Date();
   const isAllTime = $derived(year === "all");
@@ -36,12 +35,10 @@
           : m.yir_title_year_in_review()),
   );
 
-  const isProfilePending = $derived(
-    profileQuery.pipe(map(($q) => toLoadingState($q))),
-  );
+  const isProfilePending = $derived(toLoadingState($profileQuery));
 
-  const hasGradient = $derived(!$isProfilePending && !$profile?.cover?.url);
-  const coverSrc = $derived($profile?.cover?.url);
+  const hasGradient = $derived(!isProfilePending && !profile?.cover?.url);
+  const coverSrc = $derived(profile?.cover?.url);
 </script>
 
 <section class="trakt-yir-title-section" class:is-all-time={isAllTime}>
@@ -52,19 +49,19 @@
   </div>
   <div class="yir-titles-wrapper">
     <div class="yir-titles">
-      {#if $profile}
-        <div class="yir-user">
+      <div class="yir-user">
+        {#if profile}
           <span class="yir-avatar-link">
-            <UserAvatar user={$profile} size="large" />
+            <UserAvatar user={profile} size="large" />
           </span>
           <span class="yir-display-name">
             <Link href={UrlBuilder.profile.user(slug)} color="inherit">
-              {$profile.name.full || $profile.username}
+              {profile.name.full || profile.username}
             </Link>
           </span>
-        </div>
-        <div class="yir-under-user"></div>
-      {/if}
+        {/if}
+      </div>
+      <div class="yir-under-user"></div>
 
       <h1 class="yir-year" class:is-text={isAllTime}>
         {isAllTime ? m.yir_label_all_time() : year}
@@ -181,6 +178,11 @@
     display: inline-flex;
     align-items: center;
     gap: var(--ni-10);
+    min-height: var(--ni-40);
+
+    @include for-mobile {
+      min-height: var(--ni-30);
+    }
   }
 
   .yir-avatar-link {

--- a/projects/client/src/lib/sections/yir/all-time/YirAllTime.svelte
+++ b/projects/client/src/lib/sections/yir/all-time/YirAllTime.svelte
@@ -40,20 +40,14 @@
       : undefined,
   );
 
-  function hasGlobalTop(items: YirDetail["globalTop"]): items is NonNullable<
-    YirDetail["globalTop"]
-  > {
+  function hasGlobalTop(
+    items: YirDetail["globalTop"],
+  ): items is NonNullable<YirDetail["globalTop"]> {
     return items != null;
   }
 </script>
 
-<!-- Title paints immediately; detail-gated sections fill in once loaded. -->
-<YirTitleSection
-  {slug}
-  year="all"
-  coverImage={detail?.images.cover}
-  subtitleOverride={titleSubtitle}
-/>
+<YirTitleSection {slug} year="all" subtitleOverride={titleSubtitle} />
 
 {#if detail}
   <YirTotalsSection stats={detail.stats.all} year="all" />
@@ -164,7 +158,6 @@
   {#if detail.lastWatched}
     <YirCalendarSection how="last" item={detail.lastWatched} year="all" />
   {/if}
-
 {:else if isLoading}
   <YirTotalsSection stats={null} year="all" />
 {/if}

--- a/projects/client/src/lib/sections/yir/default/YirDefault.svelte
+++ b/projects/client/src/lib/sections/yir/default/YirDefault.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
   import type { YirDetail } from "$lib/requests/models/YirDetail";
-  import YirTotalsSection from "../_internal/YirTotalsSection.svelte";
   import YirCalendarSection from "../_internal/YirCalendarSection.svelte";
-  import YirStatsSection from "../_internal/YirStatsSection.svelte";
-  import YirMostWatchedSection from "../_internal/YirMostWatchedSection.svelte";
   import YirGenresSection from "../_internal/YirGenresSection.svelte";
+  import YirMostWatchedSection from "../_internal/YirMostWatchedSection.svelte";
   import YirNetworksSection from "../_internal/YirNetworksSection.svelte";
-  import YirStudiosSection from "../_internal/YirStudiosSection.svelte";
-  import YirRatedSection from "../_internal/YirRatedSection.svelte";
   import YirPeopleSection from "../_internal/YirPeopleSection.svelte";
+  import YirRatedSection from "../_internal/YirRatedSection.svelte";
+  import YirStatsSection from "../_internal/YirStatsSection.svelte";
+  import YirStudiosSection from "../_internal/YirStudiosSection.svelte";
   import YirTitleSection from "../_internal/YirTitleSection.svelte";
+  import YirTotalsSection from "../_internal/YirTotalsSection.svelte";
   import YirUpgradeSection from "../_internal/YirUpgradeSection.svelte";
 
   const {
@@ -25,9 +25,7 @@
   } = $props();
 </script>
 
-<!-- Title section paints immediately (cover image falls back to the
-     DEFAULT_COVER constant inside the component when unavailable). -->
-<YirTitleSection {slug} {year} coverImage={detail?.images.cover} />
+<YirTitleSection {slug} {year} />
 
 {#if detail}
   <YirTotalsSection stats={detail.stats.all} {year} />
@@ -84,7 +82,6 @@
   {#if detail.lastWatched}
     <YirCalendarSection how="last" item={detail.lastWatched} {year} />
   {/if}
-
 {:else if isLoading}
   <YirTotalsSection stats={null} {year} />
 {/if}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Only rely on user cover src for background in yir template.
  - The api sends the widget version, which is not suitable for background usage.
- Fixes the background gradient being shown for a short duration, even when there is a cover image.
- Stabilizes the title section to not jump in height after data is loaded.