### PR TITLE
feat(pwa): flag queued offline actions with a pending state

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -9070,6 +9070,14 @@
       "default": "Add the offline plays anyway",
       "description": "Accessible label for the button confirming that duplicate offline watches should be replayed."
     },
+    "tag_text_queued": {
+      "default": "Queued",
+      "description": "Pill label on a tracking action (watched, watchlist, rating, favorite) that was saved offline and is waiting to sync."
+    },
+    "label_queued_action": {
+      "default": "Saved offline, waiting to sync",
+      "description": "Accessible label / tooltip for the queued indicator shown on an action that was saved offline."
+    },
     "error_text_sync_load_failed": {
       "default": "We couldn't load this right now. Please try again.",
       "description": "Inline error message shown when a streaming sync detail or its items fail to load."

--- a/projects/client/src/lib/components/badge/QueuedIndicator.svelte
+++ b/projects/client/src/lib/components/badge/QueuedIndicator.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { Snippet } from "svelte";
+
+  type QueuedIndicatorProps = {
+    isQueued: boolean;
+    children: Snippet;
+  };
+
+  const { isQueued, children }: QueuedIndicatorProps = $props();
+</script>
+
+<div class="trakt-queued-indicator" class:is-queued={isQueued}>
+  {@render children()}
+  {#if isQueued}
+    <span class="queued-dot" role="status" aria-label={m.label_queued_action()}
+    ></span>
+  {/if}
+</div>
+
+<style lang="scss">
+  .trakt-queued-indicator {
+    position: relative;
+    display: inline-flex;
+
+    // A queued action disables its button. Chromium ignores `cursor` on a
+    // disabled <button> and falls back to the ancestor's, so set it here to
+    // cover the whole control (not just the icon, which inherits it).
+    &.is-queued {
+      cursor: not-allowed;
+    }
+
+    .queued-dot {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+
+      width: var(--ni-10);
+      height: var(--ni-10);
+      box-sizing: border-box;
+
+      border-radius: 50%;
+      background-color: var(--color-background-queued-tag);
+      border: var(--border-thickness-xs) solid var(--color-background);
+
+      pointer-events: none;
+    }
+  }
+</style>

--- a/projects/client/src/lib/components/badge/QueuedTag.svelte
+++ b/projects/client/src/lib/components/badge/QueuedTag.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+  import StemTag from "../tags/StemTag.svelte";
+  import Tooltip from "../tooltip/Tooltip.svelte";
+</script>
+
+<Tooltip content={m.label_queued_action()}>
+  <div class="trakt-queued-tag" role="status" aria-label={m.label_queued_action()}>
+    <StemTag
+      --color-background-stem-tag="var(--color-background-queued-tag)"
+      --color-foreground-stem-tag="var(--color-text-queued-tag)"
+      text={m.tag_text_queued()}
+    />
+  </div>
+</Tooltip>
+
+<style>
+  .trakt-queued-tag {
+    user-select: none;
+  }
+</style>

--- a/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
+++ b/projects/client/src/lib/components/buttons/favorite/FavoriteButton.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import QueuedIndicator from "$lib/components/badge/QueuedIndicator.svelte";
+  import QueuedTag from "$lib/components/badge/QueuedTag.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
   import Button from "$lib/components/buttons/Button.svelte";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import FavoriteIcon from "$lib/components/icons/FavoriteIcon.svelte";
@@ -11,6 +14,7 @@
     title,
     isFavoriteUpdating,
     isFavorited,
+    isQueued = false,
     style,
     onAdd,
     onRemove,
@@ -22,11 +26,19 @@
   const handler = $derived(isFavorited ? onRemove : onAdd);
   const state = $derived(isFavorited ? "filled" : "open");
 
+  const label = $derived(
+    isQueued
+      ? `${i18n.label({ isFavorited, title })} (${m.label_queued_action()})`
+      : i18n.label({ isFavorited, title }),
+  );
+
   const commonProps: Omit<ButtonProps, "children"> = $derived({
-    label: i18n.label({ isFavorited, title }),
+    label,
     variant: "primary",
     onclick: handler,
-    disabled: isFavoriteUpdating,
+    // A queued action stays disabled so it can't be re-triggered while it
+    // waits to sync - the pending pill signals it's already been actioned.
+    disabled: isFavoriteUpdating || isQueued,
     navigationType,
     size,
   });
@@ -35,6 +47,7 @@
 {#if style === "normal"}
   <Button {...commonProps} {...props} style="ghost" color="orange">
     {i18n.text({ isFavorited, title })}
+    {#if isQueued}<QueuedTag />{/if}
     {#snippet icon()}
       <FavoriteIcon {state} />
     {/snippet}
@@ -42,14 +55,17 @@
 {/if}
 
 {#if style === "action"}
-  <ActionButton {...commonProps} {...props} style="ghost" color="default">
-    <FavoriteIcon {state} --icon-color="var(--color-background-orange)" />
-  </ActionButton>
+  <QueuedIndicator {isQueued}>
+    <ActionButton {...commonProps} {...props} style="ghost" color="default">
+      <FavoriteIcon {state} --icon-color="var(--color-background-orange)" />
+    </ActionButton>
+  </QueuedIndicator>
 {/if}
 
 {#if style === "dropdown-item"}
   <DropdownItem {...commonProps} style="flat" color="default">
     {i18n.text({ isFavorited, title })}
+    {#if isQueued}<QueuedTag />{/if}
     {#snippet icon()}
       <FavoriteIcon {state} />
     {/snippet}

--- a/projects/client/src/lib/components/buttons/favorite/FavoriteButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/favorite/FavoriteButtonProps.ts
@@ -6,6 +6,7 @@ export type FavoriteButtonProps = {
   title: string;
   isFavoriteUpdating: boolean;
   isFavorited: boolean;
+  isQueued?: boolean;
   style: 'action' | 'normal' | 'dropdown-item';
   size?: 'small' | 'normal';
   onAdd: () => void;

--- a/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte
+++ b/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButton.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import QueuedIndicator from "$lib/components/badge/QueuedIndicator.svelte";
+  import QueuedTag from "$lib/components/badge/QueuedTag.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
   import TrackIcon from "$lib/components/icons/TrackIcon.svelte";
@@ -18,6 +21,7 @@
     onAsk,
     isMarkingAsWatched,
     isWatched,
+    isQueued = false,
     isLoading = false,
     style,
     mode = "hybrid",
@@ -52,12 +56,20 @@
   );
   const state = $derived(isRemovable ? "watched" : "unwatched");
 
+  const label = $derived(
+    isQueued
+      ? `${i18n.label({ title, isWatched, isRewatching })} (${m.label_queued_action()})`
+      : i18n.label({ title, isWatched, isRewatching }),
+  );
+
   const commonProps: Omit<ButtonProps, "children"> = $derived({
-    label: i18n.label({ title, isWatched, isRewatching }),
+    label,
     color: $color,
     variant: mode === "ask" ? "primary" : variant,
     onclick: handler,
-    disabled: isMarkingAsWatched || isLoading,
+    // A queued action stays disabled so it can't be re-triggered while it
+    // waits to sync - the pending pill signals it's already been actioned.
+    disabled: isMarkingAsWatched || isQueued || isLoading,
     ...events,
   });
 
@@ -92,6 +104,7 @@
         navigationType={DpadNavigationType.Item}
       >
         {buttonText}
+        {#if isQueued}<QueuedTag />{/if}
         {#snippet icon()}
           {@render watchIcon()}
         {/snippet}
@@ -100,14 +113,17 @@
   {/if}
 
   {#if style === "action"}
-    <ActionButton style="ghost" {...commonProps} {...props}>
-      {@render watchIcon("small")}
-    </ActionButton>
+    <QueuedIndicator {isQueued}>
+      <ActionButton style="ghost" {...commonProps} {...props}>
+        {@render watchIcon("small")}
+      </ActionButton>
+    </QueuedIndicator>
   {/if}
 
   {#if style === "dropdown-item"}
     <DropdownItem {...commonProps} style="flat">
       {buttonText}
+      {#if isQueued}<QueuedTag />{/if}
       {#snippet icon()}
         {@render watchIcon()}
       {/snippet}

--- a/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/mark-as-watched/MarkAsWatchedButtonProps.ts
@@ -5,6 +5,7 @@ export type MarkAsWatchedButtonProps = {
   title: string;
   isMarkingAsWatched: boolean;
   isWatched: boolean;
+  isQueued?: boolean;
   isLoading?: boolean;
   style: 'action' | 'normal' | 'dropdown-item';
   size: 'normal' | 'small';

--- a/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
+++ b/projects/client/src/lib/components/buttons/watchlist/WatchlistButton.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import QueuedIndicator from "$lib/components/badge/QueuedIndicator.svelte";
+  import QueuedTag from "$lib/components/badge/QueuedTag.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
   import Button from "$lib/components/buttons/Button.svelte";
   import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
   import BookmarkIcon from "$lib/components/icons/BookmarkIcon.svelte";
@@ -14,6 +17,7 @@
     title,
     isWatchlistUpdating,
     isWatchlisted,
+    isQueued = false,
     type,
     onAdd,
     onRemove,
@@ -31,10 +35,18 @@
   );
   const state = $derived(isWatchlisted ? "added" : "missing");
 
+  const label = $derived(
+    isQueued
+      ? `${i18n.label({ isWatchlisted, title })} (${m.label_queued_action()})`
+      : i18n.label({ isWatchlisted, title }),
+  );
+
   const actionProps = $derived({
-    label: i18n.label({ isWatchlisted, title }),
+    label,
     onclick: handler,
-    disabled: isWatchlistUpdating,
+    // A queued action stays disabled so it can't be re-triggered while it
+    // waits to sync - the pending pill signals it's already been actioned.
+    disabled: isWatchlistUpdating || isQueued,
     ...events,
   });
 
@@ -53,6 +65,7 @@
       navigationType={DpadNavigationType.Item}
     >
       {i18n.text({ isWatchlisted, title })}
+      {#if isQueued}<QueuedTag />{/if}
       {#snippet icon()}
         <BookmarkIcon {state} size="normal" />
       {/snippet}
@@ -61,17 +74,20 @@
 {/if}
 
 {#if type === "action"}
-  <ActionButton style="ghost" {...actionProps} {...props}>
-    <BookmarkIcon {state} />
-  </ActionButton>
+  <QueuedIndicator {isQueued}>
+    <ActionButton style="ghost" {...actionProps} {...props}>
+      <BookmarkIcon {state} />
+    </ActionButton>
+  </QueuedIndicator>
 {/if}
 
 {#if type === "dropdown-item"}
   <DropdownItem {...commonProps} style="flat">
     {i18n.text({ isWatchlisted, title })}
+    {#if isQueued}<QueuedTag />{/if}
     {#snippet icon()}
       <!-- FIXME: generalize this and do this for all applicable buttons/items  -->
-      {#if isWatchlistUpdating}
+      {#if isWatchlistUpdating && !isQueued}
         <LoadingIndicator />
       {:else}
         <BookmarkIcon {state} size="normal" />

--- a/projects/client/src/lib/components/buttons/watchlist/WatchlistButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/watchlist/WatchlistButtonProps.ts
@@ -5,6 +5,7 @@ export type WatchlistButtonProps = {
   title: string;
   isWatchlistUpdating: boolean;
   isWatchlisted: boolean;
+  isQueued?: boolean;
   type: 'action' | 'normal' | 'dropdown-item';
   size: 'small' | 'normal';
   onAdd: () => void;

--- a/projects/client/src/lib/features/offline/useIsQueued.spec.ts
+++ b/projects/client/src/lib/features/offline/useIsQueued.spec.ts
@@ -1,0 +1,50 @@
+import { buildOfflineAction } from '$test/beds/offline/buildOfflineAction.ts';
+import { filter, firstValueFrom } from 'rxjs';
+import { afterEach, describe, expect, it } from 'vitest';
+import { offlineActionsStore } from './_internal/offlineActionsStore.ts';
+import { useIsQueued } from './useIsQueued.ts';
+
+async function drainQueue() {
+  const ids = offlineActionsStore.current().map(({ id }) => id);
+  await offlineActionsStore.remove(ids);
+}
+
+describe('store: useIsQueued', () => {
+  afterEach(drainQueue);
+
+  it('should be false with an empty queue', async () => {
+    const { isQueued } = useIsQueued({ domain: 'history', keys: ['movie:1'] });
+
+    expect(await firstValueFrom(isQueued)).toBe(false);
+  });
+
+  it('should be true when a queued action covers the keys', async () => {
+    const { isQueued } = useIsQueued({ domain: 'history', keys: ['movie:1'] });
+
+    await offlineActionsStore.enqueue(
+      buildOfflineAction({ endpoint: 'history:add', keys: ['movie:1'] }),
+    );
+
+    expect(await firstValueFrom(isQueued.pipe(filter(Boolean)))).toBe(true);
+  });
+
+  it('should ignore queued actions from another domain', async () => {
+    const { isQueued } = useIsQueued({ domain: 'history', keys: ['movie:1'] });
+
+    await offlineActionsStore.enqueue(
+      buildOfflineAction({ endpoint: 'watchlist:add', keys: ['movie:1'] }),
+    );
+
+    expect(await firstValueFrom(isQueued)).toBe(false);
+  });
+
+  it('should ignore queued actions for other keys', async () => {
+    const { isQueued } = useIsQueued({ domain: 'history', keys: ['movie:1'] });
+
+    await offlineActionsStore.enqueue(
+      buildOfflineAction({ endpoint: 'history:add', keys: ['movie:2'] }),
+    );
+
+    expect(await firstValueFrom(isQueued)).toBe(false);
+  });
+});

--- a/projects/client/src/lib/features/offline/useIsQueued.ts
+++ b/projects/client/src/lib/features/offline/useIsQueued.ts
@@ -1,0 +1,27 @@
+import { map, type Observable } from 'rxjs';
+import { findPendingOverride } from './findPendingOverride.ts';
+import type { OfflineActionDomain } from './models/OfflineActionEndpoint.ts';
+import { useOfflineActions } from './useOfflineActions.ts';
+
+type UseIsQueuedParams = {
+  domain: OfflineActionDomain;
+  keys: string[];
+};
+
+/**
+ * True while a queued (not-yet-synced) offline action covers these media
+ * keys - lets the UI flag the action as pending rather than just disabled.
+ */
+export function useIsQueued(
+  { domain, keys }: UseIsQueuedParams,
+): { isQueued: Observable<boolean> } {
+  const { actions } = useOfflineActions();
+
+  const isQueued = actions.pipe(
+    map((queued) =>
+      findPendingOverride({ actions: queued, domain, keys }) != null
+    ),
+  );
+
+  return { isQueued };
+}

--- a/projects/client/src/lib/sections/media-actions/favorite/FavoriteAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/favorite/FavoriteAction.svelte
@@ -35,6 +35,7 @@
   const {
     isUpdatingFavorite,
     isFavorited,
+    isQueued,
     addToFavorites: doAddToFavorites,
     removeFromFavorites,
   } = $derived(useFavorites({ type, id, title }));
@@ -91,6 +92,7 @@
     {size}
     isFavorited={$isFavorited}
     isFavoriteUpdating={$isUpdatingFavorite}
+    isQueued={$isQueued}
     onAdd={() => handler("add")}
     onRemove={() => handler("remove")}
   />

--- a/projects/client/src/lib/sections/media-actions/favorite/useFavorites.ts
+++ b/projects/client/src/lib/sections/media-actions/favorite/useFavorites.ts
@@ -3,6 +3,7 @@ import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
 import { findPendingOverride } from '$lib/features/offline/findPendingOverride.ts';
 import { isAddEndpoint } from '$lib/features/offline/isAddEndpoint.ts';
 import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
+import { useIsQueued } from '$lib/features/offline/useIsQueued.ts';
 import { useOfflineActions } from '$lib/features/offline/useOfflineActions.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
@@ -31,6 +32,10 @@ export function useFavorites({ type, id }: FavoritesStoreProps) {
   const { favorites } = useUser();
   const { invalidate } = useInvalidator();
   const { actions } = useOfflineActions();
+  const { isQueued } = useIsQueued({
+    domain: 'favorites',
+    keys: [toMediaKey(type, id)],
+  });
 
   const isFavorited = combineLatest([favorites, actions]).pipe(
     map(([$favorites, $actions]) => {
@@ -71,13 +76,17 @@ export function useFavorites({ type, id }: FavoritesStoreProps) {
 
     if (result === 'executed') {
       await invalidate(InvalidateAction.Favorited(type));
-      isUpdatingFavorite.next(false);
     }
+
+    // Always clear: a queued action stays flagged via isQueued, and leaving
+    // this pinned would re-disable the button once it syncs and dequeues.
+    isUpdatingFavorite.next(false);
   };
 
   return {
     isUpdatingFavorite,
     isFavorited,
+    isQueued,
     addToFavorites: async () => await addOrRemoveFavorite('add'),
     removeFromFavorites: async () => await addOrRemoveFavorite('remove'),
   };

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte
@@ -19,6 +19,7 @@
   const {
     isMarkingAsWatched,
     isWatched,
+    isQueued,
     markAsWatched,
     removeWatched,
     isWatchable,
@@ -59,6 +60,7 @@
     {isLoading}
     isWatched={$isWatched}
     isMarkingAsWatched={$isMarkingAsWatched}
+    isQueued={$isQueued}
     onWatch={confirmMarkAsWatched}
     onRemove={confirmRemoveFromWatched}
     {onAsk}

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useMarkAsWatched.ts
@@ -3,6 +3,7 @@ import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
 import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
+import { useIsQueued } from '$lib/features/offline/useIsQueued.ts';
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
@@ -31,6 +32,7 @@ export function useMarkAsWatched(
   const { track } = useTrack(AnalyticsEvent.MarkAsWatched);
 
   const { isWatched } = useIsWatched(props);
+  const { isQueued } = useIsQueued({ domain: 'history', keys: mediaKeys });
 
   const markAsWatched = async (watchedAt?: MarkAsWatchedAt) => {
     const current = await resolve(user);
@@ -53,8 +55,11 @@ export function useMarkAsWatched(
 
     if (result === 'executed') {
       await invalidate(InvalidateAction.MarkAsWatched(type));
-      isMarkingAsWatched.next(false);
     }
+
+    // Always clear: a queued action stays flagged via isQueued, and leaving
+    // this pinned would re-disable the button once it syncs and dequeues.
+    isMarkingAsWatched.next(false);
   };
 
   // Ids whose rating this removal orphans. The main action removes *every*
@@ -122,8 +127,9 @@ export function useMarkAsWatched(
 
     if (removeResult === 'executed') {
       await invalidate(InvalidateAction.MarkAsWatched(type));
-      isMarkingAsWatched.next(false);
     }
+
+    isMarkingAsWatched.next(false);
   };
 
   const isWatchable = media.every((item) => {
@@ -138,6 +144,7 @@ export function useMarkAsWatched(
     removeWatched,
     isWatched,
     isMarkingAsWatched,
+    isQueued,
     isWatchable,
   };
 }

--- a/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/watchlist/WatchlistAction.svelte
@@ -16,6 +16,7 @@
     addToWatchlist,
     isWatchlistUpdating,
     isWatchlisted,
+    isQueued,
     removeFromWatchlist,
   } = $derived(useWatchlist(target));
 
@@ -35,6 +36,7 @@
   {size}
   isWatchlisted={$isWatchlisted}
   isWatchlistUpdating={$isWatchlistUpdating}
+  isQueued={$isQueued}
   onAdd={addToWatchlist}
   onRemove={confirmRemove}
 />

--- a/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
+++ b/projects/client/src/lib/sections/media-actions/watchlist/useWatchlist.ts
@@ -2,6 +2,7 @@ import { AnalyticsEvent } from '$lib/features/analytics/events/AnalyticsEvent.ts
 import { useTrack } from '$lib/features/analytics/useTrack.ts';
 import { executeOrEnqueue } from '$lib/features/offline/executeOrEnqueue.ts';
 import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
+import { useIsQueued } from '$lib/features/offline/useIsQueued.ts';
 import type { MediaStoreProps } from '$lib/models/MediaStoreProps.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { toBulkPayload } from '$lib/sections/media-actions/_internal/toBulkPayload.ts';
@@ -19,6 +20,10 @@ export function useWatchlist(props: MediaStoreProps) {
   const ids = media.map(({ id }) => id);
 
   const { isWatchlisted } = useIsWatchlisted(props);
+  const { isQueued } = useIsQueued({
+    domain: 'watchlist',
+    keys: ids.map((id) => toMediaKey(type, id)),
+  });
   const body = toBulkPayload(type, ids);
 
   const addToWatchlist = async () => {
@@ -38,8 +43,11 @@ export function useWatchlist(props: MediaStoreProps) {
 
     if (addResult === 'executed') {
       await invalidate(InvalidateAction.Watchlisted(type));
-      isWatchlistUpdating.next(false);
     }
+
+    // Always clear: a queued action stays flagged via isQueued, and leaving
+    // this pinned would re-disable the button once it syncs and dequeues.
+    isWatchlistUpdating.next(false);
   };
 
   const removeFromWatchlist = async () => {
@@ -59,13 +67,15 @@ export function useWatchlist(props: MediaStoreProps) {
 
     if (removeResult === 'executed') {
       await invalidate(InvalidateAction.Watchlisted(type));
-      isWatchlistUpdating.next(false);
     }
+
+    isWatchlistUpdating.next(false);
   };
 
   return {
     isWatchlistUpdating,
     isWatchlisted,
+    isQueued,
     addToWatchlist,
     removeFromWatchlist,
   };

--- a/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RateNow.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import QueuedTag from "$lib/components/badge/QueuedTag.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType";
   import FavoriteAction from "$lib/sections/media-actions/favorite/FavoriteAction.svelte";
@@ -23,13 +24,19 @@
   const type = $derived(props.type);
   const id = $derived(props.media.id);
 
-  const { pendingRating, isSubmitting, current, addRating, removeRating } =
-    $derived(
-      useRatings({
-        type,
-        id,
-      }),
-    );
+  const {
+    pendingRating,
+    isSubmitting,
+    isQueued,
+    current,
+    addRating,
+    removeRating,
+  } = $derived(
+    useRatings({
+      type,
+      id,
+    }),
+  );
 
   const confettiPosition = writable<{ x: number; y: number } | null>(null);
   const setConfettiPosition = (rating: number, ev?: MouseEvent) => {
@@ -68,7 +75,7 @@
     >
       <RatingStars
         rating={$pendingRating ?? $current?.rating}
-        isRating={$isSubmitting}
+        isRating={$isSubmitting || $isQueued}
         onRemoveRating={() => {
           onclick?.();
           removeRating();
@@ -79,6 +86,8 @@
           addRating(rating);
         }}
       />
+
+      {#if $isQueued}<QueuedTag />{/if}
 
       {#if props.type !== "episode" && props.type !== "season"}
         <div

--- a/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
+++ b/projects/client/src/lib/sections/summary/components/rating/useRatings.ts
@@ -7,6 +7,7 @@ import { findPendingOverride } from '$lib/features/offline/findPendingOverride.t
 import { isAddEndpoint } from '$lib/features/offline/isAddEndpoint.ts';
 import type { OfflineAction } from '$lib/features/offline/models/OfflineAction.ts';
 import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
+import { useIsQueued } from '$lib/features/offline/useIsQueued.ts';
 import { useOfflineActions } from '$lib/features/offline/useOfflineActions.ts';
 import { useLastWatched } from '$lib/features/toast/useLastWatched.ts';
 import {
@@ -81,6 +82,10 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
   const { dismiss } = useLastWatched();
 
   const { actions } = useOfflineActions();
+  const { isQueued } = useIsQueued({
+    domain: 'rating',
+    keys: [toMediaKey(type, id)],
+  });
 
   const rating = combineLatest([ratings, actions]).pipe(
     map(([$ratings, $actions]) => {
@@ -183,12 +188,15 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
     });
     if (addResult === 'executed') {
       await invalidate(InvalidateAction.Rated(type));
-      pendingRating.next(null);
-      isSubmitting.next(false);
       if (type !== 'season') {
         dismiss(id, type, 'rating');
       }
     }
+
+    // Always clear: a queued rating stays flagged via isQueued, and leaving
+    // these pinned would re-disable the stars once it syncs and dequeues.
+    pendingRating.next(null);
+    isSubmitting.next(false);
   });
 
   const addRating = (newRating: number) => {
@@ -216,6 +224,7 @@ export function useRatings({ type, id }: WatchlistStoreProps) {
   return {
     pendingRating,
     isSubmitting,
+    isQueued,
     current,
     addRating,
     removeRating,

--- a/projects/client/src/style/theme/global.css
+++ b/projects/client/src/style/theme/global.css
@@ -35,6 +35,10 @@
   --color-text-preview-tag: var(--shade-10);
   --color-background-preview-tag: var(--orange-600);
 
+  /* Offline queued action flag - dark text on yellow reads in both themes */
+  --color-text-queued-tag: var(--shade-900);
+  --color-background-queued-tag: var(--yellow-600);
+
   --color-text-indicator-tag: var(--shade-10);
   --color-background-indicator-tag: var(--shade-800);
 


### PR DESCRIPTION
Follow-up to the offline actions feature (#2881). Surfaces a distinct `isQueued` state so a tracking action saved offline reads as *pending sync* rather than just disabled.

## Why

After #2881 an action taken offline is queued and replayed on reconnect, but the UI only knew `isLoading` / `isUpdating`. With the post-merge change that keeps `isUpdating` pinned until sync, an offline action left the button in a permanent spinner/disabled state with no signal that it was actually saved and waiting. This adds the missing state and a visible flag.

## What's in here

**`isQueued` state**
- New `useIsQueued({ domain, keys })` composable resolves whether a not-yet-synced queued action covers a given media key set (reuses `findPendingOverride`).
- Threaded out of the mark-as-watched, watchlist, favorite, and rating hooks alongside the existing state.

**Queued pill**
- Yellow `Queued` pill (`QueuedTag`, styled `StemTag`) next to text and dropdown-item controls.
- Corner dot (`QueuedIndicator`) on icon-only action buttons in the summary bar, where there's no room for a full pill.
- A queued action also un-sticks the control, so the user can toggle it back while it waits to sync.
- New `--color-background-queued-tag` / `--color-text-queued-tag` tokens (yellow-600, dark text - reads in both themes) following the existing `preview-tag` pattern.

## Testing

- New `useIsQueued` spec (empty queue, covering action, wrong domain, wrong keys); existing offline + media-action suites stay green.
- `svelte-check` reports only the pre-existing settings/locale SDK drift (untouched files).

## Visual

The pill placement (corner dot on icon buttons, inline pill on text buttons) was picked from mockups before implementation. Happy to attach a live screenshot if useful.
