### PR TITLE
feat(redirects): redirect legacy v2 paths to trakt-web equivalents

### DIFF
--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -8,6 +8,7 @@ import { handle as handleDeployment } from '$lib/features/deployment/handle.ts';
 import { handle as handleDevice } from '$lib/features/devices/handle.ts';
 import { handle as handleLocale } from '$lib/features/i18n/handle.ts';
 import { handle as handleImage } from '$lib/features/image/handle.ts';
+import { handle as handleLegacyRedirect } from '$lib/features/legacy-redirects/handle.ts';
 import { handle as handleMobileOperatingSystem } from '$lib/features/mobile-os/handle.ts';
 import { handle as handleSearchConfig } from '$lib/features/search/handle.ts';
 import { handle as handleTheme } from '$lib/features/theme/handle.ts';
@@ -78,6 +79,8 @@ export const handle: Handle = sequence(
     ],
   }),
   sentryHandle(),
+  // Retire legacy trakt.tv paths with a 301 before any routing/auth/i18n work.
+  handleLegacyRedirect,
   // Must run before any feature that touches `event.locals` or session
   // state so missing-asset requests (which carry no user context) skip the
   // rest of the pipeline entirely.

--- a/projects/client/src/lib/features/legacy-redirects/handle.ts
+++ b/projects/client/src/lib/features/legacy-redirects/handle.ts
@@ -1,0 +1,25 @@
+import { resolveLegacyRedirect } from '$lib/features/legacy-redirects/resolveLegacyRedirect.ts';
+import type { Handle } from '@sveltejs/kit';
+
+// The v2 site (trakt.tv) is retired; its paths now land on trakt-web. Any
+// legacy shape with a known trakt-web equivalent is 301'd here, before routing,
+// so no auth/i18n/data work runs for a request we're about to redirect anyway.
+export const handle: Handle = ({ event, resolve }) => {
+  const target = resolveLegacyRedirect(event.url.pathname);
+
+  if (!target || target === event.url.pathname) {
+    return resolve(event);
+  }
+
+  const search = event.url.search;
+  // Merge the incoming query string, accounting for targets (e.g. the episode
+  // drawer) that already carry their own params.
+  const location = search && target.includes('?')
+    ? `${target}&${search.slice(1)}`
+    : `${target}${search}`;
+
+  return new Response(null, {
+    status: 301,
+    headers: { Location: location },
+  });
+};

--- a/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.spec.ts
+++ b/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.spec.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import { resolveLegacyRedirect } from './resolveLegacyRedirect.ts';
+
+describe('util: resolveLegacyRedirect', () => {
+  describe('media structural rename', () => {
+    it('should map singular show to plural', () => {
+      expect(resolveLegacyRedirect('/show/breaking-bad')).toBe(
+        '/shows/breaking-bad',
+      );
+    });
+
+    it('should map singular show season to the seasons drawer', () => {
+      expect(resolveLegacyRedirect('/show/breaking-bad/season/2')).toBe(
+        '/shows/breaking-bad?view=seasons&season=2',
+      );
+    });
+
+    it('should map singular show episode to the episode drawer', () => {
+      expect(
+        resolveLegacyRedirect('/show/breaking-bad/season/2/episode/5'),
+      ).toBe('/shows/breaking-bad?view=episode&season=2&episode=5');
+    });
+
+    it('should map singular movie to plural', () => {
+      expect(resolveLegacyRedirect('/movie/heretic-2024')).toBe(
+        '/movies/heretic-2024',
+      );
+    });
+
+    it('should map singular user to plural', () => {
+      expect(resolveLegacyRedirect('/user/sean')).toBe('/users/sean');
+    });
+  });
+
+  describe('chart / collection pages', () => {
+    it('should map discover-backed show charts to discover with mode', () => {
+      expect(resolveLegacyRedirect('/shows/trending')).toBe(
+        '/discover/trending?mode=show',
+      );
+      expect(resolveLegacyRedirect('/shows/popular')).toBe(
+        '/discover/popular?mode=show',
+      );
+      expect(resolveLegacyRedirect('/shows/anticipated')).toBe(
+        '/discover/anticipated?mode=show',
+      );
+    });
+
+    it('should map discover-backed movie charts to discover with mode', () => {
+      expect(resolveLegacyRedirect('/movies/trending')).toBe(
+        '/discover/trending?mode=movie',
+      );
+      expect(resolveLegacyRedirect('/movies/releases')).toBe(
+        '/discover/releases?mode=movie',
+      );
+    });
+
+    it('should fold charts without a drilldown to discover with mode', () => {
+      expect(resolveLegacyRedirect('/shows/played')).toBe(
+        '/discover?mode=show',
+      );
+      expect(resolveLegacyRedirect('/shows/library')).toBe(
+        '/discover?mode=show',
+      );
+      expect(resolveLegacyRedirect('/movies/boxoffice')).toBe(
+        '/discover?mode=movie',
+      );
+    });
+
+    it('should map the bare media index to discover with mode', () => {
+      expect(resolveLegacyRedirect('/shows')).toBe('/discover?mode=show');
+      expect(resolveLegacyRedirect('/movies')).toBe('/discover?mode=movie');
+    });
+  });
+
+  describe('media sub-routes fold to nearest parent', () => {
+    it('should fold show sub-routes to the show page', () => {
+      expect(resolveLegacyRedirect('/shows/breaking-bad/comments')).toBe(
+        '/shows/breaking-bad',
+      );
+      expect(resolveLegacyRedirect('/shows/breaking-bad/credits')).toBe(
+        '/shows/breaking-bad',
+      );
+    });
+
+    it('should fold seasons/all to the seasons drawer on the first season', () => {
+      expect(resolveLegacyRedirect('/shows/breaking-bad/seasons/all')).toBe(
+        '/shows/breaking-bad?view=seasons&season=1',
+      );
+    });
+
+    it('should fold season sub-routes to the season drawer', () => {
+      expect(
+        resolveLegacyRedirect('/shows/breaking-bad/seasons/2/comments'),
+      ).toBe('/shows/breaking-bad?view=seasons&season=2');
+    });
+
+    it('should fold episode sub-routes to the episode drawer', () => {
+      expect(
+        resolveLegacyRedirect(
+          '/shows/breaking-bad/seasons/2/episodes/5/comments',
+        ),
+      ).toBe('/shows/breaking-bad?view=episode&season=2&episode=5');
+    });
+
+    it('should fold movie sub-routes to the movie page', () => {
+      expect(resolveLegacyRedirect('/movies/heretic-2024/releases')).toBe(
+        '/movies/heretic-2024',
+      );
+    });
+
+    it('should fold person lists to the person page', () => {
+      expect(resolveLegacyRedirect('/people/bryan-cranston/lists')).toBe(
+        '/people/bryan-cranston',
+      );
+    });
+  });
+
+  describe('user profile sub-routes', () => {
+    it('should map history to the profile history page', () => {
+      expect(resolveLegacyRedirect('/users/sean/history')).toBe(
+        '/profile/sean/history',
+      );
+    });
+
+    it('should map favorites to the profile favorites page', () => {
+      expect(resolveLegacyRedirect('/users/sean/favorites')).toBe(
+        '/profile/sean/favorites',
+      );
+    });
+
+    it('should map ratings and comments to the profile activity drawer', () => {
+      expect(resolveLegacyRedirect('/users/sean/ratings')).toBe(
+        '/profile/sean?view=activity',
+      );
+      expect(resolveLegacyRedirect('/users/sean/comments/movies')).toBe(
+        '/profile/sean?view=activity',
+      );
+    });
+
+    it('should map hidden to the signed-in user media progress page', () => {
+      expect(resolveLegacyRedirect('/users/sean/hidden')).toBe(
+        '/profile/me/progress?mode=media',
+      );
+    });
+
+    it('should fold remaining profile sub-routes to the profile home', () => {
+      expect(resolveLegacyRedirect('/users/sean/likes')).toBe('/profile/sean');
+      expect(resolveLegacyRedirect('/users/sean/network')).toBe(
+        '/profile/sean',
+      );
+    });
+
+    it('should fold numeric-id user lists to the lists overview', () => {
+      expect(resolveLegacyRedirect('/users/sean/lists/12345')).toBe(
+        '/users/sean/lists',
+      );
+    });
+  });
+
+  describe('top-level pages', () => {
+    it('should map dashboard to home', () => {
+      expect(resolveLegacyRedirect('/dashboard')).toBe('/');
+      expect(resolveLegacyRedirect('/dashboard/on_deck')).toBe('/');
+    });
+
+    it('should map official lists', () => {
+      expect(resolveLegacyRedirect('/officiallist/best-of-2024')).toBe(
+        '/lists/official/best-of-2024',
+      );
+    });
+  });
+
+  describe('no sensible target falls back to home', () => {
+    it.each([
+      '/seasons/12345',
+      '/episodes/67890',
+      '/comments/all/movies',
+      '/share/abc123',
+      '/tmdb/updates',
+    ])('should redirect %s to home', (path) => {
+      expect(resolveLegacyRedirect(path)).toBe('/');
+    });
+  });
+
+  describe('numeric-id lists fall back to the user lists landing', () => {
+    it.each([
+      '/lists/12345',
+      '/watchlist/12345',
+    ])('should redirect %s to /users/me/lists', (path) => {
+      expect(resolveLegacyRedirect(path)).toBe('/users/me/lists');
+    });
+  });
+
+  describe('native paths pass through untouched', () => {
+    it.each([
+      '/shows/breaking-bad',
+      '/shows/breaking-bad/lists',
+      '/shows/breaking-bad/related',
+      '/shows/breaking-bad/seasons',
+      '/shows/breaking-bad/seasons/2',
+      '/shows/breaking-bad/seasons/2/episodes/5',
+      '/movies/heretic-2024',
+      '/movies/heretic-2024/lists',
+      '/people/bryan-cranston',
+      '/users/sean',
+      '/users/sean/lists',
+      '/users/sean/watchlist',
+      '/users/sean/progress',
+      '/users/sean/collection',
+      '/calendar',
+      '/search',
+      '/settings/advanced',
+      '/',
+    ])('should return null for %s', (path) => {
+      expect(resolveLegacyRedirect(path)).toBeNull();
+    });
+  });
+});

--- a/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.ts
+++ b/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.ts
@@ -1,0 +1,241 @@
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
+
+/**
+ * Maps a legacy trakt.tv (v2) path to its canonical trakt-web equivalent.
+ *
+ * The v2 site is being retired and every legacy `trakt.tv/*` path now lands
+ * on trakt-web. Many legacy shapes differ from trakt-web's routes (singular
+ * `show/:id`, chart pages like `shows/played`, sub-routes like
+ * `shows/:id/comments`) and would 404. Each rule rewrites one such shape to the
+ * closest sensible trakt-web page.
+ *
+ * Returns the canonical path (with any query params the target itself needs),
+ * or `null` when the path already maps natively and should pass through
+ * untouched. Pure: same input -> same output, no side effects.
+ */
+
+type LegacyRule = {
+  readonly pattern: RegExp;
+  readonly to: (match: RegExpMatchArray) => string;
+};
+
+// Chart words backed by a trakt-web discover page: mapped to the canonical
+// `/discover/:word?mode=:type` URL.
+const discoverBuilders = {
+  trending: UrlBuilder.trending,
+  popular: UrlBuilder.popular,
+  anticipated: UrlBuilder.anticipated,
+  recommended: UrlBuilder.recommended,
+  releases: UrlBuilder.releases,
+} as const;
+const discoverChartWords = Object.keys(discoverBuilders).join('|');
+
+// Chart/collection words with no discover drilldown -> discover, mode-filtered.
+// A media slug never collides with these (v2 reserved them), so this is safe.
+const indexChartWords =
+  'played|watched|collected|favorited|streaming|hot|library|boxoffice';
+
+// Sub-route leaves that have no trakt-web page and fold back to their parent.
+const showSubroutes = 'comments|credits|stats|history|progress|ratings|people';
+const movieSubroutes = 'comments|credits|releases|stats|history|people';
+const seasonSubroutes = 'comments|credits|stats|wikipedia|lists|people';
+const episodeSubroutes = 'comments|credits|stats|wikipedia|lists|people';
+
+// User sub-routes whose content lives in the profile activity drawer.
+const userActivitySubroutes = 'ratings|comments';
+// Remaining user sub-routes with no dedicated trakt-web page -> profile home.
+const userToProfileSubroutes = 'notes|likes|reactions|charts|network';
+
+const episodeDrawer = (m: RegExpMatchArray): string =>
+  UrlBuilder.episodeDrawer(m[1], Number(m[2]), Number(m[3]));
+
+const seasonDrawer = (m: RegExpMatchArray): string =>
+  UrlBuilder.seasonDrawer(m[1], Number(m[2]));
+
+const rules: ReadonlyArray<LegacyRule> = [
+  // --- A. Media: structural rename (singular -> plural / segment rename) ---
+  // Episode (drawer format) must precede the shorter show/season rules.
+  {
+    pattern: /^\/show\/([^/]+)\/season\/([^/]+)\/episode\/([^/]+)\/?$/,
+    to: episodeDrawer,
+  },
+  {
+    pattern: /^\/show\/([^/]+)\/season\/([^/]+)\/?$/,
+    to: seasonDrawer,
+  },
+  {
+    pattern: /^\/show\/([^/]+)\/?$/,
+    to: (m) => UrlBuilder.show(m[1]),
+  },
+  {
+    pattern: /^\/movie\/([^/]+)\/?$/,
+    to: (m) => UrlBuilder.movie(m[1]),
+  },
+  {
+    pattern: /^\/user\/([^/]+)\/?$/,
+    to: (m) => `/users/${m[1]}`,
+  },
+
+  // --- C. Chart/collection index pages (would otherwise hit [slug]) ---
+  // Discover-backed charts -> canonical /discover/:word?mode=:type.
+  {
+    pattern: new RegExp(`^\\/shows\\/(${discoverChartWords})\\/?$`),
+    to: (m) =>
+      discoverBuilders[m[1] as keyof typeof discoverBuilders]({
+        mode: 'show',
+      }),
+  },
+  {
+    pattern: new RegExp(`^\\/movies\\/(${discoverChartWords})\\/?$`),
+    to: (m) =>
+      discoverBuilders[m[1] as keyof typeof discoverBuilders]({
+        mode: 'movie',
+      }),
+  },
+  // Charts with no discover drilldown -> discover, filtered by mode.
+  {
+    pattern: new RegExp(`^\\/shows\\/(?:${indexChartWords})\\/?$`),
+    to: () => UrlBuilder.discover({ mode: 'show' }),
+  },
+  {
+    pattern: new RegExp(`^\\/movies\\/(?:${indexChartWords})\\/?$`),
+    to: () => UrlBuilder.discover({ mode: 'movie' }),
+  },
+  // Bare media index -> discover, filtered by mode.
+  {
+    pattern: /^\/shows\/?$/,
+    to: () => UrlBuilder.discover({ mode: 'show' }),
+  },
+  {
+    pattern: /^\/movies\/?$/,
+    to: () => UrlBuilder.discover({ mode: 'movie' }),
+  },
+
+  // --- B. Media sub-routes with no trakt-web page -> nearest parent ---
+  // Episode sub-routes -> episode drawer.
+  {
+    pattern: new RegExp(
+      `^\\/shows\\/([^/]+)\\/seasons\\/([^/]+)\\/episodes\\/([^/]+)\\/(?:${episodeSubroutes})\\/?$`,
+    ),
+    to: episodeDrawer,
+  },
+  // Season sub-routes -> season drawer.
+  {
+    pattern: new RegExp(
+      `^\\/shows\\/([^/]+)\\/seasons\\/([^/]+)\\/(?:${seasonSubroutes})\\/?$`,
+    ),
+    to: seasonDrawer,
+  },
+  // `seasons/all` overview -> seasons drawer, defaulting to the first season
+  // (the drawer requires a season number).
+  {
+    pattern: /^\/shows\/([^/]+)\/seasons\/all\/?$/,
+    to: (m) => UrlBuilder.seasonDrawer(m[1], 1),
+  },
+  // Show sub-routes -> show page.
+  {
+    pattern: new RegExp(`^\\/shows\\/([^/]+)\\/(?:${showSubroutes})\\/?$`),
+    to: (m) => UrlBuilder.show(m[1]),
+  },
+  // Movie sub-routes -> movie page.
+  {
+    pattern: new RegExp(`^\\/movies\\/([^/]+)\\/(?:${movieSubroutes})\\/?$`),
+    to: (m) => UrlBuilder.movie(m[1]),
+  },
+
+  // --- D. User profile sub-routes (v2 /users/:id/*) ---
+  {
+    pattern: /^\/users\/([^/]+)\/history\/?$/,
+    to: (m) => UrlBuilder.profile.history(m[1]),
+  },
+  {
+    pattern: /^\/users\/([^/]+)\/favorites\/?$/,
+    to: (m) => UrlBuilder.profile.favorites(m[1]),
+  },
+  // Hidden items are private to the owner and surface on their own progress
+  // page, so point at the signed-in user's media progress.
+  {
+    pattern: /^\/users\/[^/]+\/hidden(?:\/.*)?$/,
+    to: () => UrlBuilder.profile.progress('me', { mode: 'media' }),
+  },
+  // Ratings / comments live in the profile activity drawer.
+  {
+    pattern: new RegExp(
+      `^\\/users\\/([^/]+)\\/(?:${userActivitySubroutes})(?:\\/.*)?$`,
+    ),
+    to: (m) => `${UrlBuilder.profile.user(m[1])}?view=activity`,
+  },
+  // Numeric-id user list -> user's lists overview (slug can't be reconstructed).
+  {
+    pattern: /^\/users\/([^/]+)\/lists\/\d+\/?$/,
+    to: (m) => UrlBuilder.lists.user(m[1]),
+  },
+  {
+    pattern: new RegExp(
+      `^\\/users\\/([^/]+)\\/(?:${userToProfileSubroutes})(?:\\/.*)?$`,
+    ),
+    to: (m) => UrlBuilder.profile.user(m[1]),
+  },
+
+  // --- E. People sub-routes with no trakt-web page -> person page ---
+  {
+    pattern: /^\/people\/([^/]+)\/lists\/?$/,
+    to: (m) => UrlBuilder.people(m[1]),
+  },
+
+  // --- Top-level pages ---
+  {
+    pattern: /^\/dashboard(?:\/.*)?$/,
+    to: () => UrlBuilder.home(),
+  },
+  {
+    pattern: /^\/officiallist\/([^/]+)\/?$/,
+    to: (m) => `/lists/official/${m[1]}`,
+  },
+
+  // --- No sensible target -> nearest-section fallback (home) ---
+  // Bare `/seasons/:id` and `/episodes/:id` are v2 API endpoints with no show
+  // context to anchor a drawer on, so there is no equivalent page; send them to
+  // home rather than 404.
+  {
+    pattern: /^\/seasons\/[^/]+\/?$/,
+    to: () => UrlBuilder.home(),
+  },
+  {
+    pattern: /^\/episodes\/[^/]+\/?$/,
+    to: () => UrlBuilder.home(),
+  },
+  // Numeric-id public list / watchlist: slug can't be reconstructed, so fall
+  // back to the signed-in user's lists landing (holds the watchlist and every
+  // other list).
+  {
+    pattern: /^\/(?:lists|watchlist)\/\d+\/?$/,
+    to: () => UrlBuilder.lists.user('me'),
+  },
+  {
+    pattern: /^\/comments\/[^/]+\/[^/]+\/?$/,
+    to: () => UrlBuilder.home(),
+  },
+  {
+    pattern: /^\/share\/[^/]+\/?$/,
+    to: () => UrlBuilder.home(),
+  },
+  {
+    pattern: /^\/tmdb(?:\/.*)?$/,
+    to: () => UrlBuilder.home(),
+  },
+];
+
+export function resolveLegacyRedirect(pathname: string): string | null {
+  const rule = rules.find(({ pattern }) => pattern.test(pathname));
+  if (!rule) {
+    return null;
+  }
+
+  const match = pathname.match(rule.pattern);
+  if (!match) {
+    return null;
+  }
+
+  return rule.to(match);
+}

--- a/projects/client/src/lib/utils/url/UrlBuilder.spec.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.spec.ts
@@ -17,4 +17,18 @@ describe('util: UrlBuilder', () => {
       expect(url).to.equal('/shows/silo?view=episode&season=0&episode=1');
     });
   });
+
+  describe('seasonDrawer', () => {
+    it('should point at the show summary page with the seasons drawer params', () => {
+      const url = UrlBuilder.seasonDrawer('breaking-bad', 2);
+
+      expect(url).to.equal('/shows/breaking-bad?view=seasons&season=2');
+    });
+
+    it('should support specials (season 0)', () => {
+      const url = UrlBuilder.seasonDrawer('silo', 0);
+
+      expect(url).to.equal('/shows/silo?view=seasons&season=0');
+    });
+  });
 });

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -212,6 +212,13 @@ export const UrlBuilder = {
       season,
       episode,
     }),
+  // Opens the show summary page with the seasons drawer pre-opened, focused on
+  // a specific season. Param contract mirrors summaryDrawerNavigation.
+  seasonDrawer: (id: string, season: number) =>
+    UrlBuilder.show(id, {
+      [DRAWER_VIEW_PARAM]: 'seasons',
+      season,
+    }),
   credits: {
     movies: (slug: string) => `/people/${slug}/movies`,
     shows: (slug: string) => `/people/${slug}/shows`,


### PR DESCRIPTION
## 🎶 Notes 🎶

- v2 (trakt.tv) is being retired and its paths now land on trakt-web, so we 301 the legacy shapes to their canonical equivalent.
- Central `handle` in `$lib/features/legacy-redirects`, wired first in the `hooks.server.ts` sequence so a legacy hit short-circuits before any routing/auth/i18n work. Mapping itself is a pure `resolveLegacyRedirect` table.
- Media: `show/:id` → `shows/:id`, `movie/:id` → `movies/:id`, `user/:id` → `users/:id`.
  - Seasons and episodes open the summary drawer: `?view=seasons&season=N` and `?view=episode&season=N&episode=N`.
- Charts: discover-backed ones (trending / popular / anticipated / recommended / releases) → `/discover/:type?mode=…`; the rest, plus bare `/shows` and `/movies`, → discover filtered by mode.
- Sub-routes with no trakt-web page fold to the nearest parent (show / movie / person).
- User sub-routes: `ratings` / `comments` → profile activity drawer, `hidden` → the signed-in user's media progress, the rest → profile home.
- Query strings are preserved, merged correctly when the target already carries params (e.g. the drawer URLs).
- Adds `UrlBuilder.seasonDrawer` alongside the existing `episodeDrawer`.
- Shapes with no sensible target fall back gracefully: `/seasons/:id`, `/episodes/:id` (v2 API-shaped ids with no show context), `/comments/*`, `/share/*`, `/tmdb/*` → home; numeric-id lists / watchlist → `/users/me/lists`.
  - `/users/:id/collection` is intentionally left to 404.
- Covered by unit tests for the mapping table and the new `seasonDrawer`.
