### PR TITLE
perf(calendar): serve hot releases from a single endpoint

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -13,7 +13,7 @@
     "npm:@ethercorps/sveltekit-og@4.3.0": "4.3.0_@sveltejs+kit@2.69.2__@sveltejs+vite-plugin-svelte@7.2.0___svelte@5.56.4___vite@8.1.4____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.4__typescript@5.8.3__vite@8.1.4___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0",
     "npm:@inlang/paraglide-js@2.21.0": "2.21.0_typescript@5.8.3",
     "npm:@jsr/libn__fuzzy@0.4.0": "0.4.0",
-    "npm:@jsr/trakt__api@0.4.21": "0.4.21_openapi3-ts@4.6.0",
+    "npm:@jsr/trakt__api@0.4.22": "0.4.22_openapi3-ts@4.6.0",
     "npm:@playwright/test@1.61.1": "1.61.1",
     "npm:@sentry/sveltekit@10.65.0": "10.65.0_@sveltejs+kit@2.69.2__@sveltejs+vite-plugin-svelte@7.2.0___svelte@5.56.4___vite@8.1.4____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.4__typescript@5.8.3__vite@8.1.4___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0",
     "npm:@svelte-put/shortcut@4.2.0": "4.2.0_svelte@5.56.4",
@@ -2084,14 +2084,14 @@
       "integrity": "sha512-aD9yjW6CMt37S3AMTc95LeuRXcKor69Zkr0aWOhYvinTOEAhEIuaJhP4pQqyQGaAC9HIrQcKh1PtRTK85kkVjA==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/libn__fuzzy/0.4.0.tgz"
     },
-    "@jsr/trakt__api@0.4.21_openapi3-ts@4.6.0": {
-      "integrity": "sha512-CTb+n4kQAslcetVrxFdWT+7MIX6P4FuYFADhmTlYHB3UNWoDDlzZu/bZuxmxJuUWNx+bjvEPfEoPh374/ZxnPA==",
+    "@jsr/trakt__api@0.4.22_openapi3-ts@4.6.0": {
+      "integrity": "sha512-uCbJgsY8RErQuc7Pb1Q1ujqoX4PGNDubCiGNpjhQq3yjYztsl7o7fsiDG6ZZ04ulQv11xHnKMlwa65DVLLFkuQ==",
       "dependencies": [
         "@anatine/zod-openapi",
         "@ts-rest/core",
         "zod"
       ],
-      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.4.21.tgz"
+      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.4.22.tgz"
     },
     "@lix-js/sdk@0.4.10": {
       "integrity": "sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==",
@@ -3369,6 +3369,22 @@
         "kolorist",
         "tinyglobby",
         "vite-plugin-pwa"
+      ]
+    },
+    "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_@opentelemetry+api@1.9.1_jsdom@29.1.1_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0": {
+      "integrity": "sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==",
+      "dependencies": [
+        "@babel/core",
+        "@istanbuljs/schema",
+        "@jridgewell/gen-mapping",
+        "@jridgewell/trace-mapping@0.3.31",
+        "istanbul-lib-coverage",
+        "istanbul-lib-report",
+        "istanbul-reports",
+        "magicast",
+        "obug",
+        "tinyrainbow",
+        "vitest"
       ]
     },
     "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_esbuild@0.28.1_sass-embedded@1.100.0_typescript@5.8.3_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0": {
@@ -7063,7 +7079,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@vitest/coverage-istanbul",
+        "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_@opentelemetry+api@1.9.1_jsdom@29.1.1_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0",
         "@vitest/expect",
         "@vitest/mocker",
         "@vitest/pretty-format",
@@ -7088,7 +7104,7 @@
       ],
       "optionalPeers": [
         "@opentelemetry/api",
-        "@vitest/coverage-istanbul",
+        "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_@opentelemetry+api@1.9.1_jsdom@29.1.1_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0",
         "jsdom"
       ],
       "bin": true
@@ -7529,7 +7545,7 @@
             "npm:@ethercorps/sveltekit-og@4.3.0",
             "npm:@inlang/paraglide-js@2.21.0",
             "npm:@jsr/libn__fuzzy@0.4.0",
-            "npm:@jsr/trakt__api@0.4.21",
+            "npm:@jsr/trakt__api@0.4.22",
             "npm:@playwright/test@1.61.1",
             "npm:@sentry/sveltekit@10.65.0",
             "npm:@svelte-put/shortcut@4.2.0",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -81,7 +81,7 @@
     "@tanstack/query-core": "5.101.2",
     "@tanstack/query-devtools": "5.101.2",
     "@tanstack/query-persist-client-core": "5.101.2",
-    "@trakt/api": "npm:@jsr/trakt__api@0.4.21",
+    "@trakt/api": "npm:@jsr/trakt__api@0.4.22",
     "@ts-rest/core": "3.52.1",
     "@use-gesture/vanilla": "10.3.1",
     "bits-ui": "2.18.1",

--- a/projects/client/src/lib/features/calendar/_internal/useReleasesCalendar.ts
+++ b/projects/client/src/lib/features/calendar/_internal/useReleasesCalendar.ts
@@ -14,8 +14,6 @@ import type { FilterParams } from '../../../requests/models/FilterParams.ts';
 import type { DiscoverMode } from '../../filters/models/DiscoverMode.ts';
 import type { Calendar } from '../models/Calendar.ts';
 
-const releasesCalendarSourceLimit = 50;
-
 type UseReleasesCalendarParams = {
   start: Date;
   days: number;
@@ -43,7 +41,6 @@ export function useReleasesCalendar(
       type: props.type,
       filter: props.filter,
       filterOverride: props.filterOverride,
-      sourceLimit: releasesCalendarSourceLimit,
     }),
   );
 

--- a/projects/client/src/lib/requests/queries/calendars/releasesCalendarQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/calendars/releasesCalendarQuery.spec.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest';
 import { releasesCalendarQuery } from './releasesCalendarQuery.ts';
 
 describe('releasesCalendarQuery', () => {
-  it('should query all calendar entries that are in releases source lists', async () => {
+  it('should merge the hot releases feed into mapped calendar entries', async () => {
     const result = await runQuery({
       factory: () =>
         createTestBedQuery(
@@ -15,7 +15,6 @@ describe('releasesCalendarQuery', () => {
             startDate: new Date(Date.now() - time.days(1)).toISOString(),
             days: 30,
             type: 'media',
-            sourceLimit: 10,
           }),
         ),
       mapper: (response) => response?.data,

--- a/projects/client/src/lib/requests/queries/calendars/releasesCalendarQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/releasesCalendarQuery.ts
@@ -4,62 +4,24 @@ import { coalesceEpisodes } from '$lib/requests/_internal/coalesceEpisodes.ts';
 import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
 import { mapToMovieEntry } from '$lib/requests/_internal/mapToMovieEntry.ts';
 import { mapToUpcomingEpisodeEntry } from '$lib/requests/_internal/mapToUpcomingEpisodeEntry.ts';
-import type { ApiParams } from '$lib/requests/api.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
 import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { MovieEntrySchema } from '$lib/requests/models/MovieEntry.ts';
-import { movieAnticipatedRequest } from '$lib/requests/queries/movies/movieAnticipatedQuery.ts';
-import { movieTrendingRequest } from '$lib/requests/queries/movies/movieTrendingQuery.ts';
-import { recommendedMoviesRequest } from '$lib/requests/queries/recommendations/recommendedMoviesQuery.ts';
-import { recommendedShowsRequest } from '$lib/requests/queries/recommendations/recommendedShowsQuery.ts';
-import { showAnticipatedRequest } from '$lib/requests/queries/shows/showAnticipatedQuery.ts';
-import { showTrendingRequest } from '$lib/requests/queries/shows/showTrendingQuery.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import type { CalendarMovieResponse, CalendarShowResponse } from '@trakt/api';
+import type {
+  CalendarMovieResponse,
+  CalendarShowResponse,
+  HotReleaseResponse,
+} from '@trakt/api';
 import { z } from 'zod';
-import {
-  UpcomingEpisodeEntrySchema,
-  upcomingEpisodesRequest,
-} from './upcomingEpisodesQuery.ts';
-import { upcomingMoviesRequest } from './upcomingMoviesQuery.ts';
-
-type IdContainer = {
-  ids: {
-    trakt: number;
-  };
-};
-
-type MovieTopListItem = {
-  movie: IdContainer;
-};
-
-type ShowTopListItem = {
-  show: IdContainer;
-};
-
-type TopListResult<T> = {
-  lists: ReadonlyArray<ReadonlyArray<T> | Nil>;
-  responses: ReadonlyArray<{ status: number }>;
-};
-
-type ReleasesCalendarBody = {
-  movies: CalendarMovieResponse[];
-  episodes: CalendarShowResponse[];
-  movieTopLists: ReadonlyArray<ReadonlyArray<MovieTopListItem> | Nil>;
-  showTopLists: ReadonlyArray<ReadonlyArray<ShowTopListItem> | Nil>;
-};
-
-type ReleasesCalendarResponse = {
-  body: ReleasesCalendarBody;
-  status: number;
-};
+import { UpcomingEpisodeEntrySchema } from './upcomingEpisodesQuery.ts';
 
 export type ReleasesCalendarParams =
   & {
     startDate: string;
     days: number;
     type: DiscoverMode;
-    sourceLimit: number;
   }
   & ApiParams
   & FilterParams;
@@ -71,226 +33,34 @@ const ReleasesCalendarEntrySchema = z.union([
 
 export type ReleasesCalendarEntry = z.infer<typeof ReleasesCalendarEntrySchema>;
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+function isCalendarMovie(
+  entry: HotReleaseResponse,
+): entry is CalendarMovieResponse {
+  return 'movie' in entry;
 }
 
-function hasTraktId(value: unknown): value is IdContainer {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  const ids = value.ids;
-  if (!isRecord(ids)) {
-    return false;
-  }
-
-  return typeof ids.trakt === 'number';
+function isCalendarShow(
+  entry: HotReleaseResponse,
+): entry is CalendarShowResponse {
+  return 'episode' in entry;
 }
 
-function isMovieTopListItem(item: unknown): item is MovieTopListItem {
-  return isRecord(item) && hasTraktId(item.movie);
-}
-
-function isShowTopListItem(item: unknown): item is ShowTopListItem {
-  return isRecord(item) && hasTraktId(item.show);
-}
-
-function isCalendarMovie(item: unknown): item is CalendarMovieResponse {
-  return isRecord(item) && isRecord(item.movie);
-}
-
-function isCalendarShow(item: unknown): item is CalendarShowResponse {
-  return isRecord(item) && isRecord(item.show) && isRecord(item.episode);
-}
-
-function toList<T>(
-  body: unknown,
-  isItem: (item: unknown) => item is T,
-): T[] {
-  if (!Array.isArray(body)) {
-    return [];
-  }
-
-  return body.filter(isItem);
-}
-
-function idsFromLists<T>(
-  lists: ReadonlyArray<ReadonlyArray<T> | Nil>,
-  getId: (item: T) => number,
-) {
-  return new Set(
-    lists.flatMap((list) => list?.map(getId) ?? []),
-  );
-}
-
-function findFailedResponse(
-  responses: ReadonlyArray<{ status: number } | Nil>,
-) {
-  return responses.find((response) =>
-    response != null && response.status !== 200
-  );
-}
-
-async function fetchMovieTopLists(
-  {
-    fetch,
-    filter,
-    filterOverride,
-    sourceLimit,
-  }: ReleasesCalendarParams,
-): Promise<TopListResult<MovieTopListItem>> {
-  const [trending, recommended, anticipated] = await Promise.all([
-    movieTrendingRequest({
-      fetch,
-      filter,
-      filterOverride,
-      limit: sourceLimit,
-      page: 1,
-    }),
-    recommendedMoviesRequest({
-      fetch,
-      filter,
-      filterOverride,
-      limit: sourceLimit,
-    }),
-    movieAnticipatedRequest({
-      fetch,
-      filter,
-      filterOverride,
-      limit: sourceLimit,
-      page: 1,
-    }),
-  ]);
-
-  return {
-    responses: [trending, recommended, anticipated],
-    lists: [
-      toList(trending.body, isMovieTopListItem),
-      toList(recommended.body, isMovieTopListItem),
-      toList(anticipated.body, isMovieTopListItem),
-    ],
-  };
-}
-
-async function fetchShowTopLists(
-  {
-    fetch,
-    filter,
-    filterOverride,
-    sourceLimit,
-  }: ReleasesCalendarParams,
-): Promise<TopListResult<ShowTopListItem>> {
-  const [trending, recommended, anticipated] = await Promise.all([
-    showTrendingRequest({
-      fetch,
-      filter,
-      filterOverride,
-      limit: sourceLimit,
-      page: 1,
-    }),
-    recommendedShowsRequest({
-      fetch,
-      filter,
-      filterOverride,
-      limit: sourceLimit,
-    }),
-    showAnticipatedRequest({
-      fetch,
-      filter,
-      filterOverride,
-      limit: sourceLimit,
-      page: 1,
-    }),
-  ]);
-
-  return {
-    responses: [trending, recommended, anticipated],
-    lists: [
-      toList(trending.body, isShowTopListItem),
-      toList(recommended.body, isShowTopListItem),
-      toList(anticipated.body, isShowTopListItem),
-    ],
-  };
-}
-
-const emptyTopListResult = <T>(): TopListResult<T> => ({
-  lists: [],
-  responses: [],
-});
-
-const emptyReleasesCalendarBody = (): ReleasesCalendarBody => ({
-  movies: [],
-  episodes: [],
-  movieTopLists: [],
-  showTopLists: [],
-});
-
-const releasesCalendarRequest = async (
-  params: ReleasesCalendarParams,
-): Promise<ReleasesCalendarResponse> => {
-  const { fetch, startDate, days, type, filter, filterOverride } = params;
-
-  const includeMovies = type !== 'show';
-  const includeShows = type !== 'movie';
-
-  const [
-    moviesResponse,
-    episodesResponse,
-    movieTopLists,
-    showTopLists,
-  ] = await Promise.all([
-    includeMovies
-      ? upcomingMoviesRequest({
-        fetch,
-        startDate,
+const releasesCalendarRequest = (
+  { fetch, startDate, days, type, filter }: ReleasesCalendarParams,
+) => {
+  return api({ fetch })
+    .calendars
+    .releasesHot({
+      query: {
+        extended: 'full,images',
+        ...filter,
+        ...(type === 'media' ? {} : { type }),
+      },
+      params: {
+        start_date: startDate,
         days,
-        filter,
-        filterOverride,
-        target: 'all',
-      })
-      : undefined,
-    includeShows
-      ? upcomingEpisodesRequest({
-        fetch,
-        startDate,
-        days,
-        filter,
-        filterOverride,
-        target: 'all',
-      })
-      : undefined,
-    includeMovies
-      ? fetchMovieTopLists(params)
-      : emptyTopListResult<MovieTopListItem>(),
-    includeShows
-      ? fetchShowTopLists(params)
-      : emptyTopListResult<ShowTopListItem>(),
-  ]);
-
-  const failedResponse = findFailedResponse([
-    moviesResponse,
-    episodesResponse,
-    ...movieTopLists.responses,
-    ...showTopLists.responses,
-  ]);
-
-  if (failedResponse) {
-    return {
-      body: emptyReleasesCalendarBody(),
-      status: failedResponse.status,
-    };
-  }
-
-  return {
-    body: {
-      movies: toList(moviesResponse?.body, isCalendarMovie),
-      episodes: toList(episodesResponse?.body, isCalendarShow),
-      movieTopLists: movieTopLists.lists,
-      showTopLists: showTopLists.lists,
-    },
-    status: 200,
-  };
+      },
+    });
 };
 
 export const releasesCalendarQuery = defineQuery({
@@ -302,8 +72,6 @@ export const releasesCalendarQuery = defineQuery({
     InvalidateAction.Drop('show'),
     InvalidateAction.Watchlisted('movie'),
     InvalidateAction.MarkAsWatched('movie'),
-    InvalidateAction.HideRecommended('show'),
-    InvalidateAction.HideRecommended('movie'),
   ],
   dependencies: (
     params: ReleasesCalendarParams,
@@ -311,32 +79,17 @@ export const releasesCalendarQuery = defineQuery({
     params.type,
     params.startDate,
     params.days,
-    params.sourceLimit,
-    ...getGlobalFilterDependencies(
-      params.filterOverride?.movie ?? params.filter,
-    ),
-    ...getGlobalFilterDependencies(
-      params.filterOverride?.show ?? params.filter,
-    ),
+    ...getGlobalFilterDependencies(params.filter),
   ],
   request: releasesCalendarRequest,
   mapper: (response) => {
-    const movieIds = idsFromLists(
-      response.body.movieTopLists,
-      (item) => item.movie.ids.trakt,
-    );
-    const showIds = idsFromLists(
-      response.body.showTopLists,
-      (item) => item.show.ids.trakt,
-    );
-
-    const movies = response.body.movies
-      .filter((entry) => movieIds.has(entry.movie.ids.trakt))
+    const movies = response.body
+      .filter(isCalendarMovie)
       .map((entry) => mapToMovieEntry(entry.movie));
 
     const episodes = coalesceEpisodes(
-      response.body.episodes
-        .filter((entry) => showIds.has(entry.show.ids.trakt))
+      response.body
+        .filter(isCalendarShow)
         .map(mapToUpcomingEpisodeEntry),
     );
 

--- a/projects/client/src/lib/sections/lists/stores/useReleasesItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/useReleasesItems.ts
@@ -18,7 +18,6 @@ type UseReleasesItemsProps = {
 } & FilterParams;
 
 const daysToFetch = 30;
-const releasesSourceLimit = 20;
 
 export function useReleasesItems(props: UseReleasesItemsProps) {
   const [yyyyMmDd] = new Date().toISOString().split('T');
@@ -34,7 +33,6 @@ export function useReleasesItems(props: UseReleasesItemsProps) {
       type: props.type,
       filter: props.filter,
       filterOverride: props.filterOverride,
-      sourceLimit: releasesSourceLimit,
     }),
   );
 

--- a/projects/client/src/mocks/handlers/calendars.ts
+++ b/projects/client/src/mocks/handlers/calendars.ts
@@ -28,4 +28,13 @@ export const calendars = [
       return HttpResponse.json(UpcomingMoviesResponseMock);
     },
   ),
+  http.get(
+    'http://localhost/calendars/releases/hot/*',
+    () => {
+      return HttpResponse.json([
+        ...UpcomingEpisodesResponseMock,
+        ...UpcomingMoviesResponseMock,
+      ]);
+    },
+  ),
 ];


### PR DESCRIPTION
## What

Replaces the client-side "hot releases" assembly with one request to the new `/calendars/releases/hot` endpoint.

Before: a releases-calendar fetch plus separate trending and anticipated fetches per media type (5-6 requests), then an in-browser intersect to keep only releases that are also trending/anticipated.

After: one request. The worker does the gating and merge server-side and returns the feed already ordered by availability date. The mapper just discriminates the union response, coalesces episodes, and sorts.

## Changes

- `releasesCalendarQuery.ts`: single `api().calendars.releasesHot(...)` call + discriminated mapper. Drops the `HideRecommended` invalidations (no recommendations in the mix anymore).
- `useReleasesItems.ts` / `useReleasesCalendar.ts`: dropped the now-dead `sourceLimit`.
- spec + MSW handler updated to the single-endpoint shape.
- `@trakt/api` bumped to 0.4.22 for the new contract.

## Dependency chain

- Endpoint: trakt/trakt-workers#1181
- Contract: trakt/trakt-api#848 (published `@trakt/api@0.4.22`)

## Verification

- `svelte-check`: 0 errors (7114 files)
- `test:unit` releasesCalendarQuery spec: passes
- `eslint`: clean

## Note on filters

The merged endpoint applies one filter set to both movies and shows (matching the worker's `filters()` middleware), so per-type `filterOverride` is no longer honored here; the global `filter` is used. The releases surface only uses the global filter.