### PR TITLE
fix(search): use media.trakt.tv for storage host

### DIFF
--- a/projects/client/src/lib/requests/queries/search/response/prependStorageHost.ts
+++ b/projects/client/src/lib/requests/queries/search/response/prependStorageHost.ts
@@ -1,4 +1,4 @@
-const WALTER = 'walter-r2.trakt.tv';
+const STORAGE_HOST = 'media.trakt.tv';
 
 export function prependStorageHost(
   url: string | Nil,
@@ -8,7 +8,11 @@ export function prependStorageHost(
     return '';
   }
 
-  const imageUrl = url.startsWith(WALTER) ? url as HttpsUrl : `${WALTER}${url}`;
+  const hasHost = url.startsWith('http') || url.includes('.trakt.tv');
+  const path = url.startsWith('/') ? url : `/${url}`;
+  const imageUrl = hasHost ? url : `${STORAGE_HOST}${path}`;
 
-  return `${imageUrl}${extension}` as HttpsUrl;
+  return imageUrl.endsWith(extension)
+    ? imageUrl as HttpsUrl
+    : `${imageUrl}${extension}` as HttpsUrl;
 }

--- a/projects/client/src/lib/requests/queries/search/response/prependStorageHost.ts
+++ b/projects/client/src/lib/requests/queries/search/response/prependStorageHost.ts
@@ -1,3 +1,5 @@
+import { prependHttps } from '$lib/utils/url/prependHttps.ts';
+
 const STORAGE_HOST = 'media.trakt.tv';
 
 export function prependStorageHost(
@@ -8,11 +10,6 @@ export function prependStorageHost(
     return '';
   }
 
-  const hasHost = url.startsWith('http') || url.includes('.trakt.tv');
   const path = url.startsWith('/') ? url : `/${url}`;
-  const imageUrl = hasHost ? url : `${STORAGE_HOST}${path}`;
-
-  return imageUrl.endsWith(extension)
-    ? imageUrl as HttpsUrl
-    : `${imageUrl}${extension}` as HttpsUrl;
+  return prependHttps(`${STORAGE_HOST}${path}${extension}`);
 }


### PR DESCRIPTION
Search poster/headshot URLs were pinned to `walter-r2.trakt.tv`. `walter-r2` should be gone — `media.trakt.tv` is the storage host now.

Now that Typesense returns fully-formed `media.trakt.tv` URLs, the old hardcoded host double-prepended (e.g. `https://walter-r2.trakt.tv/https://media.trakt.tv/…jpg.webp.webp`).

- Storage host → `media.trakt.tv`
- Pass through URLs that already carry a host (no double host)
- Normalize the leading slash whether the path comes with or without it
- Don't duplicate the `.webp` extension