### PR TITLE
perf(calendar): serve upcoming media from a single endpoint

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -13,7 +13,7 @@
     "npm:@ethercorps/sveltekit-og@4.3.0": "4.3.0_@sveltejs+kit@2.69.2__@sveltejs+vite-plugin-svelte@7.2.0___svelte@5.56.4___vite@8.1.4____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.4__typescript@5.8.3__vite@8.1.4___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0",
     "npm:@inlang/paraglide-js@2.21.0": "2.21.0_typescript@5.8.3",
     "npm:@jsr/libn__fuzzy@0.4.0": "0.4.0",
-    "npm:@jsr/trakt__api@0.4.22": "0.4.22_openapi3-ts@4.6.0",
+    "npm:@jsr/trakt__api@0.4.23": "0.4.23_openapi3-ts@4.6.0",
     "npm:@playwright/test@1.61.1": "1.61.1",
     "npm:@sentry/sveltekit@10.65.0": "10.65.0_@sveltejs+kit@2.69.2__@sveltejs+vite-plugin-svelte@7.2.0___svelte@5.56.4___vite@8.1.4____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.4__typescript@5.8.3__vite@8.1.4___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0",
     "npm:@svelte-put/shortcut@4.2.0": "4.2.0_svelte@5.56.4",
@@ -34,7 +34,7 @@
     "npm:@types/serviceworker@0.0.199": "0.0.199",
     "npm:@use-gesture/vanilla@10.3.1": "10.3.1",
     "npm:@vite-pwa/sveltekit@1.1.0": "1.1.0_@sveltejs+kit@2.69.2__@sveltejs+vite-plugin-svelte@7.2.0___svelte@5.56.4___vite@8.1.4____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.4__typescript@5.8.3__vite@8.1.4___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0",
-    "npm:@vitest/coverage-istanbul@4.1.10": "4.1.10_vitest@4.1.10_esbuild@0.28.1_sass-embedded@1.100.0_typescript@5.8.3_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0",
+    "npm:@vitest/coverage-istanbul@4.1.10": "4.1.10_vitest@4.1.10_@opentelemetry+api@1.9.1_jsdom@29.1.1_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0",
     "npm:bits-ui@2.18.1": "2.18.1_svelte@5.56.4_esbuild@0.28.1_sass-embedded@1.100.0_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0",
     "npm:concurrently@10.0.3": "10.0.3",
     "npm:cross-env@10.1.0": "10.1.0",
@@ -2084,14 +2084,14 @@
       "integrity": "sha512-aD9yjW6CMt37S3AMTc95LeuRXcKor69Zkr0aWOhYvinTOEAhEIuaJhP4pQqyQGaAC9HIrQcKh1PtRTK85kkVjA==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/libn__fuzzy/0.4.0.tgz"
     },
-    "@jsr/trakt__api@0.4.22_openapi3-ts@4.6.0": {
-      "integrity": "sha512-uCbJgsY8RErQuc7Pb1Q1ujqoX4PGNDubCiGNpjhQq3yjYztsl7o7fsiDG6ZZ04ulQv11xHnKMlwa65DVLLFkuQ==",
+    "@jsr/trakt__api@0.4.23_openapi3-ts@4.6.0": {
+      "integrity": "sha512-djeYLwUy5Gi7fmwqUpaHsFgKX8EoxfPRRbuU6oE1afeHY4/WVzuw6xMA/TW84Kmn2bid10ncRbshC3cZvDf4Kw==",
       "dependencies": [
         "@anatine/zod-openapi",
         "@ts-rest/core",
         "zod"
       ],
-      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.4.22.tgz"
+      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.4.23.tgz"
     },
     "@lix-js/sdk@0.4.10": {
       "integrity": "sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==",
@@ -3372,22 +3372,6 @@
       ]
     },
     "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_@opentelemetry+api@1.9.1_jsdom@29.1.1_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0": {
-      "integrity": "sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==",
-      "dependencies": [
-        "@babel/core",
-        "@istanbuljs/schema",
-        "@jridgewell/gen-mapping",
-        "@jridgewell/trace-mapping@0.3.31",
-        "istanbul-lib-coverage",
-        "istanbul-lib-report",
-        "istanbul-reports",
-        "magicast",
-        "obug",
-        "tinyrainbow",
-        "vitest"
-      ]
-    },
-    "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_esbuild@0.28.1_sass-embedded@1.100.0_typescript@5.8.3_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0": {
       "integrity": "sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==",
       "dependencies": [
         "@babel/core",
@@ -7079,7 +7063,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_@opentelemetry+api@1.9.1_jsdom@29.1.1_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0",
+        "@vitest/coverage-istanbul",
         "@vitest/expect",
         "@vitest/mocker",
         "@vitest/pretty-format",
@@ -7104,7 +7088,7 @@
       ],
       "optionalPeers": [
         "@opentelemetry/api",
-        "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_@opentelemetry+api@1.9.1_jsdom@29.1.1_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0",
+        "@vitest/coverage-istanbul",
         "jsdom"
       ],
       "bin": true
@@ -7545,7 +7529,7 @@
             "npm:@ethercorps/sveltekit-og@4.3.0",
             "npm:@inlang/paraglide-js@2.21.0",
             "npm:@jsr/libn__fuzzy@0.4.0",
-            "npm:@jsr/trakt__api@0.4.22",
+            "npm:@jsr/trakt__api@0.4.23",
             "npm:@playwright/test@1.61.1",
             "npm:@sentry/sveltekit@10.65.0",
             "npm:@svelte-put/shortcut@4.2.0",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -81,7 +81,7 @@
     "@tanstack/query-core": "5.101.2",
     "@tanstack/query-devtools": "5.101.2",
     "@tanstack/query-persist-client-core": "5.101.2",
-    "@trakt/api": "npm:@jsr/trakt__api@0.4.22",
+    "@trakt/api": "npm:@jsr/trakt__api@0.4.23",
     "@ts-rest/core": "3.52.1",
     "@use-gesture/vanilla": "10.3.1",
     "bits-ui": "2.18.1",

--- a/projects/client/src/lib/features/calendar/_internal/useCalendar.ts
+++ b/projects/client/src/lib/features/calendar/_internal/useCalendar.ts
@@ -8,6 +8,7 @@ import {
   type UpcomingEpisodeEntry,
   upcomingEpisodesQuery,
 } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
+import { upcomingMediaQuery } from '$lib/requests/queries/calendars/upcomingMediaQuery.ts';
 import { upcomingMoviesQuery } from '$lib/requests/queries/calendars/upcomingMoviesQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
@@ -51,8 +52,7 @@ function typeToQueries({ start, days, type, filter }: UseCalendarParams) {
       ];
     case 'media':
       return [
-        upcomingMoviesQuery(params) as CreateQueryOptions<CalendarItems>,
-        upcomingEpisodesQuery(params) as CreateQueryOptions<CalendarItems>,
+        upcomingMediaQuery(params) as CreateQueryOptions<CalendarItems>,
       ];
   }
 }

--- a/projects/client/src/lib/requests/queries/calendars/upcomingMediaQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingMediaQuery.ts
@@ -1,19 +1,20 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
 import { coalesceEpisodes } from '$lib/requests/_internal/coalesceEpisodes.ts';
 import { mapToUpcomingEpisodeEntry } from '$lib/requests/_internal/mapToUpcomingEpisodeEntry.ts';
-import { type ApiParams } from '$lib/requests/api.ts';
+import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { time } from '$lib/utils/timing/time.ts';
+import type {
+  CalendarMovieResponse,
+  CalendarShowResponse,
+  HotReleaseResponse,
+} from '@trakt/api';
 import z from 'zod';
 import { getGlobalFilterDependencies } from '../../_internal/getGlobalFilterDependencies.ts';
 import { mapToMovieEntry } from '../../_internal/mapToMovieEntry.ts';
 import type { FilterParams } from '../../models/FilterParams.ts';
 import { MovieEntrySchema } from '../../models/MovieEntry.ts';
-import {
-  UpcomingEpisodeEntrySchema,
-  upcomingEpisodesRequest,
-} from './upcomingEpisodesQuery.ts';
-import { upcomingMoviesRequest } from './upcomingMoviesQuery.ts';
+import { UpcomingEpisodeEntrySchema } from './upcomingEpisodesQuery.ts';
 
 export type CalendarMediaParams =
   & {
@@ -28,6 +29,18 @@ const UpcomingMediaSchema = z.union([
   UpcomingEpisodeEntrySchema,
   MovieEntrySchema,
 ]);
+
+function isCalendarMovie(
+  entry: HotReleaseResponse,
+): entry is CalendarMovieResponse {
+  return 'movie' in entry;
+}
+
+function isCalendarShow(
+  entry: HotReleaseResponse,
+): entry is CalendarShowResponse {
+  return 'episode' in entry;
+}
 
 export const upcomingMediaQuery = defineQuery({
   key: 'upcomingMedia',
@@ -45,26 +58,32 @@ export const upcomingMediaQuery = defineQuery({
     params.target,
     params.startDate,
     params.days,
-    ...getGlobalFilterDependencies(
-      params.filterOverride?.movie ?? params.filter,
-    ),
-    ...getGlobalFilterDependencies(
-      params.filterOverride?.show ?? params.filter,
-    ),
+    ...getGlobalFilterDependencies(params.filter),
   ],
-  request: (params) =>
-    Promise.all([
-      upcomingEpisodesRequest(params),
-      upcomingMoviesRequest(params),
-    ]),
-  mapper: ([episodesResponse, moviesResponse]) => {
+  request: ({ fetch, startDate, days, target = 'my', filter }) =>
+    api({ fetch })
+      .calendars
+      .media({
+        query: {
+          extended: 'full,images',
+          ...filter,
+        },
+        params: {
+          target,
+          start_date: startDate,
+          days,
+        },
+      }),
+  mapper: (response) => {
     const episodes = coalesceEpisodes(
-      episodesResponse.body.map(mapToUpcomingEpisodeEntry),
+      response.body
+        .filter(isCalendarShow)
+        .map(mapToUpcomingEpisodeEntry),
     );
 
-    const movies = moviesResponse.body.map((entry) =>
-      mapToMovieEntry(entry.movie)
-    );
+    const movies = response.body
+      .filter(isCalendarMovie)
+      .map((entry) => mapToMovieEntry(entry.movie));
 
     return [...episodes, ...movies]
       .toSorted((a, b) =>

--- a/projects/client/src/mocks/handlers/calendars.ts
+++ b/projects/client/src/mocks/handlers/calendars.ts
@@ -37,4 +37,13 @@ export const calendars = [
       ]);
     },
   ),
+  http.get(
+    'http://localhost/calendars/:target/media/*',
+    () => {
+      return HttpResponse.json([
+        ...UpcomingEpisodesResponseMock,
+        ...UpcomingMoviesResponseMock,
+      ]);
+    },
+  ),
 ];


### PR DESCRIPTION
## What

Replaces the two-request upcoming "media" feed with one request to `/calendars/:target/media`.

Before: `upcomingMediaQuery` fetched movies and episodes separately (`Promise.all`) and merged in the browser; `useCalendar`'s `media` case ran two queries and flat-merged.

After: one `api().calendars.media(...)` call. The worker merges and orders server-side; the mapper discriminates the union response, and `useCalendar`'s media case uses the single query.

## Changes

- `upcomingMediaQuery.ts`: single request + discriminated union mapper.
- `useCalendar.ts`: `media` case → the single query (drops the two-query merge).
- `useUpcomingItems` benefits automatically (already routes `media` through `upcomingMediaQuery`).
- MSW handler for `/calendars/:target/media`; `@trakt/api` bumped to 0.4.23.

## Dependency chain

- Endpoint + route consolidation: trakt/trakt-workers#1182 (merged)
- Contract: trakt/trakt-api#849 (published `@trakt/api@0.4.23`)

## Note on ordering

`coalesceEpisodes` (calendar-day card grouping: `full_season` / `multiple_episodes`) is trakt-web presentation and stays client-side, so the mapper still coalesces + re-sorts. The endpoint's win is collapsing two requests into one round trip. Moving the grouping server-side (opt-in `?group=day`, so raw consumers keep raw entries) is tracked in trakt/trakt-workers#1183, to be applied across all calendar endpoints.

## Verification

- `svelte-check`: 0 errors (9150 files)
- `eslint`: clean