### PR TITLE
feat(import): prefer episode TVDB id over positional matching

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -73,6 +73,7 @@ module.exports = {
         'gestures',
         'guards',
         'i18n',
+        'import',
         'landing',
         'layout',
         'legal',

--- a/projects/client/src/lib/sections/settings/import/engine/buildHistoryPayload.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/engine/buildHistoryPayload.spec.ts
@@ -206,7 +206,7 @@ describe('buildHistoryPayload', () => {
       expect(result.episodes).toHaveLength(0);
     });
 
-    it('should prefer positional resolution over the episode id', () => {
+    it('should prefer the episode id over positional resolution', () => {
       const item: UniversalImportItem = {
         action: 'history',
         type: 'episode',
@@ -219,11 +219,8 @@ describe('buildHistoryPayload', () => {
 
       const result = buildHistoryPayload([item]);
 
-      expect(result.shows).toEqual([{
-        ids: { tvdb: 9001 },
-        seasons: [{ number: 2, episodes: [{ number: 1, watched_at }] }],
-      }]);
-      expect(result.episodes).toHaveLength(0);
+      expect(result.episodes).toEqual([{ ids: { tvdb: 4321 }, watched_at }]);
+      expect(result.shows).toHaveLength(0);
     });
 
     it('should add an episode by its id when not positionally resolvable', () => {

--- a/projects/client/src/lib/sections/settings/import/engine/buildHistoryPayload.ts
+++ b/projects/client/src/lib/sections/settings/import/engine/buildHistoryPayload.ts
@@ -26,9 +26,14 @@ function toHistoryShow(
   return null;
 }
 
-// Prefer positional resolution (show id + season/episode number) over the
-// episode's own id: many Trakt episodes have no TVDB id, while the show does,
-// and (show, season, number) identifies an episode unambiguously.
+// Prefer the episode's own id (tvdb/trakt) over positional resolution: the
+// export's episode id is the exact identity of what was watched and survives
+// season/episode renumbering divergence between TVDB and Trakt. Positional
+// (show id + season/number) is the fallback for episodes carrying no own id.
+function hasEpisodeId(item: UniversalImportItem): boolean {
+  return pickIds(item.ids, EPISODE_IDS) != null;
+}
+
 function isPositional(
   item: UniversalImportItem,
 ): item is UniversalImportItem & { season: number; episode: number } {
@@ -84,8 +89,11 @@ export function buildHistoryPayload(
   items: UniversalImportItem[],
 ): HistoryAddRequest {
   const episodeItems = items.filter((item) => item.type === 'episode');
-  const positionalEpisodes = episodeItems.filter(isPositional);
-  const idEpisodes = episodeItems.filter((item) => !isPositional(item));
+  const idEpisodes = episodeItems.filter(hasEpisodeId);
+  const nonIdEpisodes = episodeItems.filter((item) => !hasEpisodeId(item));
+
+  const positionalEpisodes = nonIdEpisodes.filter(isPositional);
+  const leftoverEpisodes = nonIdEpisodes.filter((item) => !isPositional(item));
 
   const movies = items
     .filter((item) => item.type === 'movie')
@@ -103,12 +111,9 @@ export function buildHistoryPayload(
       .filter((item) => item.type === 'show')
       .flatMap((item) => toHistoryShow(item) ?? []),
     ...toPositionalShows(positionalEpisodes),
-    ...idEpisodes.flatMap(({ ids, watched_at }) => {
-      const resolvedIds = pickIds(ids, EPISODE_IDS);
-      return !resolvedIds && ids.imdb
-        ? [{ ids: { imdb: ids.imdb } as never, watched_at }]
-        : [];
-    }),
+    ...leftoverEpisodes.flatMap(({ ids, watched_at }) =>
+      ids.imdb ? [{ ids: { imdb: ids.imdb } as never, watched_at }] : []
+    ),
   ];
 
   return { movies, shows, episodes };

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeRealExports.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeRealExports.spec.ts
@@ -85,10 +85,11 @@ describe('TvTimeCsvParser: real anonymized exports', () => {
     ).toBe(true);
   });
 
-  it('routes real episode watches through positional history resolution', async () => {
-    // TV Time episodes carry a TVDB id, but many Trakt episodes have none, so
-    // id-based history drops them; they must be sent as show + season/episode
-    // number instead. Proven here end-to-end on a real export.
+  it('routes real episode watches by their own TVDB id', async () => {
+    // TV Time episodes carry a TVDB id (the exact identity of what was
+    // watched); with episode tvdb_id now backfilled on Trakt it resolves
+    // directly and survives season/episode renumbering divergence. Positional
+    // is the fallback only for episodes carrying no own id.
     const result = await TvTimeCsvParser.parse([
       csvFile(
         'gdpr-v2-tracking-prod-records-v2.csv',
@@ -98,17 +99,17 @@ describe('TvTimeCsvParser: real anonymized exports', () => {
 
     const payload = buildHistoryPayload([...result]);
 
-    // No episode goes out by its own id; all 8 route positionally under shows.
-    expect(payload.episodes).toHaveLength(0);
+    // All 8 go out by their own episode TVDB id, none positionally under shows.
+    expect(payload.episodes).toHaveLength(8);
+    expect(
+      payload.episodes?.every((episode) =>
+        'ids' in episode && episode.ids != null && 'tvdb' in episode.ids
+      ),
+    ).toBe(true);
     const positionalEpisodes = (payload.shows ?? [])
       .flatMap((show) => ('seasons' in show ? show.seasons ?? [] : []))
       .flatMap((season) => season.episodes ?? []);
-    expect(positionalEpisodes).toHaveLength(8);
-    expect(
-      (payload.shows ?? []).every((show) =>
-        'ids' in show && show.ids != null && 'tvdb' in show.ids
-      ),
-    ).toBe(true);
+    expect(positionalEpisodes).toHaveLength(0);
   });
 
   it('imports a real current-format export from loose tvtime-*.csv files', async () => {


### PR DESCRIPTION
Prefers an episode's own TVDB id over season/episode positional matching during import.

## What

When a parsed import item carries an episode TVDB id, history resolution sends it by that id instead of nesting it under the show as a season + episode number. Positional matching (show id + season/number) stays the fallback for episodes that carry no own id, and imdb-only items are unchanged.

## Why

An episode's TVDB id is an exact identifier. Positional matching breaks when a show's season/episode numbering differs from the source people import from (absolute vs seasonal numbering, split premieres, year-based seasons) and silently lands the watch on the wrong episode. Sending the episode id sidesteps that.

Scope: only history used positional resolution; ratings and watchlist operate at the movie/show level and are untouched.

## Tests

- Flipped the two specs that asserted the old positional-first precedence.
- Full import suite green (250 tests).

## Housekeeping

- Adds `import` to the commitlint `scope-enum` so `feat(import)` passes the gate.
