### PR TITLE
fix(toggle): commits immediately with reduced motion

### DIFF
--- a/projects/client/src/lib/components/toggles/Toggler.svelte
+++ b/projects/client/src/lib/components/toggles/Toggler.svelte
@@ -27,16 +27,12 @@
   let trackerElement: HTMLDivElement;
   let pending = $state<{ index: number; href?: string } | null>(null);
 
-  const handleChange = (index: number, href?: string) => {
-    pending = { index, href };
-    trackerIndex.set(index);
-    trackerElement?.classList.add("moving");
-  };
+  const prefersReducedMotion = () =>
+    globalThis.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ??
+    false;
 
-  const handleTransitionEnd = (event: TransitionEvent) => {
-    if (event.propertyName === "opacity" || !pending) return;
-
-    (event.currentTarget as HTMLDivElement).classList.remove("moving");
+  const commit = () => {
+    if (!pending) return;
 
     const { index, href } = pending;
     pending = null;
@@ -47,6 +43,27 @@
       // eslint-disable-next-line svelte/no-navigation-without-resolve
       goto(href, { replaceState: true, keepFocus: true, noScroll: true });
     }
+  };
+
+  const handleChange = (index: number, href?: string) => {
+    pending = { index, href };
+    trackerIndex.set(index);
+
+    // With reduced motion the tracker transition is 0ms, so transitionend
+    // never fires - commit immediately instead of waiting for it.
+    if (prefersReducedMotion()) {
+      commit();
+      return;
+    }
+
+    trackerElement?.classList.add("moving");
+  };
+
+  const handleTransitionEnd = (event: TransitionEvent) => {
+    if (event.propertyName === "opacity" || !pending) return;
+
+    (event.currentTarget as HTMLDivElement).classList.remove("moving");
+    commit();
   };
 
   const getTriggerProps = (option: ToggleOption<T>, index: number) => {
@@ -131,7 +148,9 @@
       var(--toggler-animation-duration) + var(--toggle-animation-delay)
     );
 
-    inset-inline-start: calc(var(--tracker-inline-start) + var(--tracker-offset));
+    inset-inline-start: calc(
+      var(--tracker-inline-start) + var(--tracker-offset)
+    );
     margin-inline-start: var(--ni-4);
 
     position: absolute;


### PR DESCRIPTION
## 🎶 Notes 🎶
- Addresses an issue where the toggler component would not commit its state change for users with `prefers-reduced-motion` enabled.
- Implements a check for `prefers-reduced-motion` to ensure the toggler's state is committed immediately when animations are disabled, bypassing reliance on the `transitionend` event.
- Refactors the state commitment logic into a dedicated `commit` function for improved clarity and maintainability.

## 👀 Example 👀
Before/after:

https://github.com/user-attachments/assets/5cfca247-d159-4034-b10a-7ee19336efc8

https://github.com/user-attachments/assets/5897b18d-39ae-46fd-bef4-9bff87fb9675

