### PR TITLE
perf(calendar): move day-grouping server-side via group=day

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -13,7 +13,7 @@
     "npm:@ethercorps/sveltekit-og@4.3.0": "4.3.0_@sveltejs+kit@2.69.2__@sveltejs+vite-plugin-svelte@7.2.0___svelte@5.56.4___vite@8.1.4____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.4__typescript@5.8.3__vite@8.1.4___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0",
     "npm:@inlang/paraglide-js@2.21.0": "2.21.0_typescript@5.8.3",
     "npm:@jsr/libn__fuzzy@0.4.0": "0.4.0",
-    "npm:@jsr/trakt__api@0.4.23": "0.4.23_openapi3-ts@4.6.0",
+    "npm:@jsr/trakt__api@0.4.25": "0.4.25_openapi3-ts@4.6.0",
     "npm:@playwright/test@1.61.1": "1.61.1",
     "npm:@sentry/sveltekit@10.65.0": "10.65.0_@sveltejs+kit@2.69.2__@sveltejs+vite-plugin-svelte@7.2.0___svelte@5.56.4___vite@8.1.4____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.4__typescript@5.8.3__vite@8.1.4___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_vite@8.1.4__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0",
     "npm:@svelte-put/shortcut@4.2.0": "4.2.0_svelte@5.56.4",
@@ -2084,14 +2084,14 @@
       "integrity": "sha512-aD9yjW6CMt37S3AMTc95LeuRXcKor69Zkr0aWOhYvinTOEAhEIuaJhP4pQqyQGaAC9HIrQcKh1PtRTK85kkVjA==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/libn__fuzzy/0.4.0.tgz"
     },
-    "@jsr/trakt__api@0.4.23_openapi3-ts@4.6.0": {
-      "integrity": "sha512-djeYLwUy5Gi7fmwqUpaHsFgKX8EoxfPRRbuU6oE1afeHY4/WVzuw6xMA/TW84Kmn2bid10ncRbshC3cZvDf4Kw==",
+    "@jsr/trakt__api@0.4.25_openapi3-ts@4.6.0": {
+      "integrity": "sha512-sbJ8gqRfGYjBaxZWQAWra4OFfCA+zqWBsVitPTYDNSqysBIOIek2INkXavtKDEG6AkWXIpf6yaaqj+NkZu/Eog==",
       "dependencies": [
         "@anatine/zod-openapi",
         "@ts-rest/core",
         "zod"
       ],
-      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.4.23.tgz"
+      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.4.25.tgz"
     },
     "@lix-js/sdk@0.4.10": {
       "integrity": "sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==",
@@ -7529,7 +7529,7 @@
             "npm:@ethercorps/sveltekit-og@4.3.0",
             "npm:@inlang/paraglide-js@2.21.0",
             "npm:@jsr/libn__fuzzy@0.4.0",
-            "npm:@jsr/trakt__api@0.4.23",
+            "npm:@jsr/trakt__api@0.4.25",
             "npm:@playwright/test@1.61.1",
             "npm:@sentry/sveltekit@10.65.0",
             "npm:@svelte-put/shortcut@4.2.0",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -81,7 +81,7 @@
     "@tanstack/query-core": "5.101.2",
     "@tanstack/query-devtools": "5.101.2",
     "@tanstack/query-persist-client-core": "5.101.2",
-    "@trakt/api": "npm:@jsr/trakt__api@0.4.23",
+    "@trakt/api": "npm:@jsr/trakt__api@0.4.25",
     "@ts-rest/core": "3.52.1",
     "@use-gesture/vanilla": "10.3.1",
     "bits-ui": "2.18.1",

--- a/projects/client/src/lib/requests/_internal/mapToPostCredits.ts
+++ b/projects/client/src/lib/requests/_internal/mapToPostCredits.ts
@@ -1,8 +1,9 @@
-import type { EpisodeResponse, MovieResponse } from '@trakt/api';
 import type { PostCredits } from '../models/PostCreditsSchema.ts';
 
 export function mapToPostCredits(
-  response: EpisodeResponse | MovieResponse | Nil,
+  response:
+    | { during_credits?: boolean | null; after_credits?: boolean | null }
+    | Nil,
 ): PostCredits[] {
   const postCredits: PostCredits[] = [];
 

--- a/projects/client/src/lib/requests/_internal/mapToUpcomingEpisodeEntry.ts
+++ b/projects/client/src/lib/requests/_internal/mapToUpcomingEpisodeEntry.ts
@@ -9,5 +9,10 @@ export function mapToUpcomingEpisodeEntry(
   return {
     show: mapToShowEntry(item.show),
     ...mapToEpisodeEntry(item.episode),
+    // `group=day` collapses multi-episode days into one card; the server sends
+    // the grouped episodes on `episode.episodes` (absent for single entries).
+    ...(item.episode.episodes
+      ? { episodes: item.episode.episodes.map(mapToEpisodeEntry) }
+      : {}),
   };
 }

--- a/projects/client/src/lib/requests/queries/calendars/releasesCalendarQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/releasesCalendarQuery.ts
@@ -1,6 +1,5 @@
 import type { DiscoverMode } from '$lib/features/filters/models/DiscoverMode.ts';
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
-import { coalesceEpisodes } from '$lib/requests/_internal/coalesceEpisodes.ts';
 import { getGlobalFilterDependencies } from '$lib/requests/_internal/getGlobalFilterDependencies.ts';
 import { mapToMovieEntry } from '$lib/requests/_internal/mapToMovieEntry.ts';
 import { mapToUpcomingEpisodeEntry } from '$lib/requests/_internal/mapToUpcomingEpisodeEntry.ts';
@@ -53,6 +52,7 @@ const releasesCalendarRequest = (
     .releasesHot({
       query: {
         extended: 'full,images',
+        group: 'day',
         ...filter,
         ...(type === 'media' ? {} : { type }),
       },
@@ -87,11 +87,9 @@ export const releasesCalendarQuery = defineQuery({
       .filter(isCalendarMovie)
       .map((entry) => mapToMovieEntry(entry.movie));
 
-    const episodes = coalesceEpisodes(
-      response.body
-        .filter(isCalendarShow)
-        .map(mapToUpcomingEpisodeEntry),
-    );
+    const episodes = response.body
+      .filter(isCalendarShow)
+      .map(mapToUpcomingEpisodeEntry);
 
     return [...episodes, ...movies]
       .toSorted((a, b) =>

--- a/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingEpisodesQuery.ts
@@ -1,5 +1,4 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
-import { coalesceEpisodes } from '$lib/requests/_internal/coalesceEpisodes.ts';
 import { mapToUpcomingEpisodeEntry } from '$lib/requests/_internal/mapToUpcomingEpisodeEntry.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
@@ -35,6 +34,7 @@ export const upcomingEpisodesRequest = (
     .shows({
       query: {
         extended: 'full,images',
+        group: 'day',
         ...filterParams,
       },
       params: {
@@ -64,8 +64,7 @@ export const upcomingEpisodesQuery = defineQuery({
     ),
   ],
   request: upcomingEpisodesRequest,
-  mapper: (response) =>
-    coalesceEpisodes(response.body.map(mapToUpcomingEpisodeEntry)),
+  mapper: (response) => response.body.map(mapToUpcomingEpisodeEntry),
   schema: UpcomingEpisodeEntrySchema.array(),
   ttl: time.minutes(30),
   refetchOnWindowFocus: true,

--- a/projects/client/src/lib/requests/queries/calendars/upcomingMediaQuery.ts
+++ b/projects/client/src/lib/requests/queries/calendars/upcomingMediaQuery.ts
@@ -1,5 +1,4 @@
 import { defineQuery } from '$lib/features/query/defineQuery.ts';
-import { coalesceEpisodes } from '$lib/requests/_internal/coalesceEpisodes.ts';
 import { mapToUpcomingEpisodeEntry } from '$lib/requests/_internal/mapToUpcomingEpisodeEntry.ts';
 import { api, type ApiParams } from '$lib/requests/api.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
@@ -66,6 +65,7 @@ export const upcomingMediaQuery = defineQuery({
       .media({
         query: {
           extended: 'full,images',
+          group: 'day',
           ...filter,
         },
         params: {
@@ -75,11 +75,9 @@ export const upcomingMediaQuery = defineQuery({
         },
       }),
   mapper: (response) => {
-    const episodes = coalesceEpisodes(
-      response.body
-        .filter(isCalendarShow)
-        .map(mapToUpcomingEpisodeEntry),
-    );
+    const episodes = response.body
+      .filter(isCalendarShow)
+      .map(mapToUpcomingEpisodeEntry);
 
     const movies = response.body
       .filter(isCalendarMovie)


### PR DESCRIPTION
## What

Completes the calendar-grouping move: drops the client-side `coalesceEpisodes` from the calendar feeds and lets the worker collapse same-show-same-day episodes via `?group=day`.

- `upcomingEpisodesQuery` (shows), `upcomingMediaQuery`, `releasesCalendarQuery` now pass `group=day`; their mappers render the server's grouped cards directly.
- `mapToUpcomingEpisodeEntry` carries the nested `episodes` array for `multiple_episodes` cards (only when present, matching the old coalesce shape).
- `@trakt/api` bumped to 0.4.25.

## Notes

- `coalesceEpisodes` is kept - still used by `coalesceBinges` (non-calendar).
- `mapToPostCredits` now takes a structural `{ during_credits?, after_credits? }` param so it accepts the widened calendar episode (which gained the `full_season`/`multiple_episodes` types) without coupling to the episode enum.

## Dependency chain

- Endpoint grouping: trakt/trakt-workers#1187 (merged, deployed)
- Contract: trakt/trakt-api#850 (group param) + #851 (flat response), `@trakt/api@0.4.25`
- Implements trakt/trakt-workers#1183

## Verification

- `svelte-check`: 0 errors
- `test:unit`: 26 passed (releasesCalendar / coalesceEpisodes / coalesceBinges specs)