### PR TITLE
fix(summary): episode-scoped history in the drawer + stable scroll on close

### DIFF
--- a/projects/client/src/lib/components/drawer/drawerNavigation.ts
+++ b/projects/client/src/lib/components/drawer/drawerNavigation.ts
@@ -5,11 +5,15 @@ import { DRAWER_VIEW_PARAM } from '$lib/components/drawer/constants/index.ts';
 export function drawerNavigation<
   T extends string,
   P extends Partial<Record<T, Record<string, string>>> = Record<never, never>,
->(params?: P) {
+>(params?: P, options?: { persistentKeys?: readonly string[] }) {
+  // Params a drawer may set when opening but must NOT strip when closing,
+  // because they double as page-owned state (e.g. the active season tab).
+  // Removing them on close would tear down the underlying page.
+  const persistentKeys = new Set(options?.persistentKeys ?? []);
   const cleanupKeys = params
-    ? Object.values(params).flatMap((p) =>
-      Object.keys(p as Record<string, string>)
-    )
+    ? Object.values(params)
+      .flatMap((p) => (p ? Object.keys(p) : []))
+      .filter((key) => !persistentKeys.has(key))
     : [];
 
   const buildDrawerLink = <D extends T>(

--- a/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
+++ b/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
@@ -67,7 +67,12 @@ function mapToDrawer(value: string | Nil) {
 }
 
 export function summaryDrawerNavigation(searchParams?: URLSearchParams) {
-  const { buildDrawerLink, close } = drawerNavigation(summaryDrawerParams);
+  // `season` is the show page's active-season tab state. The episode drawer
+  // sets it on open, but closing must keep it: stripping it flips the page's
+  // `currentSeason` to NaN, tearing down and remounting the whole page.
+  const { buildDrawerLink, close } = drawerNavigation(summaryDrawerParams, {
+    persistentKeys: [seasonParam],
+  });
   const drawer = mapToDrawer(searchParams?.get(DRAWER_VIEW_PARAM));
   const commentId = searchParams?.get(commentIdParam);
   const sourceCommentId = commentId != null ? Number(commentId) : undefined;

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/EpisodeDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/EpisodeDrawerHost.svelte
@@ -10,13 +10,13 @@
   import DrawerCastSection from "$lib/sections/summary/components/_internal/DrawerCastSection.svelte";
   import MediaStats from "$lib/sections/summary/components/details/_internal/MediaStats.svelte";
   import MediaStatsSkeleton from "$lib/sections/summary/components/details/_internal/MediaStatsSkeleton.svelte";
+  import HistoryDrawerHost from "$lib/sections/summary/components/history/HistoryDrawerHost.svelte";
   import RatingsDrawer from "$lib/sections/summary/components/rating/RatingsDrawer.svelte";
   import SeasonEpisodesTab from "$lib/sections/summary/components/seasons/SeasonEpisodesTab.svelte";
   import SocialDrawerHost from "$lib/sections/summary/components/social/SocialDrawerHost.svelte";
   import { episodeActivityTitle } from "$lib/utils/intl/episodeActivityTitle.ts";
   import { episodeNumberLabel } from "$lib/utils/intl/episodeNumberLabel.ts";
   import { fromRune } from "$lib/utils/store/fromRune.svelte.ts";
-  import { writable } from "$lib/utils/store/WritableSubject.ts";
   import { onMount } from "svelte";
   import { fade } from "svelte/transition";
   import EpisodeInfoHeader from "./_internal/EpisodeInfoHeader.svelte";
@@ -42,11 +42,12 @@
   let isOpen = $state(false);
   let activeTab = $state("info");
 
-  // Ratings distribution and social activities open as drawers stacked on top
-  // of this one, mounted locally (not via the `view=` URL param, which would
+  // Ratings, social activities and history open as drawers stacked on top of
+  // this one, mounted locally (not via the `view=` URL param, which would
   // replace this drawer and resolve show-scoped data instead of the episode).
-  const isRatingsOpen = writable(false);
-  const isSocialOpen = writable(false);
+  let isRatingsOpen = $state(false);
+  let isSocialOpen = $state(false);
+  let isHistoryOpen = $state(false);
 
   const socialTarget = $derived({
     type: "episode" as const,
@@ -181,8 +182,9 @@
         isCrewLoading={$isPeopleLoading}
         {socialTarget}
         {socialTitle}
-        onRatingsOpen={() => isRatingsOpen.set(true)}
-        onSocialOpen={() => isSocialOpen.set(true)}
+        onRatingsOpen={() => (isRatingsOpen = true)}
+        onSocialOpen={() => (isSocialOpen = true)}
+        onHistoryOpen={() => (isHistoryOpen = true)}
       />
 
       <TabView
@@ -213,7 +215,7 @@
   {/if}
 </Drawer>
 
-{#if $isRatingsOpen && $episodeEntry}
+{#if isRatingsOpen && $episodeEntry}
   <RatingsDrawer
     type="episode"
     episode={$episodeEntry}
@@ -221,16 +223,27 @@
     crew={$crew}
     {seasons}
     elevated
-    onClose={() => isRatingsOpen.set(false)}
+    onClose={() => (isRatingsOpen = false)}
   />
 {/if}
 
-{#if $isSocialOpen}
+{#if isSocialOpen}
   <SocialDrawerHost
     target={socialTarget}
     title={socialTitle}
     elevated
-    onClose={() => isSocialOpen.set(false)}
+    onClose={() => (isSocialOpen = false)}
+  />
+{/if}
+
+{#if isHistoryOpen && $episodeEntry}
+  <HistoryDrawerHost
+    type="episode"
+    episode={$episodeEntry}
+    {show}
+    crew={$crew}
+    elevated
+    onClose={() => (isHistoryOpen = false)}
   />
 {/if}
 

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
@@ -45,6 +45,7 @@
     socialTitle,
     onRatingsOpen,
     onSocialOpen,
+    onHistoryOpen,
   }: {
     show: ShowEntry;
     seasons: Season[];
@@ -57,6 +58,7 @@
     socialTitle: string;
     onRatingsOpen: () => void;
     onSocialOpen: () => void;
+    onHistoryOpen: () => void;
   } = $props();
 
   // The ratings query only needs the slug/season/episode numbers, so it can
@@ -287,6 +289,7 @@
             {show}
             title={entry.title}
             showTitle={show.title}
+            {onHistoryOpen}
           />
         </RenderFor>
 

--- a/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/EpisodeActions.svelte
@@ -11,16 +11,18 @@
     show,
     title,
     showTitle,
+    onHistoryOpen,
   }: {
     episode: EpisodeEntry;
     show: ShowEntry;
     title: string;
     showTitle: string;
+    onHistoryOpen?: () => void;
   } = $props();
 </script>
 
 {#snippet popupActions()}
-  <EpisodePopupActions {episode} {show} {title} {showTitle} />
+  <EpisodePopupActions {episode} {show} {title} {showTitle} {onHistoryOpen} />
 {/snippet}
 
 <SummaryActionsBar

--- a/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode/v2/_internal/EpisodePopupActions.svelte
@@ -17,11 +17,13 @@
     show,
     title,
     showTitle,
+    onHistoryOpen,
   }: {
     episode: EpisodeEntry;
     show: ShowEntry;
     title: string;
     showTitle: string;
+    onHistoryOpen?: () => void;
   } = $props();
 
   const { isWatched } = $derived(
@@ -56,7 +58,7 @@
   variant="primary"
 />
 
-<HistoryButton />
+<HistoryButton onclick={onHistoryOpen} />
 
 <RenderFor audience="authenticated">
   <ReportButton

--- a/projects/client/src/lib/sections/summary/components/history/HistoryButton.svelte
+++ b/projects/client/src/lib/sections/summary/components/history/HistoryButton.svelte
@@ -8,10 +8,23 @@
     summaryDrawerNavigation,
   } from "$lib/sections/summary/_internal/summaryDrawerNavigation.ts";
 
-  const { variant = "primary" }: { variant?: "primary" | "secondary" } =
-    $props();
+  const {
+    variant = "primary",
+    onclick,
+  }: {
+    variant?: "primary" | "secondary";
+    onclick?: () => void;
+  } = $props();
 
   const { buildDrawerLink } = summaryDrawerNavigation();
+
+  // In stacked contexts (e.g. the episode drawer) the caller opens a locally
+  // mounted, episode-scoped history drawer via `onclick`. The default
+  // `view=history` link resolves against the page behind the drawer (the
+  // show), which would show the wrong history.
+  const itemProps = $derived(
+    onclick ? { onclick } : buildDrawerLink(SummaryDrawers.History),
+  );
 </script>
 
 <RenderFor audience="authenticated">
@@ -19,7 +32,7 @@
     style="flat"
     color="default"
     {variant}
-    {...buildDrawerLink(SummaryDrawers.History)}
+    {...itemProps}
     label={m.button_label_view_all_history()}
   >
     {m.list_title_history()}

--- a/projects/client/src/lib/sections/summary/components/history/HistoryDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/history/HistoryDrawerHost.svelte
@@ -10,8 +10,11 @@
   import HistoryList from "../details/_internal/HistoryList.svelte";
   import type { MediaDetailsProps } from "../details/MediaDetailsProps.ts";
 
-  const { onClose, ...props }: { onClose: () => void } & MediaDetailsProps =
-    $props();
+  const {
+    onClose,
+    elevated = false,
+    ...props
+  }: { onClose: () => void; elevated?: boolean } & MediaDetailsProps = $props();
 
   const { list, isLoading, hasNextPage } = $derived(
     useRecentlyWatchedList({
@@ -62,6 +65,7 @@
   onOpened={() => (isOpen = true)}
   title={m.list_title_history()}
   size="auto"
+  {elevated}
   {drilldown}
 >
   {#if isOpen}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2896
- The history action in the episode drawer opened the whole show's history. Now opens a locally-mounted, episode-scoped history drawer stacked on top, same pattern as ratings/social.
  - Went local instead of a `view=history` link: the URL param resolves against the page behind the drawer (the show), and would replace the drawer rather than stack on it.
- Closing the episode drawer remounted the entire show page and jumped scroll back to the top.
  - Cause: `close()` stripped every drawer param, including `season`. But `season` is the show page's active-tab state, so dropping it flipped `currentSeason` to NaN, the page tore down and re-navigated to re-add it, remounting `ShowSummary`.
  - Fix: `season` is now a persistent param on `drawerNavigation`. Set on open, kept on close.
