### PR TITLE
fix(player): stop plyr sprite xhr from crashing the page

### DIFF
--- a/projects/client/src/lib/features/errors/ErrorProvider.svelte
+++ b/projects/client/src/lib/features/errors/ErrorProvider.svelte
@@ -61,7 +61,15 @@
       // browser extensions as a second copy alongside Plyr's own instance.
       // When the iframe is torn down during SPA navigation the orphaned
       // API copy accesses stale registry entries; not actionable for us.
-      error.stack?.includes("www-widgetapi.js");
+      error.stack?.includes("www-widgetapi.js") ||
+      // Plyr's own scripts throw from an XHR error listener on network-layer
+      // failures (e.g. Error: 0). Sentry wraps XMLHttpRequest and injects an
+      // app-origin frame, so the hostname check above lets these through even
+      // though the originating frame is third-party. A cosmetic player hiccup
+      // must not escalate to the full-page error screen. Match both the CDN
+      // host and the bare filename so self-hosted/bundled Plyr is covered too.
+      error.stack?.includes("cdn.plyr.io") ||
+      error.stack?.includes("plyr.js");
 
     if (isExternalNoise) return;
 

--- a/projects/client/src/lib/features/player/YoutubePlayerProvider.svelte
+++ b/projects/client/src/lib/features/player/YoutubePlayerProvider.svelte
@@ -15,6 +15,14 @@
     const options: Plyr.Options = {
       controls: ["play", "progress", "current-time", "mute", "fullscreen"],
       iconUrl: asset("/plyr/plyr.svg"),
+      /**
+       * Reference the icon sprite via an external `<use>` instead of letting
+       * Plyr XHR-fetch and inline it. Plyr's sprite loader throws
+       * `new Error(xhr.status)` from the XHR `error` listener (uncaught, outside
+       * its own try/catch), so any network-layer failure surfaces as an
+       * uncaught `Error: 0` and escalates to the full-page error screen.
+       */
+      loadSprite: false,
       autoplay,
       fullscreen: {
         enabled: true,


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #2387
- Fixes #2803
- Fixes #2819
- Fixes #2879
- All four are the same bug: users randomly hit the full-page error screen with `Error: 0` from `cdn.plyr.io/3.8.3/plyr.js`.
- Plyr's sprite loader throws `new Error(xhr.status)` from the XHR `error` listener, outside its own try/catch. Any network blip (offline, ad-block, flaky connection) escapes uncaught as `Error: 0`.
  - Our `.catch()` never sees it, it lands in the global `onerror` in `ErrorProvider` instead.
  - The external-noise filter should drop it, but Sentry wraps `XMLHttpRequest` and injects an `app.trakt.tv` frame, so the hostname check passes and it escalates to the error screen.
- Fix: `loadSprite: false` so icons reference the same-origin sprite via `<use>` instead of being XHR-fetched. Throwing path never runs.
- Also filter `cdn.plyr.io` frames in `ErrorProvider` as a safety net.
- Not reproducible on a healthy connection, which is why it slipped.
  - ⚠️ Icons load via external `<use>` now instead of inlined sprite. Fine locally, worth a glance on prod.
