### PR TITLE
fix(polyfill): add Array.prototype.toReversed for old browsers

### DIFF
--- a/projects/client/src/hooks.client.ts
+++ b/projects/client/src/hooks.client.ts
@@ -1,6 +1,7 @@
 import '$lib/polyfills/at.ts';
 import '$lib/polyfills/mapGroupBy.ts';
 import '$lib/polyfills/randomUUID.ts';
+import '$lib/polyfills/toReversed.ts';
 import '$lib/polyfills/toSorted.ts';
 import { captureWebviewSession } from '$lib/features/webview/captureWebviewSession.ts';
 import { SENTRY_DSN } from '$lib/utils/constants.ts';

--- a/projects/client/src/lib/polyfills/toReversed.spec.ts
+++ b/projects/client/src/lib/polyfills/toReversed.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import './toReversed.ts';
+
+describe('Array.prototype.toReversed polyfill', () => {
+  it('returns a reversed copy without mutating the source', () => {
+    const source = [1, 2, 3];
+    const reversed = source.toReversed();
+
+    expect(reversed).toEqual([3, 2, 1]);
+    expect(source).toEqual([1, 2, 3]);
+  });
+});

--- a/projects/client/src/lib/polyfills/toReversed.ts
+++ b/projects/client/src/lib/polyfills/toReversed.ts
@@ -2,6 +2,7 @@
 // Sentry: TRAKT-WEB-AW2 — older Firefox/Safari/Chrome builds reach the app and
 // crash on uses like `calendar.toReversed()` (e.g. /history calendar ordering).
 if (typeof Array.prototype.toReversed !== 'function') {
+  // skipcq: JS-0061
   Object.defineProperty(Array.prototype, 'toReversed', {
     value<T>(this: ArrayLike<T>): T[] {
       return Array.from(this).reverse();

--- a/projects/client/src/lib/polyfills/toReversed.ts
+++ b/projects/client/src/lib/polyfills/toReversed.ts
@@ -1,0 +1,12 @@
+// Polyfill for Array.prototype.toReversed (ES2023).
+// Sentry: TRAKT-WEB-AW2 — older Firefox/Safari/Chrome builds reach the app and
+// crash on uses like `calendar.toReversed()` (e.g. /history calendar ordering).
+if (typeof Array.prototype.toReversed !== 'function') {
+  Object.defineProperty(Array.prototype, 'toReversed', {
+    value<T>(this: ArrayLike<T>): T[] {
+      return Array.from(this).reverse();
+    },
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes TRAKT-WEB-AW2
- Firefox 115 (and other older builds) don't ship the ES2023 `Array.prototype.toReversed`, so `/history` crashes on `calendar.toReversed()`.
- Adds a `toReversed` polyfill mirroring the existing `toSorted` one, registered in `hooks.client.ts`.
- Global patch, so it also covers the other call site in `createCalendarAccumulator.ts`.