### PR TITLE
feat: calendar/releases incl. today

### DIFF
--- a/projects/client/src/lib/features/calendar/CalendarItem.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarItem.svelte
@@ -3,7 +3,7 @@
   import EpisodeStatusTag from "$lib/components/episode/tags/EpisodeStatusTag.svelte";
   import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
   import AirTimeTag from "$lib/components/media/tags/AirTimeTag.svelte";
-  import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
+  import { CalendarTagIntlProvider } from "./_internal/CalendarTagIntlProvider";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import EpisodeItem from "$lib/sections/lists/components/EpisodeItem.svelte";
   import DropAction from "$lib/sections/media-actions/drop/DropAction.svelte";
@@ -79,7 +79,7 @@
           <AirTimeTag airDate={item.airDate} />
         {:else}
           <AirDateTag
-            i18n={TagIntlProvider}
+            i18n={CalendarTagIntlProvider}
             airDate={item.effectiveReleaseDate}
             type="tag"
           />

--- a/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
+++ b/projects/client/src/lib/features/calendar/CalendarMediaCard.svelte
@@ -7,7 +7,7 @@
   import CardCover from "$lib/components/card/CardCover.svelte";
   import LandscapeCard from "$lib/components/media/card/LandscapeCard.svelte";
   import AirDateTag from "$lib/components/media/tags/AirDateTag.svelte";
-  import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
+  import { CalendarTagIntlProvider } from "./_internal/CalendarTagIntlProvider";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { MediaCardProps } from "$lib/sections/lists/components/models/MediaCardProps";
@@ -42,7 +42,7 @@
 
 {#snippet tag()}
   <div class="trakt-media-tag">
-    <AirDateTag i18n={TagIntlProvider} airDate={media.airDate} type="tag" />
+    <AirDateTag i18n={CalendarTagIntlProvider} airDate={media.airDate} type="tag" />
   </div>
 {/snippet}
 

--- a/projects/client/src/lib/features/calendar/_internal/CalendarTagIntlProvider.ts
+++ b/projects/client/src/lib/features/calendar/_internal/CalendarTagIntlProvider.ts
@@ -1,0 +1,23 @@
+import { TagIntlProvider } from '$lib/components/media/tags/TagIntlProvider.ts';
+import type { TagIntl } from '$lib/components/media/tags/TagIntl.ts';
+import { getLocale } from '$lib/features/i18n/index.ts';
+import { getStartOfDay } from '$lib/utils/date/getStartOfDay.ts';
+import { toHumanETA } from '$lib/utils/formatting/date/toHumanETA.ts';
+
+function toCalendarReleaseEstimate(airDate: Date): string {
+  const now = new Date();
+  const airedEarlierToday = airDate.getTime() < now.getTime() &&
+    airDate.getTime() >= getStartOfDay(now).getTime();
+
+  if (airedEarlierToday) {
+    return new Intl.RelativeTimeFormat(getLocale(), { numeric: 'auto' })
+      .format(0, 'day');
+  }
+
+  return toHumanETA(now, airDate, getLocale());
+}
+
+export const CalendarTagIntlProvider: TagIntl = {
+  ...TagIntlProvider,
+  toReleaseEstimate: toCalendarReleaseEstimate,
+};

--- a/projects/client/src/lib/sections/lists/stores/_internal/filterReleasesItems.spec.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/filterReleasesItems.spec.ts
@@ -41,25 +41,25 @@ function movieOn(day: number, id: number): ReleasesCalendarEntry {
 }
 
 describe('filterReleasesItems', () => {
-  it('should keep only future items and the next episode per show', () => {
-    const pastEpisode = episodeOn(1, 100);
-    const movie = movieOn(2, 200);
+  it('should keep today and future items and the next episode per show', () => {
+    const yesterdayEpisode = episodeOn(1, 100);
+    const todayMovie = movieOn(2, 200);
     const firstShowEpisode = episodeOn(3, 101);
     const secondShowEpisode = episodeOn(4, 102);
 
     const result = filterReleasesItems({
       entries: [
         secondShowEpisode,
-        pastEpisode,
-        movie,
+        yesterdayEpisode,
+        todayMovie,
         firstShowEpisode,
       ],
       limit: 10,
-      now: releaseDate(1),
+      now: releaseDate(2),
     });
 
     expect(result).to.deep.equal([
-      movie,
+      todayMovie,
       firstShowEpisode,
     ]);
   });

--- a/projects/client/src/lib/sections/lists/stores/_internal/filterReleasesItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/filterReleasesItems.ts
@@ -1,5 +1,6 @@
 import type { ReleasesCalendarEntry } from '$lib/requests/queries/calendars/releasesCalendarQuery.ts';
 import type { UpcomingEpisodeEntry } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
+import { getStartOfDay } from '$lib/utils/date/getStartOfDay.ts';
 
 type FilterReleasesItemsParams = {
   entries: readonly ReleasesCalendarEntry[];
@@ -23,10 +24,10 @@ export function filterReleasesItems({
   }
 
   const seenShowIds = new Set<number>();
-  const nowTime = now.getTime();
+  const startOfToday = getStartOfDay(now).getTime();
 
   return entries
-    .filter((entry) => entry.effectiveReleaseDate.getTime() > nowTime)
+    .filter((entry) => entry.effectiveReleaseDate.getTime() >= startOfToday)
     .toSorted((a, b) =>
       a.effectiveReleaseDate.getTime() - b.effectiveReleaseDate.getTime()
     )

--- a/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
@@ -13,6 +13,7 @@ import {
 import { upcomingMediaQuery } from '$lib/requests/queries/calendars/upcomingMediaQuery.ts';
 import { upcomingMoviesQuery } from '$lib/requests/queries/calendars/upcomingMoviesQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { getStartOfDay } from '$lib/utils/date/getStartOfDay.ts';
 import { time } from '$lib/utils/timing/time.ts';
 import { map } from 'rxjs';
 
@@ -64,11 +65,12 @@ export function useUpcomingItems(props: UseUpcomingItemsProps) {
   const baseLoading = query.pipe(map(($query) => $query.isLoading));
 
   const list = query.pipe(
-    map(($query) =>
-      ($query.data ?? [])
-        .filter((d) => d.effectiveReleaseDate.getTime() > Date.now())
-        .slice(0, props.limit)
-    ),
+    map(($query) => {
+      const startOfToday = getStartOfDay(new Date()).getTime();
+      return ($query.data ?? [])
+        .filter((d) => d.effectiveReleaseDate.getTime() >= startOfToday)
+        .slice(0, props.limit);
+    }),
     overlay.operator,
   );
 


### PR DESCRIPTION
- sync on forgotten adjustment for Calendar and Releases sections
- include Today released items in the sections so that they do not disappear immediately after releasing + smoother transition into L2 screen (which defaults to today)

Results:

<img width="1493" height="285" alt="image" src="https://github.com/user-attachments/assets/82e60df4-2428-407c-9990-3be0116694e9" />

<img width="1657" height="465" alt="image" src="https://github.com/user-attachments/assets/1ba92dad-b139-4f04-bdbe-008da02e71a0" />


cc @tysonkerridge for sync