### PR TITLE
feat: streak cells UI tweak

### DIFF
--- a/projects/client/src/lib/sections/stats/ActivityHeatmap.svelte
+++ b/projects/client/src/lib/sections/stats/ActivityHeatmap.svelte
@@ -153,6 +153,7 @@
   .trakt-heatmap-cell {
     width: 100%;
     aspect-ratio: 1;
+    box-sizing: border-box;
     border-radius: var(--border-radius-s);
     transition: transform calc(0.5 * var(--transition-increment)) ease-in-out;
     cursor: default;
@@ -173,9 +174,10 @@
       background: var(--color-heatmap-l4);
     }
 
-    &[data-future] {
-      background: var(--color-heatmap-empty);
-      opacity: 0.35;
+    &[data-future],
+    &[data-today][data-intensity="0"] {
+      background: transparent;
+      border: var(--border-thickness-xxs) solid var(--color-heatmap-empty);
     }
 
     &[data-today] {


### PR DESCRIPTION
- a proposal PR (well actually Android does this at the moment :P)
- currently both busted past days and yet to come days share the same grey fill which could be confusing
- PR proposes an outline for future days (and today without activity -> a buckets yet to be filled or busted) as differentiation from "busted" days that already passed

cc @tysonkerridge @kevincador @ElMagnea @vladjerca for syncs

<img width="300" alt="image" src="https://github.com/user-attachments/assets/8bb1c3e0-02b9-4d2b-b0ac-240edb2c1f2a" />
