### PR TITLE
feat(recommended): cap free-user dashboard recs with VIP upsell card

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5395,6 +5395,10 @@
       "default": "Upgrade to VIP to unlock more insights.",
       "description": "Text shown to encourage non-VIP users to subscribe to explore a more detailed sentiment analysis of a movie or show."
     },
+    "text_vip_upsell_smart_recommendations": {
+      "default": "Get Smart Recs. Built on your stats, not the crowd.",
+      "description": "Heading on the upsell card shown to free users in place of the fourth recommendation on the dashboard, encouraging them to subscribe to VIP for personalized smart recommendations."
+    },
     "text_sentiment_example": {
       "default": "Example from \"{title}\"",
       "description": "Text used to indicate that a sentiment analysis example is from a specific movie or show.",

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedList.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import { useUser } from "$lib/features/auth/stores/useUser";
   import Toggler from "$lib/components/toggles/Toggler.svelte";
   import { useToggler } from "$lib/components/toggles/useToggler";
   import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
@@ -8,12 +9,20 @@
   import { useFilter } from "$lib/features/filters/useFilter";
   import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import type { FilterOverrideParams } from "$lib/requests/models/FilterParams";
+  import { IS_DEV } from "$lib/utils/env";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { map } from "rxjs";
   import CtaItem from "../components/cta/CtaItem.svelte";
   import DrillableMediaList from "../drilldown/DrillableMediaList.svelte";
   import { extractWatchWindowParam } from "./extractWatchWindowParam";
   import RecommendedListItem from "./RecommendedListItem.svelte";
+  import RecommendedUpsellCard from "./RecommendedUpsellCard.svelte";
   import { useRecommendedList } from "./useRecommendedList";
+
+  /** Free users get a taste of recommendations, then a VIP upsell as the
+   * fourth slot. Capping to three keeps us at or below SectionList's cta
+   * cut-off so the upsell renders as the trailing card. */
+  const FREE_RECOMMENDATION_LIMIT = 3;
 
   type RecommendationListProps = {
     title: string;
@@ -29,11 +38,24 @@
     filterOverride,
   }: RecommendationListProps = $props();
   const { filterMap } = useFilter();
+  const { user } = useUser();
 
   const { current, set, options } = useToggler("recommendation");
   const { isEnabled } = useFeatureFlag();
   const isSmartEnabled = isEnabled(FeatureFlag.SmartRecommendations);
   const isSmart = $derived($isSmartEnabled && $current.value === "smart");
+
+  // Dev-only: preview the free-tier layout as any user (e.g. a VIP) via
+  // `?preview-free`. Guarded by IS_DEV, so it is inert in production.
+  const isPreviewingFree = $derived(
+    IS_DEV && page.url.searchParams.has("preview-free"),
+  );
+
+  // Wait for the user to resolve before capping so a VIP never flashes the
+  // upsell card. Unresolved -> treat as non-free (no cap).
+  const isFreeUser = $derived(
+    isPreviewingFree || ($user != null && !$user.isVip),
+  );
 
   const cta = $derived({
     type: "recommended" as const,
@@ -57,7 +79,17 @@
     ...extractWatchWindowParam(page.url.searchParams),
   }}
   {filterOverride}
-  useList={(params) => useRecommendedList({ ...params, isSmart })}
+  useList={(params) => {
+    const store = useRecommendedList({ ...params, isSmart });
+    if (!isFreeUser) return store;
+
+    return {
+      ...store,
+      list: store.list.pipe(
+        map((items) => items.slice(0, FREE_RECOMMENDATION_LIMIT)),
+      ),
+    };
+  }}
   urlBuilder={() => UrlBuilder.recommended()}
 >
   {#snippet actions()}
@@ -82,7 +114,11 @@
   {/snippet}
 
   {#snippet ctaItem()}
-    <CtaItem {cta} variant="card" />
+    {#if isFreeUser}
+      <RecommendedUpsellCard />
+    {:else}
+      <CtaItem {cta} variant="card" />
+    {/if}
   {/snippet}
 
   {#snippet empty()}

--- a/projects/client/src/lib/sections/lists/recommended/RecommendedUpsellCard.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedUpsellCard.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import Button from "$lib/components/buttons/Button.svelte";
+  import Card from "$lib/components/card/Card.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+
+  const UPSELL_SOURCE = "recommended-list";
+
+  const { track } = useTrack(AnalyticsEvent.VipUpsell);
+</script>
+
+<Card variant="transparent" --width-card="var(--width-portrait-card)">
+  <div class="trakt-recommended-upsell-card">
+    <p class="upsell-heading bold">
+      {m.text_vip_upsell_smart_recommendations()}
+    </p>
+
+    <div class="upsell-action">
+      <Button
+        href={UrlBuilder.vip()}
+        label={m.badge_text_get_vip()}
+        variant="primary"
+        style="flat"
+        color="default"
+        text="uppercase"
+        onclick={() => track({ source: UPSELL_SOURCE })}
+      >
+        {m.badge_text_get_vip()}
+      </Button>
+    </div>
+  </div>
+</Card>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-recommended-upsell-card {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: var(--gap-m);
+
+    // Fill the Card's content box; the Card owns the card dimensions.
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+
+    padding: var(--ni-16);
+
+    border-radius: var(--border-radius-m);
+    box-shadow: var(--shadow-base);
+
+    // Aspirational VIP gradient (purple -> blue -> warm) so the slot reads as
+    // an invitation, not a paywall. Mirrors the primitive-driven approach used
+    // by VipUpsellBadge. Deliberately uses the darker steps of each family
+    // (same hues, ~L32-36) so white text on the light-glass CTA stays legible.
+    background: linear-gradient(
+      145deg,
+      var(--purple-800) 0%,
+      var(--blue-900) 45%,
+      color-mix(in srgb, var(--purple-800) 65%, var(--red-800)) 100%
+    );
+    color: var(--shade-10);
+
+    @include for-mobile {
+      padding: var(--ni-12);
+      gap: var(--gap-s);
+    }
+  }
+
+  .upsell-heading {
+    margin: 0;
+    // Slightly larger than body copy so the pitch leads the card.
+    font-size: var(--font-size-h6);
+    line-height: 1.25;
+
+    // Keep the message legible over the gradient's brighter mid-tones.
+    text-shadow: 0 var(--ni-1) var(--ni-4)
+      color-mix(in srgb, var(--shade-950) 45%, transparent);
+  }
+
+  .upsell-action {
+    :global(.trakt-button) {
+      width: 100%;
+
+      // Outlined "stroked" CTA: transparent fill lets the darkened gradient
+      // show through; the dark bg carries the white label's contrast on its own.
+      background: transparent;
+      color: var(--shade-10);
+
+      border: var(--ni-1) solid
+        color-mix(in srgb, var(--shade-10) 80%, transparent);
+
+      transition:
+        background var(--transition-increment) ease-in-out,
+        border-color var(--transition-increment) ease-in-out;
+    }
+
+    @include for-mouse {
+      :global(.trakt-button:hover),
+      :global(.trakt-button:focus-visible) {
+        background: color-mix(in srgb, var(--shade-10) 14%, transparent);
+        border-color: var(--shade-10);
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
## What

Free users now get a taste of recommendations on the dashboard — the first **3 items** — followed by a **VIP upsell card** in the 4th slot. VIP users are unaffected.

## Design

<img width="711" height="326" alt="Screenshot 2026-07-15 at 20 00 41" src="https://github.com/user-attachments/assets/e4ef0587-da5b-410a-b763-a25a4ab848b4" />


- Portrait card sized to match the recommendation posters.
- Darkened brand gradient (purple → blue → red, using each family's darker steps so white text stays legible).
- Stroked-out, uppercase **GET VIP** button (transparent fill, white stroke).

## How it works

- **Scope:** dashboard `RecommendedList` only. The `/discover/recommended` paginated page is untouched.
- **Cap:** free users are detected via `useUser` (`$user != null && !$user.isVip`) and the list is sliced client-side to 3. No query/backend change, so nothing to refetch if a user upgrades.
- **4th slot:** `SectionList` already renders its trailing `ctaItem` only when `items.length <= 4`. Capping to 3 makes the upsell render as the 4th card for free users automatically; VIP users load the full 10 (>4) so the slot never appears for them.
- **Analytics:** the button fires `AnalyticsEvent.VipUpsell` with source `recommended-list`.
- **i18n:** new key `text_vip_upsell_smart_recommendations`.

## Notes for reviewer

- **`?preview-free` dev toggle** — `RecommendedList` includes an `IS_DEV`-gated override so the free-tier layout can be previewed while signed in as any user (e.g. a VIP): visit the dashboard with `?preview-free`. It's inert in production. Happy to strip it if you'd rather keep the diff pure.
- **Contrast** — the darkened gradient was chosen so the white label on the stroked button clears ~4.5:1.

## Testing

- `deno task check` — 0 errors.
- `deno fmt` + eslint clean.
- Previewed locally via `?preview-free`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
