### PR TITLE
YIR: ignore bad anchors instead of killing the page

### DIFF
--- a/projects/client/src/lib/features/errors/ErrorProvider.svelte
+++ b/projects/client/src/lib/features/errors/ErrorProvider.svelte
@@ -8,6 +8,7 @@
   import * as Sentry from "@sentry/sveltekit";
   import { onMount } from "svelte";
   import { isErrorExempt } from "./_internal/errorExemptions.ts";
+  import { isInjectedScriptError } from "./_internal/isInjectedScriptError.ts";
   import { mapToWellKnownError } from "./_internal/mapToWellKnownError";
   import { FETCH_ERROR_EVENT } from "./constants";
   import { EXTENSION_PROTOCOLS } from "./constants/index.ts";
@@ -56,6 +57,12 @@
     // Filter out extension noise and third-party scripts
     const isExternalNoise =
       !error.stack?.includes(window.location.hostname) ||
+      // Scripts injected into the page (e.g. the iOS app's WKWebView
+      // evaluateJavaScript scrolling to a YIR anchor that does not exist
+      // for this year) throw as `global code` attributed to the document
+      // URL. Nothing the page can act on — ignore instead of replacing
+      // the page with the full-screen error.
+      isInjectedScriptError(error) ||
       EXTENSION_PROTOCOLS.some((protocol) => error.stack?.includes(protocol)) ||
       // YouTube IFrame API (www-widgetapi.js) can be injected by
       // browser extensions as a second copy alongside Plyr's own instance.

--- a/projects/client/src/lib/features/errors/_internal/isInjectedScriptError.spec.ts
+++ b/projects/client/src/lib/features/errors/_internal/isInjectedScriptError.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { isInjectedScriptError } from './isInjectedScriptError.ts';
+
+function errorWithStack(stack: string | undefined): Error {
+  const error = new Error('null is not an object');
+  error.stack = stack;
+  return error;
+}
+
+describe('util: isInjectedScriptError', () => {
+  it('should match a WKWebView-injected script error attributed to the document URL', () => {
+    const error = errorWithStack(
+      'global code@https://app.trakt.tv/users/hank_/year/2026:1:42',
+    );
+
+    expect(isInjectedScriptError(error)).toBe(true);
+  });
+
+  it('should not match app errors originating from bundled scripts', () => {
+    const error = errorWithStack(
+      [
+        'someFunction@https://app.trakt.tv/_app/immutable/chunks/entry.abc123.js:1:100',
+        'global code@https://app.trakt.tv/_app/immutable/entry/start.def456.js:1:1',
+      ].join('\n'),
+    );
+
+    expect(isInjectedScriptError(error)).toBe(false);
+  });
+
+  it('should not match app errors originating from dev-served source files', () => {
+    const error = errorWithStack(
+      [
+        'someFunction@https://app.trakt.tv/src/lib/features/errors/ErrorProvider.svelte:52:10',
+        'global code@https://app.trakt.tv/src/lib/features/errors/_internal/errorExemptions.ts:35:10',
+      ].join('\n'),
+    );
+
+    expect(isInjectedScriptError(error)).toBe(false);
+  });
+
+  it('should not match Chromium-style stacks without a global code frame', () => {
+    const error = errorWithStack(
+      [
+        "TypeError: Cannot read properties of null (reading 'scrollIntoView')",
+        '    at <anonymous>:1:42',
+      ].join('\n'),
+    );
+
+    expect(isInjectedScriptError(error)).toBe(false);
+  });
+
+  it('should not match errors without a stack', () => {
+    const error = errorWithStack(undefined);
+
+    expect(isInjectedScriptError(error)).toBe(false);
+  });
+});

--- a/projects/client/src/lib/features/errors/_internal/isInjectedScriptError.ts
+++ b/projects/client/src/lib/features/errors/_internal/isInjectedScriptError.ts
@@ -1,0 +1,19 @@
+/*
+  Frames from our own code always reference a bundled script file. WebKit
+  attributes errors thrown by injected script strings (e.g. the iOS app's
+  WKWebView `evaluateJavaScript`, which drives anchor scrolling in embedded
+  views like Year in Review) to the document URL as `global code@<page-url>`,
+  so they slip past the hostname-based external-noise check even though no
+  app code is involved.
+*/
+// Includes .ts/.tsx/.svelte so dev-served (or source-mapped) stacks are
+// still recognized as app code.
+const SCRIPT_FILE_FRAME = /\.([cm]?[jt]sx?|svelte)\b/;
+
+export function isInjectedScriptError(error: Error): boolean {
+  const stack = error.stack;
+  if (!stack) return false;
+  if (!stack.includes('global code@')) return false;
+
+  return !SCRIPT_FILE_FRAME.test(stack);
+}


### PR DESCRIPTION
# Summary

Fixes #2797

The iOS app embeds YIR in a WKWebView and drives its native section menu by injecting `document.getElementById('section-...').scrollIntoView(...)` via `evaluateJavaScript`. Every section in the web templates is `{#if}`-gated on data, so any anchor can legitimately be missing for a given year (and a couple of the app's ids, like `section-shows-map`, never exist at all). When the element is missing, the injected script throws, WebKit attributes the error to the document URL (`global code@https://app.trakt.tv/users/.../year/...:1:42`), and because that stack contains our hostname it slipped past `ErrorProvider`'s external-noise filter — replacing the whole page with the full-screen unexpected error.

# Changes

- Added `isInjectedScriptError`: treats an error as injected-script noise when its stack has a `global code@` frame but no frame referencing an actual script file (`.js`/`.mjs`/`.cjs`). Real app errors always originate in a bundled file under `/_app/`, so legitimate errors can't match.
- Wired it into the `isExternalNoise` check in `ErrorProvider.svelte`, so these errors are ignored entirely — no Sentry capture, no error page. A tap on a missing anchor now just does nothing.
- Added a spec covering the exact stack from the issue, a bundled-script stack, a Chromium-style `<anonymous>` stack (Android WebView — already filtered by the existing hostname check), and a missing stack.

# Notes

With this fix the page no longer dies, but anchors the app requests that the web never renders (`section-shows-map`, `section-*-trends` outside the 2024 template) will silently no-op — the app should drop or remap those if it wants them functional.
