### PR TITLE
fix(sentiment): restore full card height on mobile so the footer isn't cut off

### DIFF
--- a/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentSummary.svelte
+++ b/projects/client/src/lib/sections/summary/components/sentiment/_internal/SentimentSummary.svelte
@@ -60,8 +60,9 @@
   }
 
   .trakt-sentiment-aspects {
-    display: flex;
-    gap: var(--gap-s);
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
 
     color: var(--color-text-primary);
   }

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -189,10 +189,6 @@
   --width-sentiment-card: min(var(--preferred-sentiment-card-width), 85vw);
   --height-sentiment-card: var(--ni-188);
 
-  @include for-mobile {
-    --height-sentiment-card: var(--ni-160);
-  }
-
   /**
    * Pulse card dimensions
    */


### PR DESCRIPTION
# Problem

On mobile viewports (≤ 480px), the sentiment card's footer with the details arrow is almost completely cut off on media detail pages.

Closes #2740

# Root cause

The sentiment summary redesign (3a0e7db) added the footer arrow and tuned the card height to 188px for the new content, but kept the previous design's mobile override of 160px. On mobile the card is actually wider than on desktop (full viewport width), so the content needs the same ~188px — the stale 160px override clipped exactly the footer's height.

# Changes

- Removed the `for-mobile` 160px height override so the sentiment card is 188px everywhere. `--height-sentiment-list` derives from the card height, so the section reserves the correct space automatically.
- Made the layout defensive in `SentimentSummary`: the aspects list now takes `flex: 1; min-height: 0; overflow: hidden`, so if content ever exceeds the card again (e.g. unusually long aspects wrapping to two lines), the excess clips inside the list region and the header and footer arrow always stay visible.