### PR TITLE
fix: introduces episode air buffer for earlier availability

### DIFF
--- a/projects/client/src/lib/utils/media/hasAired.spec.ts
+++ b/projects/client/src/lib/utils/media/hasAired.spec.ts
@@ -1,5 +1,5 @@
 import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { hasAired } from './hasAired.ts';
 
 function addDays(date: Date, days: number): Date {
@@ -9,6 +9,16 @@ function addDays(date: Date, days: number): Date {
 }
 
 describe('hasAired', () => {
+  beforeEach(() => {
+    // Freeze time to keep buffer boundary assertions deterministic.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe('for movies', () => {
     it('returns true for movies with status "released"', () => {
       expect(
@@ -94,10 +104,19 @@ describe('hasAired', () => {
       ).toBe(true);
     });
 
-    it('returns false for items that will air tomorrow', () => {
-      const tomorrow = addDays(new Date(), 1);
+    if (type !== 'episode') {
+      it('returns false for items that will air tomorrow', () => {
+        const tomorrow = addDays(new Date(), 1);
+        expect(
+          hasAired({ effectiveReleaseDate: tomorrow, type }),
+        ).toBe(false);
+      });
+    }
+
+    it('returns false for items that will air in 2 days', () => {
+      const inTwoDays = addDays(new Date(), 2);
       expect(
-        hasAired({ effectiveReleaseDate: tomorrow, type }),
+        hasAired({ effectiveReleaseDate: inTwoDays, type }),
       ).toBe(false);
     });
 
@@ -122,5 +141,49 @@ describe('hasAired', () => {
 
   describe('for episodes', () => {
     runCommonTests('episode');
+  });
+
+  describe('episode air buffer', () => {
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
+    it('treats an episode airing within 24h as aired', () => {
+      const inTwelveHours = new Date(Date.now() + DAY_MS / 2);
+      expect(
+        hasAired({
+          effectiveReleaseDate: inTwelveHours,
+          type: 'episode',
+        }),
+      ).toBe(true);
+    });
+
+    it('does not treat an episode airing beyond 24h as aired', () => {
+      const inTwoDays = new Date(Date.now() + DAY_MS * 2);
+      expect(
+        hasAired({
+          effectiveReleaseDate: inTwoDays,
+          type: 'episode',
+        }),
+      ).toBe(false);
+    });
+
+    it('does not apply the buffer to shows', () => {
+      const inTwelveHours = new Date(Date.now() + DAY_MS / 2);
+      expect(
+        hasAired({
+          effectiveReleaseDate: inTwelveHours,
+          type: 'show',
+        }),
+      ).toBe(false);
+    });
+
+    it('does not apply the buffer to movies', () => {
+      const inTwelveHours = new Date(Date.now() + DAY_MS / 2);
+      expect(
+        hasAired({
+          effectiveReleaseDate: inTwelveHours,
+          type: 'movie',
+        }),
+      ).toBe(false);
+    });
   });
 });

--- a/projects/client/src/lib/utils/media/hasAired.ts
+++ b/projects/client/src/lib/utils/media/hasAired.ts
@@ -1,6 +1,7 @@
 import { type EpisodeType } from '$lib/requests/models/EpisodeType.ts';
 import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
 import type { MediaStatus } from '$lib/requests/models/MediaStatus.ts';
+import { time } from '$lib/utils/timing/time.ts';
 
 type HasAiredProps = {
   type: ExtendedMediaType | EpisodeType;
@@ -8,8 +9,17 @@ type HasAiredProps = {
   status?: MediaStatus;
 };
 
+/**
+ * Grace window before an episode's air date during which it is already
+ * considered aired. Covers timezone/scheduling skew so check-ins and other
+ * aired-gated UI don't lag behind the actual broadcast.
+ */
+const episodeAirBuffer = time.hours(24);
+
 export function hasAired(props: HasAiredProps): boolean {
-  const isAvailable = props.effectiveReleaseDate <= new Date();
+  const buffer = props.type === 'episode' ? episodeAirBuffer : 0;
+  const isAvailable =
+    props.effectiveReleaseDate.getTime() - buffer <= Date.now();
 
   if (props.type === 'movie' && Boolean(props.status)) {
     return props.status === 'released' || isAvailable;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds 24hr buffer to the `hasAired` check for episodes.