### PR TITLE
fix(card): prevent history card date/time subtitle overflow

### DIFF
--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -14,6 +14,7 @@
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { EPISODE_COVER_PLACEHOLDER } from "$lib/utils/assets";
   import { toHumanDate } from "$lib/utils/formatting/date/toHumanDate";
+  import { toHumanTime } from "$lib/utils/formatting/date/toHumanTime.ts";
   import { toRelativeHumanDay } from "$lib/utils/formatting/date/toRelativeHumanDay";
   import { episodeNumberLabel } from "$lib/utils/intl/episodeNumberLabel";
   import { episodeSubtitle } from "$lib/utils/intl/episodeSubtitle";
@@ -88,9 +89,8 @@
       };
     }
 
-    const seasonPoster = rest.type === "season"
-      ? rest.season.poster?.url.thumb
-      : undefined;
+    const seasonPoster =
+      rest.type === "season" ? rest.season.poster?.url.thumb : undefined;
 
     return {
       background: media.cover.url.thumb,
@@ -203,13 +203,21 @@
           {media.title}
         </p>
       {/if}
-      <p class="trakt-card-subtitle small secondary ellipsis capitalize">
-        {#if rest.activityType === "social"}
+      <p
+        class="trakt-card-subtitle small secondary ellipsis capitalize"
+        title={toHumanDate(new Date(), rest.date, getLocale())}
+      >
+        {#if rest.activityType === "social" || hasMultiLineTitles}
           {toRelativeHumanDay(new Date(), rest.date, getLocale())}
         {:else}
           {toHumanDate(new Date(), rest.date, getLocale())}
         {/if}
       </p>
+      {#if rest.activityType === "personal" && hasMultiLineTitles}
+        <p class="trakt-card-subtitle small secondary ellipsis capitalize">
+          {toHumanTime({ date: rest.date, locale: getLocale() })}
+        </p>
+      {/if}
     {:else if isShowContext && rest.type === "episode"}
       <p class="trakt-card-title ellipsis">
         <Spoiler media={rest.episode} show={media} type="episode">


### PR DESCRIPTION
# Summary

Fixes #1995

On history summary cards the watched date/time rendered as a single string that got clamped after two lines. In the narrow desktop/tablet grid cards the date alone often filled both lines, cutting off the time entirely — and there was no hover title to reveal it.

# Screenshot

<img width="372" height="600" alt="image" src="https://github.com/user-attachments/assets/08cc3af5-a322-417e-a56b-ae678d35b28f" />

# Changes

- On narrow grid cards (tablet-lg/desktop, where the two-line clamp applies), personal history now renders the date and time as two independent lines: a relative day line ("yesterday", "last Thursday", "April 29th, 2025") and a dedicated time line ("7:38 PM"). The time can no longer be pushed out of view by a long date.
- Full-width rows (mobile/tablet-sm and compact/minimal layouts) keep the combined single-line format from `toHumanDate`, since there is enough horizontal room there.
- The subtitle now carries a `title` attribute with the full absolute date and time, so truncated content is reachable on hover — this also gives relative labels like "yesterday" an exact timestamp on hover.
- Social activity cards keep their day-only display in both modes.

The layout switch reuses the existing `hasMultiLineTitles` media-query-driven derived, so resizing across the breakpoint updates the format live. Profile ratings cards share the same `activity` variant and pick up the same behavior.