### PR TITLE
feat(filter): add negative filtering to advanced multi-selects

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2405,6 +2405,42 @@
       "default": "All",
       "description": "Text for the 'All' option in dropdowns or filters."
     },
+    "option_label_excluded": {
+      "default": "{label} (excluded from results)",
+      "description": "Aria-label for a multi-select filter option that is currently excluded. {label} is the option name, e.g. a genre.",
+      "variables": {
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "option_text_excluded": {
+      "default": "-{label}",
+      "description": "Trigger label for a multi-select filter option that is currently excluded. {label} is the option name, e.g. a genre.",
+      "variables": {
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "button_label_include_option": {
+      "default": "Include {label}",
+      "description": "Aria-label for the button that includes a multi-select filter option. {label} is the option name, e.g. a genre.",
+      "variables": {
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "button_label_exclude_option": {
+      "default": "Exclude {label}",
+      "description": "Aria-label for the button that excludes a multi-select filter option. {label} is the option name, e.g. a genre.",
+      "variables": {
+        "label": {
+          "type": "string"
+        }
+      }
+    },
     "option_text_comment_language_all": {
       "default": "All languages",
       "description": "Option in the comment language filter that shows comments written in any language."

--- a/projects/client/src/lib/components/icons/AddIcon.svelte
+++ b/projects/client/src/lib/components/icons/AddIcon.svelte
@@ -1,0 +1,11 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path d="M7 12L17 12" stroke="currentColor" stroke-width="2" />
+  <path d="M12 7L12 17" stroke="currentColor" stroke-width="2" />
+  <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" />
+</svg>

--- a/projects/client/src/lib/components/select/MultiSelect.svelte
+++ b/projects/client/src/lib/components/select/MultiSelect.svelte
@@ -1,24 +1,81 @@
 <script lang="ts">
   import SelectBase from "./_internal/SelectBase.svelte";
   import SelectItem from "./_internal/SelectItem.svelte";
-  import type { MultiSelectProps } from "./models/MultiSelectProps";
+  import type { MultiSelectProps } from "./models/MultiSelectProps.ts";
+  import type { MultiSelectState } from "./models/MultiSelectState.ts";
+  import * as m from "$lib/features/i18n/messages.ts";
 
   const {
     options,
-    value = [],
+    included = [],
+    excluded = [],
     placeholder,
     disabled = false,
     onChange,
   }: MultiSelectProps = $props();
 
+  const includedSet = $derived(new Set(included));
+  const excludedSet = $derived(new Set(excluded));
+
+  /*
+    bits-ui treats included and excluded values alike as "selected", so both
+    stay highlighted in the list. The tri-state cycle is resolved on change.
+  */
+  const value = $derived([...included, ...excluded]);
+
+  const stateOf = (optionValue: string): MultiSelectState | undefined => {
+    if (includedSet.has(optionValue)) return "included";
+    if (excludedSet.has(optionValue)) return "excluded";
+    return undefined;
+  };
+
   const selectedLabel = $derived(
     value.length
       ? options
-        .filter((option) => value.includes(option.value))
-        .map((option) => option.label)
+        .filter(
+          (option) =>
+            includedSet.has(option.value) || excludedSet.has(option.value),
+        )
+        .map((option) =>
+          excludedSet.has(option.value)
+            ? m.option_text_excluded({ label: option.label })
+            : option.label
+        )
         .join(", ")
       : placeholder,
   );
+
+  const setState = (
+    optionValue: string,
+    next: MultiSelectState | undefined,
+  ) => {
+    const withoutOption = (list: string[]) =>
+      list.filter((current) => current !== optionValue);
+
+    onChange({
+      included: next === "included"
+        ? [...withoutOption(included), optionValue]
+        : withoutOption(included),
+      excluded: next === "excluded"
+        ? [...withoutOption(excluded), optionValue]
+        : withoutOption(excluded),
+    });
+  };
+
+  /*
+    Clicking or keyboard-toggling a row handles inclusion: an untouched option
+    becomes included, an already included/excluded one clears. Exclusion is
+    driven explicitly by the per-row toggle buttons via setState.
+  */
+  const onRowToggle = (next: string[]) => {
+    const nextSet = new Set(next);
+    const toggled = value.find((current) => !nextSet.has(current)) ??
+      next.find((current) => !stateOf(current));
+
+    if (!toggled) return;
+
+    setState(toggled, stateOf(toggled) === undefined ? "included" : undefined);
+  };
 </script>
 
 <SelectBase
@@ -28,9 +85,15 @@
   {disabled}
   triggerLabel={selectedLabel}
   hasValue={value.length > 0}
-  onValueChange={onChange}
+  onValueChange={onRowToggle}
 >
   {#each options as option (option.value)}
-    <SelectItem value={option.value} label={option.label} />
+    <SelectItem
+      value={option.value}
+      label={option.label}
+      state={stateOf(option.value)}
+      excludable={option.excludable ?? true}
+      onCommit={(next) => setState(option.value, next)}
+    />
   {/each}
 </SelectBase>

--- a/projects/client/src/lib/components/select/_internal/SelectItem.svelte
+++ b/projects/client/src/lib/components/select/_internal/SelectItem.svelte
@@ -1,15 +1,76 @@
 <script lang="ts">
+  import AddIcon from "$lib/components/icons/AddIcon.svelte";
   import CheckIcon from "$lib/components/icons/CheckIcon.svelte";
+  import RemoveIcon from "$lib/components/icons/RemoveIcon.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
   import { Select } from "bits-ui";
+  import type { MultiSelectState } from "../models/MultiSelectState.ts";
+  import type { SelectItemProps } from "./SelectItemProps.ts";
 
-  const { value, label }: { value: string; label: string } = $props();
+  const {
+    value,
+    label,
+    state,
+    excludable = true,
+    onCommit,
+  }: SelectItemProps = $props();
+
+  const hasToggle = $derived(onCommit != null && excludable);
+
+  // Keep the pointer sequence from reaching the row so bits-ui does not also
+  // toggle selection - the buttons are the single source of truth.
+  const block = (event: Event) => event.stopPropagation();
+
+  const toggle = (event: MouseEvent, target: MultiSelectState) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onCommit?.(state === target ? undefined : target);
+  };
 </script>
+
+{#snippet sideToggle(target: MultiSelectState)}
+  <button
+    type="button"
+    class="toggle-side"
+    class:is-include={target === "included"}
+    class:is-exclude={target === "excluded"}
+    aria-label={target === "included"
+      ? m.button_label_include_option({ label })
+      : m.button_label_exclude_option({ label })}
+    aria-pressed={state === target}
+    onpointerdown={block}
+    onpointerup={block}
+    onclick={(event) => toggle(event, target)}
+  >
+    {#if target === "included"}
+      <AddIcon />
+    {:else}
+      <RemoveIcon />
+    {/if}
+  </button>
+{/snippet}
 
 <Select.Item {value} {label}>
   {#snippet child({ props, selected })}
-    <div {...props} class="trakt-select-item">
+    <div
+      {...props}
+      class="trakt-select-item"
+      class:has-toggle={hasToggle}
+      class:is-excluded={state === "excluded"}
+      data-state={state ?? "none"}
+      aria-label={state === "excluded"
+        ? m.option_label_excluded({ label })
+        : undefined}
+    >
+      {#if hasToggle}
+        {@render sideToggle("included")}
+      {/if}
+
       <span class="ellipsis capitalize">{label}</span>
-      {#if selected}
+
+      {#if hasToggle}
+        {@render sideToggle("excluded")}
+      {:else if selected}
         <CheckIcon />
       {/if}
     </div>
@@ -54,6 +115,73 @@
 
     &[data-highlighted] {
       background-color: var(--color-background-item-hover);
+    }
+
+    /* label sits between two fixed side slots so it never shifts */
+    &.has-toggle {
+      display: grid;
+      grid-template-columns: var(--ni-24) 1fr var(--ni-24);
+      gap: var(--gap-s);
+    }
+
+    &.is-excluded .ellipsis {
+      color: var(--red-500);
+      text-decoration: line-through;
+    }
+
+    .ellipsis {
+      text-align: start;
+    }
+
+    .toggle-side {
+      all: unset;
+
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      width: var(--ni-24);
+      height: var(--ni-24);
+      box-sizing: border-box;
+
+      border-radius: var(--border-radius-xs);
+      cursor: pointer;
+
+      color: var(--shade-500);
+      opacity: 0.35;
+
+      transition: var(--transition-increment) ease-in-out;
+      transition-property: background-color, color, opacity;
+
+      @include for-mouse {
+        &:hover {
+          opacity: 1;
+        }
+      }
+
+      &:focus-visible {
+        outline: var(--border-thickness-xs) solid var(--color-foreground);
+        opacity: 1;
+      }
+    }
+
+    /* the chosen side stays solid regardless of hover */
+    &[data-state="included"] .toggle-side.is-include {
+      opacity: 1;
+      color: var(--shade-10);
+      background-color: var(--purple-500);
+    }
+
+    &[data-state="excluded"] .toggle-side.is-exclude {
+      opacity: 1;
+      color: var(--shade-10);
+      background-color: var(--red-500);
+    }
+
+    :global(svg) {
+      width: var(--ni-16);
+      height: var(--ni-16);
+      flex-shrink: 0;
     }
   }
 </style>

--- a/projects/client/src/lib/components/select/_internal/SelectItemProps.ts
+++ b/projects/client/src/lib/components/select/_internal/SelectItemProps.ts
@@ -1,0 +1,9 @@
+import type { MultiSelectState } from '../models/MultiSelectState.ts';
+
+export type SelectItemProps = {
+  value: string;
+  label: string;
+  state?: MultiSelectState;
+  excludable?: boolean;
+  onCommit?: (next: MultiSelectState | undefined) => void;
+};

--- a/projects/client/src/lib/components/select/models/MultiSelectProps.ts
+++ b/projects/client/src/lib/components/select/models/MultiSelectProps.ts
@@ -1,9 +1,11 @@
+import type { MultiSelectSelection } from './MultiSelectSelection.ts';
 import type { SelectOption } from './SelectOption.ts';
 
 export type MultiSelectProps = {
   options: ReadonlyArray<SelectOption>;
-  value?: string[];
+  included?: string[];
+  excluded?: string[];
   placeholder: string;
   disabled?: boolean;
-  onChange: (values: string[]) => void;
+  onChange: (selection: MultiSelectSelection) => void;
 };

--- a/projects/client/src/lib/components/select/models/MultiSelectSelection.ts
+++ b/projects/client/src/lib/components/select/models/MultiSelectSelection.ts
@@ -1,0 +1,4 @@
+export type MultiSelectSelection = {
+  included: string[];
+  excluded: string[];
+};

--- a/projects/client/src/lib/components/select/models/MultiSelectState.ts
+++ b/projects/client/src/lib/components/select/models/MultiSelectState.ts
@@ -1,0 +1,1 @@
+export type MultiSelectState = 'included' | 'excluded';

--- a/projects/client/src/lib/components/select/models/SelectOption.ts
+++ b/projects/client/src/lib/components/select/models/SelectOption.ts
@@ -1,4 +1,6 @@
 export type SelectOption = {
   label: string;
   value: string;
+  /* Multi-select only: when false the option cannot be excluded (no toggle). */
+  excludable?: boolean;
 };

--- a/projects/client/src/lib/features/filters/_internal/exclusionPrefix.ts
+++ b/projects/client/src/lib/features/filters/_internal/exclusionPrefix.ts
@@ -1,0 +1,7 @@
+/*
+  Excluded multi-select values are serialized inline in the same filter param,
+  prefixed with a minus (e.g. `genres=action,-comedy`). Keeping exclusions in
+  the same key means simple filters, smart-list URLs, and filter preservation
+  keep working unchanged - they never emit the prefix.
+*/
+export const EXCLUSION_PREFIX = '-';

--- a/projects/client/src/lib/features/filters/_internal/mapToSearchParamValue.spec.ts
+++ b/projects/client/src/lib/features/filters/_internal/mapToSearchParamValue.spec.ts
@@ -102,6 +102,26 @@ describe('mapToSearchParamValue', () => {
       expect(result).toBe('action,comedy,drama,action');
     });
 
+    it('should keep the exclusion prefix on plain excluded values', () => {
+      const result = mapToSearchParamValue({
+        filter: listFilter,
+        value: 'action,-comedy',
+        user: mockUser,
+      });
+
+      expect(result).toBe('action,-comedy');
+    });
+
+    it('should expand a mapper and prefix each expanded excluded token', () => {
+      const result = mapToSearchParamValue({
+        filter: listFilter,
+        value: '-favorites',
+        user: mockUser,
+      });
+
+      expect(result).toBe('-action,-comedy,-drama');
+    });
+
     it('should throw error when value is undefined for list filter', () => {
       expect(() => {
         mapToSearchParamValue({

--- a/projects/client/src/lib/features/filters/_internal/mapToSearchParamValue.ts
+++ b/projects/client/src/lib/features/filters/_internal/mapToSearchParamValue.ts
@@ -1,6 +1,7 @@
 import type { UserSettings } from '$lib/features/auth/queries/currentUserSettingsQuery.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import type { Filter } from '../models/Filter.ts';
+import { EXCLUSION_PREFIX } from './exclusionPrefix.ts';
 
 type mapToSearchParamValueProps = {
   filter: Filter;
@@ -16,9 +17,16 @@ export function mapToSearchParamValue({
   const filterValue = assertDefined(value, 'Filter value is required');
 
   if ('options' in filter) {
-    const mapValue = (v: string) => {
+    const mapValue = (rawValue: string) => {
+      const isExcluded = rawValue.startsWith(EXCLUSION_PREFIX);
+      const v = isExcluded ? rawValue.slice(EXCLUSION_PREFIX.length) : rawValue;
+
       const option = filter.options.find((opt) => opt.value === v);
-      return option?.mapper ? option.mapper(user).split(',') : [v];
+      const mapped = option?.mapper ? option.mapper(user).split(',') : [v];
+
+      return isExcluded
+        ? mapped.map((token) => `${EXCLUSION_PREFIX}${token}`)
+        : mapped;
     };
 
     return filterValue.split(',').flatMap(mapValue).join(',');

--- a/projects/client/src/lib/features/filters/fromMultiSelectSelection.spec.ts
+++ b/projects/client/src/lib/features/filters/fromMultiSelectSelection.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { fromMultiSelectSelection } from './fromMultiSelectSelection.ts';
+import { toMultiSelectSelection } from './toMultiSelectSelection.ts';
+
+describe('util: fromMultiSelectSelection', () => {
+  it('should return null for an empty selection', () => {
+    expect(fromMultiSelectSelection({ included: [], excluded: [] })).toBeNull();
+  });
+
+  it('should join included values without a prefix', () => {
+    expect(
+      fromMultiSelectSelection({ included: ['action', 'drama'], excluded: [] }),
+    ).toBe('action,drama');
+  });
+
+  it('should prefix excluded values and append them after included ones', () => {
+    expect(
+      fromMultiSelectSelection({
+        included: ['action'],
+        excluded: ['comedy', 'horror'],
+      }),
+    ).toBe('action,-comedy,-horror');
+  });
+
+  it('should round-trip through toMultiSelectSelection', () => {
+    const raw = 'action,-comedy,-pg-13';
+    expect(fromMultiSelectSelection(toMultiSelectSelection(raw))).toBe(raw);
+  });
+});

--- a/projects/client/src/lib/features/filters/fromMultiSelectSelection.ts
+++ b/projects/client/src/lib/features/filters/fromMultiSelectSelection.ts
@@ -1,0 +1,13 @@
+import type { MultiSelectSelection } from '$lib/components/select/models/MultiSelectSelection.ts';
+import { EXCLUSION_PREFIX } from './_internal/exclusionPrefix.ts';
+
+export function fromMultiSelectSelection(
+  { included, excluded }: MultiSelectSelection,
+): string | null {
+  const tokens = [
+    ...included,
+    ...excluded.map((value) => `${EXCLUSION_PREFIX}${value}`),
+  ];
+
+  return tokens.length > 0 ? tokens.join(',') : null;
+}

--- a/projects/client/src/lib/features/filters/toMultiSelectSelection.spec.ts
+++ b/projects/client/src/lib/features/filters/toMultiSelectSelection.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { toMultiSelectSelection } from './toMultiSelectSelection.ts';
+
+describe('util: toMultiSelectSelection', () => {
+  it('should return empty groups for a nullish value', () => {
+    expect(toMultiSelectSelection(null)).toEqual({
+      included: [],
+      excluded: [],
+    });
+    expect(toMultiSelectSelection(undefined)).toEqual({
+      included: [],
+      excluded: [],
+    });
+    expect(toMultiSelectSelection('')).toEqual({ included: [], excluded: [] });
+  });
+
+  it('should treat unprefixed tokens as included', () => {
+    expect(toMultiSelectSelection('action,drama')).toEqual({
+      included: ['action', 'drama'],
+      excluded: [],
+    });
+  });
+
+  it('should treat prefixed tokens as excluded and strip the prefix', () => {
+    expect(toMultiSelectSelection('action,-comedy,-horror')).toEqual({
+      included: ['action'],
+      excluded: ['comedy', 'horror'],
+    });
+  });
+
+  it('should preserve hyphens inside a value once the prefix is stripped', () => {
+    expect(toMultiSelectSelection('-pg-13')).toEqual({
+      included: [],
+      excluded: ['pg-13'],
+    });
+  });
+});

--- a/projects/client/src/lib/features/filters/toMultiSelectSelection.ts
+++ b/projects/client/src/lib/features/filters/toMultiSelectSelection.ts
@@ -1,0 +1,15 @@
+import type { MultiSelectSelection } from '$lib/components/select/models/MultiSelectSelection.ts';
+import { EXCLUSION_PREFIX } from './_internal/exclusionPrefix.ts';
+
+export function toMultiSelectSelection(
+  raw: string | Nil,
+): MultiSelectSelection {
+  const tokens = raw ? raw.split(',').filter(Boolean) : [];
+
+  return {
+    included: tokens.filter((token) => !token.startsWith(EXCLUSION_PREFIX)),
+    excluded: tokens
+      .filter((token) => token.startsWith(EXCLUSION_PREFIX))
+      .map((token) => token.slice(EXCLUSION_PREFIX.length)),
+  };
+}

--- a/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/MultiSelectFilter.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/filters/_internal/MultiSelectFilter.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   import MultiSelect from "$lib/components/select/MultiSelect.svelte";
-  import { type AdvancedMultiSelectFilter } from "$lib/features/filters/models/Filter";
-  import { FilterMode } from "$lib/features/filters/models/FilterMode";
-  import { useFilter } from "$lib/features/filters/useFilter";
+  import type { MultiSelectSelection } from "$lib/components/select/models/MultiSelectSelection.ts";
+  import { type AdvancedMultiSelectFilter } from "$lib/features/filters/models/Filter.ts";
+  import { FilterMode } from "$lib/features/filters/models/FilterMode.ts";
+  import { fromMultiSelectSelection } from "$lib/features/filters/fromMultiSelectSelection.ts";
+  import { toMultiSelectSelection } from "$lib/features/filters/toMultiSelectSelection.ts";
+  import { useFilter } from "$lib/features/filters/useFilter.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import Filter from "./Filter.svelte";
-  import { useFilterSetter } from "./useFilterSetter";
+  import { useFilterSetter } from "./useFilterSetter.ts";
 
   const resetValue = "__reset_filter__";
 
@@ -17,17 +20,15 @@
   const { getFilterValue } = useFilter();
   const currentValueRaw = $derived(getFilterValue(filter.key));
 
-  const selectedValues = $derived(
-    $currentValueRaw ? $currentValueRaw.split(",") : [],
-  );
+  const selection = $derived(toMultiSelectSelection($currentValueRaw));
 
   const { gotoFilteredState } = useFilterSetter();
 
-  const onChange = (values: string[]) => {
-    const hasReset = values.includes(resetValue);
-    const hasValues = values.length > 0;
+  const onChange = (next: MultiSelectSelection) => {
+    const hasReset = next.included.includes(resetValue) ||
+      next.excluded.includes(resetValue);
 
-    const value = !hasReset && hasValues ? values.join(",") : null;
+    const value = hasReset ? null : fromMultiSelectSelection(next);
 
     gotoFilteredState({
       value,
@@ -40,13 +41,15 @@
     (filter.advanced.options ?? filter.options).map((option) => ({
       label: option.label(),
       value: option.value,
+      // "My Favorites" expands to a saved set; excluding it is not meaningful.
+      excludable: option.value !== "favorites",
     })),
   );
 
   // FIXME: this is a temporary solution, to be followed up by
   // making this a feature of the MultiSelect
   const optionsWithAll = $derived([
-    { label: m.button_label_reset_filter(), value: resetValue },
+    { label: m.button_label_reset_filter(), value: resetValue, excludable: false },
     ...advancedOptions,
   ]);
 </script>
@@ -54,7 +57,8 @@
 <Filter title={filter.advanced.label?.() ?? filter.label()}>
   <MultiSelect
     options={optionsWithAll}
-    value={selectedValues}
+    included={selection.included}
+    excluded={selection.excluded}
     placeholder={m.option_text_all()}
     {disabled}
     {onChange}

--- a/projects/client/src/routes/_design_system/icons/+page.svelte
+++ b/projects/client/src/routes/_design_system/icons/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import AddIcon from "$lib/components/icons/AddIcon.svelte";
   import AndroidIcon from "$lib/components/icons/AndroidIcon.svelte";
   import AnticipatedIcon from "$lib/components/icons/AnticipatedIcon.svelte";
   import AppleIcon from "$lib/components/icons/AppleIcon.svelte";
@@ -218,6 +219,7 @@
         <IconTile name="ReactionIcon edit">
           <ReactionIcon state="edit" />
         </IconTile>
+        <IconTile name="AddIcon"><AddIcon /></IconTile>
         <IconTile name="RemoveIcon"><RemoveIcon /></IconTile>
         <IconTile name="RenameIcon"><RenameIcon /></IconTile>
         <IconTile name="ReplyIcon"><ReplyIcon /></IconTile>


### PR DESCRIPTION
## What

Adds "negative filtering" to advanced multi-select filters (genres, certifications, countries, status, streaming). Every excludable option carries a per-row include/exclude control:

- **Include** - plus on the inline-start, fills purple
- **Exclude** - minus on the inline-end, fills red, label struck through
- Both glyphs are always visible (faint until chosen), so the exclude affordance is discoverable at a glance, on touch and mouse alike.

The buttons set state directly and swallow the pointer sequence so bits-ui does not double-toggle the row. Row click / keyboard select still handle inclusion. The Reset and "My Favorites" options stay plain (no toggle) since excluding them is not meaningful. Single-select is unaffected.

## Serialization

Exclusions ride inline in the existing filter param, prefixed with a minus:

```
?genres=action,-comedy
```

Rationale for same-param-prefix over a separate `exclude_genres` key:

- Same `FilterKey` carries both sides, so no new API params, no new plumbing.
- Simple filters never emit the prefix, so they stay unaffected.
- Smart-list URLs and filter preservation keep working unchanged since the value stays in one param.

`mapToSearchParamValue` was made prefix-aware so mapper-backed options expand correctly (e.g. `-favorites` -> `-action,-comedy,-drama`).

## Scope

Tri-state is confined to the advanced multi-select path (`MultiSelectFilter` -> `MultiSelect`). Simple filters use a separate native `<select>` path and are untouched. The Smart List creator reuses the advanced path via `FilterTabs`, so it inherits exclusions with no changes.

## Heads-up on the API

Trakt's discover filter params are OR-only strings with no native negation (confirmed against `@trakt/api`'s filter schema). This PR ships the full frontend representation + URL/smart-list persistence, but actual server-side exclusion depends on the API honoring `-` tokens, which it currently does not. Real filtering would need a backend/API change, tracked separately if we want it.

## Tests

- Unit specs for `toMultiSelectSelection`, `fromMultiSelectSelection` (incl. round-trip), and prefix-aware `mapToSearchParamValue`.
- Include/exclude toggle behavior, include-first (regression), and serialization verified live in the browser.