### PR TITLE
feat(stats): match streak preview pill colors to full heatmap

### DIFF
--- a/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
+++ b/projects/client/src/lib/sections/stats/_internal/StreakAccumulator.svelte
@@ -61,12 +61,10 @@
     height: var(--ni-32);
 
     border-radius: var(--border-radius-s);
-    background: transparent;
-    border: var(--ni-1) solid var(--color-streak-day);
-    transition: var(--transition-increment) ease-in-out;
-    transition-property: transform, opacity;
-
-    opacity: 0.5;
+    background: var(--color-heatmap-empty);
+    border: var(--ni-1) solid transparent;
+    transition: transform calc(0.5 * var(--transition-increment)) ease-in-out,
+      opacity var(--transition-increment) ease-in-out;
 
     @include for-tablet-sm-and-below {
       height: var(--ni-18);
@@ -75,17 +73,22 @@
     @include for-mouse {
       &:hover {
         transform: scaleX(1.5) scaleY(1.2);
-        opacity: 1;
       }
     }
 
     &[data-active] {
       background: var(--color-streak-day);
       border-color: transparent;
+      opacity: 0.5;
+    }
+
+    &[data-future],
+    &[data-today]:not([data-active]) {
+      background: transparent;
+      border-color: var(--color-heatmap-empty);
     }
 
     &[data-today] {
-      border-color: var(--color-streak-day);
       outline: var(--ni-1) solid var(--color-streak-day);
       outline-offset: var(--ni-1);
       opacity: 1;


### PR DESCRIPTION
Extension to https://github.com/trakt/trakt-web/pull/2911

Past-unwatched days now render as a solid grey fill and today/future unwatched days as a grey outline, mirroring the activity heatmap's empty-day treatment instead of the previous purple opacity trick.

cc @michaldrabik @kevincador @ElMagnea 

~~Note: @seferturan The colours adjusted as I expected but for some reason the "sizes" of the pills/capsules changed somehow? If there's a way to keep the sizing but also colours feel free to adjust. I can't say I understand some of the actual changes such as inclusion of `box-sizing: border-box;` or the other adjustments 🫣~~

NOTE: Preview images has slight difference in size in 'After' but is fixed in latest and is the same size

Before/After Light
<img height="400" alt="ws5" src="https://github.com/user-attachments/assets/11f7fcc7-78cb-415e-9e01-81f4333888a8" /><img height="400" alt="ws6" src="https://github.com/user-attachments/assets/0010edbe-9b53-4d99-8602-1a99e5897628" />

Before/After Dark
<img height="400" alt="ws7" src="https://github.com/user-attachments/assets/2a40fa86-20fd-497a-81b2-c17243b7c1b8" /><img height="400" alt="ws8" src="https://github.com/user-attachments/assets/a0f74b21-33b2-403f-85f9-75367d3635ad" />

Before/After Dark but Watched
<img height="400" alt="ws9" src="https://github.com/user-attachments/assets/d67f6072-2c46-44d7-bec5-e82ecad8889f" /><img height="400" alt="ws10" src="https://github.com/user-attachments/assets/1f453ed6-59c5-4d73-b34d-207f3932cf95" />
