### PR TITLE
feat(summary): add episode drawer keyboard shortcuts

### DIFF
--- a/projects/client/src/lib/components/drawer/isTopmostDrawer.ts
+++ b/projects/client/src/lib/components/drawer/isTopmostDrawer.ts
@@ -1,0 +1,25 @@
+const DRAWER_SELECTOR = '.trakt-drawer';
+
+const zIndexOf = (drawer: HTMLElement) =>
+  Number.parseInt(getComputedStyle(drawer).zIndex, 10) || 0;
+
+/**
+ * Whether the drawer containing `element` is the topmost drawer on screen.
+ *
+ * Drawers portal to `document.body`; stacked (elevated) drawers sit at a higher
+ * z-index than the base drawer, so window-level shortcuts can ask this at event
+ * time instead of threading an "is something stacked on me" flag down as a prop.
+ *
+ * FIXME: remove once we eliminate drawer-in-drawer in the episode drawer.
+ */
+export function isTopmostDrawer(element: HTMLElement): boolean {
+  const ownDrawer = element.closest<HTMLElement>(DRAWER_SELECTOR);
+  if (!ownDrawer) {
+    return false;
+  }
+
+  const drawers = document.querySelectorAll<HTMLElement>(DRAWER_SELECTOR);
+  const topZIndex = Math.max(...Array.from(drawers, zIndexOf));
+
+  return zIndexOf(ownDrawer) >= topZIndex;
+}

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
+  import { shortcut } from "@svelte-put/shortcut";
+  import { isTopmostDrawer } from "$lib/components/drawer/isTopmostDrawer.ts";
   import SwipeX from "$lib/components/gestures/SwipeX.svelte";
   import CaretLeftIcon from "$lib/components/icons/CaretLeftIcon.svelte";
   import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
@@ -27,6 +29,7 @@
   import { toHumanDate } from "$lib/utils/formatting/date/toHumanDate";
   import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration";
   import { toTranslatedGenre } from "$lib/utils/formatting/string/toTranslatedGenre";
+  import { createArrowNavTriggers } from "$lib/utils/events/createArrowNavTriggers.ts";
   import { fromRune } from "$lib/utils/store/fromRune.svelte.ts";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import { fade } from "svelte/transition";
@@ -60,6 +63,8 @@
     onSocialOpen: () => void;
     onHistoryOpen: () => void;
   } = $props();
+
+  let headerElement = $state<HTMLElement>();
 
   // The ratings query only needs the slug/season/episode numbers, so it can
   // resolve independently of the episode summary entry.
@@ -146,6 +151,23 @@
 
   const isTouch = useMedia(WellKnownMediaQuery.touch);
 
+  const navigateToEpisode = (url: string) => {
+    goto(url, { replaceState: true, noScroll: true, keepFocus: true });
+  };
+
+  const arrowNavigationTriggers = $derived(
+    createArrowNavTriggers({
+      prevUrl: previousEpisodeLink?.href,
+      nextUrl: nextEpisodeLink?.href,
+      modifier: false,
+      // Only steer episode navigation while this drawer is on top; a stacked
+      // ratings/social/history drawer keeps the arrow keys for itself.
+      canNavigate: () =>
+        headerElement != null && isTopmostDrawer(headerElement),
+      goto: navigateToEpisode,
+    }),
+  );
+
   // Touch devices: swiping the cover mirrors the prev/next buttons. Swipe right ->
   // previous episode, swipe left -> next. Missing targets are a no-op and the
   // indicator stays inactive so the swipe reads as disabled.
@@ -155,9 +177,15 @@
       return;
     }
 
-    goto(link.href, { replaceState: true, noScroll: true });
+    navigateToEpisode(link.href);
   };
 </script>
+
+<svelte:window
+  use:shortcut={{
+    trigger: arrowNavigationTriggers,
+  }}
+/>
 
 {#snippet cover()}
   {#if entry}
@@ -171,7 +199,7 @@
   {/if}
 {/snippet}
 
-<div class="episode-info-header">
+<div class="episode-info-header" bind:this={headerElement}>
   <div class="episode-info-poster-ratings">
     {#if $isTouch}
       <SwipeX

--- a/projects/client/src/lib/utils/events/createArrowNavTriggers.spec.ts
+++ b/projects/client/src/lib/utils/events/createArrowNavTriggers.spec.ts
@@ -1,0 +1,108 @@
+import type {
+  ShortcutEventDetail,
+  ShortcutTrigger,
+} from '@svelte-put/shortcut';
+import { describe, expect, it, vi } from 'vitest';
+import { createArrowNavTriggers } from './createArrowNavTriggers.ts';
+
+function triggerShortcut(
+  trigger: ShortcutTrigger | undefined,
+  originalEvent: KeyboardEvent,
+) {
+  trigger?.callback?.(
+    {
+      node: document.body,
+      trigger,
+      originalEvent,
+    } satisfies ShortcutEventDetail,
+  );
+}
+
+describe('util: createArrowNavTriggers', () => {
+  it('should navigate backward and forward with the configured modifier', () => {
+    const goto = vi.fn();
+    const triggers = createArrowNavTriggers({
+      prevUrl: '/previous',
+      nextUrl: '/next',
+      modifier: false,
+      goto,
+    });
+    const previousEvent = new KeyboardEvent('keydown', { cancelable: true });
+    const nextEvent = new KeyboardEvent('keydown', { cancelable: true });
+
+    expect(triggers.map((trigger) => trigger.modifier)).toEqual([false, false]);
+
+    triggerShortcut(triggers.at(0), previousEvent);
+    triggerShortcut(triggers.at(1), nextEvent);
+
+    expect(previousEvent.defaultPrevented).toBe(true);
+    expect(nextEvent.defaultPrevented).toBe(true);
+    expect(goto).toHaveBeenNthCalledWith(1, '/previous');
+    expect(goto).toHaveBeenNthCalledWith(2, '/next');
+  });
+
+  it('should disable a direction when its destination is unavailable', () => {
+    const triggers = createArrowNavTriggers({
+      nextUrl: '/next',
+      canGoNext: false,
+      goto: vi.fn(),
+    });
+
+    expect(triggers.at(0)?.enabled).toBe(false);
+    expect(triggers.at(1)?.enabled).toBe(false);
+  });
+
+  it('should leave the key untouched when navigation is blocked', () => {
+    const goto = vi.fn();
+    const triggers = createArrowNavTriggers({
+      prevUrl: '/previous',
+      nextUrl: '/next',
+      modifier: false,
+      canNavigate: () => false,
+      goto,
+    });
+    const previousEvent = new KeyboardEvent('keydown', { cancelable: true });
+
+    triggerShortcut(triggers.at(0), previousEvent);
+
+    expect(previousEvent.defaultPrevented).toBe(false);
+    expect(goto).not.toHaveBeenCalled();
+  });
+
+  it('should navigate when navigation is allowed', () => {
+    const goto = vi.fn();
+    const triggers = createArrowNavTriggers({
+      prevUrl: '/previous',
+      nextUrl: '/next',
+      modifier: false,
+      canNavigate: () => true,
+      goto,
+    });
+    const previousEvent = new KeyboardEvent('keydown', { cancelable: true });
+
+    triggerShortcut(triggers.at(0), previousEvent);
+
+    expect(previousEvent.defaultPrevented).toBe(true);
+    expect(goto).toHaveBeenCalledWith('/previous');
+  });
+
+  it('should ignore text inputs and events handled by another control', () => {
+    const goto = vi.fn();
+    const triggers = createArrowNavTriggers({
+      prevUrl: '/previous',
+      nextUrl: '/next',
+      goto,
+    });
+    const inputEvent = new KeyboardEvent('keydown', { cancelable: true });
+    Object.defineProperty(inputEvent, 'target', {
+      value: document.createElement('input'),
+    });
+    const handledEvent = new KeyboardEvent('keydown', { cancelable: true });
+    handledEvent.preventDefault();
+
+    triggerShortcut(triggers.at(0), inputEvent);
+    triggerShortcut(triggers.at(1), handledEvent);
+
+    expect(goto).not.toHaveBeenCalled();
+  });
+});

--- a/projects/client/src/lib/utils/events/createArrowNavTriggers.ts
+++ b/projects/client/src/lib/utils/events/createArrowNavTriggers.ts
@@ -3,9 +3,13 @@ import type { ShortcutTrigger } from '@svelte-put/shortcut';
 import { isTextInputTarget } from './isTextInputTarget';
 
 type ArrowNavTriggersParams = {
-  prevUrl: string;
-  nextUrl: string;
+  prevUrl?: string;
+  nextUrl?: string;
   canGoNext?: boolean;
+  modifier?: ShortcutTrigger['modifier'];
+  // Evaluated at keypress time; when it returns false the key is left untouched
+  // (no preventDefault) so a drawer stacked on top can still handle it.
+  canNavigate?: () => boolean;
   goto: (url: string) => void;
 };
 
@@ -15,11 +19,16 @@ export function createArrowNavTriggers({
   prevUrl,
   nextUrl,
   canGoNext = true,
+  modifier = ARROW_NAV_MODIFIER,
+  canNavigate,
   goto,
 }: ArrowNavTriggersParams): ShortcutTrigger[] {
   const navigate =
-    (url: string) => ({ originalEvent }: { originalEvent: KeyboardEvent }) => {
+    (url: string | undefined) =>
+    ({ originalEvent }: { originalEvent: KeyboardEvent }) => {
+      if (!url || originalEvent.defaultPrevented) return;
       if (isTextInputTarget(originalEvent.target)) return;
+      if (canNavigate && !canNavigate()) return;
       originalEvent.preventDefault();
       goto(url);
     };
@@ -27,13 +36,14 @@ export function createArrowNavTriggers({
   return [
     {
       key: 'ArrowLeft',
-      modifier: ARROW_NAV_MODIFIER,
+      modifier,
+      enabled: prevUrl != null,
       callback: navigate(prevUrl),
     },
     {
       key: 'ArrowRight',
-      modifier: ARROW_NAV_MODIFIER,
-      enabled: canGoNext,
+      modifier,
+      enabled: canGoNext && nextUrl != null,
       callback: navigate(nextUrl),
     },
   ];


### PR DESCRIPTION
# Summary

Closes #1399.

Completes quick previous and next episode navigation in the new episode drawer by adding keyboard shortcuts alongside the existing artwork controls.

# Changes

- Pressing `ArrowLeft` navigates to the previous episode.
- Pressing `ArrowRight` navigates to the next episode.
- Navigation continues across season boundaries using the existing episode targets.
- Shortcuts are disabled when the requested direction is unavailable or when ratings, social, or history drawers are stacked above the episode drawer.
- Text inputs and controls that already consume arrow keys retain their normal behavior.
- Focus and scroll position are preserved during episode navigation.
- The shared arrow-navigation helper now supports plain arrow shortcuts and unavailable destinations while preserving its existing modifier defaults.

# Screenshots

<img width="400" height="242" alt="keyboard-shortcuts-meme" src="https://github.com/user-attachments/assets/7afc9e6d-3e05-409a-b018-579255ab57c6" />
