### PR TITLE
fix(navbar): prevent crash from undefined header object

### DIFF
--- a/projects/client/src/lib/sections/navbar/_internal/NavbarHeader.svelte
+++ b/projects/client/src/lib/sections/navbar/_internal/NavbarHeader.svelte
@@ -9,12 +9,12 @@
   {@const header = $state.header}
   <div class="trakt-navbar-header">
     {#snippet titleContent()}
-      {#if header.back}
+      {#if header?.back}
         <span class="header-back-caret"><CaretLeftIcon /></span>
       {/if}
       <div class="trakt-navbar-header-title">
-        <h1 class="ellipsis">{header.title}</h1>
-        {#if header.metaInfo}
+        <h1 class="ellipsis">{header?.title}</h1>
+        {#if header?.metaInfo}
           {#if typeof header.metaInfo === "string"}
             <span class="ellipsis bold meta-info">{header.metaInfo}</span>
           {:else}
@@ -24,7 +24,7 @@
       </div>
     {/snippet}
 
-    {#if header.back}
+    {#if header?.back}
       <a
         class="trakt-navbar-header-back"
         href={header.back.href}
@@ -36,7 +36,7 @@
       {@render titleContent()}
     {/if}
 
-    {#if header.actions}
+    {#if header?.actions}
       <div class="trakt-navbar-header-actions">
         {@render header.actions()}
       </div>


### PR DESCRIPTION
## 🎶 Notes 🎶

- The `back` feature wrapped the navbar header title in a `{#snippet}` + `{@render}`, which runs in its own reactive scope.
- On settings → home navigation the `header` const flips from `{title, back}` to `undefined`, and the snippet re-runs reading `header.back` before the `{#if}` guard tears down. That throws and takes the home dashboard render down with it (half content + console error).
- Fix optional-chains the header reads in `NavbarHeader.svelte` so a transient nil header renders nothing and tears down cleanly.
- ⚠️ Related smell left for later: `useNavbarState.set()` strips `undefined`, so pages without a `header` can't clear the one a previous page left behind. Pre-existing store-design issue, out of scope here.