### PR TITLE
feat(buttons): mouse-only hover tooltips on icon controls

### DIFF
--- a/projects/client/src/lib/components/buttons/ActionButton.svelte
+++ b/projects/client/src/lib/components/buttons/ActionButton.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { useActiveLink } from "$lib/stores/useActiveLink";
   import { Button } from "bits-ui";
   import { useGuardedHref } from "../../features/auth/stores/useGuardedHref";
@@ -16,9 +18,16 @@
     style = "flat",
     navigationType,
     disabled,
+    tooltip = true,
     classList = "",
     ...props
   }: TraktActionButtonProps | TraktActionButtonAnchorProps = $props();
+
+  // Icon-only buttons carry no visible text, so their required `label` doubles
+  // as a hover tooltip - a pointer-only affordance, gated on mouse so touch is
+  // untouched (tap just fires the action). Opt out with `tooltip={false}` where
+  // the caller supplies its own tooltip (e.g. custom copy/side).
+  const isMouse = useMedia(WellKnownMediaQuery.mouse);
 
   const { guardedHref, originalHref } = $derived(
     useGuardedHref((props as TraktActionButtonAnchorProps).href),
@@ -61,9 +70,11 @@
   });
 </script>
 
-<Button.Root {...host.rootProps}>
-  {@render children()}
-</Button.Root>
+<Tooltip content={label} variant="compact" disabled={!tooltip || !$isMouse}>
+  <Button.Root {...host.rootProps}>
+    {@render children()}
+  </Button.Root>
+</Tooltip>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;

--- a/projects/client/src/lib/components/buttons/TraktActionButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/TraktActionButtonProps.ts
@@ -7,4 +7,10 @@ export type TraktActionButtonProps = ButtonProps & {
   style?: 'flat' | 'ghost';
   navigationType?: DpadNavigationType;
   classList?: string;
+  /**
+   * Whether the icon-only button shows its `label` as a hover tooltip
+   * (pointer devices only). Defaults to `true`. Set `false` when the caller
+   * wraps the button in its own tooltip with bespoke copy or placement.
+   */
+  tooltip?: boolean;
 };

--- a/projects/client/src/lib/components/toggles/Toggler.svelte
+++ b/projects/client/src/lib/components/toggles/Toggler.svelte
@@ -1,6 +1,8 @@
 <script lang="ts" generics="T">
   import { goto } from "$app/navigation";
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
   import { DpadNavigationType } from "$lib/features/navigation/models/DpadNavigationType.ts";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { writable } from "$lib/utils/store/WritableSubject.ts";
   import Toggle from "./_internal/Toggle.svelte";
   import ToggleIcon from "./_internal/ToggleIcon.svelte";
@@ -15,6 +17,10 @@
   }
 
   const { value, onChange, options, variant = "icon" }: TogglerProps = $props();
+
+  // Tooltips are a pointer affordance only - on touch the tap selects the
+  // option, so gating on mouse keeps the tooltip from firing on tap.
+  const isMouse = useMedia(WellKnownMediaQuery.mouse);
 
   const trackerIndex = $derived(
     writable(options.findIndex((option) => value === option.value)),
@@ -95,22 +101,28 @@
     ontransitionend={handleTransitionEnd}
   ></div>
   {#each options as option, index (option.value)}
-    <Toggle
-      isPressed={$trackerIndex === index}
-      label={option.label()}
-      {variant}
-      {...getTriggerProps(option, index)}
+    <Tooltip
+      content={option.text()}
+      variant="compact"
+      disabled={!$isMouse || variant === "text"}
     >
-      {#snippet icon()}
-        <ToggleIcon {option} />
-      {/snippet}
+      <Toggle
+        isPressed={$trackerIndex === index}
+        label={option.label()}
+        {variant}
+        {...getTriggerProps(option, index)}
+      >
+        {#snippet icon()}
+          <ToggleIcon {option} />
+        {/snippet}
 
-      {#if option.content}
-        {@render option.content()}
-      {:else}
-        {option.text()}
-      {/if}
-    </Toggle>
+        {#if option.content}
+          {@render option.content()}
+        {:else}
+          {option.text()}
+        {/if}
+      </Toggle>
+    </Tooltip>
   {/each}
 </div>
 

--- a/projects/client/src/lib/components/tooltip/Tooltip.svelte
+++ b/projects/client/src/lib/components/tooltip/Tooltip.svelte
@@ -35,7 +35,7 @@
         <div
           {...props}
           class="trakt-tooltip-trigger"
-          onclick={!$isMouse ? () => (open = !open) : undefined}
+          onclick={!$isMouse && !disabled ? () => (open = !open) : undefined}
         >
           {@render children()}
         </div>

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/TrackAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/TrackAction.svelte
@@ -67,6 +67,12 @@
     display: flex;
     flex-grow: 1;
 
+    /* ActionButton renders a wrapper around its button, so stretch the direct
+       child to keep the grow chain intact down to the button. */
+    > :global(*) {
+      flex-grow: 1;
+    }
+
     :global(.trakt-action-button) {
       flex-grow: 1;
 

--- a/projects/client/src/lib/sections/navbar/components/filter/FilterSidebar.svelte
+++ b/projects/client/src/lib/sections/navbar/components/filter/FilterSidebar.svelte
@@ -35,6 +35,7 @@
           label={m.button_label_reset_all_filters()}
           style="ghost"
           color="red"
+          tooltip={false}
           disabled={!$hasActiveFilter}
           onclick={resetFilters}
         >
@@ -49,6 +50,7 @@
         <ActionButton
           label={m.button_label_save_filters()}
           style="ghost"
+          tooltip={false}
           onclick={() => {
             saveFilters();
             onClose();


### PR DESCRIPTION
## What

Icon-only controls carry no visible text, so you can't tell what they do until you click. This surfaces each one's existing accessible `label` as a **hover tooltip on pointer devices**, so they explain themselves upfront. Built into the shared primitives, so it lands everywhere at once:

- **`ActionButton`** renders its required `label` as a compact tooltip. Covers **mark-as-watched, add/remove watchlist, watch trailer, more-options (burger), share, settings**, the comment **language filter** + **add-review**, and every other icon action button (56 call sites).
- **`Toggler`** shows each option's `text()` over its icon — progress (watching/completed/dropped), discover, social, activity, library, related, etc.

## Mobile-safe by construction

Strictly gated on `useMedia(mouse)` (`(hover: hover) and (pointer: fine)`):
- On touch the tooltip is `disabled`, and `Tooltip` now also drops its tap-handler when disabled — so tapping an icon just fires its action. **Mobile/touch is completely unchanged.**
- `useMedia` returns `false` during SSR, so gating via the `disabled` prop is a prop-value change on hydration, not a structural one → no hydration mismatch.

## Opt-out

`ActionButton` gains a `tooltip` prop (default `true`). `FilterSidebar`'s reset/save buttons pass `tooltip={false}` because they already supply bespoke tooltips (custom copy + `side="bottom"`).

## Notes for review

- **Blast radius is intentional** — every `ActionButton` self-tooltips (incl. media-card action buttons) for consistency. Opt any out with `tooltip={false}`.
- The more-options burger inherits its aria-label, so its tooltip reads `Pop up menu for "{title}"` — accurate; can be shortened later if we want dedicated copy.

## Verification

- `svelte-check`: 0 errors / 0 warnings (7164 files)
- `deno fmt`: clean
- Manually verified on the running app (desktop): Summary actions, navbar Share/Settings, Reviews language + add-review all show tooltips on hover; language dropdown still opens; touch shows none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)