### PR TITLE
fix(yir): prevent duplicate each keys crashing year in review

### DIFF
--- a/projects/client/src/lib/requests/_internal/mapToYirPerson.spec.ts
+++ b/projects/client/src/lib/requests/_internal/mapToYirPerson.spec.ts
@@ -1,0 +1,53 @@
+import type { PersonResponse } from '@trakt/api';
+import { describe, expect, it } from 'vitest';
+import { mapToYirPeople } from './mapToYirPerson.ts';
+
+type RawYirPersonTitle = {
+  title: string;
+  type: 'show' | 'movie';
+  trakt_id: number;
+  episode_count?: number;
+  year?: number | null;
+};
+
+function rawPerson(
+  titles: RawYirPersonTitle[],
+): Parameters<typeof mapToYirPeople>[0][number] {
+  return {
+    person: {
+      name: 'Cillian Murphy',
+      ids: { trakt: 1, slug: 'cillian-murphy' },
+      images: {},
+    } as unknown as PersonResponse,
+    count: { movies: 1, shows: 1 },
+    titles,
+  };
+}
+
+describe('mapToYirPeople', () => {
+  describe('title keys', () => {
+    it('should keep a movie and a show that share the same trakt id', () => {
+      const [person] = mapToYirPeople([
+        rawPerson([
+          { title: 'Oppenheimer', type: 'movie', trakt_id: 42 },
+          { title: 'Peaky Blinders', type: 'show', trakt_id: 42 },
+        ]),
+      ]);
+
+      const keys = person?.titles.map((t) => t.key);
+      expect(keys).toEqual(['movie-42', 'show-42']);
+    });
+
+    it('should drop a duplicate title with the same type and trakt id', () => {
+      const [person] = mapToYirPeople([
+        rawPerson([
+          { title: 'Oppenheimer', type: 'movie', trakt_id: 42 },
+          { title: 'Oppenheimer', type: 'movie', trakt_id: 42 },
+        ]),
+      ]);
+
+      expect(person?.titles).toHaveLength(1);
+      expect(person?.titles.at(0)?.title).toBe('Oppenheimer');
+    });
+  });
+});

--- a/projects/client/src/lib/requests/_internal/mapToYirPerson.ts
+++ b/projects/client/src/lib/requests/_internal/mapToYirPerson.ts
@@ -1,5 +1,5 @@
 import type { PersonResponse } from '@trakt/api';
-import type { YirPerson } from '../models/YirPerson.ts';
+import type { YirPerson, YirPersonTitle } from '../models/YirPerson.ts';
 import { mapToHeadshot } from './mapToHeadshot.ts';
 
 type RawYirPersonTitle = {
@@ -19,6 +19,32 @@ type RawYirPerson = {
   titles: RawYirPersonTitle[];
 };
 
+function mapTitle(raw: RawYirPersonTitle): YirPersonTitle {
+  return {
+    // A trakt id is only unique within a media type, so a movie and a show can
+    // share the same numeric id. Key on `type` + id to keep them distinct.
+    key: `${raw.type}-${raw.trakt_id}`,
+    title: raw.title,
+    type: raw.type,
+    traktId: raw.trakt_id,
+    episodeCount: raw.episode_count,
+    year: raw.year,
+  };
+}
+
+// Titles are keyed by `key` everywhere they render, so drop any duplicate that
+// would collide on that composite key and crash the keyed `{#each}`.
+function dedupeTitles(titles: RawYirPersonTitle[]): YirPersonTitle[] {
+  const seen = new Set<string>();
+
+  return titles.map(mapTitle).filter((title) => {
+    if (seen.has(title.key)) return false;
+
+    seen.add(title.key);
+    return true;
+  });
+}
+
 function mapPerson(raw: RawYirPerson): YirPerson {
   return {
     id: raw.person.ids.trakt,
@@ -26,13 +52,7 @@ function mapPerson(raw: RawYirPerson): YirPerson {
     slug: raw.person.ids.slug,
     headshot: mapToHeadshot(raw.person.images),
     count: raw.count,
-    titles: raw.titles.map((t) => ({
-      title: t.title,
-      type: t.type,
-      traktId: t.trakt_id,
-      episodeCount: t.episode_count,
-      year: t.year,
-    })),
+    titles: dedupeTitles(raw.titles),
   };
 }
 

--- a/projects/client/src/lib/requests/models/YirPerson.ts
+++ b/projects/client/src/lib/requests/models/YirPerson.ts
@@ -2,6 +2,11 @@ import { z } from 'zod';
 import { ImageUrlsSchema } from './ImageUrlsSchema.ts';
 
 const YirPersonTitleSchema = z.object({
+  /**
+   * Composite `type-traktId` key. A trakt id is only unique within a media
+   * type, so a movie and a show can share the same numeric id.
+   */
+  key: z.string(),
   title: z.string(),
   type: z.enum(['show', 'movie']),
   traktId: z.number(),

--- a/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PersonRow.svelte
+++ b/projects/client/src/lib/sections/yir/2024/_internal/Yir2024PersonRow.svelte
@@ -103,7 +103,7 @@
 
   {#if expanded}
     <ul id="titles-{person.id}" class="yir-2024-person-titles" role="list">
-      {#each person.titles as title (title.traktId)}
+      {#each person.titles as title (title.key)}
         {@const meta = titleMeta(title)}
         <li class="yir-2024-person-title" role="listitem">
           <Link

--- a/projects/client/src/lib/sections/yir/_internal/YirPeopleGroup.svelte
+++ b/projects/client/src/lib/sections/yir/_internal/YirPeopleGroup.svelte
@@ -121,7 +121,7 @@
             side="top"
           >
             {#snippet content()}
-              {#each person.titles as title (title.traktId)}
+              {#each person.titles as title (title.key)}
                 <div class="yir-tooltip-title">
                   {#if title.type === "show" && title.episodeCount}
                     <span>{title.title} —</span>


### PR DESCRIPTION
# Summary

Fixes #2938 — the Year in Review page crashes with Svelte's [`each_key_duplicate`](https://svelte.dev/e/each_key_duplicate) error when opening year-in-review details from a personnel profile.

# Root cause

The people section renders each person's titles in a keyed `{#each}` keyed only on `title.traktId`. Trakt IDs are only unique *within* a media type, so a movie and a show can share the same numeric id. When a top actor/director/writer has both a movie and a show with the same trakt id in their title list, two rendered items collide on the same key and Svelte throws, taking down the whole page. The list renders on hover (current-year tooltip) or on expand (2024 template), which is why it surfaces when drilling into a person's details.

# Fix

Key titles by their real identity — media type plus id — everywhere they render, and dedupe at the mapper so an accidental exact-duplicate title from the aggregation endpoint can't crash the render either.

- `mapToYirPerson.ts` — dedupe titles by the composite `type-traktId` key.
- `YirPeopleGroup.svelte` — key the titles `{#each}` on `` `${title.type}-${title.traktId}` ``.
- `Yir2024PersonRow.svelte` — same key fix for the 2024 template.
- `mapToYirPerson.spec.ts` — new spec: a movie + show sharing an id stay distinct, and a true duplicate is dropped.

# Testing

`vitest --run src/lib/requests/_internal/mapToYirPerson.spec.ts` — 2 passed.
