### PR TITLE
refactor(filter): expand lower runtime ranges

### DIFF
--- a/projects/client/src/lib/features/filters/_internal/generateRuntimeOptions.ts
+++ b/projects/client/src/lib/features/filters/_internal/generateRuntimeOptions.ts
@@ -2,7 +2,9 @@ import type { FilterOption } from '$lib/features/filters/models/FilterOptions.ts
 import * as m from '$lib/features/i18n/messages.ts';
 
 const RUNTIME_RANGES = [
-  { value: '0-90', label: () => m.filter_label_runtime({ range: '0-90' }) },
+  { value: '0-30', label: () => m.filter_label_runtime({ range: '0-30' }) },
+  { value: '31-60', label: () => m.filter_label_runtime({ range: '31-60' }) },
+  { value: '61-90', label: () => m.filter_label_runtime({ range: '61-90' }) },
   { value: '91-120', label: () => m.filter_label_runtime({ range: '91-120' }) },
   { value: '121-', label: () => m.filter_label_runtime({ range: '121+' }) },
 ];


### PR DESCRIPTION
# Summary

Splits the coarse `0-90` minute runtime filter option into three finer, contiguous buckets so short-form titles (e.g. half-hour sitcoms) can be filtered directly without dropping into the advanced runtime slider.

Closes #2935

# Changes

Replaced the single `0-90` list option with `0-30`, `31-60`, and `61-90` in `generateRuntimeOptions.ts`. The `91-120` and `121+` options are unchanged, so the full set is now `0-30`, `31-60`, `61-90`, `91-120`, `121+` — non-overlapping and contiguous, matching the existing range style.

# Notes

No i18n change was needed: the existing `filter_label_runtime` key renders `"{range} minutes"`, so the new options display as "0-30 minutes", "31-60 minutes", etc. The values flow straight through to the `runtimes` query param with no validation or reverse-mapping to update, so this is a single-file change.
