### PR TITLE
fix(calendar): honor Display Watched / Watchlisted toggles client-side

### DIFF
--- a/projects/client/src/lib/features/calendar/_internal/useCalendar.ts
+++ b/projects/client/src/lib/features/calendar/_internal/useCalendar.ts
@@ -1,3 +1,4 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { createBulkIntlOverlay } from '$lib/features/intl-overlay/createBulkIntlOverlay.ts';
 import { episodeWithShowOrMovieTargets } from '$lib/features/intl-overlay/episodeWithShowOrMovieTargets.ts';
 import { withOverlayLoading } from '$lib/features/intl-overlay/withOverlayLoading.ts';
@@ -17,6 +18,8 @@ import { combineLatest, map, type Observable } from 'rxjs';
 import type { FilterParams } from '../../../requests/models/FilterParams.ts';
 import type { DiscoverMode } from '../../filters/models/DiscoverMode.ts';
 import type { Calendar } from '../models/Calendar.ts';
+import { filterWatchedCalendarItems } from '../filterWatchedCalendarItems.ts';
+import { filterWatchlistedCalendarItems } from '../filterWatchlistedCalendarItems.ts';
 
 export type CalendarItem = UpcomingEpisodeEntry | MediaEntry;
 type CalendarItems = CalendarItem[];
@@ -63,6 +66,8 @@ export function useCalendar(
   const queries = typeToQueries(props)
     .map((query) => useQuery(query));
 
+  const { history, watchlist } = useUser();
+
   const baseLoading = combineLatest(queries).pipe(
     map(($queries) => $queries.some(toLoadingState)),
   );
@@ -81,9 +86,21 @@ export function useCalendar(
     overlay.operator,
   );
 
+  const unwatchedItems = filterWatchedCalendarItems({
+    items: allItems,
+    history,
+    filter: props.filter,
+  });
+
+  const visibleItems = filterWatchlistedCalendarItems({
+    items: unwatchedItems,
+    watchlist,
+    filter: props.filter,
+  });
+
   return {
     isLoading: withOverlayLoading(baseLoading, overlay.intlLoading$),
-    calendar: allItems.pipe(
+    calendar: visibleItems.pipe(
       map(($allItems) => {
         return Array.from({ length: props.days }, (_, i) => {
           const date = new Date(props.start);

--- a/projects/client/src/lib/features/calendar/_internal/useReleasesCalendar.ts
+++ b/projects/client/src/lib/features/calendar/_internal/useReleasesCalendar.ts
@@ -1,3 +1,4 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { createBulkIntlOverlay } from '$lib/features/intl-overlay/createBulkIntlOverlay.ts';
 import { episodeWithShowOrMovieTargets } from '$lib/features/intl-overlay/episodeWithShowOrMovieTargets.ts';
 import { withOverlayLoading } from '$lib/features/intl-overlay/withOverlayLoading.ts';
@@ -13,6 +14,8 @@ import { map, type Observable } from 'rxjs';
 import type { FilterParams } from '../../../requests/models/FilterParams.ts';
 import type { DiscoverMode } from '../../filters/models/DiscoverMode.ts';
 import type { Calendar } from '../models/Calendar.ts';
+import { filterWatchedCalendarItems } from '../filterWatchedCalendarItems.ts';
+import { filterWatchlistedCalendarItems } from '../filterWatchlistedCalendarItems.ts';
 
 type UseReleasesCalendarParams = {
   start: Date;
@@ -44,6 +47,8 @@ export function useReleasesCalendar(
     }),
   );
 
+  const { history, watchlist } = useUser();
+
   const baseLoading = query.pipe(
     map(toLoadingState),
   );
@@ -52,11 +57,26 @@ export function useReleasesCalendar(
     getTargets: episodeWithShowOrMovieTargets,
   });
 
+  const allItems = query.pipe(
+    map(($query) => $query.data ?? []),
+    overlay.operator,
+  );
+
+  const unwatchedItems = filterWatchedCalendarItems({
+    items: allItems,
+    history,
+    filter: props.filter,
+  });
+
+  const visibleItems = filterWatchlistedCalendarItems({
+    items: unwatchedItems,
+    watchlist,
+    filter: props.filter,
+  });
+
   return {
     isLoading: withOverlayLoading(baseLoading, overlay.intlLoading$),
-    calendar: query.pipe(
-      map(($query) => $query.data ?? []),
-      overlay.operator,
+    calendar: visibleItems.pipe(
       map(($items) =>
         Array.from({ length: props.days }, (_, i) => {
           const date = new Date(props.start);

--- a/projects/client/src/lib/features/calendar/filterWatchedCalendarItems.spec.ts
+++ b/projects/client/src/lib/features/calendar/filterWatchedCalendarItems.spec.ts
@@ -1,0 +1,137 @@
+import type { UserHistory } from '$lib/features/auth/stores/useCurrentUserHistory.ts';
+import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { UpcomingEpisodeEntry } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
+import { firstValueFrom, of } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { filterWatchedCalendarItems } from './filterWatchedCalendarItems.ts';
+
+function episode(
+  id: number,
+  showId: number,
+  episodeIds?: number[],
+): UpcomingEpisodeEntry {
+  return {
+    id,
+    show: { id: showId },
+    ...(episodeIds ? { episodes: episodeIds.map((eid) => ({ id: eid })) } : {}),
+  } as unknown as UpcomingEpisodeEntry;
+}
+
+function movie(id: number): MediaEntry {
+  return { id, type: 'movie' } as unknown as MediaEntry;
+}
+
+function history(
+  { shows = {}, movies = [] }: {
+    shows?: Record<number, number[]>;
+    movies?: number[];
+  },
+): UserHistory {
+  return {
+    shows: new Map(
+      Object.entries(shows).map(([showId, episodeIds]) => [
+        Number(showId),
+        { episodes: episodeIds.map((episodeId) => ({ episodeId })) },
+      ]),
+    ),
+    movies: new Map(movies.map((id) => [id, {}])),
+  } as unknown as UserHistory;
+}
+
+// The URL/filterMap carries the toggle as a string, so exercise the real value.
+const IGNORE_WATCHED = {
+  ignore_watched: 'true',
+} as unknown as FilterParams['filter'];
+
+describe('util: filterWatchedCalendarItems', () => {
+  it('should pass items through unchanged when the toggle is absent', async () => {
+    const items = [episode(1, 10), movie(2)];
+
+    const result = await firstValueFrom(
+      filterWatchedCalendarItems({
+        items: of(items),
+        history: of(history({ shows: { 10: [1] }, movies: [2] })),
+        filter: {},
+      }),
+    );
+
+    expect(result).toBe(items);
+  });
+
+  it('should pass items through when the toggle is explicitly off', async () => {
+    const items = [episode(1, 10)];
+    const off = {
+      ignore_watched: 'false',
+    } as unknown as FilterParams['filter'];
+
+    const result = await firstValueFrom(
+      filterWatchedCalendarItems({
+        items: of(items),
+        history: of(history({ shows: { 10: [1] } })),
+        filter: off,
+      }),
+    );
+
+    expect(result).toBe(items);
+  });
+
+  it('should not filter while history is still loading', async () => {
+    const items = [episode(1, 10)];
+
+    const result = await firstValueFrom(
+      filterWatchedCalendarItems({
+        items: of(items),
+        history: of(null),
+        filter: IGNORE_WATCHED,
+      }),
+    );
+
+    expect(result).toEqual(items);
+  });
+
+  it('should hide a watched episode and keep an unwatched one', async () => {
+    const watched = episode(1, 10);
+    const unwatched = episode(2, 10);
+
+    const result = await firstValueFrom(
+      filterWatchedCalendarItems({
+        items: of([watched, unwatched]),
+        history: of(history({ shows: { 10: [1] } })),
+        filter: IGNORE_WATCHED,
+      }),
+    );
+
+    expect(result).toEqual([unwatched]);
+  });
+
+  it('should hide a grouped card only when every collapsed episode is watched', async () => {
+    const fullyWatched = episode(1, 10, [101, 102]);
+    const partiallyWatched = episode(2, 10, [201, 202]);
+
+    const result = await firstValueFrom(
+      filterWatchedCalendarItems({
+        items: of([fullyWatched, partiallyWatched]),
+        history: of(history({ shows: { 10: [101, 102, 201] } })),
+        filter: IGNORE_WATCHED,
+      }),
+    );
+
+    expect(result).toEqual([partiallyWatched]);
+  });
+
+  it('should hide a watched movie and keep an unwatched one', async () => {
+    const watched = movie(1);
+    const unwatched = movie(2);
+
+    const result = await firstValueFrom(
+      filterWatchedCalendarItems({
+        items: of([watched, unwatched]),
+        history: of(history({ movies: [1] })),
+        filter: IGNORE_WATCHED,
+      }),
+    );
+
+    expect(result).toEqual([unwatched]);
+  });
+});

--- a/projects/client/src/lib/features/calendar/filterWatchedCalendarItems.ts
+++ b/projects/client/src/lib/features/calendar/filterWatchedCalendarItems.ts
@@ -1,0 +1,67 @@
+import type { UserHistory } from '$lib/features/auth/stores/useCurrentUserHistory.ts';
+import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { UpcomingEpisodeEntry } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
+import { combineLatest, map, type Observable } from 'rxjs';
+
+type WatchableCalendarItem = UpcomingEpisodeEntry | MediaEntry;
+
+function isCalendarItemWatched(
+  item: WatchableCalendarItem,
+  history: UserHistory,
+): boolean {
+  if ('show' in item) {
+    const watchedEpisodes = history.shows.get(item.show.id)?.episodes ?? [];
+
+    // Common case: a single-episode card needs one membership check, so scan
+    // directly instead of allocating a Set. Only grouped multi-episode cards
+    // (checked with `every` below) benefit from the Set.
+    if (item.episodes == null) {
+      return watchedEpisodes.some((episode) => episode.episodeId === item.id);
+    }
+
+    const watchedIds = new Set(
+      watchedEpisodes.map((episode) => episode.episodeId),
+    );
+    return item.episodes.every((episode) => watchedIds.has(episode.id));
+  }
+
+  if (item.type === 'movie') {
+    return history.movies.has(item.id);
+  }
+
+  return false;
+}
+
+type FilterWatchedCalendarItemsParams<T extends WatchableCalendarItem> = {
+  items: Observable<T[]>;
+  history: Observable<UserHistory | null>;
+  filter: FilterParams['filter'];
+};
+
+/*
+  The calendar endpoints ignore the `ignore_watched` filter server-side, so
+  "hide watched" is applied here against the user's watched history - the same
+  store that drives the per-card watched checkmark. A grouped multi-episode card
+  is only hidden when every episode it collapses has been watched. While history
+  is still loading, nothing is filtered so items don't flash in and out.
+*/
+export function filterWatchedCalendarItems<T extends WatchableCalendarItem>({
+  items,
+  history,
+  filter,
+}: FilterWatchedCalendarItemsParams<T>): Observable<T[]> {
+  const ignoreWatched = `${filter?.ignore_watched ?? ''}` === 'true';
+
+  if (!ignoreWatched) {
+    return items;
+  }
+
+  return combineLatest([items, history]).pipe(
+    map(([$items, $history]) =>
+      $history == null
+        ? $items
+        : $items.filter((item) => !isCalendarItemWatched(item, $history))
+    ),
+  );
+}

--- a/projects/client/src/lib/features/calendar/filterWatchlistedCalendarItems.spec.ts
+++ b/projects/client/src/lib/features/calendar/filterWatchlistedCalendarItems.spec.ts
@@ -1,0 +1,103 @@
+import type { UserWatchlist } from '$lib/features/auth/queries/currentUserWatchlistQuery.ts';
+import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { UpcomingEpisodeEntry } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
+import { firstValueFrom, of } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { filterWatchlistedCalendarItems } from './filterWatchlistedCalendarItems.ts';
+
+function episode(id: number, showId: number): UpcomingEpisodeEntry {
+  return { id, show: { id: showId } } as unknown as UpcomingEpisodeEntry;
+}
+
+function movie(id: number): MediaEntry {
+  return { id, type: 'movie' } as unknown as MediaEntry;
+}
+
+function watchlist(
+  { shows = [], movies = [] }: { shows?: number[]; movies?: number[] },
+): UserWatchlist {
+  return { shows: new Set(shows), movies: new Set(movies) };
+}
+
+// The URL/filterMap carries the toggle as a string, so exercise the real value.
+const IGNORE_WATCHLISTED = {
+  ignore_watchlisted: 'true',
+} as unknown as FilterParams['filter'];
+
+describe('util: filterWatchlistedCalendarItems', () => {
+  it('should pass items through unchanged when the toggle is absent', async () => {
+    const items = [episode(1, 10)];
+
+    const result = await firstValueFrom(
+      filterWatchlistedCalendarItems({
+        items: of(items),
+        watchlist: of(watchlist({ shows: [10] })),
+        filter: {},
+      }),
+    );
+
+    expect(result).toBe(items);
+  });
+
+  it('should pass items through when the toggle is explicitly off', async () => {
+    const items = [episode(1, 10)];
+    const off = {
+      ignore_watchlisted: 'false',
+    } as unknown as FilterParams['filter'];
+
+    const result = await firstValueFrom(
+      filterWatchlistedCalendarItems({
+        items: of(items),
+        watchlist: of(watchlist({ shows: [10] })),
+        filter: off,
+      }),
+    );
+
+    expect(result).toBe(items);
+  });
+
+  it('should not filter while the watchlist is undefined', async () => {
+    const items = [episode(1, 10)];
+
+    const result = await firstValueFrom(
+      filterWatchlistedCalendarItems({
+        items: of(items),
+        watchlist: of(undefined),
+        filter: IGNORE_WATCHLISTED,
+      }),
+    );
+
+    expect(result).toEqual(items);
+  });
+
+  it('should hide an episode when its show is watchlisted', async () => {
+    const listed = episode(1, 10);
+    const notListed = episode(2, 20);
+
+    const result = await firstValueFrom(
+      filterWatchlistedCalendarItems({
+        items: of([listed, notListed]),
+        watchlist: of(watchlist({ shows: [10] })),
+        filter: IGNORE_WATCHLISTED,
+      }),
+    );
+
+    expect(result).toEqual([notListed]);
+  });
+
+  it('should hide a watchlisted movie and keep one that is not', async () => {
+    const listed = movie(1);
+    const notListed = movie(2);
+
+    const result = await firstValueFrom(
+      filterWatchlistedCalendarItems({
+        items: of([listed, notListed]),
+        watchlist: of(watchlist({ movies: [1] })),
+        filter: IGNORE_WATCHLISTED,
+      }),
+    );
+
+    expect(result).toEqual([notListed]);
+  });
+});

--- a/projects/client/src/lib/features/calendar/filterWatchlistedCalendarItems.ts
+++ b/projects/client/src/lib/features/calendar/filterWatchlistedCalendarItems.ts
@@ -1,0 +1,57 @@
+import type { UserWatchlist } from '$lib/features/auth/queries/currentUserWatchlistQuery.ts';
+import type { FilterParams } from '$lib/requests/models/FilterParams.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { UpcomingEpisodeEntry } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
+import { combineLatest, map, type Observable } from 'rxjs';
+
+type WatchableCalendarItem = UpcomingEpisodeEntry | MediaEntry;
+
+function isCalendarItemWatchlisted(
+  item: WatchableCalendarItem,
+  watchlist: UserWatchlist,
+): boolean {
+  if ('show' in item) {
+    return watchlist.shows.has(item.show.id);
+  }
+
+  if (item.type === 'movie') {
+    return watchlist.movies.has(item.id);
+  }
+
+  return false;
+}
+
+type FilterWatchlistedCalendarItemsParams<T extends WatchableCalendarItem> = {
+  items: Observable<T[]>;
+  watchlist: Observable<UserWatchlist | undefined>;
+  filter: FilterParams['filter'];
+};
+
+/*
+  The calendar endpoints ignore the `ignore_watchlisted` filter server-side, so
+  "hide watchlisted" is applied here against the user's watchlist. An episode is
+  hidden when its show is watchlisted; a movie when the movie itself is
+  watchlisted. While the watchlist is still loading, nothing is filtered so items
+  don't flash in and out.
+*/
+export function filterWatchlistedCalendarItems<T extends WatchableCalendarItem>(
+  {
+    items,
+    watchlist,
+    filter,
+  }: FilterWatchlistedCalendarItemsParams<T>,
+): Observable<T[]> {
+  const ignoreWatchlisted = `${filter?.ignore_watchlisted ?? ''}` === 'true';
+
+  if (!ignoreWatchlisted) {
+    return items;
+  }
+
+  return combineLatest([items, watchlist]).pipe(
+    map(([$items, $watchlist]) =>
+      $watchlist == null
+        ? $items
+        : $items.filter((item) => !isCalendarItemWatchlisted(item, $watchlist))
+    ),
+  );
+}

--- a/projects/client/src/lib/sections/lists/stores/useReleasesItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/useReleasesItems.ts
@@ -1,3 +1,6 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { filterWatchedCalendarItems } from '$lib/features/calendar/filterWatchedCalendarItems.ts';
+import { filterWatchlistedCalendarItems } from '$lib/features/calendar/filterWatchlistedCalendarItems.ts';
 import type { DiscoverMode } from '$lib/features/filters/models/DiscoverMode.ts';
 import { createBulkIntlOverlay } from '$lib/features/intl-overlay/createBulkIntlOverlay.ts';
 import { episodeWithShowOrMovieTargets } from '$lib/features/intl-overlay/episodeWithShowOrMovieTargets.ts';
@@ -36,16 +39,32 @@ export function useReleasesItems(props: UseReleasesItemsProps) {
     }),
   );
 
+  const { history, watchlist } = useUser();
+
   const overlay = createBulkIntlOverlay<ReleasesCalendarEntry>({
     getTargets: episodeWithShowOrMovieTargets,
   });
 
   const baseLoading = query.pipe(map(($query) => $query.isLoading));
 
-  const list = query.pipe(
-    map(($query) =>
+  const entries = query.pipe(map(($query) => $query.data ?? []));
+
+  const unwatchedEntries = filterWatchedCalendarItems({
+    items: entries,
+    history,
+    filter: props.filter,
+  });
+
+  const visibleEntries = filterWatchlistedCalendarItems({
+    items: unwatchedEntries,
+    watchlist,
+    filter: props.filter,
+  });
+
+  const list = visibleEntries.pipe(
+    map(($entries) =>
       filterReleasesItems({
-        entries: $query.data ?? [],
+        entries: $entries,
         limit: props.limit,
         now: new Date(),
       })

--- a/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
@@ -1,3 +1,6 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import { filterWatchedCalendarItems } from '$lib/features/calendar/filterWatchedCalendarItems.ts';
+import { filterWatchlistedCalendarItems } from '$lib/features/calendar/filterWatchlistedCalendarItems.ts';
 import type { DiscoverMode } from '$lib/features/filters/models/DiscoverMode.ts';
 import { createBulkIntlOverlay } from '$lib/features/intl-overlay/createBulkIntlOverlay.ts';
 import { episodeWithShowOrMovieTargets } from '$lib/features/intl-overlay/episodeWithShowOrMovieTargets.ts';
@@ -58,19 +61,35 @@ export function useUpcomingItems(props: UseUpcomingItemsProps) {
   );
 
   const query = useQuery(getUpcomingCalendarQuery(startDate, props));
+  const { history, watchlist } = useUser();
   const overlay = createBulkIntlOverlay<MediaEntry | UpcomingEpisodeEntry>({
     getTargets: episodeWithShowOrMovieTargets,
   });
 
   const baseLoading = query.pipe(map(($query) => $query.isLoading));
 
-  const list = query.pipe(
+  const entries = query.pipe(
     map(($query) => {
       const startOfToday = getStartOfDay(new Date()).getTime();
       return ($query.data ?? [])
-        .filter((d) => d.effectiveReleaseDate.getTime() >= startOfToday)
-        .slice(0, props.limit);
+        .filter((d) => d.effectiveReleaseDate.getTime() >= startOfToday);
     }),
+  );
+
+  const unwatchedEntries = filterWatchedCalendarItems({
+    items: entries,
+    history,
+    filter: props.filter,
+  });
+
+  const visibleEntries = filterWatchlistedCalendarItems({
+    items: unwatchedEntries,
+    watchlist,
+    filter: props.filter,
+  });
+
+  const list = visibleEntries.pipe(
+    map(($entries) => $entries.slice(0, props.limit)),
     overlay.operator,
   );
 


### PR DESCRIPTION
# Summary

The calendar's "Display Watched" and "Display Watchlisted" toggles did nothing. This honors both filters client-side across every calendar surface, so hiding watched or watchlisted items works again.

Closes #2941.

# Root cause

The calendar is served by the `trakt-hyperdrive` Cloudflare Worker (via `apiz.trakt.tv`), not the Rails v2 API — its `getCalendar` handler queries the database directly and never reads `ignore_watched` or `ignore_watchlisted`. Rails' `calendars_controller` doesn't honor them either (only the discover/recommendation controllers do). The web client sent the params in good faith — the SDK contract even types them — but nothing on the server acted on them and there was no client-side fallback, so both toggles were inert on the calendar.

# Fix

Rather than touch the worker, the toggles are now honored on the client against data the app already holds — the same stores that draw the per-card watched checkmark and watchlist state.

- Watched (`filterWatchedCalendarItems`): hides an episode when it is in the user's history, and a movie when it has been watched. A grouped multi-episode card is hidden only when every collapsed episode is watched.
- Watchlisted (`filterWatchlistedCalendarItems`): hides an episode when its show is watchlisted, and a movie when the movie itself is watchlisted.

Both helpers are pure pass-throughs when their toggle is off (no added subscriptions) and skip filtering while the underlying store is still loading, so items don't flash in and out.

# Scope

Applied to all four surfaces that expose the filters, with the filters running before each surface's own dedup/slice so a toggle can't produce a short list.

- `/calendar` (`useCalendar`)
- `/discover/releases` (`useReleasesCalendar`)
- Home upcoming row (`useUpcomingItems`)
- Discover releases row (`useReleasesItems`)

# Notes

- The now-inert `ignore_watched` / `ignore_watchlisted` query params are still sent. If the worker ever learns them, server-side filtering simply takes over and the client filter becomes a redundant no-op.
- The two calendar pages navigate to past dates where watched items actually appear — the real bug surface. The home/discover rows are today+future only, so their practical effect is limited to same-day items, but the toggles now behave consistently everywhere they are shown.

# Testing

Open `/calendar`, scroll back to a past week containing episodes you've watched, and toggle Display Watched off — they disappear. Toggle Display Watchlisted off with a watchlisted show in view — its episodes disappear. Both toggles leave the calendar unchanged when on.
