### PR TITLE
fix(person): honor Display Watched / Watchlisted on credits pages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -89,6 +89,7 @@ module.exports = {
         'notes',
         'out-now',
         'parameter',
+        'person',
         'player',
         'popover',
         'popular',

--- a/projects/client/src/lib/sections/lists/stores/_internal/isCreditHidden.spec.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/isCreditHidden.spec.ts
@@ -1,0 +1,123 @@
+import type { UserWatchlist } from '$lib/features/auth/queries/currentUserWatchlistQuery.ts';
+import type { UserHistory } from '$lib/features/auth/stores/useCurrentUserHistory.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import { describe, expect, it } from 'vitest';
+import { isCreditHidden } from './isCreditHidden.ts';
+
+function media(type: MediaType, id: number): MediaEntry {
+  return { id, type } as unknown as MediaEntry;
+}
+
+function history(
+  { movies = [], shows = [] }: { movies?: number[]; shows?: number[] },
+): UserHistory {
+  return {
+    movies: new Map(movies.map((id) => [id, {}])),
+    shows: new Map(shows.map((id) => [id, {}])),
+  } as unknown as UserHistory;
+}
+
+function watchlist(
+  { movies = [], shows = [] }: { movies?: number[]; shows?: number[] },
+): UserWatchlist {
+  return { movies: new Set(movies), shows: new Set(shows) };
+}
+
+describe('util: isCreditHidden', () => {
+  it('should not hide anything when both toggles are off', () => {
+    const hidden = isCreditHidden({
+      media: media('movie', 1),
+      history: history({ movies: [1] }),
+      watchlist: watchlist({ movies: [1] }),
+      ignoreWatched: false,
+      ignoreWatchlisted: false,
+    });
+
+    expect(hidden).toBe(false);
+  });
+
+  it('should hide a watched movie when Display Watched is off', () => {
+    const hidden = isCreditHidden({
+      media: media('movie', 1),
+      history: history({ movies: [1] }),
+      watchlist: watchlist({}),
+      ignoreWatched: true,
+      ignoreWatchlisted: false,
+    });
+
+    expect(hidden).toBe(true);
+  });
+
+  it('should keep an unwatched movie when Display Watched is off', () => {
+    const hidden = isCreditHidden({
+      media: media('movie', 2),
+      history: history({ movies: [1] }),
+      watchlist: watchlist({}),
+      ignoreWatched: true,
+      ignoreWatchlisted: false,
+    });
+
+    expect(hidden).toBe(false);
+  });
+
+  it('should hide a show the user has watch history for', () => {
+    const hidden = isCreditHidden({
+      media: media('show', 10),
+      history: history({ shows: [10] }),
+      watchlist: watchlist({}),
+      ignoreWatched: true,
+      ignoreWatchlisted: false,
+    });
+
+    expect(hidden).toBe(true);
+  });
+
+  it('should hide a watchlisted movie when Display Watchlisted is off', () => {
+    const hidden = isCreditHidden({
+      media: media('movie', 1),
+      history: history({}),
+      watchlist: watchlist({ movies: [1] }),
+      ignoreWatched: false,
+      ignoreWatchlisted: true,
+    });
+
+    expect(hidden).toBe(true);
+  });
+
+  it('should hide a watchlisted show when Display Watchlisted is off', () => {
+    const hidden = isCreditHidden({
+      media: media('show', 10),
+      history: history({}),
+      watchlist: watchlist({ shows: [10] }),
+      ignoreWatched: false,
+      ignoreWatchlisted: true,
+    });
+
+    expect(hidden).toBe(true);
+  });
+
+  it('should not hide while history is still loading', () => {
+    const hidden = isCreditHidden({
+      media: media('movie', 1),
+      history: null,
+      watchlist: watchlist({}),
+      ignoreWatched: true,
+      ignoreWatchlisted: false,
+    });
+
+    expect(hidden).toBe(false);
+  });
+
+  it('should not hide while the watchlist is still loading', () => {
+    const hidden = isCreditHidden({
+      media: media('movie', 1),
+      history: history({}),
+      watchlist: undefined,
+      ignoreWatched: false,
+      ignoreWatchlisted: true,
+    });
+
+    expect(hidden).toBe(false);
+  });
+});

--- a/projects/client/src/lib/sections/lists/stores/_internal/isCreditHidden.ts
+++ b/projects/client/src/lib/sections/lists/stores/_internal/isCreditHidden.ts
@@ -1,0 +1,70 @@
+import type { UserWatchlist } from '$lib/features/auth/queries/currentUserWatchlistQuery.ts';
+import type { UserHistory } from '$lib/features/auth/stores/useCurrentUserHistory.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+
+type IsCreditHiddenParams = {
+  media: MediaEntry;
+  history: UserHistory | null;
+  watchlist: UserWatchlist | undefined;
+  ignoreWatched: boolean;
+  ignoreWatchlisted: boolean;
+};
+
+function isMediaWatched(media: MediaEntry, history: UserHistory): boolean {
+  if (media.type === 'movie') {
+    return history.movies.has(media.id);
+  }
+
+  // A credit only carries a base media entry (no total episode count), so
+  // "watched" for a show means the user has watch history for it - matching how
+  // discover's ignore_watched treats shows.
+  if (media.type === 'show') {
+    return history.shows.has(media.id);
+  }
+
+  return false;
+}
+
+function isMediaWatchlisted(
+  media: MediaEntry,
+  watchlist: UserWatchlist,
+): boolean {
+  if (media.type === 'movie') {
+    return watchlist.movies.has(media.id);
+  }
+
+  if (media.type === 'show') {
+    return watchlist.shows.has(media.id);
+  }
+
+  return false;
+}
+
+/*
+  The person credits endpoints ignore the `ignore_watched` / `ignore_watchlisted`
+  filters server-side, so the "Display Watched" / "Display Watchlisted" toggles
+  are honored here against the user's history and watchlist. A credit is hidden
+  when an active toggle matches its media. While a store is still loading
+  (null/undefined) its toggle is treated as inactive so items don't flash in and
+  out.
+*/
+export function isCreditHidden({
+  media,
+  history,
+  watchlist,
+  ignoreWatched,
+  ignoreWatchlisted,
+}: IsCreditHiddenParams): boolean {
+  if (ignoreWatched && history != null && isMediaWatched(media, history)) {
+    return true;
+  }
+
+  if (
+    ignoreWatchlisted && watchlist != null &&
+    isMediaWatchlisted(media, watchlist)
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/projects/client/src/lib/sections/lists/stores/useCreditsList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useCreditsList.ts
@@ -1,3 +1,4 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import type { DiscoverMode } from '$lib/features/filters/models/DiscoverMode.ts';
 import { createBulkIntlOverlay } from '$lib/features/intl-overlay/createBulkIntlOverlay.ts';
 import { makeTargets } from '$lib/features/intl-overlay/makeTargets.ts';
@@ -11,6 +12,7 @@ import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { personMovieCreditsQuery } from '$lib/requests/queries/people/personMovieCreditsQuery.ts';
 import { personShowCreditsQuery } from '$lib/requests/queries/people/personShowCreditsQuery.ts';
 import { combineLatest, map, type Observable, of, switchMap } from 'rxjs';
+import { isCreditHidden } from './_internal/isCreditHidden.ts';
 
 type UseCreditsListProps = {
   type$: Observable<MediaType>;
@@ -94,21 +96,40 @@ export function useCreditsList(
     getTargets: flatCreditTargets,
   });
 
+  const { history, watchlist } = useUser();
+
   // switchMap keeps the flatten -> overlay -> rebuild chain bound to the
   // same `query` emission so navigating between credits pages can never
   // pair fresh credits with stale localized titles.
-  const credits = combineLatest([query, mode$]).pipe(
-    switchMap(([$query, mode]) =>
-      of(
-        flattenCredits($query.data).filter(
-          ({ credit }) => mode === 'media' || credit.media.type === mode,
-        ),
-      ).pipe(
-        overlay.operator,
-        map(($flat) => rebuildCredits($query.data, $flat)),
-      )
-    ),
-  );
+  const credits = combineLatest([query, mode$, filter$, history, watchlist])
+    .pipe(
+      switchMap(([$query, mode, $filter, $history, $watchlist]) => {
+        // The credits endpoint ignores these filters server-side, so honor the
+        // "Display Watched" / "Display Watchlisted" toggles here.
+        const ignoreWatched = `${$filter.ignore_watched ?? ''}` === 'true';
+        const ignoreWatchlisted = `${$filter.ignore_watchlisted ?? ''}` ===
+          'true';
+
+        return of(
+          flattenCredits($query.data)
+            .filter(({ credit }) =>
+              mode === 'media' || credit.media.type === mode
+            )
+            .filter(({ credit }) =>
+              !isCreditHidden({
+                media: credit.media,
+                history: $history,
+                watchlist: $watchlist,
+                ignoreWatched,
+                ignoreWatchlisted,
+              })
+            ),
+        ).pipe(
+          overlay.operator,
+          map(($flat) => rebuildCredits($query.data, $flat)),
+        );
+      }),
+    );
 
   return {
     credits,


### PR DESCRIPTION
# Summary

The "Display Watched" (and "Display Watchlisted") toggles did nothing on a person's credits pages. This honors both filters client-side for movie and show credits.

Closes #2943.

# Root cause

The person credits pages send `ignore_watched` / `ignore_watchlisted` to `/people/:id/movies` and `/people/:id/shows`, but those endpoints (worker-served, `getPersonMovies` / `getPersonShows`) apply only the generic `filters()` middleware and never filter by watched or watchlisted status — the SDK contract doesn't even define the ignore params for `people.*`. So the toggles had no effect. Same class of bug as the calendar (#2941), different surface.

# Fix

A pure predicate `isCreditHidden` decides whether a credit should be hidden given the two toggles and the user's `history` / `watchlist`. `useCreditsList` folds `filter$`, `history`, and `watchlist` into the credits pipeline and drops hidden credits before the intl overlay, so it works on the movies page, the shows page, and combined `media` mode. When a toggle is off, or its backing store is still loading, nothing is filtered.

- Movies: watched via `history.movies`, watchlisted via `watchlist.movies`.
- Shows: watched via `history.shows`, watchlisted via `watchlist.shows`.

# Show "watched" semantics

A credit only carries a base `MediaEntry`, which has no total episode count, so the fully-watched check used elsewhere (`useIsWatched`) can't be computed here. A show credit is treated as watched when the user has any watch history for it (`history.shows.has(id)`) — the same way discover's `ignore_watched` treats shows. If we want strict fully-watched here, the credits mapper would need to carry the aired-episode count; that can be a follow-up.

# Tests

`isCreditHidden.spec.ts` covers movie/show against watched/watchlisted, both toggles off, and pass-through while history/watchlist are still loading.

# Notes

If every credit in a crew position is hidden, that position still appears (empty) in the position selector. Easy to filter out as a follow-up if desired.
