### PR TITLE
feat(search): serve exact media matches from the API

### DIFF
--- a/projects/client/src/app.d.ts
+++ b/projects/client/src/app.d.ts
@@ -184,7 +184,6 @@ declare global {
     keys: {
       media: {
         default: string;
-        exact: string;
       };
       people: string;
     };

--- a/projects/client/src/lib/features/search/fetchSearchKeys.ts
+++ b/projects/client/src/lib/features/search/fetchSearchKeys.ts
@@ -9,7 +9,6 @@ const TypesenseConfigSchema = z.object({
   keys: z.object({
     media: z.object({
       default: z.string(),
-      exact: z.string(),
     }),
     people: z.string(),
   }),

--- a/projects/client/src/lib/features/search/mintSearchKeys.ts
+++ b/projects/client/src/lib/features/search/mintSearchKeys.ts
@@ -36,7 +36,6 @@ export function mintSearchKeys(
     keys: {
       media: {
         default: scope('search:media'),
-        exact: scope('search:media:exact'),
       },
       people: scope('search:people'),
     },

--- a/projects/client/src/lib/requests/queries/search/getMedia.ts
+++ b/projects/client/src/lib/requests/queries/search/getMedia.ts
@@ -8,7 +8,6 @@ type GetMediaProps = {
   limit: number;
   types: MediaType[];
   config: TypesenseConfig;
-  exact: boolean;
 };
 
 export async function getMedia({
@@ -16,15 +15,13 @@ export async function getMedia({
   limit,
   types,
   config,
-  exact,
 }: GetMediaProps): Promise<SearchResultResponse[]> {
   const { hits } = await lookup({
-    key: exact ? config.keys.media.exact : config.keys.media.default,
+    key: config.keys.media.default,
     server: config.server,
     query,
     limit,
     types,
-    exact,
   });
 
   return hits

--- a/projects/client/src/lib/requests/queries/search/getPeople.ts
+++ b/projects/client/src/lib/requests/queries/search/getPeople.ts
@@ -21,7 +21,6 @@ export async function getPeople({
     query,
     limit,
     types: [type],
-    exact: false,
   });
 
   return hits

--- a/projects/client/src/lib/requests/queries/search/searchMediaQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/search/searchMediaQuery.spec.ts
@@ -20,7 +20,6 @@ describe('searchMediaQuery', () => {
               keys: {
                 media: {
                   default: '',
-                  exact: '',
                 },
                 people: '',
               },

--- a/projects/client/src/lib/requests/queries/search/searchMediaQuery.ts
+++ b/projects/client/src/lib/requests/queries/search/searchMediaQuery.ts
@@ -60,7 +60,7 @@ function mapToSearchResultEntry(
   }
 }
 
-const searchRequest = async (
+const searchRequest = (
   { query, type, config, limit, exact }: SearchParams,
 ) => {
   const queryParams = {
@@ -70,25 +70,12 @@ const searchRequest = async (
 
   const types = type ?? 'movie,show';
 
-  const response = await getMedia({
-    ...queryParams,
-    config,
-    types: types.split(',') as MediaType[],
-    exact,
-  })
-    .then((body) => ({
-      body,
-      status: 200,
-    }))
-    .catch(() => {
-      const searchApi = api({
-        fetch,
-      })
-        .search;
-
-      const searchQuery = exact ? searchApi.exact : searchApi.query;
-
-      return searchQuery({
+  // Exact matches are served by the API's exact endpoint. The fuzzy pass keeps
+  // querying the search index directly and falls back to the API on failure.
+  if (exact) {
+    return api({ fetch })
+      .search
+      .exact({
         query: {
           ...queryParams,
           extended: 'full,images',
@@ -97,9 +84,30 @@ const searchRequest = async (
           type: types,
         },
       });
-    });
+  }
 
-  return response;
+  return getMedia({
+    ...queryParams,
+    config,
+    types: types.split(',') as MediaType[],
+  })
+    .then((body) => ({
+      body,
+      status: 200,
+    }))
+    .catch(() =>
+      api({ fetch })
+        .search
+        .query({
+          query: {
+            ...queryParams,
+            extended: 'full,images',
+          },
+          params: {
+            type: types,
+          },
+        })
+    );
 };
 
 export const searchMediaQuery = defineQuery({

--- a/projects/client/src/lib/requests/search/lookup.ts
+++ b/projects/client/src/lib/requests/search/lookup.ts
@@ -18,7 +18,6 @@ type SearchParams<T extends SearchCategory> = {
   query: string;
   limit: number;
   types: T[];
-  exact: boolean;
 };
 
 const COLLECTION_MAP: Record<SearchCategory, string> = {
@@ -33,22 +32,13 @@ const PRESET_MAP: Record<SearchCategory, string> = {
   person: 'search:people',
 };
 
-const EXACT_PRESET_MAP: Record<SearchCategory, string> = {
-  movie: 'search:media:exact',
-  show: 'search:media:exact',
-  person: 'search:people',
-};
-
 export function lookup<T extends SearchCategory>({
   key,
   server,
   query: q,
   limit,
   types,
-  exact,
 }: SearchParams<T>) {
-  const targetPresetMap = exact ? EXACT_PRESET_MAP : PRESET_MAP;
-
   return createSearcher({
     key,
     server,
@@ -57,7 +47,7 @@ export function lookup<T extends SearchCategory>({
     .perform<SchemaForCategory<T>[]>({
       searches: types.map((type) => ({
         collection: COLLECTION_MAP[type],
-        preset: targetPresetMap[type],
+        preset: PRESET_MAP[type],
       })),
       union: true,
     }, {

--- a/projects/client/test/beds/_internal/TestProvider.svelte
+++ b/projects/client/test/beds/_internal/TestProvider.svelte
@@ -27,7 +27,6 @@
             keys: {
               media: {
                 default: "",
-                exact: "",
               },
               people: "",
             },


### PR DESCRIPTION
Routes the exact media-search pass through the API's exact endpoint (`GET /search/:type/exact`) instead of querying the search index directly from the client. The API now owns exact-match semantics, so the client shouldn't be re-implementing them against the index.

## What changed

- `searchMediaQuery` now calls `api().search.exact` for the exact pass. The fuzzy pass is unchanged: it still queries the search index client-side and falls back to `api().search.query` on failure.
- The client no longer mints or uses a dedicated exact search key (removed from `mintSearchKeys` / `fetchSearchKeys` / the `TypesenseConfig` type), and the now-unused exact branch in `getMedia` / `lookup` is dropped.

## Behavior

No visible change. For media searches the client still fires an exact pass in parallel with the fuzzy pass and dedupes the exact hits to the top of the combined list; only the source of the exact hits moves from the client-side index query to the API. People and lists search are untouched.

## Test plan

- [x] `deno fmt` + `deno lint` clean on the changed files
- [x] CI gate (`deno task check` + vitest) - relies on the pipeline (worktree can't install the full toolchain locally)
- [x] Manual: exact-title search (e.g. a movie/show title) still returns the expected top result, combined with fuzzy results below

Depends on the API exposing `/search/:type/exact` (already in the `@trakt/api` contract).
