### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/actions/setup-deno/action.yml
+++ b/.github/actions/setup-deno/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Secure the Evidence aka Checkout Code
       id: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Summon the Digital Oracle aka Install Deno
       uses: denoland/setup-deno@v2

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -27,7 +27,7 @@ jobs:
       workflows: ${{ steps.changes.outputs.workflows }}
     steps:
       - name: Unveiling the Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: The Chronicle of Alterations
         uses: dorny/paths-filter@v3
@@ -60,7 +60,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Secure the Evidence aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Deno Environment
         uses: ./.github/actions/setup-deno
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Secure the Evidence aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Deno Environment
         uses: ./.github/actions/setup-deno
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Secure the Evidence aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Deno Environment
         uses: ./.github/actions/setup-deno
@@ -172,7 +172,7 @@ jobs:
 
     steps:
       - name: Secure the Evidence aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Deno Environment
         uses: ./.github/actions/setup-deno
@@ -197,7 +197,7 @@ jobs:
 
     steps:
       - name: Secure the Evidence aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Deno Environment
         uses: ./.github/actions/setup-deno
@@ -238,7 +238,7 @@ jobs:
 
     steps:
       - name: Secure the Evidence aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Deno Environment
         uses: ./.github/actions/setup-deno
@@ -301,7 +301,7 @@ jobs:
 
     steps:
       - name: Secure the Evidence aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Deno Environment
         uses: ./.github/actions/setup-deno

--- a/.github/workflows/i18n_crowdin_languages.yml
+++ b/.github/workflows/i18n_crowdin_languages.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Sync locales to CrowdIn target languages
         env:

--- a/.github/workflows/i18n_sync.yml
+++ b/.github/workflows/i18n_sync.yml
@@ -29,7 +29,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-token.outputs.token }}
 

--- a/.github/workflows/i18n_translate.yml
+++ b/.github/workflows/i18n_translate.yml
@@ -24,7 +24,7 @@ jobs:
           permission-contents: write
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-token.outputs.token }}
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -41,7 +41,7 @@ jobs:
           permission-issues: write
 
       - name: Secure the Evidence aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-token.outputs.token }}
 

--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Unveiling the Code Codex
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -41,7 +41,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Unveiling the Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use the Power of GitHub CLI
         run: gh pr merge --rebase --auto ${{ github.event.pull_request.number }}

--- a/.github/workflows/rotate_secrets.yml
+++ b/.github/workflows/rotate_secrets.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Secure the Evidence aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Awaken the Node Ancient (Setup Node 22 for Wrangler)
         uses: actions/setup-node@v4

--- a/.github/workflows/supply_chain.yml
+++ b/.github/workflows/supply_chain.yml
@@ -37,7 +37,7 @@ jobs:
             release-assets.githubusercontent.com:443
 
       - name: Secure the Evidence aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -125,7 +125,7 @@ jobs:
             www-api.ibm.com:443
 
       - name: Secure the Evidence aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Scrutinizing the Lockfile Delta aka Dependency Review
         uses: actions/dependency-review-action@v4


### PR DESCRIPTION
Bumps `actions/checkout` from v4 to v5 across all workflows.

v4 pins Node 20, now deprecated on GitHub-hosted runners and force-run on Node 24. v5 targets Node 24 natively. No behavior change.

Files touched:
- `.github/actions/setup-deno/action.yml`
- `.github/workflows/ci_cd.yml`
- `.github/workflows/i18n_crowdin_languages.yml`
- `.github/workflows/i18n_sync.yml`
- `.github/workflows/i18n_translate.yml`
- `.github/workflows/packages.yml`
- `.github/workflows/pr_gate.yml`
- `.github/workflows/rotate_secrets.yml`
- `.github/workflows/supply_chain.yml`