### PR TITLE
fix(summary): opens correct history when clicking on episode cover tag

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SummaryPosterTags.svelte
@@ -14,6 +14,7 @@
     isDropped?: boolean;
     isStarted?: boolean;
     isRewatching?: boolean;
+    onWatchCountClick?: () => void;
   };
 
   const {
@@ -22,6 +23,7 @@
     isDropped,
     isStarted,
     isRewatching,
+    onWatchCountClick,
   }: SummaryPosterTagsProps = $props();
 
   const { isEnabled } = useFeatureFlag();
@@ -42,7 +44,11 @@
 {/if}
 
 {#if !showRewatching && watchCount > 0}
-  <WatchCountTag count={watchCount} i18n={TagIntlProvider} />
+  <WatchCountTag
+    count={watchCount}
+    i18n={TagIntlProvider}
+    onclick={onWatchCountClick}
+  />
 {/if}
 
 {#if !showRewatching && isStarted && watchCount === 0 && !isDropped}

--- a/projects/client/src/lib/sections/summary/components/_internal/WatchCountTag.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/WatchCountTag.svelte
@@ -10,7 +10,11 @@
     summaryDrawerNavigation,
   } from "../../_internal/summaryDrawerNavigation.ts";
 
-  const { count, i18n }: { count: number; i18n: TagIntl } = $props();
+  const {
+    count,
+    i18n,
+    onclick,
+  }: { count: number; i18n: TagIntl; onclick?: () => void } = $props();
 
   const { buildDrawerLink } = summaryDrawerNavigation();
 
@@ -18,38 +22,54 @@
   // FIXME: replace the one in the tags folder when new design is leading
 </script>
 
-<watch-count-tag>
-  <Link {...buildDrawerLink(SummaryDrawers.History)}>
-    <StemTag
-      --color-background-stem-tag="var(--color-background-indicator-tag)"
-      --color-foreground-stem-tag="var(--color-text-indicator-tag)"
-    >
-      <TrackIcon />
+{#snippet tag()}
+  <StemTag
+    --color-background-stem-tag="var(--color-background-indicator-tag)"
+    --color-foreground-stem-tag="var(--color-text-indicator-tag)"
+  >
+    <TrackIcon />
 
-      <p class="bold uppercase no-wrap">{i18n.watchedLabel()}</p>
-      {#if count > 1}
-        <p class="bold">·</p>
-        <div transition:slide={{ axis: "x", duration: 150 }}>
-          {#key count}
-            <p
-              class="bold uppercase no-wrap counter"
-              transition:slide={{
-                easing: linear,
-                axis: "y",
-                duration: transitionDuration,
-              }}
-            >
-              {count}
-            </p>
-          {/key}
-        </div>
-      {/if}
-    </StemTag>
-  </Link>
+    <p class="bold uppercase no-wrap">{i18n.watchedLabel()}</p>
+    {#if count > 1}
+      <p class="bold">·</p>
+      <div transition:slide={{ axis: "x", duration: 150 }}>
+        {#key count}
+          <p
+            class="bold uppercase no-wrap counter"
+            transition:slide={{
+              easing: linear,
+              axis: "y",
+              duration: transitionDuration,
+            }}
+          >
+            {count}
+          </p>
+        {/key}
+      </div>
+    {/if}
+  </StemTag>
+{/snippet}
+
+<watch-count-tag>
+  {#if onclick}
+    <button type="button" class="watch-count-trigger" {onclick}>
+      {@render tag()}
+    </button>
+  {:else}
+    <Link {...buildDrawerLink(SummaryDrawers.History)}>
+      {@render tag()}
+    </Link>
+  {/if}
 </watch-count-tag>
 
 <style>
   watch-count-tag {
+    .watch-count-trigger {
+      all: unset;
+      -webkit-tap-highlight-color: transparent;
+      cursor: pointer;
+    }
+
     :global(.trakt-tag) {
       position: relative;
 

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
@@ -201,7 +201,7 @@
 
 {#snippet cover()}
   {#if entry}
-    <EpisodeInfoPoster {show} episode={entry} />
+    <EpisodeInfoPoster {show} episode={entry} {onHistoryOpen} />
   {:else}
     <div class="skeleton-cover">
       <div class="skeleton-cover-inner">

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoPoster.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoPoster.svelte
@@ -10,9 +10,11 @@
   const {
     show,
     episode,
+    onHistoryOpen,
   }: {
     show: ShowEntry;
     episode: EpisodeEntry;
+    onHistoryOpen?: () => void;
   } = $props();
 
   const src = $derived(
@@ -26,7 +28,11 @@
 </script>
 
 {#snippet posterTags()}
-  <SummaryPosterTags {postCreditsCount} watchCount={$watchCount} />
+  <SummaryPosterTags
+    {postCreditsCount}
+    watchCount={$watchCount}
+    onWatchCountClick={onHistoryOpen}
+  />
 {/snippet}
 
 <SummaryPoster


### PR DESCRIPTION
## 🎶 Notes 🎶

- The watch count tag on the episode drawer cover opened the whole show's history instead of that episode's.
- Cause: the tag always navigated via the `view=history` URL param, which replaces the drawer and resolves show-scoped data.
- Fix: the episode drawer now passes an `onclick` down to the tag, so it opens the locally-mounted, episode-scoped history drawer (same one the popup menu already uses).
- Other surfaces (show/movie/episode summary pages) keep the URL-based navigation, so no change there.