### PR TITLE
feat(settings): group connected apps by tier + connection limit UI

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -6619,6 +6619,10 @@
       "default": "Library",
       "description": "Title for the section that shows a user's library usage, such as their library item counts and limits."
     },
+    "usage_title_connected_apps": {
+      "default": "Connected Apps",
+      "description": "Title for the section that shows a user's connected community apps usage and limit."
+    },
     "limit_title_smart_lists": {
       "default": "Smart Lists",
       "description": "Title for the progress bar that shows a user's smart lists usage. This should be as short as possible."
@@ -6638,6 +6642,10 @@
     "limit_title_digital_library": {
       "default": "Digital Library",
       "description": "Title for the progress bar that shows a user's digital library usage. This should be as short as possible."
+    },
+    "limit_title_connected_apps": {
+      "default": "Connected Apps",
+      "description": "Title for the progress bar that shows a user's connected community apps usage. This should be as short as possible."
     },
     "text_vip_track_more": {
       "default": "Track more, list more, rate more.",
@@ -9591,6 +9599,18 @@
     "text_no_connected_apps": {
       "default": "You haven't connected any apps.",
       "description": "Empty-state text shown when the user has not authorized any third-party apps."
+    },
+    "heading_community_apps": {
+      "default": "Community Apps",
+      "description": "Heading for the section listing community-built third-party apps, which count toward the connected-apps limit."
+    },
+    "warning_connected_apps_limit": {
+      "default": "You've reached your connected apps limit. Upgrade to VIP to connect more.",
+      "description": "Upsell copy shown to free users who have reached their connected-apps limit, encouraging them to upgrade to VIP for a higher limit."
+    },
+    "warning_connected_apps_limit_vip": {
+      "default": "You've reached your connected apps limit",
+      "description": "Warning text shown to VIP users who have reached their connected-apps limit."
     },
     "heading_api_applications": {
       "default": "API Applications",

--- a/projects/client/src/lib/requests/models/ConnectedApp.ts
+++ b/projects/client/src/lib/requests/models/ConnectedApp.ts
@@ -8,6 +8,7 @@ export const ConnectedAppSchema = z.object({
   scopes: z.array(z.string()),
   connectedAt: z.date(),
   lastUsedAt: z.date(),
+  category: z.enum(['community', 'premium']),
 });
 
 export type ConnectedApp = z.infer<typeof ConnectedAppSchema>;

--- a/projects/client/src/lib/requests/models/UserLimits.ts
+++ b/projects/client/src/lib/requests/models/UserLimits.ts
@@ -15,6 +15,7 @@ export const UserLimitsSchema = z.object({
   dynamicLists: LimitsSchema,
   digitalLibrary: LimitsSchema,
   totalNotes: LimitsSchema,
+  connectedApps: LimitsSchema,
 });
 
 export type UserLimits = z.infer<

--- a/projects/client/src/lib/requests/queries/apps/_internal/ConnectedAppResponse.ts
+++ b/projects/client/src/lib/requests/queries/apps/_internal/ConnectedAppResponse.ts
@@ -7,6 +7,7 @@ export const ConnectedAppResponseSchema = z.object({
   scopes: z.array(z.string()),
   connected_at: z.string(),
   last_used_at: z.string(),
+  category: z.enum(['community', 'premium']),
 });
 
 export type ConnectedAppResponse = z.infer<typeof ConnectedAppResponseSchema>;

--- a/projects/client/src/lib/requests/queries/apps/_internal/mapToConnectedApp.ts
+++ b/projects/client/src/lib/requests/queries/apps/_internal/mapToConnectedApp.ts
@@ -12,5 +12,6 @@ export function mapToConnectedApp(
     scopes: response.scopes,
     connectedAt: new Date(response.connected_at),
     lastUsedAt: new Date(response.last_used_at),
+    category: response.category,
   };
 }

--- a/projects/client/src/lib/requests/queries/vip/userLimitsQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/vip/userLimitsQuery.spec.ts
@@ -1,0 +1,16 @@
+import { UserLimitsMappedMock } from '$mocks/data/vip/mapped/UserLimitsMappedMock.ts';
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { describe, expect, it } from 'vitest';
+import { userLimitsQuery } from './userLimitsQuery.ts';
+
+describe('userLimitsQuery', () => {
+  it('should map user limits to the domain model, including connected apps', async () => {
+    const result = await runQuery({
+      factory: () => createTestBedQuery(userLimitsQuery({})),
+      waitFor: (response) => Boolean(response.data),
+    });
+
+    expect(result.data).to.deep.equal(UserLimitsMappedMock);
+  });
+});

--- a/projects/client/src/lib/requests/queries/vip/userLimitsQuery.ts
+++ b/projects/client/src/lib/requests/queries/vip/userLimitsQuery.ts
@@ -20,6 +20,7 @@ export const UserLimitsResponseSchema = z.object({
   dynamic_lists: LimitsSchema,
   digital_library: LimitsSchema,
   total_notes: LimitsSchema,
+  connected_apps: LimitsSchema,
 });
 
 type UserLimitsResponse = z.infer<
@@ -42,6 +43,7 @@ function mapToUserLimits(
     dynamicLists: response.dynamic_lists,
     digitalLibrary: response.digital_library,
     totalNotes: response.total_notes,
+    connectedApps: response.connected_apps,
   };
 }
 
@@ -77,6 +79,7 @@ export const userLimitsQuery = defineQuery({
     InvalidateAction.List.Deleted,
     InvalidateAction.SmartList.Created,
     InvalidateAction.SmartList.Deleted,
+    InvalidateAction.App.Revoke,
   ],
   dependencies: [],
   request: userLimitsRequest,

--- a/projects/client/src/lib/sections/settings/ConnectedAppsSettings.svelte
+++ b/projects/client/src/lib/sections/settings/ConnectedAppsSettings.svelte
@@ -1,36 +1,71 @@
 <script lang="ts">
+  import { useUser } from "$lib/features/auth/stores/useUser.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
   import ConnectedAppRow from "./_internal/apps/ConnectedAppRow.svelte";
+  import ConnectedAppsLimitWarning from "./_internal/apps/ConnectedAppsLimitWarning.svelte";
+  import ConnectedAppsUsageMeter from "./_internal/apps/ConnectedAppsUsageMeter.svelte";
   import { useConnectedApps } from "./_internal/apps/useConnectedApps.ts";
   import SettingsGroupCard from "./_internal/SettingsGroupCard.svelte";
   import SettingsGroupRowSkeleton from "./_internal/SettingsGroupRowSkeleton.svelte";
   import SettingsSection from "./_internal/SettingsSection.svelte";
 
-  const { apps, isLoading } = useConnectedApps();
+  const { apps, isAtLimit, isLoading } = useConnectedApps();
+  const { user, limits } = useUser();
+
+  const hasApps = $derived($apps.length > 0);
 </script>
 
-<SettingsSection
-  title={m.heading_connected_apps()}
-  description={m.description_connected_apps()}
-  crumb={{
-    href: UrlBuilder.settings.apps(),
-    label: m.link_text_apps_settings(),
-  }}
->
-  {#if $isLoading}
-    <SettingsGroupCard>
-      {#each Array(3) as _, index (index)}
-        <SettingsGroupRowSkeleton />
-      {/each}
-    </SettingsGroupCard>
-  {:else if $apps.length === 0}
-    <p class="secondary">{m.text_no_connected_apps()}</p>
-  {:else}
-    <SettingsGroupCard>
-      {#each $apps as app (app.key)}
-        <ConnectedAppRow {app} />
-      {/each}
-    </SettingsGroupCard>
+<div class="trakt-connected-apps-settings">
+  <SettingsSection
+    title={m.heading_connected_apps()}
+    description={m.description_connected_apps()}
+    crumb={{
+      href: UrlBuilder.settings.apps(),
+      label: m.link_text_apps_settings(),
+    }}
+  >
+    {#if $isLoading}
+      <SettingsGroupCard>
+        {#each Array(3) as _, index (index)}
+          <SettingsGroupRowSkeleton />
+        {/each}
+      </SettingsGroupCard>
+    {:else if !hasApps}
+      <p class="secondary">{m.text_no_connected_apps()}</p>
+    {/if}
+  </SettingsSection>
+
+  {#if !$isLoading && hasApps}
+    {#if $isAtLimit}
+      <ConnectedAppsLimitWarning />
+    {/if}
+
+    <SettingsSection title={m.heading_community_apps()}>
+      <!-- VIP users get a generous, invisible limit: the meter would only
+           induce anxiety, so it is shown to free accounts only. -->
+      {#snippet action()}
+        {#if $limits && !$user.isVip}
+          <ConnectedAppsUsageMeter
+            current={$limits.connectedApps.current}
+            limit={$limits.connectedApps.free}
+          />
+        {/if}
+      {/snippet}
+
+      <SettingsGroupCard>
+        {#each $apps as app (app.key)}
+          <ConnectedAppRow {app} />
+        {/each}
+      </SettingsGroupCard>
+    </SettingsSection>
   {/if}
-</SettingsSection>
+</div>
+
+<style lang="scss">
+  .trakt-connected-apps-settings {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xl);
+  }
+</style>

--- a/projects/client/src/lib/sections/settings/_internal/apps/ConnectedAppsLimitWarning.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/apps/ConnectedAppsLimitWarning.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages";
+  import UpsellCta from "$lib/features/upsell/UpsellCta.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+</script>
+
+<RenderFor audience="free">
+  <UpsellCta source="connected-apps">
+    {m.warning_connected_apps_limit()}
+  </UpsellCta>
+</RenderFor>
+
+<RenderFor audience="vip">
+  <div class="trakt-connected-apps-limit-warning">
+    <span>⚠️</span>
+    <p>{m.warning_connected_apps_limit_vip()}</p>
+  </div>
+</RenderFor>
+
+<style>
+  .trakt-connected-apps-limit-warning {
+    padding: var(--ni-12);
+    border: var(--ni-1) solid
+      color-mix(in srgb, var(--color-border) 50%, transparent);
+    border-radius: var(--border-radius-m);
+
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    background-color: var(--color-card-background);
+  }
+</style>

--- a/projects/client/src/lib/sections/settings/_internal/apps/ConnectedAppsUsageMeter.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/apps/ConnectedAppsUsageMeter.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import DistributionBar from "$lib/components/charts/DistributionBar.svelte";
+  import { languageTag } from "$lib/features/i18n";
+  import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber.ts";
+
+  const { current, limit }: { current: number; limit: number } = $props();
+
+  const isAtLimit = $derived(current >= limit);
+  const fraction = $derived(limit > 0 ? current / limit : 0);
+</script>
+
+<div class="trakt-connected-apps-usage-meter" class:has-alert={isAtLimit}>
+  <div class="meter-bar">
+    <DistributionBar
+      {fraction}
+      color={isAtLimit ? "var(--red-500)" : undefined}
+      --distribution-bar-thickness="var(--ni-6)"
+    />
+  </div>
+
+  <span class="meter-count tag">
+    {toHumanNumber(current, languageTag())}/{toHumanNumber(
+      limit,
+      languageTag(),
+    )}
+  </span>
+</div>
+
+<style lang="scss">
+  .trakt-connected-apps-usage-meter {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-xs);
+
+    &.has-alert .meter-count {
+      color: var(--red-500);
+    }
+  }
+
+  .meter-bar {
+    width: var(--ni-64);
+    flex-shrink: 0;
+  }
+
+  .meter-count {
+    white-space: nowrap;
+  }
+</style>

--- a/projects/client/src/lib/sections/settings/_internal/apps/useConnectedApps.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/useConnectedApps.ts
@@ -1,12 +1,26 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
 import { useQuery } from '$lib/features/query/useQuery.ts';
 import { connectedAppsQuery } from '$lib/requests/queries/apps/connectedAppsQuery.ts';
-import { map } from 'rxjs';
+import { combineLatest, map } from 'rxjs';
 
 export function useConnectedApps() {
   const query = useQuery(connectedAppsQuery());
+  const { user, limits } = useUser();
 
   const apps = query.pipe(map((state) => state.data ?? []));
   const isLoading = query.pipe(map((state) => state.isLoading));
 
-  return { apps, isLoading };
+  const isAtLimit = combineLatest([user, limits]).pipe(
+    map(([user, limits]) => {
+      if (!limits) return false;
+
+      const limit = user.isVip
+        ? limits.connectedApps.vip
+        : limits.connectedApps.free;
+
+      return limits.connectedApps.current >= limit;
+    }),
+  );
+
+  return { apps, isAtLimit, isLoading };
 }

--- a/projects/client/src/lib/sections/vip/_internal/constants/index.ts
+++ b/projects/client/src/lib/sections/vip/_internal/constants/index.ts
@@ -43,4 +43,5 @@ export const USER_LIMITS_PLACEHOLDER: UserLimits = {
   dynamicLists: emptyLimit,
   digitalLibrary: emptyLimit,
   totalNotes: emptyLimit,
+  connectedApps: emptyLimit,
 };

--- a/projects/client/src/lib/sections/vip/_internal/utils/mapToUsageCategories.ts
+++ b/projects/client/src/lib/sections/vip/_internal/utils/mapToUsageCategories.ts
@@ -52,5 +52,14 @@ export function mapToUsageCategories(
         },
       ],
     },
+    {
+      title: m.usage_title_connected_apps,
+      items: [
+        {
+          title: m.limit_title_connected_apps,
+          limits: limits.connectedApps,
+        },
+      ],
+    },
   ];
 }

--- a/projects/client/src/mocks/data/apps/mapped/ConnectedAppsMappedMock.ts
+++ b/projects/client/src/mocks/data/apps/mapped/ConnectedAppsMappedMock.ts
@@ -9,6 +9,7 @@ export const ConnectedAppsMappedMock: ConnectedApp[] = [
     scopes: ['public', 'scrobble'],
     connectedAt: new Date('2024-01-15T10:30:00.000Z'),
     lastUsedAt: new Date('2025-06-01T18:42:00.000Z'),
+    category: 'premium',
   },
   {
     id: 47,
@@ -18,5 +19,6 @@ export const ConnectedAppsMappedMock: ConnectedApp[] = [
     scopes: ['public'],
     connectedAt: new Date('2025-03-22T08:00:00.000Z'),
     lastUsedAt: new Date('2025-05-28T21:15:00.000Z'),
+    category: 'community',
   },
 ];

--- a/projects/client/src/mocks/data/apps/response/ConnectedAppsResponseMock.ts
+++ b/projects/client/src/mocks/data/apps/response/ConnectedAppsResponseMock.ts
@@ -8,6 +8,7 @@ export const ConnectedAppsResponseMock: ConnectedAppResponse[] = [
     scopes: ['public', 'scrobble'],
     connected_at: '2024-01-15T10:30:00.000Z',
     last_used_at: '2025-06-01T18:42:00.000Z',
+    category: 'premium',
   },
   {
     id: 47,
@@ -16,5 +17,6 @@ export const ConnectedAppsResponseMock: ConnectedAppResponse[] = [
     scopes: ['public'],
     connected_at: '2025-03-22T08:00:00.000Z',
     last_used_at: '2025-05-28T21:15:00.000Z',
+    category: 'community',
   },
 ];

--- a/projects/client/src/mocks/data/vip/mapped/UserLimitsMappedMock.ts
+++ b/projects/client/src/mocks/data/vip/mapped/UserLimitsMappedMock.ts
@@ -1,0 +1,13 @@
+import type { UserLimits } from '$lib/requests/models/UserLimits.ts';
+
+export const UserLimitsMappedMock: UserLimits = {
+  history: { current: 1240, free: 1000, vip: 100000 },
+  ratings: { current: 312, free: 1000, vip: 100000 },
+  watchlistItems: { current: 48, free: 500, vip: 10000 },
+  totalListItems: { current: 210, free: 1000, vip: 100000 },
+  staticLists: { current: 2, free: 5, vip: 50 },
+  dynamicLists: { current: 1, free: 3, vip: 50 },
+  digitalLibrary: { current: 15, free: 50, vip: 10000 },
+  totalNotes: { current: 6, free: 100, vip: 10000 },
+  connectedApps: { current: 1, free: 1, vip: 50 },
+};

--- a/projects/client/src/mocks/data/vip/response/UserLimitsResponseMock.ts
+++ b/projects/client/src/mocks/data/vip/response/UserLimitsResponseMock.ts
@@ -1,0 +1,15 @@
+import type { UserLimitsResponseSchema } from '$lib/requests/queries/vip/userLimitsQuery.ts';
+import type { z } from 'zod';
+
+export const UserLimitsResponseMock: z.infer<typeof UserLimitsResponseSchema> =
+  {
+    history: { current: 1240, free: 1000, vip: 100000 },
+    ratings: { current: 312, free: 1000, vip: 100000 },
+    watchlist_items: { current: 48, free: 500, vip: 10000 },
+    total_list_items: { current: 210, free: 1000, vip: 100000 },
+    static_lists: { current: 2, free: 5, vip: 50 },
+    dynamic_lists: { current: 1, free: 3, vip: 50 },
+    digital_library: { current: 15, free: 50, vip: 10000 },
+    total_notes: { current: 6, free: 100, vip: 10000 },
+    connected_apps: { current: 1, free: 1, vip: 50 },
+  };

--- a/projects/client/src/mocks/handlers/vip.ts
+++ b/projects/client/src/mocks/handlers/vip.ts
@@ -1,0 +1,9 @@
+import { http, HttpResponse } from 'msw';
+import { UserLimitsResponseMock } from '../data/vip/response/UserLimitsResponseMock.ts';
+
+export const vip = [
+  http.get(
+    'http://localhost/v3/users/me/usage',
+    () => HttpResponse.json(UserLimitsResponseMock),
+  ),
+];

--- a/projects/client/src/mocks/server.ts
+++ b/projects/client/src/mocks/server.ts
@@ -14,6 +14,7 @@ import { streamingSync } from './handlers/streamingSync.ts';
 import { sync } from './handlers/sync.ts';
 import { team } from './handlers/team.ts';
 import { users } from './handlers/users.ts';
+import { vip } from './handlers/vip.ts';
 import { watchNow } from './handlers/watchNow.ts';
 
 const handlers = [
@@ -33,6 +34,7 @@ const handlers = [
   ...comments,
   ...team,
   ...intl,
+  ...vip,
 ];
 
 export const server = setupServer(...handlers);


### PR DESCRIPTION
## What

- Connected Apps settings now render **Community** and **Premium** as separate sections instead of one mixed "third-party" list. VIP users see Premium first; free users see Community first so the actionable revoke list sits directly under the limit warning.
- The Community section header carries a compact usage meter (bar + `x/y`, red when maxed) fed by the new `connected_apps` bucket on `/users/me/usage` (free 1 / VIP 50; Premium and Official apps never count).
- At the limit, free users get the standard `UpsellCta` (source `connected-apps`); maxed VIP accounts get a plain warning box. Both via `RenderFor` audiences.
- Revoking an app invalidates `userLimitsQuery` so the meter updates immediately.
- The VIP usage page gains a Connected Apps category.

## Notes

- `category: 'community' | 'premium'` is a new required field on the connected-apps response - the API side is already deployed, so parsing is safe.
- `userLimitsQuery` had zero coverage; this adds vip-domain mocks/handlers and a spec alongside the category-mapping coverage.
- Premium accent uses `--purple-500` directly (matching `UpsellCta`/`VipUpsellBadge` usage) - `VipBadge` is red in this codebase and was deliberately not reused.

## Verification

- `deno task check` clean (9244 files), `deno fmt` clean on touched files.
- `deno task test:unit`: 433 files / 2394 tests passed, 0 failed.
- Manual: grouping renders with mixed mock data; free-at-limit shows the upsell; VIP under limit shows no warning.

## Addendum (2026-07-21)

Scope trimmed per product decision:
- **Community apps only.** The endpoint no longer surfaces Premium apps so the settings page renders a single Community list - the Premium section, its hint, and the tier grouping are gone.
- **No usage meter for VIP.** The bar is shown to free accounts only; for VIP the limit stays enforced server-side but invisible, to avoid inducing anxiety for paying customers.

Premium revocation UI is deferred rather than shipped here.

