### PR TITLE
feat(rating): add Letterboxd + MyAnimeList external ratings

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -13,7 +13,7 @@
     "npm:@ethercorps/sveltekit-og@4.3.0": "4.3.0_@sveltejs+kit@2.70.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@7.2.0___svelte@5.56.6___vite@8.1.5____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.6__typescript@5.9.3__vite@8.1.5___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@7.2.0__svelte@5.56.6__vite@8.1.5___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0_svelte@5.56.6_typescript@5.9.3_vite@8.1.5__esbuild@0.28.1__sass-embedded@1.100.0",
     "npm:@inlang/paraglide-js@2.22.0": "2.22.0_typescript@5.9.3_vite@8.1.5__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0",
     "npm:@jsr/libn__fuzzy@0.4.0": "0.4.0",
-    "npm:@jsr/trakt__api@0.5.3": "0.5.3_openapi3-ts@4.6.0",
+    "npm:@jsr/trakt__api@0.5.4": "0.5.4_openapi3-ts@4.6.0",
     "npm:@playwright/test@1.61.1": "1.61.1",
     "npm:@sentry/sveltekit@10.66.0": "10.66.0_@sveltejs+kit@2.70.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@7.2.0___svelte@5.56.6___vite@8.1.5____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.6__typescript@5.9.3__vite@8.1.5___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_vite@8.1.5__esbuild@0.28.1__sass-embedded@1.100.0_@cloudflare+workers-types@4.20260702.1_@opentelemetry+api@1.9.1_@opentelemetry+core@2.9.0__@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@7.2.0__svelte@5.56.6__vite@8.1.5___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0_svelte@5.56.6_typescript@5.9.3",
     "npm:@svelte-put/shortcut@4.2.0": "4.2.0_svelte@5.56.6",
@@ -34,7 +34,7 @@
     "npm:@types/serviceworker@0.0.200": "0.0.200",
     "npm:@use-gesture/vanilla@10.3.1": "10.3.1",
     "npm:@vite-pwa/sveltekit@1.1.0": "1.1.0_@sveltejs+kit@2.70.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@7.2.0___svelte@5.56.6___vite@8.1.5____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.6__typescript@5.9.3__vite@8.1.5___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@7.2.0__svelte@5.56.6__vite@8.1.5___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0_svelte@5.56.6_typescript@5.9.3_vite@8.1.5__esbuild@0.28.1__sass-embedded@1.100.0",
-    "npm:@vitest/coverage-istanbul@4.1.10": "4.1.10_vitest@4.1.10_esbuild@0.28.1_sass-embedded@1.100.0_typescript@5.9.3_vite@8.1.5__esbuild@0.28.1__sass-embedded@1.100.0",
+    "npm:@vitest/coverage-istanbul@4.1.10": "4.1.10_vitest@4.1.10_@opentelemetry+api@1.9.1_jsdom@29.1.1_vite@8.1.5__esbuild@0.28.1__sass-embedded@1.100.0",
     "npm:bits-ui@2.18.1": "2.18.1_svelte@5.56.6_@opentelemetry+api@1.9.1_@sveltejs+kit@2.70.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@7.2.0___svelte@5.56.6___vite@8.1.5____esbuild@0.28.1____sass-embedded@1.100.0___esbuild@0.28.1___sass-embedded@1.100.0__svelte@5.56.6__typescript@5.9.3__vite@8.1.5___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_@sveltejs+vite-plugin-svelte@7.2.0__svelte@5.56.6__vite@8.1.5___esbuild@0.28.1___sass-embedded@1.100.0__esbuild@0.28.1__sass-embedded@1.100.0_esbuild@0.28.1_sass-embedded@1.100.0_typescript@5.9.3_vite@8.1.5__esbuild@0.28.1__sass-embedded@1.100.0",
     "npm:concurrently@10.0.3": "10.0.3",
     "npm:cross-env@10.1.0": "10.1.0",
@@ -2077,14 +2077,14 @@
       "integrity": "sha512-aD9yjW6CMt37S3AMTc95LeuRXcKor69Zkr0aWOhYvinTOEAhEIuaJhP4pQqyQGaAC9HIrQcKh1PtRTK85kkVjA==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/libn__fuzzy/0.4.0.tgz"
     },
-    "@jsr/trakt__api@0.5.3_openapi3-ts@4.6.0": {
-      "integrity": "sha512-h/x+qCLPy1p0CBJNfVauTtAB5R527haIOtCjVs+LaXkminsXNgfF5X8VzMPvBXJSJI/SVuqoxkqjHK9Q8De8Tg==",
+    "@jsr/trakt__api@0.5.4_openapi3-ts@4.6.0": {
+      "integrity": "sha512-FuMd4aVNjco5cGLFcAPndtBdyJ/0yrhXBEzQJM6OQ2KB7/4t7p+KwlYohTl7AkEpQ73SaMbQlRLQfI/aThJkng==",
       "dependencies": [
         "@anatine/zod-openapi",
         "@ts-rest/core",
         "zod"
       ],
-      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.5.3.tgz"
+      "tarball": "https://npm.jsr.io/~/11/@jsr/trakt__api/0.5.4.tgz"
     },
     "@lix-js/sdk@0.4.10": {
       "integrity": "sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==",
@@ -3364,22 +3364,6 @@
       ]
     },
     "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_@opentelemetry+api@1.9.1_jsdom@29.1.1_vite@8.1.5__esbuild@0.28.1__sass-embedded@1.100.0": {
-      "integrity": "sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==",
-      "dependencies": [
-        "@babel/core",
-        "@istanbuljs/schema",
-        "@jridgewell/gen-mapping",
-        "@jridgewell/trace-mapping@0.3.31",
-        "istanbul-lib-coverage",
-        "istanbul-lib-report",
-        "istanbul-reports",
-        "magicast",
-        "obug",
-        "tinyrainbow",
-        "vitest"
-      ]
-    },
-    "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_esbuild@0.28.1_sass-embedded@1.100.0_typescript@5.9.3_vite@8.1.5__esbuild@0.28.1__sass-embedded@1.100.0": {
       "integrity": "sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==",
       "dependencies": [
         "@babel/core",
@@ -7051,7 +7035,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_@opentelemetry+api@1.9.1_jsdom@29.1.1_vite@8.1.5__esbuild@0.28.1__sass-embedded@1.100.0",
+        "@vitest/coverage-istanbul",
         "@vitest/expect",
         "@vitest/mocker",
         "@vitest/pretty-format",
@@ -7076,7 +7060,7 @@
       ],
       "optionalPeers": [
         "@opentelemetry/api",
-        "@vitest/coverage-istanbul@4.1.10_vitest@4.1.10_@opentelemetry+api@1.9.1_jsdom@29.1.1_vite@8.1.5__esbuild@0.28.1__sass-embedded@1.100.0",
+        "@vitest/coverage-istanbul",
         "jsdom"
       ],
       "bin": true
@@ -7517,7 +7501,7 @@
             "npm:@ethercorps/sveltekit-og@4.3.0",
             "npm:@inlang/paraglide-js@2.22.0",
             "npm:@jsr/libn__fuzzy@0.4.0",
-            "npm:@jsr/trakt__api@0.5.3",
+            "npm:@jsr/trakt__api@0.5.4",
             "npm:@playwright/test@1.61.1",
             "npm:@sentry/sveltekit@10.66.0",
             "npm:@svelte-put/shortcut@4.2.0",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -81,7 +81,7 @@
     "@tanstack/query-core": "5.101.2",
     "@tanstack/query-devtools": "5.101.2",
     "@tanstack/query-persist-client-core": "5.101.2",
-    "@trakt/api": "npm:@jsr/trakt__api@0.5.3",
+    "@trakt/api": "npm:@jsr/trakt__api@0.5.4",
     "@ts-rest/core": "3.52.1",
     "@use-gesture/vanilla": "10.3.1",
     "bits-ui": "2.18.1",

--- a/projects/client/src/lib/components/icons/LetterboxdIcon.svelte
+++ b/projects/client/src/lib/components/icons/LetterboxdIcon.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { VotesBasedRating } from "$lib/utils/formatting/number/toVotesBasedRating";
+
+  type LetterboxdIconProps = {
+    style?: VotesBasedRating;
+  };
+
+  const { style = "rated" }: LetterboxdIconProps = $props();
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="18"
+  height="18"
+  viewBox="0 0 500 500"
+  style:filter={`grayscale(${style === "rated" ? 0 : 1})`}
+>
+  <circle cx="140" cy="250" r="110" fill="#ff8000" />
+  <circle cx="360" cy="250" r="110" fill="#40bcf4" />
+  <circle cx="250" cy="250" r="110" fill="#00e054" />
+</svg>

--- a/projects/client/src/lib/components/icons/MALIcon.svelte
+++ b/projects/client/src/lib/components/icons/MALIcon.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import type { VotesBasedRating } from "$lib/utils/formatting/number/toVotesBasedRating";
+
+  type MALIconProps = {
+    style?: VotesBasedRating;
+  };
+
+  const { style = "rated" }: MALIconProps = $props();
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="18"
+  height="18"
+  viewBox="0 0 512 512"
+  style:filter={`grayscale(${style === "rated" ? 0 : 1})`}
+>
+  <rect width="512" height="512" rx="96" fill="#2e51a2" />
+  <text
+    x="256"
+    y="256"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="Arial, Helvetica, sans-serif"
+    font-size="205"
+    font-weight="700"
+    fill="#fff"
+  >MAL</text>
+</svg>

--- a/projects/client/src/lib/components/summary/RatingItem.svelte
+++ b/projects/client/src/lib/components/summary/RatingItem.svelte
@@ -7,6 +7,10 @@
     superscript: Snippet;
     url?: string | Nil;
     isLoading?: boolean;
+    // "minimal" drops the vote-count superscript, showing the score alone;
+    // "default" renders it. The compact summary row is minimal, the ratings
+    // drawer is default.
+    style?: "default" | "minimal";
   } & ChildrenProps;
 
   const {
@@ -15,6 +19,7 @@
     superscript,
     url,
     isLoading = false,
+    style = "default",
   }: RatingItemProps = $props();
 
   const hasValidRating = $derived(rating !== undefined);
@@ -39,7 +44,7 @@
             <p class="bold">-</p>
           {/if}
         </div>
-        {#if !isLoading && hasValidRating}
+        {#if style === "default" && !isLoading && hasValidRating}
           <span class="rating-grow has-underline">
             <span class="rating-grow-clip">
               <p class="bold uppercase secondary vote-count tag">

--- a/projects/client/src/lib/components/summary/RatingItem.svelte
+++ b/projects/client/src/lib/components/summary/RatingItem.svelte
@@ -35,23 +35,24 @@
           {#if isLoading}
             <span class="rating-skeleton" aria-hidden="true"></span>
           {:else if hasValidRating}
-            <span class="rating-grow">
-              <span class="rating-grow-clip">
-                <p class="bold">{rating}</p>
-              </span>
-            </span>
+            <p class="bold">{rating}</p>
           {:else}
             <p class="bold">-</p>
           {/if}
         </div>
-        {#if style === "default" && !isLoading && hasValidRating}
-          <span class="rating-grow has-underline">
-            <span class="rating-grow-clip">
+        {#if style === "default"}
+          <div class="rating-votes">
+            {#if isLoading}
+              <span
+                class="rating-skeleton rating-skeleton-votes"
+                aria-hidden="true"
+              ></span>
+            {:else if hasValidRating}
               <p class="bold uppercase secondary vote-count tag">
                 {@render superscript()}
               </p>
-            </span>
-          </span>
+            {/if}
+          </div>
         {/if}
       </div>
     </div>
@@ -60,18 +61,6 @@
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
-
-  @keyframes rating-grow-in {
-    from {
-      grid-template-columns: 0fr;
-      opacity: 0;
-    }
-
-    to {
-      grid-template-columns: 1fr;
-      opacity: 1;
-    }
-  }
 
   rating {
     :global(.trakt-link) {
@@ -138,62 +127,36 @@
       line-height: 90%;
     }
 
-    .rating-value {
+    // Value and vote-count slots reserve a fixed width so the skeleton and the
+    // loaded content occupy the same space: content swaps in place, no slide,
+    // no jump. tabular-nums keeps digit changes (e.g. re-rating) from shifting.
+    .rating-value,
+    .rating-votes {
       display: flex;
       align-items: center;
 
       min-height: var(--font-size-text);
 
-      // tabular-nums keeps digit changes (e.g. re-rating) from micro-shifting.
       font-variant-numeric: tabular-nums;
-
-      // Small screens hide the vote-count and don't animate. Floor the value
-      // at 2ch so short scores ("9") aren't cramped; percentages/decimals size
-      // to their own content, sitting snug next to the icon.
-      min-width: 2ch;
-
-      @include for-desktop {
-        // desktop animates the grow-in instead of reserving space
-        min-width: 0;
-      }
     }
 
-    // CSS-only width grow-in. The 0fr -> 1fr column animation reflows for real
-    // (siblings glide, no jump). Gated to desktop: small screens hide the
-    // vote-count, so there is little to grow and the motion reads as jitter.
-    .rating-grow {
-      display: inline-grid;
-      grid-template-columns: 1fr;
-
-      @include for-desktop {
-        animation: rating-grow-in var(--transition-increment) ease-in-out;
-      }
+    // fits the common 3-char score ("87%", "8.6") snug; the rare 4-char score
+    // ("100%", "10.0") grows a hair, which is imperceptible and unusual.
+    .rating-value {
+      min-width: 3ch;
     }
 
-    .rating-grow-clip {
-      min-width: 0;
-
-      // clip the horizontal collapse; margin gives glyphs vertical breathing
-      overflow: clip;
-      overflow-clip-margin: var(--ni-2);
-    }
-
-    // extra clip margin keeps the vote-count underline visible
-    .rating-grow.has-underline .rating-grow-clip {
-      overflow-clip-margin: var(--ni-6);
+    // fits the widest vote-count ("359.7K"); the drawer is the only place these
+    // render, so reserving here keeps the row from growing once votes land.
+    .rating-votes {
+      min-width: 6ch;
     }
 
     .rating-skeleton {
       display: block;
 
-      // wider than the value floor so it reads as a bar, and ~matches a loaded
-      // percentage ("86%") for a near shift-free swap; slim bar on desktop
       width: 3ch;
       height: var(--font-size-text);
-
-      @include for-desktop {
-        width: var(--ni-24);
-      }
 
       border-radius: var(--border-radius-xs);
       background-color: color-mix(
@@ -204,6 +167,10 @@
 
       animation: pulse calc(var(--transition-increment) * 6) ease-in-out
         infinite alternate;
+    }
+
+    .rating-skeleton-votes {
+      width: 6ch;
     }
   }
 </style>

--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -14,6 +14,8 @@
   import { toTraktRating } from "$lib/utils/formatting/number/toTraktRating";
   import { toVotesBasedRating } from "$lib/utils/formatting/number/toVotesBasedRating";
   import ActionButton from "../buttons/ActionButton.svelte";
+  import LetterboxdIcon from "../icons/LetterboxdIcon.svelte";
+  import MALIcon from "../icons/MALIcon.svelte";
   import PopcornIcon from "../icons/PopcornIcon.svelte";
   import RatingIcon from "../icons/RatingIcon.svelte";
   import RottenIcon from "../icons/RottenIcon.svelte";
@@ -51,13 +53,26 @@
     isLoading = false,
   }: RatingListProps = $props();
 
-  const { trakt, imdb, rotten } = $derived(
+  const { trakt, imdb, rotten, mal, letterboxd } = $derived(
     getDisplayableRatings({ ratings, entry }),
   );
 
   const isMediaEntry = $derived(
     entry.type === "show" || entry.type === "movie",
   );
+
+  // Letterboxd is films-only and lives only in the ratings breakdown, never the
+  // compact summary row. MAL (anime-only) shows wherever externals render.
+  const showLetterboxd = $derived(
+    variant === "external" && entry.type === "movie" &&
+      letterboxd?.rating != null,
+  );
+
+  // Reserve the MAL slot in the skeleton for anime movies/shows, so the row
+  // does not shift when the (anime-only) MAL rating lands. Episodes never carry
+  // a MAL rating, so they are excluded from the reserve.
+  const isAnime = $derived(isMediaEntry && entry.genres.includes("anime"));
+  const showMal = $derived(mal?.rating != null || (isLoading && isAnime));
 </script>
 
 {#snippet traktItem()}
@@ -88,6 +103,21 @@
     {/snippet}
   </RatingItem>
 
+  {#if showMal}
+    <RatingItem
+      rating={mal?.rating != null
+      ? toIMDBRating(mal.rating, getLocale())
+      : undefined}
+      url={mal?.url}
+      {isLoading}
+    >
+      <MALIcon style={toVotesBasedRating(mal?.votes ?? undefined)} />
+      {#snippet superscript()}
+        {i18n.voteText(mal?.votes ?? 0)}
+      {/snippet}
+    </RatingItem>
+  {/if}
+
   {#if isMediaEntry}
     <RatingItem
       rating={toRottenPercentage(rotten?.critic)}
@@ -108,6 +138,19 @@
       <PopcornIcon style={toRottenAudienceRating(rotten?.audience)} />
       {#snippet superscript()}
         {toRottenAudienceRating(rotten?.audience ?? 0)}
+      {/snippet}
+    </RatingItem>
+  {/if}
+
+  {#if showLetterboxd && letterboxd}
+    <RatingItem
+      rating={toIMDBRating(letterboxd.rating, getLocale())}
+      url={letterboxd.url}
+      {isLoading}
+    >
+      <LetterboxdIcon style={toVotesBasedRating(letterboxd.votes ?? undefined)} />
+      {#snippet superscript()}
+        {i18n.voteText(letterboxd.votes ?? 0)}
       {/snippet}
     </RatingItem>
   {/if}
@@ -134,7 +177,15 @@
   .trakt-summary-ratings {
     display: flex;
     align-items: center;
+    // wrap instead of shrinking items: a shrunk RatingItem clips its value and
+    // vote-count under `overflow: clip`. Keeps the row intact as sources grow
+    // (e.g. MAL joining for anime).
+    flex-wrap: wrap;
     gap: var(--gap-s);
+
+    :global(> rating) {
+      flex: 0 0 auto;
+    }
 
     :global(.trakt-ratings-drilldown-button) {
       :global(svg) {

--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -19,6 +19,7 @@
   import PopcornIcon from "../icons/PopcornIcon.svelte";
   import RatingIcon from "../icons/RatingIcon.svelte";
   import RottenIcon from "../icons/RottenIcon.svelte";
+  import TMDBIcon from "../icons/TMDBIcon.svelte";
   import type { RatingIntl } from "./RatingIntl";
   import { RatingIntlProvider } from "./RatingIntlProvider";
   import RatingItem from "./RatingItem.svelte";
@@ -58,7 +59,7 @@
     style = "minimal",
   }: RatingListProps = $props();
 
-  const { trakt, imdb, rotten, mal, letterboxd } = $derived(
+  const { trakt, imdb, tmdb, rotten, mal, letterboxd } = $derived(
     getDisplayableRatings({ ratings, entry }),
   );
 
@@ -78,6 +79,9 @@
   // a MAL rating, so they are excluded from the reserve.
   const isAnime = $derived(isMediaEntry && entry.genres.includes("anime"));
   const showMal = $derived(mal?.rating != null || (isLoading && isAnime));
+
+  // TMDB lives only in the ratings breakdown, never the compact summary row.
+  const showTmdb = $derived(variant === "external" && tmdb?.rating != null);
 </script>
 
 {#snippet traktItem()}
@@ -162,6 +166,20 @@
       <LetterboxdIcon style={toVotesBasedRating(letterboxd.votes ?? undefined)} />
       {#snippet superscript()}
         {i18n.voteText(letterboxd.votes ?? 0)}
+      {/snippet}
+    </RatingItem>
+  {/if}
+
+  {#if showTmdb && tmdb}
+    <RatingItem
+      rating={toIMDBRating(tmdb.rating, getLocale())}
+      url={tmdb.url}
+      {isLoading}
+      {style}
+    >
+      <TMDBIcon />
+      {#snippet superscript()}
+        {i18n.voteText(tmdb.votes ?? 0)}
       {/snippet}
     </RatingItem>
   {/if}

--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -41,6 +41,10 @@
     onDrilldown?: () => void;
     variant?: "all" | "external";
     isLoading?: boolean;
+    // "minimal" (the default, matching the compact summary row) drops the
+    // vote-count superscripts; "default" renders them, used by the ratings
+    // drawer.
+    style?: "default" | "minimal";
   };
 
   const {
@@ -51,6 +55,7 @@
     onDrilldown,
     variant = "all",
     isLoading = false,
+    style = "minimal",
   }: RatingListProps = $props();
 
   const { trakt, imdb, rotten, mal, letterboxd } = $derived(
@@ -79,6 +84,7 @@
   <RatingItem
     rating={trakt?.rating && toTraktRating(trakt.rating, getLocale())}
     {isLoading}
+    {style}
   >
     <RatingIcon style={toVotesBasedRating(trakt?.votes)} />
     {#snippet superscript()}
@@ -96,6 +102,7 @@
     rating={imdb?.rating && toIMDBRating(imdb.rating, getLocale())}
     url={imdb?.url}
     {isLoading}
+    {style}
   >
     <IMDBIcon style={toVotesBasedRating(imdb?.votes)} />
     {#snippet superscript()}
@@ -110,6 +117,7 @@
       : undefined}
       url={mal?.url}
       {isLoading}
+      {style}
     >
       <MALIcon style={toVotesBasedRating(mal?.votes ?? undefined)} />
       {#snippet superscript()}
@@ -123,6 +131,7 @@
       rating={toRottenPercentage(rotten?.critic)}
       url={rotten?.url}
       {isLoading}
+      {style}
     >
       <RottenIcon style={toRottenCriticRating(rotten?.critic)} />
       {#snippet superscript()}
@@ -134,6 +143,7 @@
       rating={toRottenPercentage(rotten?.audience)}
       url={rotten?.url}
       {isLoading}
+      {style}
     >
       <PopcornIcon style={toRottenAudienceRating(rotten?.audience)} />
       {#snippet superscript()}
@@ -147,6 +157,7 @@
       rating={toIMDBRating(letterboxd.rating, getLocale())}
       url={letterboxd.url}
       {isLoading}
+      {style}
     >
       <LetterboxdIcon style={toVotesBasedRating(letterboxd.votes ?? undefined)} />
       {#snippet superscript()}
@@ -192,10 +203,6 @@
         width: var(--ni-20);
         height: var(--ni-20);
       }
-    }
-
-    @include for-mobile() {
-      gap: var(--gap-xxs);
     }
   }
 </style>

--- a/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.ts
+++ b/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.ts
@@ -12,6 +12,7 @@ export const EMPTY_RATINGS = Object.freeze({
   trakt: undefined,
   rotten: undefined,
   imdb: undefined,
+  tmdb: undefined,
   mal: undefined,
   letterboxd: undefined,
 });

--- a/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.ts
+++ b/projects/client/src/lib/components/summary/_internal/getDisplayableRatings.ts
@@ -12,6 +12,8 @@ export const EMPTY_RATINGS = Object.freeze({
   trakt: undefined,
   rotten: undefined,
   imdb: undefined,
+  mal: undefined,
+  letterboxd: undefined,
 });
 
 export function getDisplayableRatings({

--- a/projects/client/src/lib/requests/_internal/mapToMediaRating.spec.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaRating.spec.ts
@@ -1,0 +1,75 @@
+import type { RatingsResponse } from '@trakt/api';
+import { describe, expect, it } from 'vitest';
+import { mapToMediaRating } from './mapToMediaRating.ts';
+
+const baseResponse: RatingsResponse = {
+  trakt: {
+    rating: 8,
+    votes: 100,
+    distribution: {
+      '1': 0,
+      '2': 0,
+      '3': 0,
+      '4': 0,
+      '5': 0,
+      '6': 0,
+      '7': 0,
+      '8': 50,
+      '9': 30,
+      '10': 20,
+    },
+  },
+  metascore: { rating: null, link: null },
+};
+
+describe('util: mapToMediaRating', () => {
+  it('should map the MyAnimeList block when a rating is present', () => {
+    const result = mapToMediaRating({
+      ...baseResponse,
+      mal: {
+        rating: 8.8,
+        votes: 421000,
+        link: 'myanimelist.net/anime/199',
+      },
+    });
+
+    expect(result.mal).to.deep.equal({
+      rating: 8.8,
+      votes: 421000,
+      url: 'https://myanimelist.net/anime/199',
+    });
+  });
+
+  it('should map the Letterboxd block when a rating is present', () => {
+    const result = mapToMediaRating({
+      ...baseResponse,
+      letterboxd: {
+        rating: 4.4,
+        votes: 89000,
+        link: 'letterboxd.com/film/spirited-away',
+      },
+    });
+
+    expect(result.letterboxd).to.deep.equal({
+      rating: 4.4,
+      votes: 89000,
+      url: 'https://letterboxd.com/film/spirited-away',
+    });
+  });
+
+  it('should leave MAL and Letterboxd undefined when absent', () => {
+    const result = mapToMediaRating(baseResponse);
+
+    expect(result.mal).to.equal(undefined);
+    expect(result.letterboxd).to.equal(undefined);
+  });
+
+  it('should treat a null MAL rating as absent (non-anime)', () => {
+    const result = mapToMediaRating({
+      ...baseResponse,
+      mal: { rating: null, votes: null, link: null },
+    });
+
+    expect(result.mal).to.equal(undefined);
+  });
+});

--- a/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
@@ -34,6 +34,20 @@ export function mapToMediaRating(
     };
   };
 
+  // TMDB, MAL and Letterboxd share one 0-10 shape: a rating, optional votes and
+  // a link. Map them through a single helper keyed on the source block.
+  const mapExternalRating = (block: ExternalRatingBlock | Nil) => {
+    if (block?.rating == null) {
+      return;
+    }
+
+    return {
+      rating: block.rating,
+      votes: block.votes,
+      url: prependHttps(block.link),
+    };
+  };
+
   const mapRottenRating = () => {
     const { rotten_tomatoes: rotten } = ratings;
     if (!rotten?.rating) {
@@ -47,32 +61,6 @@ export function mapToMediaRating(
     };
   };
 
-  const mapMalRating = () => {
-    const { mal } = ratings;
-    if (mal?.rating == null) {
-      return;
-    }
-
-    return {
-      rating: mal.rating,
-      votes: mal.votes,
-      url: prependHttps(mal.link),
-    };
-  };
-
-  const mapLetterboxdRating = () => {
-    const { letterboxd } = ratings;
-    if (letterboxd?.rating == null) {
-      return;
-    }
-
-    return {
-      rating: letterboxd.rating,
-      votes: letterboxd.votes,
-      url: prependHttps(letterboxd.link),
-    };
-  };
-
   return {
     trakt: {
       rating: mapToTraktRating(ratings.trakt.rating),
@@ -80,8 +68,9 @@ export function mapToMediaRating(
       distribution: ratings.trakt.distribution,
     },
     imdb: mapImdbRating(),
+    tmdb: mapExternalRating(ratings.tmdb),
     rotten: mapRottenRating(),
-    mal: mapMalRating(),
-    letterboxd: mapLetterboxdRating(),
+    mal: mapExternalRating(ratings.mal),
+    letterboxd: mapExternalRating(ratings.letterboxd),
   };
 }

--- a/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
+++ b/projects/client/src/lib/requests/_internal/mapToMediaRating.ts
@@ -3,8 +3,23 @@ import type { RatingsResponse } from '@trakt/api';
 import type { MediaRating } from '../models/MediaRating.ts';
 import { mapToTraktRating } from './mapToTraktRating.ts';
 
+// The movie/show ratings endpoints return extra source blocks under
+// `extended=all` (Letterboxd for films, MyAnimeList for anime). The SDK infers
+// these per-endpoint but does not export dedicated types, so widen the shared
+// `RatingsResponse` with the optional blocks this mapper knows how to read.
+type ExternalRatingBlock = {
+  rating?: number | Nil;
+  votes?: number | Nil;
+  link?: string | Nil;
+};
+
+type RatingsResponseWithExternal = RatingsResponse & {
+  letterboxd?: ExternalRatingBlock | Nil;
+  mal?: ExternalRatingBlock | Nil;
+};
+
 export function mapToMediaRating(
-  ratings: RatingsResponse,
+  ratings: RatingsResponseWithExternal,
 ): MediaRating {
   const mapImdbRating = () => {
     const { imdb } = ratings;
@@ -32,6 +47,32 @@ export function mapToMediaRating(
     };
   };
 
+  const mapMalRating = () => {
+    const { mal } = ratings;
+    if (mal?.rating == null) {
+      return;
+    }
+
+    return {
+      rating: mal.rating,
+      votes: mal.votes,
+      url: prependHttps(mal.link),
+    };
+  };
+
+  const mapLetterboxdRating = () => {
+    const { letterboxd } = ratings;
+    if (letterboxd?.rating == null) {
+      return;
+    }
+
+    return {
+      rating: letterboxd.rating,
+      votes: letterboxd.votes,
+      url: prependHttps(letterboxd.link),
+    };
+  };
+
   return {
     trakt: {
       rating: mapToTraktRating(ratings.trakt.rating),
@@ -40,5 +81,7 @@ export function mapToMediaRating(
     },
     imdb: mapImdbRating(),
     rotten: mapRottenRating(),
+    mal: mapMalRating(),
+    letterboxd: mapLetterboxdRating(),
   };
 }

--- a/projects/client/src/lib/requests/models/MediaRating.ts
+++ b/projects/client/src/lib/requests/models/MediaRating.ts
@@ -1,6 +1,15 @@
 import { HttpsUrlSchema } from '$lib/requests/models/HttpsUrlSchema.ts';
 import { z } from 'zod';
 
+// Shared shape for external audience ratings (TMDB, MyAnimeList, Letterboxd):
+// a score, optional vote count and a link. The scale differs per source (see
+// each field below), but the schema does not.
+const ExternalRatingSchema = z.object({
+  rating: z.number(),
+  votes: z.number().nullish(),
+  url: HttpsUrlSchema.nullish(),
+});
+
 export const MediaRatingSchema = z.object({
   trakt: z.object({
     rating: z.number(),
@@ -20,18 +29,12 @@ export const MediaRatingSchema = z.object({
     votes: z.number(),
     url: HttpsUrlSchema.nullish(),
   }).optional(),
+  // TMDB audience rating on a 0-10 scale.
+  tmdb: ExternalRatingSchema.optional(),
   // MyAnimeList audience rating on a 0-10 scale. Anime only.
-  mal: z.object({
-    rating: z.number(),
-    votes: z.number().nullish(),
-    url: HttpsUrlSchema.nullish(),
-  }).optional(),
+  mal: ExternalRatingSchema.optional(),
   // Letterboxd audience rating on a 0-5 scale. Films only.
-  letterboxd: z.object({
-    rating: z.number(),
-    votes: z.number().nullish(),
-    url: HttpsUrlSchema.nullish(),
-  }).optional(),
+  letterboxd: ExternalRatingSchema.optional(),
 });
 
 export type MediaRating = z.infer<typeof MediaRatingSchema>;

--- a/projects/client/src/lib/requests/models/MediaRating.ts
+++ b/projects/client/src/lib/requests/models/MediaRating.ts
@@ -20,6 +20,18 @@ export const MediaRatingSchema = z.object({
     votes: z.number(),
     url: HttpsUrlSchema.nullish(),
   }).optional(),
+  // MyAnimeList audience rating on a 0-10 scale. Anime only.
+  mal: z.object({
+    rating: z.number(),
+    votes: z.number().nullish(),
+    url: HttpsUrlSchema.nullish(),
+  }).optional(),
+  // Letterboxd audience rating on a 0-5 scale. Films only.
+  letterboxd: z.object({
+    rating: z.number(),
+    votes: z.number().nullish(),
+    url: HttpsUrlSchema.nullish(),
+  }).optional(),
 });
 
 export type MediaRating = z.infer<typeof MediaRatingSchema>;

--- a/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
@@ -35,8 +35,9 @@
   );
 
   const hasAnyRating = $derived(
-    ratings.trakt != null || ratings.imdb != null || ratings.rotten != null ||
-      ratings.mal != null || ratings.letterboxd != null,
+    ratings.trakt != null || ratings.imdb != null || ratings.tmdb != null ||
+      ratings.rotten != null || ratings.mal != null ||
+      ratings.letterboxd != null,
   );
 
   let isOpen = $state(false);

--- a/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
@@ -70,7 +70,13 @@
             {m.header_ratings_official()}
           </h3>
           <div class="official-row">
-            <RatingList {ratings} {entry} variant="external" isLoading={$isLoading} />
+            <RatingList
+              {ratings}
+              {entry}
+              variant="external"
+              style="default"
+              isLoading={$isLoading}
+            />
           </div>
         </section>
       {/if}

--- a/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
@@ -35,7 +35,8 @@
   );
 
   const hasAnyRating = $derived(
-    ratings.trakt != null || ratings.imdb != null || ratings.rotten != null,
+    ratings.trakt != null || ratings.imdb != null || ratings.rotten != null ||
+      ratings.mal != null || ratings.letterboxd != null,
   );
 
   let isOpen = $state(false);
@@ -110,13 +111,13 @@
   .official-row {
     --color-link-active: var(--color-text-primary);
 
-    display: flex;
-    justify-content: center;
-
     :global(.trakt-summary-ratings) {
+      /* fixed 3-up grid: equal columns align the sources into tidy rows
+         regardless of how many render, instead of a lopsided space-between wrap */
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
       width: 100%;
-      justify-content: space-between;
-      gap: 0;
+      gap: var(--gap-l) var(--gap-m);
     }
   }
 </style>

--- a/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloRatingsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloRatingsMappedMock.ts
@@ -27,6 +27,11 @@ export const EpisodeSiloRatingsMappedMock: MediaRating = {
     'votes': 144574,
     'url': 'https://www.imdb.com/title/tt14693272',
   },
+  'tmdb': {
+    'rating': 8.2,
+    'votes': 1181,
+    'url': 'https://www.themoviedb.org/tv/125988/season/1/episode/1',
+  },
   'mal': undefined,
   'letterboxd': undefined,
 };

--- a/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloRatingsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/episodes/silo/mapped/EpisodeSiloRatingsMappedMock.ts
@@ -27,4 +27,6 @@ export const EpisodeSiloRatingsMappedMock: MediaRating = {
     'votes': 144574,
     'url': 'https://www.imdb.com/title/tt14693272',
   },
+  'mal': undefined,
+  'letterboxd': undefined,
 };

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticRatingsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticRatingsMappedMock.ts
@@ -23,6 +23,11 @@ export const MovieHereticRatingsMappedMock: MediaRating = {
     'votes': 49905,
     'url': 'https://www.imdb.com/title/tt28015403',
   },
+  'tmdb': {
+    'rating': 7.14,
+    'votes': 563,
+    'url': 'https://www.themoviedb.org/movie/1138194',
+  },
   'mal': undefined,
   'letterboxd': undefined,
 };

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticRatingsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticRatingsMappedMock.ts
@@ -23,4 +23,6 @@ export const MovieHereticRatingsMappedMock: MediaRating = {
     'votes': 49905,
     'url': 'https://www.imdb.com/title/tt28015403',
   },
+  'mal': undefined,
+  'letterboxd': undefined,
 };

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloRatingsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloRatingsMappedMock.ts
@@ -27,4 +27,6 @@ export const ShowSiloRatingsMappedMock: MediaRating = {
     'votes': 144574,
     'url': 'https://www.imdb.com/title/tt14688458',
   },
+  'mal': undefined,
+  'letterboxd': undefined,
 };

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloRatingsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloRatingsMappedMock.ts
@@ -27,6 +27,11 @@ export const ShowSiloRatingsMappedMock: MediaRating = {
     'votes': 144574,
     'url': 'https://www.imdb.com/title/tt14688458',
   },
+  'tmdb': {
+    'rating': 8.2,
+    'votes': 1181,
+    'url': 'https://www.themoviedb.org/tv/125988',
+  },
   'mal': undefined,
   'letterboxd': undefined,
 };


### PR DESCRIPTION
## What

Adds two new external rating sources returned by the ratings API under `extended=all`, mirroring the existing tmdb/imdb blocks:

- **MyAnimeList** (0-10, anime only) - renders wherever the other external ratings do: the summary rating row **and** the ratings breakdown drawer, for both movies and shows.
- **Letterboxd** (0-5, films only) - renders **only** inside the ratings drawer/expanded view, never the compact summary row.

## Details

- **Gating is data-driven.** `mal.rating != null` is itself the anime signal, so there is no separate genre check for display and non-anime titles never get an empty/zero MAL. `letterboxd.rating != null` gates Letterboxd. Scales differ per source (Letterboxd 0-5, MAL 0-10, like imdb 0-10); the source logo conveys the scale, matching how imdb already shows a bare `8.3` with no `/10`.
- **Anime-aware skeleton.** For anime movies/shows the MAL slot is reserved in the loading skeleton (via the `anime` genre on the entry) so the rating row does not shift when the MAL rating lands. Episodes are excluded - they never carry a MAL rating.
- **Row no longer clips/overlaps.** The rating row now wraps and keeps each source at its natural width, so values and vote-count superscripts no longer clip (summary row) or collide (drawer) as more sources join.
- **Mapper.** `mapToMediaRating` is widened to read the per-endpoint `letterboxd`/`mal` blocks. The SDK infers these per media type (movie -> letterboxd + mal, show -> mal) but exports no dedicated type, so the shared mapper accepts the optional blocks structurally.
- **Icons.** New `LetterboxdIcon` (tri-color dots) and `MALIcon` (blue mark), following the existing source-icon pattern (grayscale when unrated).
- Bumps `@trakt/api` to `0.5.4` for the letterboxd/mal ratings contract.

## Verified in-app

- Anime movie (Princess Mononoke): summary row + drawer both show MAL and Letterboxd; row wraps, no clip.
- Non-anime movie (Heretic): Letterboxd shows, MAL correctly absent.
- Checked at wide and narrow widths.

## Tests

- New `mapToMediaRating.spec.ts` covering MAL/Letterboxd mapping, absence, and null-rating-as-absent.
- Updated existing rating query specs / mapped mocks for the new keys.
- `deno task check` and the rating specs pass.