### PR TITLE
fix(profile): do not clip avatar glow

### DIFF
--- a/projects/client/src/lib/sections/profile/components/ProfileContainer.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileContainer.svelte
@@ -25,7 +25,11 @@
     max-width: var(--ni-1280);
     height: var(--ni-232);
 
-    overflow: hidden;
+    // Keep visible so the VIP avatar's glow can bleed past the card edge
+    // instead of being clipped near the top-inline-start corner. The card's
+    // own background/border stay rounded via border-radius, which is
+    // independent of overflow.
+    overflow: visible;
 
     align-self: center;
 
@@ -59,7 +63,6 @@
       box-shadow: none;
 
       height: auto;
-      overflow: visible;
 
       &.is-vip {
         background: none;

--- a/projects/client/src/lib/sections/profile/components/ProfileDetails.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileDetails.svelte
@@ -67,7 +67,9 @@
 
     width: 100%;
     height: 100%;
-    overflow: hidden;
+    // Visible so the VIP avatar glow isn't clipped: the avatar sits flush in
+    // the top-inline-start grid cell, so hidden overflow would cut the glow.
+    overflow: visible;
 
     display: grid;
     grid-template-columns: repeat(var(--details-column-count), minmax(0, 1fr));
@@ -84,7 +86,6 @@
     @include for-tablet-sm-and-below {
       --details-column-count: 1;
 
-      overflow: visible;
       gap: var(--gap-s);
     }
   }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes clipping of avatar glow

## 👀 Example 👀
Before/after:
<img width="324" height="364" alt="Screenshot 2026-07-21 at 17 13 17" src="https://github.com/user-attachments/assets/f87401d6-5f06-4ad0-af99-7d1b57c06aa7" />

<img width="324" height="364" alt="Screenshot 2026-07-21 at 17 18 24" src="https://github.com/user-attachments/assets/18b9545b-79d5-47c8-80de-7328325f4af6" />
