### PR TITLE
feat(client): serve apple-app-site-association for iOS universal links

### DIFF
--- a/projects/client/_headers
+++ b/projects/client/_headers
@@ -1,0 +1,2 @@
+/.well-known/apple-app-site-association
+  Content-Type: application/json

--- a/projects/client/static/.well-known/apple-app-site-association
+++ b/projects/client/static/.well-known/apple-app-site-association
@@ -1,0 +1,25 @@
+{
+    "activitycontinuation": {
+        "apps": [
+            "GZG6JGPM44.tv.trakt.trakt"
+        ]
+    },
+    "applinks": {
+        "apps": [],
+        "details": [
+            {
+                "appID": "GZG6JGPM44.tv.trakt.trakt",
+                "paths": [
+                    "NOT /movies/*/?*",
+                    "/movies/?*",
+                    "NOT /shows/*/seasons/*/episodes/*/?*",
+                    "/shows/*/seasons/*/episodes/?*",
+                    "NOT /shows/*/?*",
+                    "/shows/?*",
+                    "NOT /people/*/?*",
+                    "/people/?*"
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Scene Setting: A Clear Description

The iOS app's associated-domains entitlement now registers `app.trakt.tv`, but the domain serves nothing at `/.well-known/apple-app-site-association` (currently a 404) — and `trakt.tv`'s old copy 301-redirects here, so universal links are dead on both ends of that redirect. This PR hosts the AASA file so iOS opens movie, show, episode, and people URLs directly in the app.

Two files, no code:

- `projects/client/static/.well-known/apple-app-site-association` — sourced **verbatim** from [`trakt-apple-internal@7a3a86f`](https://github.com/trakt/trakt-apple-internal/blob/7a3a86fa78843b2daed02b2f7a6df66e4e5634fc/iOSUniversalLinks/apple-app-site-association) (path rules documented in the [companion notes](https://github.com/trakt/trakt-apple-internal/blob/7a3a86fa78843b2daed02b2f7a6df66e4e5634fc/iOSUniversalLinks/apple-app-site-association.md), see also trakt/trakt-apple-internal#206)
- `projects/client/_headers` — Cloudflare serves extensionless static assets with **no** `Content-Type` header, and Apple's CDN requires `application/json`, so one `_headers` rule sets it explicitly. It lives in the project root (not `static/`) because that's where `adapter-cloudflare` picks it up and copies it into the deployed assets.

Static assets are matched before the worker runs, so the SvelteKit router never sees this path.

## Show, Don't Tell: Screenshots and Videos

Response from the exact deployed file pair served through `wrangler dev` (workerd, same static-assets pipeline as production):

```
HTTP/1.1 200 OK
Content-Type: application/json
Cache-Control: public, max-age=0, must-revalidate
ETag: "00bb9175703316fc2d418346c6880097"
```

## Testing: The Dress Rehearsal

No unit tests — there's no app code to test; the behavior under test is Cloudflare's static-asset serving. That was verified empirically with a minimal Workers fixture using the repo's own `wrangler` 4.66:

1. **Failure proven first**: the extensionless AASA served via bare `assets` returned **no Content-Type header** (a sibling `test.json` correctly got `application/json`) — confirming `static/` alone isn't enough.
2. **Fix proven**: with the `_headers` rule added, the same request returned `Content-Type: application/json`.
3. **Real files re-verified**: the actual two files from this PR served through the fixture → `200` + `application/json`, body spot-checked (`applinks.details[0].appID` = `GZG6JGPM44.tv.trakt.trakt`). JSON validated with `jq`; 644 bytes (Apple's cap is 128 KB).
4. The remaining link — the build copying both files into `.svelte-kit/cloudflare` — is confirmed in `adapter-cloudflare@7.2.7/index.js` (copies root `_headers` into the output; `static/*` is copied wholesale).

Post-deploy check: `curl -sI https://app.trakt.tv/.well-known/apple-app-site-association` should show `200` + `application/json`; Apple's cached copy is visible at `https://app-site-association.cdn-apple.com/a/v1/app.trakt.tv` (CDN pickup can take up to 24h).