### PR TITLE
List: type a rank to reorder list items

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -3173,6 +3173,15 @@
         }
       }
     },
+    "button_label_reorder_item": {
+      "default": "Reorder {title}",
+      "description": "Aria-label for the button that opens a menu with actions to move a list item to a different position.",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
+    },
     "button_text_continue": {
       "default": "Continue",
       "description": "Text for the button that allows users to continue to next screen etc."

--- a/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
+++ b/projects/client/src/lib/components/buttons/popup/PopupMenu.svelte
@@ -5,6 +5,7 @@
   import { disableTransitionOn } from "$lib/utils/actions/disableTransitionOn";
   import { slide } from "svelte/transition";
   import type { PopupMenuProps } from "./PopupMenuProps";
+  import { closeOnSelect } from "./_internal/closeOnSelect";
   import { usePopupMenu } from "./_internal/usePopupMenu";
 
   const {
@@ -50,8 +51,8 @@
 
 {#if variant === "drawer"}
   {#if $isOpened}
-    <Drawer onClose={close} {title} size="auto">
-      <ul class="popup-menu-drawer-item">
+    <Drawer onClose={close} {title} size="auto" elevated>
+      <ul class="popup-menu-drawer-item" use:closeOnSelect={close}>
         {@render items()}
       </ul>
     </Drawer>

--- a/projects/client/src/lib/components/buttons/popup/_internal/closeOnSelect.spec.ts
+++ b/projects/client/src/lib/components/buttons/popup/_internal/closeOnSelect.spec.ts
@@ -1,0 +1,91 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from 'vitest';
+import { closeOnSelect } from './closeOnSelect.ts';
+
+describe('closeOnSelect', () => {
+  let node: HTMLElement;
+  let close: Mock<() => void>;
+
+  beforeEach(() => {
+    node = document.createElement('ul');
+    document.body.appendChild(node);
+    close = vi.fn(() => {});
+  });
+
+  afterEach(() => {
+    node.remove();
+  });
+
+  it('should close when the node is clicked', async () => {
+    closeOnSelect(node, close);
+
+    node.click();
+    await Promise.resolve();
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('should close when a child item is clicked', async () => {
+    const item = document.createElement('li');
+    node.appendChild(item);
+
+    closeOnSelect(node, close);
+
+    item.click();
+    await Promise.resolve();
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('should defer the close until the click has finished dispatching', async () => {
+    closeOnSelect(node, close);
+
+    node.click();
+    expect(close).not.toHaveBeenCalled();
+
+    await Promise.resolve();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('should NOT close when a child stops propagation', async () => {
+    const item = document.createElement('li');
+    item.addEventListener('click', (event) => event.stopPropagation());
+    node.appendChild(item);
+
+    closeOnSelect(node, close);
+
+    item.click();
+    await Promise.resolve();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('should call the updated callback after update', async () => {
+    const updated = vi.fn(() => {});
+    const action = closeOnSelect(node, close);
+
+    action.update(updated);
+    node.click();
+    await Promise.resolve();
+
+    expect(close).not.toHaveBeenCalled();
+    expect(updated).toHaveBeenCalledOnce();
+  });
+
+  it('should NOT close after destroy', async () => {
+    const action = closeOnSelect(node, close);
+
+    action.destroy();
+    node.click();
+    await Promise.resolve();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+});

--- a/projects/client/src/lib/components/buttons/popup/_internal/closeOnSelect.ts
+++ b/projects/client/src/lib/components/buttons/popup/_internal/closeOnSelect.ts
@@ -1,0 +1,16 @@
+export function closeOnSelect(node: HTMLElement, close: () => void) {
+  let onSelect = close;
+
+  const handler = () => queueMicrotask(() => onSelect());
+
+  node.addEventListener('click', handler);
+
+  return {
+    update(next: () => void) {
+      onSelect = next;
+    },
+    destroy() {
+      node.removeEventListener('click', handler);
+    },
+  };
+}

--- a/projects/client/src/lib/components/drawer/Drawer.svelte
+++ b/projects/client/src/lib/components/drawer/Drawer.svelte
@@ -258,7 +258,6 @@
     backdrop-filter: blur(var(--ni-12));
 
     &[data-header-variant="overlay"] {
-      z-index: calc(var(--layer-menu) + 1);
       gap: 0;
       padding-top: 0;
       padding-bottom: 0;

--- a/projects/client/src/lib/components/icons/ArrowDownToLineIcon.svelte
+++ b/projects/client/src/lib/components/icons/ArrowDownToLineIcon.svelte
@@ -1,0 +1,27 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M4 20H20"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+  <path
+    d="M12 3V16"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+  <path
+    d="M7 11L12 16L17 11"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/projects/client/src/lib/components/icons/ArrowUpToLineIcon.svelte
+++ b/projects/client/src/lib/components/icons/ArrowUpToLineIcon.svelte
@@ -1,0 +1,27 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M4 4H20"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+  <path
+    d="M12 21V8"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+  <path
+    d="M7 13L12 8L17 13"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/projects/client/src/lib/sections/lists/user/_internal/RankEditor.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/RankEditor.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  import Button from "$lib/components/buttons/Button.svelte";
+  import PopupMenu from "$lib/components/buttons/popup/PopupMenu.svelte";
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import DropdownItem from "$lib/components/dropdown/DropdownItem.svelte";
+  import ArrowDownToLineIcon from "$lib/components/icons/ArrowDownToLineIcon.svelte";
+  import ArrowUpToLineIcon from "$lib/components/icons/ArrowUpToLineIcon.svelte";
+  import ReorderIcon from "$lib/components/icons/ReorderIcon.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { clamp } from "$lib/utils/number/clamp.ts";
+
+  type RankEditorProps = {
+    rank: number;
+    total: number;
+    title: string;
+    onMove: (targetRank: number) => void;
+  };
+
+  const { rank, total, title, onMove }: RankEditorProps = $props();
+
+  const label = $derived(m.button_label_reorder_item({ title }));
+  const menuTitle = $derived(`#${rank} • ${title}`);
+
+  let open = $state(false);
+  let sheetInput = $state<HTMLInputElement | null>(null);
+  let draft = $state("");
+
+  function resolveTargetRank(raw: string): number {
+    const parsed = Number.parseInt(raw, 10);
+
+    return Number.isFinite(parsed)
+      ? clamp({ value: parsed, min: 1, max: total })
+      : rank;
+  }
+
+  function openSheet() {
+    draft = `${rank}`;
+    open = true;
+  }
+
+  function selectAll(input: HTMLInputElement | null) {
+    requestAnimationFrame(() => input?.select());
+  }
+
+  function submitSheet() {
+    const targetRank = resolveTargetRank(draft);
+
+    if (targetRank !== rank) {
+      onMove(targetRank);
+    }
+
+    open = false;
+  }
+
+  function handleSheetKeydown(event: KeyboardEvent) {
+    if (event.key !== "Enter") {
+      return;
+    }
+
+    event.preventDefault();
+    submitSheet();
+  }
+</script>
+
+<div class="trakt-rank-editor">
+  <PopupMenu mode="standalone" {label} title={menuTitle}>
+    {#snippet icon()}
+      <span class="bold">#{rank}</span>
+    {/snippet}
+
+    {#snippet items()}
+      <DropdownItem
+        style="flat"
+        color="default"
+        variant="secondary"
+        disabled={rank === 1}
+        onclick={() => onMove(1)}
+      >
+        {m.button_text_move_to_top()}
+
+        {#snippet icon()}
+          <ArrowUpToLineIcon />
+        {/snippet}
+      </DropdownItem>
+
+      <DropdownItem
+        style="flat"
+        color="default"
+        variant="secondary"
+        onclick={openSheet}
+      >
+        {m.button_text_move_to_position()}
+
+        {#snippet icon()}
+          <ReorderIcon />
+        {/snippet}
+      </DropdownItem>
+
+      <DropdownItem
+        style="flat"
+        color="default"
+        variant="secondary"
+        disabled={rank === total}
+        onclick={() => onMove(total)}
+      >
+        {m.button_text_move_to_bottom()}
+
+        {#snippet icon()}
+          <ArrowDownToLineIcon />
+        {/snippet}
+      </DropdownItem>
+    {/snippet}
+  </PopupMenu>
+</div>
+
+{#if open}
+  <Drawer
+    onClose={() => (open = false)}
+    onOpened={() => selectAll(sheetInput)}
+    title={m.button_text_move_to_position()}
+    size="auto"
+    elevated
+  >
+    <div class="rank-edit-sheet">
+      <p class="secondary small">
+        {m.dialog_prompt_move_to_position({ title })}
+      </p>
+      <input
+        bind:this={sheetInput}
+        bind:value={draft}
+        class="rank-input"
+        type="text"
+        inputmode="numeric"
+        autocomplete="off"
+        aria-label={m.input_placeholder_reorder_position({ count: total })}
+        placeholder={m.input_placeholder_reorder_position({ count: total })}
+        onkeydown={handleSheetKeydown}
+      />
+      <div class="rank-edit-actions">
+        <Button
+          size="small"
+          color="default"
+          label={m.button_label_cancel()}
+          onclick={() => (open = false)}
+        >
+          {m.button_text_cancel()}
+        </Button>
+        <Button
+          size="small"
+          variant="primary"
+          color="purple"
+          label={m.button_text_apply()}
+          onclick={submitSheet}
+        >
+          {m.button_text_apply()}
+        </Button>
+      </div>
+    </div>
+  </Drawer>
+{/if}
+
+<style lang="scss">
+  .trakt-rank-editor {
+    display: inline-flex;
+
+    :global(.trakt-popup-menu-button) {
+      width: auto;
+      min-width: var(--ni-40);
+      height: var(--ni-28);
+      padding-inline: var(--ni-8);
+
+      color: var(--color-text-primary);
+      font-variant-numeric: tabular-nums;
+      outline: var(--border-thickness-xxs) solid var(--color-border);
+      outline-offset: calc(-1 * var(--border-thickness-xxs));
+    }
+  }
+
+  .rank-edit-sheet {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-12);
+  }
+
+  .rank-input {
+    all: unset;
+    box-sizing: border-box;
+    width: 100%;
+    height: var(--ni-40);
+    padding-block: var(--ni-8);
+    padding-inline: var(--ni-16);
+    text-align: start;
+    font-variant-numeric: tabular-nums;
+    background: var(--color-input-background);
+    border-radius: var(--border-radius-m);
+    outline: var(--border-thickness-xxs) solid var(--color-border);
+    outline-offset: calc(-1 * var(--border-thickness-xxs));
+    transition: outline-color var(--transition-increment) ease-in-out;
+
+    &:focus-visible {
+      outline-color: var(--color-input-focus);
+    }
+  }
+
+  .rank-edit-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--ni-8);
+  }
+</style>

--- a/projects/client/src/lib/sections/lists/user/_internal/ReorderDrawer.svelte
+++ b/projects/client/src/lib/sections/lists/user/_internal/ReorderDrawer.svelte
@@ -8,14 +8,20 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import CrossOriginImage from "$lib/features/image/components/CrossOriginImage.svelte";
   import { MEDIA_POSTER_PLACEHOLDER } from "$lib/utils/assets.ts";
+  import { clamp } from "$lib/utils/number/clamp.ts";
+  import { time } from "$lib/utils/timing/time.ts";
+  import { onDestroy, tick } from "svelte";
   import { flip } from "svelte/animate";
   import { cubicOut } from "svelte/easing";
   import type { ReorderableListItem } from "./models/ReorderableListItem.ts";
+  import { moveReorderableItem } from "./moveReorderableItem.ts";
+  import RankEditor from "./RankEditor.svelte";
   import { type DragGhost, reorderDrag } from "./reorderDrag.ts";
   import {
     itemOrderSignature,
     sortReorderableItems,
   } from "./reorderListItems.ts";
+  import { scrollIntoViewWhen } from "./scrollIntoViewWhen.ts";
 
   const {
     items,
@@ -37,6 +43,8 @@
 
   const { confirm } = useConfirm();
 
+  const flashDuration = time.seconds(1.5);
+
   let localOrder = $state<{
     signature: string;
     items: ReorderableListItem[];
@@ -46,6 +54,8 @@
   let instantPosterKeys = $state<readonly string[]>([]);
   let placeholderIndex = $state<number | null>(null);
   let dragGhost = $state<DragGhost | null>(null);
+  let flashKey = $state<string | null>(null);
+  let flashTimeout: ReturnType<typeof setTimeout> | null = null;
 
   const rankOrderedItems = $derived(sortReorderableItems(items));
   const rankSignature = $derived(itemOrderSignature(rankOrderedItems));
@@ -135,30 +145,70 @@
     cancelled: boolean,
   ) {
     if (!cancelled && key != null && finalIndex != null) {
-      const item = orderedItems.find((i) => i.key === key);
-
-      if (item) {
-        const visible = orderedItems.filter((i) => i.key !== key);
-
-        localOrder = {
-          signature: rankSignature,
-          items: [
-            ...visible.slice(0, finalIndex),
-            item,
-            ...visible.slice(finalIndex),
-          ],
-        };
-      }
-
-      if (!instantPosterKeys.includes(key)) {
-        instantPosterKeys = [...instantPosterKeys, key];
-      }
+      moveItemToIndex(key, finalIndex);
     }
 
     draggedKey = null;
     placeholderIndex = null;
     dragGhost = null;
+
+    if (!cancelled && key != null) {
+      highlightMovedRow(key);
+    }
   }
+
+  function moveItemToIndex(key: string, targetIndex: number) {
+    const items = moveReorderableItem({
+      items: orderedItems,
+      key,
+      targetIndex,
+    });
+
+    if (items === orderedItems) {
+      return;
+    }
+
+    localOrder = { signature: rankSignature, items };
+
+    if (!instantPosterKeys.includes(key)) {
+      instantPosterKeys = [...instantPosterKeys, key];
+    }
+  }
+
+  function moveItemToRank(key: string, targetRank: number) {
+    const currentIndex = orderedItems.findIndex((item) => item.key === key);
+    const targetIndex =
+      clamp({ value: targetRank, min: 1, max: orderedItems.length }) - 1;
+
+    if (currentIndex < 0 || targetIndex === currentIndex) {
+      return;
+    }
+
+    moveItemToIndex(key, targetIndex);
+    highlightMovedRow(key);
+  }
+
+  async function highlightMovedRow(key: string) {
+    if (flashTimeout != null) {
+      clearTimeout(flashTimeout);
+    }
+
+    flashKey = null;
+
+    await tick();
+
+    flashKey = key;
+    flashTimeout = setTimeout(() => {
+      flashKey = null;
+      flashTimeout = null;
+    }, flashDuration);
+  }
+
+  onDestroy(() => {
+    if (flashTimeout != null) {
+      clearTimeout(flashTimeout);
+    }
+  });
 
   async function handleApply() {
     if (!canApply) {
@@ -253,7 +303,10 @@
     </ActionButton>
   {/snippet}
 
-  <div class="reorder-drawer">
+  <div
+    class="reorder-drawer"
+    style="--reorder-flash-duration: {flashDuration}ms"
+  >
     {#if !isLoaded}
       <div class="reorder-loading" role="status" aria-live="polite">
         <LoadingIndicator />
@@ -274,14 +327,24 @@
           class:has-active-drag={draggedKey != null}
         >
           {#each renderRows as row (row.key)}
+            {@const isFlashing = row.type === "item" &&
+            row.item.key === flashKey}
             <tr
               data-reorder-key={row.type === "item" ? row.item.key : undefined}
               class:drag-placeholder={row.type === "placeholder"}
+              class:is-flashing={isFlashing}
+              use:scrollIntoViewWhen={isFlashing}
               animate:flip={{ duration: 220, easing: cubicOut }}
             >
               <td class="rank-cell">
                 {#if row.type === "item"}
-                  <span class="bold">#{row.rank}</span>
+                  <RankEditor
+                    rank={row.rank}
+                    total={orderedItems.length}
+                    title={row.item.title}
+                    onMove={(targetRank) =>
+                    moveItemToRank(row.item.key, targetRank)}
+                  />
                 {/if}
               </td>
               <td>
@@ -365,6 +428,9 @@
 
   tbody {
     tr {
+      scroll-margin-block-start: var(--drawer-header-overlay-height);
+      scroll-margin-block-end: var(--gap-m);
+
       cursor: default;
       filter: drop-shadow(
         var(--ni-1) var(--ni-1) var(--ni-4)
@@ -432,12 +498,54 @@
     }
   }
 
+  .is-flashing td {
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: var(--color-background-purple);
+      opacity: 0;
+      animation: reorder-flash var(--reorder-flash-duration) ease-out;
+    }
+
+    &:first-child::after {
+      border-start-start-radius: var(--border-radius-m);
+      border-end-start-radius: var(--border-radius-m);
+    }
+
+    &:last-child::after {
+      border-start-end-radius: var(--border-radius-m);
+      border-end-end-radius: var(--border-radius-m);
+    }
+  }
+
+  @keyframes reorder-flash {
+    0% {
+      opacity: 0.28;
+    }
+
+    35% {
+      opacity: 0.28;
+    }
+
+    100% {
+      opacity: 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .is-flashing td::after {
+      animation: none;
+    }
+  }
+
   .placeholder-space {
     min-height: calc(var(--ni-40) * 1.5);
   }
 
   .rank-cell {
-    width: var(--ni-56);
+    width: var(--ni-72);
     text-align: center;
     font-variant-numeric: tabular-nums;
   }
@@ -474,7 +582,8 @@
   .reorder-actions {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-end;
+    gap: var(--ni-2);
   }
 
   .drag-handle {
@@ -506,7 +615,7 @@
     pointer-events: none;
 
     display: grid;
-    grid-template-columns: var(--ni-56) minmax(0, 1fr) var(--ni-56);
+    grid-template-columns: var(--ni-72) minmax(0, 1fr) var(--ni-56);
     align-items: center;
     box-sizing: border-box;
 

--- a/projects/client/src/lib/sections/lists/user/_internal/moveReorderableItem.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/moveReorderableItem.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { ReorderableListItem } from './models/ReorderableListItem.ts';
+import { moveReorderableItem } from './moveReorderableItem.ts';
+
+function createItems(): ReorderableListItem[] {
+  return [
+    { key: 'a', listItemId: 1, rank: 1, title: 'A' },
+    { key: 'b', listItemId: 2, rank: 2, title: 'B' },
+    { key: 'c', listItemId: 3, rank: 3, title: 'C' },
+    { key: 'd', listItemId: 4, rank: 4, title: 'D' },
+  ];
+}
+
+function keysOf(items: ReorderableListItem[]) {
+  return items.map((item) => item.key);
+}
+
+describe('moveReorderableItem', () => {
+  it('should move an item down the list', () => {
+    const result = moveReorderableItem({
+      items: createItems(),
+      key: 'a',
+      targetIndex: 2,
+    });
+
+    expect(keysOf(result)).toEqual(['b', 'c', 'a', 'd']);
+  });
+
+  it('should move an item up the list', () => {
+    const result = moveReorderableItem({
+      items: createItems(),
+      key: 'd',
+      targetIndex: 1,
+    });
+
+    expect(keysOf(result)).toEqual(['a', 'd', 'b', 'c']);
+  });
+
+  it('should move an item to the top', () => {
+    const result = moveReorderableItem({
+      items: createItems(),
+      key: 'c',
+      targetIndex: 0,
+    });
+
+    expect(keysOf(result)).toEqual(['c', 'a', 'b', 'd']);
+  });
+
+  it('should move an item to the bottom', () => {
+    const result = moveReorderableItem({
+      items: createItems(),
+      key: 'a',
+      targetIndex: 3,
+    });
+
+    expect(keysOf(result)).toEqual(['b', 'c', 'd', 'a']);
+  });
+
+  it('should keep the order when moving an item onto itself', () => {
+    const result = moveReorderableItem({
+      items: createItems(),
+      key: 'b',
+      targetIndex: 1,
+    });
+
+    expect(keysOf(result)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('should clamp a target index beyond the end to the last position', () => {
+    const result = moveReorderableItem({
+      items: createItems(),
+      key: 'a',
+      targetIndex: 999,
+    });
+
+    expect(keysOf(result)).toEqual(['b', 'c', 'd', 'a']);
+  });
+
+  it('should clamp a negative target index to the first position', () => {
+    const result = moveReorderableItem({
+      items: createItems(),
+      key: 'd',
+      targetIndex: -1,
+    });
+
+    expect(keysOf(result)).toEqual(['d', 'a', 'b', 'c']);
+  });
+
+  it('should clamp a large negative target index to the first position', () => {
+    const result = moveReorderableItem({
+      items: createItems(),
+      key: 'd',
+      targetIndex: -5,
+    });
+
+    expect(keysOf(result)).toEqual(['d', 'a', 'b', 'c']);
+  });
+
+  it('should return the original list when the key is unknown', () => {
+    const items = createItems();
+    const result = moveReorderableItem({
+      items,
+      key: 'missing',
+      targetIndex: 0,
+    });
+
+    expect(result).toBe(items);
+  });
+
+  it('should NOT mutate the input list', () => {
+    const items = createItems();
+
+    moveReorderableItem({ items, key: 'a', targetIndex: 3 });
+
+    expect(keysOf(items)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('should handle a single item list', () => {
+    const items: ReorderableListItem[] = [
+      { key: 'a', listItemId: 1, rank: 1, title: 'A' },
+    ];
+
+    const result = moveReorderableItem({ items, key: 'a', targetIndex: 5 });
+
+    expect(keysOf(result)).toEqual(['a']);
+  });
+});

--- a/projects/client/src/lib/sections/lists/user/_internal/moveReorderableItem.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/moveReorderableItem.ts
@@ -1,0 +1,29 @@
+import { clamp } from '$lib/utils/number/clamp.ts';
+import type { ReorderableListItem } from './models/ReorderableListItem.ts';
+
+type MoveReorderableItemProps = {
+  items: ReorderableListItem[];
+  key: string;
+  targetIndex: number;
+};
+
+export function moveReorderableItem({
+  items,
+  key,
+  targetIndex,
+}: MoveReorderableItemProps): ReorderableListItem[] {
+  const item = items.find((entry) => entry.key === key);
+
+  if (item == null) {
+    return items;
+  }
+
+  const withoutItem = items.filter((entry) => entry.key !== key);
+  const index = clamp({ value: targetIndex, min: 0, max: withoutItem.length });
+
+  return [
+    ...withoutItem.slice(0, index),
+    item,
+    ...withoutItem.slice(index),
+  ];
+}

--- a/projects/client/src/lib/sections/lists/user/_internal/nearestScrollTop.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/nearestScrollTop.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { nearestScrollTop } from './nearestScrollTop.ts';
+
+const base = {
+  elementHeight: 50,
+  marginStart: 0,
+  marginEnd: 0,
+  scrollTop: 200,
+  viewportHeight: 400,
+};
+
+describe('nearestScrollTop', () => {
+  it('should NOT scroll when the element is already fully visible', () => {
+    expect(nearestScrollTop({ ...base, elementTop: 300 })).toBeNull();
+  });
+
+  it('should scroll up when the element sits above the viewport', () => {
+    expect(nearestScrollTop({ ...base, elementTop: 100 })).toBe(100);
+  });
+
+  it('should scroll down when the element sits below the viewport', () => {
+    expect(nearestScrollTop({ ...base, elementTop: 700 })).toBe(350);
+  });
+
+  it('should offset an upward scroll by the start margin', () => {
+    expect(
+      nearestScrollTop({ ...base, elementTop: 100, marginStart: 80 }),
+    ).toBe(20);
+  });
+
+  it('should offset a downward scroll by the end margin', () => {
+    expect(nearestScrollTop({ ...base, elementTop: 700, marginEnd: 24 })).toBe(
+      374,
+    );
+  });
+
+  it('should scroll when the start margin pushes a visible element under the header', () => {
+    expect(
+      nearestScrollTop({ ...base, elementTop: 220, marginStart: 80 }),
+    ).toBe(140);
+  });
+
+  it('should never return a negative scroll position', () => {
+    expect(
+      nearestScrollTop({
+        ...base,
+        elementTop: 0,
+        marginStart: 80,
+        scrollTop: 40,
+      }),
+    ).toBe(0);
+  });
+
+  it('should treat an element taller than the viewport as an upward scroll', () => {
+    expect(
+      nearestScrollTop({ ...base, elementTop: 100, elementHeight: 900 }),
+    ).toBe(100);
+  });
+});

--- a/projects/client/src/lib/sections/lists/user/_internal/nearestScrollTop.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/nearestScrollTop.ts
@@ -1,0 +1,30 @@
+type NearestScrollTopProps = {
+  elementTop: number;
+  elementHeight: number;
+  marginStart: number;
+  marginEnd: number;
+  scrollTop: number;
+  viewportHeight: number;
+};
+
+export function nearestScrollTop({
+  elementTop,
+  elementHeight,
+  marginStart,
+  marginEnd,
+  scrollTop,
+  viewportHeight,
+}: NearestScrollTopProps): number | null {
+  const top = elementTop - marginStart;
+  const bottom = elementTop + elementHeight + marginEnd;
+
+  if (top < scrollTop) {
+    return Math.max(top, 0);
+  }
+
+  if (bottom > scrollTop + viewportHeight) {
+    return Math.max(bottom - viewportHeight, 0);
+  }
+
+  return null;
+}

--- a/projects/client/src/lib/sections/lists/user/_internal/scrollIntoViewWhen.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/scrollIntoViewWhen.ts
@@ -1,0 +1,60 @@
+import { nearestScrollTop } from './nearestScrollTop.ts';
+
+const scrollContainerClassName = 'trakt-drawer-content';
+
+function layoutTop(element: HTMLElement) {
+  let top = 0;
+  let current: HTMLElement | null = element;
+
+  while (current != null) {
+    top += current.offsetTop;
+    current = current.offsetParent as HTMLElement | null;
+  }
+
+  return top;
+}
+
+function toPixels(value: string) {
+  const parsed = Number.parseFloat(value);
+
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function scrollIntoViewWhen(node: HTMLElement, active: boolean) {
+  const scroll = (shouldScroll: boolean) => {
+    if (!shouldScroll) {
+      return;
+    }
+
+    const container = node.closest<HTMLElement>(
+      `.${scrollContainerClassName}`,
+    );
+
+    if (container == null) {
+      return;
+    }
+
+    const style = globalThis.getComputedStyle(node);
+
+    const target = nearestScrollTop({
+      elementTop: layoutTop(node) - layoutTop(container),
+      elementHeight: node.offsetHeight,
+      marginStart: toPixels(style.scrollMarginBlockStart),
+      marginEnd: toPixels(style.scrollMarginBlockEnd),
+      scrollTop: container.scrollTop,
+      viewportHeight: container.clientHeight,
+    });
+
+    if (target == null) {
+      return;
+    }
+
+    container.scrollTo({ top: target, behavior: 'smooth' });
+  };
+
+  scroll(active);
+
+  return {
+    update: scroll,
+  };
+}


### PR DESCRIPTION
# Overview

Adds fast rank editing to the list-reorder drawer, on top of the existing drag-and-drop. Applies to both reorder drawers — the all-lists drawer and the per-list/watchlist drawer — since both render the shared `ReorderDrawer`. No API or model changes; everything persists through the existing reorder request.

# Desktop

The rank number on each row is now an inline editable field. Clicking (or tabbing into) it selects the value, so you can type a new position and press Enter or blur the field to move the item there. Escape reverts. The value clamps to `1…length` and every other row renumbers automatically. Next to the drag handle there are move-to-top and move-to-bottom icon buttons (iOS-style `arrow.up/down.to.line` glyphs), disabled when the row is already first or last.

https://github.com/user-attachments/assets/123b5a09-0cc2-42de-8587-35d4839f9378

# Mobile

Tapping the rank opens a bottom-sheet drawer with a number input and Cancel/Apply, instead of an anchored popover that the on-screen keyboard would cover. The same move-to-top and move-to-bottom buttons are available.

https://github.com/user-attachments/assets/95999c5d-97e0-4a89-9a28-6b022cab9133

# Shared behaviour

Drag-and-drop is unchanged and still live-updates the rank numbers as you drag, including the floating drag ghost. Every way of moving an item — the inline field, the mobile sheet, the top/bottom buttons, and drag-and-drop — routes through one code path that scrolls the moved row into view and briefly highlights it with a ~1.5s fade, so it is easy to see where the item landed. Accessible names are provided on the rank control, the animation respects `prefers-reduced-motion`, and the layout stays RTL-safe.

# Implementation notes

- New `RankEditor` component splits desktop (inline field) vs mobile (bottom sheet) via `useMedia`; the nested sheet uses `Drawer` with `elevated` so it stacks correctly above the reorder drawer.
- New `ArrowUpToLineIcon` / `ArrowDownToLineIcon` icons.
- A single `moveItemToRank` helper backs all move actions; `highlightMovedRow` handles the scroll + flash.
- Reuses the previously-staged i18n keys (move to top/bottom, position prompt); no new message keys were added.
