### PR TITLE
fix: glow effect clipping fix

### DIFF
--- a/projects/client/src/lib/sections/navbar/components/UserMenu.svelte
+++ b/projects/client/src/lib/sections/navbar/components/UserMenu.svelte
@@ -151,7 +151,7 @@
       width: 100%;
       border-radius: 0;
       padding: 0 calc(var(--ni-16) * 0.5);
-      overflow: hidden;
+      overflow: visible;
       background-color: transparent;
       box-shadow: none;
     }

--- a/projects/client/src/lib/sections/profile-banner/ProfileImage.svelte
+++ b/projects/client/src/lib/sections/profile-banner/ProfileImage.svelte
@@ -194,7 +194,7 @@
       .profile-image {
         box-shadow:
           0 0 var(--ni-8) color-mix(in srgb, var(--purple-400) 60%, transparent),
-          0 0 var(--ni-20)
+          0 0 var(--ni-16)
           color-mix(in srgb, var(--purple-500) 50%, transparent);
       }
     }

--- a/projects/client/src/lib/sections/profile/components/ProfileItem.svelte
+++ b/projects/client/src/lib/sections/profile/components/ProfileItem.svelte
@@ -55,7 +55,7 @@
     padding: var(--ni-10) var(--ni-0);
     box-sizing: border-box;
 
-    overflow: hidden;
+    overflow: visible;
 
     &[data-navigation-type="dpad"] {
       &:focus-within {


### PR DESCRIPTION
- when you see it cant unsee it so here is the fix
- also lowered radius a bit so glows do not intersect / go into text next to profile avatars

Bugged:
<img width="172" height="135" alt="image" src="https://github.com/user-attachments/assets/ab57b4c4-1c61-41a1-9c76-2f0347b46f57" />
<img width="122" height="135" alt="image" src="https://github.com/user-attachments/assets/4ba7f724-d27b-4826-ace4-ca57a580920b" />

Fixed:
<img width="82" height="94" alt="image" src="https://github.com/user-attachments/assets/cfb72f81-9a8d-49e1-87fa-7033a4be9de0" />
<img width="144" height="165" alt="image" src="https://github.com/user-attachments/assets/d8874c6f-c838-47a0-a1f2-0cd3ab941e8d" />
