### PR TITLE
feat: official ratings as tiles

### DIFF
--- a/projects/client/src/lib/components/summary/RatingItem.svelte
+++ b/projects/client/src/lib/components/summary/RatingItem.svelte
@@ -11,6 +11,10 @@
     // "default" renders it. The compact summary row is minimal, the ratings
     // drawer is default.
     style?: "default" | "minimal";
+    // "row" (default) is the compact inline logo → value → votes layout.
+    // "tile" stacks a large logo above the value and sublabel inside a
+    // full-height clickable card, used by the ratings drawer grid.
+    layout?: "row" | "tile";
   } & ChildrenProps;
 
   const {
@@ -20,15 +24,20 @@
     url,
     isLoading = false,
     style = "default",
+    layout = "row",
   }: RatingItemProps = $props();
 
   const hasValidRating = $derived(rating !== undefined);
   const ratingLink = $derived(hasValidRating ? url : undefined);
 </script>
 
-<rating>
+<rating data-layout={layout}>
   <Link href={ratingLink} target="_blank">
-    <div class="rating-item" class:has-valid-rating={hasValidRating}>
+    <div
+      class="rating-item"
+      data-layout={layout}
+      class:has-valid-rating={hasValidRating}
+    >
       {@render children()}
       <div class="rating-info">
         <div class="rating-value">
@@ -48,7 +57,7 @@
                 aria-hidden="true"
               ></span>
             {:else if hasValidRating}
-              <p class="bold uppercase secondary vote-count tag">
+              <p class="bold secondary vote-count tag">
                 {@render superscript()}
               </p>
             {/if}
@@ -61,6 +70,25 @@
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
+
+  rating[data-layout="tile"] {
+    display: block;
+    height: 100%;
+
+    :global(.trakt-link),
+    :global(.trakt-no-link) {
+      display: block;
+      height: 100%;
+    }
+
+    :global(.vote-count)::after {
+      display: none;
+    }
+
+    :global(.vote-count) {
+      color: var(--color-text-secondary);
+    }
+  }
 
   rating {
     :global(.trakt-link) {
@@ -85,7 +113,7 @@
 
       &:hover {
         :global(svg) {
-          transform: scale(1.15);
+          transform: scale(1.1);
         }
       }
     }
@@ -116,6 +144,26 @@
         filter: grayscale(0);
       }
     }
+
+    &[data-layout="tile"] {
+      flex-direction: column;
+      justify-content: center;
+      gap: var(--gap-s);
+
+      height: 100%;
+      box-sizing: border-box;
+      padding: var(--ni-16) var(--ni-12);
+
+      background: var(--color-card-background);
+      border-radius: var(--border-radius-m);
+      text-align: center;
+
+      // Direct-child only: the source logo. Scoped so nested glyphs (e.g. the
+      // vote-count person icon) keep their own smaller size.
+      > :global(svg) {
+        height: var(--ni-28);
+      }
+    }
   }
 
   .rating-info {
@@ -125,6 +173,37 @@
 
     p {
       line-height: 90%;
+    }
+
+    [data-layout="tile"] & {
+      flex-direction: column;
+      align-items: center;
+      gap: var(--gap-xs);
+
+      .rating-value,
+      .rating-votes {
+        justify-content: center;
+      }
+
+      .rating-value :global(p) {
+        font-size: var(--ni-20);
+      }
+
+      :global(.vote-count) {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--gap-xxs);
+
+        // ::first-letter (the .capitalize utility) doesn't apply to this
+        // inline-flex box, so capitalize the enum labels (fresh/hot/…) here.
+        text-transform: capitalize;
+
+        :global(svg) {
+          height: var(--font-size-tag);
+          width: auto;
+          filter: none;
+        }
+      }
     }
 
     // Value and vote-count slots reserve a fixed width so the skeleton and the

--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -20,6 +20,7 @@
   import RatingIcon from "../icons/RatingIcon.svelte";
   import RottenIcon from "../icons/RottenIcon.svelte";
   import TMDBIcon from "../icons/TMDBIcon.svelte";
+  import WatchersIcon from "../icons/WatchersIcon.svelte";
   import type { RatingIntl } from "./RatingIntl";
   import { RatingIntlProvider } from "./RatingIntlProvider";
   import RatingItem from "./RatingItem.svelte";
@@ -46,6 +47,9 @@
     // vote-count superscripts; "default" renders them, used by the ratings
     // drawer.
     style?: "default" | "minimal";
+    // "row" (default) lays sources out inline; "tile" renders each source as a
+    // card in a grid, used by the ratings drawer.
+    layout?: "row" | "tile";
   };
 
   const {
@@ -57,6 +61,7 @@
     variant = "all",
     isLoading = false,
     style = "minimal",
+    layout = "row",
   }: RatingListProps = $props();
 
   const { trakt, imdb, tmdb, rotten, mal, letterboxd } = $derived(
@@ -84,20 +89,28 @@
   const showTmdb = $derived(variant === "external" && tmdb?.rating != null);
 </script>
 
+{#snippet voteCount(votes: number | Nil)}
+  {#if layout === "tile"}
+    <WatchersIcon />
+  {/if}
+  {i18n.voteText(votes ?? 0)}
+{/snippet}
+
 {#snippet traktItem()}
   <RatingItem
     rating={trakt?.rating && toTraktRating(trakt.rating, getLocale())}
     {isLoading}
     {style}
+    {layout}
   >
     <RatingIcon style={toVotesBasedRating(trakt?.votes)} />
     {#snippet superscript()}
-      {i18n.voteText(trakt?.votes ?? 0)}
+      {@render voteCount(trakt?.votes)}
     {/snippet}
   </RatingItem>
 {/snippet}
 
-<div class="trakt-summary-ratings">
+<div class="trakt-summary-ratings" data-layout={layout}>
   {#if variant === "all"}
     {@render traktItem()}
   {/if}
@@ -107,10 +120,11 @@
     url={imdb?.url}
     {isLoading}
     {style}
+    {layout}
   >
     <IMDBIcon style={toVotesBasedRating(imdb?.votes)} />
     {#snippet superscript()}
-      {i18n.voteText(imdb?.votes ?? 0)}
+      {@render voteCount(imdb?.votes)}
     {/snippet}
   </RatingItem>
 
@@ -122,10 +136,11 @@
       url={mal?.url}
       {isLoading}
       {style}
+      {layout}
     >
       <MALIcon style={toVotesBasedRating(mal?.votes ?? undefined)} />
       {#snippet superscript()}
-        {i18n.voteText(mal?.votes ?? 0)}
+        {@render voteCount(mal?.votes)}
       {/snippet}
     </RatingItem>
   {/if}
@@ -136,6 +151,7 @@
       url={rotten?.url}
       {isLoading}
       {style}
+      {layout}
     >
       <RottenIcon style={toRottenCriticRating(rotten?.critic)} />
       {#snippet superscript()}
@@ -148,6 +164,7 @@
       url={rotten?.url}
       {isLoading}
       {style}
+      {layout}
     >
       <PopcornIcon style={toRottenAudienceRating(rotten?.audience)} />
       {#snippet superscript()}
@@ -162,10 +179,11 @@
       url={letterboxd.url}
       {isLoading}
       {style}
+      {layout}
     >
       <LetterboxdIcon style={toVotesBasedRating(letterboxd.votes ?? undefined)} />
       {#snippet superscript()}
-        {i18n.voteText(letterboxd.votes ?? 0)}
+        {@render voteCount(letterboxd.votes)}
       {/snippet}
     </RatingItem>
   {/if}
@@ -176,10 +194,11 @@
       url={tmdb.url}
       {isLoading}
       {style}
+      {layout}
     >
       <TMDBIcon />
       {#snippet superscript()}
-        {i18n.voteText(tmdb.votes ?? 0)}
+        {@render voteCount(tmdb.votes)}
       {/snippet}
     </RatingItem>
   {/if}
@@ -214,6 +233,18 @@
 
     :global(> rating) {
       flex: 0 0 auto;
+    }
+
+    // Tile layout: equal-column grid of source cards, matching the drawer's
+    // stat-tile surfaces. Overrides the inline flex row above.
+    &[data-layout="tile"] {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: var(--gap-s);
+
+      :global(> rating) {
+        flex: initial;
+      }
     }
 
     :global(.trakt-ratings-drilldown-button) {

--- a/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
@@ -67,7 +67,7 @@
         {/if}
 
         <section class="official-section">
-          <h3 class="card-title bold secondary">
+          <h3 class="bold secondary small">
             {m.header_ratings_official()}
           </h3>
           <div class="official-grid">
@@ -90,17 +90,11 @@
   .trakt-ratings-drawer-content {
     display: flex;
     flex-direction: column;
-    gap: var(--gap-m);
+    gap: var(--gap-l);
   }
 
   .ratings-empty {
     color: var(--color-text-secondary);
-  }
-
-  .card-title {
-    color: var(--color-text-secondary);
-    margin: 0;
-    font-size: var(--font-size-text-small);
   }
 
   .official-section {

--- a/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
@@ -66,16 +66,17 @@
           <SeasonRatingsChart {seasons} />
         {/if}
 
-        <section class="ratings-card official-card">
+        <section class="official-section">
           <h3 class="card-title bold secondary">
             {m.header_ratings_official()}
           </h3>
-          <div class="official-row">
+          <div class="official-grid">
             <RatingList
               {ratings}
               {entry}
               variant="external"
               style="default"
+              layout="tile"
               isLoading={$isLoading}
             />
           </div>
@@ -96,35 +97,19 @@
     color: var(--color-text-secondary);
   }
 
-  .ratings-card {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-s);
-    padding: var(--ni-12) var(--ni-16);
-    border-radius: var(--border-radius-l);
-    background: var(--color-card-background);
-  }
-
   .card-title {
     color: var(--color-text-secondary);
     margin: 0;
     font-size: var(--font-size-text-small);
   }
 
-  .official-card {
-    padding-block: var(--ni-16);
+  .official-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
   }
 
-  .official-row {
+  .official-grid {
     --color-link-active: var(--color-text-primary);
-
-    :global(.trakt-summary-ratings) {
-      /* fixed 3-up grid: equal columns align the sources into tidy rows
-         regardless of how many render, instead of a lopsided space-between wrap */
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      width: 100%;
-      gap: var(--gap-l) var(--gap-m);
-    }
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte
@@ -79,7 +79,7 @@
   .trakt-ratings-distribution {
     display: flex;
     flex-direction: column;
-    gap: var(--gap-s);
+    gap: var(--gap-m);
 
     padding: var(--ni-12) var(--ni-16);
     border-radius: var(--border-radius-l);

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/RatingsDistribution.svelte
@@ -36,39 +36,41 @@
 </script>
 
 <section class="trakt-ratings-distribution">
-  <h3 class="card-title bold secondary">{m.header_ratings_trakt()}</h3>
+  <h3 class="bold secondary small">{m.header_ratings_trakt()}</h3>
 
-  <div class="ratings-row">
-    <div class="trakt-display">
-      <p class="trakt-rating-value bold">{traktPercent}</p>
-      <p class="trakt-rating-votes secondary uppercase tag">
-        {m.text_ratings_votes({ count: voteCountText })}
-      </p>
-    </div>
+  <div class="ratings-card">
+    <div class="ratings-row">
+      <div class="trakt-display">
+        <p class="trakt-rating-value bold">{traktPercent}</p>
+        <p class="trakt-rating-votes secondary capitalize tag">
+          {m.text_ratings_votes({ count: voteCountText })}
+        </p>
+      </div>
 
-    <div class="trakt-histogram">
-      {#each buckets as bucket, i (bucket.star)}
-        <Tooltip
-          content={toHumanNumber(bucket.value, getLocale())}
-          variant="compact"
-          sideOffset={4}
-        >
-          <div class="histogram-column">
-            <div class="histogram-bar">
-              <DistributionBar
-                orientation="vertical"
-                fraction={ratio({ value: bucket.value, total: maxValue })}
-                active={bucket.value === maxValue && maxValue > 0}
-                minVisible={0.04}
-                index={i}
-                label="{bucket.star}: {toHumanNumber(bucket.value, getLocale())}"
-                --distribution-bar-thickness="100%"
-              />
+      <div class="trakt-histogram">
+        {#each buckets as bucket, i (bucket.star)}
+          <Tooltip
+            content={toHumanNumber(bucket.value, getLocale())}
+            variant="compact"
+            sideOffset={4}
+          >
+            <div class="histogram-column">
+              <div class="histogram-bar">
+                <DistributionBar
+                  orientation="vertical"
+                  fraction={ratio({ value: bucket.value, total: maxValue })}
+                  active={bucket.value === maxValue && maxValue > 0}
+                  minVisible={0.04}
+                  index={i}
+                  label="{bucket.star}: {toHumanNumber(bucket.value, getLocale())}"
+                  --distribution-bar-thickness="100%"
+                />
+              </div>
+              <span class="histogram-label tag secondary">{bucket.star}</span>
             </div>
-            <span class="histogram-label tag secondary">{bucket.star}</span>
-          </div>
-        </Tooltip>
-      {/each}
+          </Tooltip>
+        {/each}
+      </div>
     </div>
   </div>
 </section>
@@ -79,17 +81,13 @@
   .trakt-ratings-distribution {
     display: flex;
     flex-direction: column;
-    gap: var(--gap-m);
+    gap: var(--gap-s);
+  }
 
+  .ratings-card {
     padding: var(--ni-12) var(--ni-16);
     border-radius: var(--border-radius-l);
     background: var(--color-card-background);
-  }
-
-  .card-title {
-    color: var(--color-text-secondary);
-    margin: 0;
-    font-size: var(--font-size-text-small);
   }
 
   .ratings-row {

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/SeasonRatingsChart.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/SeasonRatingsChart.svelte
@@ -47,10 +47,11 @@
 
 {#if points.length >= 2}
   <section class="trakt-season-ratings-chart">
-    <div class="header">
-      <h3 class="card-title bold secondary">
-        {m.header_ratings_quality_over_time()}
-      </h3>
+    <h3 class="bold secondary small">
+      {m.header_ratings_quality_over_time()}
+    </h3>
+
+    <div class="chart-card">
       {#if peak && trough}
         <span class="meta tag secondary">
           {m.text_ratings_season_extremes({
@@ -61,9 +62,8 @@
           })}
         </span>
       {/if}
-    </div>
 
-    <div class="chart">
+      <div class="chart">
       <LineChart
         {data}
         {tickLabels}
@@ -82,6 +82,7 @@
           </span>
         {/snippet}
       </LineChart>
+      </div>
     </div>
   </section>
 {/if}
@@ -91,23 +92,15 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-s);
+  }
+
+  .chart-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
     padding: var(--ni-12) var(--ni-16);
     border-radius: var(--border-radius-l);
     background: var(--color-card-background);
-  }
-
-  .header {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--gap-s);
-    flex-wrap: wrap;
-  }
-
-  .card-title {
-    color: var(--color-text-secondary);
-    margin: 0;
-    font-size: var(--font-size-text-small);
   }
 
   .meta {


### PR DESCRIPTION
- probably no need to keep official ratings cramped and tiny as currently
- PR applies similar tiles pattern from other places for official ratings
- also considered adding scale suffix UI there but left as is for now. Ping if you would like to add it (IMDB -> 7.7 / 10, Letterbox -> 3.9 / 5).

Now:
<img width="422" height="544" alt="image" src="https://github.com/user-attachments/assets/5e17da76-7a09-49d2-b67b-01d9dfeae64b" />

After:
<img width="420" height="539" alt="image" src="https://github.com/user-attachments/assets/2f9625c6-3409-4cb6-989e-ac38def48487" />

