### PR TITLE
fix(list): stop media detail lists rearranging on like/unlike

### DIFF
--- a/projects/client/src/lib/sections/summary/components/lists/useListSummary.ts
+++ b/projects/client/src/lib/sections/summary/components/lists/useListSummary.ts
@@ -1,6 +1,8 @@
+import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
 import type { MediaType } from '$lib/requests/models/MediaType.ts';
 import { movieListsQuery } from '$lib/requests/queries/movies/movieListsQuery.ts';
 import { usePaginatedListQuery } from '$lib/sections/lists/stores/usePaginatedListQuery.ts';
+import { useStableArray } from '$lib/sections/lists/stores/useStableArray.ts';
 import { combineLatest, map } from 'rxjs';
 import { showListsQuery } from '../../../../requests/queries/shows/showListsQuery.ts';
 import { MAX_LISTS } from './_internal/constants.ts';
@@ -26,6 +28,9 @@ function typeToQuery(
   }
 }
 
+const isSameList = (left: MediaListSummary, right: MediaListSummary) =>
+  left.key === right.key;
+
 export function useListSummary(
   { slug, type, limit = MAX_LISTS }: ListSummaryProps,
 ) {
@@ -43,7 +48,16 @@ export function useListSummary(
     map(($states) => $states.some(Boolean)),
   );
 
-  const list = combineLatest([personalLists.list, officialLists.list]).pipe(
+  const { list: stablePersonalList } = useStableArray(
+    isSameList,
+    personalLists.list,
+  );
+  const { list: stableOfficialList } = useStableArray(
+    isSameList,
+    officialLists.list,
+  );
+
+  const list = combineLatest([stablePersonalList, stableOfficialList]).pipe(
     map(([$personal, $official]) => [...$official, ...$personal]),
   );
 


### PR DESCRIPTION
## Scene Setting: A Clear Description

Fixes #2973. Liking or unliking a list on a media detail page made the whole lists section remount and shuffle the list into a new spot.

The cause: `movieListsQuery` / `showListsQuery` declared `InvalidateAction.List.Like`, so every like/unlike refetched them — and since they fetch with `sort: 'popular'` and liking changes popularity, the refetch reorders the section. The invalidation isn't needed for the heart state; that comes from `currentUserLikesQuery`, which keeps its own `List.Like` invalidation. So this just drops the token from both queries.

**Trade-off:** the invalidation was originally added (d0579a8ef, #1710) so the like *count* on these cards refreshes after you like. With it removed, the count you see on media detail list cards is stale by one until the 30-min TTL — heart state still updates instantly, all other surfaces (liked lists, personal lists, list detail) keep their invalidations. IMO an off-by-one count beats the section jumping around; if we want live counts back we can optimistically patch `likeCount` in `useLikeList` as a follow-up.

## Show, Don't Tell: Screenshots and Videos

Repro video on #2973 shows the before. 

After:

https://github.com/user-attachments/assets/ade9547c-6671-42ea-ba3f-bb837a1e7eee



## Testing: The Dress Rehearsal

- `movieListsQuery.spec.ts` and `showListsQuery.spec.ts` pass.
- Manual: on `/movies/hell-or-high-water-2016?mode=media`, like/unlike lists in the lists section — no remount, no reorder, no refetch of `/movies/.../lists` in the network tab.