### PR TITLE
fix(search): hide progress indicator when show episode count is unknown

### DIFF
--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.spec.ts
@@ -3,7 +3,7 @@ import { toMediaKey } from '$lib/features/offline/toMediaKey.ts';
 import { server } from '$mocks/server.ts';
 import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
 import { http, HttpResponse } from 'msw';
-import { firstValueFrom } from 'rxjs';
+import { filter, firstValueFrom } from 'rxjs';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { useIsWatched } from './useIsWatched.ts';
 
@@ -57,6 +57,34 @@ describe('store: useIsWatched', () => {
       );
 
       expect(await firstValueFrom(isWatched)).toBe(false);
+    });
+  });
+
+  describe('show: unknown episode count', () => {
+    // show 147971 has season 1 plays in WatchedShowPlaysResponseMock
+    const SHOW_ID = 147971;
+
+    it('should not report partial progress when the episode count is unknown', async () => {
+      const { control, isWatched, isPartiallyWatched } = await renderStore(
+        () => {
+          const finite = useIsWatched({
+            type: 'show',
+            media: { id: SHOW_ID, episode: { count: 1000 } },
+          });
+          const unknown = useIsWatched({
+            type: 'show',
+            media: { id: SHOW_ID, episode: { count: NaN } },
+          });
+
+          return { control: finite.isPartiallyWatched, ...unknown };
+        },
+      );
+
+      // the finite-count store proves history has loaded with plays
+      expect(await firstValueFrom(control.pipe(filter(Boolean)))).toBe(true);
+
+      expect(await firstValueFrom(isWatched)).toBe(false);
+      expect(await firstValueFrom(isPartiallyWatched)).toBe(false);
     });
   });
 });

--- a/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
+++ b/projects/client/src/lib/sections/media-actions/mark-as-watched/useIsWatched.ts
@@ -122,7 +122,10 @@ export function useIsWatched(props: IsWatchedProps) {
           const isPartiallyWatched = !isWatched && shows.some((show) => {
             const watchedShow = $history.shows.get(show.id);
 
-            if (!watchedShow) {
+            // Without a finite episode count (e.g. unmapped search results),
+            // plays cannot distinguish in-progress from completed - claim
+            // neither.
+            if (!watchedShow || !Number.isFinite(show.episode?.count)) {
               return false;
             }
 


### PR DESCRIPTION
## Scene Setting: A Clear Description

Refs #2975 — partial mitigation, does **not** close it (see the follow-up issue linked below).

Show search results can carry a `NaN` aired episode count (`mapToShowEntry.ts` defaults `aired_episodes ?? NaN`), and in `useIsWatched`'s show branch `NaN` is falsy — so the `isWatched` check bailed out to `false`, while `plays > 0` still claimed partial progress. Fully watched shows were therefore tagged "In Progress".

This PR is the defensive layer: the partial-progress claim now requires a finite episode count. Without one, plays can't distinguish in-progress from completed, so we claim neither state — no indicator instead of a wrong one.

How #2975 actually gets resolved, in three parts:
1. **#2983** (this PR's base): mapper falls back to Typesense `episode_count` — fixes the indicator and the NaN count label for **ended** shows, where total = aired.
2. **This PR**: missing/NaN counts can never claim "In Progress" again, on any surface.
3. **Follow-up (separate PR)**: caught-up **airing** shows still show partial in search, because Typesense `episode_count` includes unaired episodes (verified against the live cluster: My Adventures with Superman 26 aired vs 30 indexed; The Westies 3 vs 8) and search data has no aired count at all. Needs the aired count sourced from the watched-shows history query instead.

Stacked on #2983 — merge that first; this PR retargets to `main` afterwards (rebase merge, so the retarget is clean).

## Show, Don't Tell: Screenshots and Videos

_Before/after per #2975 — completed show poster in search results no longer shows the "In Progress" ring._

## Testing: The Dress Rehearsal

- `useIsWatched.spec.ts` — new case `show: unknown episode count > should not report partial progress when the episode count is unknown`: renders two stores against the watched-plays fixture (show 147971), a finite-count control proving history loaded with plays, and a `NaN`-count store asserting both `isWatched` and `isPartiallyWatched` are `false`. Verified red without the guard, green with it.
- Full unit suite passes (2415 tests).
- Manual: searched a fully watched ended show on this branch — poster shows "Watched"; mid-watch shows still show "In Progress"; unwatched shows none.