### PR TITLE
fix(list): seed sort params from URL to avoid duplicate first fetch

### DIFF
--- a/projects/client/src/lib/sections/lists/progress/useUpNextSorting.spec.ts
+++ b/projects/client/src/lib/sections/lists/progress/useUpNextSorting.spec.ts
@@ -2,12 +2,16 @@ import { FeatureFlag } from '$lib/features/feature-flag/models/FeatureFlag.ts';
 import { useFeatureFlag } from '$lib/features/feature-flag/useFeatureFlag.ts';
 import { renderStore } from '$test/beds/store/renderStore.ts';
 import { filter, firstValueFrom, map, take } from 'rxjs';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { useUpNextSorting } from './useUpNextSorting.ts';
 
 describe('useUpNextSorting', () => {
   beforeEach(() => {
     localStorage.clear();
+  });
+
+  afterEach(() => {
+    history.replaceState(null, '', '/');
   });
 
   it('should hide smart sorting until the preview flag is enabled', async () => {
@@ -38,6 +42,8 @@ describe('useUpNextSorting', () => {
   });
 
   it('should ignore smart sorting from the URL until the preview flag is enabled', async () => {
+    history.replaceState(null, '', '/?sort_by=smart');
+
     const { sorting, featureFlag } = await renderStore(() => ({
       sorting: useUpNextSorting('me'),
       featureFlag: useFeatureFlag(),
@@ -46,8 +52,6 @@ describe('useUpNextSorting', () => {
       firstValueFrom(
         sorting.current.pipe(map((current) => current.sorting.value)),
       );
-
-    sorting.update({ sort_by: 'smart' });
 
     expect(await currentSortBy()).toBeUndefined();
 

--- a/projects/client/src/lib/sections/lists/progress/useUpNextSorting.ts
+++ b/projects/client/src/lib/sections/lists/progress/useUpNextSorting.ts
@@ -2,18 +2,13 @@ import { FeatureFlag } from '$lib/features/feature-flag/models/FeatureFlag.ts';
 import { useFeatureFlag } from '$lib/features/feature-flag/useFeatureFlag.ts';
 import * as m from '$lib/features/i18n/messages.ts';
 import type { UpNextSortBy } from '$lib/sections/lists/progress/UpNextSortBy.ts';
+import { useSortParams } from '$lib/sections/lists/stores/useSortParams.ts';
 import type { ListUrlBuilder } from '$lib/sections/lists/user/models/ListUrlBuilder.ts';
 import type { SortDirection } from '$lib/sections/lists/user/models/SortDirection.ts';
 import type { Sorting } from '$lib/sections/lists/user/models/Sorting.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
-import {
-  BehaviorSubject,
-  combineLatest,
-  map,
-  type Observable,
-  startWith,
-} from 'rxjs';
+import { combineLatest, map, type Observable, startWith } from 'rxjs';
 
 const upNextSortOptions: Sorting<UpNextSortBy>[] = [
   {
@@ -44,7 +39,6 @@ type UpNextSorting = {
     sortHow: SortDirection;
   }>;
   options: Observable<Sorting<UpNextSortBy>[]>;
-  update: (params: Record<string, string>) => void;
   urlBuilder: ListUrlBuilder<UpNextSortBy>;
 };
 
@@ -74,22 +68,12 @@ export function useUpNextSorting(user: string): UpNextSorting {
     startWith(getSortOptions(false)),
   );
 
-  const params = new BehaviorSubject<Record<string, string | null>>({
-    sort_by: null,
-    sort_how: null,
-  });
-
-  function update(newParams: Record<string, string>) {
-    params.next({ ...newParams });
-  }
-
   return {
-    update,
     options,
-    current: combineLatest([params, options]).pipe(
+    current: combineLatest([useSortParams(), options]).pipe(
       map(([$params, $options]) => {
-        const sortBy = mapToSortBy($params.sort_by, $options);
-        const sortHow = mapToDirection($params.sort_how);
+        const sortBy = mapToSortBy($params.sortBy, $options);
+        const sortHow = mapToDirection($params.sortHow);
 
         const sorting = $options.find(
           (option) => option.value === sortBy,

--- a/projects/client/src/lib/sections/lists/stores/useSortParams.ts
+++ b/projects/client/src/lib/sections/lists/stores/useSortParams.ts
@@ -1,0 +1,21 @@
+import { useParameters } from '$lib/features/parameters/useParameters.ts';
+import { distinctUntilChanged, map, type Observable } from 'rxjs';
+
+type SortParams = {
+  sortBy: string | Nil;
+  sortHow: string | Nil;
+};
+
+export function useSortParams(): Observable<SortParams> {
+  const { url } = useParameters();
+
+  return url.pipe(
+    map(($url) => ({
+      sortBy: $url.searchParams.get('sort_by'),
+      sortHow: $url.searchParams.get('sort_how'),
+    })),
+    distinctUntilChanged((a, b) =>
+      a.sortBy === b.sortBy && a.sortHow === b.sortHow
+    ),
+  );
+}

--- a/projects/client/src/lib/sections/lists/user/ListSortActions.svelte
+++ b/projects/client/src/lib/sections/lists/user/ListSortActions.svelte
@@ -2,7 +2,6 @@
   lang="ts"
   generics="T extends SortBy | UpNextSortBy | UserListsSortBy"
 >
-  import { page } from "$app/state";
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
   import SortIcon from "$lib/components/icons/SortIcon.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
@@ -19,25 +18,13 @@
     options,
     current,
     urlBuilder,
-    onUpdate,
     disabled,
   }: {
     options: Sorting<T>[];
     current: { sortHow: SortDirection; sorting: Sorting<T> };
     urlBuilder: ListUrlBuilder<T>;
-    onUpdate: (params: Record<string, string>) => void;
     disabled?: boolean;
   } = $props();
-
-  const sortHowParam = $derived(page.url.searchParams.get("sort_how"));
-  const sortByParam = $derived(page.url.searchParams.get("sort_by"));
-
-  $effect(() => {
-    const params: Record<string, string> = {};
-    if (sortHowParam) params.sort_how = sortHowParam;
-    if (sortByParam) params.sort_by = sortByParam;
-    onUpdate(params);
-  });
 
   const isOpen = writable(false);
 </script>

--- a/projects/client/src/lib/sections/lists/user/_internal/useListSorting.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useListSorting.spec.ts
@@ -1,0 +1,64 @@
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { tap } from 'rxjs';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useListSorting } from './useListSorting.ts';
+
+describe('store: useListSorting', () => {
+  afterEach(() => {
+    history.replaceState(null, '', '/');
+  });
+
+  describe('watchlist', () => {
+    const props = { type: 'watchlist', intent: 'default' } as const;
+
+    it('should derive the sorting from the URL', async () => {
+      history.replaceState(null, '', '/?sort_by=added&sort_how=asc');
+
+      const { sorting, sortHow } = await runQuery({
+        factory: () => useListSorting(props).current,
+      });
+
+      expect(sorting.value).toBe('added');
+      expect(sortHow).toBe('asc');
+    });
+
+    it('should derive the defaults when the URL has no sort params', async () => {
+      const { sorting, sortHow } = await runQuery({
+        factory: () => useListSorting(props).current,
+      });
+
+      expect(sorting.value).toBe(undefined);
+      expect(sortHow).toBe('desc');
+    });
+
+    it('should not emit a fallback sort before the URL sort', async () => {
+      history.replaceState(null, '', '/?sort_by=added&sort_how=asc');
+
+      const emissions: string[] = [];
+      await runQuery({
+        factory: () =>
+          useListSorting(props).current.pipe(
+            tap(({ sorting, sortHow }) =>
+              emissions.push(`${sorting.value}-${sortHow}`)
+            ),
+          ),
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(emissions).toEqual(['added-asc']);
+    });
+  });
+
+  describe('favorites', () => {
+    const props = { type: 'favorites', slug: 'sefer' } as const;
+
+    it('should derive the defaults when the URL has no sort params', async () => {
+      const { sorting, sortHow } = await runQuery({
+        factory: () => useListSorting(props).current,
+      });
+
+      expect(sorting.value).toBe('added');
+      expect(sortHow).toBe('desc');
+    });
+  });
+});

--- a/projects/client/src/lib/sections/lists/user/_internal/useListSorting.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/useListSorting.ts
@@ -1,6 +1,7 @@
 import type { MediaListSummary } from '$lib/requests/models/MediaListSummary.ts';
 import type { WatchListIntent } from '$lib/requests/models/WatchListIntent.ts';
-import { BehaviorSubject, map, type Observable } from 'rxjs';
+import { useSortParams } from '$lib/sections/lists/stores/useSortParams.ts';
+import { map, type Observable } from 'rxjs';
 import { assertDefined } from '../../../../utils/assert/assertDefined.ts';
 import {
   getListUrl,
@@ -35,7 +36,6 @@ type ListSorting = {
     sortHow: SortDirection;
   }>;
   options: Sorting[];
-  update: (params: Record<string, string>) => void;
   urlBuilder: ListUrlBuilder;
 };
 
@@ -92,24 +92,15 @@ export function useListSorting(
   props: UseListSortingProps,
 ): ListSorting {
   const options = getSortOptions(props);
-  const params = new BehaviorSubject<Record<string, string | null>>({
-    sort_by: null,
-    sort_how: null,
-  });
-
-  function update(newParams: Record<string, string>) {
-    params.next({ ...newParams });
-  }
 
   return {
-    update,
     options,
-    current: params.pipe(
+    current: useSortParams().pipe(
       map(($params) => {
         const defaultDirection = getDefaultDirection(props);
-        const sortBy = mapToSortBy($params.sort_by, options) ??
+        const sortBy = mapToSortBy($params.sortBy, options) ??
           getDefaultSortBy(props);
-        const sortHow = mapToDirection($params.sort_how) ?? defaultDirection;
+        const sortHow = mapToDirection($params.sortHow) ?? defaultDirection;
 
         const sorting = options.find(
           (option) => option.value === sortBy,

--- a/projects/client/src/lib/sections/lists/user/useUserListsSorting.ts
+++ b/projects/client/src/lib/sections/lists/user/useUserListsSorting.ts
@@ -1,7 +1,8 @@
 import type { UserListsSortBy } from '$lib/requests/models/UserListsSortBy.ts';
+import { useSortParams } from '$lib/sections/lists/stores/useSortParams.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
-import { BehaviorSubject, map, type Observable } from 'rxjs';
+import { map, type Observable } from 'rxjs';
 import { userListsSortOptions } from './constants/userListsSortOptions.ts';
 import type {
   ListUrlBuilder,
@@ -16,7 +17,6 @@ type UserListsSorting = {
     sortHow: SortDirection;
   }>;
   options: Sorting<UserListsSortBy>[];
-  update: (params: Record<string, string>) => void;
   urlBuilder: ListUrlBuilder<UserListsSortBy>;
 };
 
@@ -40,22 +40,12 @@ function defaultDirection(sortBy: UserListsSortBy): SortDirection {
 export function useUserListsSorting(
   props: UseUserListsSortingProps,
 ): UserListsSorting {
-  const params = new BehaviorSubject<Record<string, string | null>>({
-    sort_by: null,
-    sort_how: null,
-  });
-
-  function update(newParams: Record<string, string>) {
-    params.next({ ...newParams });
-  }
-
   return {
-    update,
     options: userListsSortOptions,
-    current: params.pipe(
+    current: useSortParams().pipe(
       map(($params) => {
-        const sortBy = mapToSortBy($params.sort_by) ?? 'rank';
-        const sortHow = mapToDirection($params.sort_how) ??
+        const sortBy = mapToSortBy($params.sortBy) ?? 'rank';
+        const sortHow = mapToDirection($params.sortHow) ??
           defaultDirection(sortBy);
         const sorting = userListsSortOptions.find(
           (option) => option.value === sortBy,

--- a/projects/client/src/routes/lists/official/[list]/+page.svelte
+++ b/projects/client/src/routes/lists/official/[list]/+page.svelte
@@ -23,7 +23,7 @@
 
   const listName = $derived($list?.name ?? "");
 
-  const { current, update, options, urlBuilder } = $derived(
+  const { current, options, urlBuilder } = $derived(
     useListSorting({ list: $list, type: "user-list" }),
   );
 </script>
@@ -55,7 +55,6 @@
         {options}
         {urlBuilder}
         current={$current}
-        onUpdate={update}
         disabled={$isLoading}
       />
     {/snippet}

--- a/projects/client/src/routes/profile/[slug]/favorites/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/favorites/+page.svelte
@@ -14,7 +14,7 @@
 
   const { mode, current: currentDiscoverMode } = useDiscover();
 
-  const { current, update, options, urlBuilder } = $derived(
+  const { current, options, urlBuilder } = $derived(
     useListSorting({ type: "favorites", slug: params.slug }),
   );
 </script>
@@ -37,7 +37,6 @@
         {options}
         {urlBuilder}
         current={$current}
-        onUpdate={update}
       />
     {/snippet}
   </ResponsiveNavbarStateSetter>

--- a/projects/client/src/routes/profile/[slug]/progress/+page.svelte
+++ b/projects/client/src/routes/profile/[slug]/progress/+page.svelte
@@ -22,7 +22,6 @@
 
   const {
     current: currentSort,
-    update,
     options: sortOptions,
     urlBuilder,
   } = $derived(useListSorting({ type: "progress", slug: params.slug }));
@@ -59,7 +58,6 @@
             options={progressSortOptions}
             {urlBuilder}
             current={$currentSort}
-            onUpdate={update}
           />
         {/if}
       {/snippet}

--- a/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/[list]/+page.svelte
@@ -24,7 +24,7 @@
 
   const listName = $derived($list?.name ?? "");
 
-  const { current, update, options, urlBuilder } = $derived(
+  const { current, options, urlBuilder } = $derived(
     useListSorting({ list: $list, type: "user-list" }),
   );
 
@@ -55,7 +55,6 @@
         {options}
         {urlBuilder}
         current={$current}
-        onUpdate={update}
         disabled={$isLoading}
       />
     {/snippet}

--- a/projects/client/src/routes/users/[user]/lists/view/personal/+page.svelte
+++ b/projects/client/src/routes/users/[user]/lists/view/personal/+page.svelte
@@ -16,7 +16,7 @@
 
   const { current } = useDiscover();
   const { isMe } = $derived(useIsMe(params.user));
-  const { current: sorting, update, options, urlBuilder } =
+  const { current: sorting, options, urlBuilder } =
     $derived(useUserListsSorting({ slug: params.user }));
 </script>
 
@@ -49,7 +49,6 @@
         {options}
         {urlBuilder}
         current={$sorting}
-        onUpdate={update}
       />
     {/snippet}
   </ResponsiveNavbarStateSetter>

--- a/projects/client/src/routes/users/[user]/progress/+page.svelte
+++ b/projects/client/src/routes/users/[user]/progress/+page.svelte
@@ -15,7 +15,6 @@
 
   const {
     current: currentSort,
-    update,
     options: sortOptions,
     urlBuilder,
   } = useUpNextSorting(page.params.user ?? "me");
@@ -37,7 +36,6 @@
         options={$sortOptions}
         {urlBuilder}
         current={$currentSort}
-        onUpdate={update}
       />
     {/snippet}
   </ResponsiveNavbarStateSetter>

--- a/projects/client/src/routes/users/[user]/start-watching/+page.svelte
+++ b/projects/client/src/routes/users/[user]/start-watching/+page.svelte
@@ -11,7 +11,7 @@
 
   const { mode, current: currentDiscoverMode } = useDiscover();
 
-  const { current, update, options, urlBuilder } = useListSorting({
+  const { current, options, urlBuilder } = useListSorting({
     type: "watchlist",
     intent: "start",
   });
@@ -36,7 +36,6 @@
         {options}
         {urlBuilder}
         current={$current}
-        onUpdate={update}
       />
     {/snippet}
   </ResponsiveNavbarStateSetter>

--- a/projects/client/src/routes/users/[user]/watchlist/+page.svelte
+++ b/projects/client/src/routes/users/[user]/watchlist/+page.svelte
@@ -14,7 +14,7 @@
 
   const { mode, current: currentDiscoverMode } = useDiscover();
 
-  const { current, update, options, urlBuilder } = useListSorting({
+  const { current, options, urlBuilder } = useListSorting({
     type: "watchlist",
     intent: "default",
   });
@@ -57,7 +57,6 @@
         {options}
         {urlBuilder}
         current={$current}
-        onUpdate={update}
       />
     {/snippet}
   </ResponsiveNavbarStateSetter>


### PR DESCRIPTION
## Scene Setting: A Clear Description

The sorting stores (`useListSorting`, `useUpNextSorting`, `useUserListsSorting`) boot with `null` sort params; the URL's `sort_by`/`sort_how` only sync in via a post-mount `$effect` in `ListSortActions`. Result: refreshing any sorted list page fetches page 1 twice — once with the fallback sort (briefly rendering the wrong order), then again with the URL's sort.

Fix: seed each store from `page.url.searchParams` at construction. The effect then pushes identical values, the query key never changes, and only one request fires.

## Show, Don't Tell: Screenshots and Videos

Refreshing `/users/me/watchlist?sort_by=rank&sort_how=asc`, before:

```
GET .../watchlist/movie,show?...&sort_by=added&sort_how=desc   ← wasted
GET .../watchlist/movie,show?...&sort_by=rank&sort_how=asc
```

After: only the second call.

## Testing: The Dress Rehearsal

- `useListSorting.spec.ts`: new spec asserting the store's first emission already carries the URL's sort.
- Manual: refresh a list page with sort params in the URL — one request in the network tab, no re-order flicker.