### PR TITLE
fix(show): resolve active season for specials-only shows

### DIFF
--- a/projects/client/src/lib/utils/media/findActiveSeason.spec.ts
+++ b/projects/client/src/lib/utils/media/findActiveSeason.spec.ts
@@ -26,10 +26,23 @@ describe('findActiveSeason', () => {
     { number: 3, episodeCount: 8 },
   ]);
 
+  const specialsOnly = createSeasons([
+    { number: 0, episodeCount: 1 },
+  ]);
+
   it('should return season 1 if there is no watched season', () => {
     const result = findActiveSeason({
       seasons,
       lastWatchedSeason: EMPTY_SEASON_INFO,
+    });
+
+    expect(result).toBe(1);
+  });
+
+  it('should return season 1 for a structural copy of the empty season info', () => {
+    const result = findActiveSeason({
+      seasons,
+      lastWatchedSeason: { ...EMPTY_SEASON_INFO },
     });
 
     expect(result).toBe(1);
@@ -101,6 +114,60 @@ describe('findActiveSeason', () => {
         number: 5,
         episodes: { count: 8 },
       },
+    });
+
+    expect(result).toBe(2);
+  });
+
+  it('should fallback to specials for a specials-only show when there is no watched season', () => {
+    const result = findActiveSeason({
+      seasons: specialsOnly,
+      lastWatchedSeason: EMPTY_SEASON_INFO,
+    });
+
+    expect(result).toBe(0);
+  });
+
+  it('should fallback to specials for a specials-only show when lastWatchedSeason not found in seasons', () => {
+    const result = findActiveSeason({
+      seasons: specialsOnly,
+      lastWatchedSeason: {
+        number: -1,
+        episodes: { count: 1 },
+      },
+    });
+
+    expect(result).toBe(0);
+  });
+
+  it('should stay on the last season when seasons are out of order', () => {
+    const unordered = createSeasons([
+      { number: 1, episodeCount: 10 },
+      { number: 2, episodeCount: 12 },
+      { number: 0, episodeCount: 3 },
+    ]);
+
+    const result = findActiveSeason({
+      seasons: unordered,
+      lastWatchedSeason: {
+        number: 2,
+        episodes: { count: 12 },
+      },
+    });
+
+    expect(result).toBe(2);
+  });
+
+  it('should fallback to the lowest non-special season when seasons are out of order', () => {
+    const unordered = createSeasons([
+      { number: 0, episodeCount: 3 },
+      { number: 3, episodeCount: 8 },
+      { number: 2, episodeCount: 12 },
+    ]);
+
+    const result = findActiveSeason({
+      seasons: unordered,
+      lastWatchedSeason: EMPTY_SEASON_INFO,
     });
 
     expect(result).toBe(2);

--- a/projects/client/src/lib/utils/media/findActiveSeason.ts
+++ b/projects/client/src/lib/utils/media/findActiveSeason.ts
@@ -1,5 +1,4 @@
 import type { Season } from '$lib/requests/models/Season.ts';
-import { EMPTY_SEASON_INFO } from '$lib/sections/lists/stores/useUserSeason.ts';
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 
 const FIRST_SEASON = 1;
@@ -19,20 +18,25 @@ export function findActiveSeason({
   seasons,
   lastWatchedSeason,
 }: FindActiveSeasonProps) {
-  if (lastWatchedSeason === EMPTY_SEASON_INFO) {
-    return FIRST_SEASON;
+  const ordered = [...seasons].sort((a, b) => a.number - b.number);
+
+  const fallbackSeason = ordered.find((s) => s.number === FIRST_SEASON) ??
+    ordered.find((s) => s.number !== SPECIAL_SEASON) ??
+    ordered.at(0);
+
+  const hasWatchedHistory = lastWatchedSeason.number >= SPECIAL_SEASON &&
+    lastWatchedSeason.episodes.count > 0;
+
+  if (!hasWatchedHistory) {
+    return fallbackSeason?.number ?? FIRST_SEASON;
   }
 
-  const lastWatched = seasons.find((s) =>
+  const lastWatched = ordered.find((s) =>
     s.number === lastWatchedSeason.number
-  );
-  const firstSeason = seasons.find((s) => s.number === FIRST_SEASON);
-  const firstNonSpecialSeason = seasons.find((s) =>
-    s.number !== SPECIAL_SEASON
   );
 
   const active = assertDefined(
-    lastWatched ?? firstSeason ?? firstNonSpecialSeason,
+    lastWatched ?? fallbackSeason,
     'Active season not found',
   );
 
@@ -41,7 +45,7 @@ export function findActiveSeason({
     active.number === lastWatchedSeason.number;
 
   const maxSeason = assertDefined(
-    seasons.at(-1),
+    ordered.at(-1),
     'Could not find last season',
   ).number;
   const nextSeason = Math.min(active.number + 1, maxSeason);


### PR DESCRIPTION
## Scene Setting: A Clear Description

Fixes #2878

`findActiveSeason` asserted `Active season not found` for shows with no season 1 and no non-special seasons — e.g. *The Farthest*, which only has Specials — crashing the show page for authenticated users. The no-watched-history path had the same blind spot: it hardcoded season 1 even when it doesn't exist, landing on an empty season.

Both paths now resolve through the same fallback chain: season 1 → first non-special season → first available season (Specials).

## Testing: The Dress Rehearsal

- Two new specs in `findActiveSeason.spec.ts`: specials-only show with and without watch history, both resolving to season 0 (9 passing).
- Verified against the live *The Farthest* page: lands on Specials (S0E1, Voyager in Space) signed in and signed out; hard refresh on `?season=0` renders fine.