### PR TITLE
fix(summary): dedupe social activity entries by user

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/useSocialActivities.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/useSocialActivities.spec.ts
@@ -1,0 +1,31 @@
+import { MediaSocialResponseMock } from '$mocks/data/summary/common/response/MediaSocialResponseMock.ts';
+import { server } from '$mocks/server.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { valueObservable } from '$test/beds/store/valueObservable.ts';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { useSocialActivities } from './useSocialActivities.ts';
+
+describe('store: useSocialActivities', () => {
+  it('should drop duplicate entries for the same user (#2834)', async () => {
+    const harry = MediaSocialResponseMock.at(0);
+
+    server.use(
+      http.get(
+        'http://localhost/movies/duplicated-social/social',
+        () => HttpResponse.json([harry, harry]),
+      ),
+    );
+
+    const entries = await runQuery({
+      factory: () =>
+        useSocialActivities(
+          valueObservable({ type: 'movie', slug: 'duplicated-social' }),
+        ).entries,
+      waitFor: (value) => value.length > 0,
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries.at(0)?.user.username).toBe(harry?.user.username);
+  });
+});

--- a/projects/client/src/lib/sections/summary/components/_internal/useSocialActivities.ts
+++ b/projects/client/src/lib/sections/summary/components/_internal/useSocialActivities.ts
@@ -6,6 +6,7 @@ import {
   mediaSocialQuery,
   type MediaSocialQueryTarget,
 } from '$lib/requests/queries/media/mediaSocialQuery.ts';
+import { dedupe } from '$lib/utils/array/dedupe.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import { map, type Observable, switchMap } from 'rxjs';
 import { sortMediaSocialEntries } from './sortMediaSocialEntries.ts';
@@ -32,10 +33,15 @@ export function useSocialActivities(
     }),
   );
 
+  // The social endpoint can return the same user twice (also across pages),
+  // which blows up keyed `{#each}` blocks downstream (see #2834).
   const entries = query.pipe(
     map(($query) =>
       sortMediaSocialEntries(
-        $query.data?.pages.flatMap((page) => page.entries) ?? [],
+        dedupe(
+          (entry) => entry.key,
+          $query.data?.pages.flatMap((page) => page.entries) ?? [],
+        ),
       )
     ),
   );


### PR DESCRIPTION
## Scene Setting

Logged-in visits to TNG S1×01 (and any media with the same data quirk) crashed with the generic error page. The `/social` endpoint can return the same followed user as two rows — duplicate rating rows left over from episode merges fan out server-side — and `AvatarPill`'s keyed `{#each}` throws `each_key_duplicate`.

This dedupes entries by user where the pages flatten in `useSocialActivities`, covering both the activities button and the social drawer.

Fixes #2834

## Testing

- New spec: a response containing the same user twice collapses to a single entry.
- Full unit suite green.
- Verified locally against the live endpoint: the episode page renders again while logged in.

---

**Belt and suspenders:** a companion PR is going up on the API to squash the duplicates at the source (ratings join fan-out). This client-side dedupe stays as defense so a bad row can never take down the page.