### PR TITLE
History: filter watched history by sync id

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -227,6 +227,37 @@
       "default": "Undone",
       "description": "Shown when a data sync has been undone."
     },
+    "text_history_sync_filter": {
+      "default": "Sync ID {id}",
+      "description": "Subtitle shown in the history page header when the list is scoped to one data sync. {id} is the numeric data sync id.",
+      "variables": {
+        "id": {
+          "type": "number",
+          "description": "The data sync id the history is filtered by.",
+          "required": true
+        }
+      }
+    },
+    "text_history_sync_filter_with_source": {
+      "default": "Sync ID {id} ({source})",
+      "description": "Subtitle shown in the history page header when the list is scoped to one data sync whose source is known. {id} is the numeric data sync id; {source} is the source/service brand name (e.g. Apple TV).",
+      "variables": {
+        "id": {
+          "type": "number",
+          "description": "The data sync id the history is filtered by.",
+          "required": true
+        },
+        "source": {
+          "type": "string",
+          "description": "The data sync source brand name, e.g. Apple TV.",
+          "required": true
+        }
+      }
+    },
+    "link_label_history_all": {
+      "default": "Back to full history",
+      "description": "Accessible label for the history header link that clears the data-sync filter and shows the full history."
+    },
     "header_data_syncs": {
       "default": "Data Syncs",
       "description": "Header for the list of recent data syncs."

--- a/projects/client/src/lib/requests/queries/users/activityHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/activityHistoryQuery.ts
@@ -27,6 +27,7 @@ type ActivityHistoryParams =
     slug: string;
     startDate?: Date;
     endDate?: Date;
+    syncId?: number;
   }
   & ApiParams
   & PaginationParams
@@ -39,7 +40,7 @@ const HistorySchema = z.discriminatedUnion('type', [
 export type ActivityHistory = z.infer<typeof HistorySchema>;
 
 export function activityHistoryRequest(
-  { fetch, slug, startDate, endDate, limit, page, filter }:
+  { fetch, slug, startDate, endDate, limit, page, filter, syncId }:
     ActivityHistoryParams,
 ) {
   const queryParams = {
@@ -48,6 +49,7 @@ export function activityHistoryRequest(
     end_at: endDate?.toISOString(),
     limit,
     page,
+    sync_id: syncId,
     ...filter,
   };
 
@@ -81,6 +83,7 @@ export const activityHistoryQuery = defineInfiniteQuery({
     params.limit,
     params.page,
     params.slug,
+    params.syncId,
     ...getGlobalFilterDependencies(params.filter),
   ],
   request: activityHistoryRequest,

--- a/projects/client/src/lib/requests/queries/users/episodeActivityHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/episodeActivityHistoryQuery.ts
@@ -20,6 +20,7 @@ type EpisodeActivityHistoryParams =
     startDate?: Date;
     endDate?: Date;
     id?: number;
+    syncId?: number;
   }
   & ApiParams
   & PaginationParams
@@ -38,7 +39,7 @@ export type EpisodeActivityHistory = z.infer<
 >;
 
 export function episodeActivityHistoryRequest(
-  { fetch, slug, startDate, endDate, limit, id, page, filter }:
+  { fetch, slug, startDate, endDate, limit, id, page, filter, syncId }:
     EpisodeActivityHistoryParams,
 ) {
   const queryParams = {
@@ -47,6 +48,7 @@ export function episodeActivityHistoryRequest(
     end_at: endDate?.toISOString(),
     limit,
     page,
+    sync_id: syncId,
     ...filter,
   };
 
@@ -87,6 +89,7 @@ export const episodeActivityHistoryQuery = defineInfiniteQuery({
     params.page,
     params.id,
     params.slug,
+    params.syncId,
     ...getGlobalFilterDependencies(params.filter),
   ],
   request: episodeActivityHistoryRequest,

--- a/projects/client/src/lib/requests/queries/users/movieActivityHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/movieActivityHistoryQuery.ts
@@ -18,6 +18,7 @@ type MovieActivityHistoryParams =
     startDate?: Date;
     endDate?: Date;
     id?: number;
+    syncId?: number;
   }
   & ApiParams
   & PaginationParams
@@ -33,7 +34,7 @@ export const MovieActivityHistorySchema = z.object({
 export type MovieActivityHistory = z.infer<typeof MovieActivityHistorySchema>;
 
 export const movieActivityHistoryRequest = (
-  { fetch, slug, startDate, endDate, limit, id, page, filter }:
+  { fetch, slug, startDate, endDate, limit, id, page, filter, syncId }:
     MovieActivityHistoryParams,
 ) => {
   const queryParams = {
@@ -42,6 +43,7 @@ export const movieActivityHistoryRequest = (
     end_at: endDate?.toISOString(),
     limit,
     page,
+    sync_id: syncId,
     ...filter,
   };
 
@@ -76,6 +78,7 @@ export const movieActivityHistoryQuery = defineInfiniteQuery({
     params.page,
     params.id,
     params.slug,
+    params.syncId,
     ...getGlobalFilterDependencies(params.filter),
   ],
   request: movieActivityHistoryRequest,

--- a/projects/client/src/lib/requests/queries/users/showActivityHistoryQuery.ts
+++ b/projects/client/src/lib/requests/queries/users/showActivityHistoryQuery.ts
@@ -21,6 +21,7 @@ type ShowActivityHistoryParams =
     startDate?: Date;
     endDate?: Date;
     id?: number;
+    syncId?: number;
   }
   & ApiParams
   & PaginationParams
@@ -30,7 +31,7 @@ type ShowActivityHistoryParams =
 export type ShowActivityHistory = EpisodeActivityHistory;
 
 const showHistoryRequest = (
-  { fetch, slug, startDate, endDate, limit, id, page, filter }:
+  { fetch, slug, startDate, endDate, limit, id, page, filter, syncId }:
     ShowActivityHistoryParams,
 ) => {
   const queryParams = {
@@ -39,6 +40,7 @@ const showHistoryRequest = (
     end_at: endDate?.toISOString(),
     limit,
     page,
+    sync_id: syncId,
     ...filter,
   };
 
@@ -77,6 +79,7 @@ export const showActivityHistoryQuery = defineInfiniteQuery({
     params.page,
     params.id,
     params.slug,
+    params.syncId,
     ...getGlobalFilterDependencies(params.filter),
   ],
   request: showHistoryRequest,

--- a/projects/client/src/lib/sections/lists/history/PersonalHistoryPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/PersonalHistoryPaginatedList.svelte
@@ -8,7 +8,7 @@
   import { toRecentlyWatchedType } from "./_internal/toRecentlyWatchedType";
   import RecentlyWatchedItem from "./RecentlyWatchedItem.svelte";
 
-  const { mode }: { mode?: DiscoverMode } = $props();
+  const { mode, syncId }: { mode?: DiscoverMode; syncId?: number } = $props();
 
   const order = "reverse-chronological" as const;
 
@@ -24,6 +24,7 @@
       slug: "me",
       limit: HISTORY_UPPER_LIMIT,
       filter: $filterMap,
+      syncId,
     }),
   );
 

--- a/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
+++ b/projects/client/src/lib/sections/lists/stores/useRecentlyWatchedList.ts
@@ -36,6 +36,7 @@ type RecentlyWatchedListStoreProps =
     limit?: number;
     slug?: string;
     page?: number;
+    syncId?: number;
   }
   & FilterParams
   & (SpecificHistory | MediaHistory);
@@ -48,6 +49,7 @@ function typeToQuery(
     slug: props.slug ?? 'me',
     page: props.page ?? 1,
     filter: props.filter,
+    syncId: props.syncId,
   };
 
   switch (props.type) {

--- a/projects/client/src/lib/sections/settings/_internal/streaming-services/DataSyncRow.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/streaming-services/DataSyncRow.svelte
@@ -5,6 +5,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import type { DataSync } from "$lib/requests/models/DataSync.ts";
   import { toHumanDate } from "$lib/utils/formatting/date/toHumanDate.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
   import StreamingServiceBadge from "./StreamingServiceBadge.svelte";
   import type { ServiceInfo } from "./toServiceInfo.ts";
   import {
@@ -68,6 +69,8 @@
   });
 
   const hasBreakdown = $derived(groups.length > 0 || flags.length > 0);
+
+  const hasHistory = $derived(toSyncCountLabels(sync.items.history).length > 0);
 </script>
 
 {#snippet pill(label: string, kind: "added" | "flag")}
@@ -138,15 +141,28 @@
         {/if}
       </div>
     {:else}
-      <Button
-        size="small"
-        variant="secondary"
-        color="default"
-        label={m.button_text_undo()}
-        onclick={onUndo}
-      >
-        {m.button_text_undo()}
-      </Button>
+      <div class="actions">
+        {#if hasHistory}
+          <Button
+            size="small"
+            variant="secondary"
+            color="default"
+            label={m.list_title_history()}
+            href={UrlBuilder.history.sync(sync.id)}
+          >
+            {m.list_title_history()}
+          </Button>
+        {/if}
+        <Button
+          size="small"
+          variant="secondary"
+          color="default"
+          label={m.button_text_undo()}
+          onclick={onUndo}
+        >
+          {m.button_text_undo()}
+        </Button>
+      </div>
     {/if}
   </div>
 </div>
@@ -246,6 +262,12 @@
 
   .action {
     flex-shrink: 0;
+  }
+
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: var(--ni-8);
   }
 
   .undone-state {

--- a/projects/client/src/lib/utils/formatting/string/toSyncSourceName.ts
+++ b/projects/client/src/lib/utils/formatting/string/toSyncSourceName.ts
@@ -1,0 +1,26 @@
+// Brand names are not localized, so this is a plain lookup rather than an i18n
+// message map. Only multi-word / stylized brands need an override; the rest
+// title-case from their slug.
+const SYNC_SOURCE_NAMES: Readonly<Record<string, string>> = {
+  appletv: 'Apple TV',
+  tvtime: 'TV Time',
+  imdb: 'IMDb',
+  hbomax: 'HBO Max',
+};
+
+export function toSyncSourceName(source: string): string {
+  const key = source.trim().toLowerCase();
+  if (key.length === 0) {
+    return source;
+  }
+
+  const known = SYNC_SOURCE_NAMES[key];
+  if (known) {
+    return known;
+  }
+
+  return key
+    .split(/[\s_-]+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -117,6 +117,8 @@ const ogSupportFactory = (username?: string): HttpsUrl | MailToUrl => {
 export const UrlBuilder = {
   history: {
     home: () => '/history',
+    sync: (syncId: number) =>
+      `/history${buildParamString({ sync_id: syncId })}`,
     category: (params: UrlBuilderParams) => {
       return categoryDrilldownFactory('history')(params);
     },

--- a/projects/client/src/routes/history/+page.svelte
+++ b/projects/client/src/routes/history/+page.svelte
@@ -1,14 +1,66 @@
-<script>
+<script lang="ts">
+  import { page } from "$app/state";
   import CalendarProvider from "$lib/features/calendar/CalendarProvider.svelte";
-  import { useDiscover } from "$lib/features/filters/useDiscover";
-  import * as m from "$lib/features/i18n/messages";
+  import { useDiscover } from "$lib/features/filters/useDiscover.ts";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { useQuery } from "$lib/features/query/useQuery.ts";
+  import { dataSyncQuery } from "$lib/requests/queries/streaming-sync/dataSyncQuery.ts";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
   import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
   import PersonalHistoryPaginatedList from "$lib/sections/lists/history/PersonalHistoryPaginatedList.svelte";
   import ResponsiveNavbarStateSetter from "$lib/sections/navbar/ResponsiveNavbarStateSetter.svelte";
-  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets.ts";
+  import { toSyncSourceName } from "$lib/utils/formatting/string/toSyncSourceName.ts";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+  import { filter, map } from "rxjs";
 
   const { mode, current } = useDiscover();
+
+  // Read off the URL, not the global parameter map, so it never sticks across
+  // navigation.
+  const syncId = $derived.by(() => {
+    const raw = page.url.searchParams.get("sync_id");
+    if (!raw) return undefined;
+
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  });
+
+  const syncId$ = fromRune(() => syncId);
+  const syncQuery = useQuery(
+    syncId$.pipe(
+      filter((id): id is number => id != null),
+      map((id) => dataSyncQuery({ id })),
+    ),
+  );
+  const syncSource = syncQuery.pipe(
+    map((queryState) => queryState.data?.source),
+  );
+
+  const syncSourceName = $derived(
+    $syncSource ? toSyncSourceName($syncSource) : undefined,
+  );
+
+  const syncMetaInfo = $derived.by(() => {
+    if (syncId == null) return undefined;
+
+    return syncSourceName == null
+      ? m.text_history_sync_filter({ id: syncId })
+      : m.text_history_sync_filter_with_source({
+          id: syncId,
+          source: syncSourceName,
+        });
+  });
+
+  const header = $derived({
+    title: m.list_title_history(),
+    metaInfo: syncId == null ? $current.text() : syncMetaInfo,
+    back: syncId == null ? undefined : {
+      href: UrlBuilder.history.home(),
+      label: m.link_label_history_all(),
+    },
+  });
 </script>
 
 <TraktPage
@@ -18,12 +70,9 @@
 >
   <TraktPageCoverSetter />
 
-  <ResponsiveNavbarStateSetter
-    hasFilters
-    header={{ title: m.list_title_history(), metaInfo: $current.text() }}
-  />
+  <ResponsiveNavbarStateSetter hasFilters {header} />
 
   <CalendarProvider>
-    <PersonalHistoryPaginatedList mode={$mode} />
+    <PersonalHistoryPaginatedList mode={$mode} {syncId} />
   </CalendarProvider>
 </TraktPage>


### PR DESCRIPTION
# Summary

Adds the ability to view your watched history scoped to a single data sync. Each row in the Data Syncs table (settings, shared by streaming/Younify and Plex) gets a **History** link that opens `/history?sync_id=<id>`, and the history page reads that id, filters the list to that sync, and shows a header subtitle naming the sync and its source, e.g. `Sync ID 10562210 (Apple TV)`.

# Changes

- Thread `sync_id` through all four history queries (`activity` / `movie` / `show` / `episode`) as a first-class param with its own cache dependency, so each sync gets a distinct query-cache entry rather than colliding with the unfiltered view.
- Add `syncId` to `useRecentlyWatchedList` and `PersonalHistoryPaginatedList` so the mode toggle (Movies / Shows / All) stays filtered.
- Add a **History** button before **Undo** in `DataSyncRow`, gated on the sync actually having imported history plays so it never links to an empty view.
- `UrlBuilder.history.forSync(syncId)` builds the filtered URL; only `sync_id` travels in it.
- The history route reads `sync_id` straight off the URL (not the sticky global parameter map, so it never persists across navigation), looks the sync up via the existing `dataSyncQuery`, and resolves the source brand name with a new `toSyncSourceName` helper.
- Header shows the sync subtitle plus a "Back to full history" link to clear the filter.
- New i18n keys: `button_text_history`, `text_history_sync_filter`, `text_history_sync_filter_with_source`, `link_label_history_all`.

# Screenshots

### History button on the Data Syncs row

<img width="743" height="244" alt="image" src="https://github.com/user-attachments/assets/4a989deb-c2d7-44d7-bec5-ce6065ae439e" />

### Filtered history page header

<img width="1058" height="552" alt="image" src="https://github.com/user-attachments/assets/9928c300-e0f1-48b0-ab70-98a8e4b4c6fa" />

# Notes

History filtering matches rows tagged with `activities_deux.sync_id` on the backend. Today only importer syncs (Apple TV, Letterboxd, etc.) carry that tag; the Younify streaming-sync pipeline does not stamp it yet, so clicking History on a Younify sync currently returns an empty list until that is addressed on the backend. The button is gated on the sync's reported history counts, not on stamped rows, so it can still surface for those.
