### PR TITLE
fix(search): filter trending results by active mode

### DIFF
--- a/projects/client/src/lib/features/search/useSearch.spec.ts
+++ b/projects/client/src/lib/features/search/useSearch.spec.ts
@@ -1,7 +1,9 @@
+import { MovieHereticResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticResponseMock.ts';
+import { ShowSiloResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloResponseMock.ts';
 import { renderStore } from '$test/beds/store/renderStore.ts';
 import { waitForEmission } from '$test/readable/waitForEmission.ts';
 import type { Subscription } from 'rxjs';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { useSearch } from './useSearch.ts';
 
 const { trackSpy } = vi.hoisted(() => ({ trackSpy: vi.fn() }));
@@ -31,6 +33,31 @@ describe('useSearch', () => {
     expect(await waitForEmission(results, 1)).toEqual(null);
   });
 
+  it('should include trending entries of every type in media mode', async () => {
+    const { search, results } = await renderStore(() => useSearch());
+
+    search(MovieHereticResponseMock.title, 'media');
+    // Emission 1 is the intl overlay's empty first pass; 2 carries the items.
+    const response = await waitForEmission(results, 2);
+
+    expect(response?.items.map((item) => item.slug)).toContain(
+      ShowSiloResponseMock.ids.slug,
+    );
+  });
+
+  it('should exclude trending entries of other types when a typed mode is active', async () => {
+    const { search, results } = await renderStore(() => useSearch());
+
+    search(MovieHereticResponseMock.title, 'movie');
+    const response = await waitForEmission(results, 2);
+    const items = response?.type === 'media' ? response.items : [];
+
+    expect(items.map((item) => item.slug)).toContain(
+      MovieHereticResponseMock.ids.slug,
+    );
+    expect(items.every((item) => item.type === 'movie')).toBe(true);
+  });
+
   /**
    * TODO: add more scenarios here once I figure out the AbortSignal error in testing
    */
@@ -51,6 +78,13 @@ describe('useSearch: tracking volume', () => {
     subscriptions.push(store.results.subscribe());
     return store;
   }
+
+  // `shareReplay(1)` keeps a pipeline alive past its subscriber, so earlier
+  // tests leave debounced tracks in flight. Drain before counting.
+  beforeAll(async () => {
+    await settle(1400);
+    trackSpy.mockClear();
+  });
 
   afterEach(() => {
     subscriptions.splice(0).forEach((entry) => entry.unsubscribe());

--- a/projects/client/src/lib/requests/queries/search/searchTrendingQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/search/searchTrendingQuery.spec.ts
@@ -1,0 +1,37 @@
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import { MovieHereticResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticResponseMock.ts';
+import { ShowSiloResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloResponseMock.ts';
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { describe, expect, it } from 'vitest';
+import { searchTrendingQuery } from './searchTrendingQuery.ts';
+
+describe('searchTrendingQuery', () => {
+  async function trendingSlugs(type?: MediaType) {
+    const result = await runQuery({
+      factory: () => createTestBedQuery(searchTrendingQuery({ type })),
+      waitFor: (response) => Boolean(response.data),
+    });
+
+    return result.data?.items.map((item) => item.slug);
+  }
+
+  it('should return trending movies and shows', async () => {
+    expect(await trendingSlugs()).toEqual([
+      ShowSiloResponseMock.ids.slug,
+      MovieHereticResponseMock.ids.slug,
+    ]);
+  });
+
+  it('should return only trending movies for the movie type', async () => {
+    expect(await trendingSlugs('movie')).toEqual([
+      MovieHereticResponseMock.ids.slug,
+    ]);
+  });
+
+  it('should return only trending shows for the show type', async () => {
+    expect(await trendingSlugs('show')).toEqual([
+      ShowSiloResponseMock.ids.slug,
+    ]);
+  });
+});

--- a/projects/client/src/mocks/data/search/response/TrendingSearchedMoviesResponseMock.ts
+++ b/projects/client/src/mocks/data/search/response/TrendingSearchedMoviesResponseMock.ts
@@ -1,0 +1,12 @@
+import { MovieHereticResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticResponseMock.ts';
+import type { TrendingSearchMovieResultResponse } from '@trakt/api';
+
+export const TrendingSearchedMoviesResponseMock:
+  TrendingSearchMovieResultResponse[] = [
+    {
+      id: MovieHereticResponseMock.ids.trakt,
+      count: 100,
+      type: 'movie',
+      movie: MovieHereticResponseMock,
+    },
+  ];

--- a/projects/client/src/mocks/data/search/response/TrendingSearchedShowsResponseMock.ts
+++ b/projects/client/src/mocks/data/search/response/TrendingSearchedShowsResponseMock.ts
@@ -1,0 +1,12 @@
+import { ShowSiloResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloResponseMock.ts';
+import type { TrendingSearchShowResultResponse } from '@trakt/api';
+
+export const TrendingSearchedShowsResponseMock:
+  TrendingSearchShowResultResponse[] = [
+    {
+      id: ShowSiloResponseMock.ids.trakt,
+      count: 200,
+      type: 'show',
+      show: ShowSiloResponseMock,
+    },
+  ];

--- a/projects/client/src/mocks/handlers/search.ts
+++ b/projects/client/src/mocks/handlers/search.ts
@@ -1,16 +1,29 @@
 import { http, HttpResponse } from 'msw';
 
+import { TrendingSearchedMoviesResponseMock } from '$mocks/data/search/response/TrendingSearchedMoviesResponseMock.ts';
+import { TrendingSearchedShowsResponseMock } from '$mocks/data/search/response/TrendingSearchedShowsResponseMock.ts';
 import { SearchHereticResponseMock } from '../data/search/response/SearchHereticResponseMock.ts';
 import { MovieHereticResponseMock } from '../data/summary/movies/heretic/response/MovieHereticResponseMock.ts';
 
 export const search = [
+  http.get(
+    'http://localhost/search/recent_by_id/global/movies',
+    () => HttpResponse.json(TrendingSearchedMoviesResponseMock),
+  ),
+  http.get(
+    'http://localhost/search/recent_by_id/global/shows',
+    () => HttpResponse.json(TrendingSearchedShowsResponseMock),
+  ),
   http.get(
     'http://localhost/search/*',
     ({ request }) => {
       const url = new URL(request.url);
       const searchQuery = url.searchParams.get('query');
 
-      if (searchQuery === MovieHereticResponseMock.title) {
+      if (
+        searchQuery?.toLowerCase() ===
+          MovieHereticResponseMock.title.toLowerCase()
+      ) {
         return HttpResponse.json(SearchHereticResponseMock);
       }
 


### PR DESCRIPTION
## Scene Setting

The mode toggles on search results filter the typed search queries, but the trending search overlay always fetches movies **and** shows and merges them in unfiltered — so shows leak into Movies mode and vice versa. This filters trending entries by the active mode before the merge. The trending cache stays shared across modes, so toggling never triggers a refetch.

Fixes #2977

## Show, Don't Tell

**Before** (from the issue — the Avatar show listed under Movies, movies mixed into Shows):

<img width="1641" alt="show listed as movie" src="https://github.com/user-attachments/assets/0a895a41-2768-45b2-8f7c-a74c2b62e676" />
<img width="1635" alt="movies mixed into shows" src="https://github.com/user-attachments/assets/cfac717a-0a19-4bcd-906d-4688b061a0ed" />

**After**

<img width="2642" height="814" alt="CleanShot 2026-07-23 at 10 43 26@2x" src="https://github.com/user-attachments/assets/4e9fdf7b-3c53-49a6-9016-19f3edd09f0e" />
<img width="2972" height="1090" alt="CleanShot 2026-07-23 at 10 44 06@2x" src="https://github.com/user-attachments/assets/347b8df1-8a4a-4bdc-bf08-41ebc82b1115" />


## Testing

- New regression specs in `useSearch.spec.ts`: media mode includes trending entries of every type; movie mode excludes other types. Verified the movie-mode spec fails without the fix.
- New `searchTrendingQuery.spec.ts` plus MSW handlers/fixtures for the trending endpoints (previously unmocked; the catch-all search mock also matched case-sensitively and could never hit, since `useSearch` lowercases terms).
