### PR TITLE
Better translation of "link_text_preview_settings" on nl-NL.json

### DIFF
--- a/projects/client/i18n/messages/nl-NL.json
+++ b/projects/client/i18n/messages/nl-NL.json
@@ -937,7 +937,7 @@
   "link_text_general_settings": "Algemeen",
   "link_text_plex_settings": "Plex",
   "link_text_policy": "Privacybeleid",
-  "link_text_preview_settings": "Voorbeeld",
+  "link_text_preview_settings": "Preview",
   "link_text_privacy": "Privacy",
   "link_text_service_status": "Trakt-servicestatus",
   "link_text_streaming_sync_settings": "Streamen",


### PR DESCRIPTION
Better translation of "link_text_preview_settings", because 'Voorbeeld' seems like 'Example'. Something like 'Bèta' could be an option too.