### PR TITLE
Reorg Account Settings

### DIFF
--- a/projects/client/i18n/messages/ar-SA.json
+++ b/projects/client/i18n/messages/ar-SA.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "إيجابي",
   "header_settings_clear_cover": "مسح صورة الغلاف",
   "header_settings_notifications": "الإخطارات",
-  "header_settings_privacy": "الخصوصية والاشتراك",
   "header_settings_tracking": "تتبع",
   "header_settings_translations": "الترجمات",
   "header_skipped_items": "العناصر التي تم تخطيها ({count})",

--- a/projects/client/i18n/messages/bg-BG.json
+++ b/projects/client/i18n/messages/bg-BG.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Положително",
   "header_settings_clear_cover": "Изчисти корицата",
   "header_settings_notifications": "Известия",
-  "header_settings_privacy": "Поверителност & Абонамент",
   "header_settings_tracking": "Проследяване",
   "header_settings_translations": "Преводи",
   "header_skipped_items": "{count} пропуснати елемента",

--- a/projects/client/i18n/messages/ca-ES.json
+++ b/projects/client/i18n/messages/ca-ES.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positiu",
   "header_settings_clear_cover": "Esborra la imatge de portada",
   "header_settings_notifications": "Notificacions",
-  "header_settings_privacy": "Privadesa i subscripció",
   "header_settings_tracking": "Seguiment",
   "header_settings_translations": "Traduccions",
   "header_skipped_items": "{count} elements omesos",

--- a/projects/client/i18n/messages/da-DK.json
+++ b/projects/client/i18n/messages/da-DK.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positiv",
   "header_settings_clear_cover": "Ryd Coverbillede",
   "header_settings_notifications": "Notifikationer",
-  "header_settings_privacy": "Privatliv & Abonnement",
   "header_settings_tracking": "Sporing",
   "header_settings_translations": "Oversættelser",
   "header_skipped_items": "{count} Oversprungne Elementer",

--- a/projects/client/i18n/messages/de-DE.json
+++ b/projects/client/i18n/messages/de-DE.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positiv",
   "header_settings_clear_cover": "Coverbild löschen",
   "header_settings_notifications": "Benachrichtigungen",
-  "header_settings_privacy": "Datenschutz & Abonnement",
   "header_settings_tracking": "Tracking",
   "header_settings_translations": "Übersetzungen",
   "header_skipped_items": "{count} übersprungene Elemente",

--- a/projects/client/i18n/messages/el-GR.json
+++ b/projects/client/i18n/messages/el-GR.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Θετικό",
   "header_settings_clear_cover": "Εκκαθάριση εικόνας εξωφύλλου",
   "header_settings_notifications": "Ειδοποιήσεις",
-  "header_settings_privacy": "Απόρρητο & Συνδρομή",
   "header_settings_tracking": "Παρακολούθηση",
   "header_settings_translations": "Μεταφράσεις",
   "header_skipped_items": "{count} Παραλειφθέντα στοιχεία",

--- a/projects/client/i18n/messages/en-AU.json
+++ b/projects/client/i18n/messages/en-AU.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positive",
   "header_settings_clear_cover": "Clear Cover Image",
   "header_settings_notifications": "Notifications",
-  "header_settings_privacy": "Privacy & Subscription",
   "header_settings_tracking": "Tracking",
   "header_settings_translations": "Translations",
   "header_skipped_items": "{count} Skipped Items",

--- a/projects/client/i18n/messages/es-ES.json
+++ b/projects/client/i18n/messages/es-ES.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positivo",
   "header_settings_clear_cover": "Borrar Imagen de Portada",
   "header_settings_notifications": "Notificaciones",
-  "header_settings_privacy": "Privacidad y Suscripción",
   "header_settings_tracking": "Seguimiento",
   "header_settings_translations": "Traducciones",
   "header_skipped_items": "{count} elementos omitidos",

--- a/projects/client/i18n/messages/es-MX.json
+++ b/projects/client/i18n/messages/es-MX.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positivo",
   "header_settings_clear_cover": "Borrar imagen de portada",
   "header_settings_notifications": "Notificaciones",
-  "header_settings_privacy": "Privacidad y Suscripción",
   "header_settings_tracking": "Seguimiento",
   "header_settings_translations": "Traducciones",
   "header_skipped_items": "{count} elementos omitidos",

--- a/projects/client/i18n/messages/fa-IR.json
+++ b/projects/client/i18n/messages/fa-IR.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "مثبت",
   "header_settings_clear_cover": "پاک کردن تصویر جلد",
   "header_settings_notifications": "اعلان‌ها",
-  "header_settings_privacy": "حریم خصوصی و اشتراک",
   "header_settings_tracking": "ردیابی",
   "header_settings_translations": "ترجمه‌ها",
   "header_skipped_items": "{count} مورد نادیده گرفته شده",

--- a/projects/client/i18n/messages/fr-CA.json
+++ b/projects/client/i18n/messages/fr-CA.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positif",
   "header_settings_clear_cover": "Effacer l'image de couverture",
   "header_settings_notifications": "Notifications",
-  "header_settings_privacy": "Confidentialité et abonnement",
   "header_settings_tracking": "Suivi",
   "header_settings_translations": "Traductions",
   "header_skipped_items": "{count} éléments ignorés",

--- a/projects/client/i18n/messages/fr-FR.json
+++ b/projects/client/i18n/messages/fr-FR.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positif",
   "header_settings_clear_cover": "Effacer l'image de couverture",
   "header_settings_notifications": "Notifications",
-  "header_settings_privacy": "Confidentialité et abonnement",
   "header_settings_tracking": "Suivi",
   "header_settings_translations": "Traductions",
   "header_skipped_items": "{count} éléments ignorés",

--- a/projects/client/i18n/messages/hu-HU.json
+++ b/projects/client/i18n/messages/hu-HU.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Pozitív",
   "header_settings_clear_cover": "Borítókép törlése",
   "header_settings_notifications": "Értesítések",
-  "header_settings_privacy": "Adatvédelem és Előfizetés",
   "header_settings_tracking": "Nyomon követés",
   "header_settings_translations": "Fordítások",
   "header_skipped_items": "{count} kihagyott elem",

--- a/projects/client/i18n/messages/id-ID.json
+++ b/projects/client/i18n/messages/id-ID.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positif",
   "header_settings_clear_cover": "Hapus Gambar Sampul",
   "header_settings_notifications": "Notifikasi",
-  "header_settings_privacy": "Privasi & Langganan",
   "header_settings_tracking": "Pelacakan",
   "header_settings_translations": "Terjemahan",
   "header_skipped_items": "{count} Item Dilewati",

--- a/projects/client/i18n/messages/it-IT.json
+++ b/projects/client/i18n/messages/it-IT.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positivo",
   "header_settings_clear_cover": "Cancella immagine di copertina",
   "header_settings_notifications": "Notifiche",
-  "header_settings_privacy": "Privacy e Abbonamento",
   "header_settings_tracking": "Tracciamento",
   "header_settings_translations": "Traduzioni",
   "header_skipped_items": "{count} elementi saltati",

--- a/projects/client/i18n/messages/ja-JP.json
+++ b/projects/client/i18n/messages/ja-JP.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "ポジティブ",
   "header_settings_clear_cover": "カバー画像をクリア",
   "header_settings_notifications": "通知",
-  "header_settings_privacy": "プライバシーとサブスクリプション",
   "header_settings_tracking": "トラッキング",
   "header_settings_translations": "翻訳",
   "header_skipped_items": "{count}個のスキップ済みアイテム",

--- a/projects/client/i18n/messages/nb-NO.json
+++ b/projects/client/i18n/messages/nb-NO.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positiv",
   "header_settings_clear_cover": "Fjern forsidebilde",
   "header_settings_notifications": "Varsler",
-  "header_settings_privacy": "Personvern og abonnement",
   "header_settings_tracking": "Sporing",
   "header_settings_translations": "Oversettelser",
   "header_skipped_items": "{count} elementer hoppet over",

--- a/projects/client/i18n/messages/nl-NL.json
+++ b/projects/client/i18n/messages/nl-NL.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positief",
   "header_settings_clear_cover": "Omslagafbeelding wissen",
   "header_settings_notifications": "Meldingen",
-  "header_settings_privacy": "Privacy & Abonnement",
   "header_settings_tracking": "Bijhouden",
   "header_settings_translations": "Vertalingen",
   "header_skipped_items": "{count} overgeslagen items",

--- a/projects/client/i18n/messages/pl-PL.json
+++ b/projects/client/i18n/messages/pl-PL.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Pozytywny",
   "header_settings_clear_cover": "Wyczyść obraz tła",
   "header_settings_notifications": "Powiadomienia",
-  "header_settings_privacy": "Prywatność i subskrypcja",
   "header_settings_tracking": "Śledzenie",
   "header_settings_translations": "Tłumaczenia",
   "header_skipped_items": "{count} pominiętych elementów",

--- a/projects/client/i18n/messages/pt-BR.json
+++ b/projects/client/i18n/messages/pt-BR.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positivo",
   "header_settings_clear_cover": "Limpar Imagem de Capa",
   "header_settings_notifications": "Notificações",
-  "header_settings_privacy": "Privacidade e Assinatura",
   "header_settings_tracking": "Rastreamento",
   "header_settings_translations": "Traduções",
   "header_skipped_items": "{count} Itens Ignorados",

--- a/projects/client/i18n/messages/pt-PT.json
+++ b/projects/client/i18n/messages/pt-PT.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positivo",
   "header_settings_clear_cover": "Remover imagem de capa",
   "header_settings_notifications": "Notificações",
-  "header_settings_privacy": "Privacidade e subscrição",
   "header_settings_tracking": "Registo",
   "header_settings_translations": "Traduções",
   "header_skipped_items": "{count} itens ignorados",

--- a/projects/client/i18n/messages/ro-RO.json
+++ b/projects/client/i18n/messages/ro-RO.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Pozitiv",
   "header_settings_clear_cover": "Șterge Imaginea de Copertă",
   "header_settings_notifications": "Notificări",
-  "header_settings_privacy": "Confidențialitate și Abonament",
   "header_settings_tracking": "Urmărire",
   "header_settings_translations": "Traduceri",
   "header_skipped_items": "{count} Elemente Omise",

--- a/projects/client/i18n/messages/ru-RU.json
+++ b/projects/client/i18n/messages/ru-RU.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Положительный",
   "header_settings_clear_cover": "Очистить обложку",
   "header_settings_notifications": "Уведомления",
-  "header_settings_privacy": "Конфиденциальность и подписка",
   "header_settings_tracking": "Отслеживание",
   "header_settings_translations": "Переводы",
   "header_skipped_items": "{count} пропущенных элементов",

--- a/projects/client/i18n/messages/sv-SE.json
+++ b/projects/client/i18n/messages/sv-SE.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Positiv",
   "header_settings_clear_cover": "Rensa omslagsbild",
   "header_settings_notifications": "Aviseringar",
-  "header_settings_privacy": "Integritet och prenumeration",
   "header_settings_tracking": "Spårning",
   "header_settings_translations": "Översättningar",
   "header_skipped_items": "{count} överhoppade objekt",

--- a/projects/client/i18n/messages/tr-TR.json
+++ b/projects/client/i18n/messages/tr-TR.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Olumlu",
   "header_settings_clear_cover": "Kapak Resmini Temizle",
   "header_settings_notifications": "Bildirimler",
-  "header_settings_privacy": "Gizlilik ve Abonelik",
   "header_settings_tracking": "Takip",
   "header_settings_translations": "Çeviriler",
   "header_skipped_items": "{count} Atlanan Öğe",

--- a/projects/client/i18n/messages/uk-UA.json
+++ b/projects/client/i18n/messages/uk-UA.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "Позитивний",
   "header_settings_clear_cover": "Очистити обкладинку",
   "header_settings_notifications": "Сповіщення",
-  "header_settings_privacy": "Приватність і Підписка",
   "header_settings_tracking": "Відстеження",
   "header_settings_translations": "Переклади",
   "header_skipped_items": "{count} пропущених елементів",

--- a/projects/client/i18n/messages/zh-CN.json
+++ b/projects/client/i18n/messages/zh-CN.json
@@ -727,7 +727,6 @@
   "header_sentiment_positive": "积极",
   "header_settings_clear_cover": "清除封面图片",
   "header_settings_notifications": "通知",
-  "header_settings_privacy": "隐私与订阅",
   "header_settings_tracking": "追踪",
   "header_settings_translations": "翻译",
   "header_skipped_items": "{count} 个已跳过项目",

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -3893,10 +3893,6 @@
       "default": "Account Details",
       "description": "Header for the section that allows users to change their account details."
     },
-    "header_settings_privacy": {
-      "default": "Privacy & Subscription",
-      "description": "Header for the settings section covering privacy options and subscription management."
-    },
     "description_account_details": {
       "default": "Change your photo, name and other details.",
       "description": "Description for the account details section."
@@ -4121,6 +4117,10 @@
     "link_text_general_settings": {
       "default": "General",
       "description": "Text for the link to the general settings page."
+    },
+    "link_text_account_settings": {
+      "default": "Account",
+      "description": "Text for the link to the account settings page."
     },
     "link_text_data_settings": {
       "default": "Data",

--- a/projects/client/src/lib/sections/settings/AccountSettings.svelte
+++ b/projects/client/src/lib/sections/settings/AccountSettings.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+  import AboutIcon from "$lib/components/icons/AboutIcon.svelte";
+  import CalendarIcon from "$lib/components/icons/CalendarIcon.svelte";
+  import EmailIcon from "$lib/components/icons/EmailIcon.svelte";
+  import GlobeIcon from "$lib/components/icons/GlobeIcon.svelte";
+  import IdIcon from "$lib/components/icons/IdIcon.svelte";
+  import LockIcon from "$lib/components/icons/LockIcon.svelte";
+  import ProfileIcon from "$lib/components/icons/ProfileIcon.svelte";
+  import StarIcon from "$lib/components/icons/StarIcon.svelte";
+  import Switch from "$lib/components/toggles/Switch.svelte";
+  import { getLocale } from "$lib/features/i18n";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import { formatLocalDate } from "$lib/utils/date/formatLocalDate.ts";
+  import { toHumanDay } from "$lib/utils/formatting/date/toHumanDay.ts";
+  import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
+  import SettingInputDrawer from "./_internal/SettingInputDrawer.svelte";
+  import SettingsGroupCard from "./_internal/SettingsGroupCard.svelte";
+  import SettingsGroupRow from "./_internal/SettingsGroupRow.svelte";
+  import { useSettings } from "./_internal/useSettings.ts";
+
+  const { profile, email, isSavingSettings } = useSettings();
+
+  const toSaveResult = (didSave: boolean, error: string) =>
+    didSave ? undefined : { error };
+
+  const promptMap = $derived({
+    name: {
+      type: "input" as const,
+      title: m.input_prompt_display_name(),
+      currentValue: $profile.displayName,
+      name: m.text_display_name(),
+      isRequired: true,
+      onSave: async (value: string) =>
+        toSaveResult(
+          await $profile.set({ name: value }),
+          m.error_text_failed_update(),
+        ),
+    },
+    username: {
+      type: "input" as const,
+      title: m.input_prompt_username(),
+      currentValue: $profile.username,
+      name: m.text_username(),
+      isRequired: true,
+      onSave: async (value: string) =>
+        toSaveResult(
+          await $profile.set({ username: value }),
+          m.error_text_username(),
+        ),
+    },
+    email: {
+      type: "input" as const,
+      title: m.input_prompt_email(),
+      currentValue: $email.value ?? "",
+      name: m.text_display_email(),
+      isRequired: true,
+      onSave: async (value: string) =>
+        toSaveResult(await $email.set(value), m.error_text_email()),
+    },
+    location: {
+      type: "input" as const,
+      title: m.input_prompt_location(),
+      currentValue: $profile.location,
+      name: m.text_location(),
+      isRequired: true,
+      onSave: async (value: string) =>
+        toSaveResult(
+          await $profile.set({ location: value }),
+          m.error_text_failed_update(),
+        ),
+    },
+    about: {
+      type: "textarea" as const,
+      title: m.input_prompt_about(),
+      currentValue: $profile.about,
+      name: m.text_about(),
+      isRequired: false,
+      onSave: async (value: string) =>
+        toSaveResult(
+          await $profile.set({ about: value }),
+          m.error_text_failed_update(),
+        ),
+    },
+    birthday: {
+      type: "datepicker" as const,
+      title: m.input_prompt_birthday(),
+      label: m.button_label_change_birthday(),
+      currentValue: $profile.birthday ?? undefined,
+      name: m.text_birthday(),
+      isRequired: true,
+      onSave: async (date: Date) =>
+        toSaveResult(
+          await $profile.set({ dob: date ? formatLocalDate(date) : null }),
+          m.error_text_failed_update(),
+        ),
+    },
+  });
+
+  type ProfileField = keyof typeof promptMap;
+  let activeField = $state<ProfileField>();
+
+  const birthdayLabel = $derived(
+    $profile.birthday
+      ? toHumanDay({ date: $profile.birthday, locale: getLocale() })
+      : "",
+  );
+</script>
+
+<div class="trakt-account-settings">
+  <SettingsGroupCard title={m.header_account_details()}>
+    <SettingsGroupRow
+      title={m.text_display_name()}
+      label={m.button_label_change_display_name()}
+      value={$profile.displayName}
+      onclick={() => (activeField = "name")}
+      disabled={$isSavingSettings}
+      variant="button"
+    >
+      {#snippet icon()}<IdIcon />{/snippet}
+    </SettingsGroupRow>
+
+    <SettingsGroupRow
+      title={m.text_username()}
+      label={m.button_label_change_username()}
+      value={$profile.username ? `@${$profile.username}` : ""}
+      onclick={() => (activeField = "username")}
+      disabled={$isSavingSettings}
+      variant="button"
+    >
+      {#snippet icon()}<ProfileIcon />{/snippet}
+    </SettingsGroupRow>
+
+    {#if $email.value}
+      <SettingsGroupRow
+        title={m.text_display_email()}
+        label={m.button_label_change_email()}
+        value={$email.value ?? ""}
+        onclick={() => (activeField = "email")}
+        disabled={$isSavingSettings}
+        variant="button"
+      >
+        {#snippet icon()}<EmailIcon />{/snippet}
+      </SettingsGroupRow>
+    {/if}
+
+    <SettingsGroupRow
+      title={m.text_birthday()}
+      label={m.button_label_change_birthday()}
+      value={birthdayLabel}
+      onclick={() => (activeField = "birthday")}
+      disabled={$isSavingSettings}
+      variant="button"
+    >
+      {#snippet icon()}<CalendarIcon />{/snippet}
+    </SettingsGroupRow>
+
+    <SettingsGroupRow
+      title={m.text_location()}
+      label={m.button_label_change_location()}
+      value={$profile.location}
+      onclick={() => (activeField = "location")}
+      disabled={$isSavingSettings}
+      variant="button"
+    >
+      {#snippet icon()}<GlobeIcon />{/snippet}
+    </SettingsGroupRow>
+
+    <SettingsGroupRow
+      title={m.text_about()}
+      label={m.button_label_change_about()}
+      description={$profile.about}
+      onclick={() => (activeField = "about")}
+      disabled={$isSavingSettings}
+      variant="button"
+    >
+      {#snippet icon()}<AboutIcon />{/snippet}
+    </SettingsGroupRow>
+
+    <SettingsGroupRow title={m.text_private_account()} variant="custom">
+      {#snippet icon()}<LockIcon />{/snippet}
+      <Switch
+        label={m.switch_label_private()}
+        checked={$profile.isPrivate}
+        onclick={() => $profile.set({ private: !$profile.isPrivate })}
+        disabled={$isSavingSettings}
+        color="purple"
+      />
+    </SettingsGroupRow>
+
+    <SettingsGroupRow
+      title={m.button_text_manage_subscription()}
+      href={UrlBuilder.vip()}
+      variant="link"
+    >
+      {#snippet icon()}<StarIcon fill="none" />{/snippet}
+    </SettingsGroupRow>
+  </SettingsGroupCard>
+</div>
+
+{#if activeField}
+  <SettingInputDrawer
+    {...promptMap[activeField]}
+    onClose={() => (activeField = undefined)}
+    isSaving={$isSavingSettings}
+  />
+{/if}
+
+<style lang="scss">
+  .trakt-account-settings {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xl);
+  }
+</style>

--- a/projects/client/src/lib/sections/settings/_internal/Profile.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/Profile.svelte
@@ -1,127 +1,16 @@
 <script lang="ts">
   import VipBadge from "$lib/components/badge/VipBadge.svelte";
-  import AboutIcon from "$lib/components/icons/AboutIcon.svelte";
-  import CalendarIcon from "$lib/components/icons/CalendarIcon.svelte";
-  import EmailIcon from "$lib/components/icons/EmailIcon.svelte";
-  import GlobeIcon from "$lib/components/icons/GlobeIcon.svelte";
-  import IdIcon from "$lib/components/icons/IdIcon.svelte";
   import Link from "$lib/components/link/Link.svelte";
-  import LockIcon from "$lib/components/icons/LockIcon.svelte";
-  import ProfileIcon from "$lib/components/icons/ProfileIcon.svelte";
-  import StarIcon from "$lib/components/icons/StarIcon.svelte";
-  import Switch from "$lib/components/toggles/Switch.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
-  import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import GetVIPLink from "$lib/sections/navbar/components/GetVIPLink.svelte";
   import ProfileImage from "$lib/sections/profile-banner/ProfileImage.svelte";
-  import { formatLocalDate } from "$lib/utils/date/formatLocalDate";
-  import { toHumanDay } from "$lib/utils/formatting/date/toHumanDay";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
-  import SettingInputDrawer from "./SettingInputDrawer.svelte";
   import SettingsGroupCard from "./SettingsGroupCard.svelte";
-  import SettingsGroupRow from "./SettingsGroupRow.svelte";
   import { useSettings } from "./useSettings";
 
   const { user } = useUser();
-  const { profile, email, isSavingSettings } = useSettings();
-
-  const promptMap = $derived({
-    name: {
-      label: m.button_label_change_display_name(),
-      drawer: {
-        type: "input" as const,
-        title: m.input_prompt_display_name(),
-        currentValue: $profile.displayName,
-        name: m.text_display_name(),
-        isRequired: true,
-        onSave: async (value: string) =>
-          (await $profile.set({ name: value }))
-            ? undefined
-            : { error: m.error_text_failed_update() },
-      },
-    },
-    username: {
-      label: m.button_label_change_username(),
-      drawer: {
-        type: "input" as const,
-        title: m.input_prompt_username(),
-        currentValue: $profile.username,
-        name: m.text_username(),
-        isRequired: true,
-        onSave: async (value: string) =>
-          (await $profile.set({ username: value }))
-            ? undefined
-            : { error: m.error_text_username() },
-      },
-    },
-    email: {
-      label: m.button_label_change_email(),
-      drawer: {
-        type: "input" as const,
-        title: m.input_prompt_email(),
-        currentValue: $email.value ?? "",
-        name: m.text_display_email(),
-        isRequired: true,
-        onSave: async (value: string) =>
-          (await $email.set(value))
-            ? undefined
-            : { error: m.error_text_email() },
-      },
-    },
-    location: {
-      label: m.button_label_change_location(),
-      drawer: {
-        type: "input" as const,
-        title: m.input_prompt_location(),
-        currentValue: $profile.location,
-        name: m.text_location(),
-        isRequired: true,
-        onSave: async (value: string) =>
-          (await $profile.set({ location: value }))
-            ? undefined
-            : { error: m.error_text_failed_update() },
-      },
-    },
-    about: {
-      label: m.button_label_change_about(),
-      drawer: {
-        type: "textarea" as const,
-        title: m.input_prompt_about(),
-        currentValue: $profile.about,
-        name: m.text_about(),
-        isRequired: false,
-        onSave: async (value: string) =>
-          (await $profile.set({ about: value }))
-            ? undefined
-            : { error: m.error_text_failed_update() },
-      },
-    },
-    birthday: {
-      label: m.button_label_change_birthday(),
-      drawer: {
-        type: "datepicker" as const,
-        title: m.input_prompt_birthday(),
-        label: m.button_label_change_birthday(),
-        currentValue: $profile.birthday ?? undefined,
-        name: m.text_birthday(),
-        isRequired: true,
-        onSave: async (date: Date) =>
-          (await $profile.set({ dob: date ? formatLocalDate(date) : null }))
-            ? undefined
-            : { error: m.error_text_failed_update() },
-      },
-    },
-  });
-
-  type ProfileField = keyof typeof promptMap;
-  let activeField = $state<ProfileField>();
-
-  const birthdayLabel = $derived(
-    $profile.birthday
-      ? toHumanDay({ date: $profile.birthday, locale: getLocale() })
-      : "",
-  );
+  const { profile } = useSettings();
 </script>
 
 <SettingsGroupCard variant={$user.isVip ? "vip" : "muted"}>
@@ -157,105 +46,6 @@
     {/if}
   </div>
 </SettingsGroupCard>
-
-<SettingsGroupCard title={m.header_account_details()}>
-  <SettingsGroupRow
-    title={m.text_display_name()}
-    label={m.button_label_change_display_name()}
-    value={$profile.displayName}
-    onclick={() => (activeField = "name")}
-    disabled={$isSavingSettings}
-    variant="button"
-  >
-    {#snippet icon()}<IdIcon />{/snippet}
-  </SettingsGroupRow>
-
-  <SettingsGroupRow
-    title={m.text_username()}
-    label={m.button_label_change_username()}
-    value={$profile.username ? `@${$profile.username}` : ""}
-    onclick={() => (activeField = "username")}
-    disabled={$isSavingSettings}
-    variant="button"
-  >
-    {#snippet icon()}<ProfileIcon />{/snippet}
-  </SettingsGroupRow>
-
-  {#if Boolean($email.value)}
-    <SettingsGroupRow
-      title={m.text_display_email()}
-      label={m.button_label_change_email()}
-      value={$email.value ?? ""}
-      onclick={() => (activeField = "email")}
-      disabled={$isSavingSettings}
-      variant="button"
-    >
-      {#snippet icon()}<EmailIcon />{/snippet}
-    </SettingsGroupRow>
-  {/if}
-
-  <SettingsGroupRow
-    title={m.text_birthday()}
-    label={m.button_label_change_birthday()}
-    value={birthdayLabel}
-    onclick={() => (activeField = "birthday")}
-    disabled={$isSavingSettings}
-    variant="button"
-  >
-    {#snippet icon()}<CalendarIcon />{/snippet}
-  </SettingsGroupRow>
-
-  <SettingsGroupRow
-    title={m.text_location()}
-    label={m.button_label_change_location()}
-    value={$profile.location}
-    onclick={() => (activeField = "location")}
-    disabled={$isSavingSettings}
-    variant="button"
-  >
-    {#snippet icon()}<GlobeIcon />{/snippet}
-  </SettingsGroupRow>
-
-  <SettingsGroupRow
-    title={m.text_about()}
-    label={m.button_label_change_about()}
-    description={$profile.about}
-    onclick={() => (activeField = "about")}
-    disabled={$isSavingSettings}
-    variant="button"
-  >
-    {#snippet icon()}<AboutIcon />{/snippet}
-  </SettingsGroupRow>
-</SettingsGroupCard>
-
-<SettingsGroupCard title={m.header_settings_privacy()}>
-  <SettingsGroupRow title={m.text_private_account()} variant="custom">
-    {#snippet icon()}<LockIcon />{/snippet}
-    <Switch
-      label={m.switch_label_private()}
-      checked={$profile.isPrivate}
-      onclick={() => $profile.set({ private: !$profile.isPrivate })}
-      disabled={$isSavingSettings}
-      color="purple"
-    />
-  </SettingsGroupRow>
-
-  <SettingsGroupRow
-    title={m.button_text_manage_subscription()}
-    href={UrlBuilder.vip()}
-    variant="link"
-  >
-    {#snippet icon()}<StarIcon fill="none" />{/snippet}
-  </SettingsGroupRow>
-</SettingsGroupCard>
-
-{#if activeField}
-  <SettingInputDrawer
-    {...promptMap[activeField].drawer}
-    onClose={() => (activeField = undefined)}
-    isSaving={$isSavingSettings}
-  />
-{/if}
 
 <style lang="scss">
   .trakt-settings-profile-card {

--- a/projects/client/src/lib/sections/settings/_internal/settingsPages.ts
+++ b/projects/client/src/lib/sections/settings/_internal/settingsPages.ts
@@ -3,6 +3,7 @@ import GearIcon from '$lib/components/icons/GearIcon.svelte';
 import LibraryIcon from '$lib/components/icons/LibraryIcon.svelte';
 import PlexLibraryIcon from '$lib/components/icons/PlexLibraryIcon.svelte';
 import PlugIcon from '$lib/components/icons/PlugIcon.svelte';
+import ProfileIcon from '$lib/components/icons/ProfileIcon.svelte';
 import ServerIcon from '$lib/components/icons/ServerIcon.svelte';
 import SparkleIcon from '$lib/components/icons/SparkleIcon.svelte';
 import { FeatureFlag } from '$lib/features/feature-flag/models/FeatureFlag.ts';
@@ -18,8 +19,9 @@ type SettingsPage = {
   flag?: FeatureFlag;
   /**
    * Destination for the mobile settings hub, when it differs from the desktop
-   * sidebar `href`. General surfaces its account details on the hub itself, so
-   * its drill-down row targets the standalone `/settings/general` route.
+   * sidebar `href`. General's `href` is the settings root, which the mobile
+   * hub already renders directly, so its drill-down row instead targets the
+   * standalone `/settings/general` route.
    */
   hubHref?: string;
 };
@@ -30,6 +32,11 @@ export const settingsPages: ReadonlyArray<SettingsPage> = [
     hubHref: UrlBuilder.settings.generalDetail(),
     label: m.link_text_general_settings,
     icon: GearIcon,
+  },
+  {
+    href: UrlBuilder.settings.account(),
+    label: m.link_text_account_settings,
+    icon: ProfileIcon,
   },
   {
     href: UrlBuilder.settings.data(),

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -314,6 +314,7 @@ export const UrlBuilder = {
   settings: {
     general: () => '/settings',
     generalDetail: () => '/settings/general',
+    account: () => '/settings/account',
     data: () => '/settings/data',
     apps: () => '/settings/apps',
     appsConnected: () => '/settings/apps/connected',

--- a/projects/client/src/routes/settings/account/+page.svelte
+++ b/projects/client/src/routes/settings/account/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import AccountSettings from "$lib/sections/settings/AccountSettings.svelte";
+</script>
+
+<AccountSettings />


### PR DESCRIPTION
Move the Account Details sections out of the settings Profile card into a new AccountSettings component, routed at /settings/account and listed below General in the settings navigation for both desktop and mobile.