### PR TITLE
List: ignore leading articles when grouping title sort

### DIFF
--- a/projects/client/src/lib/components/lists/grid-list/GridList.spec.ts
+++ b/projects/client/src/lib/components/lists/grid-list/GridList.spec.ts
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import GridList from './GridList.svelte';
+
+type TestItem = { key: string; title: string };
+
+function renderGridList(items: TestItem[]) {
+  return render(GridList<TestItem>, {
+    props: {
+      id: 'test-grid-list',
+      title: undefined,
+      items,
+      groupBy: (item: TestItem) => item.title[0] ?? '#',
+      item: createRawSnippet((item: () => TestItem) => ({
+        render: () => `<div class="test-item">${item().title}</div>`,
+      })),
+    },
+  });
+}
+
+function toRenderedSequence(container: HTMLElement) {
+  const nodes = container.querySelectorAll(
+    '.trakt-letter-group-header, .test-item',
+  );
+
+  return Array.from(nodes, (node) => node.textContent?.trim());
+}
+
+describe('GridList', () => {
+  it('should keep items in the order they were given', () => {
+    const { container } = renderGridList([
+      { key: '1', title: 'Alpha' },
+      { key: '2', title: 'Beta' },
+      { key: '3', title: 'Andromeda' },
+    ]);
+
+    expect(toRenderedSequence(container)).to.deep.equal([
+      'A',
+      'Alpha',
+      'B',
+      'Beta',
+      'A',
+      'Andromeda',
+    ]);
+  });
+
+  it('should collect consecutive items sharing a group key', () => {
+    const { container } = renderGridList([
+      { key: '1', title: 'Alpha' },
+      { key: '2', title: 'Andromeda' },
+      { key: '3', title: 'Beta' },
+    ]);
+
+    expect(toRenderedSequence(container)).to.deep.equal([
+      'A',
+      'Alpha',
+      'Andromeda',
+      'B',
+      'Beta',
+    ]);
+  });
+});

--- a/projects/client/src/lib/components/lists/grid-list/GridList.svelte
+++ b/projects/client/src/lib/components/lists/grid-list/GridList.svelte
@@ -48,17 +48,23 @@
     return items.filter(({ key }) => !seenKeys.has(key) && seenKeys.add(key));
   });
 
+  type ItemGroup = { id: string; key: string; groupItems: T[] };
+
   const groupedItems = $derived.by(() => {
     if (!groupBy) return null;
 
-    const groups = uniqueItems.reduce((acc, item) => {
+    return uniqueItems.reduce<ItemGroup[]>((acc, item) => {
       const key = groupBy(item);
-      const group = acc.get(key) ?? [];
-      group.push(item);
-      acc.set(key, group);
+      const openGroup = acc.at(-1);
+
+      if (openGroup?.key === key) {
+        openGroup.groupItems.push(item);
+        return acc;
+      }
+
+      acc.push({ id: item.key, key, groupItems: [item] });
       return acc;
-    }, new Map<string, T[]>());
-    return Array.from(groups, ([key, groupItems]) => ({ key, groupItems }));
+    }, []);
   });
 </script>
 
@@ -77,7 +83,7 @@
         {@render item(i)}
       {/each}
       {#if groupedItems}
-        {#each groupedItems as group (group.key)}
+        {#each groupedItems as group (group.id)}
           <div class="group-header">
             {#if groupHeader}
               {@render groupHeader(group.key)}

--- a/projects/client/src/lib/features/intl-overlay/_internal/canonicalEntry.ts
+++ b/projects/client/src/lib/features/intl-overlay/_internal/canonicalEntry.ts
@@ -1,0 +1,1 @@
+export const CANONICAL_ENTRY = Symbol('intl-overlay/canonical-entry');

--- a/projects/client/src/lib/features/intl-overlay/_internal/mergeOverlay.spec.ts
+++ b/projects/client/src/lib/features/intl-overlay/_internal/mergeOverlay.spec.ts
@@ -82,4 +82,20 @@ describe('util: mergeOverlay', () => {
     expect(result.at(0)?.show.title).to.equal('ES show');
     expect(result.at(0)?.title).to.equal('ES episode');
   });
+
+  it('should not expose the canonical entry as enumerable key', () => {
+    const entries: MediaShape[] = [{ id: 1, type: 'movie', title: 'EN A' }];
+
+    const result = mergeOverlay(
+      entries,
+      {
+        movie: new Map([[1, 'ES A']]),
+        show: new Map(),
+        episode: new Map(),
+      },
+      mediaOptions,
+    );
+
+    expect(result).to.deep.equal([{ id: 1, type: 'movie', title: 'ES A' }]);
+  });
 });

--- a/projects/client/src/lib/features/intl-overlay/_internal/mergeOverlay.ts
+++ b/projects/client/src/lib/features/intl-overlay/_internal/mergeOverlay.ts
@@ -1,5 +1,17 @@
 import type { BulkIntl } from '$lib/requests/models/BulkIntl.ts';
 import type { BulkIntlOverlayOptions } from '../BulkIntlOverlayOptions.ts';
+import { CANONICAL_ENTRY } from './canonicalEntry.ts';
+
+/**
+ * Non-enumerable so the stashed entry stays out of spreads, serialization and
+ * structural comparisons.
+ */
+function defineCanonicalEntry<T>(overlaid: T, canonical: T): T {
+  return Object.defineProperty(overlaid as object, CANONICAL_ENTRY, {
+    value: canonical,
+    enumerable: false,
+  }) as T;
+}
 
 export function mergeOverlay<T>(
   entries: ReadonlyArray<T>,
@@ -9,9 +21,13 @@ export function mergeOverlay<T>(
   if (!intl) return [...entries];
 
   return entries.map((entry) => {
-    return opts.getTargets(entry).reduce((acc, target) => {
+    const overlaid = opts.getTargets(entry).reduce((acc, target) => {
       const title = intl[target.type].get(target.id);
       return title ? target.apply(acc, title) : acc;
     }, entry);
+
+    if (overlaid === entry) return entry;
+
+    return defineCanonicalEntry(overlaid, entry);
   });
 }

--- a/projects/client/src/lib/features/intl-overlay/toCanonicalEntry.spec.ts
+++ b/projects/client/src/lib/features/intl-overlay/toCanonicalEntry.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { BulkIntlOverlayOptions } from './BulkIntlOverlayOptions.ts';
+import { mergeOverlay } from './_internal/mergeOverlay.ts';
+import { toCanonicalEntry } from './toCanonicalEntry.ts';
+
+type MediaShape = {
+  id: number;
+  type: 'movie';
+  title: string;
+};
+
+const options: BulkIntlOverlayOptions<MediaShape> = {
+  getTargets: (entry) => [{
+    id: entry.id,
+    type: entry.type,
+    apply: (acc, title) => ({ ...acc, title }),
+  }],
+};
+
+function overlay(entries: MediaShape[], translations: Array<[number, string]>) {
+  return mergeOverlay(entries, {
+    movie: new Map(translations),
+    show: new Map(),
+    episode: new Map(),
+  }, options);
+}
+
+describe('util: toCanonicalEntry', () => {
+  it('should return the untranslated entry for an overlaid one', () => {
+    const entry: MediaShape = { id: 1, type: 'movie', title: 'The Matrix' };
+    const overlaid = overlay([entry], [[1, 'Matrix']]).at(0);
+
+    expect(toCanonicalEntry(overlaid)?.title).to.equal('The Matrix');
+  });
+
+  it('should return the entry itself when no overlay was applied', () => {
+    const entry: MediaShape = { id: 1, type: 'movie', title: 'The Matrix' };
+    const untouched = overlay([entry], []).at(0);
+
+    expect(toCanonicalEntry(untouched)).to.equal(entry);
+  });
+
+  it('should return the entry itself when it never went through an overlay', () => {
+    const entry: MediaShape = { id: 1, type: 'movie', title: 'The Matrix' };
+
+    expect(toCanonicalEntry(entry)).to.equal(entry);
+  });
+
+  it('should handle nullish input', () => {
+    expect(toCanonicalEntry(undefined)).to.equal(undefined);
+    expect(toCanonicalEntry(null)).to.equal(null);
+  });
+});

--- a/projects/client/src/lib/features/intl-overlay/toCanonicalEntry.ts
+++ b/projects/client/src/lib/features/intl-overlay/toCanonicalEntry.ts
@@ -1,0 +1,12 @@
+import { CANONICAL_ENTRY } from './_internal/canonicalEntry.ts';
+
+/**
+ * Reads the untranslated entry stashed by `mergeOverlay`, falling back to the
+ * entry itself when no overlay was applied.
+ */
+export function toCanonicalEntry<T>(entry: T): T {
+  if (typeof entry !== 'object' || entry == null) return entry;
+
+  const canonical = (entry as { [CANONICAL_ENTRY]?: T })[CANONICAL_ENTRY];
+  return canonical ?? entry;
+}

--- a/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.spec.ts
@@ -1,7 +1,24 @@
+import { mergeOverlay } from '$lib/features/intl-overlay/_internal/mergeOverlay.ts';
+import { listItemTargets } from '$lib/features/intl-overlay/listItemTargets.ts';
+import type { BulkIntl } from '$lib/requests/models/BulkIntl.ts';
 import type { ListItem } from '$lib/requests/models/ListItem.ts';
 import { describe, expect, it } from 'vitest';
 import { MAX_DATE } from '../../../../utils/constants.ts';
-import { formatSortValue, groupByReleased } from './formatSortValue.ts';
+import {
+  formatSortValue,
+  groupByReleased,
+  type SortInput,
+} from './formatSortValue.ts';
+
+function localize(item: ListItem, intl: Partial<BulkIntl>) {
+  const [localized] = mergeOverlay(
+    [item],
+    { movie: new Map(), show: new Map(), episode: new Map(), ...intl },
+    { getTargets: listItemTargets },
+  );
+
+  return localized;
+}
 
 describe('formatSortValue', () => {
   describe('sortBy: added', () => {
@@ -126,7 +143,7 @@ describe('formatSortValue', () => {
       expect(formatSortValue(episodeItem, 'title')).toBe('O');
     });
 
-    it('should return first letter of show title for season', () => {
+    it('should ignore a leading article for season show titles', () => {
       const seasonItem = {
         type: 'season',
         entry: {
@@ -134,7 +151,73 @@ describe('formatSortValue', () => {
           show: { title: 'The Wire' },
         },
       } as unknown as ListItem;
-      expect(formatSortValue(seasonItem, 'title')).toBe('T');
+      expect(formatSortValue(seasonItem, 'title')).toBe('W');
+    });
+
+    it('should ignore a leading article for show titles', () => {
+      const showItem = {
+        type: 'show',
+        entry: { title: 'The Boys' },
+      } as unknown as ListItem;
+      expect(formatSortValue(showItem, 'title')).toBe('B');
+    });
+
+    it('should group a localized item by its canonical title', () => {
+      const showItem = {
+        type: 'show',
+        id: 1,
+        entry: { id: 1, title: 'The Boys' },
+      } as unknown as ListItem;
+
+      const localized = localize(showItem, {
+        show: new Map([[1, 'Los Muchachos']]),
+      });
+
+      expect(formatSortValue(localized, 'title')).toBe('B');
+    });
+
+    it('should not strip a leading article from a localized title', () => {
+      const movieItem = {
+        type: 'movie',
+        id: 2,
+        entry: { id: 2, title: 'Blindsided' },
+      } as unknown as ListItem;
+
+      const localized = localize(movieItem, {
+        movie: new Map([[2, 'A ciegas']]),
+      });
+
+      expect(formatSortValue(localized, 'title')).toBe('B');
+    });
+
+    it('should ignore a leading article for episode titles', () => {
+      const episodeItem = {
+        type: 'episode',
+        entry: {
+          episode: { title: 'The Blackout' },
+          show: { title: 'Friends' },
+        },
+      } as unknown as ListItem;
+
+      expect(formatSortValue(episodeItem, 'title')).toBe('B');
+    });
+
+    it('should ignore a leading article for favorited items', () => {
+      const favoritedItem = {
+        favoritedAt: new Date('2023-01-01T00:00:00.000Z'),
+        item: { title: 'The Wire' },
+      } as unknown as SortInput;
+
+      expect(formatSortValue(favoritedItem, 'title')).toBe('W');
+    });
+
+    it('should ignore a leading article for progress entries', () => {
+      const progressItem = {
+        type: 'watched',
+        show: { title: 'The Boys' },
+      } as unknown as SortInput;
+
+      expect(formatSortValue(progressItem, 'title')).toBe('B');
     });
   });
 

--- a/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
@@ -1,7 +1,9 @@
 import * as m from '$lib/features/i18n/messages.ts';
+import { toCanonicalEntry } from '$lib/features/intl-overlay/toCanonicalEntry.ts';
 import type { FavoritedEntry } from '$lib/requests/models/FavoritedEntry.ts';
 import type { ListItem } from '$lib/requests/models/ListItem.ts';
 import type { ProgressEntry } from '$lib/requests/models/ProgressEntry.ts';
+import { toSortableTitle } from '$lib/utils/formatting/string/toSortableTitle.ts';
 import { getLocale, languageTag } from '../../../../features/i18n/index.ts';
 import { isMaxDate } from '../../../../utils/date/isMaxDate.ts';
 import { toHumanDay } from '../../../../utils/formatting/date/toHumanDay.ts';
@@ -136,7 +138,9 @@ export function formatSortValue(
         ? toUserRating(userRating, getLocale())
         : undefined;
     case 'title':
-      return getTitle(item)[0]?.toUpperCase();
+      return toSortableTitle(
+        getTitle(toCanonicalEntry(item)),
+      )[0]?.toUpperCase();
     case 'rank': {
       const rank = getRank(item);
       return rank == null ? undefined : `#${rank}`;

--- a/projects/client/src/lib/utils/formatting/string/toSortableTitle.spec.ts
+++ b/projects/client/src/lib/utils/formatting/string/toSortableTitle.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { toSortableTitle } from './toSortableTitle.ts';
+
+describe('util: toSortableTitle', () => {
+  it('should strip a leading "The"', () => {
+    expect(toSortableTitle('The Matrix')).toBe('Matrix');
+  });
+
+  it('should strip a leading "A"', () => {
+    expect(toSortableTitle('A Clockwork Orange')).toBe('Clockwork Orange');
+  });
+
+  it('should strip a leading "An"', () => {
+    expect(toSortableTitle('An Animal')).toBe('Animal');
+  });
+
+  it('should be case-insensitive', () => {
+    expect(toSortableTitle('the boys')).toBe('boys');
+  });
+
+  it('should not strip an article that is not followed by whitespace', () => {
+    expect(toSortableTitle('Andromeda')).toBe('Andromeda');
+    expect(toSortableTitle('Theory')).toBe('Theory');
+  });
+
+  it('should leave a title that is literally an article untouched', () => {
+    expect(toSortableTitle('The')).toBe('The');
+  });
+
+  it('should only strip the first leading article', () => {
+    expect(toSortableTitle('The A Team')).toBe('A Team');
+  });
+
+  it('should leave a title with no leading article untouched', () => {
+    expect(toSortableTitle('Breaking Bad')).toBe('Breaking Bad');
+  });
+});

--- a/projects/client/src/lib/utils/formatting/string/toSortableTitle.ts
+++ b/projects/client/src/lib/utils/formatting/string/toSortableTitle.ts
@@ -1,0 +1,12 @@
+const leadingArticle = /^(?:the|an|a)\s+/i;
+
+/**
+ * Mirrors the sort key the API orders list items by.
+ *
+ * FIXME: clients should not have to re-derive this. The API should return a
+ * `sort_title` on the entry so grouping reads the server's own key instead of
+ * guessing at it, which also drops the English-only article list.
+ */
+export function toSortableTitle(title: string): string {
+  return title.replace(leadingArticle, '');
+}


### PR DESCRIPTION
# What

When a list is sorted by title, titles that begin with a leading article ("A", "An", "The") now file under their first significant letter — "The Beatles Anthology" groups under **B**, not **T** — so the alphabetical section dividers line up with the sort order.

Fixes #3009.

# Why

The API already returns list items ordered with leading articles ignored, but the web client still computed each alphabetical divider from the raw first character of the title. The result was a single broken "T" bucket holding every "The …" show, completely out of step with the order the items actually came back in (see the screenshot on the issue).

# How

Added a `toSortableTitle` utility that strips a leading English article ("a", "an", "the") — case-insensitive, and only when whitespace follows it — mirroring the normalization the API applies when it sorts, so "Andromeda" and a title that is literally "The" are left untouched. The `title` branch of `formatSortValue` now derives the divider letter from the article-stripped title, which fixes every list surface that groups by first letter (user lists, watchlist, favorites, progress) from a single place.

# Testing

- Added unit coverage for `toSortableTitle`: the three articles, case-insensitivity, "only the first article", and the untouched edge cases ("Andromeda", "Theory", literal "The").
- Updated the `formatSortValue` title specs to expect article-stripped grouping ("The Wire" → W, "The Boys" → B).
