### PR TITLE
Spoiler: respect spoiler setting in episode button titles

### DIFF
--- a/projects/client/src/lib/features/spoilers/useSpoilerFreeEpisodeTitle.spec.ts
+++ b/projects/client/src/lib/features/spoilers/useSpoilerFreeEpisodeTitle.spec.ts
@@ -1,0 +1,100 @@
+import { episodeSubtitle } from '$lib/utils/intl/episodeSubtitle.ts';
+import { clone } from '$lib/utils/object/clone.ts';
+import { deepAssign } from '$lib/utils/object/deepAssign.ts';
+import { EpisodeSiloMappedMock } from '$mocks/data/summary/episodes/silo/mapped/EpisodeSiloMappedMock.ts';
+import { ExtendedUsersResponseMock } from '$mocks/data/users/response/ExtendedUserSettingsResponseMock.ts';
+import { server } from '$mocks/server.ts';
+import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
+import { waitForValue } from '$test/readable/waitForValue.ts';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { useSpoilerFreeEpisodeTitle } from './useSpoilerFreeEpisodeTitle.ts';
+
+// Neither show is in the watched-history mock, so episodes read as unwatched
+// unless `markEpisodeWatched` puts one there.
+const show = { id: 1337, title: 'Silo' };
+const watchedShow = { id: 1338, title: 'Silo' };
+
+function overrideShowSpoiler(shows: 'hide_title' | null) {
+  const user = deepAssign(clone(ExtendedUsersResponseMock), {
+    browsing: {
+      spoilers: {
+        actors: null,
+        comments: null,
+        episodes: null,
+        movies: null,
+        ratings: null,
+        shows,
+      },
+    },
+  });
+
+  server.use(
+    http.get(
+      'http://localhost/users/settings',
+      () => HttpResponse.json(user),
+    ),
+  );
+}
+
+function markEpisodeWatched() {
+  server.use(
+    http.get('http://localhost/users/me/watched/shows*', ({ request }) => {
+      const page = Number(new URL(request.url).searchParams.get('page') ?? 1);
+
+      if (page > 1) {
+        return HttpResponse.json({});
+      }
+
+      return HttpResponse.json({
+        [watchedShow.id]: {
+          '100|1': {
+            [EpisodeSiloMappedMock.id]: ['2024-12-27T16:28:32.000Z'],
+          },
+        },
+      });
+    }),
+  );
+}
+
+function renderTitle(target = show) {
+  return renderStore(() =>
+    useSpoilerFreeEpisodeTitle({
+      episode: EpisodeSiloMappedMock,
+      show: target,
+    })
+  );
+}
+
+describe('store: useSpoilerFreeEpisodeTitle', () => {
+  it('should surface the episode title when spoilers are not hidden', async () => {
+    setAuthorization(true);
+    overrideShowSpoiler(null);
+
+    const title = await renderTitle();
+
+    expect(await waitForValue(title, EpisodeSiloMappedMock.title))
+      .toBe(EpisodeSiloMappedMock.title);
+  });
+
+  it('should mask the title with its season/episode label when spoilers are hidden', async () => {
+    setAuthorization(true);
+    overrideShowSpoiler('hide_title');
+
+    const title = await renderTitle();
+    const masked = episodeSubtitle(EpisodeSiloMappedMock);
+
+    expect(await waitForValue(title, masked)).toBe(masked);
+  });
+
+  it('should surface the episode title for a watched episode when spoilers are hidden', async () => {
+    setAuthorization(true);
+    overrideShowSpoiler('hide_title');
+    markEpisodeWatched();
+
+    const title = await renderTitle(watchedShow);
+
+    expect(await waitForValue(title, EpisodeSiloMappedMock.title))
+      .toBe(EpisodeSiloMappedMock.title);
+  });
+});

--- a/projects/client/src/lib/features/spoilers/useSpoilerFreeEpisodeTitle.ts
+++ b/projects/client/src/lib/features/spoilers/useSpoilerFreeEpisodeTitle.ts
@@ -1,0 +1,27 @@
+import type { EpisodeEntry } from '$lib/requests/models/EpisodeEntry.ts';
+import { episodeSubtitle } from '$lib/utils/intl/episodeSubtitle.ts';
+import { map } from 'rxjs';
+import { useMediaSpoiler } from './useMediaSpoiler.ts';
+
+type SpoilerFreeEpisodeTitleProps = {
+  episode: EpisodeEntry;
+  show: { id: number; title: string };
+};
+
+export function useSpoilerFreeEpisodeTitle(
+  props: SpoilerFreeEpisodeTitleProps,
+) {
+  const { episode, show } = props;
+
+  const { isSpoilerHidden } = useMediaSpoiler({
+    show,
+    media: episode,
+    type: 'episode',
+  });
+
+  return isSpoilerHidden.pipe(
+    map(($isSpoilerHidden) =>
+      $isSpoilerHidden ? episodeSubtitle(episode) : episode.title
+    ),
+  );
+}

--- a/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeCard.svelte
@@ -12,6 +12,7 @@
   import * as m from "$lib/features/i18n/messages.ts";
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
   import { useEpisodeSpoilerImage } from "$lib/features/spoilers/useEpisodeSpoilerImage";
+  import { useSpoilerFreeEpisodeTitle } from "$lib/features/spoilers/useSpoilerFreeEpisodeTitle.ts";
   import {
     EPISODE_COVER_PLACEHOLDER,
     MEDIA_POSTER_PLACEHOLDER,
@@ -39,6 +40,10 @@
     useEpisodeSpoilerImage({ episode, show, variant: rest.variant }),
   );
 
+  const spoilerFreeTitle = $derived(
+    useSpoilerFreeEpisodeTitle({ episode, show }),
+  );
+
   const episodeLink = $derived(
     rest.urlOverride ?? {
       href: UrlBuilder.episodeDrawer(show.slug, episode.season, episode.number),
@@ -55,8 +60,8 @@
     <CardActionBar>
       {#snippet actions()}
         <PopupMenu
-          label={m.button_label_popup_menu({ title: episode.title })}
-          title={episode.title}
+          label={m.button_label_popup_menu({ title: $spoilerFreeTitle })}
+          title={$spoilerFreeTitle}
         >
           {#snippet items()}
             {@render externalPopupActions()}
@@ -81,7 +86,7 @@
       <CardCover
         title={show.title}
         src={show.poster.url.thumb ?? MEDIA_POSTER_PLACEHOLDER}
-        alt={`${show.title} - ${episode.title}`}
+        alt={`${show.title} - ${$spoilerFreeTitle}`}
         {badge}
       />
 
@@ -108,7 +113,7 @@
       <CardCover
         title={show.title}
         src={$src ?? EPISODE_COVER_PLACEHOLDER}
-        alt={`${show.title} - ${episode.title}`}
+        alt={`${show.title} - ${$spoilerFreeTitle}`}
         {badge}
         {tag}
       />

--- a/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/EpisodeItem.svelte
@@ -11,6 +11,7 @@
   import { TagIntlProvider } from "$lib/components/media/tags/TagIntlProvider";
   import TagBar from "$lib/components/tags/TagBar.svelte";
   import TextTag from "$lib/components/tags/TextTag.svelte";
+  import { useSpoilerFreeEpisodeTitle } from "$lib/features/spoilers/useSpoilerFreeEpisodeTitle.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import MarkAsWatchedAction from "$lib/sections/media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import { useIsWatched } from "$lib/sections/media-actions/mark-as-watched/useIsWatched";
@@ -54,6 +55,13 @@
     useIsWatched({ type: "episode", media: props.episode, show: props.media }),
   );
 
+  const spoilerFreeTitle = $derived(
+    useSpoilerFreeEpisodeTitle({
+      episode: props.episode,
+      show: props.media,
+    }),
+  );
+
   const hasMarkAsWatched = $derived.by(() => {
     if (isListItem || isFuture || isHidden || isActivity) {
       return false;
@@ -90,7 +98,7 @@
           style="action"
           type="episode"
           size="small"
-          title={props.episode.title}
+          title={$spoilerFreeTitle}
           media={props.episode}
           show={props.media}
         />

--- a/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
+++ b/projects/client/src/lib/sections/lists/components/MediaSummaryCard.svelte
@@ -11,6 +11,7 @@
   import { getLocale } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import Spoiler from "$lib/features/spoilers/components/Spoiler.svelte";
+  import { useSpoilerFreeEpisodeTitle } from "$lib/features/spoilers/useSpoilerFreeEpisodeTitle.ts";
   import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia";
   import { EPISODE_COVER_PLACEHOLDER } from "$lib/utils/assets";
   import { toHumanDate } from "$lib/utils/formatting/date/toHumanDate";
@@ -20,6 +21,7 @@
   import { episodeSubtitle } from "$lib/utils/intl/episodeSubtitle";
   import { seasonLabel } from "$lib/utils/intl/seasonLabel";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import { of } from "rxjs";
   import type { Snippet } from "svelte";
   import SummaryCardBackgroundImage from "./_internal/SummaryCardBackgroundImage.svelte";
   import SummaryCardBottomBar from "./_internal/SummaryCardBottomBar.svelte";
@@ -77,6 +79,15 @@
     rest.type === "episode" && "context" in rest && rest.context === "show",
   );
 
+  const spoilerFreeTitle = $derived(
+    rest.type === "episode"
+      ? useSpoilerFreeEpisodeTitle({
+          episode: rest.episode,
+          show: media,
+        })
+      : of(media.title),
+  );
+
   const coverData = $derived.by(() => {
     if (rest.type === "episode") {
       const episodeCover = rest.episode.cover.url ?? EPISODE_COVER_PLACEHOLDER;
@@ -85,7 +96,7 @@
       return {
         background: !isMinimal ? episodeCover : undefined,
         poster: posterOverride ?? media.poster.url.thumb,
-        title: rest.episode.title,
+        title: $spoilerFreeTitle,
       };
     }
 
@@ -156,10 +167,6 @@
         )
       : UrlBuilder.media(media.type, media.slug);
   });
-
-  const popupMenuTitle = $derived(
-    rest.type === "episode" ? rest.episode.title : media.title,
-  );
 </script>
 
 {#snippet cardContent()}
@@ -278,7 +285,7 @@
     <CardActionBar variant={isCompact || isMinimal ? "standalone" : "default"}>
       {#snippet actions()}
         <PopupMenu
-          label={m.button_label_popup_menu({ title: popupMenuTitle })}
+          label={m.button_label_popup_menu({ title: $spoilerFreeTitle })}
           mode="standalone"
           title={media.title}
         >

--- a/projects/client/src/lib/sections/lists/progress/_internal/UpNextItem.svelte
+++ b/projects/client/src/lib/sections/lists/progress/_internal/UpNextItem.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+  import { useSpoilerFreeEpisodeTitle } from "$lib/features/spoilers/useSpoilerFreeEpisodeTitle.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { EpisodeProgressEntry } from "$lib/requests/models/EpisodeProgressEntry";
   import type { MovieProgressEntry } from "$lib/requests/models/MovieProgressEntry";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry";
   import RestoreAction from "$lib/sections/media-actions/restore/RestoreAction.svelte";
+  import { of } from "rxjs";
   import DropAction from "../../../media-actions/drop/DropAction.svelte";
   import MarkAsWatchedAction from "../../../media-actions/mark-as-watched/MarkAsWatchedAction.svelte";
   import EpisodeItem from "../../components/EpisodeItem.svelte";
@@ -26,6 +28,15 @@
   };
 
   const { style, ...props }: UpNextProps = $props();
+
+  const spoilerFreeTitle = $derived(
+    "episode" in props
+      ? useSpoilerFreeEpisodeTitle({
+          episode: props.episode,
+          show: props.show,
+        })
+      : of(""),
+  );
 </script>
 
 {#if "episode" in props}
@@ -47,7 +58,7 @@
           <MarkAsWatchedAction
             style="dropdown-item"
             type="episode"
-            title={props.episode.title}
+            title={$spoilerFreeTitle}
             show={props.show}
             media={props.episode}
           />

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
@@ -12,6 +12,7 @@
   import ClampedText from "$lib/components/text/ClampedText.svelte";
   import { getLocale, languageTag } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
+  import { useSpoilerFreeEpisodeTitle } from "$lib/features/spoilers/useSpoilerFreeEpisodeTitle.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import type { EpisodeEntry } from "$lib/requests/models/EpisodeEntry.ts";
   import type { MediaCrew } from "$lib/requests/models/MediaCrew.ts";
@@ -86,6 +87,12 @@
     entry
       ? useIsRateable({ type: "episode", media: entry, show })
       : { isRateable: of(false) },
+  );
+
+  const spoilerFreeTitle = $derived(
+    entry
+      ? useSpoilerFreeEpisodeTitle({ episode: entry, show })
+      : of(""),
   );
 
   const { buildEpisodeDrawerLink } = summaryDrawerNavigation();
@@ -327,7 +334,7 @@
           <EpisodeActions
             episode={entry}
             {show}
-            title={entry.title}
+            title={$spoilerFreeTitle}
             showTitle={show.title}
             {onHistoryOpen}
           />


### PR DESCRIPTION
# Summary

Closes #2972. Spoiler-hidden episode titles were still visible in the track button's tooltip / `aria-label` in Continue Watching and the episode drawer. Cards blur the title visually via `<Spoiler>`, but the raw `episode.title` was folded into plain button strings (tooltips, `aria-label`s, popup headers) that aren't blurred, so the spoiler leaked there.

# Fix

Added `useSpoilerFreeEpisodeTitle`, a small hook mirroring the existing `useEpisodeSpoilerImage` pattern. It reuses `useMediaSpoiler` (unwatched + spoiler preference → hidden, the same signal that drives the visual blur) and swaps in a spoiler-free season/episode label (e.g. `S1 • E5`) when hidden, otherwise passing the real title through unchanged.

Applied it everywhere the title was folded into a button string on a surface that blurs the title:

- Continue Watching track button (the one in the issue screenshot) and all cover-card "next" buttons — `EpisodeItem.svelte`
- Episode drawer track button — `EpisodeInfoHeader.svelte` (the drawer only shows the S/E number, never the title heading)
- Continue Watching popup "Mark as watched" item — `UpNextItem.svelte`
- Continue Watching card "⋯" popup `aria-label` + mobile drawer header — `EpisodeCard.svelte`
- Summary-style card "⋯" popup `aria-label` — `MediaSummaryCard.svelte`

# Scope

The full episode summary page is intentionally left untouched: it renders the title openly as a heading, so masking only its button tooltip would be inconsistent. When an episode is watched, or spoilers are off, behavior is unchanged and the real title flows through as before.

# Testing

Added a colocated spec `useSpoilerFreeEpisodeTitle.spec.ts` covering both branches (title shown when not hidden, season/episode label when hidden). Ran the spoilers feature suite via `vitest` directly — new spec 2 passed, whole spoilers feature 15 passed.
