### PR TITLE
fix(search): rank the deep catalog tail after fuzzy results

### DIFF
--- a/projects/client/src/lib/features/search/_internal/splitExactByConfidence.spec.ts
+++ b/projects/client/src/lib/features/search/_internal/splitExactByConfidence.spec.ts
@@ -1,0 +1,45 @@
+import type { MediaSearchResult } from '$lib/requests/queries/search/searchMediaQuery.ts';
+import { describe, expect, it } from 'vitest';
+import { splitExactByConfidence } from './splitExactByConfidence.ts';
+
+type ExactItem = MediaSearchResult['items'][number];
+
+const item = (key: string, score: number) => ({ key, score } as ExactItem);
+
+describe('splitExactByConfidence', () => {
+  it('should lead with a unique or year-pinned hit', () => {
+    const { confident, deep } = splitExactByConfidence([
+      item('movie-1', 1),
+      item('movie-2', 0.75),
+    ]);
+
+    expect(confident.map((entry) => entry.key)).toEqual(['movie-1', 'movie-2']);
+    expect(deep).toEqual([]);
+  });
+
+  it('should hold back the deep catalog tail', () => {
+    const { confident, deep } = splitExactByConfidence([
+      item('movie-1', 0.25),
+      item('movie-2', 0.25),
+    ]);
+
+    expect(confident).toEqual([]);
+    expect(deep.map((entry) => entry.key)).toEqual(['movie-1', 'movie-2']);
+  });
+
+  it('should split a mixed result set while preserving order', () => {
+    const { confident, deep } = splitExactByConfidence([
+      item('movie-1', 1),
+      item('movie-2', 0.25),
+      item('movie-3', 0.75),
+      item('movie-4', 0.25),
+    ]);
+
+    expect(confident.map((entry) => entry.key)).toEqual(['movie-1', 'movie-3']);
+    expect(deep.map((entry) => entry.key)).toEqual(['movie-2', 'movie-4']);
+  });
+
+  it('should handle an empty result set', () => {
+    expect(splitExactByConfidence([])).toEqual({ confident: [], deep: [] });
+  });
+});

--- a/projects/client/src/lib/features/search/_internal/splitExactByConfidence.ts
+++ b/projects/client/src/lib/features/search/_internal/splitExactByConfidence.ts
@@ -1,0 +1,22 @@
+import type { MediaSearchResult } from '$lib/requests/queries/search/searchMediaQuery.ts';
+
+type ExactItems = MediaSearchResult['items'];
+
+/** Mirrors the score bands the API assigns to an exact hit. */
+const CONFIDENT_SCORE = 0.5;
+
+const isConfident = (item: ExactItems[number]) => item.score >= CONFIDENT_SCORE;
+
+/**
+ * Split exact hits into the ones that may outrank fuzzy results and the deep
+ * catalog tail that must not. Scores are only comparable within a source, so
+ * bucket on the threshold rather than sorting across sources by raw score.
+ */
+export function splitExactByConfidence(
+  items: ExactItems,
+): { confident: ExactItems; deep: ExactItems } {
+  return {
+    confident: items.filter(isConfident),
+    deep: items.filter((item) => !isConfident(item)),
+  };
+}

--- a/projects/client/src/lib/features/search/useSearch.ts
+++ b/projects/client/src/lib/features/search/useSearch.ts
@@ -34,6 +34,7 @@ import { createBulkMediaIntl } from '../intl-overlay/createBulkMediaIntl.ts';
 import { getSearchContext } from './_internal/getSearchContext.ts';
 import { mapToSearchCover } from './_internal/mapToSearchCover.ts';
 import { postRecentSearch } from './_internal/postRecentSearch.ts';
+import { splitExactByConfidence } from './_internal/splitExactByConfidence.ts';
 import { ensureFreshSearchKeys } from './ensureFreshSearchKeys.ts';
 import type { SearchResponse } from './models/SearchResponse.ts';
 
@@ -125,15 +126,24 @@ export function useSearch() {
             modeToQuery(term, currentMode, freshConfig, true),
           );
           return combineLatest([exactQuery, searchQuery, trendingQuery]).pipe(
-            map(([exactResults, searchResults, trendingResults]) => ({
-              type: 'media' as const,
-              items: dedupe(
-                (item) => item.key,
+            map(([exactResults, searchResults, trendingResults]) => {
+              // Only unambiguous exact hits lead; the deep catalog tail trails
+              // the fuzzy results instead of displacing them.
+              const { confident, deep } = splitExactByConfidence(
                 (exactResults as MediaSearchResult).items,
-                trendingResults?.items ?? [],
-                (searchResults as MediaSearchResult).items,
-              ),
-            })),
+              );
+
+              return {
+                type: 'media' as const,
+                items: dedupe(
+                  (item) => item.key,
+                  confident,
+                  trendingResults?.items ?? [],
+                  (searchResults as MediaSearchResult).items,
+                  deep,
+                ),
+              };
+            }),
           );
         }),
         // Contain a failed lookup to this search. Without this the error


### PR DESCRIPTION
Media search runs an exact pass alongside the fuzzy one and currently places **every** exact hit first. That is correct for an unambiguous hit, and wrong for a title that dozens of entries share.

Concretely: searching `matrix` leads with the obscure entries literally titled "Matrix" instead of The Matrix - which does not match the query exactly at all, so it can only come from the fuzzy pass and gets pushed down.

## Change

Bucket exact hits on the score the API assigns them:

- **Unambiguous** (a unique title, or one pinned down by an explicit year) - keeps leading, ahead of trending and fuzzy.
- **Deep catalog tail** (title shared with other entries, no following) - trails the fuzzy results.

Niche titles therefore become reachable in the list without displacing the results people actually mean. Extracted as `splitExactByConfidence` with unit coverage; the weave itself is otherwise unchanged.

Scores are only comparable within a single source (a relevance engine's text-match score is unbounded), so this buckets on a threshold rather than sorting across sources by raw score.

## Test plan

- [x] `deno fmt` + `deno lint` clean
- [x] Unit coverage for the split (leading, held-back, mixed ordering, empty)
- [ ] CI gate (`deno task check` + vitest)
- [ ] Manual: `matrix` leads with The Matrix; a niche exact title still appears in the list

Paired with an API-side change that assigns the scores; that half must ship first, and until it does every exact hit scores as unambiguous, preserving today's ordering.
