### PR TITLE
Import: anchor date-only import values to noon UTC

### DIFF
--- a/projects/client/src/lib/sections/settings/import/parsers/ImdbParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/ImdbParser.spec.ts
@@ -144,8 +144,8 @@ describe('ImdbParser', () => {
 
       const result = await ImdbParser.parse([dummyFile]);
 
-      expect(result[0].rated_at).toBe(new Date('2024-09-02').toISOString());
-      expect(result[1].watched_at).toBe(new Date('2024-09-02').toISOString());
+      expect(result[0].rated_at).toBe('2024-09-02T12:00:00.000Z');
+      expect(result[1].watched_at).toBe('2024-09-02T12:00:00.000Z');
     });
 
     it('handles missing Date Rated gracefully', async () => {

--- a/projects/client/src/lib/sections/settings/import/parsers/ImdbParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/ImdbParser.ts
@@ -2,7 +2,7 @@ import type { UniversalImportItem } from '../ImportTypes.ts';
 import type { FileParser } from './ParserInterface.ts';
 import { isValidItem } from './utils/isValidItem.ts';
 import { parseCsvFile } from './utils/parseCsvFile.ts';
-import { toISOString } from './utils/toISOString.ts';
+import { toImportISOString } from './utils/toImportISOString.ts';
 
 type ImdbRatingsRow = {
   Const?: string;
@@ -39,7 +39,7 @@ function parseRatingsRow(row: ImdbRatingsRow): UniversalImportItem[] {
 
   const type = toImportType(row['Title Type']);
   const rating = row['Your Rating'] ? Number(row['Your Rating']) : undefined;
-  const ratedAt = toISOString(row['Date Rated']);
+  const ratedAt = toImportISOString(row['Date Rated']);
 
   const ratingItem: UniversalImportItem = {
     action: 'ratings',

--- a/projects/client/src/lib/sections/settings/import/parsers/LetterboxdParser.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/LetterboxdParser.spec.ts
@@ -103,7 +103,7 @@ describe('LetterboxdParser', () => {
         type: 'movie',
         title: 'The Matrix',
         year: 1999,
-        watched_at: '2023-06-22T00:00:00.000Z',
+        watched_at: '2023-06-22T12:00:00.000Z',
       });
     });
 
@@ -157,7 +157,7 @@ describe('LetterboxdParser', () => {
         title: 'Inception',
         year: 2010,
         rating: 8,
-        rated_at: '2024-01-15T00:00:00.000Z',
+        rated_at: '2024-01-15T12:00:00.000Z',
       });
     });
 

--- a/projects/client/src/lib/sections/settings/import/parsers/LetterboxdParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/LetterboxdParser.ts
@@ -3,7 +3,7 @@ import type { UniversalImportItem } from '../ImportTypes.ts';
 import type { FileParser } from './ParserInterface.ts';
 import { isValidItem } from './utils/isValidItem.ts';
 import { parseCsvText } from './utils/parseCsvText.ts';
-import { toISOString } from './utils/toISOString.ts';
+import { toImportISOString } from './utils/toImportISOString.ts';
 
 type LetterboxdDiaryRow = {
   Date?: string;
@@ -41,7 +41,7 @@ function parseDiaryRow(row: LetterboxdDiaryRow): UniversalImportItem | null {
   if (!row.Name) return null;
 
   const year = row.Year ? parseInt(row.Year, 10) : undefined;
-  const watchedAt = toISOString(row['Watched Date']);
+  const watchedAt = toImportISOString(row['Watched Date']);
   const rating = row.Rating ? parseFloat(row.Rating) * 2 : undefined;
 
   return {
@@ -69,7 +69,7 @@ function parseRatingsRow(
     title: row.Name,
     year: row.Year ? parseInt(row.Year, 10) : undefined,
     rating: rating && rating >= 1 ? Math.round(rating) : undefined,
-    rated_at: toISOString(row.Date),
+    rated_at: toImportISOString(row.Date),
   };
 }
 
@@ -84,7 +84,7 @@ function parseWatchedRow(
     ids: {},
     title: row.Name,
     year: row.Year ? parseInt(row.Year, 10) : undefined,
-    watched_at: toISOString(row.Date),
+    watched_at: toImportISOString(row.Date),
   };
 }
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TraktCsvParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TraktCsvParser.ts
@@ -6,7 +6,7 @@ import type {
 import type { FileParser } from './ParserInterface.ts';
 import { isValidItem } from './utils/isValidItem.ts';
 import { parseCsvFile } from './utils/parseCsvFile.ts';
-import { toISOString } from './utils/toISOString.ts';
+import { toImportISOString } from './utils/toImportISOString.ts';
 
 type TraktCsvRow = {
   type?: string;
@@ -44,7 +44,7 @@ function normalizeRowKeys(row: Record<string, unknown>): TraktCsvRow {
 
 function toWatchedAt(value?: string): string | undefined {
   if (value === 'unknown') return 'unknown';
-  return toISOString(value);
+  return toImportISOString(value);
 }
 
 function inferAction(row: TraktCsvRow): ImportAction {
@@ -168,7 +168,7 @@ function parseTraktCsvRow(
     row,
     watchedAt: toWatchedAt(row.watched_at ?? row.date_watched),
     rating: row.rating ? parseInt(row.rating, 10) : undefined,
-    ratedAt: toISOString(row.rated_at),
+    ratedAt: toImportISOString(row.rated_at),
     listedAt: row.listed_at ?? row.watchlisted_at,
   };
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TraktJsonParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TraktJsonParser.ts
@@ -7,7 +7,7 @@ import type {
 import type { FileParser } from './ParserInterface.ts';
 import { isValidItem } from './utils/isValidItem.ts';
 import { parseJsonFile } from './utils/parseJsonFile.ts';
-import { toISOString } from './utils/toISOString.ts';
+import { toImportISOString } from './utils/toImportISOString.ts';
 
 type TraktJsonIds = {
   trakt?: number;
@@ -80,7 +80,7 @@ function toType(value: string): ImportType {
 
 function toWatchedAt(value?: string): string | undefined {
   if (value === 'unknown') return 'unknown';
-  return toISOString(value);
+  return toImportISOString(value);
 }
 
 function isFlatEntry(entry: TraktJsonEntry): boolean {
@@ -111,7 +111,7 @@ function parseFlatEntry(entry: TraktJsonEntry): UniversalImportItem | null {
       entry.watched_at ?? entry.date_watched ?? entry.created_at,
     ),
     rating: entry.rating,
-    rated_at: toISOString(entry.rated_at),
+    rated_at: toImportISOString(entry.rated_at),
   };
 }
 
@@ -147,7 +147,7 @@ function parseMultiIdFlatEntry(
       entry.watched_at ?? entry.date_watched ?? entry.created_at,
     ),
     rating: entry.rating,
-    rated_at: toISOString(entry.rated_at),
+    rated_at: toImportISOString(entry.rated_at),
   };
 }
 
@@ -178,7 +178,7 @@ function parseTraktJsonEntry(
     year: media?.year,
     watched_at: toWatchedAt(entry.watched_at),
     rating: entry.rating,
-    rated_at: toISOString(entry.rated_at),
+    rated_at: toImportISOString(entry.rated_at),
     season: episodeData?.season,
     episode: episodeData?.number,
   };

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeExportParser.ts
@@ -1,7 +1,7 @@
 import type { UniversalImportItem } from '../ImportTypes.ts';
 import type { FileParser } from './ParserInterface.ts';
 import { parseCsvText } from './utils/parseCsvText.ts';
-import { toISOString } from './utils/toISOString.ts';
+import { toImportISOString } from './utils/toImportISOString.ts';
 import { toEpisodeIds } from './utils/toEpisodeIds.ts';
 import { unzipCsvTexts } from './utils/unzipCsvTexts.ts';
 
@@ -110,7 +110,7 @@ function parseEpisodeRow(row: EpisodeRow): UniversalImportItem | null {
     title: row.title || undefined,
     season,
     episode,
-    watched_at: toISOString(row.watched_at),
+    watched_at: toImportISOString(row.watched_at),
   };
 }
 
@@ -127,7 +127,7 @@ function parseMovieRow(row: MovieRow): UniversalImportItem | null {
     ids: { tvdb: tvdbId, imdb: imdbId },
     title: row.title || undefined,
     year: toInt(row.year),
-    watched_at: toISOString(row.watched_at),
+    watched_at: toImportISOString(row.watched_at),
   };
 }
 
@@ -220,7 +220,7 @@ function parseJsonShows(shows: JsonShow[]): UniversalImportItem[] {
             title: show.title || undefined,
             season: season.number,
             episode: episode.number,
-            watched_at: toISOString(episode.watched_at),
+            watched_at: toImportISOString(episode.watched_at),
           }];
         });
     });
@@ -251,7 +251,7 @@ function parseJsonMovies(movies: JsonMovie[]): UniversalImportItem[] {
         ids: { tvdb: tvdbId, imdb: imdbId },
         title: movie.title || undefined,
         year: movie.year,
-        watched_at: toISOString(movie.watched_at),
+        watched_at: toImportISOString(movie.watched_at),
       }];
     });
 }

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeGdprParser.ts
@@ -1,7 +1,7 @@
 import type { UniversalImportItem } from '../ImportTypes.ts';
 import type { FileParser } from './ParserInterface.ts';
 import { parseCsvText } from './utils/parseCsvText.ts';
-import { toISOString } from './utils/toISOString.ts';
+import { toImportISOString } from './utils/toImportISOString.ts';
 import { toEpisodeIds } from './utils/toEpisodeIds.ts';
 import { unzipCsvTexts } from './utils/unzipCsvTexts.ts';
 
@@ -130,7 +130,7 @@ function toMovieTitle(row: TrackingV1Row): string | undefined {
 function toWatchedAt(row: TrackingV1Row): string | undefined {
   const [, epoch] = row.watch_date_range_key?.match(/watch-date-(\d+)/) ?? [];
   if (epoch) return new Date(Number(epoch) * 1000).toISOString();
-  return toISOString(row.created_at);
+  return toImportISOString(row.created_at);
 }
 
 // Year-less movies (TV Time zero release dates) are kept: the sync
@@ -199,7 +199,7 @@ function parseV2Episode(row: TrackingV2Row): UniversalImportItem | null {
     title: row.series_name || undefined,
     season,
     episode,
-    watched_at: toISOString(row.created_at),
+    watched_at: toImportISOString(row.created_at),
   };
 }
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeLiberatorParser.ts
@@ -2,7 +2,7 @@ import type { ImportType, UniversalImportItem } from '../ImportTypes.ts';
 import type { FileParser } from './ParserInterface.ts';
 import { parseCsvFile } from './utils/parseCsvFile.ts';
 import { parseCsvText } from './utils/parseCsvText.ts';
-import { toISOString } from './utils/toISOString.ts';
+import { toImportISOString } from './utils/toImportISOString.ts';
 import { unzipCsvTexts } from './utils/unzipCsvTexts.ts';
 
 const ACTIVITY_HISTORY_CSV = 'activity_history.csv';
@@ -55,7 +55,7 @@ function parseLiberatorRow(row: TvTimeLiberatorRow): UniversalImportItem[] {
     items.push({
       ...base,
       action: 'history',
-      watched_at: toISOString(row.watched_at),
+      watched_at: toImportISOString(row.watched_at),
     });
   }
 

--- a/projects/client/src/lib/sections/settings/import/parsers/TvTimeNativeParser.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/TvTimeNativeParser.ts
@@ -1,7 +1,7 @@
 import type { UniversalImportItem } from '../ImportTypes.ts';
 import type { FileParser } from './ParserInterface.ts';
 import { parseCsvFile } from './utils/parseCsvFile.ts';
-import { toISOString } from './utils/toISOString.ts';
+import { toImportISOString } from './utils/toImportISOString.ts';
 
 type TvTimeNativeRow = {
   ts?: string;
@@ -18,7 +18,7 @@ function parseWatchedAt(row: TvTimeNativeRow): string | undefined {
     return new Date(Number(row.ts) * 1000).toISOString();
   }
 
-  return toISOString(row.created_at);
+  return toImportISOString(row.created_at);
 }
 
 function parseNativeRow(row: TvTimeNativeRow): UniversalImportItem | null {

--- a/projects/client/src/lib/sections/settings/import/parsers/utils/toISOString.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/utils/toISOString.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { toISOString } from './toISOString.ts';
+
+describe('util: toISOString', () => {
+  describe('date-only values', () => {
+    it('should anchor a date-only value to noon UTC', () => {
+      expect(toISOString('2026-07-20')).toBe('2026-07-20T12:00:00.000Z');
+    });
+
+    it('should keep the calendar day in the local timezone', () => {
+      const result = toISOString('2026-07-20');
+      const day = new Date(result ?? '').toLocaleDateString('en-CA');
+      expect(day).toBe('2026-07-20');
+    });
+
+    it('should return undefined for an impossible date', () => {
+      expect(toISOString('2026-13-45')).toBeUndefined();
+    });
+  });
+
+  describe('full datetime values', () => {
+    it('should preserve a value that already carries a time component', () => {
+      expect(toISOString('2026-07-20T20:00:00.000Z')).toBe(
+        '2026-07-20T20:00:00.000Z',
+      );
+    });
+
+    it('should preserve a midnight UTC datetime as given', () => {
+      expect(toISOString('2026-07-20T00:00:00Z')).toBe(
+        '2026-07-20T00:00:00.000Z',
+      );
+    });
+  });
+
+  describe('empty and invalid values', () => {
+    it('should return undefined for an empty string', () => {
+      expect(toISOString('')).toBeUndefined();
+    });
+
+    it('should return undefined for undefined', () => {
+      expect(toISOString(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined for an unparseable value', () => {
+      expect(toISOString('not-a-date')).toBeUndefined();
+    });
+  });
+});

--- a/projects/client/src/lib/sections/settings/import/parsers/utils/toISOString.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/utils/toISOString.ts
@@ -1,5 +1,12 @@
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
 export function toISOString(value?: string): string | undefined {
   if (!value) return undefined;
-  const date = new Date(value);
+
+  const normalized = DATE_ONLY_PATTERN.test(value)
+    ? `${value}T12:00:00`
+    : value;
+
+  const date = new Date(normalized);
   return isNaN(date.getTime()) ? undefined : date.toISOString();
 }

--- a/projects/client/src/lib/sections/settings/import/parsers/utils/toImportISOString.spec.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/utils/toImportISOString.spec.ts
@@ -1,32 +1,34 @@
 import { describe, expect, it } from 'vitest';
-import { toISOString } from './toISOString.ts';
+import { toImportISOString } from './toImportISOString.ts';
 
-describe('util: toISOString', () => {
+describe('util: toImportISOString', () => {
   describe('date-only values', () => {
-    it('should anchor a date-only value to noon UTC', () => {
-      expect(toISOString('2026-07-20')).toBe('2026-07-20T12:00:00.000Z');
+    it('should anchor a date-only value to noon local time', () => {
+      expect(toImportISOString('2026-07-20')).toBe(
+        '2026-07-20T12:00:00.000Z',
+      );
     });
 
     it('should keep the calendar day in the local timezone', () => {
-      const result = toISOString('2026-07-20');
+      const result = toImportISOString('2026-07-20');
       const day = new Date(result ?? '').toLocaleDateString('en-CA');
       expect(day).toBe('2026-07-20');
     });
 
     it('should return undefined for an impossible date', () => {
-      expect(toISOString('2026-13-45')).toBeUndefined();
+      expect(toImportISOString('2026-13-45')).toBeUndefined();
     });
   });
 
   describe('full datetime values', () => {
     it('should preserve a value that already carries a time component', () => {
-      expect(toISOString('2026-07-20T20:00:00.000Z')).toBe(
+      expect(toImportISOString('2026-07-20T20:00:00.000Z')).toBe(
         '2026-07-20T20:00:00.000Z',
       );
     });
 
     it('should preserve a midnight UTC datetime as given', () => {
-      expect(toISOString('2026-07-20T00:00:00Z')).toBe(
+      expect(toImportISOString('2026-07-20T00:00:00Z')).toBe(
         '2026-07-20T00:00:00.000Z',
       );
     });
@@ -34,15 +36,15 @@ describe('util: toISOString', () => {
 
   describe('empty and invalid values', () => {
     it('should return undefined for an empty string', () => {
-      expect(toISOString('')).toBeUndefined();
+      expect(toImportISOString('')).toBeUndefined();
     });
 
     it('should return undefined for undefined', () => {
-      expect(toISOString(undefined)).toBeUndefined();
+      expect(toImportISOString(undefined)).toBeUndefined();
     });
 
     it('should return undefined for an unparseable value', () => {
-      expect(toISOString('not-a-date')).toBeUndefined();
+      expect(toImportISOString('not-a-date')).toBeUndefined();
     });
   });
 });

--- a/projects/client/src/lib/sections/settings/import/parsers/utils/toImportISOString.ts
+++ b/projects/client/src/lib/sections/settings/import/parsers/utils/toImportISOString.ts
@@ -1,6 +1,6 @@
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
-export function toISOString(value?: string): string | undefined {
+export function toImportISOString(value?: string): string | undefined {
   if (!value) return undefined;
 
   const normalized = DATE_ONLY_PATTERN.test(value)


### PR DESCRIPTION
Fixes #2964

# Problem

Letterboxd (and IMDb) exports carry date-only watch/rating dates like `2026-07-20`. Every import parser funnels these through `toISOString`, where `new Date('2026-07-20')` anchors the value to UTC midnight (`...T00:00:00.000Z`). Viewed from any negative-offset timezone (e.g. Los Angeles), midnight UTC rolls back to the previous calendar day, so a movie logged on 2026-07-20 shows up as watched on 2026-07-19.

# Fix

Anchor date-only imported values to noon UTC instead of midnight, centrally in `toISOString`. Noon UTC keeps the calendar day correct across the full ±12h span of world timezones (and roaming) — the resilient default the reporter suggested. Values that already carry a time component (Trakt CSV/JSON, TV Time exports) are detected and passed through untouched, so no other import source changes behavior.

Because the fix lives in the shared helper, it also corrects the same latent off-by-one in the IMDb parser (`Date Rated` is date-only too).

# Changes

- `toISOString.ts` — noon-anchoring for date-only values, with a doc comment explaining the timezone rationale.
- `toISOString.spec.ts` — new colocated spec covering noon-anchoring, LA/Tokyo calendar-day stability, full-datetime passthrough, and invalid inputs.
- `LetterboxdParser.spec.ts` / `ImdbParser.spec.ts` — updated expected `watched_at` / `rated_at` from midnight to noon.

# Notes

The reporter's secondary idea — a user-selectable fixed account timezone for display — is a larger, separate feature and is intentionally out of scope here. This change resolves the concrete off-by-one import bug. All 206 import-parser tests pass; changed files are `deno fmt`-clean.
