### PR TITLE
Cover: show active state on the Set as cover image button

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4276,6 +4276,19 @@
         }
       }
     },
+    "button_subtitle_cover_image_selected": {
+      "default": "Current cover",
+      "description": "Sub-label under the set cover image button, indicating the movie, show, or episode is already set as the users cover image. This must be as short as possible."
+    },
+    "button_label_cover_image_selected": {
+      "default": "\"{title}\" is your cover image.",
+      "description": "Aria-label for the button that indicates the movie, show, or episode is already set as the users cover image.",
+      "variables": {
+        "title": {
+          "type": "string"
+        }
+      }
+    },
     "page_title_start_watching": {
       "default": "Start Watching",
       "description": "Title for the Start Watching page, which shows the movies or shows a user should start watching."

--- a/projects/client/src/lib/components/dropdown/DropdownItem.svelte
+++ b/projects/client/src/lib/components/dropdown/DropdownItem.svelte
@@ -9,6 +9,7 @@
     tabindex?: number;
     icon?: Snippet;
     end?: Snippet;
+    subtitle?: Snippet;
     style?: "ghost" | "flat";
     variant?: "primary" | "secondary";
     selected?: boolean;
@@ -25,6 +26,7 @@
     children,
     icon,
     end,
+    subtitle,
     ...props
   }: DropdownItemProps | DropdownItemAnchorProps = $props();
 
@@ -44,7 +46,12 @@
 </script>
 
 {#snippet text()}
-  <p class="bold capitalize ellipsis">{@render children()}</p>
+  <div class="item-label">
+    <p class="bold capitalize ellipsis">{@render children()}</p>
+    {#if subtitle}
+      <p class="small ellipsis">{@render subtitle()}</p>
+    {/if}
+  </div>
 {/snippet}
 
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
@@ -57,6 +64,7 @@
   data-style={style}
   data-variant={variant}
   class:is-selected={selected}
+  class:has-subtitle={subtitle != null}
   {...props}
 >
   {#if href}
@@ -116,6 +124,15 @@
 
     transition: var(--transition-increment) ease-in-out;
     transition-property: background, color;
+
+    &.has-subtitle {
+      height: auto;
+      padding-block: var(--ni-8);
+    }
+
+    .item-label {
+      min-width: 0;
+    }
 
     .item-icon {
       display: flex;

--- a/projects/client/src/lib/features/feature-flag/isRecentlyAddedFeature.spec.ts
+++ b/projects/client/src/lib/features/feature-flag/isRecentlyAddedFeature.spec.ts
@@ -1,8 +1,17 @@
 import { time } from '$lib/utils/timing/time.ts';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isRecentlyAddedFeature } from './isRecentlyAddedFeature.ts';
 
 describe('util: isRecentlyAddedFeature', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-02-21T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe('past 1-day window', () => {
     it('should return true for a feature added within the last day', () => {
       const anHourAgo = new Date(Date.now() - time.hours(1));

--- a/projects/client/src/lib/sections/media-actions/cover-image/SetCoverImageAction.svelte
+++ b/projects/client/src/lib/sections/media-actions/cover-image/SetCoverImageAction.svelte
@@ -5,6 +5,7 @@
   import * as m from "$lib/features/i18n/messages";
   import type { ExtendedMediaType } from "$lib/requests/models/ExtendedMediaType";
   import { useCoverImage } from "./useCoverImage";
+  import { useIsCover } from "./useIsCover";
   import LoadingIndicator from "$lib/components/icons/LoadingIndicator.svelte";
 
   type SetCoverImageActionProps = {
@@ -26,11 +27,18 @@
   const { isSettingCoverImage, setCoverImage } = $derived(
     useCoverImage({ type, id }),
   );
+  const { isCover } = $derived(useIsCover({ type, id }));
+
+  const label = $derived(
+    $isCover
+      ? m.button_label_cover_image_selected({ title })
+      : m.button_label_set_cover_image({ title }),
+  );
 
   const commonProps = $derived({
     onclick: setCoverImage,
-    label: m.button_label_set_cover_image({ title }),
-    disabled: $isSettingCoverImage,
+    label,
+    disabled: $isSettingCoverImage || $isCover,
   });
 </script>
 
@@ -42,6 +50,10 @@
   {/if}
 {/snippet}
 
+{#snippet coverSubtitle()}
+  {m.button_subtitle_cover_image_selected()}
+{/snippet}
+
 {#if style === "action"}
   <ActionButton style="ghost" {...commonProps}>
     {@render icon()}
@@ -49,7 +61,14 @@
 {/if}
 
 {#if style === "dropdown-item"}
-  <DropdownItem color="default" style="flat" {variant} {...commonProps} {icon}>
+  <DropdownItem
+    color="default"
+    style="flat"
+    {variant}
+    subtitle={$isCover ? coverSubtitle : undefined}
+    {...commonProps}
+    {icon}
+  >
     {m.button_text_set_cover_image()}
   </DropdownItem>
 {/if}

--- a/projects/client/src/lib/sections/media-actions/cover-image/_internal/toCoverMediaRef.spec.ts
+++ b/projects/client/src/lib/sections/media-actions/cover-image/_internal/toCoverMediaRef.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { toCoverMediaRef } from './toCoverMediaRef.ts';
+
+describe('util: toCoverMediaRef', () => {
+  it('should recover a movie reference from a fanart url', () => {
+    expect(
+      toCoverMediaRef(
+        'https://walter-r2.trakt.tv/images/movies/000/916/302/fanarts/medium/626327d7b4.jpg.webp',
+      ),
+    ).toEqual({ type: 'movie', id: 916302 });
+  });
+
+  it('should recover a show reference from a fanart url', () => {
+    expect(
+      toCoverMediaRef(
+        'https://walter-r2.trakt.tv/images/shows/000/180/770/fanarts/thumb/80d39f8578.jpg.webp',
+      ),
+    ).toEqual({ type: 'show', id: 180770 });
+  });
+
+  it('should recover an episode reference from a screenshot url', () => {
+    expect(
+      toCoverMediaRef(
+        'https://walter-r2.trakt.tv/images/episodes/000/298/461/screenshots/medium/abc123.jpg.webp',
+      ),
+    ).toEqual({ type: 'episode', id: 298461 });
+  });
+
+  it('should ignore image size and extension differences', () => {
+    const original = toCoverMediaRef(
+      'https://walter-r2.trakt.tv/images/movies/000/916/302/fanarts/original/626327d7b4.jpg',
+    );
+    const thumb = toCoverMediaRef(
+      'https://walter-r2.trakt.tv/images/movies/000/916/302/fanarts/thumb/626327d7b4.jpg.webp',
+    );
+
+    expect(original).toEqual({ type: 'movie', id: 916302 });
+    expect(original).toEqual(thumb);
+  });
+
+  it('should return null for a non-media cover (e.g. a vip header)', () => {
+    expect(
+      toCoverMediaRef(
+        'https://walter.trakt.tv/images/users/014/366/083/headers/original/disco_cop.png',
+      ),
+    ).toBeNull();
+  });
+
+  it('should return null for nullish input', () => {
+    expect(toCoverMediaRef(null)).toBeNull();
+    expect(toCoverMediaRef(undefined)).toBeNull();
+    expect(toCoverMediaRef('')).toBeNull();
+  });
+});

--- a/projects/client/src/lib/sections/media-actions/cover-image/_internal/toCoverMediaRef.ts
+++ b/projects/client/src/lib/sections/media-actions/cover-image/_internal/toCoverMediaRef.ts
@@ -1,0 +1,34 @@
+import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
+
+type CoverMediaRef = {
+  type: ExtendedMediaType;
+  id: number;
+};
+
+// The cover endpoint only echoes back the image URL, never the media id/type,
+// so both are recovered from the zero-padded id in the path.
+const coverPathPattern =
+  /\/images\/(movies|shows|episodes)\/(\d{3})\/(\d{3})\/(\d{3})\//;
+
+const mediaTypeMap: Record<string, ExtendedMediaType> = {
+  movies: 'movie',
+  shows: 'show',
+  episodes: 'episode',
+};
+
+export function toCoverMediaRef(url: string | Nil): CoverMediaRef | null {
+  const match = url?.match(coverPathPattern);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, urlType, high, mid, low] = match;
+  const type = urlType ? mediaTypeMap[urlType] : undefined;
+
+  if (!type) {
+    return null;
+  }
+
+  return { type, id: Number(`${high}${mid}${low}`) };
+}

--- a/projects/client/src/lib/sections/media-actions/cover-image/useIsCover.ts
+++ b/projects/client/src/lib/sections/media-actions/cover-image/useIsCover.ts
@@ -1,0 +1,22 @@
+import { useUser } from '$lib/features/auth/stores/useUser.ts';
+import type { ExtendedMediaType } from '$lib/requests/models/ExtendedMediaType.ts';
+import { map } from 'rxjs';
+import { toCoverMediaRef } from './_internal/toCoverMediaRef.ts';
+
+type UseIsCoverProps = {
+  type: ExtendedMediaType;
+  id: number;
+};
+
+export function useIsCover({ type, id }: UseIsCoverProps) {
+  const { user } = useUser();
+
+  const isCover = user.pipe(
+    map((current) => {
+      const cover = toCoverMediaRef(current?.cover.url);
+      return cover?.type === type && cover?.id === id;
+    }),
+  );
+
+  return { isCover };
+}


### PR DESCRIPTION
# Overview

Closes #2728. The "Set as cover image" action in the media actions menu gave no feedback once you'd chosen a cover — the button looked identical before and after, even after a reload — so there was no way to tell which item was your current cover. This adds the common "on"/selected state to that button.

# What changed

- `toCoverMediaRef` — pure helper that recovers `{ type, id }` from a Trakt cover-image URL path (the settings endpoint only echoes back the image URL, never the media id/type).
- `useIsCover` — small state hook that reports whether the media item being viewed is the user's current cover, reading `useUser()` and comparing against the button's own `type`/`id`.
- `SetCoverImageAction.svelte` — renders the shared `selected` state on the `DropdownItem` and swaps the text to "Your cover image" (aria-label `"{title}" is your cover image.`) when active.
- i18n — two new source messages in `i18n/meta/en.json`.

# How it works

The cover settings response only stores the resulting image URL, not a media id/type. Trakt image URLs encode both in their path (`/images/movies/000/916/302/…` → movie `916302`), so `toCoverMediaRef` parses the type + zero-padded trakt id out of `user.cover.url` and compares it against the button's `type`/`id`. That comparison is size- and extension-agnostic, so it holds even though the cover is served at a different size than the summary hero requests.

Both cases from the issue fall out of the same derived comparison: setting a cover already invalidates the user-settings query, so the state flips on immediately after pressing; and on a later visit the state is recovered from the freshly loaded settings.

# Testing

- Unit tests added for `toCoverMediaRef` — movie/show/episode parsing, size/extension invariance, non-media VIP header, and nullish input.
- Manual pass still to do: confirm the selected state + "Your cover image" label on a movie/show/episode you've set as your cover, and that it survives a reload.
