### PR TITLE
fix(auth): keep the authenticated shell on cold load

### DIFF
--- a/projects/client/src/lib/features/auth/authMarker.ts
+++ b/projects/client/src/lib/features/auth/authMarker.ts
@@ -1,0 +1,40 @@
+import { createStore, get, set, type UseStore } from 'idb-keyval';
+
+const DB_NAME = 'trakt-auth';
+const STORE_NAME = 'auth-marker';
+const MARKER_KEY = 'is-authorized';
+
+// The service worker needs auth state but cannot read the httpOnly session
+// cookie, and `cookieStore` is Chromium-only. IDB is readable from both.
+let store: UseStore | undefined;
+
+function getStore(): UseStore | null {
+  if (typeof indexedDB === 'undefined') {
+    return null;
+  }
+
+  try {
+    store ??= createStore(DB_NAME, STORE_NAME);
+    return store;
+  } catch {
+    return null;
+  }
+}
+
+export async function readAuthMarker(): Promise<boolean> {
+  const current = getStore();
+  if (!current) {
+    return false;
+  }
+
+  return await get<boolean>(MARKER_KEY, current).catch(() => false) ?? false;
+}
+
+export async function writeAuthMarker(isAuthorized: boolean): Promise<void> {
+  const current = getStore();
+  if (!current) {
+    return;
+  }
+
+  await set(MARKER_KEY, isAuthorized, current).catch(() => {});
+}

--- a/projects/client/src/lib/features/auth/components/AuthProvider.spec.ts
+++ b/projects/client/src/lib/features/auth/components/AuthProvider.spec.ts
@@ -1,0 +1,17 @@
+import { renderStore, setAuthorization } from '$test/beds/store/renderStore.ts';
+import { describe, expect, it } from 'vitest';
+import { getUserManager } from '../stores/userManager.ts';
+
+describe('component: AuthProvider', () => {
+  it('should not render children before the user manager is set', async () => {
+    setAuthorization(false);
+
+    // `/callback` reaches for `getUserManager()` in its own `onMount`, which
+    // Svelte fires before the provider's. Rendering children in the provider's
+    // first cycle therefore hands them a null manager and the sign-in callback
+    // silently never runs.
+    const manager = await renderStore(() => getUserManager());
+
+    expect(manager).not.toBeNull();
+  });
+});

--- a/projects/client/src/lib/features/auth/components/AuthProvider.svelte
+++ b/projects/client/src/lib/features/auth/components/AuthProvider.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { iffy } from "$lib/utils/function/iffy";
+  import { resolveBrowserAuthState } from "../resolveBrowserAuthState";
   import { createAuthContext } from "../stores/createAuthContext";
   import { initializeUserManager } from "../stores/initializeUserManager";
   import { useUser } from "../stores/useUser";
+  import { setToken } from "../token/index";
 
   type AuthProviderProps = {
     isAuthorized: boolean;
@@ -15,15 +17,41 @@
     accessToken,
   }: AuthProviderProps = $props();
 
+  // The SSR flag describes the document, not the viewer: a cache-replayed
+  // document was rendered for whoever populated the entry. Storage is truth.
+  const clientAuth = iffy(resolveBrowserAuthState);
+
+  // Optimistic: an expired session still seeds authorized, since
+  // `automaticSilentRenew` almost always renews it before it matters.
+  const isAuthorized = iffy(() => clientAuth?.hasSession ?? isAuthorizedOidc);
+
+  // `useUser` subscribes authorized queries during this first render, before
+  // `initializeUserManager` mounts; without a token they 401 and sign out.
+  iffy(() => {
+    if (clientAuth?.token.value == null) {
+      return;
+    }
+
+    setToken(clientAuth.token);
+  });
+
   const ctx = iffy(() =>
     createAuthContext({
-      isAuthorized: isAuthorizedOidc,
-      token: null,
+      isAuthorized,
+      token: clientAuth?.token ?? null,
     }),
   );
 
   const { isInitializing } = iffy(() =>
-    initializeUserManager({ ctx, tokenFromServer: accessToken }),
+    initializeUserManager({
+      ctx,
+      tokenFromServer: accessToken,
+      // Only skip the gate for a session we actually found. Ungating an
+      // unauthorized tree renders children in this same cycle, and their
+      // `onMount` runs before ours - so `/callback` would reach for
+      // `getUserManager()` before `setUserManager` has been called.
+      isResolved: clientAuth?.hasSession === true,
+    }),
   );
   const { user } = useUser();
 </script>

--- a/projects/client/src/lib/features/auth/oidcUserStoreKey.ts
+++ b/projects/client/src/lib/features/auth/oidcUserStoreKey.ts
@@ -1,0 +1,11 @@
+type OidcUserStoreKeyProps = {
+  authority: string;
+  clientId: string;
+};
+
+// Key shape is dictated by oidc-client-ts, not by us.
+export function oidcUserStoreKey(
+  { authority, clientId }: OidcUserStoreKeyProps,
+): string {
+  return `oidc.user:${authority}:${clientId}`;
+}

--- a/projects/client/src/lib/features/auth/portWorkerAuthSession.ts
+++ b/projects/client/src/lib/features/auth/portWorkerAuthSession.ts
@@ -1,3 +1,5 @@
+import { oidcUserStoreKey } from './oidcUserStoreKey.ts';
+
 type SessionStore = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
 type PortWorkerAuthSessionProps = {
@@ -6,9 +8,6 @@ type PortWorkerAuthSessionProps = {
   fromAuthority: string;
   toAuthority: string;
 };
-
-const userStoreKey = (authority: string, clientId: string) =>
-  `oidc.user:${authority}:${clientId}`;
 
 // oidc-client-ts keys the stored session by authority. When the authority
 // changes, the session is orphaned under the old key and the user is logged
@@ -20,17 +19,18 @@ export function portWorkerAuthSession(
     return false;
   }
 
-  const toKey = userStoreKey(toAuthority, clientId);
+  const toKey = oidcUserStoreKey({ authority: toAuthority, clientId });
   if (store.getItem(toKey) != null) {
     return false;
   }
 
-  const stored = store.getItem(userStoreKey(fromAuthority, clientId));
+  const fromKey = oidcUserStoreKey({ authority: fromAuthority, clientId });
+  const stored = store.getItem(fromKey);
   if (stored == null) {
     return false;
   }
 
   store.setItem(toKey, stored);
-  store.removeItem(userStoreKey(fromAuthority, clientId));
+  store.removeItem(fromKey);
   return true;
 }

--- a/projects/client/src/lib/features/auth/resolveBrowserAuthState.ts
+++ b/projects/client/src/lib/features/auth/resolveBrowserAuthState.ts
@@ -1,0 +1,21 @@
+import { browser } from '$app/environment';
+import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
+import {
+  type ClientAuthState,
+  resolveClientAuthState,
+} from './resolveClientAuthState.ts';
+import { resolveOidcAuthority } from './resolveOidcAuthority.ts';
+
+// Null where there is no storage to read (SSR, bots, restricted engines),
+// which is the caller's signal to fall back to the server value.
+export function resolveBrowserAuthState(): ClientAuthState | null {
+  if (!browser) {
+    return null;
+  }
+
+  return resolveClientAuthState({
+    store: safeLocalStorage,
+    authority: resolveOidcAuthority(),
+    clientId: TRAKT_CLIENT_ID,
+  });
+}

--- a/projects/client/src/lib/features/auth/resolveClientAuthState.spec.ts
+++ b/projects/client/src/lib/features/auth/resolveClientAuthState.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { resolveClientAuthState } from './resolveClientAuthState.ts';
+
+const CLIENT_ID = 'cid';
+const AUTHORITY = 'https://auth.trakt.tv';
+const KEY = `oidc.user:${AUTHORITY}:${CLIENT_ID}`;
+
+const NOW = 1_000_000_000_000;
+
+function makeStore(initial: Record<string, string> = {}) {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+  };
+}
+
+function resolve(store: Pick<Storage, 'getItem'>) {
+  return resolveClientAuthState({
+    store,
+    authority: AUTHORITY,
+    clientId: CLIENT_ID,
+    now: NOW,
+  });
+}
+
+describe('resolveClientAuthState', () => {
+  it('reports no session when storage is empty', () => {
+    expect(resolve(makeStore())).toEqual({
+      hasSession: false,
+      isExpired: true,
+      token: { value: null, expiresAt: null },
+    });
+  });
+
+  it('reports no session when the entry is not valid JSON', () => {
+    expect(resolve(makeStore({ [KEY]: 'not-json' })).hasSession).toBe(false);
+  });
+
+  it('reports no session when the entry carries no access token', () => {
+    const stored = JSON.stringify({ expires_at: NOW / 1000 + 60 });
+
+    expect(resolve(makeStore({ [KEY]: stored })).hasSession).toBe(false);
+  });
+
+  it('resolves a live session with its token', () => {
+    const expiresAtSeconds = NOW / 1000 + 60;
+    const stored = JSON.stringify({
+      access_token: 'TOKEN',
+      expires_at: expiresAtSeconds,
+    });
+
+    expect(resolve(makeStore({ [KEY]: stored }))).toEqual({
+      hasSession: true,
+      isExpired: false,
+      token: { value: 'TOKEN', expiresAt: expiresAtSeconds * 1000 },
+    });
+  });
+
+  it('flags an expired session while still reporting it', () => {
+    const stored = JSON.stringify({
+      access_token: 'TOKEN',
+      expires_at: NOW / 1000 - 60,
+    });
+
+    const result = resolve(makeStore({ [KEY]: stored }));
+
+    expect(result.hasSession).toBe(true);
+    expect(result.isExpired).toBe(true);
+  });
+
+  it('treats a session without an expiry as live', () => {
+    const stored = JSON.stringify({ access_token: 'TOKEN' });
+
+    const result = resolve(makeStore({ [KEY]: stored }));
+
+    expect(result.isExpired).toBe(false);
+    expect(result.token.expiresAt).toBeNull();
+  });
+});

--- a/projects/client/src/lib/features/auth/resolveClientAuthState.ts
+++ b/projects/client/src/lib/features/auth/resolveClientAuthState.ts
@@ -1,0 +1,61 @@
+import { time } from '$lib/utils/timing/time.ts';
+import { oidcUserStoreKey } from './oidcUserStoreKey.ts';
+import type { Token } from './token/index.ts';
+
+type StoredOidcUser = {
+  access_token?: string;
+  expires_at?: number;
+};
+
+type ResolveClientAuthStateProps = {
+  store: Pick<Storage, 'getItem'>;
+  authority: string;
+  clientId: string;
+  now?: number;
+};
+
+export type ClientAuthState = {
+  hasSession: boolean;
+  isExpired: boolean;
+  token: Token;
+};
+
+const NO_SESSION: ClientAuthState = {
+  hasSession: false,
+  isExpired: true,
+  token: { value: null, expiresAt: null },
+};
+
+function parseStoredUser(raw: string): StoredOidcUser | null {
+  try {
+    return JSON.parse(raw) as StoredOidcUser;
+  } catch {
+    return null;
+  }
+}
+
+// `UserManager.getUser()` wraps this same `localStorage.getItem` in a promise,
+// and that one-tick delay is long enough to paint the wrong audience.
+export function resolveClientAuthState(
+  { store, authority, clientId, now = Date.now() }: ResolveClientAuthStateProps,
+): ClientAuthState {
+  const raw = store.getItem(oidcUserStoreKey({ authority, clientId }));
+  if (raw == null) {
+    return NO_SESSION;
+  }
+
+  const user = parseStoredUser(raw);
+  if (!user?.access_token) {
+    return NO_SESSION;
+  }
+
+  const expiresAt = user.expires_at == null
+    ? null
+    : time.seconds(user.expires_at);
+
+  return {
+    hasSession: true,
+    isExpired: expiresAt != null && expiresAt <= now,
+    token: { value: user.access_token, expiresAt },
+  };
+}

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -6,6 +6,7 @@ import { workerRequest } from '$worker/workerRequest.ts';
 import { type User, UserManager } from 'oidc-client-ts';
 import { BehaviorSubject, of } from 'rxjs';
 import { onMount } from 'svelte';
+import { writeAuthMarker } from '../authMarker.ts';
 import { deriveStandardAuthority } from '../deriveStandardAuthority.ts';
 import { getOidcConfig } from '../getOidcConfig.ts';
 import { portWorkerAuthSession } from '../portWorkerAuthSession.ts';
@@ -28,10 +29,12 @@ function mapToToken(user: User | null): Token {
 type InitializeUserManagerParams = {
   ctx: AuthContextType;
   tokenFromServer?: string | null;
+  /** Skip the `manager.getUser()` gate when the caller already seeded `ctx`. */
+  isResolved?: boolean;
 };
 
 export function initializeUserManager(
-  { ctx, tokenFromServer }: InitializeUserManagerParams,
+  { ctx, tokenFromServer, isResolved = false }: InitializeUserManagerParams,
 ) {
   if (!browser) {
     return {
@@ -39,7 +42,7 @@ export function initializeUserManager(
     };
   }
 
-  const isInitializing = new BehaviorSubject(true);
+  const isInitializing = new BehaviorSubject(!isResolved);
 
   onMount(() => {
     // Carry an existing session across an authority change so it is kept
@@ -69,15 +72,15 @@ export function initializeUserManager(
       ctx.token.next(token);
 
       const nextIsAuthorized = !isExpired;
-      // Client auth resolved differently than the SSR-seeded value the cached
-      // navigation document was rendered with. Evict it so the next load isn't
-      // served a stale unauthorized shell that flickers into the dashboard.
-      // Mirrors the logout-time bust in useAuth.
       const didAuthorizationChange =
         ctx.isAuthorized.value !== nextIsAuthorized;
 
       ctx.isAuthorized.next(nextIsAuthorized);
       isInitializing.next(false);
+
+      // Written on every resolution, not just on change, so the worker stays
+      // correct after a cache eviction or a fresh install.
+      void writeAuthMarker(nextIsAuthorized);
 
       if (didAuthorizationChange) {
         // Best-effort: the SW may be unavailable (private mode, blocked).

--- a/projects/client/src/lib/features/auth/stores/useAuth.ts
+++ b/projects/client/src/lib/features/auth/stores/useAuth.ts
@@ -3,6 +3,7 @@ import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { WorkerMessage } from '$worker/WorkerMessage.ts';
 import { workerRequest } from '$worker/workerRequest.ts';
+import { writeAuthMarker } from '../authMarker.ts';
 import { setToken } from '../token/index.ts';
 import { getAuthContext } from './getAuthContext.ts';
 import { getUserManager } from './userManager.ts';
@@ -18,6 +19,9 @@ export function useAuth() {
 
     setToken(null);
     isAuthorized.next(false);
+    // `signoutRedirect` marks storage via `addUserUnloaded`, but navigates away
+    // on the next statement with that write unawaited. Await it here instead.
+    await writeAuthMarker(false);
 
     await invalidate(InvalidateAction.Auth);
     await workerRequest(WorkerMessage.CacheBust);

--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -13,6 +13,7 @@ import {
   NetworkFirst,
   StaleWhileRevalidate,
 } from 'workbox-strategies';
+import { readAuthMarker } from './lib/features/auth/authMarker.ts';
 import { LOCALE_COOKIE_NAME } from './lib/features/i18n/constants.ts';
 import { time } from './lib/utils/timing/time.ts';
 import { CacheKey } from './worker/CacheKey.ts';
@@ -108,33 +109,34 @@ self.addEventListener('message', (event) => {
 // Precache static assets
 precacheAndRoute(self.__WB_MANIFEST);
 
-// Vary the navigation cache key by locale so a document rendered for one
-// locale is never served to a request for another (the SSR HTML is
-// locale-specific). Falls back to the plain key where the Cookie Store API is
-// unavailable (Safari/Firefox), which stay covered by the CacheBust message
-// and the activate-time purge.
-const localeAwareCacheKey = {
+// `+layout.server.ts` bakes both locale and `oidcAuth.isAuthorized` into the
+// SSR payload, so a cached document must only be replayed to a request it was
+// rendered for. Auth has no safe fallback (an unkeyed document is the bug), so
+// an unreadable marker keys as signed-out and the viewer misses the cache.
+const documentCacheKey = {
   cacheKeyWillBeUsed: async ({ request }: { request: Request }) => {
-    const cookie = await self.cookieStore?.get(LOCALE_COOKIE_NAME).catch(
-      () => null,
-    );
+    const url = new URL(request.url);
 
-    if (!cookie?.value) {
-      return request;
+    const [locale, isAuthorized] = await Promise.all([
+      self.cookieStore?.get(LOCALE_COOKIE_NAME).catch(() => null),
+      readAuthMarker(),
+    ]);
+
+    if (locale?.value) {
+      url.searchParams.set('__locale', locale.value);
     }
 
-    const url = new URL(request.url);
-    url.searchParams.set('__locale', cookie.value);
+    url.searchParams.set('__auth', String(isAuthorized));
+
     return url.href;
   },
 };
 
-// Navigation routes: StaleWhileRevalidate for fast cold loads, keyed per locale
-// to avoid cross-locale poisoning.
+// StaleWhileRevalidate for fast cold loads.
 const navigationHandler = new StaleWhileRevalidate({
   cacheName: CacheKey.navigation,
   plugins: [
-    localeAwareCacheKey,
+    documentCacheKey,
     expiration(time.hours(12)),
   ],
 });

--- a/projects/client/test/beds/store/renderStore.ts
+++ b/projects/client/test/beds/store/renderStore.ts
@@ -1,9 +1,30 @@
+import { oidcUserStoreKey } from '$lib/features/auth/oidcUserStoreKey.ts';
+import { resolveOidcAuthority } from '$lib/features/auth/resolveOidcAuthority.ts';
+import { OidcUserMock } from '$mocks/data/auth/OidcUserMock.ts';
 import { isAuthorized } from '$test/beds/_internal/isAuthorized.ts';
 import { render } from '@testing-library/svelte';
 import StoreTestBed from './StoreTestBed.svelte';
 
+const oidcSessionKey = () =>
+  oidcUserStoreKey({
+    authority: resolveOidcAuthority(),
+    clientId: TRAKT_CLIENT_ID,
+  });
+
 export function setAuthorization(state: boolean) {
   isAuthorized.next(state);
+
+  // `AuthProvider` reads the browser's audience from storage, not from its
+  // prop, so the bed has to mirror the flag there too.
+  if (!state) {
+    globalThis.localStorage.removeItem(oidcSessionKey());
+    return;
+  }
+
+  globalThis.localStorage.setItem(
+    oidcSessionKey(),
+    JSON.stringify(OidcUserMock),
+  );
 }
 
 export function renderStore<T>(factory: () => T): Promise<T> {


### PR DESCRIPTION
## What

On a cold load with a valid session the app painted the logged-out landing page
(`Landing` / `MobileLanding`, "discover / track / share", Login button) for a few
hundred milliseconds before swapping to the authenticated dashboard.

Two independent causes. Fixing either one alone left the flash visible, so both
are here.

## Why it happened

**1. The service worker served an auth-mismatched document.**

`+layout.server.ts` reads the `trakt-oidc-auth` cookie and bakes
`oidcAuth.isAuthorized` into the SSR payload, so auth state is frozen into the
HTML at render time. `service-worker.ts` cached navigations with
`StaleWhileRevalidate` keyed by URL + locale only. Auth was not part of the key,
so a document rendered signed-out got replayed to a signed-in viewer and
hydrated signed-out.

There is no CSS fix for this: `RenderForAudience` renders nothing for the
non-matching audience, so the authenticated markup is not present in that
document to un-hide. The cache key had to change.

**2. Client auth resolution was needlessly async.**

`initializeUserManager` waited for `onMount`, then `await manager.getUser()`
before calling `ctx.isAuthorized.next(...)`. The underlying read is a plain
`localStorage.getItem` behind a promise API, so there was no real async work.
That promise round-trip is what let the wrong audience paint and then correct
itself.

Every existing mitigation (`didAuthorizationChange` -> `CacheBust`, the logout
bust in `useAuth`, the `_cb` param) repairs the *next* load. None can prevent a
paint already in flight.

## What changed

- **`resolveClientAuthState.ts`** (new, unit-tested) reads the oidc-client-ts
  entry out of storage synchronously and reports
  `{ hasSession, isExpired, token }`. Handles a missing entry, unparseable JSON,
  no `access_token`, and no `expires_at`.
- **`resolveBrowserAuthState.ts`** (new) binds that pure function to
  `safeLocalStorage` / `resolveOidcAuthority()` / `TRAKT_CLIENT_ID`, and returns
  `null` where there is no storage to read.
- **`oidcUserStoreKey.ts`** (new) extracts the `oidc.user:{authority}:{clientId}`
  builder that was private to `portWorkerAuthSession.ts` and now has a second
  call site.
- **`AuthProvider.svelte`** seeds `createAuthContext` from the resolved client
  state in the browser, falling back to the `isAuthorized` prop only for SSR and
  bots.
- **`initializeUserManager.ts`** takes `isResolved`; when the caller already
  seeded from storage, `isInitializing` starts `false` so the tree is not gated
  on `manager.getUser()`. The manager still reconciles and handles renew/logout
  events.
- **`authMarker.ts`** (new) is an IDB-backed boolean, written on every auth
  resolution rather than only on change, so the worker stays correct after a
  cache eviction or a fresh install.
- **`service-worker.ts`** keys the navigation cache on `__locale` **and**
  `__auth`.

### Why IDB for the marker

The service worker needs auth state and cannot get it any other way: the session
cookie is `httpOnly`, service workers cannot read the request `Cookie` header,
and `cookieStore` is Chromium-only. IDB is readable from both contexts in every
browser.

Unlike locale there is no safe fallback here, because an unkeyed document is
precisely the bug. An unreadable marker keys as signed-out, so a signed-in viewer
misses the cache instead of being served the wrong shell.

## Please review these on purpose

**Expired sessions seed as authorized.** An expired session still counts as
authorized when seeding. `automaticSilentRenew` succeeds almost always, and the
alternative flashes the public shell on every token expiry. The cost is a rare
reverse flash when a refresh token is genuinely dead. Deliberate, but worth a
second opinion.

**Cache invalidation is free.** Adding `__auth` changes every existing navigation
cache key, so the first load after deploy is a guaranteed miss. That turns out to
cost nothing: the `activate` handler already calls `removeNavigationCache()` on
every service worker update, so that load was always a miss.

**Three things surfaced during implementation and are folded in:**

1. Seeding the audience synchronously means `useUser` subscribes its authorized
   queries during the first render, before `initializeUserManager` mounts.
   `+layout.ts` seeds the module-level token from the SSR payload, which on a
   cache-replayed signed-out document is `null`, so those queries would have gone
   out Bearer-less and the resulting 401 would call `removeUser()` and reload.
   `AuthProvider` therefore also seeds the module token from the same storage
   read. `IS_DEV` suppresses that reload path, so dev testing would not have
   caught it.
2. `useAuth.logout()` sets `ctx.isAuthorized` directly rather than going through
   `setAuthState`, so it never wrote the marker. `signoutRedirect` does fire
   `addUserUnloaded`, but it navigates away on the next statement and that write
   was unawaited. A marker left reading `true` would key the post-logout landing
   document as authorized and reintroduce this exact flash on the next sign-in.
   `logout()` now awaits `writeAuthMarker(false)`.
3. `isResolved` initially meant "the resolver ran", which is true in the browser
   even when storage holds no session. On `/callback` the code has not been
   exchanged yet, so there is no `oidc.user:*` entry: the audience resolved
   unauthorized, `useUser` emitted `ANONYMOUS_USER` synchronously via `of()`, and
   the `$user != null` gate opened during the provider's own first render. Svelte
   fires child `onMount` before the parent's, so `callback/+page.svelte` reached
   `getUserManager()` before `setUserManager` had been called, the optional chain
   short-circuited, and `signinCallback()` never ran. That left the sign-in stuck
   on a blank page, since the route sets `body { display: none }`. `isResolved` is
   now `clientAuth?.hasSession === true`, which makes the two cases disjoint: a
   found session gates on the user query instead, and no session keeps the old
   gate until `setAuthState` runs inside the provider's `onMount`.
   `AuthProvider.spec.ts` covers it.

## Out of scope

The `{#if !$isInitializing && $user != null}` gate in `AuthProvider` is
unchanged. Because `enabled: browser` disables queries during SSR, `$user` is
`undefined` for an authenticated server render, so that document is blank below
`<head>`. Post-fix the transition is blank -> dashboard rather than landing ->
dashboard, which is the acceptable interim. Letting the app shell render without
waiting on `$user` would change the assumptions of ~103 `audience="authenticated"`
call sites and belongs in its own PR.

## Testing

- `resolveClientAuthState.spec.ts` covers empty storage, invalid JSON, a missing
  access token, a live session, an expired session, and a session with no expiry.
- `renderStore`'s `setAuthorization` now mirrors the session into local storage.
  `TestProvider` drove auth purely through `AuthProvider`'s prop, which the
  browser path no longer reads, so the bed had to model storage.
- `AuthProvider.spec.ts` asserts the provider does not render children before
  `setUserManager` has run, which is the invariant `/callback` depends on. It
  fails without the `isResolved` fix.
- `deno task check`: 0 errors, 0 warnings.
- `deno task lint`: unchanged from the `main` baseline.
- `deno task test:doctor`: 441 files / 2431 tests passing.

No spec covers the logout marker write: `indexedDB` is absent in the jsdom test
env, so `writeAuthMarker` no-ops there and an assertion would be vacuous without
adding `fake-indexeddb`.

The sign-in redirect flow is confirmed working locally after fix 3 above. The
flash itself is **not yet frame-verified**, and none of the automated checks
catch one. To confirm:

1. `deno task dev`, sign in, hard-reload once so the SW caches a signed-in
   document.
2. DevTools -> Application -> Cache Storage: confirm the navigation cache holds
   separate `__auth=true` / `__auth=false` entries.
3. Sign out, load the landing page to populate a signed-out entry, sign back in,
   then cold-load with Network throttled to Slow 3G and CPU 4x slowdown. Record
   and step the frames: there must be no landing-page frame.
4. Repeat in Safari and Firefox, where `cookieStore` is absent. The IDB marker
   must still key the cache correctly.
