### PR TITLE
Adds legacy OAuth app management redirects

### DIFF
--- a/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.spec.ts
+++ b/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.spec.ts
@@ -168,6 +168,43 @@ describe('util: resolveLegacyRedirect', () => {
         '/lists/official/best-of-2024',
       );
     });
+
+    it('should map oauth app management to the apps settings', () => {
+      expect(resolveLegacyRedirect('/oauth/applications')).toBe(
+        '/settings/apps/api',
+      );
+      expect(resolveLegacyRedirect('/oauth/authorized_applications')).toBe(
+        '/settings/apps/connected',
+      );
+    });
+
+    it('should map oauth app pages to their settings equivalent', () => {
+      expect(resolveLegacyRedirect('/oauth/applications/new')).toBe(
+        '/settings/apps/api/new',
+      );
+      expect(resolveLegacyRedirect('/oauth/applications/901')).toBe(
+        '/settings/apps/api/901',
+      );
+      expect(resolveLegacyRedirect('/oauth/applications/901/edit')).toBe(
+        '/settings/apps/api/901/edit',
+      );
+    });
+  });
+
+  describe('live oauth endpoints are never hijacked', () => {
+    it.each([
+      '/oauth/authorize',
+      '/oauth/authorize/native',
+      '/oauth/token',
+      '/oauth/token/info',
+      '/oauth/revoke',
+      '/oauth/introspect',
+      '/oauth/userinfo',
+      '/oauth/consent',
+      '/oauth/device/code',
+    ])('should return null for %s', (path) => {
+      expect(resolveLegacyRedirect(path)).toBeNull();
+    });
   });
 
   describe('no sensible target falls back to home', () => {

--- a/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.ts
+++ b/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.ts
@@ -192,6 +192,26 @@ const rules: ReadonlyArray<LegacyRule> = [
     pattern: /^\/officiallist\/([^/]+)\/?$/,
     to: (m) => `/lists/official/${m[1]}`,
   },
+  {
+    pattern: /^\/oauth\/applications\/new\/?$/,
+    to: () => UrlBuilder.settings.appsApiNew(),
+  },
+  {
+    pattern: /^\/oauth\/applications\/(\d+)\/edit\/?$/,
+    to: (m) => UrlBuilder.settings.appsApiEdit(m[1]),
+  },
+  {
+    pattern: /^\/oauth\/applications\/(\d+)\/?$/,
+    to: (m) => UrlBuilder.settings.appsApiDetail(m[1]),
+  },
+  {
+    pattern: /^\/oauth\/authorized_applications\/?$/,
+    to: () => UrlBuilder.settings.appsConnected(),
+  },
+  {
+    pattern: /^\/oauth\/applications\/?$/,
+    to: () => UrlBuilder.settings.appsApi(),
+  },
 
   // --- No sensible target -> nearest-section fallback (home) ---
   // Bare `/seasons/:id` and `/episodes/:id` are v2 API endpoints with no show


### PR DESCRIPTION
## 🎶 Notes 🎶
- Adds redirect rules for `/oauth/applications` to `/settings/apps/api`.
- Adds redirect rules for `/oauth/authorized_applications` to `/settings/apps/connected`.
- Includes unit tests to verify the new redirect logic.