### PR TITLE
feat(about): live registered member counter

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7539,6 +7539,18 @@
       "default": "Follow friends, see what the team is watching, and discover shared favourites. Watching together is better.",
       "description": "Description for the social/community feature card on the About page."
     },
+    "label_registered_accounts": {
+      "default": "Registered accounts",
+      "description": "Label above the live registered-account counter on the About page."
+    },
+    "text_member_count_tagline": {
+      "default": "people tracking what they watch, and counting",
+      "description": "Caption under the live registered-account counter on the About page."
+    },
+    "text_member_count_accessible": {
+      "default": "Over {count} registered Trakt accounts",
+      "description": "Screen-reader label for the live member counter. Uses a rounded value so it does not change as the counter ticks."
+    },
     "page_title_welcome": {
       "default": "Welcome",
       "description": "Page title for the Welcome page shown to new users."

--- a/projects/client/src/lib/components/counter/OdometerNumber.svelte
+++ b/projects/client/src/lib/components/counter/OdometerNumber.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import { getLocale } from "$lib/features/i18n";
+  import { useMedia, WellKnownMediaQuery } from "$lib/stores/css/useMedia.ts";
+  import { toGroupedNumber } from "$lib/utils/formatting/number/toGroupedNumber.ts";
+  import type { OdometerNumberProps } from "./_internal/OdometerNumberProps.ts";
+  import { toDigitPosition } from "./_internal/toDigitPosition.ts";
+  import { toLocaleDigits } from "./_internal/toLocaleDigits.ts";
+  import { toOdometerCells } from "./_internal/toOdometerCells.ts";
+
+  const { value, accessibleLabel, reserveFor = value }: OdometerNumberProps =
+    $props();
+
+  const isReduced = useMedia(WellKnownMediaQuery.reducedMotion);
+
+  const locale = $derived(getLocale());
+  // Deriving off the floored value keeps `Intl` out of the frame loop; the roll
+  // offsets below are pure arithmetic on the raw float.
+  const whole = $derived(Math.floor(value));
+  const cells = $derived(toOdometerCells({ value: whole, locale }));
+  const text = $derived(toGroupedNumber(whole, locale));
+  // Trailing repeat of the first glyph makes the 9 -> 0 wrap seamless.
+  const strip = $derived.by(() => {
+    const digits = toLocaleDigits(locale);
+    return [...digits, ...digits.slice(0, 1)];
+  });
+  const reserved = $derived(
+    toGroupedNumber(Math.floor(reserveFor), locale).length,
+  );
+</script>
+
+<span class="trakt-odometer-number" style="--character-count: {reserved}">
+  <span class="odometer-label">{accessibleLabel}</span>
+
+  {#if $isReduced}
+    <span class="odometer-static" aria-hidden="true" aria-live="off">
+      {text}
+    </span>
+  {:else}
+    <span class="odometer-cells" aria-hidden="true" aria-live="off">
+      {#each cells as cell, index (index)}
+        {#if cell.kind === "separator"}
+          <span class="odometer-separator">{cell.text}</span>
+        {:else}
+          <span
+            class="odometer-digit"
+            style="--position: {toDigitPosition({ value, place: cell.place })}"
+          >
+            <span class="digit-strip">
+              {#each strip as glyph, position (position)}
+                <span class="digit-glyph">{glyph}</span>
+              {/each}
+            </span>
+          </span>
+        {/if}
+      {/each}
+    </span>
+  {/if}
+</span>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  // The global `span` rule pins font-size and weight, and cell geometry is in
+  // `em`, so one span left at body size collapses its column. Every span in the
+  // reel has to opt back into inheriting, not just the classed ones.
+  .trakt-odometer-number,
+  .trakt-odometer-number span {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  .trakt-odometer-number {
+    // Cell box is taller than the glyph so ascenders never clip mid-roll.
+    --odometer-cell-height: 1.15em;
+
+    display: inline-flex;
+    justify-content: center;
+    // Numbers read most-significant-first in every locale, RTL included, so the
+    // digit run is not a layout side that should mirror.
+    direction: ltr;
+
+    min-width: calc(var(--character-count) * 1ch);
+
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum";
+  }
+
+  .odometer-label {
+    @include visually-hidden;
+  }
+
+  .odometer-cells {
+    display: inline-flex;
+    align-items: flex-start;
+  }
+
+  .odometer-separator,
+  .odometer-digit {
+    // Shared box model, so digit/separator alignment is structural rather than a
+    // per-font baseline negotiation.
+    display: inline-block;
+    height: var(--odometer-cell-height);
+    line-height: var(--odometer-cell-height);
+    text-align: center;
+  }
+
+  .odometer-digit {
+    width: 1ch;
+    overflow: hidden;
+  }
+
+  .digit-strip {
+    display: block;
+    // No CSS transition: easing already happened in the projection, and a
+    // transition would animate the 9 -> 0 wrap backwards through the strip.
+    transform: translateY(
+      calc(var(--position) * var(--odometer-cell-height) * -1)
+    );
+    will-change: transform;
+  }
+
+  .digit-glyph {
+    display: block;
+    height: var(--odometer-cell-height);
+    line-height: var(--odometer-cell-height);
+  }
+</style>

--- a/projects/client/src/lib/components/counter/_internal/OdometerNumberProps.ts
+++ b/projects/client/src/lib/components/counter/_internal/OdometerNumberProps.ts
@@ -1,0 +1,12 @@
+export type OdometerNumberProps = {
+  /** Live value; the fractional part rolls, it is never rendered. */
+  value: number;
+  /**
+   * Static, coarse description of the value. The digits are `aria-hidden`, so
+   * this is all a screen reader hears - keep it coarse enough not to change on
+   * a tick.
+   */
+  accessibleLabel: string;
+  /** Value to reserve width for, so surrounding copy never reflows. */
+  reserveFor?: number;
+};

--- a/projects/client/src/lib/components/counter/_internal/toDigitPosition.spec.ts
+++ b/projects/client/src/lib/components/counter/_internal/toDigitPosition.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { toDigitPosition } from './toDigitPosition.ts';
+
+describe('util: toDigitPosition', () => {
+  describe('for the ones column', () => {
+    it('should rest flush on an exact value', () => {
+      expect(toDigitPosition({ value: 17_002_054, place: 0 })).toBe(4);
+    });
+
+    it('should still rest flush at the midpoint of its step', () => {
+      expect(toDigitPosition({ value: 100.5, place: 0 })).toBe(0);
+    });
+
+    it('should travel through the second half of its step', () => {
+      expect(toDigitPosition({ value: 100.75, place: 0 })).toBeCloseTo(0.5, 6);
+    });
+
+    it('should settle onto the next digit as the step completes', () => {
+      expect(toDigitPosition({ value: 100.999, place: 0 }))
+        .toBeGreaterThan(0.99);
+      expect(toDigitPosition({ value: 101, place: 0 })).toBe(1);
+    });
+
+    it('should wrap from nine to the repeated strip origin', () => {
+      expect(toDigitPosition({ value: 109.99, place: 0 }))
+        .toBeGreaterThan(9.99);
+      expect(toDigitPosition({ value: 110, place: 0 })).toBe(0);
+    });
+  });
+
+  describe('for columns above the ones', () => {
+    it('should rest flush while the column below is mid-step', () => {
+      expect(toDigitPosition({ value: 17_002_054.4, place: 1 })).toBe(5);
+    });
+
+    it('should stay flush until the carry window opens', () => {
+      expect(toDigitPosition({ value: 17_002_057, place: 1 })).toBe(5);
+    });
+
+    it('should travel through the carry window', () => {
+      // Dividing a 17M value down loses low-order bits, so this is compared at
+      // far more precision than a sub-pixel roll offset needs.
+      expect(toDigitPosition({ value: 17_002_059, place: 1 }))
+        .toBeCloseTo(5.5, 5);
+    });
+
+    it('should land flush on the next digit after the carry', () => {
+      expect(toDigitPosition({ value: 17_002_060, place: 1 })).toBe(6);
+    });
+
+    it('should hold a high column flush across a low-column carry', () => {
+      expect(toDigitPosition({ value: 17_002_059, place: 5 })).toBe(0);
+    });
+  });
+
+  it('should stay within a single strip revolution', () => {
+    expect(toDigitPosition({ value: 17_002_054, place: 7 })).toBeLessThan(10);
+  });
+
+  it('should clamp a negative value to the strip origin', () => {
+    expect(toDigitPosition({ value: -5, place: 0 })).toBe(0);
+  });
+});

--- a/projects/client/src/lib/components/counter/_internal/toDigitPosition.ts
+++ b/projects/client/src/lib/components/counter/_internal/toDigitPosition.ts
@@ -1,0 +1,27 @@
+// Fraction of a column's step during which the carry travels; outside it the
+// column rests flush. Without a detent every column sits permanently
+// part-rolled, which reads as a rendering fault rather than motion. The ones
+// column gets a wide window so it is settled about half the time even at the
+// real rate of ~1 signup every 8s.
+const ONES_CARRY_WINDOW = 0.5;
+const CARRY_WINDOW = 0.2;
+
+const smoothstep = (t: number) => t * t * (3 - 2 * t);
+
+/**
+ * Strip offset for the digit column at `place`, in the range [0, 10). Every
+ * column derives its own offset from the same raw value, so no two can disagree
+ * about a carry.
+ */
+export function toDigitPosition(
+  { value, place }: { value: number; place: number },
+): number {
+  const scaled = Math.max(0, value) / Math.pow(10, place);
+  const digit = Math.floor(scaled) % 10;
+  const fraction = scaled - Math.floor(scaled);
+
+  const window = place === 0 ? ONES_CARRY_WINDOW : CARRY_WINDOW;
+  const travel = (fraction - (1 - window)) / window;
+
+  return digit + smoothstep(Math.min(1, Math.max(0, travel)));
+}

--- a/projects/client/src/lib/components/counter/_internal/toLocaleDigits.ts
+++ b/projects/client/src/lib/components/counter/_internal/toLocaleDigits.ts
@@ -1,0 +1,15 @@
+import { getIntlLocale } from '$lib/features/i18n/index.ts';
+import type { AvailableLanguage } from '$lib/features/i18n/index.ts';
+
+/**
+ * The locale's own 0-9 glyphs, in order, for building a roll strip. Hardcoding
+ * `'0123456789'` would print Latin digits next to `fa-IR` separators.
+ */
+export function toLocaleDigits(locale: string): string[] {
+  const formatter = new Intl.NumberFormat(
+    getIntlLocale(locale as AvailableLanguage),
+    { useGrouping: false },
+  );
+
+  return Array.from({ length: 10 }, (_, digit) => formatter.format(digit));
+}

--- a/projects/client/src/lib/components/counter/_internal/toOdometerCells.spec.ts
+++ b/projects/client/src/lib/components/counter/_internal/toOdometerCells.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { toOdometerCells } from './toOdometerCells.ts';
+
+describe('util: toOdometerCells', () => {
+  const places = (cells: ReturnType<typeof toOdometerCells>) =>
+    cells.flatMap((cell) => cell.kind === 'digit' ? [cell.place] : []);
+
+  const separators = (cells: ReturnType<typeof toOdometerCells>) =>
+    cells.flatMap((cell) => cell.kind === 'separator' ? [cell.text] : []);
+
+  describe('for en', () => {
+    it('should assign descending places from the most significant digit', () => {
+      expect(places(toOdometerCells({ value: 17_002_054, locale: 'en' })))
+        .toEqual([7, 6, 5, 4, 3, 2, 1, 0]);
+    });
+
+    it('should emit the locale group separator between groups', () => {
+      expect(separators(toOdometerCells({ value: 17_002_054, locale: 'en' })))
+        .toEqual([',', ',']);
+    });
+
+    it('should not pad a small value with leading digits', () => {
+      expect(places(toOdometerCells({ value: 7, locale: 'en' }))).toEqual([0]);
+    });
+  });
+
+  describe('for de', () => {
+    it('should use the locale separator rather than a comma', () => {
+      expect(separators(toOdometerCells({ value: 17_002_054, locale: 'de' })))
+        .toEqual(['.', '.']);
+    });
+  });
+
+  describe('for a fractional value', () => {
+    it('should lay out columns from the floored integer', () => {
+      expect(places(toOdometerCells({ value: 999.94, locale: 'en' })))
+        .toEqual([2, 1, 0]);
+    });
+  });
+});

--- a/projects/client/src/lib/components/counter/_internal/toOdometerCells.ts
+++ b/projects/client/src/lib/components/counter/_internal/toOdometerCells.ts
@@ -1,0 +1,48 @@
+import { getIntlLocale } from '$lib/features/i18n/index.ts';
+import type { AvailableLanguage } from '$lib/features/i18n/index.ts';
+
+export type OdometerCell =
+  // `place` is the power of ten this column renders, so a cell derives its own
+  // roll offset from the raw value without being told its digit.
+  | { kind: 'digit'; place: number }
+  | { kind: 'separator'; text: string };
+
+/**
+ * Split a number into odometer columns. Grouping comes from `formatToParts`, so
+ * `1,234,567`, `1.234.567`, and the Indic `12,34,567` all lay out correctly.
+ */
+export function toOdometerCells(
+  { value, locale }: { value: number; locale: string },
+): OdometerCell[] {
+  const parts = new Intl.NumberFormat(
+    getIntlLocale(locale as AvailableLanguage),
+    { maximumFractionDigits: 0 },
+  ).formatToParts(Math.floor(Math.max(0, value)));
+
+  const digitCount = parts
+    .filter((part) => part.type === 'integer')
+    .reduce((total, part) => total + part.value.length, 0);
+
+  return parts.reduce<{ cells: OdometerCell[]; place: number }>(
+    ({ cells, place }, part) => {
+      if (part.type !== 'integer') {
+        return {
+          place,
+          cells: [...cells, { kind: 'separator', text: part.value }],
+        };
+      }
+
+      return {
+        place: place - part.value.length,
+        cells: [
+          ...cells,
+          ...[...part.value].map((_, index) => ({
+            kind: 'digit' as const,
+            place: place - 1 - index,
+          })),
+        ],
+      };
+    },
+    { cells: [], place: digitCount },
+  ).cells;
+}

--- a/projects/client/src/lib/features/member-count/_internal/approachTarget.spec.ts
+++ b/projects/client/src/lib/features/member-count/_internal/approachTarget.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { approachTarget } from './approachTarget.ts';
+
+describe('util: approachTarget', () => {
+  it('should close exactly half the distance in one half-life', () => {
+    expect(approachTarget({
+      current: 100,
+      target: 200,
+      deltaMs: 500,
+      halfLifeMs: 500,
+    })).toBe(150);
+  });
+
+  it('should close three quarters over two half-lives', () => {
+    expect(approachTarget({
+      current: 0,
+      target: 100,
+      deltaMs: 1000,
+      halfLifeMs: 500,
+    })).toBe(75);
+  });
+
+  it('should be frame-rate independent', () => {
+    const halfLifeMs = 500;
+    const oneStep = approachTarget({
+      current: 0,
+      target: 100,
+      deltaMs: 100,
+      halfLifeMs,
+    });
+    const twoSteps = [50, 50].reduce(
+      (current, deltaMs) =>
+        approachTarget({ current, target: 100, deltaMs, halfLifeMs }),
+      0,
+    );
+
+    expect(twoSteps).toBeCloseTo(oneStep, 10);
+  });
+
+  it('should hold the current value when no time has passed', () => {
+    expect(approachTarget({
+      current: 42,
+      target: 100,
+      deltaMs: 0,
+      halfLifeMs: 500,
+    })).toBe(42);
+  });
+
+  it('should approach without ever overshooting the target', () => {
+    expect(approachTarget({
+      current: 0,
+      target: 100,
+      deltaMs: 10_000,
+      halfLifeMs: 500,
+    })).toBeLessThan(100);
+  });
+});

--- a/projects/client/src/lib/features/member-count/_internal/approachTarget.ts
+++ b/projects/client/src/lib/features/member-count/_internal/approachTarget.ts
@@ -1,0 +1,23 @@
+type ApproachTargetParams = {
+  current: number;
+  target: number;
+  deltaMs: number;
+  halfLifeMs: number;
+};
+
+/**
+ * Exponential ease: after `halfLifeMs` the remaining distance to `target` has
+ * halved. Keyed off elapsed time rather than a per-frame factor so 30fps and
+ * 120fps devices reconcile over the same wall-clock duration.
+ */
+export function approachTarget(
+  { current, target, deltaMs, halfLifeMs }: ApproachTargetParams,
+): number {
+  // Snapping here would defeat the easing on the first frame after a re-anchor.
+  if (deltaMs <= 0) return current;
+  if (halfLifeMs <= 0) return target;
+
+  const factor = 1 - Math.pow(2, -deltaMs / halfLifeMs);
+
+  return current + (target - current) * factor;
+}

--- a/projects/client/src/lib/features/member-count/_internal/projectMemberCount.spec.ts
+++ b/projects/client/src/lib/features/member-count/_internal/projectMemberCount.spec.ts
@@ -1,0 +1,47 @@
+import { time } from '$lib/utils/timing/time.ts';
+import { describe, expect, it } from 'vitest';
+import { projectMemberCount } from './projectMemberCount.ts';
+
+describe('util: projectMemberCount', () => {
+  const anchor = {
+    total: 17_002_054,
+    anchoredAt: Date.parse('2026-07-28T17:35:07.071Z'),
+    ratePerDay: 8_640, // exactly one signup per 10 seconds
+  };
+
+  it('should return the authoritative total at the anchor instant', () => {
+    expect(projectMemberCount({ anchor, now: anchor.anchoredAt }))
+      .toBe(anchor.total);
+  });
+
+  it('should project forward at the measured rate', () => {
+    const now = anchor.anchoredAt + time.seconds(50);
+
+    expect(projectMemberCount({ anchor, now })).toBe(anchor.total + 5);
+  });
+
+  it('should never project below the total when the client clock lags', () => {
+    const now = anchor.anchoredAt - time.minutes(30);
+
+    expect(projectMemberCount({ anchor, now })).toBe(anchor.total);
+  });
+
+  it('should stop projecting once the anchor is too stale to trust', () => {
+    const capped = projectMemberCount({
+      anchor,
+      now: anchor.anchoredAt + time.minutes(5),
+    });
+
+    expect(projectMemberCount({
+      anchor,
+      now: anchor.anchoredAt + time.days(1),
+    })).toBe(capped);
+  });
+
+  it('should hold still for a zero rate', () => {
+    expect(projectMemberCount({
+      anchor: { ...anchor, ratePerDay: 0 },
+      now: anchor.anchoredAt + time.minutes(1),
+    })).toBe(anchor.total);
+  });
+});

--- a/projects/client/src/lib/features/member-count/_internal/projectMemberCount.ts
+++ b/projects/client/src/lib/features/member-count/_internal/projectMemberCount.ts
@@ -1,0 +1,22 @@
+import type { RegisteredMemberCount } from '$lib/requests/models/RegisteredMemberCount.ts';
+import { time } from '$lib/utils/timing/time.ts';
+
+// Past this, a dead endpoint would be fabricating signups, so the counter
+// freezes on the last honest value. Only reachable when polling is broken.
+const MAX_PROJECTION_WINDOW = time.minutes(5);
+
+/**
+ * Project the registered total forward from the server anchor at the measured
+ * signup rate. Clamped at both ends: a client clock behind the server would
+ * otherwise render below the authoritative total.
+ */
+export function projectMemberCount(
+  { anchor, now }: { anchor: RegisteredMemberCount; now: number },
+): number {
+  const elapsed = Math.min(
+    Math.max(0, now - anchor.anchoredAt),
+    MAX_PROJECTION_WINDOW,
+  );
+
+  return anchor.total + elapsed * (anchor.ratePerDay / time.days(1));
+}

--- a/projects/client/src/lib/features/member-count/useProjectedCount.svelte.ts
+++ b/projects/client/src/lib/features/member-count/useProjectedCount.svelte.ts
@@ -1,0 +1,65 @@
+import { approachTarget } from '$lib/features/member-count/_internal/approachTarget.ts';
+import { projectMemberCount } from '$lib/features/member-count/_internal/projectMemberCount.ts';
+import type { RegisteredMemberCount } from '$lib/requests/models/RegisteredMemberCount.ts';
+import { useMedia, WellKnownMediaQuery } from '$lib/stores/css/useMedia.ts';
+
+// Long enough to read as motion, short enough that the number is never
+// meaningfully behind the server.
+const REANCHOR_HALF_LIFE = 300;
+
+/**
+ * Animate a monotonically climbing counter from a server anchor. Returns a
+ * float, so a consumer can floor it for text or roll a digit by its fraction.
+ */
+export function useProjectedCount(anchor: () => RegisteredMemberCount) {
+  // Outside `$state` so the frame loop can read it without depending on its own
+  // writes. Monotonic: a downward correction freezes rather than rewinds.
+  let floor = projectMemberCount({ anchor: anchor(), now: Date.now() });
+  let rendered = $state(floor);
+
+  const advanceTo = (next: number) => {
+    floor = Math.max(floor, next);
+    rendered = floor;
+  };
+
+  let isReduced = $state(false);
+  $effect(() => {
+    const subscription = useMedia(WellKnownMediaQuery.reducedMotion)
+      .subscribe((matches) => isReduced = matches);
+
+    return () => subscription.unsubscribe();
+  });
+
+  $effect(() => {
+    const current = anchor();
+
+    if (isReduced) {
+      advanceTo(projectMemberCount({ anchor: current, now: Date.now() }));
+      return;
+    }
+
+    let frame = 0;
+    let previous = performance.now();
+
+    const tick = (elapsed: number) => {
+      advanceTo(approachTarget({
+        current: floor,
+        target: projectMemberCount({ anchor: current, now: Date.now() }),
+        deltaMs: elapsed - previous,
+        halfLifeMs: REANCHOR_HALF_LIFE,
+      }));
+      previous = elapsed;
+      frame = requestAnimationFrame(tick);
+    };
+
+    frame = requestAnimationFrame(tick);
+
+    return () => cancelAnimationFrame(frame);
+  });
+
+  return {
+    get value() {
+      return rendered;
+    },
+  };
+}

--- a/projects/client/src/lib/features/member-count/useRegisteredMemberCount.svelte.ts
+++ b/projects/client/src/lib/features/member-count/useRegisteredMemberCount.svelte.ts
@@ -1,0 +1,46 @@
+import { useProjectedCount } from '$lib/features/member-count/useProjectedCount.svelte.ts';
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { RegisteredMemberCount } from '$lib/requests/models/RegisteredMemberCount.ts';
+import { registeredMemberCountQuery } from '$lib/requests/queries/stats/registeredMemberCountQuery.ts';
+
+// First-paint value, and the fallback when the endpoint is down: never a zero,
+// a spinner, or a width that reflows. `ratePerDay: 0` keeps it static until the
+// server anchor lands; monotonicity means it can only be corrected upward.
+// Bump on milestones.
+const REGISTERED_MEMBER_FLOOR: RegisteredMemberCount = {
+  total: 17_000_000,
+  anchoredAt: 0,
+  ratePerDay: 0,
+};
+
+/**
+ * Live registered-account total for the about page: polls the public stats
+ * endpoint and animates between anchors off the measured signup rate.
+ */
+export function useRegisteredMemberCount() {
+  const query = useQuery(registeredMemberCountQuery());
+
+  // Copied, not the constant itself: `$state` proxies its target, so seeding it
+  // directly would let a property write reach module state.
+  let anchor = $state({ ...REGISTERED_MEMBER_FLOOR });
+
+  $effect(() => {
+    const subscription = query.subscribe(({ data }) => {
+      if (data) anchor = data;
+    });
+
+    return () => subscription.unsubscribe();
+  });
+
+  const projected = useProjectedCount(() => anchor);
+
+  return {
+    get value() {
+      return projected.value;
+    },
+    // Floored, not live, so SSR and every later frame reserve the same width.
+    get reserveFor() {
+      return Math.max(REGISTERED_MEMBER_FLOOR.total, anchor.total);
+    },
+  };
+}

--- a/projects/client/src/lib/features/query/_internal/buildCommonOptions.ts
+++ b/projects/client/src/lib/features/query/_internal/buildCommonOptions.ts
@@ -4,6 +4,7 @@ export function buildCommonOptions<TRequestParams extends ApiParams>(
   params: {
     ttl: number | Nil;
     refetchOnWindowFocus?: boolean;
+    refetchInterval?: number;
     retry?: number;
     enabled?: (params: TRequestParams) => boolean;
   },
@@ -12,6 +13,7 @@ export function buildCommonOptions<TRequestParams extends ApiParams>(
   return {
     staleTime: params.ttl == null ? undefined : params.ttl,
     refetchOnWindowFocus: params.refetchOnWindowFocus,
+    refetchInterval: params.refetchInterval,
     retry: params.retry,
     enabled: params.enabled?.(requestParams) ?? true,
   };

--- a/projects/client/src/lib/features/query/models/DefineQueryProps.ts
+++ b/projects/client/src/lib/features/query/models/DefineQueryProps.ts
@@ -18,6 +18,9 @@ export type DefineQueryProps<
   schema: TOutput;
   ttl: number | Nil;
   refetchOnWindowFocus?: boolean;
+  // Poll cadence for endpoints whose value moves on its own. Paused while the
+  // tab is backgrounded by TanStack's `refetchIntervalInBackground: false`.
+  refetchInterval?: number;
   retry?: number;
   enabled?: (params: TRequestParams) => boolean;
 };

--- a/projects/client/src/lib/requests/models/RegisteredMemberCount.ts
+++ b/projects/client/src/lib/requests/models/RegisteredMemberCount.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const RegisteredMemberCountSchema = z.object({
+  // Authoritative at `anchoredAt`.
+  total: z.number().int(),
+  anchoredAt: z.number(),
+  // Trailing mean of the last seven closed days: a measured rate, which is what
+  // makes interpolating between polls honest.
+  ratePerDay: z.number(),
+});
+
+export type RegisteredMemberCount = z.infer<typeof RegisteredMemberCountSchema>;

--- a/projects/client/src/lib/requests/queries/stats/registeredMemberCountQuery.ts
+++ b/projects/client/src/lib/requests/queries/stats/registeredMemberCountQuery.ts
@@ -1,0 +1,62 @@
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import {
+  type RegisteredMemberCount,
+  RegisteredMemberCountSchema,
+} from '$lib/requests/models/RegisteredMemberCount.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { z } from 'zod';
+
+// `/v3/stats/users` is not published in `@trakt/api` yet, so the wire shape is
+// validated locally. Drop this schema once the SDK exposes the endpoint.
+const RegisteredMemberCountResponseSchema = z.object({
+  registered: z.object({
+    total: z.number().int(),
+    updated_at: z.string().datetime(),
+    rate_per_day: z.number(),
+  }),
+});
+
+type RegisteredMemberCountResponse = z.infer<
+  typeof RegisteredMemberCountResponseSchema
+>;
+
+const mapToRegisteredMemberCount = (
+  { registered }: RegisteredMemberCountResponse,
+): RegisteredMemberCount => ({
+  total: registered.total,
+  anchoredAt: Date.parse(registered.updated_at),
+  ratePerDay: registered.rate_per_day,
+});
+
+const registeredMemberCountRequest = async ({ fetch }: ApiParams) => {
+  const response = await rawApiFetch({
+    fetch,
+    path: '/v3/stats/users',
+    // Public figure: no Bearer token, so a 401 can never tear down the session
+    // of a signed-in visitor.
+    authenticated: false,
+  });
+
+  return response.ok
+    ? {
+      body: RegisteredMemberCountResponseSchema.parse(await response.json()),
+      status: 200,
+    }
+    : { body: undefined, status: 200 };
+};
+
+export const registeredMemberCountQuery = defineQuery({
+  key: 'registeredMemberCount',
+  invalidations: [],
+  dependencies: [],
+  request: registeredMemberCountRequest,
+  mapper: ({ body }) => body ? mapToRegisteredMemberCount(body) : null,
+  schema: RegisteredMemberCountSchema.nullable(),
+  // Uncached and moves between requests. The counter interpolates the digits in
+  // between, so there is no reason to poll harder.
+  ttl: time.seconds(10),
+  refetchInterval: time.seconds(10),
+  refetchOnWindowFocus: true,
+  retry: 1,
+});

--- a/projects/client/src/lib/sections/about/About.svelte
+++ b/projects/client/src/lib/sections/about/About.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
+  import { useRegisteredMemberCount } from "$lib/features/member-count/useRegisteredMemberCount.svelte.ts";
   import MeetTheTeam from "./components/MeetTheTeam.svelte";
+  import MemberCountHero from "./components/MemberCountHero.svelte";
   import WhatIsTrakt from "./components/WhatIsTrakt.svelte";
+
+  // Owned here so the page polls once, not once per presentation.
+  const count = useRegisteredMemberCount();
 </script>
 
 <div class="trakt-about">
   <WhatIsTrakt />
+  <div class="trakt-about-divider"></div>
+  <MemberCountHero {count} />
   <div class="trakt-about-divider"></div>
   <MeetTheTeam />
 </div>

--- a/projects/client/src/lib/sections/about/components/MemberCountHero.svelte
+++ b/projects/client/src/lib/sections/about/components/MemberCountHero.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import OdometerNumber from "$lib/components/counter/OdometerNumber.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { MemberCountProps } from "./_internal/MemberCountProps.ts";
+  import { toAnnounceValue } from "./_internal/toAnnounceValue.ts";
+  import { toMemberCountLabel } from "./_internal/toMemberCountLabel.ts";
+
+  const { count }: MemberCountProps = $props();
+
+  const announced = $derived(toAnnounceValue(count.value));
+  const accessibleLabel = $derived(toMemberCountLabel(announced));
+</script>
+
+<section class="trakt-member-count-hero">
+  <p class="member-count-eyebrow tag uppercase">
+    {m.label_registered_accounts()}
+  </p>
+
+  <div class="member-count-figure">
+    <OdometerNumber
+      value={count.value}
+      reserveFor={count.reserveFor}
+      {accessibleLabel}
+    />
+  </div>
+
+  <p class="member-count-tagline secondary">{m.text_member_count_tagline()}</p>
+</section>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-member-count-hero {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--gap-s);
+
+    width: 100%;
+    text-align: center;
+  }
+
+  .member-count-eyebrow {
+    letter-spacing: var(--ni-2);
+    color: var(--purple-400);
+  }
+
+  .member-count-figure {
+    font-size: var(--ni-96);
+    font-weight: 700;
+    // The number is the headline, so the digits are set tighter than body copy.
+    letter-spacing: -0.03em;
+    line-height: 1;
+
+    // Not a `background-clip: text` gradient: transformed strips contribute no
+    // glyphs to a text clip, so a gradient renders only the separators.
+    color: var(--color-text-primary);
+
+    transition: font-size var(--transition-increment) ease-in-out;
+
+    @include for-tablet-lg-and-below {
+      font-size: var(--ni-72);
+    }
+
+    @include for-mobile {
+      font-size: var(--ni-40);
+    }
+  }
+
+  .member-count-tagline {
+    font-size: var(--ni-18);
+    max-width: var(--ni-480);
+
+    @include for-mobile {
+      font-size: var(--font-size-text);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/about/components/_internal/MemberCountProps.ts
+++ b/projects/client/src/lib/sections/about/components/_internal/MemberCountProps.ts
@@ -1,0 +1,9 @@
+export type MemberCountProps = {
+  // Passed in rather than fetched here, so the page owns the single poll.
+  count: {
+    /** Live projected total; the fractional part drives the digit roll. */
+    value: number;
+    /** Highest value to reserve layout width for. */
+    reserveFor: number;
+  };
+};

--- a/projects/client/src/lib/sections/about/components/_internal/toAnnounceValue.ts
+++ b/projects/client/src/lib/sections/about/components/_internal/toAnnounceValue.ts
@@ -1,0 +1,10 @@
+const ANNOUNCE_GRANULARITY = 100_000;
+
+/**
+ * Coarsen a live count to the value a screen reader should hear. Separate from
+ * formatting on purpose: a `$derived` off this only recomputes when the
+ * announced magnitude moves, keeping `Intl` out of the frame loop.
+ */
+export function toAnnounceValue(value: number): number {
+  return Math.floor(value / ANNOUNCE_GRANULARITY) * ANNOUNCE_GRANULARITY;
+}

--- a/projects/client/src/lib/sections/about/components/_internal/toMemberCountLabel.ts
+++ b/projects/client/src/lib/sections/about/components/_internal/toMemberCountLabel.ts
@@ -1,0 +1,10 @@
+import { getLocale } from '$lib/features/i18n/index.ts';
+import * as m from '$lib/features/i18n/messages.ts';
+import { toHumanNumber } from '$lib/utils/formatting/number/toHumanNumber.ts';
+
+/** Expects an already-coarsened value from `toAnnounceValue`. */
+export function toMemberCountLabel(announceValue: number): string {
+  return m.text_member_count_accessible({
+    count: toHumanNumber(announceValue, getLocale()),
+  });
+}

--- a/projects/client/src/lib/stores/css/useMedia.ts
+++ b/projects/client/src/lib/stores/css/useMedia.ts
@@ -19,6 +19,7 @@ export const WellKnownMediaQuery = {
   desktop: `(min-width: ${breakpointDesktop})`,
   mouse: '(hover: hover) and (pointer: fine)',
   touch: '(hover: none) and (pointer: coarse)',
+  reducedMotion: '(prefers-reduced-motion: reduce)',
 };
 
 class MediaQueryManager {

--- a/projects/client/src/lib/utils/formatting/number/toGroupedNumber.ts
+++ b/projects/client/src/lib/utils/formatting/number/toGroupedNumber.ts
@@ -1,0 +1,14 @@
+import { getIntlLocale } from '$lib/features/i18n/index.ts';
+import type {
+  AvailableLanguage,
+  AvailableLocale,
+} from '$lib/features/i18n/index.ts';
+
+export function toGroupedNumber(
+  value: number,
+  locale: AvailableLocale | AvailableLanguage | string = 'en',
+) {
+  return new Intl.NumberFormat(getIntlLocale(locale as AvailableLanguage), {
+    maximumFractionDigits: 0,
+  }).format(value);
+}

--- a/projects/client/src/routes/_design_system/_internal/designSystemPages.ts
+++ b/projects/client/src/routes/_design_system/_internal/designSystemPages.ts
@@ -79,6 +79,13 @@ export const DESIGN_SYSTEM_GROUPS: DesignSystemGroup[] = [
         kind: 'Component',
       },
       {
+        title: 'Member Counter',
+        href: '/_design_system/member-counter',
+        description:
+          'Live registered-account counter: hero, odometer, and ambient presentations.',
+        kind: 'Component',
+      },
+      {
         title: 'Links',
         href: '/_design_system/links',
         description: 'Inline and navigational link styling.',

--- a/projects/client/src/routes/_design_system/member-counter/+page.svelte
+++ b/projects/client/src/routes/_design_system/member-counter/+page.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+  import { useProjectedCount } from "$lib/features/member-count/useProjectedCount.svelte.ts";
+  import MemberCountHero from "$lib/sections/about/components/MemberCountHero.svelte";
+
+  // Synthetic anchor, not `useRegisteredMemberCount`: the preview must render
+  // without `/v3/stats/users`, and the real rate is too slow to judge motion by.
+  const DEMO_TOTAL = 17_002_054;
+  const REAL_RATE_PER_DAY = 10_700;
+
+  const RATE_PRESETS = [
+    { label: "Real (~10.7k/day)", ratePerDay: REAL_RATE_PER_DAY },
+    { label: "1 / second", ratePerDay: 86_400 },
+    { label: "100 / second", ratePerDay: 8_640_000 },
+  ];
+
+  let anchor = $state({
+    total: DEMO_TOTAL,
+    anchoredAt: Date.now(),
+    ratePerDay: REAL_RATE_PER_DAY,
+  });
+
+  const projected = useProjectedCount(() => anchor);
+
+  const count = $derived({
+    value: projected.value,
+    reserveFor: DEMO_TOTAL,
+  });
+
+  // Always re-anchor from where the counter currently is, so a change bends the
+  // curve instead of teleporting the number.
+  const reanchor = (
+    { total, ratePerDay }: { total: number; ratePerDay: number },
+  ) => {
+    anchor = { total, anchoredAt: Date.now(), ratePerDay };
+  };
+
+  const setRate = (ratePerDay: number) =>
+    reanchor({ total: Math.floor(projected.value), ratePerDay });
+
+  // Positive exercises the ease-up path, negative the never-rewind guard.
+  const reanchorBy = (delta: number) =>
+    reanchor({
+      total: Math.floor(projected.value) + delta,
+      ratePerDay: anchor.ratePerDay,
+    });
+</script>
+
+<main class="trakt-member-counter-preview">
+  <!-- A div, not a <header>: the PWA Android preview page ships an unscoped
+       `:global(header, footer, …) { display: none !important }` that survives
+       client-side navigation. -->
+  <div class="preview-intro">
+    <h1>Member Counter</h1>
+    <p class="secondary">
+      The live registered-account total as it ships on the about page: anchored
+      on the server value, interpolated against the measured signup rate, and
+      never rewinding. Under <code>prefers-reduced-motion: reduce</code> it falls
+      back to a static, locale-formatted number with no frame loop.
+    </p>
+  </div>
+
+  <section class="preview-controls card">
+    <div class="control-group">
+      <p class="tag secondary uppercase">Signup rate</p>
+      <div class="control-buttons">
+        {#each RATE_PRESETS as preset (preset.ratePerDay)}
+          <button
+            type="button"
+            class:is-active={anchor.ratePerDay === preset.ratePerDay}
+            onclick={() => setRate(preset.ratePerDay)}
+          >
+            {preset.label}
+          </button>
+        {/each}
+      </div>
+    </div>
+
+    <div class="control-group">
+      <p class="tag secondary uppercase">Re-anchor</p>
+      <div class="control-buttons">
+        <button type="button" onclick={() => reanchorBy(500)}>
+          Server ahead (+500)
+        </button>
+        <button type="button" onclick={() => reanchorBy(-500)}>
+          Server behind (-500)
+        </button>
+      </div>
+      <p class="caption tag secondary">
+        Ahead should ease up smoothly. Behind should freeze the digits until the
+        projection catches up - never count down.
+      </p>
+    </div>
+  </section>
+
+  <section class="preview-variant">
+    <h2>Hero statement</h2>
+    <p class="caption tag secondary">
+      The number is the headline. Per-digit roll at display size, tight tracking,
+      minimal supporting copy.
+    </p>
+    <div class="preview-stage"><MemberCountHero {count} /></div>
+  </section>
+</main>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-member-counter-preview {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xxl);
+
+    // Matches the about page's own content width so the variants are judged at
+    // the size they will actually ship at.
+    max-width: var(--ni-1280);
+    margin: 0 auto;
+    padding: var(--gap-xl);
+    box-sizing: border-box;
+  }
+
+  .preview-intro {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-s);
+    max-width: var(--ni-640);
+  }
+
+  .preview-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-xl);
+
+    padding: var(--gap-l);
+
+    background: color-mix(in srgb, var(--color-card-background) 80%, transparent);
+    border: var(--border-thickness-xxs) solid
+      color-mix(in srgb, var(--color-border) 50%, transparent);
+    border-radius: var(--border-radius-l);
+  }
+
+  .control-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+
+  .control-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-xs);
+  }
+
+  .control-buttons button {
+    padding: var(--gap-xs) var(--gap-m);
+
+    color: var(--color-text-primary);
+    background: var(--color-background-alternate);
+    border: var(--border-thickness-xxs) solid
+      color-mix(in srgb, var(--color-border) 60%, transparent);
+    border-radius: var(--border-radius-m);
+    cursor: pointer;
+
+    &.is-active {
+      border-color: var(--purple-500);
+      color: var(--purple-400);
+    }
+  }
+
+  .preview-variant {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+
+  .preview-stage {
+    display: flex;
+    justify-content: center;
+
+    margin-top: var(--gap-m);
+    padding: var(--gap-xxl) var(--gap-l);
+
+    border: var(--border-thickness-xxs) dashed
+      color-mix(in srgb, var(--color-border) 45%, transparent);
+    border-radius: var(--border-radius-l);
+  }
+</style>


### PR DESCRIPTION
## What

Puts Trakt's all-time registered-account total on the about page, sat between
"What is Trakt?" and "Meet the Team" so the number reads as evidence for the
pitch above it rather than as a context-free figure above the fold.

The new public endpoint (`GET /v3/stats/users`, no auth, uncached) returns the
total, the instant it was accurate at, and the trailing seven-day mean of daily
signups:

```json
{
  "registered": {
    "total": 17002054,
    "updated_at": "2026-07-28T17:35:07.071Z",
    "rate_per_day": 9184
  }
}
```

## How the number moves

Re-rendering the polled value every 10s gives you a number that sits dead and
then jumps. Instead the counter anchors on `total` and projects forward against
the measured `rate_per_day`:

```ts
const projected = total + (Date.now() - Date.parse(updated_at)) * ratePerMs;
```

Every poll re-anchors and the display eases toward the correction, so the digits
between real signups are an interpolation off a real measured rate and the
counter reconciles to the server continuously instead of snapping.

Three guarantees that are easy to get wrong, so they are enforced rather than
assumed:

- **It never rewinds.** A server value *below* what we projected freezes the
  digits until the projection catches up. It never counts down.
- **Projection is clamped at both ends.** A client clock behind the server would
  render below the authoritative total; an unbounded window would let a dead
  endpoint fabricate signups. It stops projecting five minutes past the anchor
  and holds the last honest value.
- **Easing is frame-rate independent.** A 30fps device and a 120fps one
  reconcile over the same wall-clock duration.

## Odometer

Per-digit vertical reel, so only the digits that change move.

- Columns come from the locale's own grouping (`formatToParts`) and the strip is
  built from the locale's own 0-9 glyphs, so `fa-IR` rolls Persian digits rather
  than printing Latin ones next to localized separators.
- Every column derives its offset from the same raw value, so no two columns can
  disagree about a carry. Columns above the ones rest flush and only travel
  during a carry. Without that detent every column sits permanently part-rolled,
  which reads as a rendering fault rather than motion.
- Cells are fixed to `1ch` with tabular figures, so digit width never jitters.
- The strip is driven per frame with no CSS transition. A transition would
  animate the 9 to 0 wrap backwards through the whole strip.

## Degradation and a11y

- **First paint** renders a static floor, not a zero, a spinner, or a width that
  reflows once the response lands. That same floor is what stays on screen if
  the endpoint is down, and monotonicity means it can only ever be corrected
  upward. Layout width is reserved from it, so surrounding copy never moves.
- **`prefers-reduced-motion`** skips the frame loop entirely and renders a
  static, locale-formatted number.
- **Screen readers** get a static label coarsened to 100k ("Over 17M registered
  Trakt accounts"); the ticking digits carry `aria-hidden` so nothing is
  announced per tick.
- Sent unauthenticated. This is a public marketing figure, and a 401 must never
  be able to tear down the session of a signed-in visitor reading the page.

## Notes for review

- `/v3/stats/users` is **not published in `@trakt/api` yet**, so the wire shape
  is validated locally per the `v3/` pattern in `requests.md`. The response
  schema is marked to be dropped once the SDK exposes the endpoint.
- `defineQuery` gained a `refetchInterval` passthrough. TanStack's default
  `refetchIntervalInBackground: false` is what stops the polling when the tab is
  backgrounded.
- The floor constant (`REGISTERED_MEMBER_FLOOR`) will drift. It is a lower bound
  only and can never be rendered above the real value, but worth bumping on
  milestones.

## Preview

`/_design_system/member-counter` renders the counter off a synthetic anchor, so
it works without the endpoint and the motion can be judged at rates far above
the real one (~1 signup per 8s is too slow to evaluate). The re-anchor controls
exercise the two behaviours that are otherwise hard to observe: a server value
ahead of the projection should ease up, one behind it should freeze.

## Testing

27 unit tests over the projection, easing, digit-position and cell-layout maths.

Driven in a real browser against the odometer, reconstructing the rendered value
from each column's offset:

```
PASS  reel climbs over time
PASS  reel never rewinds while climbing
PASS  reel never rewinds on a downward correction
PASS  reel eases up, does not snap (46 intermediate frames)
PASS  reel reconciles to the server value
PASS  reel never rewinds during reconcile
PASS  digit columns share one width (8 cols @ 55.09px)
```

Also confirmed end to end against the live endpoint (renders real data, not the
floor), plus the floor fallback path when the request fails, in both themes and
at the mobile breakpoint. `deno task check` clean.

## Follow-ups, not in scope here

- `_design_system/pwa/android/+page.svelte:242` ships an unscoped
  `:global(header, footer, ...) { display: none !important }` that survives
  client-side navigation and hides `<header>` on every page visited afterwards.
- Every `.svelte.ts` file in the repo fails ESLint parsing
  (`Unexpected token {`); the svelte parser is picking them up instead of the TS
  one.

## Pull Request Checklist

- [x] **Clear and Concise Title:** Does your title shine a spotlight on the
      essence of your changes?
- [x] **Detailed Description:** Have you set the stage with a compelling
      narrative that explains the "why" and "how" of your changes?
- [ ] **Screenshots/Videos:** Have you captured the magic with visual evidence
      that showcases your changes in action? _(not attached: the counter is
      motion, so `/_design_system/member-counter` is the honest way to review
      it)_
- [x] **Tests:** Has your code undergone a rigorous dress rehearsal with unit
      tests to ensure it performs flawlessly under pressure?
- [x] **Coding Standards:** Does your code adhere to the project's style guide,
      ensuring it's as elegant as a film score?
- [x] **Commit Messages:** Are your commit messages clear and concise, guiding
      the audience through the evolution of your code?
- [x] **Documentation:** If your changes impact the script, have you updated the
      documentation accordingly?
- [x] **Code Review:** Are you prepared to embrace feedback from the discerning
      eyes of the project maintainers and fellow contributors?
