### PR TITLE
Calendar: episode type filter

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -1560,6 +1560,30 @@
       "default": "Status",
       "description": "Header for the status section."
     },
+    "button_text_episode_type_all": {
+      "default": "All",
+      "description": "Text for the toggle that shows every upcoming release, rather than only premieres or only finales. This should be as short as possible."
+    },
+    "button_label_episode_type_all": {
+      "default": "Show all releases",
+      "description": "Accessible label for the toggle that shows every upcoming release, rather than only premieres or only finales."
+    },
+    "button_text_episode_type_premieres": {
+      "default": "Premieres",
+      "description": "Text for the toggle that shows only premiere episodes: series, season and mid-season premieres. This should be as short as possible."
+    },
+    "button_label_episode_type_premieres": {
+      "default": "Show only premieres",
+      "description": "Accessible label for the toggle that shows only premiere episodes: series, season and mid-season premieres."
+    },
+    "button_text_episode_type_finales": {
+      "default": "Finales",
+      "description": "Text for the toggle that shows only finale episodes: series, season and mid-season finales. This should be as short as possible."
+    },
+    "button_label_episode_type_finales": {
+      "default": "Show only finales",
+      "description": "Accessible label for the toggle that shows only finale episodes: series, season and mid-season finales."
+    },
     "translated_value_status_released": {
       "default": "Released",
       "description": "Status value for released media items. The value is sent back from the Trakt API."

--- a/projects/client/src/lib/components/icons/FinaleIcon.svelte
+++ b/projects/client/src/lib/components/icons/FinaleIcon.svelte
@@ -1,0 +1,11 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  height="24px"
+  viewBox="0 -960 960 960"
+  width="24px"
+  fill="currentColor"
+>
+  <path
+    d="M360-720h80v-80h-80v80Zm160 0v-80h80v80h-80ZM360-400v-80h80v80h-80Zm320-160v-80h80v80h-80Zm0 160v-80h80v80h-80Zm-160 0v-80h80v80h-80Zm160-320v-80h80v80h-80Zm-240 80v-80h80v80h-80ZM200-160v-640h80v80h80v80h-80v80h80v80h-80v320h-80Zm400-320v-80h80v80h-80Zm-160 0v-80h80v80h-80Zm-80-80v-80h80v80h-80Zm160 0v-80h80v80h-80Zm80-80v-80h80v80h-80Z"
+  />
+</svg>

--- a/projects/client/src/lib/components/icons/PremiereIcon.svelte
+++ b/projects/client/src/lib/components/icons/PremiereIcon.svelte
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m12.296 3.464 3.02 3.956" />
+  <path d="M20.2 6 3 11l-.9-2.4c-.3-1.1.3-2.2 1.3-2.5l13.5-4c1.1-.3 2.2.3 2.5 1.3z" />
+  <path d="M3 11h18v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+  <path d="m6.18 5.276 3.1 3.899" />
+</svg>

--- a/projects/client/src/lib/components/select/_internal/SelectItem.svelte
+++ b/projects/client/src/lib/components/select/_internal/SelectItem.svelte
@@ -49,7 +49,6 @@
     <div
       {...props}
       class="trakt-select-item"
-      class:is-excluded={state === "excluded"}
       data-state={state ?? "none"}
       aria-label={state === "excluded"
         ? m.option_label_excluded({ label: option.label })
@@ -115,7 +114,11 @@
       background-color: var(--color-background-item-hover);
     }
 
-    &.is-excluded .trakt-select-item-label {
+    &[data-state="included"] .trakt-select-item-label {
+      color: var(--purple-500);
+    }
+
+    &[data-state="excluded"] .trakt-select-item-label {
       color: var(--red-500);
       text-decoration: line-through;
     }

--- a/projects/client/src/lib/components/toggles/ToggleOption.ts
+++ b/projects/client/src/lib/components/toggles/ToggleOption.ts
@@ -6,6 +6,7 @@ export interface ToggleOption<T> {
   value: T;
   text: IntlFn;
   label: IntlFn;
+  icon?: Snippet;
   content?: Snippet;
   href?: string;
 }

--- a/projects/client/src/lib/components/toggles/Toggler.svelte
+++ b/projects/client/src/lib/components/toggles/Toggler.svelte
@@ -113,7 +113,11 @@
         {...getTriggerProps(option, index)}
       >
         {#snippet icon()}
-          <ToggleIcon {option} />
+          {#if option.icon}
+            {@render option.icon()}
+          {:else}
+            <ToggleIcon {option} />
+          {/if}
         {/snippet}
 
         {#if option.content}

--- a/projects/client/src/lib/components/toggles/_internal/ToggleIcon.svelte
+++ b/projects/client/src/lib/components/toggles/_internal/ToggleIcon.svelte
@@ -5,6 +5,7 @@
   import CrewIcon from "$lib/components/icons/CrewIcon.svelte";
   import CustomLibraryIcon from "$lib/components/icons/CustomLibraryIcon.svelte";
   import DropIcon from "$lib/components/icons/DropIcon.svelte";
+  import FinaleIcon from "$lib/components/icons/FinaleIcon.svelte";
   import FollowersIcon from "$lib/components/icons/FollowersIcon.svelte";
   import FollowingIcon from "$lib/components/icons/FollowingIcon.svelte";
   import HourglassIcon from "$lib/components/icons/HourglassIcon.svelte";
@@ -15,6 +16,7 @@
   import PeopleIcon from "$lib/components/icons/PeopleIcon.svelte";
   import PlexLibraryIcon from "$lib/components/icons/PlexLibraryIcon.svelte";
   import PopularIcon from "$lib/components/icons/PopularIcon.svelte";
+  import PremiereIcon from "$lib/components/icons/PremiereIcon.svelte";
   import RatingIcon from "$lib/components/icons/RatingIcon.svelte";
   import RecentIcon from "$lib/components/icons/RecentIcon.svelte";
   import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
@@ -30,7 +32,7 @@
   // FIXME: make the icon a prop of ToggleOption
 </script>
 
-{#if option.value === "all" || option.value === "media"}
+{#if option.value === "media"}
   <MediaIcon />
 {/if}
 
@@ -120,4 +122,12 @@
 
 {#if option.value === "smart"}
   <BrainIcon />
+{/if}
+
+{#if option.value === "premieres"}
+  <PremiereIcon />
+{/if}
+
+{#if option.value === "finales"}
+  <FinaleIcon />
 {/if}

--- a/projects/client/src/lib/components/toggles/_internal/constants.ts
+++ b/projects/client/src/lib/components/toggles/_internal/constants.ts
@@ -1,3 +1,4 @@
+import type { EpisodeTypeFilter } from '$lib/features/calendar/models/EpisodeTypeFilter.ts';
 import type { DiscoverMode } from '$lib/features/filters/models/DiscoverMode.ts';
 import * as m from '$lib/features/i18n/messages.ts';
 import type { CommentSortType } from '$lib/requests/models/CommentSortType.ts';
@@ -10,7 +11,8 @@ export type TogglerId =
   | 'trivia'
   | 'progress'
   | 'activity'
-  | 'library';
+  | 'library'
+  | 'episodeType';
 
 type DiscoverToggleType = DiscoverMode;
 type SocialToggleType = 'following' | 'followers' | 'requests';
@@ -19,6 +21,7 @@ type TriviaToggleType = 'spoilers' | 'no-spoilers';
 type ProgressToggleType = 'in-progress' | 'dropped' | 'completed';
 type ActivityToggleType = 'reviews' | 'ratings';
 type LibraryToggleType = 'plex' | 'other';
+type EpisodeTypeToggleType = EpisodeTypeFilter;
 
 type Toggler<T, K> = {
   id: T;
@@ -34,6 +37,7 @@ export type TogglerValueMap = {
   progress: ProgressToggleType;
   activity: ActivityToggleType;
   library: LibraryToggleType;
+  episodeType: EpisodeTypeToggleType;
 };
 
 type ToggleDefinition<K extends TogglerId> = Toggler<K, TogglerValueMap[K]>;
@@ -172,6 +176,28 @@ const library: ToggleDefinition<'library'> = {
   ],
 };
 
+const episodeType: ToggleDefinition<'episodeType'> = {
+  id: 'episodeType',
+  default: 'all',
+  options: [
+    {
+      value: 'all',
+      text: m.button_text_episode_type_all,
+      label: m.button_label_episode_type_all,
+    },
+    {
+      value: 'premieres',
+      text: m.button_text_episode_type_premieres,
+      label: m.button_label_episode_type_premieres,
+    },
+    {
+      value: 'finales',
+      text: m.button_text_episode_type_finales,
+      label: m.button_label_episode_type_finales,
+    },
+  ],
+};
+
 export const TOGGLERS: {
   [K in TogglerId]: Toggler<K, TogglerValueMap[K]>;
 } = {
@@ -182,4 +208,5 @@ export const TOGGLERS: {
   progress,
   activity,
   library,
+  episodeType,
 } as const;

--- a/projects/client/src/lib/features/calendar/Calendar.svelte
+++ b/projects/client/src/lib/features/calendar/Calendar.svelte
@@ -2,6 +2,7 @@
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import { getDaysDifference } from "$lib/utils/date/getDaysDifference";
   import { useFilter } from "../filters/useFilter";
+  import { useEpisodeType } from "./useEpisodeType";
   import {
     useCalendar,
     type CalendarItem as CalendarItemEntry,
@@ -29,19 +30,23 @@
 
   const { filterMap } = useFilter();
 
-  const { isLoading, calendar } = $derived(
+  const { episodeType } = useEpisodeType();
+
+  const { isLoading, calendar, hasUpstreamItems } = $derived(
     useCalendar({
       start: $startDate,
       days,
       type: $mode,
       filter: $filterMap,
+      episodeType,
     }),
   );
 
   const periods: CalendarPeriod<CalendarItemEntry>[] = $derived(
     accumulate({
       calendar: $calendar,
-      fingerprint: `${$mode}:${JSON.stringify($filterMap)}`,
+      fingerprint: `${$mode}:${JSON.stringify($filterMap)}:${$episodeType}`,
+      isEmpty: !$hasUpstreamItems,
     }),
   );
 

--- a/projects/client/src/lib/features/calendar/EpisodeTypeToggles.svelte
+++ b/projects/client/src/lib/features/calendar/EpisodeTypeToggles.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import MediaIcon from "$lib/components/icons/MediaIcon.svelte";
+  import MovieIcon from "$lib/components/icons/MovieIcon.svelte";
+  import ShowIcon from "$lib/components/icons/ShowIcon.svelte";
+  import Toggler from "$lib/components/toggles/Toggler.svelte";
+  import { useDiscover } from "$lib/features/filters/useDiscover";
+  import { useEpisodeType } from "./useEpisodeType";
+
+  const { episodeType, onEpisodeTypeChange, options, isApplicable } =
+    useEpisodeType();
+  const { mode } = useDiscover();
+
+  const togglerOptions = options.map((option) =>
+    option.value === "all" ? { ...option, icon: discoverModeIcon } : option
+  );
+</script>
+
+{#snippet discoverModeIcon()}
+  {#if $mode === "movie"}
+    <MovieIcon />
+  {:else if $mode === "show"}
+    <ShowIcon />
+  {:else}
+    <MediaIcon />
+  {/if}
+{/snippet}
+
+{#if $isApplicable}
+  <Toggler
+    value={$episodeType}
+    onChange={onEpisodeTypeChange}
+    options={togglerOptions}
+  />
+{/if}

--- a/projects/client/src/lib/features/calendar/_internal/createCalendarAccumulator.spec.ts
+++ b/projects/client/src/lib/features/calendar/_internal/createCalendarAccumulator.spec.ts
@@ -250,6 +250,37 @@ describe('createCalendarAccumulator', () => {
       expect(canLoadMore()).toBe(true);
     });
 
+    it('should keep loading when a period is only empty after client side filtering', () => {
+      const { accumulate, canLoadMore } = createCalendarAccumulator(
+        'chronological',
+      );
+
+      for (let i = 0; i < 5; i++) {
+        const emptyPeriod = mockCalendar(`2024-01-0${i + 1}`, 1);
+        accumulate({
+          calendar: emptyPeriod,
+          fingerprint: 'a',
+          isEmpty: false,
+        });
+      }
+
+      expect(canLoadMore()).toBe(true);
+    });
+
+    it('should stop loading when the upstream period is empty', () => {
+      const { accumulate, canLoadMore } = createCalendarAccumulator(
+        'chronological',
+      );
+
+      for (let i = 0; i < 5; i++) {
+        const period = mockCalendar(`2024-01-0${i + 1}`, 1);
+        period[0]?.items.push({ key: 'item' });
+        accumulate({ calendar: period, fingerprint: 'a', isEmpty: true });
+      }
+
+      expect(canLoadMore()).toBe(false);
+    });
+
     it('should reset consecutive empty periods counter upon clearing', () => {
       const { accumulate, clear, canLoadMore } = createCalendarAccumulator(
         'chronological',

--- a/projects/client/src/lib/features/calendar/_internal/createCalendarAccumulator.ts
+++ b/projects/client/src/lib/features/calendar/_internal/createCalendarAccumulator.ts
@@ -21,6 +21,7 @@ function sortPeriods<T>(
 type AccumulatorParams<T> = {
   calendar: Calendar<T>;
   fingerprint: string;
+  isEmpty?: boolean;
 };
 
 export function createCalendarAccumulator(order: CalendarOrder) {
@@ -47,6 +48,7 @@ export function createCalendarAccumulator(order: CalendarOrder) {
   function accumulate<T>({
     calendar,
     fingerprint,
+    isEmpty = calendar.every((day) => day.items.length === 0),
   }: AccumulatorParams<T>): CalendarPeriod<T>[] {
     if (fingerprint != null && fingerprint !== lastFingerprint) {
       accumulatedMap.clear();
@@ -69,8 +71,6 @@ export function createCalendarAccumulator(order: CalendarOrder) {
       }
 
       clearedToKey = undefined;
-
-      const isEmpty = calendar.every((day) => day.items.length === 0);
 
       if (!accumulatedMap.has(key) || !isEmpty) {
         setPeriodCount(isEmpty);

--- a/projects/client/src/lib/features/calendar/_internal/useCalendar.ts
+++ b/projects/client/src/lib/features/calendar/_internal/useCalendar.ts
@@ -17,6 +17,8 @@ import { combineLatest, map, type Observable } from 'rxjs';
 import type { FilterParams } from '../../../requests/models/FilterParams.ts';
 import type { DiscoverMode } from '../../filters/models/DiscoverMode.ts';
 import type { Calendar } from '../models/Calendar.ts';
+import { matchesEpisodeTypeFilter } from '../matchesEpisodeTypeFilter.ts';
+import type { EpisodeTypeFilter } from '../models/EpisodeTypeFilter.ts';
 
 export type CalendarItem = UpcomingEpisodeEntry | MediaEntry;
 type CalendarItems = CalendarItem[];
@@ -25,11 +27,13 @@ type UseCalendarParams = {
   start: Date;
   days: number;
   type: DiscoverMode;
+  episodeType: Observable<EpisodeTypeFilter>;
 } & FilterParams;
 
 type CalendarResult = {
   isLoading: Observable<boolean>;
   calendar: Observable<Calendar<CalendarItem>>;
+  hasUpstreamItems: Observable<boolean>;
 };
 
 function typeToQueries({ start, days, type, filter }: UseCalendarParams) {
@@ -71,18 +75,25 @@ export function useCalendar(
     getTargets: episodeWithShowOrMovieTargets,
   });
 
-  const allItems = combineLatest(queries).pipe(
+  const sorted = combineLatest(queries).pipe(
     map(($queries) => {
       return $queries.flatMap((query) => query.data ?? []).toSorted((a, b) => {
         return a.effectiveReleaseDate.getTime() -
           b.effectiveReleaseDate.getTime();
       });
     }),
+  );
+
+  const allItems = combineLatest([sorted, props.episodeType]).pipe(
+    map(([$sorted, $episodeType]) =>
+      $sorted.filter((item) => matchesEpisodeTypeFilter(item, $episodeType))
+    ),
     overlay.operator,
   );
 
   return {
     isLoading: withOverlayLoading(baseLoading, overlay.intlLoading$),
+    hasUpstreamItems: sorted.pipe(map(($sorted) => $sorted.length > 0)),
     calendar: allItems.pipe(
       map(($allItems) => {
         return Array.from({ length: props.days }, (_, i) => {

--- a/projects/client/src/lib/features/calendar/matchesEpisodeTypeFilter.spec.ts
+++ b/projects/client/src/lib/features/calendar/matchesEpisodeTypeFilter.spec.ts
@@ -1,0 +1,92 @@
+import type { EpisodeType } from '$lib/requests/models/EpisodeType.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { UpcomingEpisodeEntry } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
+import { describe, expect, it } from 'vitest';
+import { matchesEpisodeTypeFilter } from './matchesEpisodeTypeFilter.ts';
+
+type EpisodeStub = {
+  type: EpisodeType;
+  episodes?: Array<{ type: EpisodeType }>;
+};
+
+const episode = ({ type, episodes }: EpisodeStub) =>
+  ({ show: { id: 1 }, type, episodes }) as unknown as UpcomingEpisodeEntry;
+
+const movie = () => ({ type: 'movie' }) as unknown as MediaEntry;
+
+describe('util: matchesEpisodeTypeFilter', () => {
+  it('should keep everything when showing all', () => {
+    expect(matchesEpisodeTypeFilter(episode({ type: 'standard' }), 'all'))
+      .toBe(true);
+    expect(matchesEpisodeTypeFilter(movie(), 'all')).toBe(true);
+  });
+
+  describe('for a single episode', () => {
+    it('should keep every kind of premiere', () => {
+      const premieres: ReadonlyArray<EpisodeType> = [
+        'series_premiere',
+        'season_premiere',
+        'mid_season_premiere',
+      ];
+
+      premieres.forEach((type) => {
+        expect(matchesEpisodeTypeFilter(episode({ type }), 'premieres'))
+          .toBe(true);
+      });
+    });
+
+    it('should keep every kind of finale', () => {
+      const finales: ReadonlyArray<EpisodeType> = [
+        'mid_season_finale',
+        'season_finale',
+        'series_finale',
+      ];
+
+      finales.forEach((type) => {
+        expect(matchesEpisodeTypeFilter(episode({ type }), 'finales'))
+          .toBe(true);
+      });
+    });
+
+    it('should drop a standard episode from both filters', () => {
+      expect(matchesEpisodeTypeFilter(episode({ type: 'standard' }), 'finales'))
+        .toBe(false);
+      expect(
+        matchesEpisodeTypeFilter(episode({ type: 'standard' }), 'premieres'),
+      ).toBe(false);
+    });
+
+    it('should not confuse a premiere for a finale', () => {
+      expect(
+        matchesEpisodeTypeFilter(
+          episode({ type: 'season_premiere' }),
+          'finales',
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('for a grouped day', () => {
+    it('should match on any of the grouped episodes', () => {
+      const grouped = episode({
+        type: 'multiple_episodes',
+        episodes: [{ type: 'standard' }, { type: 'season_finale' }],
+      });
+
+      expect(matchesEpisodeTypeFilter(grouped, 'finales')).toBe(true);
+      expect(matchesEpisodeTypeFilter(grouped, 'premieres')).toBe(false);
+    });
+
+    it('should answer to both filters for a full season', () => {
+      const fullSeason = episode({ type: 'full_season' });
+
+      expect(matchesEpisodeTypeFilter(fullSeason, 'premieres')).toBe(true);
+      expect(matchesEpisodeTypeFilter(fullSeason, 'finales')).toBe(true);
+    });
+  });
+
+  it('should drop movies from a role specific feed', () => {
+    expect(matchesEpisodeTypeFilter(movie(), 'premieres')).toBe(false);
+    expect(matchesEpisodeTypeFilter(movie(), 'finales')).toBe(false);
+  });
+});

--- a/projects/client/src/lib/features/calendar/matchesEpisodeTypeFilter.ts
+++ b/projects/client/src/lib/features/calendar/matchesEpisodeTypeFilter.ts
@@ -1,0 +1,54 @@
+import {
+  EpisodeComputedType,
+  type EpisodeType,
+} from '$lib/requests/models/EpisodeType.ts';
+import type { MediaEntry } from '$lib/requests/models/MediaEntry.ts';
+import type { UpcomingEpisodeEntry } from '$lib/requests/queries/calendars/upcomingEpisodesQuery.ts';
+import type { EpisodeTypeFilter } from './models/EpisodeTypeFilter.ts';
+
+const ROLES: Record<
+  Exclude<EpisodeTypeFilter, 'all'>,
+  ReadonlyArray<EpisodeType>
+> = {
+  premieres: ['series_premiere', 'season_premiere', 'mid_season_premiere'],
+  finales: ['mid_season_finale', 'season_finale', 'series_finale'],
+};
+
+const FULL_SEASON_ROLES: ReadonlyArray<EpisodeType> = [
+  'season_premiere',
+  'season_finale',
+];
+
+function toEpisodeRoles(
+  item: UpcomingEpisodeEntry | MediaEntry,
+): ReadonlyArray<EpisodeType> | null {
+  if (!('show' in item)) {
+    return null;
+  }
+
+  if (item.type === EpisodeComputedType.full_season) {
+    return FULL_SEASON_ROLES;
+  }
+
+  const grouped = item.episodes ?? [];
+  return grouped.length > 0
+    ? grouped.map((episode) => episode.type)
+    : [item.type];
+}
+
+export function matchesEpisodeTypeFilter(
+  item: UpcomingEpisodeEntry | MediaEntry,
+  filter: EpisodeTypeFilter,
+): boolean {
+  if (filter === 'all') {
+    return true;
+  }
+
+  const roles = toEpisodeRoles(item);
+
+  if (roles == null) {
+    return false;
+  }
+
+  return roles.some((role) => ROLES[filter].includes(role));
+}

--- a/projects/client/src/lib/features/calendar/models/EpisodeTypeFilter.ts
+++ b/projects/client/src/lib/features/calendar/models/EpisodeTypeFilter.ts
@@ -1,0 +1,1 @@
+export type EpisodeTypeFilter = 'all' | 'premieres' | 'finales';

--- a/projects/client/src/lib/features/calendar/useEpisodeType.ts
+++ b/projects/client/src/lib/features/calendar/useEpisodeType.ts
@@ -1,0 +1,34 @@
+import { useToggler } from '$lib/components/toggles/useToggler.ts';
+import { useDiscover } from '$lib/features/filters/useDiscover.ts';
+import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
+import { combineLatest, distinctUntilChanged, map } from 'rxjs';
+import type { EpisodeTypeFilter } from './models/EpisodeTypeFilter.ts';
+
+export function useEpisodeType() {
+  const { options, set, current } = useToggler('episodeType');
+  const { mode } = useDiscover();
+
+  const episodeType = combineLatest([current, mode]).pipe(
+    map(([$current, $mode]): EpisodeTypeFilter =>
+      $mode === 'movie' ? 'all' : $current.value
+    ),
+    distinctUntilChanged(),
+  );
+
+  const currentOption = episodeType.pipe(
+    map((value) =>
+      assertDefined(
+        options.find((option) => option.value === value),
+        `Invalid episode type: ${value}`,
+      )
+    ),
+  );
+
+  return {
+    options,
+    episodeType,
+    current: currentOption,
+    isApplicable: mode.pipe(map(($mode) => $mode !== 'movie')),
+    onEpisodeTypeChange: set,
+  };
+}

--- a/projects/client/src/lib/sections/lists/UpcomingList.svelte
+++ b/projects/client/src/lib/sections/lists/UpcomingList.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
+  import EpisodeTypeToggles from "$lib/features/calendar/EpisodeTypeToggles.svelte";
   import CalendarItem from "$lib/features/calendar/CalendarItem.svelte";
+  import { useEpisodeType } from "$lib/features/calendar/useEpisodeType";
+  import type { DiscoverMode } from "$lib/features/filters/models/DiscoverMode";
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import { useFilter } from "$lib/features/filters/useFilter";
   import * as m from "$lib/features/i18n/messages.ts";
+  import type { FilterParams } from "$lib/requests/models/FilterParams";
+  import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CtaItem from "./components/cta/CtaItem.svelte";
   import DrillableMediaList from "./drilldown/DrillableMediaList.svelte";
@@ -12,11 +17,23 @@
 
   const { filterMap } = useFilter();
 
+  const { episodeType, current, isApplicable } = useEpisodeType();
+
+  const useList = (
+    props: { type: DiscoverMode; limit: number } & FilterParams,
+  ) => useUpcomingItems({ ...props, episodeType });
+
   const cta = $derived({
     type: "upcoming" as const,
     mediaType: $mode === "media" ? undefined : $mode,
   });
 </script>
+
+{#snippet metaInfo()}
+  {#if $isApplicable}
+    <ListMetaInfo text={$current.text()} />
+  {/if}
+{/snippet}
 
 <DrillableMediaList
   id={{
@@ -26,13 +43,18 @@
   type={$mode}
   variant="landscape"
   filter={$filterMap}
-  useList={useUpcomingItems}
+  {useList}
+  {metaInfo}
   urlBuilder={UrlBuilder.calendar}
   drilldownLabel={m.button_label_calendar()}
   title={m.list_title_upcoming_schedule()}
 >
   {#snippet item(entry)}
     <CalendarItem item={entry} />
+  {/snippet}
+
+  {#snippet actions()}
+    <EpisodeTypeToggles />
   {/snippet}
 
   {#snippet ctaItem()}

--- a/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
+++ b/projects/client/src/lib/sections/lists/stores/useUpcomingItems.ts
@@ -1,3 +1,5 @@
+import { matchesEpisodeTypeFilter } from '$lib/features/calendar/matchesEpisodeTypeFilter.ts';
+import type { EpisodeTypeFilter } from '$lib/features/calendar/models/EpisodeTypeFilter.ts';
 import type { DiscoverMode } from '$lib/features/filters/models/DiscoverMode.ts';
 import { createBulkIntlOverlay } from '$lib/features/intl-overlay/createBulkIntlOverlay.ts';
 import { episodeWithShowOrMovieTargets } from '$lib/features/intl-overlay/episodeWithShowOrMovieTargets.ts';
@@ -15,11 +17,12 @@ import { upcomingMoviesQuery } from '$lib/requests/queries/calendars/upcomingMov
 import { assertDefined } from '$lib/utils/assert/assertDefined.ts';
 import { getStartOfDay } from '$lib/utils/date/getStartOfDay.ts';
 import { time } from '$lib/utils/timing/time.ts';
-import { map } from 'rxjs';
+import { combineLatest, map, type Observable } from 'rxjs';
 
 type UseUpcomingItemsProps = {
   type: DiscoverMode;
   limit: number;
+  episodeType: Observable<EpisodeTypeFilter>;
 } & FilterParams;
 
 type UpcomingList = Array<MediaEntry | UpcomingEpisodeEntry>;
@@ -64,11 +67,12 @@ export function useUpcomingItems(props: UseUpcomingItemsProps) {
 
   const baseLoading = query.pipe(map(($query) => $query.isLoading));
 
-  const list = query.pipe(
-    map(($query) => {
+  const list = combineLatest([query, props.episodeType]).pipe(
+    map(([$query, $episodeType]) => {
       const startOfToday = getStartOfDay(new Date()).getTime();
       return ($query.data ?? [])
         .filter((d) => d.effectiveReleaseDate.getTime() >= startOfToday)
+        .filter((d) => matchesEpisodeTypeFilter(d, $episodeType))
         .slice(0, props.limit);
     }),
     overlay.operator,

--- a/projects/client/src/routes/calendar/+page.svelte
+++ b/projects/client/src/routes/calendar/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import Calendar from "$lib/features/calendar/Calendar.svelte";
+  import EpisodeTypeToggles from "$lib/features/calendar/EpisodeTypeToggles.svelte";
+  import { useEpisodeType } from "$lib/features/calendar/useEpisodeType";
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import * as m from "$lib/features/i18n/messages";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
@@ -9,7 +11,12 @@
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
 
   const { current } = useDiscover();
+  const { current: episodeType, isApplicable } = useEpisodeType();
 </script>
+
+{#snippet episodeTypeToggles()}
+  <EpisodeTypeToggles />
+{/snippet}
 
 <TraktPage
   audience="authenticated"
@@ -20,7 +27,11 @@
 
   <ResponsiveNavbarStateSetter
     hasFilters
-    header={{ title: m.header_calendar(), metaInfo: $current.text() }}
+    header={{
+      title: m.header_calendar(),
+      metaInfo: $isApplicable ? $episodeType.text() : $current.text(),
+      actions: episodeTypeToggles,
+    }}
   />
 
   <Calendar />


### PR DESCRIPTION
Closes #2948

# Summary

Adds an episode type filter to the upcoming feeds, so the calendar can be narrowed to premieres or finales. This is the v0 discussed on the issue: episode roles only, with the broader "All vs My Services" mode left for a follow up.

It is a three way toggle rather than an entry in the filters panel: **All** (default), **Premieres**, **Finales**. The control sits beside the title on both surfaces that show upcoming releases, so it reads as part of the feed rather than something buried behind the filter drawer.

# Screenshots

## Home > Calendar > All
<img width="1449" height="304" alt="image" src="https://github.com/user-attachments/assets/8aad4fc1-ac4f-4b1c-abda-a6c6d395ffe8" />

## Home > Calendar > Premieres
<img width="1232" height="299" alt="image" src="https://github.com/user-attachments/assets/759891fe-135e-4c00-9f20-28f0b55b006f" />

## Home > Calendar > Finales
<img width="768" height="293" alt="image" src="https://github.com/user-attachments/assets/d292d306-d871-49d6-999b-bbd02613a5a3" />

## Calendar > All
<img width="1460" height="1491" alt="image" src="https://github.com/user-attachments/assets/e5fdcf1a-54e9-4430-af88-dce14aaf5c3d" />

## Calendar > Premieres
<img width="1454" height="790" alt="image" src="https://github.com/user-attachments/assets/5e9a1f16-b6ee-4847-a5c8-33dfe1ebd81d" />

## Calendar > Finales
<img width="1459" height="1012" alt="image" src="https://github.com/user-attachments/assets/a7574fb7-5ea9-4901-8c5c-a650be32983b" />

## Calendar > Movies
<img width="1463" height="560" alt="image" src="https://github.com/user-attachments/assets/69f3a427-0efc-4e5b-b983-0c4dd614226c" />

# How it works

The toggle is a normal entry in the shared toggler registry, so it is the same component and behaviour as the Progress toggle on a profile. It is backed by `useToggler('episodeType')` for persistence and mirrored onto an `episode_type` URL parameter through `GlobalParameterSetter`, the same way the discover mode toggle works. The parameter wins whenever it holds a known value, which keeps a filtered calendar shareable, and home and the calendar page read the same toggler so a choice made on one carries to the other.

Filtering happens on the client. The calendar endpoints accept no episode role parameter, so `matchesEpisodeTypeFilter` narrows the entries that already arrived rather than anything being sent upstream. `useCalendar` and `useUpcomingItems` both take the selection as an `Observable`, so changing it re-filters what is in hand instead of re-instantiating the hook and rebuilding the whole `QueryObserver` chain. The narrowing runs ahead of the intl overlay so we do not fetch translations for entries about to be dropped, and on home it runs ahead of the row limit so the row fills with matches rather than with whatever survived the first page.

Premieres covers series, season and mid-season premieres; Finales covers series, season and mid-season finales.

# Grouped days

The upcoming feeds request `group=day`. A day holding several episodes of one show arrives as a single `multiple_episodes` card that still carries its episodes, so those are matched exactly. A day holding both a premiere and a finale arrives as a `full_season` card with the individual episodes dropped, so all that survives is that the span opens and closes a season. Those cards therefore answer to both filters rather than being hidden from each of them, which is the right trade for the binge watching case the issue describes: a full season drop genuinely is both.

# Infinite scroll

The calendar stops loading further periods once enough of them come back empty. Filtering after the fetch would make a narrow selection empty almost every window, so the calendar would stop scrolling after five of them even though matches exist further out. `useCalendar` now exposes `hasUpstreamItems`, taken before the filter runs, and the accumulator's emptiness check accepts it as an override. The heuristic answers "is the feed exhausted", not "did the filter hide everything".

# Movies

A movie carries no episode role, so the toggle hides itself when the discover mode is movies and the selection is forced back to All while it is hidden. Without the second half, switching to Movies while on Premieres would leave an empty feed with no visible control to undo it.

# Icons

Two new icons, both taken from Material Symbols so they carry the same weight and grid alignment as the rest of the set: a four point sparkle for Premieres, and the checkered flag (`sports_score`) for Finales.

# Also in here

The `+` state on advanced multi select filters now renders its label in `--purple-500`, mirroring the existing `--red-500` treatment on `-`. Both tokens sit in the same lightness band so the two states read with equivalent contrast, and the include colour matches the chip that sets it. This is a shared component, so it applies to every advanced multi select filter.

# Testing

Unit coverage for the role matching, including grouped days, full season cards and the movie case, plus both directions of the accumulator override. Full client suite passes with no new failures.
