### PR TITLE
fix(link): use in-app routes instead of trakt.tv redirects

### DIFF
--- a/projects/client/src/lib/sections/banner/_internal/BannerLink.svelte
+++ b/projects/client/src/lib/sections/banner/_internal/BannerLink.svelte
@@ -17,6 +17,8 @@
       tag?: Snippet;
     } = $props();
   const { track } = useTrack(AnalyticsEvent.Link);
+
+  const isExternal = $derived(target === "_blank");
 </script>
 
 <div class="trakt-banner-link">
@@ -30,7 +32,9 @@
     color="inherit"
     onclick={() => track({ source, target: href ?? "banner-link" })}
   >
-    <ExternalLinkIcon size="small" />
+    {#if isExternal}
+      <ExternalLinkIcon size="small" />
+    {/if}
     <span class="no-wrap">{@render children()}</span>
   </Link>
 </div>

--- a/projects/client/src/lib/sections/banner/black-friday/_internal/ClaimOfferLink.svelte
+++ b/projects/client/src/lib/sections/banner/black-friday/_internal/ClaimOfferLink.svelte
@@ -8,7 +8,7 @@
   const { promotion }: { promotion: Promotion } = $props();
 </script>
 
-<BannerLink href={UrlBuilder.og.vip()} target="_blank" source={promotion.id}>
+<BannerLink href={UrlBuilder.vip()} source={promotion.id}>
   {#snippet tag()}
     <RenderFor audience="all" device={["desktop", "tablet-lg"]}>
       <DealEnd endDate={promotion.end} />

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -304,9 +304,6 @@ export const UrlBuilder = {
   status: () => 'https://status.trakt.tv',
   renewVip: () => 'vip/renew',
   og: {
-    vip: () => 'https://trakt.tv/vip',
-    about: () => 'https://trakt.tv/about',
-    branding: () => 'https://trakt.tv/branding',
     support: (username?: string) => ogSupportFactory(username),
     forums: () => 'https://forums.trakt.tv/c/trakt',
     widgets: {


### PR DESCRIPTION
trakt.tv now 301s everything to app.trakt.tv. This removes the `og.*` entries
that were pointing at it for pages we already serve ourselves.

## What changes

- **`og.vip()`** was an absolute trakt.tv URL redirecting to a page this app
  serves at `/vip`. The Black Friday CTA now uses the internal route and drops
  `target="_blank"`, so it navigates client-side instead of opening a new tab
  onto a redirect.
- **`og.about()`** and **`og.branding()`** are deleted. Neither had callers, and
  `UrlBuilder.about()` / `.branding()` already exist.
- **`BannerLink`** rendered an external-link icon unconditionally, so in-app
  banner links promised a new tab that never arrived. The icon now follows the
  href. That also corrects the two year-in-review banner links, which were
  mislabelled before this change.

Three `og.*` entries stay, because none has an in-app equivalent:

| Entry | Why it stays |
| - | - |
| `og.support()` | returns a `mailto:` or a Discourse new-message URL |
| `og.forums()` | Discourse, not us |
| `og.widgets.yir()` | feeds an Open Graph image, which must be absolute or crawlers cannot resolve it |

`og.privacy()` is untouched here on purpose: #3029 already removes it, and
editing the same line on both branches would guarantee a conflict.

## A note on the app store links

While tracing trakt.tv references, this branch originally also fixed
`app.android()` and `app.ios()`. Those pointed at `trakt.tv/a/trakt-android`
and `/a/trakt-ios`, which 301 into `app.trakt.tv/a/*`, where no route exists,
so both ended on a 404 across the footer, the landing page and TraktApps.

`38d2549e8 fix(footer): update app links for Android and iOS` landed on main
independently and fixed the same thing, reaching the same Play listing and the
same App Store id. This PR keeps main's URLs verbatim and only adds a comment
above them recording why they must not be routed back through trakt.tv, so the
next person does not reintroduce the 404.

(The one difference I had was a locale-less App Store URL, which lets Apple
resolve the visitor's storefront rather than pinning `/us/`. I checked it: both
forms return 200, the app is published in every storefront sampled, and on iOS
the universal link corrects itself. Not worth a conflict, so main's form stands.)

## Verification

- `deno fmt --check src i18n/meta`: clean under deno v2.7.5, the version CI
  currently pins.
- `deno task check`: 0 errors across 7163 files.
- Suite: 2501 passing.
- Rebased onto current main, so the earlier conflict is resolved.

## Notes

The banner icon change alters rendered output for three banners (Black Friday
plus the two year-in-review links). All three are date-gated, so none renders
today, which is why there is no screenshot. In each case the change is the
removal of an external-link icon from a link that does not leave the app.

## Pull Request Checklist

- [x] **Clear and Concise Title:** Does your title shine a spotlight on the
      essence of your changes?
- [x] **Detailed Description:** Have you set the stage with a compelling
      narrative that explains the "why" and "how" of your changes?
- [ ] **Screenshots/Videos:** Have you captured the magic with visual evidence
      that showcases your changes in action? (n/a: affected banners are
      date-gated, see Notes)
- [x] **Tests:** Has your code undergone a rigorous dress rehearsal with unit
      tests to ensure it performs flawlessly under pressure?
- [x] **Coding Standards:** Does your code adhere to the project's style guide,
      ensuring it's as elegant as a film score?
- [x] **Commit Messages:** Are your commit messages clear and concise, guiding
      the audience through the evolution of your code?
- [x] **Documentation:** If your changes impact the script, have you updated the
      documentation accordingly?
- [x] **Code Review:** Are you prepared to embrace feedback from the discerning
      eyes of the project maintainers and fellow contributors?
