### PR TITLE
fix(search): report one search per query, not per keystroke

### DIFF
--- a/projects/client/src/lib/features/search/useSearch.spec.ts
+++ b/projects/client/src/lib/features/search/useSearch.spec.ts
@@ -1,7 +1,14 @@
 import { renderStore } from '$test/beds/store/renderStore.ts';
 import { waitForEmission } from '$test/readable/waitForEmission.ts';
-import { describe, expect, it } from 'vitest';
+import type { Subscription } from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useSearch } from './useSearch.ts';
+
+const { trackSpy } = vi.hoisted(() => ({ trackSpy: vi.fn() }));
+
+vi.mock('../analytics/useTrack.ts', () => ({
+  useTrack: () => ({ track: trackSpy }),
+}));
 
 describe('useSearch', () => {
   it('should initialize with empty results', async () => {
@@ -27,4 +34,68 @@ describe('useSearch', () => {
   /**
    * TODO: add more scenarios here once I figure out the AbortSignal error in testing
    */
+});
+
+// Real timers: rxjs captures its own scheduler, so vitest's fake timers do not
+// drive `debounceTime` here. Waits are kept just past the tracking debounce.
+const settle = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('useSearch: tracking volume', () => {
+  let subscription: Subscription | undefined;
+
+  // Tracking only runs while `results` is subscribed, so every case needs a
+  // live subscription and a teardown.
+  async function renderTrackedSearch() {
+    const { search, results } = await renderStore(() => useSearch());
+    subscription = results.subscribe();
+    return search;
+  }
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    trackSpy.mockClear();
+  });
+
+  it(
+    'should report one search for a query typed a character at a time',
+    async () => {
+      const search = await renderTrackedSearch();
+
+      // 300ms between keystrokes is slower than the query debounce, which is
+      // what a touch keyboard looks like.
+      const query = 'silo';
+      for (let length = 1; length <= query.length; length++) {
+        search(query.slice(0, length), 'media');
+        await settle(300);
+      }
+
+      await settle(1400);
+
+      expect(trackSpy).toHaveBeenCalledTimes(1);
+      expect(trackSpy).toHaveBeenCalledWith({ mode: 'media' });
+    },
+    15000,
+  );
+
+  it('should report each query when typing settles between them', async () => {
+    const search = await renderTrackedSearch();
+
+    search('silo', 'media');
+    await settle(1400);
+
+    search('severance', 'media');
+    await settle(1400);
+
+    expect(trackSpy).toHaveBeenCalledTimes(2);
+  }, 15000);
+
+  it('should not report a search for an empty term', async () => {
+    const search = await renderTrackedSearch();
+
+    search('   ', 'media');
+    await settle(1400);
+
+    expect(trackSpy).not.toHaveBeenCalled();
+  }, 15000);
 });

--- a/projects/client/src/lib/features/search/useSearch.ts
+++ b/projects/client/src/lib/features/search/useSearch.ts
@@ -2,10 +2,13 @@ import { browser } from '$app/environment';
 import { useQueryClient } from '$lib/features/query/_internal/queryClientContext.ts';
 import type { CreateQueryOptions } from '$lib/features/query/types.ts';
 import { multicast } from '$lib/utils/store/multicast.ts';
-import { BehaviorSubject, combineLatest, from, of } from 'rxjs';
+import { time } from '$lib/utils/timing/time.ts';
+import { BehaviorSubject, combineLatest, from, merge, of } from 'rxjs';
 import {
   catchError,
   debounceTime,
+  filter,
+  ignoreElements,
   map,
   shareReplay,
   switchMap,
@@ -37,6 +40,11 @@ import { postRecentSearch } from './_internal/postRecentSearch.ts';
 import { splitExactByConfidence } from './_internal/splitExactByConfidence.ts';
 import { ensureFreshSearchKeys } from './ensureFreshSearchKeys.ts';
 import type { SearchResponse } from './models/SearchResponse.ts';
+
+const QUERY_DEBOUNCE = 250;
+// Deliberately longer than the query debounce: a keystroke gap on a touch
+// keyboard exceeds 250ms, so sharing one reports a search per character.
+const TRACK_DEBOUNCE = time.seconds(1);
 
 function modeToQuery(
   query: string,
@@ -93,11 +101,26 @@ export function useSearch() {
 
   const searchTerm$ = new BehaviorSubject<string>('');
 
-  const results = client == null ? of(null) : combineLatest([
+  const searchIntent$ = combineLatest([
     searchTerm$,
     mode,
   ]).pipe(
-    debounceTime(250),
+    debounceTime(QUERY_DEBOUNCE),
+    multicast(),
+  );
+
+  const trackedSearch$ = searchIntent$.pipe(
+    map(([rawTerm, currentMode]) => ({
+      term: rawTerm.toLowerCase().trim(),
+      mode: currentMode,
+    })),
+    filter(({ term }) => term.length > 0),
+    debounceTime(TRACK_DEBOUNCE),
+    tap(({ mode: currentMode }) => track({ mode: currentMode })),
+    ignoreElements(),
+  );
+
+  const searchResults$ = client == null ? of(null) : searchIntent$.pipe(
     switchMap(([rawTerm, currentMode]) => {
       const term = rawTerm.toLowerCase().trim();
 
@@ -106,7 +129,6 @@ export function useSearch() {
       }
 
       isSearching.next(true);
-      track({ mode: currentMode });
 
       return from(ensureFreshSearchKeys(config)).pipe(
         switchMap((freshConfig) => {
@@ -155,6 +177,9 @@ export function useSearch() {
     tap(() => isSearching.next(false)),
     multicast(),
   );
+
+  // Tracking rides the results subscription, so it needs no separate teardown.
+  const results = merge(searchResults$, trackedSearch$);
 
   const overlay = createBulkMediaIntl<MediaSearchResult['items'][number]>();
 


### PR DESCRIPTION
`action.search` was 71% of the analytics dataset at ~59 events per visit to the
search page. It was counting keystrokes, not searches.

## Cause

Not an un-debounced handler. `SearchInput` navigates on every `oninput`, and
`useSearch` debounced the query pipeline at 250ms with the tracking call already
inside that debounced `switchMap`, next to the request.

The 250ms is tuned for how quickly results should appear. It is **shorter than
the gap between keystrokes on a touch keyboard**, so for anyone thumb-typing
every character settles the debounce by itself and emitted its own event. That is
why the ratio matched average query length rather than anything about user
behaviour.

## Change

Raising the shared debounce would fix the metric by making search feel slower.
Instead, analytics rides its own longer debounce off the same intent stream:

- query keeps `debounceTime(250)`, unchanged latency
- tracking waits `time.seconds(1)` of no typing
- `ignoreElements` folds the tracking stream into `results`, so its subscription
  follows the consumer's rather than leaking one with separate teardown

No client-side counting or dedupe state was added.

## Contract

Unchanged. Same event name, same `mode` dim, and no query text, which stays out
both because HAL would reject it and because it is personal data.

## Verification

Three specs in `useSearch.spec.ts`, and I checked they fail against the old
behaviour rather than just passing against the new one. With the tracking
debounce collapsed back to 250ms:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 4 times
```

A four-character query typed at 300ms per keystroke reported four events. At one
second it reports one. Two queries separated by a pause still report two, so
distinct searches are not swallowed, and a whitespace-only term reports none.

`deno task check` 0 errors, suite 2510 passing.

Volume is server-side observable, so the real confirmation is the
`action.search` to `page_view where route='/search'` ratio after this ships.

## Pull Request Checklist

- [x] **Clear and Concise Title:** Does your title shine a spotlight on the
      essence of your changes?
- [x] **Detailed Description:** Have you set the stage with a compelling
      narrative that explains the "why" and "how" of your changes?
- [ ] **Screenshots/Videos:** Have you captured the magic with visual evidence
      that showcases your changes in action? (n/a: no visual change, the
      difference is event volume)
- [x] **Tests:** Has your code undergone a rigorous dress rehearsal with unit
      tests to ensure it performs flawlessly under pressure?
- [x] **Coding Standards:** Does your code adhere to the project's style guide,
      ensuring it's as elegant as a film score?
- [x] **Commit Messages:** Are your commit messages clear and concise, guiding
      the audience through the evolution of your code?
- [x] **Documentation:** If your changes impact the script, have you updated the
      documentation accordingly?
- [x] **Code Review:** Are you prepared to embrace feedback from the discerning
      eyes of the project maintainers and fellow contributors?
