### PR TITLE
VIP: add paid until detail, adjust date format

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7476,6 +7476,10 @@
         }
       }
     },
+    "header_paid_until": {
+      "default": "Paid Until",
+      "description": "Header for the paid until section, which indicates the date the VIP subscription is already paid through when it extends past the next renewal date."
+    },
     "header_renewal_date": {
       "default": "Renewal Date",
       "description": "Header for the renewal date section, which indicates the date on when a VIP subscription renews."

--- a/projects/client/src/lib/sections/vip/_internal/AccountDetails.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/AccountDetails.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import VipBadge from "$lib/components/badge/VipBadge.svelte";
   import { useUser } from "$lib/features/auth/stores/useUser";
-  import { getLocale } from "$lib/features/i18n";
+  import { languageTag } from "$lib/features/i18n";
   import { m } from "$lib/features/i18n/messages";
   import { type VipSubscription } from "$lib/requests/models/VipSubscription";
   import ProfileImage from "$lib/sections/profile-banner/ProfileImage.svelte";
-  import { toHumanDay } from "$lib/utils/formatting/date/toHumanDay";
+  import { toHumanLongDate } from "$lib/utils/formatting/date/toHumanLongDate";
   import { toDisplayableName } from "$lib/utils/profile/toDisplayableName";
   import LifetimeBadge from "./LifetimeBadge.svelte";
   import SubscriptionActions from "./SubscriptionActions.svelte";
@@ -38,10 +38,7 @@
           {#if subscription?.memberSince}
             <p>
               {m.text_member_since({
-                date: toHumanDay({
-                  date: subscription.memberSince,
-                  locale: getLocale(),
-                }),
+                date: toHumanLongDate(subscription.memberSince, languageTag()),
               })}
             </p>
           {/if}

--- a/projects/client/src/lib/sections/vip/_internal/SubscriptionDetails.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/SubscriptionDetails.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import CalendarIcon from "$lib/components/icons/CalendarIcon.svelte";
-  import { getLocale } from "$lib/features/i18n";
+  import { languageTag } from "$lib/features/i18n";
   import { m } from "$lib/features/i18n/messages";
   import { type VipSubscription } from "$lib/requests/models/VipSubscription";
-  import { toHumanDay } from "$lib/utils/formatting/date/toHumanDay";
+  import { getStartOfDay } from "$lib/utils/date/getStartOfDay";
+  import { toHumanLongDate } from "$lib/utils/formatting/date/toHumanLongDate";
   import CrownIcon from "./icons/CrownIcon.svelte";
   import PaymentMethodDetail from "./PaymentMethodDetail.svelte";
   import SubscriptionDetail from "./SubscriptionDetail.svelte";
@@ -18,23 +19,45 @@
       toVipDurationLabel(subscription?.type) ??
       undefined,
   );
+
+  const paidUntil = $derived.by(() => {
+    if (!subscription?.renewsAt || !subscription.expiresAt) {
+      return null;
+    }
+
+    const paidThroughDay = getStartOfDay(subscription.expiresAt);
+    const renewalDay = getStartOfDay(subscription.renewsAt);
+
+    return paidThroughDay.getTime() > renewalDay.getTime()
+      ? subscription.expiresAt
+      : null;
+  });
 </script>
 
 {#if subscription}
   <div class="trakt-vip-subscription-details">
+    {#if paidUntil}
+      <SubscriptionDetail title={m.header_paid_until()}>
+        {#snippet icon()}
+          <CalendarIcon />
+        {/snippet}
+        {toHumanLongDate(paidUntil, languageTag())}
+      </SubscriptionDetail>
+    {/if}
+
     {#if subscription.renewsAt}
       <SubscriptionDetail title={m.header_renewal_date()}>
         {#snippet icon()}
           <CalendarIcon />
         {/snippet}
-        {toHumanDay({ date: subscription.renewsAt, locale: getLocale() })}
+        {toHumanLongDate(subscription.renewsAt, languageTag())}
       </SubscriptionDetail>
     {:else if subscription.expiresAt}
       <SubscriptionDetail title={m.header_expiration_date()}>
         {#snippet icon()}
           <CalendarIcon />
         {/snippet}
-        {toHumanDay({ date: subscription.expiresAt, locale: getLocale() })}
+        {toHumanLongDate(subscription.expiresAt, languageTag())}
       </SubscriptionDetail>
     {/if}
 


### PR DESCRIPTION
# Summary

Adds a "Paid Until" detail to the VIP page header. Users sometimes have a paid-through date that differs from their renewal date (credits, gift codes, plan changes), and the header previously only surfaced the renewal date, which led to support questions about the mismatch.

<img width="860" height="713" alt="image" src="https://github.com/user-attachments/assets/45f1eef0-48ae-4ddf-a332-3d10b63d8823" />

# Changes

The `/vip/details` response already includes `expires_at`, so no API changes were needed. `SubscriptionDetails.svelte` now derives a `paidUntil` value and renders it ahead of the Renewal Date, but only when `expiresAt` falls on a later calendar day than `renewsAt`. The comparison uses `getStartOfDay` on both dates so a few hours of drift between the two timestamps does not surface a redundant detail. When the dates land on the same day (or there is no renewal), the header is unchanged, and the cancelled-subscription path still falls through to the existing Expiration Date detail.

To keep the wider details row compact, all dates in the header (Paid Until, Renewal Date, Expiration Date, and the member-since line in `AccountDetails.svelte`) switch from the ordinal `toHumanDay` format ("February 17th, 2028") to the existing `toHumanLongDate` format ("February 17, 2028").

Adds the `header_paid_until` key to `i18n/meta/en.json`; other locales fall back to English until the translation pipeline picks it up.
