### PR TITLE
feat(i18n): add new keys for VIP preview, auto-tracking card, and tvOS settings

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -171,6 +171,10 @@
       "default": "VIP",
       "description": "Tag indicating a streaming service requires Trakt VIP. Keep short."
     },
+    "tag_text_vip_preview": {
+      "default": "VIP Preview",
+      "description": "Tag shown on a VIP feature card to a non-VIP user previewing what the feature looks like. Keep short."
+    },
     "text_streaming_profile": {
       "default": "Profile",
       "description": "Label for the streaming service profile name."
@@ -7571,6 +7575,34 @@
       "default": "Import again",
       "description": "Call-to-action button on the TV Time importer-update banner that opens the data import settings page."
     },
+    "auto_tracking_card_heading": {
+      "default": "Automatically track across your streaming services",
+      "description": "Heading on the home screen card promoting automatic tracking of streaming services."
+    },
+    "auto_tracking_card_detail_sync": {
+      "default": "Sync your existing watched history and ratings.",
+      "description": "First detail line on the home screen automatic tracking card."
+    },
+    "auto_tracking_card_detail_scrobble": {
+      "default": "Automatic scrobbling when you watch and rate new things.",
+      "description": "Second detail line on the home screen automatic tracking card."
+    },
+    "auto_tracking_card_action": {
+      "default": "Connect Your Services",
+      "description": "Call-to-action button on the home screen automatic tracking card that opens the streaming services connection flow."
+    },
+    "dialog_title_hide_auto_tracking": {
+      "default": "Confirm Hide",
+      "description": "Title of the confirmation dialog shown when hiding the home screen automatic tracking card."
+    },
+    "dialog_prompt_hide_auto_tracking": {
+      "default": "You can always access Automatic Tracking from the settings.",
+      "description": "Message in the confirmation dialog shown when hiding the home screen automatic tracking card."
+    },
+    "button_text_hide_auto_tracking": {
+      "default": "Hide",
+      "description": "Destructive action in the confirmation dialog that hides the home screen automatic tracking card."
+    },
     "welcome_greeting": {
       "default": "Welcome to Trakt, {name}",
       "description": "Main heading on the Welcome page, greeting the signed-in user by name."
@@ -9900,6 +9932,18 @@
     "text_info_report_sent": {
       "default": "Report has been submitted.",
       "description": "Text shown in a snackbar after a user successfully submits a report."
+    },
+    "screen_account_settings_language_system_message_tvos": {
+      "default": "Trakt uses your Apple TV language settings. To update it, go to:\n\nApple TV Settings > General > Apple TV Languages",
+      "description": "Explanatory message shown in the tvOS account settings language info alert, directing users to the system Settings app since tvOS has no in-app language override."
+    },
+    "action_open_system_settings_tvos": {
+      "default": "Open Settings",
+      "description": "Button in the tvOS account settings language info alert that opens the tvOS system Settings app (not app-specific settings, since tvOS has no per-app settings page)."
+    },
+    "error_search_partial_results": {
+      "default": "Some results may be missing",
+      "description": "Shown below search results when the fuzzy search pass failed but exact results still loaded, alongside a retry action."
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds source strings for the VIP preview tag, the home screen automatic tracking promo card (including its hide-confirmation dialog), the tvOS language settings info alert, and the search partial-results notice
- The tvOS language settings message points to Settings > General > Apple TV Languages per Apple's own tvOS support docs — not a combined "Language & Region" menu, which is the iOS pattern and doesn't exist on tvOS

<img width="282" height="320" alt="i1 Small" src="https://github.com/user-attachments/assets/f2a79bf7-cdc9-4f35-8c3d-36eb6184c78d" />
<img width="281" height="320" alt="i2 Small" src="https://github.com/user-attachments/assets/03025aa9-986e-4cda-9610-15fa50e6ea6b" />
<img width="237" height="320" alt="i3 Small" src="https://github.com/user-attachments/assets/38c77553-0a78-49a7-b9af-59a67eb6b941" />
<img width="320" height="225" alt="ti1 Small" src="https://github.com/user-attachments/assets/c6665457-e08c-42a3-b3ab-c21d780147cc" />

cc @ElMagnea 