### PR TITLE
feat(banner): unify intro banner CTAs and refresh TV Time copy

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7745,11 +7745,11 @@
       "description": "Heading on the banner shown to users who joined Trakt around the TV Time shutdown announcement, promoting the TV Time-style companion app."
     },
     "tv_time_banner_description": {
-      "default": "TV Time is shutting down on July 15. Feel right at home with our familiar companion app, powered by your Trakt account.",
+      "default": "Feel right at home with our familiar companion app, powered by your Trakt account.",
       "description": "Description on the TV Time migration banner explaining that tvtime.trakt.tv is a familiar companion app backed by Trakt."
     },
     "tv_time_banner_action": {
-      "default": "Open tvtime.trakt.tv",
+      "default": "tvtime.trakt.tv",
       "description": "Call-to-action link on the TV Time migration banner that opens the tvtime.trakt.tv companion app in a new tab."
     },
     "tv_time_import_banner_heading": {

--- a/projects/client/src/lib/components/buttons/TraktButtonProps.ts
+++ b/projects/client/src/lib/components/buttons/TraktButtonProps.ts
@@ -8,6 +8,6 @@ export type TraktButtonProps = ButtonProps & {
   icon?: Snippet;
   subtitle?: Snippet;
   size?: 'normal' | 'small' | 'tag';
-  text?: 'capitalize' | 'uppercase';
+  text?: 'capitalize' | 'uppercase' | 'none';
   navigationType?: DpadNavigationType;
 };

--- a/projects/client/src/lib/components/icons/TvTimeIcon.svelte
+++ b/projects/client/src/lib/components/icons/TvTimeIcon.svelte
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <circle
+    cx="24"
+    cy="24"
+    r="19.7"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="4.6"
+  />
+  <path fill="currentColor" d="M14 14h20v5h-7.5v15h-5V19H14v-5Z" />
+</svg>

--- a/projects/client/src/lib/sections/banner/_internal/BannerCta.svelte
+++ b/projects/client/src/lib/sections/banner/_internal/BannerCta.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import Button from "$lib/components/buttons/Button.svelte";
+  import type { TraktButtonProps } from "$lib/components/buttons/TraktButtonProps.ts";
+  import type { Snippet } from "svelte";
+
+  const {
+    children,
+    href,
+    target,
+    label,
+    icon,
+    iconPosition = "trailing",
+    text,
+    onclick,
+  }: ChildrenProps &
+    Pick<HTMLAnchorProps, "href" | "target"> &
+    Pick<TraktButtonProps, "text"> & {
+      label: string;
+      icon?: Snippet;
+      iconPosition?: "leading" | "trailing";
+      onclick?: () => void;
+    } = $props();
+</script>
+
+<div class="trakt-banner-cta" data-icon-position={iconPosition}>
+  <Button
+    {href}
+    {target}
+    {label}
+    {icon}
+    {text}
+    {onclick}
+    color="purple"
+    variant="primary"
+    style="outline"
+    size="small"
+  >
+    {@render children()}
+  </Button>
+</div>
+
+<style lang="scss">
+  .trakt-banner-cta {
+    display: contents;
+
+    :global(.trakt-button) {
+      min-width: var(--ni-132);
+      justify-content: center;
+      gap: var(--gap-xs);
+    }
+
+    &[data-icon-position="leading"] :global(.button-icon) {
+      order: -1;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/banner/tv-time-import/TvTimeImportBanner.svelte
+++ b/projects/client/src/lib/sections/banner/tv-time-import/TvTimeImportBanner.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import Button from "$lib/components/buttons/Button.svelte";
   import LogoMarkCircle from "$lib/components/logo/LogoMarkCircle.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
   import BannerContainer from "../_internal/BannerContainer.svelte";
+  import BannerCta from "../_internal/BannerCta.svelte";
   import DismissButton from "../_internal/DismissButton.svelte";
   import { useTvTimeImportBanner } from "./_internal/useTvTimeImportBanner.ts";
 
@@ -34,16 +34,12 @@
         <p class="secondary">{m.tv_time_import_banner_description()}</p>
       </div>
 
-      <Button
+      <BannerCta
         href={UrlBuilder.settings.data()}
-        color="purple"
-        variant="primary"
-        style="flat"
-        size="small"
         label={m.tv_time_import_banner_action()}
       >
         {m.tv_time_import_banner_action()}
-      </Button>
+      </BannerCta>
     </section>
   </BannerContainer>
 {/if}

--- a/projects/client/src/lib/sections/banner/tv-time/TvTimeBanner.svelte
+++ b/projects/client/src/lib/sections/banner/tv-time/TvTimeBanner.svelte
@@ -1,15 +1,21 @@
 <script lang="ts">
-  import LogoMarkCircle from "$lib/components/logo/LogoMarkCircle.svelte";
+  import ExternalLinkIcon from "$lib/components/icons/ExternalLinkIcon.svelte";
+  import TvTimeIcon from "$lib/components/icons/TvTimeIcon.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
   import BannerContainer from "../_internal/BannerContainer.svelte";
-  import BannerLink from "../_internal/BannerLink.svelte";
+  import BannerCta from "../_internal/BannerCta.svelte";
   import DismissButton from "../_internal/DismissButton.svelte";
   import { useTvTimeBanner } from "./_internal/useTvTimeBanner.ts";
   import { TV_TIME_BANNER_ID } from "./constants/index.ts";
 
   const { isVisible, dismiss } = useTvTimeBanner();
+  const { track } = useTrack(AnalyticsEvent.Link);
+
+  const tvTimeUrl = UrlBuilder.app.tvTime();
 </script>
 
 {#if $isVisible}
@@ -21,7 +27,7 @@
 
       <RenderFor audience="all" device={["tablet-lg", "desktop"]}>
         <div class="tv-time-banner-icon" aria-hidden="true">
-          <LogoMarkCircle />
+          <TvTimeIcon />
         </div>
       </RenderFor>
 
@@ -29,19 +35,24 @@
         <h2 class="bold tv-time-banner-title">
           {m.tv_time_banner_heading()}
           <RenderFor audience="all" device={["tablet-sm", "mobile"]}>
-            <LogoMarkCircle />
+            <TvTimeIcon />
           </RenderFor>
         </h2>
         <p class="secondary">{m.tv_time_banner_description()}</p>
       </div>
 
-      <BannerLink
-        href={UrlBuilder.app.tvTime()}
+      <BannerCta
+        href={tvTimeUrl}
         target="_blank"
-        source={TV_TIME_BANNER_ID}
+        text="none"
+        label={m.tv_time_banner_action()}
+        onclick={() => track({ source: TV_TIME_BANNER_ID, target: tvTimeUrl })}
       >
+        {#snippet icon()}
+          <ExternalLinkIcon size="small" />
+        {/snippet}
         {m.tv_time_banner_action()}
-      </BannerLink>
+      </BannerCta>
     </section>
   </BannerContainer>
 {/if}
@@ -95,6 +106,10 @@
 
       padding: var(--gap-l);
       padding-inline-end: var(--ni-48);
+    }
+
+    :global(.trakt-button .button-icon svg) {
+      height: var(--ni-14);
     }
   }
 

--- a/projects/client/src/lib/sections/banner/welcome/WelcomeBanner.svelte
+++ b/projects/client/src/lib/sections/banner/welcome/WelcomeBanner.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
-  import Button from "$lib/components/buttons/Button.svelte";
   import SparkleStarIcon from "$lib/components/icons/SparkleStarIcon.svelte";
   import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
   import LogoMarkCircle from "$lib/components/logo/LogoMarkCircle.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
-  import GetVIPLink from "$lib/sections/navbar/components/GetVIPLink.svelte";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder.ts";
   import BannerContainer from "../_internal/BannerContainer.svelte";
+  import BannerCta from "../_internal/BannerCta.svelte";
   import DismissButton from "../_internal/DismissButton.svelte";
   import { useWelcomeBanner } from "./_internal/useWelcomeBanner.ts";
 
   const { isVisible, dismiss } = useWelcomeBanner();
+  const { track } = useTrack(AnalyticsEvent.VipUpsell);
 </script>
 
 {#if $isVisible}
@@ -44,16 +46,12 @@
           </p>
         </div>
 
-        <Button
+        <BannerCta
           href={UrlBuilder.settings.data()}
-          color="purple"
-          variant="primary"
-          style="flat"
-          size="small"
           label={m.welcome_banner_action()}
         >
           {m.welcome_banner_action()}
-        </Button>
+        </BannerCta>
       </div>
 
       <RenderFor audience="free">
@@ -72,7 +70,17 @@
           </div>
 
           <div class="upsell-cta">
-            <GetVIPLink source="welcome-banner" />
+            <BannerCta
+              href={UrlBuilder.vip()}
+              label={m.link_label_get_vip()}
+              iconPosition="leading"
+              onclick={() => track({ source: "welcome-banner" })}
+            >
+              {#snippet icon()}
+                <SparkleStarIcon />
+              {/snippet}
+              {m.badge_text_get_vip()}
+            </BannerCta>
           </div>
         </div>
       </RenderFor>


### PR DESCRIPTION
## What

The new-user intro banners (welcome, VIP upsell, TV Time, TV Time import) rendered their CTAs through three different components with three different looks — flat `Button`, `BannerLink` pill, and the glowing `VipUpsellBadge`. This unifies all four on the shared `Button`:

- `style=outline` / purple / small across the board, with a shared `--ni-132` min-width floor so the stacked CTAs align
- **Get VIP** leads with a sparkle; **tvtime.trakt.tv** trails a compact external-link glyph — both centered clusters
- new `TvTimeIcon` (circled T) replaces the Trakt mark on the "Coming from TV Time?" banner
- the bare-domain label opts out of the button's first-letter capitalisation ("Tvtime…" read wrong)

## Copy

- dropped the "TV Time is shutting down on July 15" sentence from EN and all 27 tracked locales — the date is in the past; the copy now leads with what the companion app offers
- CTA label compacted from "Open tvtime.trakt.tv" to the bare domain, set locale-invariantly (a URL needs no translation)

## How to test

Banners are gated (welcome = zero-activity account, TV Time = joined after 2026-07-01, dismissals persist in localStorage `trakt-dismissed-banners`). Quickest preview: clear that key and use a fresh account, or temporarily force `isVisible` in the `use*Banner` hooks.

- verify all visible CTAs share width and outline treatment, hover fills ~18% purple
- check light theme (icon + stroke ride `--color-foreground` / purple tokens)
- spot-check a locale (de-DE / ja-JP) for the stripped copy

Verified: `deno fmt` · `svelte-check` 0/0 · vitest 2414 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)