### PR TITLE
Season: use season titles if available

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -1502,6 +1502,18 @@
         }
       }
     },
+    "text_season_number_with_title": {
+      "default": "{number} - {title}",
+      "description": "Compact dropdown label combining a season number with its custom season title, e.g. '1: Murder House'.",
+      "variables": {
+        "number": {
+          "type": "number"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
     "text_season_specials": {
       "default": "Specials",
       "description": "Text for the specials season of a show. This should be as short and concise as possible."

--- a/projects/client/src/lib/requests/_internal/mapToSeason.ts
+++ b/projects/client/src/lib/requests/_internal/mapToSeason.ts
@@ -5,6 +5,17 @@ import { findDefined } from '$lib/utils/string/findDefined.ts';
 import type { SeasonsResponse } from '@trakt/api';
 import type { Season } from '../models/Season.ts';
 
+const toDistinctSeasonTitle = (item: SeasonsResponse[0]): string | null => {
+  const title = item.title?.trim();
+  if (!title) return null;
+
+  const normalized = title.toLowerCase();
+  if (normalized === 'specials') return null;
+  if (/^season \d+$/.test(normalized)) return null;
+
+  return title;
+};
+
 export const mapToSeason = (item: SeasonsResponse[0]): Season => {
   const poster = findDefined(
     ...(item.images?.poster ?? []),
@@ -14,6 +25,7 @@ export const mapToSeason = (item: SeasonsResponse[0]): Season => {
     id: item.ids.trakt,
     key: `season-${item.ids.trakt}`,
     number: item.number,
+    title: toDistinctSeasonTitle(item),
     episodes: {
       count: item.episode_count ?? 0,
     },

--- a/projects/client/src/lib/requests/models/Season.ts
+++ b/projects/client/src/lib/requests/models/Season.ts
@@ -5,6 +5,7 @@ export const SeasonSchema = z.object({
   id: z.number(),
   key: z.string(),
   number: z.number(),
+  title: z.string().nullish(),
   episodes: z.object({
     count: z.number(),
   }),

--- a/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
+++ b/projects/client/src/lib/sections/lists/components/SeasonItem.svelte
@@ -5,6 +5,7 @@
   import CardFooter from "$lib/components/card/CardFooter.svelte";
   import Link from "$lib/components/link/Link.svelte";
   import PortraitCard from "$lib/components/media/card/PortraitCard.svelte";
+  import PosterTags from "$lib/components/media/tags/PosterTags.svelte";
   import SeasonLabelTag from "$lib/components/media/tags/SeasonLabelTag.svelte";
   import IndicatorTags from "$lib/components/tags/IndicatorTags.svelte";
   import TagBar from "$lib/components/tags/TagBar.svelte";
@@ -18,7 +19,6 @@
   import type { Snippet } from "svelte";
   import MediaSummaryCard from "./MediaSummaryCard.svelte";
   import type { SeasonCardProps } from "./models/SeasonCardProps";
-  import PosterTags from "$lib/components/media/tags/PosterTags.svelte";
 
   const {
     season,
@@ -41,6 +41,8 @@
   const { isWatched, isPartiallyWatched } = $derived(
     useIsWatched({ type: "season", media: season, show: media }),
   );
+
+  const isEmphasized = $derived(isCurrentSeason && !season.title);
 
   const scrollToItem = (element: HTMLElement, active: boolean) => {
     if (variant === "list-item") return;
@@ -108,11 +110,16 @@
           <p
             use:lineClamp={{ lines: 2 }}
             class="trakt-season-title"
-            class:trakt-card-title={isCurrentSeason}
-            class:trakt-card-subtitle={!isCurrentSeason}
+            class:trakt-card-title={isEmphasized}
+            class:trakt-card-subtitle={!isEmphasized}
           >
             {seasonLabel(season.number)}
           </p>
+          {#if season.title}
+            <p class="trakt-season-subtitle trakt-card-subtitle ellipsis">
+              {season.title}
+            </p>
+          {/if}
         {/if}
       </CardFooter>
     </PortraitCard>
@@ -146,6 +153,16 @@
     transition: opacity var(--transition-increment) ease-in-out;
 
     &[data-variant="default"] {
+      :global(.trakt-card-footer) {
+        align-items: flex-start;
+      }
+
+      &.is-current-season {
+        p.trakt-season-title {
+          color: var(--color-text-primary);
+        }
+      }
+
       &:not(.is-current-season) {
         opacity: var(--de-emphasized-opacity);
 

--- a/projects/client/src/lib/sections/lists/season/SeasonDropdown.svelte
+++ b/projects/client/src/lib/sections/lists/season/SeasonDropdown.svelte
@@ -2,6 +2,7 @@
   import { goto } from "$app/navigation";
   import SingleSelect from "$lib/components/select/SingleSelect.svelte";
   import * as m from "$lib/features/i18n/messages";
+  import type { Season } from "$lib/requests/models/Season.ts";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import type { SeasonDropdownProps } from "./SeasonDropdownProps.ts";
 
@@ -12,14 +13,22 @@
     urlBuilder ?? ((n: number) => UrlBuilder.show(showSlug, { season: n })),
   );
 
-  const seasonText = (seasonNumber: number) => {
-    return seasonNumber === 0 ? m.text_season_specials() : `${seasonNumber}`;
+  const seasonText = (season: Season) => {
+    if (season.number === 0) return m.text_season_specials();
+    if (season.title) {
+      return m.text_season_number_with_title({
+        number: season.number,
+        title: season.title,
+      });
+    }
+
+    return `${season.number}`;
   };
 
   const options = $derived(
     seasons.map((season) => ({
       value: `${season.number}`,
-      label: seasonText(season.number),
+      label: seasonText(season),
     })),
   );
 

--- a/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
+++ b/projects/client/src/lib/sections/lists/season/_internal/SeasonPosterList.svelte
@@ -5,6 +5,7 @@
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import { SummaryDrawers } from "$lib/sections/summary/SummaryDrawers.ts";
   import { summaryDrawerNavigation } from "$lib/sections/summary/summaryDrawerNavigation.ts";
+  import { hasSeasonTitles } from "$lib/utils/media/hasSeasonTitles.ts";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import SeasonPosterItem from "./SeasonPosterItem.svelte";
 
@@ -25,6 +26,8 @@
   }: SeasonListProps = $props();
 
   const { buildDrawerLink } = summaryDrawerNavigation();
+
+  const hasTitles = $derived(hasSeasonTitles(seasons));
 </script>
 
 <SectionList
@@ -40,8 +43,12 @@
     source: { id: "seasons" },
     label: m.button_text_view_all(),
   }}
-  --height-list="var(--height-poster-list-sm)"
-  --height-override-card="var(--height-portrait-card-sm)"
+  --height-list={hasTitles
+    ? "var(--height-poster-list)"
+    : "var(--height-poster-list-sm)"}
+  --height-override-card={hasTitles
+    ? "var(--height-portrait-card)"
+    : "var(--height-portrait-card-sm)"}
 >
   {#snippet item(season)}
     <SeasonPosterItem

--- a/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/seasons/SeasonsDrawerHost.svelte
@@ -10,6 +10,7 @@
   import type { Season } from "$lib/requests/models/Season";
   import type { ShowEntry } from "$lib/requests/models/ShowEntry.ts";
   import SeasonDropdown from "$lib/sections/lists/season/SeasonDropdown.svelte";
+  import { hasSeasonTitles } from "$lib/utils/media/hasSeasonTitles.ts";
   import { fade } from "svelte/transition";
   import SeasonDrawerItem from "./_internal/SeasonDrawerItem.svelte";
   import SeasonEpisodesTab from "./SeasonEpisodesTab.svelte";
@@ -38,6 +39,8 @@
   const currentSeasonData = $derived(
     seasons.find((s) => s.number === currentSeason),
   );
+
+  const hasTitles = $derived(hasSeasonTitles(seasons));
 
   const buildSeasonLink = (seasonNumber: number) => {
     const url = new URL(page.url);
@@ -97,7 +100,7 @@
   {#if isOpen}
     <div class="seasons-drawer-content" transition:fade={{ duration: 150 }}>
       {#if seasons.length > 1}
-        <div class="seasons-section">
+        <div class="seasons-section" class:has-season-titles={hasTitles}>
           <SectionList
             id={{
               scope: "season-poster-list",
@@ -168,6 +171,11 @@
 
   .seasons-section {
     --column-count: 4;
+    --season-card-footer-height: var(--height-card-footer-sm);
+
+    &.has-season-titles {
+      --season-card-footer-height: var(--height-card-footer);
+    }
 
     --container-width: calc(
       var(--drawer-size) - 2 * var(--drawer-padding) - var(--list-gap)
@@ -178,7 +186,7 @@
     );
     --height-override-card-cover: calc(var(--width-override-card) * 1.5);
     --height-override-card: calc(
-      var(--height-override-card-cover) + var(--height-card-footer-sm)
+      var(--height-override-card-cover) + var(--season-card-footer-height)
     );
 
     --height-list: calc(

--- a/projects/client/src/lib/utils/media/hasSeasonTitles.spec.ts
+++ b/projects/client/src/lib/utils/media/hasSeasonTitles.spec.ts
@@ -1,0 +1,30 @@
+import { ShowSiloSeasonsMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts';
+import { describe, expect, it } from 'vitest';
+import { hasSeasonTitles } from './hasSeasonTitles.ts';
+
+describe('util: hasSeasonTitles', () => {
+  it('should return false for an empty list', () => {
+    expect(hasSeasonTitles([])).toBe(false);
+  });
+
+  it('should return false when no season has a title', () => {
+    expect(hasSeasonTitles(ShowSiloSeasonsMappedMock)).toBe(false);
+  });
+
+  it('should return true when a single season has a title', () => {
+    const seasons = ShowSiloSeasonsMappedMock.map((season, index) =>
+      index === 0 ? { ...season, title: 'Murder House' } : season
+    );
+
+    expect(hasSeasonTitles(seasons)).toBe(true);
+  });
+
+  it('should return false when titles are empty', () => {
+    const seasons = ShowSiloSeasonsMappedMock.map((season) => ({
+      ...season,
+      title: '',
+    }));
+
+    expect(hasSeasonTitles(seasons)).toBe(false);
+  });
+});

--- a/projects/client/src/lib/utils/media/hasSeasonTitles.ts
+++ b/projects/client/src/lib/utils/media/hasSeasonTitles.ts
@@ -1,0 +1,5 @@
+import type { Season } from '$lib/requests/models/Season.ts';
+
+export function hasSeasonTitles(seasons: ReadonlyArray<Season>): boolean {
+  return seasons.some((season) => Boolean(season.title));
+}

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSeasonsMappedMock.ts
@@ -6,6 +6,7 @@ export const ShowSiloSeasonsMappedMock: Season[] = [
     'id': 257490,
     'key': 'season-257490',
     'number': 1,
+    'title': null,
     'episodes': {
       'count': 10,
     },
@@ -28,6 +29,7 @@ export const ShowSiloSeasonsMappedMock: Season[] = [
     'id': 402288,
     'key': 'season-402288',
     'number': 2,
+    'title': null,
     'episodes': {
       'count': 10,
     },
@@ -50,6 +52,7 @@ export const ShowSiloSeasonsMappedMock: Season[] = [
     'id': 456019,
     'key': 'season-456019',
     'number': 3,
+    'title': null,
     'episodes': {
       'count': 1,
     },


### PR DESCRIPTION
# Summary

Some shows have custom season titles (e.g. American Horror Story's "Murder House", "Asylum", "Coven"). The API returns a title for every season, but only ones that differ from the generic "Season {number}" / "Specials" defaults are real custom titles, so the mapper normalizes generic titles to null and everything downstream treats `season.title` as "has a custom title".

# Changes

- `Season` model gets a nullable `title`, populated by `mapToSeason` only when the API title isn't a generic default.
- `SeasonDropdown` labels become `1: Murder House` when a custom title exists (plain `1` otherwise, `Specials` for season 0). This covers the summary page dropdown, the seasons drawer badge, and the episodes tab in the episode drawer, since they share the component.
- Season poster cards (`SeasonItem`) show the custom title as a second line under the always-bold `Season 1` line. The selected season's number line uses the primary text color; footer text is top-aligned so title-less cards line up.
- The seasons drawer strip and mobile poster list switch to the taller card footer only when the show actually has custom titles, so shows without them keep the compact layout.
- New i18n key `text_season_number_with_title` (`{number}: {title}`) so the separator is translatable.
- Silo mapped season mock updated with `title: null`.

# Screenshot

<img width="1788" height="954" alt="image" src="https://github.com/user-attachments/assets/80eb54a3-fa79-4e63-9af3-bfc3a0f4fabd" />