### PR TITLE
fix(auth): port the oidc session before seeding the audience

### DIFF
--- a/projects/client/src/lib/features/auth/resolveBrowserAuthState.spec.ts
+++ b/projects/client/src/lib/features/auth/resolveBrowserAuthState.spec.ts
@@ -1,0 +1,41 @@
+import { OidcUserMock } from '$mocks/data/auth/OidcUserMock.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { deriveStandardAuthority } from './deriveStandardAuthority.ts';
+import { oidcUserStoreKey } from './oidcUserStoreKey.ts';
+import { resolveBrowserAuthState } from './resolveBrowserAuthState.ts';
+import { resolveOidcAuthority } from './resolveOidcAuthority.ts';
+
+const legacyKey = oidcUserStoreKey({
+  authority: deriveStandardAuthority(),
+  clientId: TRAKT_CLIENT_ID,
+});
+
+const currentKey = oidcUserStoreKey({
+  authority: resolveOidcAuthority(),
+  clientId: TRAKT_CLIENT_ID,
+});
+
+describe('resolveBrowserAuthState', () => {
+  beforeEach(() => {
+    globalThis.localStorage.removeItem(legacyKey);
+    globalThis.localStorage.removeItem(currentKey);
+  });
+
+  it('should report no session when storage is empty', () => {
+    expect(resolveBrowserAuthState()?.hasSession).toBe(false);
+  });
+
+  it('should resolve a session stored under the current authority', () => {
+    globalThis.localStorage.setItem(currentKey, JSON.stringify(OidcUserMock));
+
+    expect(resolveBrowserAuthState()?.hasSession).toBe(true);
+  });
+
+  it('should resolve a session still stored under the pre-migration authority', () => {
+    globalThis.localStorage.setItem(legacyKey, JSON.stringify(OidcUserMock));
+
+    // Reading before the port ran would report no session and paint the public
+    // shell at a viewer who is in fact signed in.
+    expect(resolveBrowserAuthState()?.hasSession).toBe(true);
+  });
+});

--- a/projects/client/src/lib/features/auth/resolveBrowserAuthState.ts
+++ b/projects/client/src/lib/features/auth/resolveBrowserAuthState.ts
@@ -1,5 +1,7 @@
 import { browser } from '$app/environment';
 import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
+import { deriveStandardAuthority } from './deriveStandardAuthority.ts';
+import { portWorkerAuthSession } from './portWorkerAuthSession.ts';
 import {
   type ClientAuthState,
   resolveClientAuthState,
@@ -13,9 +15,22 @@ export function resolveBrowserAuthState(): ClientAuthState | null {
     return null;
   }
 
+  const authority = resolveOidcAuthority();
+
+  // Migrate before reading, not in `initializeUserManager`'s `onMount`. A
+  // session still under the pre-migration authority key reads as "no session",
+  // which downgrades an authorized viewer to the public shell until the manager
+  // resolves - the flash this whole path exists to remove.
+  portWorkerAuthSession({
+    store: safeLocalStorage,
+    clientId: TRAKT_CLIENT_ID,
+    fromAuthority: deriveStandardAuthority(),
+    toAuthority: authority,
+  });
+
   return resolveClientAuthState({
     store: safeLocalStorage,
-    authority: resolveOidcAuthority(),
+    authority,
     clientId: TRAKT_CLIENT_ID,
   });
 }


### PR DESCRIPTION
## What

Follow-up to #3017. That change removed the logged-out flash by seeding the
audience synchronously from the oidc session in local storage, but it read the
session one step too early in the migration, so a subset of viewers still saw a
landing frame on their first visit after deploy.

Reported symptom: visiting `https://app.trakt.tv/` showed the unauthenticated
shell briefly before redirecting to `/?mode=media`, while reloading
`/?mode=media` never flashed.

## Root cause

`resolveBrowserAuthState` reads the session under `resolveOidcAuthority()`
(`https://auth.trakt.tv`). The migration off the pre-migration authority key
(`https://trakt.tv`) lives in `portWorkerAuthSession`, which
`initializeUserManager` calls inside `onMount` - after that synchronous read.

For any viewer whose session was still under the old key:

1. The read finds nothing and reports `hasSession: false`.
2. The seed is `clientAuth?.hasSession ?? isAuthorizedOidc`. Since `hasSession`
   is `false` rather than nullish, `false ?? prop` evaluates to `false` - so it
   overrides a correctly authorized document rather than deferring to it.
3. The unauthorized shell is server-rendered with full landing markup, so it
   paints without waiting on hydration.
4. `setAuthState` writes an `isAuthorized: false` auth marker, which keys the
   next navigation document as signed-out.
5. `onMount` then ports the session, `manager.getUser()` finds it, and the tree
   flips to authorized.

The visit that flashed is also the visit that performed the migration, which is
exactly why a reload was always clean, and why this self-heals per viewer.

## Fix

Port before reading, in `resolveBrowserAuthState`.

The `onMount` call is deliberately left in place. `portWorkerAuthSession`
returns early once the target key exists, so the second call is a no-op rather
than duplicated work.

## Ruled out along the way

Recording these so nobody re-treads them:

- **Precached home document.** The shipped precache manifest carries 858 asset
  entries and no HTML, so `/` does go through the navigation route.
- **Edge / browser HTTP caching.** `curl` reports
  `public, max-age=86400, s-maxage=120` with `cf-cache-status: HIT` for `/`,
  which looks damning, but that is the bot branch in `hooks.server.ts`
  (`isBotAgent` matches curl's UA) plus a Cloudflare Browser TTL override. With
  a real browser User-Agent both `/` and `/?mode=media` return
  `private, no-store, no-cache, must-revalidate`, so no shared cache is
  involved.

## Testing

`resolveBrowserAuthState.spec.ts` covers empty storage, a session under the
current authority, and a session still under the pre-migration authority. The
third case fails without this change (`expected false to be true`).

The two authorities are verified distinct in the test environment
(`https://trakt.tv` vs `https://auth.trakt.tv`), so that case is not vacuous.

- `deno task check`: 0 errors, 0 warnings.
- `deno task lint`: unchanged from the `main` baseline.
- `deno task test:doctor`: 453 files / 2526 tests passing.

Worth verifying by hand, since no automated check catches a flash: with a
signed-in session, move the `oidc.user:https://auth.trakt.tv:<client id>` entry
in local storage back to `oidc.user:https://trakt.tv:<client id>`, then cold-load
`/` throttled to Slow 3G with 4x CPU. There must be no landing frame, and the
entry should be back under the new key afterwards.
