### PR TITLE
feat(summary): add VIP soundtrack section with Spotify playback

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -10005,6 +10005,62 @@
     "error_search_partial_results": {
       "default": "Some results may be missing",
       "description": "Shown below search results when the fuzzy search pass failed but exact results still loaded, alongside a retry action."
+    },
+    "list_title_soundtrack": {
+      "default": "Soundtrack",
+      "description": "Title for the section listing the music credited in a movie or show. This title should be as short and concise as possible."
+    },
+    "text_soundtrack_music_by": {
+      "default": "Music by",
+      "description": "Small label above the name of the composer who wrote most of a soundtrack."
+    },
+    "text_soundtrack_playable_ratio": {
+      "default": "{playable} of {total} playable",
+      "description": "Shows how many of a soundtrack's credited tracks can be played. 'playable' is the number that can be played, 'total' is the number of credited tracks."
+    },
+    "text_soundtrack_pick_a_track": {
+      "default": "Pick a track to play it here.",
+      "description": "Hint shown in the empty soundtrack player before the reader has chosen a track."
+    },
+    "text_soundtrack_unmatched": {
+      "default": "Not available to play",
+      "description": "Accessible label for a soundtrack track that is credited but cannot be played."
+    },
+    "text_soundtrack_upsell": {
+      "default": "Hear the score.",
+      "description": "Headline inviting a non-VIP reader to unlock the soundtrack section."
+    },
+    "button_label_play_track": {
+      "default": "Play {title}",
+      "description": "Aria-label for the button that plays a soundtrack track. 'title' is the name of the track."
+    },
+    "button_label_pause_track": {
+      "default": "Pause {title}",
+      "description": "Aria-label for the button that pauses a playing soundtrack track. 'title' is the name of the track."
+    },
+    "button_label_view_soundtrack": {
+      "default": "View soundtrack",
+      "description": "Aria-label for the link that opens the full soundtrack listing."
+    },
+    "iframe_title_spotify_player": {
+      "default": "Spotify player for {title}",
+      "description": "Accessible title for the embedded Spotify player. 'title' is the name of the track being played."
+    },
+    "vip_feature_title_soundtrack": {
+      "default": "Soundtrack",
+      "description": "Title for the Soundtrack VIP feature."
+    },
+    "vip_feature_description_soundtrack": {
+      "default": "See every track credited in a movie or show, and play the ones we can match.",
+      "description": "Description for the Soundtrack VIP feature."
+    },
+    "preview_feature_title_soundtrack": {
+      "default": "Soundtrack",
+      "description": "Product feature name for the soundtrack preview feature."
+    },
+    "preview_feature_description_soundtrack": {
+      "default": "Adds a soundtrack section to movie and show pages, with playback where a track can be matched.",
+      "description": "Description for the soundtrack preview feature."
     }
   }
 }

--- a/projects/client/src/app.html
+++ b/projects/client/src/app.html
@@ -17,13 +17,13 @@
         default-src 'self';
         img-src 'self' data: https://*.trakt.tv https://trakt.tv https://secure.gravatar.com https://i0.wp.com https://i1.wp.com https://i2.wp.com https://*.reddit.com https://*.youtube.com https://*.ytimg.com https://fonts.gstatic.com https://t.co;
         script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.trakt.tv;
-        script-src-elem 'self' 'unsafe-inline' https://*.cloudflareinsights.com https://*.trakt.tv/ https://cdnjs.cloudflare.com https://cdn.plyr.io https://*.youtube.com;
+        script-src-elem 'self' 'unsafe-inline' https://*.cloudflareinsights.com https://*.trakt.tv/ https://cdnjs.cloudflare.com https://cdn.plyr.io https://*.youtube.com https://open.spotify.com https://*.spotifycdn.com;
         worker-src 'self' blob:;
         connect-src 'self' https://*.jsdelivr.net https://*.googleapis.com https://*.gstatic.com https://trakt.tv https://*.trakt.tv https://*.sentry.io https://*.ingest.de.sentry.io wss://db0xjc18bh.execute-api.us-east-1.amazonaws.com wss://*.execute-api.us-east-1.amazonaws.com https://*.typesense.net https://cdn.plyr.io https://noembed.com;
         font-src 'self' data: https://fonts.gstatic.com http://fonts.gstatic.com;
         style-src 'self' 'unsafe-inline' https://*.googleapis.com https://*.jsdelivr.net https://*.trakt.tv https://cdn.plyr.io;
         style-src-elem 'self' 'unsafe-inline' https://*.googleapis.com https://*.jsdelivr.net https://*.trakt.tv https://cdn.plyr.io;
-        frame-src 'self' https://trakt.tv http://localhost:3000 https://*.youtube.com;
+        frame-src 'self' https://trakt.tv http://localhost:3000 https://*.youtube.com https://open.spotify.com;
       "
     >
     <!-- PWA -->

--- a/projects/client/src/lib/components/icons/MusicNoteIcon.svelte
+++ b/projects/client/src/lib/components/icons/MusicNoteIcon.svelte
@@ -1,0 +1,11 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  height="40px"
+  viewBox="0 -960 960 960"
+  width="40px"
+  fill="currentColor"
+>
+  <path
+    d="M400-120q-66 0-113-47t-47-113q0-66 47-113t113-47q23 0 42.5 5.5T480-418v-422h240v160H560v518q0 66-47 113t-113 47Z"
+  />
+</svg>

--- a/projects/client/src/lib/components/icons/PauseIcon.svelte
+++ b/projects/client/src/lib/components/icons/PauseIcon.svelte
@@ -1,0 +1,9 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  height="40px"
+  viewBox="0 -960 960 960"
+  width="40px"
+  fill="currentColor"
+>
+  <path d="M560-200v-560h160v560H560Zm-320 0v-560h160v560H240Z" />
+</svg>

--- a/projects/client/src/lib/components/icons/PlayArrowIcon.svelte
+++ b/projects/client/src/lib/components/icons/PlayArrowIcon.svelte
@@ -1,0 +1,9 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  height="40px"
+  viewBox="0 -960 960 960"
+  width="40px"
+  fill="currentColor"
+>
+  <path d="M366-232v-496l390 248-390 248Z" />
+</svg>

--- a/projects/client/src/lib/components/icons/SpotifyIcon.svelte
+++ b/projects/client/src/lib/components/icons/SpotifyIcon.svelte
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <rect width="256" height="256" fill="none" />
+  <circle
+    cx="128"
+    cy="128"
+    r="96"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="16"
+  />
+  <path
+    d="M104,166a51,51,0,0,1,48,0"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="16"
+  />
+  <path
+    d="M72,110a119,119,0,0,1,112,0"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="16"
+  />
+  <path
+    d="M88,138a85,85,0,0,1,80,0"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="16"
+  />
+</svg>

--- a/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEvent.ts
@@ -50,6 +50,7 @@ export const AnalyticsEvent = {
   CheckIn: buildEventKey(MEDIA_ACTION_PREFIX, 'check-in'),
   Extras: buildEventKey(MEDIA_ACTION_PREFIX, 'extras'),
   Trailer: buildEventKey(MEDIA_ACTION_PREFIX, 'trailer'),
+  Soundtrack: buildEventKey(MEDIA_ACTION_PREFIX, 'soundtrack'),
   StreamOn: buildEventKey(MEDIA_ACTION_PREFIX, 'stream-on'),
   HideRecommendation: buildEventKey(MEDIA_ACTION_PREFIX, 'hide-recommendation'),
 

--- a/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
@@ -28,6 +28,13 @@ type FollowType = {
 };
 type BlockType = { action: 'block' | 'unblock' };
 type ExtrasType = { slug: string; type: MediaVideoType };
+// `matched_on` records which rewording resolved the track. It is deliberately
+// absent from the UI and reported here instead, so match quality can be
+// measured against how often a track actually gets played.
+type SoundtrackType = SourceType & {
+  position: number;
+  matched_on: 'credit' | 'title' | 'artist' | 'both';
+};
 type CommentType = { action: 'post' | 'reply' | 'edit' };
 type ReactionType = { action: 'add' | 'remove'; type: 'comment' };
 type CalendarType = { action: 'reset' | 'next' | 'previous' };
@@ -103,6 +110,7 @@ export type AnalyticsEventDataMap = {
   [AnalyticsEvent.CheckIn]: CheckInType;
   [AnalyticsEvent.Extras]: ExtrasType;
   [AnalyticsEvent.Trailer]: { slug: string };
+  [AnalyticsEvent.Soundtrack]: SoundtrackType;
   [AnalyticsEvent.StreamOn]: StreamOnType;
   [AnalyticsEvent.HideRecommendation]: { type: MediaType };
 

--- a/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
+++ b/projects/client/src/lib/features/feature-flag/models/FeatureFlag.ts
@@ -5,4 +5,5 @@ export enum FeatureFlag {
   Rewatching = 'rewatching',
   Leaderboard = 'leaderboard',
   ParentalGuide = 'parental-guide',
+  Soundtrack = 'soundtrack',
 }

--- a/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
+++ b/projects/client/src/lib/features/feature-flag/models/featureFlagDefinitions.ts
@@ -1,6 +1,7 @@
 import EditModeIcon from '$lib/components/icons/EditModeIcon.svelte';
 import FastRewindIcon from '$lib/components/icons/FastRewindIcon.svelte';
 import FavoriteIcon from '$lib/components/icons/FavoriteIcon.svelte';
+import MusicNoteIcon from '$lib/components/icons/MusicNoteIcon.svelte';
 import NoSpoilerIcon from '$lib/components/icons/NoSpoilerIcon.svelte';
 import PeopleIcon from '$lib/components/icons/PeopleIcon.svelte';
 import SmartListIcon from '$lib/components/icons/SmartListIcon.svelte';
@@ -72,6 +73,12 @@ export const featureFlagDefinitions: FeatureFlagDefinitions = {
     title: () => m.preview_feature_title_leaderboard(),
     addedAt: new Date('2026-07-09'),
     description: () => m.preview_feature_description_leaderboard(),
+  },
+  [FeatureFlag.Soundtrack]: {
+    icon: MusicNoteIcon,
+    title: () => m.preview_feature_title_soundtrack(),
+    addedAt: new Date('2026-08-03'),
+    description: () => m.preview_feature_description_soundtrack(),
   },
   [FeatureFlag.ParentalGuide]: {
     icon: NoSpoilerIcon,

--- a/projects/client/src/lib/requests/_internal/mapToSoundtrackTrack.ts
+++ b/projects/client/src/lib/requests/_internal/mapToSoundtrackTrack.ts
@@ -1,0 +1,18 @@
+import type { SoundtrackResponse } from '../models/SoundtrackResponse.ts';
+import type { SoundtrackTrack } from '../models/SoundtrackTrack.ts';
+
+type SoundtrackItemResponse = SoundtrackResponse[0];
+
+export function mapToSoundtrackTrack(
+  keyPrefix: string,
+  response: SoundtrackItemResponse,
+): SoundtrackTrack {
+  return {
+    key: `${keyPrefix}_${response.position}`,
+    title: response.title,
+    performer: response.performer,
+    spotifyId: response.spotify_id,
+    matchedOn: response.matched_on,
+    position: response.position,
+  };
+}

--- a/projects/client/src/lib/requests/_internal/soundtrackInfo.ts
+++ b/projects/client/src/lib/requests/_internal/soundtrackInfo.ts
@@ -1,0 +1,6 @@
+// Spotify-resolved soundtrack credits. Every credited track is present; the
+// ones we could not resolve simply carry a null `spotify_id`.
+export const SOUNDTRACK_INFO = {
+  infoType: 15,
+  infoVersion: 1,
+} as const;

--- a/projects/client/src/lib/requests/_internal/toMediaInfoPath.ts
+++ b/projects/client/src/lib/requests/_internal/toMediaInfoPath.ts
@@ -5,15 +5,16 @@ type MediaInfoPathParams = {
   type: MediaType;
   slug: string;
   infoType: number;
+  infoVersion?: number;
   locale: AvailableLocale;
 };
 
 // `locale` carries the full tag; the API resolves it to an exact, same-language,
 // or English row, so every info query must send it or readers get English.
 export function toMediaInfoPath(
-  { type, slug, infoType, locale }: MediaInfoPathParams,
+  { type, slug, infoType, infoVersion = 1, locale }: MediaInfoPathParams,
 ) {
   const params = new URLSearchParams({ locale });
 
-  return `/v3/media/${type}/${slug}/info/${infoType}/version/1?${params.toString()}`;
+  return `/v3/media/${type}/${slug}/info/${infoType}/version/${infoVersion}?${params.toString()}`;
 }

--- a/projects/client/src/lib/requests/models/SoundtrackResponse.ts
+++ b/projects/client/src/lib/requests/models/SoundtrackResponse.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const SoundtrackResponseSchema = z.array(
+  z.object({
+    title: z.string(),
+    performer: z.string().nullish(),
+    spotify_id: z.string().nullish(),
+    // Records which rewording produced the match. Kept out of the UI; it
+    // travels with the play event so we can measure match quality.
+    matched_on: z.enum(['credit', 'title', 'artist', 'both']).nullish(),
+    position: z.number(),
+  }),
+);
+
+export type SoundtrackResponse = z.infer<typeof SoundtrackResponseSchema>;

--- a/projects/client/src/lib/requests/models/SoundtrackTrack.ts
+++ b/projects/client/src/lib/requests/models/SoundtrackTrack.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const SoundtrackTrackSchema = z.object({
+  key: z.string(),
+  title: z.string(),
+  performer: z.string().nullish(),
+  spotifyId: z.string().nullish(),
+  matchedOn: z.enum(['credit', 'title', 'artist', 'both']).nullish(),
+  position: z.number(),
+});
+
+export type SoundtrackTrack = z.infer<typeof SoundtrackTrackSchema>;

--- a/projects/client/src/lib/requests/queries/movies/movieSoundtrackQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieSoundtrackQuery.spec.ts
@@ -1,0 +1,86 @@
+import { MovieHereticMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticMappedMock.ts';
+import { MovieHereticSoundtrackMappedMock } from '$mocks/data/summary/movies/heretic/mapped/MovieHereticSoundtrackMappedMock.ts';
+import { MovieHereticSoundtrackResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticSoundtrackResponseMock.ts';
+import { server } from '$mocks/server.ts';
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { movieSoundtrackQuery } from './movieSoundtrackQuery.ts';
+
+const path =
+  `http://localhost/v3/media/movie/${MovieHereticMappedMock.slug}/info/15/version/1`;
+
+function query(locale: 'en' | 'pt-BR' = 'en') {
+  return createTestBedQuery(
+    movieSoundtrackQuery({ slug: MovieHereticMappedMock.slug, locale }),
+  );
+}
+
+describe('movieSoundtrackQuery', () => {
+  it('should query for the movie soundtrack', async () => {
+    const result = await runQuery({
+      factory: () => query(),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(MovieHereticSoundtrackMappedMock);
+  });
+
+  it('should order tracks by position regardless of payload order', async () => {
+    server.use(
+      http.get(path, () =>
+        HttpResponse.json(
+          [...MovieHereticSoundtrackResponseMock].reverse(),
+        )),
+    );
+
+    const result = await runQuery({
+      factory: () => query(),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(MovieHereticSoundtrackMappedMock);
+  });
+
+  it('should return an empty list when the endpoint denies access', async () => {
+    server.use(
+      http.get(path, () => new HttpResponse(null, { status: 401 })),
+    );
+
+    const result = await runQuery({
+      factory: () => query(),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal([]);
+  });
+
+  it('should request the given locale', async () => {
+    const requestedLocales: Array<string | null> = [];
+
+    server.use(
+      http.get(path, ({ request }) => {
+        requestedLocales.push(new URL(request.url).searchParams.get('locale'));
+        return HttpResponse.json(MovieHereticSoundtrackResponseMock);
+      }),
+    );
+
+    await runQuery({
+      factory: () => query('pt-BR'),
+      mapper: (response) => response?.data,
+    });
+
+    expect(requestedLocales).to.deep.equal(['pt-BR']);
+  });
+
+  it('should cache per locale', () => {
+    const toKey = (locale: 'en' | 'pt-BR') =>
+      movieSoundtrackQuery({
+        slug: MovieHereticMappedMock.slug,
+        locale,
+      }).queryKey;
+
+    expect(toKey('en')).to.not.deep.equal(toKey('pt-BR'));
+  });
+});

--- a/projects/client/src/lib/requests/queries/movies/movieSoundtrackQuery.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieSoundtrackQuery.ts
@@ -1,0 +1,43 @@
+import type { AvailableLocale } from '$lib/features/i18n/index.ts';
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { mapToSoundtrackTrack } from '../../_internal/mapToSoundtrackTrack.ts';
+import { toMediaInfoPath } from '../../_internal/toMediaInfoPath.ts';
+import { SOUNDTRACK_INFO } from '../../_internal/soundtrackInfo.ts';
+import { SoundtrackResponseSchema } from '../../models/SoundtrackResponse.ts';
+import { SoundtrackTrackSchema } from '../../models/SoundtrackTrack.ts';
+
+type MovieSoundtrackParams = {
+  slug: string;
+  locale: AvailableLocale;
+} & ApiParams;
+
+const movieSoundtrackRequest = async (
+  { fetch, slug, locale }: MovieSoundtrackParams,
+) => {
+  const response = await rawApiFetch({
+    fetch,
+    path: toMediaInfoPath({ type: 'movie', slug, locale, ...SOUNDTRACK_INFO }),
+  });
+
+  return {
+    body: SoundtrackResponseSchema.parse(
+      response.ok ? await response.json() : [],
+    ),
+    status: 200,
+  };
+};
+
+export const movieSoundtrackQuery = defineQuery({
+  key: 'movieSoundtrack',
+  invalidations: [],
+  dependencies: (params) => [params.slug, params.locale],
+  request: movieSoundtrackRequest,
+  mapper: (response) =>
+    response.body
+      .map((entry) => mapToSoundtrackTrack('movie_soundtrack', entry))
+      .sort((a, b) => a.position - b.position),
+  schema: SoundtrackTrackSchema.array(),
+  ttl: time.hours(12),
+});

--- a/projects/client/src/lib/requests/queries/shows/showSoundtrackQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSoundtrackQuery.spec.ts
@@ -1,0 +1,20 @@
+import { ShowSiloMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloMappedMock.ts';
+import { ShowSiloSoundtrackMappedMock } from '$mocks/data/summary/shows/silo/mapped/ShowSiloSoundtrackMappedMock.ts';
+import { createTestBedQuery } from '$test/beds/query/createTestBedQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { describe, expect, it } from 'vitest';
+import { showSoundtrackQuery } from './showSoundtrackQuery.ts';
+
+describe('showSoundtrackQuery', () => {
+  it('should query for the show soundtrack', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createTestBedQuery(
+          showSoundtrackQuery({ slug: ShowSiloMappedMock.slug, locale: 'en' }),
+        ),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.deep.equal(ShowSiloSoundtrackMappedMock);
+  });
+});

--- a/projects/client/src/lib/requests/queries/shows/showSoundtrackQuery.ts
+++ b/projects/client/src/lib/requests/queries/shows/showSoundtrackQuery.ts
@@ -1,0 +1,43 @@
+import type { AvailableLocale } from '$lib/features/i18n/index.ts';
+import { defineQuery } from '$lib/features/query/defineQuery.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { mapToSoundtrackTrack } from '../../_internal/mapToSoundtrackTrack.ts';
+import { toMediaInfoPath } from '../../_internal/toMediaInfoPath.ts';
+import { SOUNDTRACK_INFO } from '../../_internal/soundtrackInfo.ts';
+import { SoundtrackResponseSchema } from '../../models/SoundtrackResponse.ts';
+import { SoundtrackTrackSchema } from '../../models/SoundtrackTrack.ts';
+
+type ShowSoundtrackParams = {
+  slug: string;
+  locale: AvailableLocale;
+} & ApiParams;
+
+const showSoundtrackRequest = async (
+  { fetch, slug, locale }: ShowSoundtrackParams,
+) => {
+  const response = await rawApiFetch({
+    fetch,
+    path: toMediaInfoPath({ type: 'show', slug, locale, ...SOUNDTRACK_INFO }),
+  });
+
+  return {
+    body: SoundtrackResponseSchema.parse(
+      response.ok ? await response.json() : [],
+    ),
+    status: 200,
+  };
+};
+
+export const showSoundtrackQuery = defineQuery({
+  key: 'showSoundtrack',
+  invalidations: [],
+  dependencies: (params) => [params.slug, params.locale],
+  request: showSoundtrackRequest,
+  mapper: (response) =>
+    response.body
+      .map((entry) => mapToSoundtrackTrack('show_soundtrack', entry))
+      .sort((a, b) => a.position - b.position),
+  schema: SoundtrackTrackSchema.array(),
+  ttl: time.hours(12),
+});

--- a/projects/client/src/lib/sections/summary/MovieSummary.svelte
+++ b/projects/client/src/lib/sections/summary/MovieSummary.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import * as m from "$lib/features/i18n/messages";
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
 
   import type { MediaStudio } from "$lib/requests/models/MediaStudio";
   import type { MediaVideo } from "$lib/requests/models/MediaVideo";
@@ -16,6 +18,7 @@
   import MediaSummary from "./components/media/MediaSummary.svelte";
   import MediaSummaryV2 from "./components/media/v2/MediaSummary.svelte";
   import Sentiment from "./components/sentiment/Sentiment.svelte";
+  import SoundtrackList from "./components/soundtrack/SoundtrackList.svelte";
   import TriviaList from "./components/trivia/TriviaList.svelte";
   import type { CommonMediaSummaryProps } from "./models/CommonMediaSummaryProps";
   import SummaryDrawer from "./SummaryDrawer.svelte";
@@ -76,6 +79,12 @@
 <Comments {media} type="movie" />
 
 <VideoList slug={media.slug} {videos} type="movie" />
+
+<RenderForFeature flag={FeatureFlag.Soundtrack}>
+  {#snippet enabled()}
+    <SoundtrackList {media} />
+  {/snippet}
+</RenderForFeature>
 
 <RelatedList
   title={m.list_title_related_movies()}

--- a/projects/client/src/lib/sections/summary/ShowSummary.svelte
+++ b/projects/client/src/lib/sections/summary/ShowSummary.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { FeatureFlag } from "$lib/features/feature-flag/models/FeatureFlag";
   import * as m from "$lib/features/i18n/messages";
 
   import RenderFor from "$lib/guards/RenderFor.svelte";
+  import RenderForFeature from "$lib/guards/RenderForFeature.svelte";
   import type { MediaStudio } from "$lib/requests/models/MediaStudio";
   import type { MediaVideo } from "$lib/requests/models/MediaVideo";
   import type { Season } from "$lib/requests/models/Season";
@@ -18,6 +20,7 @@
   import MediaSummary from "./components/media/MediaSummary.svelte";
   import MediaSummaryV2 from "./components/media/v2/MediaSummary.svelte";
   import Sentiment from "./components/sentiment/Sentiment.svelte";
+  import SoundtrackList from "./components/soundtrack/SoundtrackList.svelte";
   import TriviaList from "./components/trivia/TriviaList.svelte";
   import type { CommonMediaSummaryProps } from "./models/CommonMediaSummaryProps";
   import SummaryDrawer from "./SummaryDrawer.svelte";
@@ -101,6 +104,12 @@
 <Comments {media} type="show" />
 
 <VideoList slug={media.slug} {videos} type="show" />
+
+<RenderForFeature flag={FeatureFlag.Soundtrack}>
+  {#snippet enabled()}
+    <SoundtrackList {media} />
+  {/snippet}
+</RenderForFeature>
 
 <RelatedList
   title={m.list_title_related_shows()}

--- a/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/SummaryDrawer.svelte
@@ -27,6 +27,7 @@
   import SeasonsDrawerHost from "./components/seasons/SeasonsDrawerHost.svelte";
   import SentimentDrawer from "./components/sentiment/SentimentDrawer.svelte";
   import SocialDrawerHost from "./components/social/SocialDrawerHost.svelte";
+  import SoundtrackDrawerHost from "./components/soundtrack/SoundtrackDrawerHost.svelte";
   import TriviaDrawerHost from "./components/trivia/TriviaDrawerHost.svelte";
   import VideoDrawerHost from "./components/videos/VideoDrawerHost.svelte";
 
@@ -119,6 +120,14 @@
 
 {#if drawer === SummaryDrawers.Trivia && media}
   <TriviaDrawerHost {media} onClose={close} />
+{/if}
+
+{#if drawer === SummaryDrawers.Soundtrack && media}
+  <RenderForFeature flag={FeatureFlag.Soundtrack}>
+    {#snippet enabled()}
+      <SoundtrackDrawerHost {media} onClose={close} />
+    {/snippet}
+  </RenderForFeature>
 {/if}
 
 {#if drawer === SummaryDrawers.History}

--- a/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
+++ b/projects/client/src/lib/sections/summary/_internal/summaryDrawerNavigation.ts
@@ -7,6 +7,7 @@ export enum SummaryDrawers {
   Cast = 'cast',
   Videos = 'videos',
   Trivia = 'trivia',
+  Soundtrack = 'soundtrack',
   History = 'history',
   Social = 'social',
   WhereToWatch = 'where-to-watch',
@@ -41,6 +42,8 @@ function mapToDrawer(value: string | Nil) {
       return SummaryDrawers.Videos;
     case SummaryDrawers.Trivia:
       return SummaryDrawers.Trivia;
+    case SummaryDrawers.Soundtrack:
+      return SummaryDrawers.Soundtrack;
     case SummaryDrawers.History:
       return SummaryDrawers.History;
     case SummaryDrawers.Social:

--- a/projects/client/src/lib/sections/summary/components/soundtrack/SoundtrackDrawerHost.svelte
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/SoundtrackDrawerHost.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import Drawer from "$lib/components/drawer/Drawer.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import UpsellCta from "$lib/features/upsell/UpsellCta.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import ListMetaInfo from "$lib/sections/components/ListMetaInfo.svelte";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte";
+  import { fade } from "svelte/transition";
+  import SoundtrackBoard from "./_internal/SoundtrackBoard.svelte";
+  import { toSoundtrackSummary } from "./_internal/toSoundtrackSummary.ts";
+  import { useSoundtrack } from "./useSoundtrack.ts";
+
+  const { media, onClose }: { media: MediaEntry; onClose: () => void } =
+    $props();
+
+  const { tracks } = useSoundtrack(
+    fromRune(() => ({ slug: media.slug, type: media.type })),
+  );
+
+  let isOpen = $state(false);
+
+  const summary = $derived(toSoundtrackSummary($tracks));
+</script>
+
+{#snippet metaInfo()}
+  <ListMetaInfo
+    text={m.text_soundtrack_playable_ratio({
+      playable: summary.playable,
+      total: summary.total,
+    })}
+  />
+{/snippet}
+
+<Drawer
+  {onClose}
+  onOpened={() => (isOpen = true)}
+  title={m.list_title_soundtrack()}
+  variant="vip"
+  size="auto"
+  {metaInfo}
+>
+  {#if isOpen}
+    <div transition:fade={{ duration: 150 }}>
+      <RenderFor audience="vip">
+        <SoundtrackBoard
+          {media}
+          tracks={$tracks}
+          {summary}
+          source="soundtrack-drawer"
+          layout="stacked"
+        />
+      </RenderFor>
+
+      <RenderFor audience="free">
+        <UpsellCta source="soundtrack" title={m.text_soundtrack_upsell()}>
+          {m.vip_feature_description_soundtrack()}
+        </UpsellCta>
+      </RenderFor>
+    </div>
+  {/if}
+</Drawer>

--- a/projects/client/src/lib/sections/summary/components/soundtrack/SoundtrackList.svelte
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/SoundtrackList.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import CaretRightIcon from "$lib/components/icons/CaretRightIcon.svelte";
+  import Link from "$lib/components/link/Link.svelte";
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import { fromRune } from "$lib/utils/store/fromRune.svelte";
+  import { slide } from "svelte/transition";
+  import {
+    SummaryDrawers,
+    summaryDrawerNavigation,
+  } from "../../_internal/summaryDrawerNavigation.ts";
+  import SoundtrackBoard from "./_internal/SoundtrackBoard.svelte";
+  import SoundtrackUpsell from "./_internal/SoundtrackUpsell.svelte";
+  import { toSoundtrackSummary } from "./_internal/toSoundtrackSummary.ts";
+  import { useSoundtrack } from "./useSoundtrack.ts";
+
+  const maxRows = 5;
+
+  const { media }: { media: MediaEntry } = $props();
+
+  const { tracks } = useSoundtrack(
+    fromRune(() => ({ slug: media.slug, type: media.type })),
+  );
+
+  const { buildDrawerLink } = summaryDrawerNavigation();
+  const { track } = useTrack(AnalyticsEvent.Drilldown);
+
+  const visibleTracks = $derived($tracks.slice(0, maxRows));
+  const summary = $derived(toSoundtrackSummary($tracks));
+  const hasMore = $derived($tracks.length > maxRows);
+</script>
+
+{#snippet title(withCaret: boolean)}
+  <span class="header-title">
+    <h2 class="header-heading">{m.list_title_soundtrack()}</h2>
+    {#if withCaret}
+      <CaretRightIcon />
+    {/if}
+  </span>
+{/snippet}
+
+{#snippet header(withDrilldown: boolean)}
+  <div class="soundtrack-header">
+    {#if withDrilldown}
+      <Link
+        {...buildDrawerLink(SummaryDrawers.Soundtrack)}
+        label={m.button_label_view_soundtrack()}
+        color="inherit"
+        onclick={() => track({ source: "soundtrack" })}
+      >
+        {@render title(true)}
+      </Link>
+    {:else}
+      {@render title(false)}
+    {/if}
+  </div>
+{/snippet}
+
+<RenderFor audience="vip">
+  {#if $tracks.length > 0}
+    <section class="trakt-soundtrack-section" transition:slide={{ duration: 150 }}>
+      {@render header(hasMore)}
+      <SoundtrackBoard
+        {media}
+        tracks={visibleTracks}
+        {summary}
+        source="soundtrack-summary"
+      />
+    </section>
+  {/if}
+</RenderFor>
+
+<SoundtrackUpsell />
+
+<style lang="scss">
+  .trakt-soundtrack-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--list-header-gap);
+
+    padding-inline: var(--layout-distance-side);
+  }
+
+  .soundtrack-header {
+    display: flex;
+    gap: var(--ni-12);
+    align-items: baseline;
+  }
+
+  .header-title {
+    display: inline-flex;
+    gap: var(--ni-4);
+    align-items: center;
+  }
+
+  .header-heading {
+    margin: 0;
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackBoard.svelte
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackBoard.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
+  import { useTrack } from "$lib/features/analytics/useTrack";
+  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import type { SoundtrackTrack } from "$lib/requests/models/SoundtrackTrack";
+  import SoundtrackPanel from "./SoundtrackPanel.svelte";
+  import SoundtrackTrackRow from "./SoundtrackTrackRow.svelte";
+  import type { SoundtrackSummary } from "./toSoundtrackSummary.ts";
+
+  // Below this the list is too short to sit beside a player without the two
+  // columns disagreeing on height, so the panel becomes a bar instead.
+  const minimumSplitRows = 5;
+
+  const {
+    media,
+    tracks,
+    summary,
+    source,
+    layout = "split",
+  }: {
+    media: MediaEntry;
+    tracks: ReadonlyArray<SoundtrackTrack>;
+    // Describes the whole soundtrack, not the rows on screen - the page only
+    // lists the first few, and a count of those would read as the total.
+    summary: SoundtrackSummary;
+    source: string;
+    layout?: "split" | "stacked";
+  } = $props();
+
+  const { track: trackEvent } = useTrack(AnalyticsEvent.Soundtrack);
+
+  let selectedKey = $state<string | null>(null);
+  let playToken = $state(0);
+  let isPlaying = $state(false);
+
+  // Only the rows on screen are clickable, so a match further down the full
+  // list does not earn a player.
+  const hasPlayableRow = $derived(
+    tracks.some((track) => Boolean(track.spotifyId)),
+  );
+  const selected = $derived(
+    tracks.find((track) => track.key === selectedKey) ?? null,
+  );
+  const effectiveLayout = $derived(
+    layout === "split" && tracks.length >= minimumSplitRows
+      ? "split"
+      : "stacked",
+  );
+
+  function onPlay(track: SoundtrackTrack) {
+    selectedKey = track.key;
+    playToken += 1;
+
+    // `matchedOn` rides the play event instead of the row: it measures our
+    // matcher, not the music, so it is a QA signal rather than a label.
+    trackEvent({
+      source,
+      position: track.position,
+      matched_on: track.matchedOn ?? "credit",
+    });
+  }
+</script>
+
+<div
+  class="trakt-soundtrack-board"
+  class:has-player={hasPlayableRow}
+  data-layout={effectiveLayout}
+  style="--rows-shown: {tracks.length}"
+>
+  {#if hasPlayableRow}
+    <SoundtrackPanel
+      {media}
+      credit={summary.credit}
+      total={summary.total}
+      playable={summary.playable}
+      track={selected}
+      {playToken}
+      layout={effectiveLayout}
+      onPlayingChange={(value) => (isPlaying = value)}
+    />
+  {/if}
+
+  <ul class="board-list">
+    {#each tracks as track (track.key)}
+      <SoundtrackTrackRow
+        {track}
+        isPlaying={isPlaying && selectedKey === track.key}
+        isSelected={selectedKey === track.key}
+        {onPlay}
+      />
+    {/each}
+  </ul>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  /* One token sizes both columns: the row count drives the list height and the
+     panel stretches to it, so the two never disagree. */
+  .trakt-soundtrack-board {
+    display: grid;
+    grid-auto-rows: min-content;
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--ni-8);
+  }
+
+  .board-list {
+    display: flex;
+    flex-direction: column;
+
+    box-sizing: border-box;
+    height: calc(var(--rows-shown) * var(--height-soundtrack-row));
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+
+    list-style: none;
+
+    background-color: var(--color-card-background);
+    border-radius: var(--border-radius-m);
+    /* Same lift every card gets - without it the surface is invisible against
+       the light-theme page. */
+    box-shadow: var(--shadow-base);
+  }
+
+  .trakt-soundtrack-board[data-layout="split"] {
+    @include for-desktop {
+      grid-auto-rows: auto;
+      gap: var(--ni-12);
+      align-items: stretch;
+
+      height: calc(var(--rows-shown) * var(--height-soundtrack-row));
+
+      /* Nothing resolved: the panel is dropped and the credit list runs the
+         full width. */
+      &.has-player {
+        grid-template-columns: var(--width-soundtrack-panel) minmax(0, 1fr);
+      }
+
+      .board-list {
+        height: 100%;
+      }
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackPanel.svelte
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackPanel.svelte
@@ -1,0 +1,357 @@
+<script lang="ts">
+  import SpotifyIcon from "$lib/components/icons/SpotifyIcon.svelte";
+  import Skeleton from "$lib/components/skeleton/Skeleton.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { MediaEntry } from "$lib/requests/models/MediaEntry";
+  import type { SoundtrackTrack } from "$lib/requests/models/SoundtrackTrack";
+  import { fade } from "svelte/transition";
+  import {
+    loadSpotifyIframeApi,
+    type SpotifyEmbedController,
+  } from "./loadSpotifyIframeApi.ts";
+
+  const {
+    media,
+    credit,
+    total,
+    playable,
+    track,
+    playToken,
+    layout,
+    onPlayingChange,
+  }: {
+    media: MediaEntry;
+    credit: string | null;
+    total: number;
+    playable: number;
+    track: SoundtrackTrack | null;
+    // Bumped on every row click so clicking the same row twice toggles
+    // playback instead of being swallowed as "no change".
+    playToken: number;
+    layout: "split" | "stacked";
+    onPlayingChange: (isPlaying: boolean) => void;
+  } = $props();
+
+  // Spotify's card reflows after it reports ready, on every load. Release the
+  // skeleton anyway if playback never reports in.
+  const settleTimeout = 2500;
+  // `playback_update` still fires for the outgoing track, so the first one
+  // after a switch cannot be trusted as "settled".
+  const settleDwell = 400;
+
+  let host = $state<HTMLDivElement>();
+  let isEmbedVisible = $state(false);
+  let controller: SpotifyEmbedController | null = null;
+  let loadedUri: string | null = null;
+  let requestedToken = -1;
+  let settleTimer: ReturnType<typeof setTimeout> | null = null;
+  let dwellTimer: ReturnType<typeof setTimeout> | null = null;
+  let sawUpdateWhileDwelling = false;
+
+  function clearTimers() {
+    if (settleTimer != null) {
+      clearTimeout(settleTimer);
+      settleTimer = null;
+    }
+
+    if (dwellTimer != null) {
+      clearTimeout(dwellTimer);
+      dwellTimer = null;
+    }
+  }
+
+  function revealEmbed() {
+    isEmbedVisible = true;
+    clearTimers();
+  }
+
+  function coverEmbed() {
+    isEmbedVisible = false;
+    sawUpdateWhileDwelling = false;
+    clearTimers();
+
+    dwellTimer = setTimeout(() => {
+      dwellTimer = null;
+
+      if (sawUpdateWhileDwelling) {
+        revealEmbed();
+      }
+    }, settleDwell);
+    settleTimer = setTimeout(revealEmbed, settleTimeout);
+  }
+
+  function onPlaybackUpdate(isPaused: boolean) {
+    if (dwellTimer != null) {
+      sawUpdateWhileDwelling = true;
+    } else {
+      revealEmbed();
+    }
+
+    onPlayingChange(!isPaused);
+  }
+
+  const embedHeight = $derived(layout === "split" ? "152" : "80");
+  const uri = $derived(
+    track?.spotifyId ? `spotify:track:${track.spotifyId}` : null,
+  );
+  const playableRatio = $derived(
+    m.text_soundtrack_playable_ratio({ playable, total }),
+  );
+
+  function attach(activeUri: string) {
+    if (!host) {
+      return;
+    }
+
+    loadSpotifyIframeApi().then((api) => {
+      if (!host) {
+        return;
+      }
+
+      api.createController(
+        host,
+        { uri: activeUri, width: "100%", height: embedHeight },
+        (created) => {
+          controller = created;
+          loadedUri = activeUri;
+          created.addListener("ready", () => created.play());
+          created.addListener("playback_update", ({ data }) =>
+            onPlaybackUpdate(data.isPaused),
+          );
+        },
+      );
+    });
+  }
+
+  $effect(() => {
+    const activeUri = uri;
+    const token = playToken;
+
+    if (activeUri == null || token === requestedToken) {
+      return;
+    }
+
+    requestedToken = token;
+
+    if (controller == null) {
+      coverEmbed();
+      attach(activeUri);
+      return;
+    }
+
+    // Same track: a toggle never reflows the card, so the embed stays visible.
+    if (loadedUri === activeUri) {
+      controller.togglePlay();
+      return;
+    }
+
+    loadedUri = activeUri;
+    coverEmbed();
+    controller.loadUri(activeUri);
+    controller.play();
+  });
+
+  $effect(() => () => {
+    clearTimers();
+    controller?.destroy();
+  });
+</script>
+
+{#snippet spotifyGlyph()}
+  <span class="media-glyph" aria-hidden="true"><SpotifyIcon /></span>
+{/snippet}
+
+{#snippet artwork()}
+  <img
+    class="media-artwork"
+    src={media.cover.url.thumb}
+    alt=""
+    loading="lazy"
+    decoding="async"
+  />
+{/snippet}
+
+<div class="trakt-soundtrack-panel" data-layout={layout}>
+  <!-- One box for every state, so nothing moves between them. The frame keeps
+       its layout throughout: Spotify never reports ready for a display:none
+       iframe. -->
+  <div class="panel-media" style:--stage-height="{embedHeight}px">
+    <div class="media-stage"><div bind:this={host}></div></div>
+
+    {#if uri == null}
+      <div class="media-overlay">
+        {@render artwork()}
+        <div class="overlay-copy">
+          <p class="overlay-title bold ellipsis">{credit ?? media.title}</p>
+          <p class="tag secondary">{playableRatio}</p>
+        </div>
+        {@render spotifyGlyph()}
+      </div>
+    {:else if !isEmbedVisible}
+      <div class="media-overlay" out:fade={{ duration: 150 }}>
+        {@render artwork()}
+        <div class="overlay-copy overlay-lines">
+          <Skeleton width="70%" height="var(--ni-12)" />
+          <Skeleton width="45%" height="var(--ni-10)" />
+          <Skeleton width="100%" height="var(--ni-4)" />
+        </div>
+        {@render spotifyGlyph()}
+      </div>
+    {/if}
+  </div>
+
+  {#if layout === "split"}
+    <p class="panel-caption tag secondary ellipsis">
+      {#if uri == null}
+        {m.text_soundtrack_pick_a_track()}
+      {:else}
+        {credit ?? media.title} &middot; {playableRatio}
+      {/if}
+    </p>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-soundtrack-panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-8);
+    justify-content: space-between;
+
+    box-sizing: border-box;
+    height: 100%;
+    padding: var(--ni-16);
+    overflow: hidden;
+
+    background-color: var(--color-card-background);
+    border-radius: var(--border-radius-m);
+    box-shadow: var(--shadow-base);
+  }
+
+  .panel-media {
+    position: relative;
+
+    flex: none;
+
+    height: var(--stage-height);
+
+    border-radius: var(--border-radius-m);
+  }
+
+  .media-stage {
+    height: 100%;
+
+    :global(iframe) {
+      display: block;
+
+      width: 100%;
+
+      border: none;
+      border-radius: var(--border-radius-m);
+    }
+  }
+
+  /* Mirrors the geometry of Spotify's own card: square art inset by the same
+     gutter, copy beside it, glyph in the corner. */
+  .media-overlay {
+    position: absolute;
+    inset: 0;
+
+    display: flex;
+    gap: var(--ni-12);
+    align-items: center;
+
+    box-sizing: border-box;
+    padding: var(--ni-12);
+
+    background-color: var(--color-background);
+    border-radius: var(--border-radius-m);
+  }
+
+  .media-artwork {
+    flex: none;
+    aspect-ratio: 1;
+
+    height: 100%;
+
+    object-fit: cover;
+
+    border-radius: var(--border-radius-s);
+  }
+
+  .overlay-copy {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: var(--ni-2);
+    min-width: 0;
+
+    :global(p) {
+      margin: 0;
+    }
+  }
+
+  .overlay-lines {
+    gap: var(--ni-8);
+  }
+
+  .overlay-title {
+    font-size: var(--font-size-text);
+  }
+
+  /* Matches the glyph Spotify draws inside its own 152px card, so the corner
+     does not shift between the placeholder and the loaded embed. */
+  .media-glyph {
+    position: absolute;
+    inset-block-start: var(--ni-10);
+    inset-inline-end: var(--ni-10);
+
+    display: inline-flex;
+
+    width: var(--ni-28);
+    height: var(--ni-28);
+
+    color: var(--color-text-secondary);
+
+    :global(svg) {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  .panel-caption {
+    flex: none;
+    margin: 0;
+  }
+
+  .trakt-soundtrack-panel[data-layout="stacked"] {
+    height: var(--height-soundtrack-panel-compact);
+    padding: 0;
+
+    background-color: transparent;
+    box-shadow: none;
+
+    .media-overlay {
+      background-color: var(--color-card-background);
+    }
+
+    /* The compact card draws a smaller glyph. */
+    .media-glyph {
+      inset-block-start: var(--ni-8);
+      inset-inline-end: var(--ni-8);
+
+      width: var(--ni-20);
+      height: var(--ni-20);
+    }
+  }
+
+  @include for-tablet-lg-and-below {
+    .trakt-soundtrack-panel {
+      position: sticky;
+      inset-block-start: var(--ni-8);
+      z-index: var(--layer-base);
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackTrackRow.svelte
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackTrackRow.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  import PauseIcon from "$lib/components/icons/PauseIcon.svelte";
+  import PlayArrowIcon from "$lib/components/icons/PlayArrowIcon.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { SoundtrackTrack } from "$lib/requests/models/SoundtrackTrack";
+
+  const {
+    track,
+    isPlaying,
+    isSelected = false,
+    onPlay,
+  }: {
+    track: SoundtrackTrack;
+    isPlaying: boolean;
+    isSelected?: boolean;
+    onPlay: (track: SoundtrackTrack) => void;
+  } = $props();
+
+  const isPlayable = $derived(Boolean(track.spotifyId));
+</script>
+
+<li
+  class="trakt-soundtrack-row"
+  class:is-muted={!isPlayable}
+  class:is-playing={isSelected}
+>
+  <span class="row-position">{track.position + 1}</span>
+
+  <span class="row-title ellipsis" class:bold={isPlayable}>{track.title}</span>
+
+  {#if track.performer}
+    <span class="row-performer tag secondary ellipsis">{track.performer}</span>
+  {/if}
+
+  {#if isPlayable}
+    <button
+      class="row-action"
+      type="button"
+      aria-label={isPlaying
+        ? m.button_label_pause_track({ title: track.title })
+        : m.button_label_play_track({ title: track.title })}
+      onclick={() => onPlay(track)}
+    >
+      {#if isPlaying}
+        <PauseIcon />
+      {:else}
+        <PlayArrowIcon />
+      {/if}
+    </button>
+  {:else}
+    <span class="row-unmatched" aria-label={m.text_soundtrack_unmatched()}>
+      &mdash;
+    </span>
+  {/if}
+</li>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-soundtrack-row {
+    display: flex;
+    gap: var(--ni-12);
+    align-items: center;
+
+    box-sizing: border-box;
+    height: var(--height-soundtrack-row);
+    padding-inline: var(--ni-12);
+
+    &:not(:first-child) {
+      border-block-start: 1px solid var(--color-border);
+    }
+
+    &.is-playing {
+      background-color: var(--color-soundtrack-row-active-background);
+    }
+
+    &.is-muted {
+      .row-title {
+        color: var(--color-text-secondary);
+      }
+    }
+  }
+
+  .row-position {
+    flex: none;
+    min-width: 2ch;
+
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-tag);
+    font-variant-numeric: tabular-nums;
+    text-align: end;
+  }
+
+  .row-title {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .row-performer {
+    flex: none;
+    max-width: 40%;
+    margin-inline-start: auto;
+  }
+
+  .row-action {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+
+    width: var(--ni-28);
+    height: var(--ni-28);
+    padding: 0;
+
+    color: var(--color-soundtrack-play-foreground);
+
+    background-color: var(--color-soundtrack-play-background);
+    border: none;
+    border-radius: 50%;
+
+    cursor: pointer;
+
+    :global(svg) {
+      width: var(--ni-16);
+      height: var(--ni-16);
+    }
+  }
+
+  .row-unmatched {
+    flex: none;
+
+    width: var(--ni-28);
+
+    color: var(--color-text-secondary);
+    text-align: center;
+  }
+
+  @include for-mobile {
+    .row-performer {
+      display: none;
+    }
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackUpsell.svelte
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackUpsell.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import * as m from "$lib/features/i18n/messages.ts";
+  import UpsellCta from "$lib/features/upsell/UpsellCta.svelte";
+  import RenderFor from "$lib/guards/RenderFor.svelte";
+  import SoundtrackTrackRow from "./SoundtrackTrackRow.svelte";
+  import { teaserTracks } from "./teaserTracks.ts";
+</script>
+
+{#snippet teaser()}
+  <section class="trakt-soundtrack-upsell">
+    <h2 class="upsell-heading">{m.list_title_soundtrack()}</h2>
+
+    <div class="upsell-board">
+      <ul class="upsell-list" aria-hidden="true">
+        {#each teaserTracks as track (track.key)}
+          <SoundtrackTrackRow {track} isPlaying={false} onPlay={() => {}} />
+        {/each}
+      </ul>
+
+      <UpsellCta source="soundtrack" title={m.text_soundtrack_upsell()}>
+        {m.vip_feature_description_soundtrack()}
+      </UpsellCta>
+    </div>
+  </section>
+{/snippet}
+
+<!-- `free` is signed-in non-VIP, `public` is signed out. The endpoint returns
+     an empty list for both, so neither may be shown a section that reads as
+     "this title has no soundtrack". -->
+<RenderFor audience="free">
+  {@render teaser()}
+</RenderFor>
+
+<RenderFor audience="public">
+  {@render teaser()}
+</RenderFor>
+
+<style lang="scss">
+  .trakt-soundtrack-upsell {
+    display: flex;
+    flex-direction: column;
+    gap: var(--list-header-gap);
+
+    padding-inline: var(--layout-distance-side);
+  }
+
+  .upsell-heading {
+    margin: 0;
+  }
+
+  .upsell-board {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ni-12);
+  }
+
+  .upsell-list {
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+
+    list-style: none;
+
+    background-color: var(--color-card-background);
+    border-radius: var(--border-radius-m);
+    box-shadow: var(--shadow-base);
+
+    /* The rows are a sample, not this title's data - blurred so they read as
+       a preview of the feature rather than as real credits. */
+    filter: blur(var(--ni-4));
+    user-select: none;
+    pointer-events: none;
+  }
+</style>

--- a/projects/client/src/lib/sections/summary/components/soundtrack/_internal/loadSpotifyIframeApi.ts
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/_internal/loadSpotifyIframeApi.ts
@@ -1,0 +1,47 @@
+export type SpotifyEmbedController = {
+  loadUri: (uri: string) => void;
+  play: () => void;
+  pause: () => void;
+  togglePlay: () => void;
+  destroy: () => void;
+  addListener: (
+    event: 'ready' | 'playback_update',
+    handler: (payload: { data: { isPaused: boolean } }) => void,
+  ) => void;
+};
+
+type SpotifyIframeApi = {
+  createController: (
+    element: HTMLElement,
+    options: { uri: string; width: string; height: string },
+    callback: (controller: SpotifyEmbedController) => void,
+  ) => void;
+};
+
+type SpotifyGlobal = {
+  onSpotifyIframeApiReady?: (api: SpotifyIframeApi) => void;
+};
+
+const SCRIPT_SRC = 'https://open.spotify.com/embed/iframe-api/v1';
+
+let pending: Promise<SpotifyIframeApi> | null = null;
+
+// The plain embed iframe needs a second click inside Spotify's own UI before
+// anything plays. The iFrame API hands back a controller we can call `play()`
+// on, so one click on a row is enough.
+export function loadSpotifyIframeApi(): Promise<SpotifyIframeApi> {
+  if (pending) {
+    return pending;
+  }
+
+  pending = new Promise((resolve) => {
+    (globalThis as SpotifyGlobal).onSpotifyIframeApiReady = resolve;
+
+    const script = document.createElement('script');
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    document.head.appendChild(script);
+  });
+
+  return pending;
+}

--- a/projects/client/src/lib/sections/summary/components/soundtrack/_internal/teaserTracks.ts
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/_internal/teaserTracks.ts
@@ -1,0 +1,28 @@
+import type { SoundtrackTrack } from '$lib/requests/models/SoundtrackTrack.ts';
+
+// Blurred sample behind the VIP upsell - shows the shape of the section
+// without implying anything about the title being viewed. The ids are
+// placeholders; the rows never become interactive.
+export const teaserTracks: ReadonlyArray<SoundtrackTrack> = [
+  {
+    key: 'teaser_0',
+    title: 'Main Title',
+    performer: null,
+    spotifyId: 'teaser',
+    position: 0,
+  },
+  {
+    key: 'teaser_1',
+    title: 'Opening Credits',
+    performer: null,
+    spotifyId: 'teaser',
+    position: 1,
+  },
+  {
+    key: 'teaser_2',
+    title: 'End Credits',
+    performer: null,
+    spotifyId: null,
+    position: 2,
+  },
+];

--- a/projects/client/src/lib/sections/summary/components/soundtrack/_internal/toSoundtrackSummary.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/_internal/toSoundtrackSummary.spec.ts
@@ -1,0 +1,65 @@
+import type { SoundtrackTrack } from '$lib/requests/models/SoundtrackTrack.ts';
+import { describe, expect, it } from 'vitest';
+import { toSoundtrackSummary } from './toSoundtrackSummary.ts';
+
+function track(
+  overrides: Partial<SoundtrackTrack> & { position: number },
+): SoundtrackTrack {
+  return {
+    key: `track_${overrides.position}`,
+    title: `Track ${overrides.position}`,
+    performer: null,
+    spotifyId: null,
+    ...overrides,
+  };
+}
+
+describe('util: toSoundtrackSummary', () => {
+  it('should count the playable tracks', () => {
+    const summary = toSoundtrackSummary([
+      track({ position: 0, spotifyId: 'a' }),
+      track({ position: 1 }),
+      track({ position: 2, spotifyId: 'b' }),
+    ]);
+
+    expect(summary.total).to.equal(3);
+    expect(summary.playable).to.equal(2);
+  });
+
+  it('should credit a composer behind most of the listing', () => {
+    const summary = toSoundtrackSummary([
+      track({ position: 0, performer: 'Hans Zimmer' }),
+      track({ position: 1, performer: 'Hans Zimmer' }),
+      track({ position: 2, performer: 'Someone Else' }),
+    ]);
+
+    expect(summary.credit).to.equal('Hans Zimmer');
+  });
+
+  it('should not credit anyone on a compilation', () => {
+    const summary = toSoundtrackSummary([
+      track({ position: 0, performer: 'One' }),
+      track({ position: 1, performer: 'Two' }),
+      track({ position: 2, performer: 'Three' }),
+    ]);
+
+    expect(summary.credit).to.equal(null);
+  });
+
+  it('should ignore blank performers', () => {
+    const summary = toSoundtrackSummary([
+      track({ position: 0, performer: '  ' }),
+      track({ position: 1, performer: null }),
+    ]);
+
+    expect(summary.credit).to.equal(null);
+  });
+
+  it('should handle an empty soundtrack', () => {
+    expect(toSoundtrackSummary([])).to.deep.equal({
+      total: 0,
+      playable: 0,
+      credit: null,
+    });
+  });
+});

--- a/projects/client/src/lib/sections/summary/components/soundtrack/_internal/toSoundtrackSummary.ts
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/_internal/toSoundtrackSummary.ts
@@ -1,0 +1,43 @@
+import type { SoundtrackTrack } from '$lib/requests/models/SoundtrackTrack.ts';
+
+export type SoundtrackSummary = {
+  total: number;
+  playable: number;
+  credit: string | null;
+};
+
+// The credit line names whoever is behind most of the listing - a score is
+// usually one composer, a compilation soundtrack has no single owner and so
+// gets no credit line at all.
+function toDominantPerformer(tracks: ReadonlyArray<SoundtrackTrack>) {
+  const counts = tracks.reduce((acc, track) => {
+    const performer = track.performer?.trim();
+
+    if (!performer) {
+      return acc;
+    }
+
+    return acc.set(performer, (acc.get(performer) ?? 0) + 1);
+  }, new Map<string, number>());
+
+  const [dominant] = Array.from(counts.entries())
+    .sort(([, a], [, b]) => b - a);
+
+  if (!dominant) {
+    return null;
+  }
+
+  const [performer, count] = dominant;
+
+  return count > tracks.length / 2 ? performer : null;
+}
+
+export function toSoundtrackSummary(
+  tracks: ReadonlyArray<SoundtrackTrack>,
+): SoundtrackSummary {
+  return {
+    total: tracks.length,
+    playable: tracks.filter((track) => Boolean(track.spotifyId)).length,
+    credit: toDominantPerformer(tracks),
+  };
+}

--- a/projects/client/src/lib/sections/summary/components/soundtrack/useSoundtrack.ts
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/useSoundtrack.ts
@@ -1,0 +1,39 @@
+import { getLocale } from '$lib/features/i18n/index.ts';
+import { useQuery } from '$lib/features/query/useQuery.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+import { movieSoundtrackQuery } from '$lib/requests/queries/movies/movieSoundtrackQuery.ts';
+import { showSoundtrackQuery } from '$lib/requests/queries/shows/showSoundtrackQuery.ts';
+import { distinctUntilChanged, map, type Observable } from 'rxjs';
+
+export type SoundtrackTarget = {
+  slug: string;
+  type: MediaType;
+};
+
+function toQuery({ slug, type }: SoundtrackTarget) {
+  const params = { slug, locale: getLocale() };
+
+  switch (type) {
+    case 'show':
+      return showSoundtrackQuery(params);
+    default:
+      return movieSoundtrackQuery(params);
+  }
+}
+
+export function useSoundtrack(target$: Observable<SoundtrackTarget>) {
+  const query = useQuery(
+    target$.pipe(
+      distinctUntilChanged(
+        (previous, next) =>
+          previous.slug === next.slug && previous.type === next.type,
+      ),
+      map(toQuery),
+    ),
+  );
+
+  return {
+    tracks: query.pipe(map(($query) => $query.data ?? [])),
+    isLoading: query.pipe(map(($query) => $query.isPending)),
+  };
+}

--- a/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticSoundtrackMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/mapped/MovieHereticSoundtrackMappedMock.ts
@@ -1,0 +1,28 @@
+import type { SoundtrackTrack } from '$lib/requests/models/SoundtrackTrack.ts';
+
+export const MovieHereticSoundtrackMappedMock: SoundtrackTrack[] = [
+  {
+    key: 'movie_soundtrack_0',
+    title: 'Prologue',
+    performer: 'Chris Bacon',
+    spotifyId: '1aBcDeFgHiJkLmNoPqRsTu',
+    matchedOn: 'credit',
+    position: 0,
+  },
+  {
+    key: 'movie_soundtrack_1',
+    title: 'The Belief Trap',
+    performer: 'Chris Bacon',
+    spotifyId: null,
+    matchedOn: null,
+    position: 1,
+  },
+  {
+    key: 'movie_soundtrack_2',
+    title: 'Disbelief',
+    performer: 'Chris Bacon',
+    spotifyId: '2vWxYzAbCdEfGhIjKlMnOp',
+    matchedOn: 'title',
+    position: 2,
+  },
+];

--- a/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticSoundtrackResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/movies/heretic/response/MovieHereticSoundtrackResponseMock.ts
@@ -1,0 +1,25 @@
+import type { SoundtrackResponse } from '$lib/requests/models/SoundtrackResponse.ts';
+
+export const MovieHereticSoundtrackResponseMock: SoundtrackResponse = [
+  {
+    title: 'Prologue',
+    performer: 'Chris Bacon',
+    spotify_id: '1aBcDeFgHiJkLmNoPqRsTu',
+    matched_on: 'credit',
+    position: 0,
+  },
+  {
+    title: 'The Belief Trap',
+    performer: 'Chris Bacon',
+    spotify_id: null,
+    matched_on: null,
+    position: 1,
+  },
+  {
+    title: 'Disbelief',
+    performer: 'Chris Bacon',
+    spotify_id: '2vWxYzAbCdEfGhIjKlMnOp',
+    matched_on: 'title',
+    position: 2,
+  },
+];

--- a/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSoundtrackMappedMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/mapped/ShowSiloSoundtrackMappedMock.ts
@@ -1,0 +1,20 @@
+import type { SoundtrackTrack } from '$lib/requests/models/SoundtrackTrack.ts';
+
+export const ShowSiloSoundtrackMappedMock: SoundtrackTrack[] = [
+  {
+    key: 'show_soundtrack_0',
+    title: 'Silo Main Title',
+    performer: 'Atli Örvarsson',
+    spotifyId: '3qRsTuVwXyZaBcDeFgHiJk',
+    matchedOn: 'both',
+    position: 0,
+  },
+  {
+    key: 'show_soundtrack_1',
+    title: 'The Down Deep',
+    performer: 'Atli Örvarsson',
+    spotifyId: null,
+    matchedOn: null,
+    position: 1,
+  },
+];

--- a/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloSoundtrackResponseMock.ts
+++ b/projects/client/src/mocks/data/summary/shows/silo/response/ShowSiloSoundtrackResponseMock.ts
@@ -1,0 +1,18 @@
+import type { SoundtrackResponse } from '$lib/requests/models/SoundtrackResponse.ts';
+
+export const ShowSiloSoundtrackResponseMock: SoundtrackResponse = [
+  {
+    title: 'Silo Main Title',
+    performer: 'Atli Örvarsson',
+    spotify_id: '3qRsTuVwXyZaBcDeFgHiJk',
+    matched_on: 'both',
+    position: 0,
+  },
+  {
+    title: 'The Down Deep',
+    performer: 'Atli Örvarsson',
+    spotify_id: null,
+    matched_on: null,
+    position: 1,
+  },
+];

--- a/projects/client/src/mocks/handlers/movies.ts
+++ b/projects/client/src/mocks/handlers/movies.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw';
 import { OfficialListsResponseMock } from '$mocks/data/lists/response/OfficialListsResponseMock.ts';
 import { MovieHereticCommentsResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticCommentsResponseMock.ts';
 import { MovieHereticSentimentResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticSentimentResponseMock.ts';
+import { MovieHereticSoundtrackResponseMock } from '$mocks/data/summary/movies/heretic/response/MovieHereticSoundtrackResponseMock.ts';
 import { MoviesAnticipatedResponseMock } from '../data/movies/response/MoviesAnticipatedResponseMock.ts';
 import { MoviesPopularResponseMock } from '../data/movies/response/MoviesPopularResponseMock.ts';
 import { MoviesTrendingResponseMock } from '../data/movies/response/MoviesTrendingResponseMock.ts';
@@ -146,6 +147,12 @@ export const movies = [
     `http://localhost/v3/media/movie/${MovieHereticResponseMock.ids.slug}/info/0/version/1`,
     () => {
       return HttpResponse.json(MovieHereticSentimentResponseMock);
+    },
+  ),
+  http.get(
+    `http://localhost/v3/media/movie/${MovieHereticResponseMock.ids.slug}/info/15/version/1`,
+    () => {
+      return HttpResponse.json(MovieHereticSoundtrackResponseMock);
     },
   ),
   http.get(

--- a/projects/client/src/mocks/handlers/shows.ts
+++ b/projects/client/src/mocks/handlers/shows.ts
@@ -7,6 +7,7 @@ import { EpisodeSiloPeopleResponseMock } from '$mocks/data/summary/episodes/silo
 import { EpisodeSiloWatchNowResponseMock } from '$mocks/data/summary/episodes/silo/response/EpisodeSiloWatchNowResponseMock.ts';
 import { ShowSiloCommentsResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloCommentsResponseMock.ts';
 import { ShowSiloSentimentResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloSentimentResponseMock.ts';
+import { ShowSiloSoundtrackResponseMock } from '$mocks/data/summary/shows/silo/response/ShowSiloSoundtrackResponseMock.ts';
 import { ShowsAnticipatedResponseMock } from '../data/shows/response/ShowsAnticipatedResponseMock.ts';
 import { ShowsPopularResponseMock } from '../data/shows/response/ShowsPopularResponseMock.ts';
 import { ShowsTrendingResponseMock } from '../data/shows/response/ShowsTrendingResponseMock.ts';
@@ -273,6 +274,12 @@ export const shows = [
     `http://localhost/v3/media/show/${ShowSiloResponseMock.ids.slug}/info/0/version/1`,
     () => {
       return HttpResponse.json(ShowSiloSentimentResponseMock);
+    },
+  ),
+  http.get(
+    `http://localhost/v3/media/show/${ShowSiloResponseMock.ids.slug}/info/15/version/1`,
+    () => {
+      return HttpResponse.json(ShowSiloSoundtrackResponseMock);
     },
   ),
   http.get(

--- a/projects/client/src/style/layout/index.scss
+++ b/projects/client/src/style/layout/index.scss
@@ -126,6 +126,12 @@
   --width-trivia-card: min(var(--ni-480), 85vw);
   --height-trivia-card: var(--ni-308);
 
+  --height-soundtrack-row: var(--ni-44);
+  // Spotify's 152px embed lays out artwork, progress and Save side by side and
+  // clips itself under roughly 20rem of width.
+  --width-soundtrack-panel: var(--ni-340);
+  --height-soundtrack-panel-compact: var(--ni-80);
+
   --width-comment-thread-card: var(--width-comment-card);
   --height-comment-thread-card: var(--ni-480);
 

--- a/projects/client/src/style/theme/modes.scss
+++ b/projects/client/src/style/theme/modes.scss
@@ -252,6 +252,10 @@
     var(--shade-20) 0%,
     color-mix(in srgb, var(--purple-950) 10%, var(--shade-10)) 100%
   );
+  --color-soundtrack-row-active-background: var(--purple-50);
+  --color-soundtrack-play-background: var(--purple-600);
+  --color-soundtrack-play-foreground: var(--shade-10);
+
   --color-vip-popular-tag: #fdc700;
   --color-vip-border-accent: var(--purple-600);
   --color-vip-surface-muted: var(--purple-50);
@@ -715,6 +719,14 @@
     var(--purple-950) 0%,
     var(--shade-1000) 100%
   );
+  --color-soundtrack-row-active-background: color-mix(
+    in srgb,
+    var(--purple-950) 45%,
+    transparent
+  );
+  --color-soundtrack-play-background: var(--purple-500);
+  --color-soundtrack-play-foreground: var(--shade-10);
+
   --color-vip-popular-tag: #fdc700;
   --color-vip-border-accent: var(--purple-500);
   --color-vip-surface-muted: var(--purple-950);


### PR DESCRIPTION
Adds a soundtrack section to movie and show pages, behind a VIP-only preview
feature flag.

## What it is

A numbered tracklist in IMDb screen order, with a Spotify player pinned beside
it on desktop and above it as a sticky bar below that. Clicking a row plays the
track in place.

The section sits after Extras on both page types.

## The central design problem

Roughly 40% of credited tracks do not resolve to a Spotify track. That is not an
edge case, it is the shape of the data: resolution tracks how mainstream the
music is, so a blockbuster can be near-fully playable while an arthouse title is
mostly plain text.

So unmatched rows stay in the list, muted and without a play control, and the
section still reads as credits when nothing resolves at all. Ordering is
`position` as given and is never re-sorted to float playable tracks up, since
that is the one thing the field means.

## Gating

The endpoints are VIP-gated server-side and return an empty list to everyone
else, so an empty response is indistinguishable from "this title has no
soundtrack". Four states, deliberately:

| Viewer | Renders |
| --- | --- |
| Signed out | Blurred sample rows + upsell |
| Signed in, free | Same |
| VIP, has tracks | The section |
| VIP, no tracks | Nothing, matching Trivia |

Signed out and free get identical treatment because the client genuinely cannot
tell them apart, and neither may be shown something that reads as a bug.

## Playback

Spotify's iFrame API rather than a bare embed iframe: the plain embed needs a
second click inside Spotify's own UI before anything starts. One frame is
created on first play and reused for every later track.

Two things that cost time and are worth knowing:

- Spotify never reports `ready` for an iframe with no layout box, so the frame
  can never be `display: none`. The loading skeleton is an overlay on top of it.
- Spotify's card reflows after it reports ready, and again on every track
  change. The skeleton is held until playback actually reports in, so that
  reflow happens behind it. Placeholder, loading and playing all render into one
  box at the embed's own height, so nothing shifts between them.

CSP needed two new hosts: `frame-src` for the embed, and `script-src-elem` for
the iFrame API, whose bootstrap on `open.spotify.com` pulls the real script from
`embed-cdn.spotifycdn.com`. The policy lives in the app shell, which the service
worker caches, so clients only pick it up once the shell updates.

## matched_on

The payload says which rewording resolved each track. It is deliberately not in
the UI: it describes our matcher rather than the music, and an "approximate" tag
on a large share of rows buys doubt with no action attached. It rides the play
analytics event instead, which measures the same thing - whether fuzzy matches
get abandoned more often than exact ones.

## Notes for review

- No `@trakt/api` work needed. `/v3/media/.../info/...` is deliberately outside
  the SDK, so this follows the `rawApiFetch` + local Zod schema pattern that
  sentiment and trivia already use. `toMediaInfoPath` grows an `infoVersion`
  param defaulting to the 1 every existing caller sends.
- Only `infoType 15` is fetched. Nothing in the design needs `writer` or
  `label`, so `infoType 3` stays unread.
- Split layout needs 5 rows. Below that the list cannot sit beside a 152px
  player without the two columns disagreeing on height, so it falls back to the
  bar.
- The drawer (`?view=soundtrack`) has not been driven in a real VIP session yet.
