### PR TITLE
feat: invert lists cards posters

### DIFF
--- a/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
+++ b/projects/client/src/lib/sections/lists/components/list-summary/_internal/ListPosters.svelte
@@ -80,6 +80,7 @@
 
     position: absolute;
     inset-inline-start: calc(var(--poster-offset) * var(--poster-index));
+    z-index: calc(var(--poster-count) - var(--poster-index));
 
     height: var(--poster-height);
     width: var(--poster-width);

--- a/projects/client/src/lib/sections/lists/smart/_internal/SmartListSummaryItem.svelte
+++ b/projects/client/src/lib/sections/lists/smart/_internal/SmartListSummaryItem.svelte
@@ -285,6 +285,7 @@
 
     position: absolute;
     inset-inline-start: calc(var(--poster-offset) * var(--poster-index));
+    z-index: calc(var(--poster-count) - var(--poster-index));
 
     height: var(--poster-height);
     width: var(--poster-width);


### PR DESCRIPTION
- this was annyoing me for a bit, maybe it makes sense to change
- for lists cards the posters were layed out from right to left -> It might make more sense to change it to natural order which also matches what you see if you go into list items details

NOW:
<img width="369" height="294" alt="image" src="https://github.com/user-attachments/assets/e7be5b52-418e-4c9c-a883-3c78d2b2491e" />
<img width="1352" height="315" alt="image" src="https://github.com/user-attachments/assets/cbdebf33-33e9-4e1a-bb43-51a220c8b72e" />


AFTER: 

<img width="365" height="285" alt="image" src="https://github.com/user-attachments/assets/c8df8725-97ed-4013-9148-69e3e2d843c5" />
<img width="1359" height="321" alt="image" src="https://github.com/user-attachments/assets/29b70bc7-04f5-4958-a5f1-31b59ed04ab6" />
