### PR TITLE
fix(summary): keep the soundtrack section working at show-aggregate scale

### DIFF
--- a/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
@@ -30,10 +30,11 @@ type BlockType = { action: 'block' | 'unblock' };
 type ExtrasType = { slug: string; type: MediaVideoType };
 // `matched_on` records which rewording resolved the track. It is deliberately
 // absent from the UI and reported here instead, so match quality can be
-// measured against how often a track actually gets played.
+// measured against how often a track actually gets played. Left an open string
+// so a tier added upstream arrives as itself rather than as a neighbour.
 type SoundtrackType = SourceType & {
   position: number;
-  matched_on: 'credit' | 'title' | 'artist' | 'both';
+  matched_on: string;
 };
 type CommentType = { action: 'post' | 'reply' | 'edit' };
 type ReactionType = { action: 'add' | 'remove'; type: 'comment' };

--- a/projects/client/src/lib/requests/_internal/soundtrackInfo.ts
+++ b/projects/client/src/lib/requests/_internal/soundtrackInfo.ts
@@ -1,5 +1,9 @@
 // Spotify-resolved soundtrack credits. Every credited track is present; the
 // ones we could not resolve simply carry a null `spotify_id`.
+//
+// `position` is screen order within a movie, and sequence across the series on
+// a show aggregate. Either way it is a stable total order, which is why it is
+// the only thing sorted on.
 export const SOUNDTRACK_INFO = {
   infoType: 15,
   infoVersion: 1,

--- a/projects/client/src/lib/requests/models/SoundtrackResponse.ts
+++ b/projects/client/src/lib/requests/models/SoundtrackResponse.ts
@@ -5,9 +5,9 @@ export const SoundtrackResponseSchema = z.array(
     title: z.string(),
     performer: z.string().nullish(),
     spotify_id: z.string().nullish(),
-    // Records which rewording produced the match. Kept out of the UI; it
-    // travels with the play event so we can measure match quality.
-    matched_on: z.enum(['credit', 'title', 'artist', 'both']).nullish(),
+    // Not an enum on purpose: the matcher gains tiers, and an unrecognised
+    // one would fail the whole array, costing the reader the tracklist.
+    matched_on: z.string().nullish(),
     position: z.number(),
   }),
 );

--- a/projects/client/src/lib/requests/models/SoundtrackTrack.ts
+++ b/projects/client/src/lib/requests/models/SoundtrackTrack.ts
@@ -5,7 +5,7 @@ export const SoundtrackTrackSchema = z.object({
   title: z.string(),
   performer: z.string().nullish(),
   spotifyId: z.string().nullish(),
-  matchedOn: z.enum(['credit', 'title', 'artist', 'both']).nullish(),
+  matchedOn: z.string().nullish(),
   position: z.number(),
 });
 

--- a/projects/client/src/lib/requests/queries/movies/movieSoundtrackQuery.spec.ts
+++ b/projects/client/src/lib/requests/queries/movies/movieSoundtrackQuery.spec.ts
@@ -18,6 +18,24 @@ function query(locale: 'en' | 'pt-BR' = 'en') {
 }
 
 describe('movieSoundtrackQuery', () => {
+  it('should keep the tracklist when the matcher reports an unknown tier', async () => {
+    server.use(
+      http.get(path, () =>
+        HttpResponse.json(
+          MovieHereticSoundtrackResponseMock.map((entry, index) =>
+            index === 0 ? { ...entry, matched_on: 'writer' } : entry
+          ),
+        )),
+    );
+
+    const result = await runQuery({
+      factory: () => query(),
+      mapper: (response) => response?.data,
+    });
+
+    expect(result).to.have.length(MovieHereticSoundtrackResponseMock.length);
+  });
+
   it('should query for the movie soundtrack', async () => {
     const result = await runQuery({
       factory: () => query(),

--- a/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackBoard.svelte
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackBoard.svelte
@@ -56,7 +56,7 @@
     trackEvent({
       source,
       position: track.position,
-      matched_on: track.matchedOn ?? "credit",
+      matched_on: track.matchedOn ?? "unknown",
     });
   }
 </script>

--- a/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackBoard.svelte
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackBoard.svelte
@@ -3,13 +3,17 @@
   import { useTrack } from "$lib/features/analytics/useTrack";
   import type { MediaEntry } from "$lib/requests/models/MediaEntry";
   import type { SoundtrackTrack } from "$lib/requests/models/SoundtrackTrack";
+  import { whenInViewport } from "$lib/utils/actions/whenInViewport.ts";
   import SoundtrackPanel from "./SoundtrackPanel.svelte";
   import SoundtrackTrackRow from "./SoundtrackTrackRow.svelte";
   import type { SoundtrackSummary } from "./toSoundtrackSummary.ts";
 
-  // Below this the list is too short to sit beside a player without the two
-  // columns disagreeing on height, so the panel becomes a bar instead.
-  const minimumSplitRows = 5;
+  // The player needs more height than a short tracklist provides, so the split
+  // board is floored at this many rows rather than dropping the player.
+  const panelMinimumRows = 5;
+  // A show aggregates every episode, so this list runs to several hundred
+  // rows. Reveal it in chunks as the reader reaches the end of one.
+  const chunkSize = 50;
 
   const {
     media,
@@ -32,6 +36,14 @@
   let selectedKey = $state<string | null>(null);
   let playToken = $state(0);
   let isPlaying = $state(false);
+  let revealedCount = $state(chunkSize);
+
+  const visibleTracks = $derived(tracks.slice(0, revealedCount));
+  const hasHiddenTracks = $derived(revealedCount < tracks.length);
+
+  function revealNextChunk() {
+    revealedCount = Math.min(revealedCount + chunkSize, tracks.length);
+  }
 
   // Only the rows on screen are clickable, so a match further down the full
   // list does not earn a player.
@@ -40,11 +52,6 @@
   );
   const selected = $derived(
     tracks.find((track) => track.key === selectedKey) ?? null,
-  );
-  const effectiveLayout = $derived(
-    layout === "split" && tracks.length >= minimumSplitRows
-      ? "split"
-      : "stacked",
   );
 
   function onPlay(track: SoundtrackTrack) {
@@ -64,8 +71,8 @@
 <div
   class="trakt-soundtrack-board"
   class:has-player={hasPlayableRow}
-  data-layout={effectiveLayout}
-  style="--rows-shown: {tracks.length}"
+  data-layout={layout}
+  style="--rows-shown: {visibleTracks.length}; --min-rows: {panelMinimumRows}"
 >
   {#if hasPlayableRow}
     <SoundtrackPanel
@@ -75,13 +82,13 @@
       playable={summary.playable}
       track={selected}
       {playToken}
-      layout={effectiveLayout}
+      {layout}
       onPlayingChange={(value) => (isPlaying = value)}
     />
   {/if}
 
   <ul class="board-list">
-    {#each tracks as track (track.key)}
+    {#each visibleTracks as track (track.key)}
       <SoundtrackTrackRow
         {track}
         isPlaying={isPlaying && selectedKey === track.key}
@@ -90,18 +97,31 @@
       />
     {/each}
   </ul>
+
+  {#if hasHiddenTracks}
+    <!-- Outside the list so the list box stays exactly as tall as its rows,
+         and keyed so each chunk gets a fresh element: `whenInViewport` is
+         one-shot and stops observing after it fires. -->
+    {#key revealedCount}
+      <div class="board-sentinel" use:whenInViewport={revealNextChunk}></div>
+    {/key}
+  {/if}
 </div>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  /* One token sizes both columns: the row count drives the list height and the
-     panel stretches to it, so the two never disagree. */
+  /* Flex rather than grid so the sticky panel's containing block is the whole
+     board: a sticky grid item cannot leave its own row. */
   .trakt-soundtrack-board {
-    display: grid;
-    grid-auto-rows: min-content;
-    grid-template-columns: minmax(0, 1fr);
+    display: flex;
+    flex-direction: column;
     gap: var(--ni-8);
+  }
+
+  .board-sentinel {
+    flex: none;
+    height: 1px;
   }
 
   .board-list {
@@ -123,13 +143,19 @@
     box-shadow: var(--shadow-base);
   }
 
+  /* Side by side, and only here: one token sizes both columns so the list and
+     the player beside it can never disagree on height. */
   .trakt-soundtrack-board[data-layout="split"] {
     @include for-desktop {
+      display: grid;
       grid-auto-rows: auto;
+      grid-template-columns: minmax(0, 1fr);
       gap: var(--ni-12);
       align-items: stretch;
 
-      height: calc(var(--rows-shown) * var(--height-soundtrack-row));
+      height: calc(
+        max(var(--rows-shown), var(--min-rows)) * var(--height-soundtrack-row)
+      );
 
       /* Nothing resolved: the panel is dropped and the credit list runs the
          full width. */

--- a/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackPanel.svelte
+++ b/projects/client/src/lib/sections/summary/components/soundtrack/_internal/SoundtrackPanel.svelte
@@ -326,15 +326,42 @@
     margin: 0;
   }
 
+  /* Above the list rather than beside it, so it has to survive the list
+     scrolling past. */
+  @mixin sticky-bar {
+    position: sticky;
+    inset-block-start: var(--ni-8);
+    z-index: var(--layer-base);
+  }
+
   .trakt-soundtrack-panel[data-layout="stacked"] {
-    height: var(--height-soundtrack-panel-compact);
+    height: auto;
+    /* Flush to the top of the scrollport and opaque edge to edge: it floats
+       over the list, so a rounded corner, a shadow or an offset band all read
+       as rows sliding through the bar. */
     padding: 0;
 
-    background-color: transparent;
+    background-color: var(--color-background);
     box-shadow: none;
+
+    @include sticky-bar;
+
+    inset-block-start: 0;
+
+    .panel-media,
+    .media-overlay {
+      height: var(--height-soundtrack-panel-compact);
+    }
 
     .media-overlay {
       background-color: var(--color-card-background);
+      /* Square against the top edge. The lift is cast downward only - the
+         negative spread cancels the offset, so nothing paints above the bar
+         where the list would show through it. */
+      border-start-start-radius: 0;
+      border-start-end-radius: 0;
+      box-shadow: 0 var(--ni-8) var(--ni-16) calc(-1 * var(--ni-8))
+        color-mix(in srgb, var(--color-shadow) 45%, transparent);
     }
 
     /* The compact card draws a smaller glyph. */
@@ -347,11 +374,11 @@
     }
   }
 
+  /* Below desktop the split board stacks too, so the panel becomes a bar
+     there without the prop changing. */
   @include for-tablet-lg-and-below {
-    .trakt-soundtrack-panel {
-      position: sticky;
-      inset-block-start: var(--ni-8);
-      z-index: var(--layer-base);
+    .trakt-soundtrack-panel[data-layout="split"] {
+      @include sticky-bar;
     }
   }
 </style>


### PR DESCRIPTION
Follow-up to the soundtrack section. The backend changed underneath it: the
matcher gained a tier, and a show's soundtrack now aggregates every episode
instead of coming from its series page.

## 1. Production bug: a new matcher tier emptied the section

`matched_on` was a closed enum. The matcher has since gained a tier the enum
does not list, and a value outside it makes the whole array parse throw - so
the query never emits and the reader loses the entire tracklist, not one
field. Any title containing such a match currently renders no soundtrack at
all.

The field is never rendered; it exists to ride the play event. Failing closed
on it can only ever cost more than it protects, so rather than adding the one
tier it is a plain string now - in the response schema, the domain model and
the analytics payload. A tier added upstream shows up in the data as itself
instead of being mapped onto a neighbour, and the play event's fallback
reports an unresolved tier as `unknown` rather than claiming an exact credit
match it did not make.

Regression test covers an unrecognised tier keeping the list intact.

## 2. Show scale

Measured against a 290-track aggregate rendered in the real page at the real
row height. The page section already slices to five rows, so track count never
reaches it. Everything below is the drawer.

**The player scrolled out of reach.** Two causes, and fixing either alone would
not have worked. The `position: sticky` rule was scoped to a breakpoint the
drawer never matches, and the board was a CSS grid - a sticky grid item is
confined to its own row and cannot travel regardless of scope. The board is a
flex column now, so the panel's containing block is the whole board. Grid stays
for the split layout, which needs it for the two columns to resolve to one
height. Previously the player left the viewport entirely and playback continued
with no visible transport.

**Making it sticky then exposed three ways for the list to show through it.**
The panel's background was transparent, which was fine while it sat above the
list and wrong the moment it floated over one. It stuck six pixels down, leaving
an open band for rows to scroll through. And the inner card's rounded top
corners and shadow both paint outside the opaque box, so the leak survived
fixing the first two. The bar is flush at the top now, opaque edge to edge,
square against that edge, and its lift is cast downward only - the shadow's
negative spread cancels its offset, so nothing paints above the bar. Verified at
3x on a 390px viewport in both themes with a row parked behind the top edge.

**The drawer rendered every row on open** - 12,760px of list. It now reveals 50
at a time as a sentinel scrolls into view, opening at 2,200px. Two details worth
knowing for review: the sentinel sits outside the list, because the list box is
exactly as tall as its rows and would clip it; and it is keyed per chunk,
because `whenInViewport` is one-shot and a static sentinel would reveal exactly
one chunk and then stop.

This was never a performance problem - 3,491 DOM nodes, 247ms for 30 scroll
frames - it was a navigation one.

## 3. Short soundtracks keep the player

Unrelated to scale but found while testing it: the board fell back to a
full-width bar under five rows, because a two-row list is shorter than the
player beside it. Some titles return two tracks, and they lost the panel
entirely. The split board is floored at five rows instead, so both columns
still agree on height and the list simply ends before the bottom. The cost is
some empty surface under a very short list, which reads better than dropping
the player.

## 4. Ordering

`position` is still a stable total order and is still never re-sorted. On a
show aggregate it is sequence across the series rather than screen order within
an episode, so only the justification in the comment changes. No shipped copy
claims listening order, so nothing user-facing needed updating.

## Deferred, needs backend

Grouping a show's tracks by episode is the right end state, and `season` /
`episode` exist on infoType 3 only. Joining the two payloads client-side is not
viable: `position` differs between them and `(title, performer)` is not unique
within a show. Adding the two fields to infoType 15 keeps this a single fetch
and needs no join at all. Not attempted here.

## Note for whoever picks up the drawer next

Deep links to any summary drawer are dropped on show pages: `?view=...` is
stripped by the season sync and rewritten to `?season=1&mode=media`. This
affects trivia the same way, so it predates the soundtrack work and is not
touched here. In-app clicks are unaffected.
