### PR TITLE
List: retain sorting params when mode is switched

### DIFF
--- a/projects/client/src/lib/features/parameters/GlobalParameterProvider.spec.ts
+++ b/projects/client/src/lib/features/parameters/GlobalParameterProvider.spec.ts
@@ -1,0 +1,27 @@
+import GlobalParameterHost from '$test/beds/parameters/GlobalParameterHost.svelte';
+import { render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('GlobalParameterProvider', () => {
+  beforeEach(() => {
+    globalThis.window.history.pushState(
+      {},
+      '',
+      '/profile/userA?mode=movie&sort_by=rank&sort_how=asc',
+    );
+  });
+
+  it('should append its context parameters to anchors rendered under it', () => {
+    const { getByTestId } = render(GlobalParameterHost, {
+      props: { href: '?mode=movie', parameter: 'mode' },
+    });
+
+    const params = new URL(
+      (getByTestId('link') as HTMLAnchorElement).href,
+    ).searchParams;
+
+    expect(params.get('mode')).toBe('movie');
+    expect(params.get('sort_by')).toBe('rank');
+    expect(params.get('sort_how')).toBe('asc');
+  });
+});

--- a/projects/client/src/lib/features/parameters/GlobalParameterProvider.svelte
+++ b/projects/client/src/lib/features/parameters/GlobalParameterProvider.svelte
@@ -3,13 +3,15 @@
   import { sanitizeGlobalParameters } from "./_internal/sanitizeGlobalParameters";
   import { useParameters } from "./useParameters";
 
-  const { update } = useParameters();
+  const { update, setUrl } = useParameters();
 
   const { children }: ChildrenProps = $props();
 
   update(sanitizeGlobalParameters(page.url.searchParams));
 
   $effect(() => {
+    setUrl(page.url);
+
     const sanitizedParams = sanitizeGlobalParameters(page.url.searchParams);
     update(sanitizedParams);
   });

--- a/projects/client/src/lib/features/parameters/_internal/createParameterContext.ts
+++ b/projects/client/src/lib/features/parameters/_internal/createParameterContext.ts
@@ -1,4 +1,3 @@
-import { afterNavigate } from '$app/navigation';
 import { page } from '$app/state';
 import { BehaviorSubject } from 'rxjs';
 import { getContext, setContext } from 'svelte';
@@ -10,21 +9,12 @@ export const PARAMETER_SETTER_CONTEXT_KEY = Symbol('parameters_setter');
 export const PARAMETER_ESCAPE_KEY = Symbol('parameters_escape');
 
 export function createParameterContext() {
-  const params = new BehaviorSubject(page.params);
-  const search = new BehaviorSubject(page.url.searchParams);
-  const url = new BehaviorSubject(page.url);
-
-  afterNavigate(() => {
-    params.next(page.params);
-    search.next(page.url.searchParams);
-    url.next(page.url);
-  });
-
   const ctx = setContext(
     PARAMETER_CONTEXT_KEY,
     getContext<ParameterContextData>(PARAMETER_CONTEXT_KEY) ??
       {
         parameters: new BehaviorSubject(new Map<string, ParameterType>()),
+        url: new BehaviorSubject(page.url),
       },
   );
 

--- a/projects/client/src/lib/features/parameters/appendGlobalParameters.spec.ts
+++ b/projects/client/src/lib/features/parameters/appendGlobalParameters.spec.ts
@@ -5,11 +5,12 @@ import { filterScopeStore } from '$lib/features/filters/filterScopeStore.ts';
 import { appendGlobalParameters } from './appendGlobalParameters.ts';
 import {
   PARAMETER_CONTEXT_KEY,
+  PARAMETER_SETTER_CONTEXT_KEY,
   type ParameterType,
 } from './_internal/createParameterContext.ts';
 
 let pageUrl = new URL('https://app.trakt.tv/profile/userA');
-let afterNavigateCallback: (() => void) | undefined;
+let urlSubject = new BehaviorSubject(pageUrl);
 
 vi.mock('$app/state', () => ({
   page: {
@@ -19,12 +20,6 @@ vi.mock('$app/state', () => ({
     get url() {
       return pageUrl;
     },
-  },
-}));
-
-vi.mock('$app/navigation', () => ({
-  afterNavigate: (cb: () => void) => {
-    afterNavigateCallback = cb;
   },
 }));
 
@@ -43,13 +38,13 @@ vi.mock('svelte', async (importOriginal) => {
 });
 
 /**
- * Changes jsdom's window.location.href (which appendGlobalParameters resolves
- * relative hrefs against) and fires any afterNavigate callback.
+ * Mimics a navigation: moves jsdom's location and publishes the new URL on the
+ * shared context subject, the way GlobalParameterProvider does.
  */
 function navigate(pathname: string) {
   globalThis.window.history.pushState({}, '', pathname);
   pageUrl = new URL(pathname, globalThis.window.location.href);
-  afterNavigateCallback?.();
+  urlSubject.next(pageUrl);
 }
 
 function makeAnchor(href: string): HTMLAnchorElement {
@@ -63,9 +58,10 @@ function makeAnchor(href: string): HTMLAnchorElement {
  * Seeds the live parameter context so useParameters().search emits the given
  * filters, mimicking filters currently applied to the page.
  */
-function seedLiveParams(params: Record<string, ParameterType>) {
+function seedLiveParams(params: Record<string, ParameterType> = {}) {
   mockSvelteContextStore.set(PARAMETER_CONTEXT_KEY, {
     parameters: new BehaviorSubject(new Map(Object.entries(params))),
+    url: urlSubject,
   });
 }
 
@@ -74,7 +70,8 @@ describe('appendGlobalParameters', () => {
     mockSvelteContextStore.clear();
     globalThis.window.history.pushState({}, '', '/profile/userA');
     pageUrl = new URL('/profile/userA', globalThis.window.location.href);
-    afterNavigateCallback = undefined;
+    urlSubject = new BehaviorSubject(pageUrl);
+    seedLiveParams();
     // Default to global scope; local-scope tests opt in explicitly.
     filterScopeStore.next(null);
   });
@@ -185,6 +182,23 @@ describe('appendGlobalParameters', () => {
     );
   });
 
+  it('picks up local sort params applied after mount (same-path mode toggle)', () => {
+    mockSvelteContextStore.set(
+      PARAMETER_SETTER_CONTEXT_KEY,
+      new BehaviorSubject('mode'),
+    );
+
+    const anchor = makeAnchor('?mode=movie');
+    appendGlobalParameters(anchor, '?mode=movie');
+
+    navigate('/profile/userA?sort_by=rank&sort_how=asc');
+
+    const params = new URL(anchor.href).searchParams;
+    expect(params.get('sort_by')).toBe('rank');
+    expect(params.get('sort_how')).toBe('asc');
+    expect(params.get('mode')).toBe('movie');
+  });
+
   it('unsubscribes from the RxJS stream on destroy', () => {
     const anchor = makeAnchor('/profile/userA');
     const action = appendGlobalParameters(anchor, '/profile/userA');
@@ -192,13 +206,8 @@ describe('appendGlobalParameters', () => {
     const hrefAfterMount = anchor.href;
     action.destroy();
 
-    // After destroy the subscription is gone. navigate() fires afterNavigate
-    // which would update the BehaviorSubjects inside createParameterContext,
-    // potentially re-triggering applyParams via the subscription, but it won't
-    // because the subscription has been torn down.
     navigate('/profile/userB');
 
-    // href must not have been mutated by the subscription firing
     expect(anchor.href).toBe(hrefAfterMount);
   });
 });

--- a/projects/client/src/lib/features/parameters/appendGlobalParameters.ts
+++ b/projects/client/src/lib/features/parameters/appendGlobalParameters.ts
@@ -11,6 +11,14 @@ import { useParameters } from '$lib/features/parameters/useParameters.ts';
 import { buildParamString } from '$lib/utils/url/buildParamString.ts';
 import { combineLatest } from 'rxjs';
 
+type ParameterSnapshot = [
+  URLSearchParams,
+  string,
+  boolean,
+  FilterScopeValue,
+  URL,
+];
+
 function buildEffectiveSearch({
   search,
   filterScope,
@@ -38,34 +46,31 @@ export function appendGlobalParameters(
   anchor: HTMLAnchorElement,
   href?: string | Nil,
 ) {
-  const { search, override, isEscaped } = useParameters();
+  const { search, override, isEscaped, url } = useParameters();
 
   // Track the original href separately — anchor.href gets mutated by applyParams,
   // so we can't re-read it on subsequent calls. The update() callback keeps this
   // in sync when the action parameter changes reactively.
   let originalHref = href ?? anchor.getAttribute('href') ?? '';
 
-  let latestValues:
-    | [URLSearchParams, string, boolean, FilterScopeValue]
-    | null = null;
+  let latestValues: ParameterSnapshot | null = null;
 
   const applyParams = () => {
     if (!latestValues) return;
 
-    const [$search, $override, $isEscaped, $filterScope] = latestValues;
+    const [$search, $override, $isEscaped, $filterScope, $url] = latestValues;
 
     if ($isEscaped) return;
 
-    const url = new URL(originalHref, globalThis.window.location.href);
+    const target = new URL(originalHref, $url.href);
 
-    const isExternal = globalThis.window.location.origin !== url.origin;
+    const isExternal = $url.origin !== target.origin;
     if (isExternal) return;
 
-    const currentUrl = new URL(globalThis.window.location.href);
-    const isSamePath = url.pathname === currentUrl.pathname;
+    const isSamePath = target.pathname === $url.pathname;
 
     const localParams = isSamePath && Boolean($override)
-      ? Array.from(currentUrl.searchParams.entries())
+      ? Array.from($url.searchParams.entries())
         .filter(([key]) => LOCAL_PARAMS.includes(key))
       : [];
 
@@ -80,20 +85,20 @@ export function appendGlobalParameters(
 
     const params = Object.fromEntries([
       ...localParams,
-      ...Array.from(url.searchParams.entries())
+      ...Array.from(target.searchParams.entries())
         .filter(([key]) =>
           key === $override || !WHITE_LISTED_PARAMS.includes(key)
         ),
       ...effectiveSearch.entries(),
     ]);
 
-    anchor.href = `${url.pathname}${buildParamString(params)}`;
+    anchor.href = `${target.pathname}${buildParamString(params)}`;
   };
 
   const subscription = combineLatest(
-    [search, override, isEscaped, filterScopeStore],
+    [search, override, isEscaped, filterScopeStore, url],
   ).subscribe({
-    next: (values: [URLSearchParams, string, boolean, FilterScopeValue]) => {
+    next: (values: ParameterSnapshot) => {
       latestValues = values;
       applyParams();
     },

--- a/projects/client/src/lib/features/parameters/useParameters.ts
+++ b/projects/client/src/lib/features/parameters/useParameters.ts
@@ -11,10 +11,11 @@ import {
 
 export type ParameterContextData = {
   parameters: BehaviorSubject<Map<string, ParameterType>>;
+  url: BehaviorSubject<URL>;
 };
 
 export function useParameters() {
-  const { parameters, override, isEscaped } = createParameterContext();
+  const { parameters, url, override, isEscaped } = createParameterContext();
 
   function update(params: Record<string, ParameterType>) {
     const current = parameters.value;
@@ -56,5 +57,7 @@ export function useParameters() {
     update,
     override,
     isEscaped,
+    url: url.asObservable(),
+    setUrl: (next: URL) => url.next(next),
   };
 }

--- a/projects/client/test/beds/parameters/GlobalParameterHost.svelte
+++ b/projects/client/test/beds/parameters/GlobalParameterHost.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { appendGlobalParameters } from "$lib/features/parameters/appendGlobalParameters";
+  import GlobalParameterProvider from "$lib/features/parameters/GlobalParameterProvider.svelte";
+  import GlobalParameterSetter from "$lib/features/parameters/GlobalParameterSetter.svelte";
+
+  type GlobalParameterHostProps = {
+    href: string;
+    parameter: string;
+  };
+
+  const { href, parameter }: GlobalParameterHostProps = $props();
+</script>
+
+<GlobalParameterProvider>
+  <GlobalParameterSetter {parameter}>
+    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+    <a data-testid="link" use:appendGlobalParameters={href} {href}>link</a>
+  </GlobalParameterSetter>
+</GlobalParameterProvider>


### PR DESCRIPTION
# Problem

On list detail pages, switching the mode via the top-of-page toggles (e.g. movies only) dropped the active sorting: the resulting URL kept only the `mode` query param. The mode filters in the filter drawer preserved sorting correctly.

Fixes #3046

# Root cause

The mode toggle anchors get their hrefs rewritten by the `appendGlobalParameters` action, which is responsible for carrying the page-local `sort_by`/`sort_how` params onto same-path links. That rewrite only re-ran when one of its subscribed streams (`search`, `override`, `isEscaped`, `filterScopeStore`) emitted. Changing the sorting is a same-path navigation that touches only local params, none of the whitelisted global ones, so nothing emitted and the toggle's href stayed frozen at its mount-time value (`?mode=movie` with no sort params). Clicking the toggle then navigated to that stale URL, wiping the sort.

The filter drawer toggles were unaffected because `applyFilterToUrl` builds from the live `page.url` at click time.

# Fix

`createParameterContext` was already maintaining a `url` BehaviorSubject via `afterNavigate` but never exposed it (dead code, along with two other unused subjects which are now removed). This PR exposes it through `useParameters` and adds it to the action's `combineLatest`, so anchor hrefs are recomputed after every navigation. `applyParams` already reads the current location live, so it picks up the sort params on re-run.

# Testing

Added a regression spec: mount a `?mode=movie` anchor under a `mode` override context, navigate to a URL with `sort_by=rank&sort_how=asc`, and assert the rewritten href contains both the sort params and the mode.
