### PR TITLE
List: TBA sort heading

### DIFF
--- a/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.spec.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.spec.ts
@@ -1,7 +1,7 @@
 import type { ListItem } from '$lib/requests/models/ListItem.ts';
 import { describe, expect, it } from 'vitest';
 import { MAX_DATE } from '../../../../utils/constants.ts';
-import { formatSortValue } from './formatSortValue.ts';
+import { formatSortValue, groupByReleased } from './formatSortValue.ts';
 
 describe('formatSortValue', () => {
   describe('sortBy: added', () => {
@@ -135,6 +135,24 @@ describe('formatSortValue', () => {
         },
       } as unknown as ListItem;
       expect(formatSortValue(seasonItem, 'title')).toBe('T');
+    });
+  });
+
+  describe('groupByReleased', () => {
+    it('should return release year if valid date', () => {
+      const validDateItem = {
+        type: 'movie',
+        entry: { airDate: new Date('2023-02-01') },
+      } as unknown as ListItem;
+      expect(groupByReleased(validDateItem)).toBe('2023');
+    });
+
+    it('should return TBA if max date', () => {
+      const maxDateItem = {
+        type: 'movie',
+        entry: { airDate: MAX_DATE },
+      } as unknown as ListItem;
+      expect(groupByReleased(maxDateItem)).toBe('TBA');
     });
   });
 

--- a/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
+++ b/projects/client/src/lib/sections/lists/user/_internal/formatSortValue.ts
@@ -154,5 +154,6 @@ export function groupByAdded(item: SortInput): string {
 }
 
 export function groupByReleased(item: SortInput): string {
-  return String(getAirDate(item).getFullYear());
+  const airDate = getAirDate(item);
+  return isMaxDate(airDate) ? m.tag_text_tba() : String(airDate.getFullYear());
 }


### PR DESCRIPTION
# Summary

Fixes the release-date group header for items without a release date on list detail pages. Items using the `MAX_DATE` sentinel (year 10000) were grouped under a literal `10000` heading; they now group under the localized TBA label, matching the tag the `released` sort already renders per item.

<img width="1104" height="391" alt="image" src="https://github.com/user-attachments/assets/2445f9f6-b419-4f28-8168-2d47f1a0aac8" />

# Changes

- `groupByReleased` now checks `isMaxDate` and returns `m.tag_text_tba()` instead of the sentinel year.
- Added spec coverage for `groupByReleased` (real date year and `MAX_DATE` → TBA).

Closes #3047