### PR TITLE
fix(credits): fall back to a populated department when the default has no credits

### DIFF
--- a/projects/client/src/lib/sections/lists/CreditsList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsList.svelte
@@ -8,17 +8,18 @@
     CrewPosition,
     CrewPositions,
   } from "$lib/requests/models/CrewPosition";
-  import type { MediaCredits } from "$lib/requests/models/MediaCredits";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import type { PersonSummary } from "$lib/requests/models/PersonSummary";
   import { useDefaultCardVariant } from "$lib/stores/useDefaultCardVariant";
   import { fromRune } from "$lib/utils/store/fromRune.svelte";
+  import { buildParamString } from "$lib/utils/url/buildParamString";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
   import CreditMediaItem from "./components/CreditMediaItem.svelte";
   import CreditsPositionDropdown from "./components/CreditsPositionDropdown.svelte";
   import NoFilterResultsPlaceholder from "./drilldown/_internal/NoFilterResultsPlaceholder.svelte";
   import { useCreditsList } from "./stores/useCreditsList";
   import { mediaListHeightResolver } from "./utils/mediaListHeightResolver";
+  import { resolveSelectedPosition } from "./utils/resolveSelectedPosition";
 
   type CreditsListProps = {
     title: string;
@@ -34,13 +35,6 @@
   const { filterMap, hasActiveFilter } = useFilter();
   const { mode } = useDiscover();
 
-  const selectedPosition = $derived.by(() => {
-    const defaultPosition = person.knownFor ?? "acting";
-    const position = positions?.[`${type}s`];
-
-    return position ?? defaultPosition;
-  });
-
   const {
     credits,
     isLoading,
@@ -52,16 +46,22 @@
     mode$: mode,
   });
 
-  const getPositionList = (mediaCredits?: MediaCredits) => {
-    if (!mediaCredits) return [];
-    return mediaCredits.get(selectedPosition) ?? [];
-  };
+  const requestedPosition = $derived(
+    positions?.[`${type}s`] ?? person.knownFor ?? "acting",
+  );
+  const selectedPosition = $derived(
+    resolveSelectedPosition({ requested: requestedPosition, credits: $credits }),
+  );
 
-  const list = $derived(getPositionList($credits));
+  const list = $derived($credits?.get(selectedPosition) ?? []);
   const defaultVariant = $derived(useDefaultCardVariant(type));
 
   const drilldownHref = $derived(
-    drilldownLink ? `${drilldownLink}?${type}s=${selectedPosition}` : undefined,
+    drilldownLink
+      ? `${drilldownLink}${
+          buildParamString({ [`${type}s`]: selectedPosition })
+        }`
+      : undefined,
   );
 
   const buildPositionHref = (position: CrewPosition) => {

--- a/projects/client/src/lib/sections/lists/CreditsPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsPaginatedList.svelte
@@ -3,16 +3,13 @@
   import GridList from "$lib/components/lists/grid-list/GridList.svelte";
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import { useFilter } from "$lib/features/filters/useFilter";
-  import {
-    crewPositionSchema,
-    type CrewPosition,
-  } from "$lib/requests/models/CrewPosition";
-  import type { MediaCredits } from "$lib/requests/models/MediaCredits";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { fromRune } from "$lib/utils/store/fromRune.svelte";
   import CreditMediaItem from "./components/CreditMediaItem.svelte";
   import NoFilterResultsPlaceholder from "./drilldown/_internal/NoFilterResultsPlaceholder.svelte";
   import { useCreditsList } from "./stores/useCreditsList";
+  import { parseRequestedPosition } from "./utils/parseRequestedPosition";
+  import { resolveSelectedPosition } from "./utils/resolveSelectedPosition";
 
   type CreditsPaginatedListProps = {
     slug: string;
@@ -24,12 +21,6 @@
   const { filterMap, hasActiveFilter } = useFilter();
   const { mode } = useDiscover();
 
-  const selectedPosition = $derived<CrewPosition>(
-    crewPositionSchema.safeParse(
-      page.url.searchParams.get(`${type}s`)?.toLowerCase(),
-    ).data ?? "acting",
-  );
-
   const { credits, isLoading } = useCreditsList({
     type$: fromRune(() => type),
     slug$: fromRune(() => slug),
@@ -37,12 +28,12 @@
     mode$: mode,
   });
 
-  const getPositionList = (mediaCredits?: MediaCredits) => {
-    if (!mediaCredits) return [];
-    return mediaCredits.get(selectedPosition) ?? [];
-  };
+  const requestedPosition = $derived(parseRequestedPosition(page.url, type));
+  const selectedPosition = $derived(
+    resolveSelectedPosition({ requested: requestedPosition, credits: $credits }),
+  );
 
-  const list = $derived(getPositionList($credits));
+  const list = $derived($credits?.get(selectedPosition) ?? []);
   const hasMatchingType = $derived($mode === "media" || $mode === type);
 </script>
 

--- a/projects/client/src/lib/sections/lists/components/CreditsPositionDropdown.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditsPositionDropdown.svelte
@@ -30,11 +30,13 @@
   };
 </script>
 
-<SingleSelect
-  {options}
-  value={selectedPosition}
-  placeholder={m.dropdown_label_person_position()}
-  disabled={allPositions.length <= 1}
-  autoWidth
-  onChange={onPositionChange}
-/>
+{#if allPositions.length > 0}
+  <SingleSelect
+    {options}
+    value={selectedPosition}
+    placeholder={m.dropdown_label_person_position()}
+    disabled={allPositions.length <= 1}
+    autoWidth
+    onChange={onPositionChange}
+  />
+{/if}

--- a/projects/client/src/lib/sections/lists/components/CreditsPositionSelector.svelte
+++ b/projects/client/src/lib/sections/lists/components/CreditsPositionSelector.svelte
@@ -2,13 +2,12 @@
   import { page } from "$app/state";
   import { useDiscover } from "$lib/features/filters/useDiscover";
   import { useFilter } from "$lib/features/filters/useFilter";
-  import {
-    crewPositionSchema,
-    type CrewPosition,
-  } from "$lib/requests/models/CrewPosition";
+  import type { CrewPosition } from "$lib/requests/models/CrewPosition";
   import type { MediaType } from "$lib/requests/models/MediaType";
   import { fromRune } from "$lib/utils/store/fromRune.svelte";
   import { useCreditsList } from "../stores/useCreditsList";
+  import { parseRequestedPosition } from "../utils/parseRequestedPosition";
+  import { resolveSelectedPosition } from "../utils/resolveSelectedPosition";
   import CreditsPositionDropdown from "./CreditsPositionDropdown.svelte";
 
   type CreditsPositionSelectorProps = {
@@ -18,21 +17,20 @@
 
   const { slug, type }: CreditsPositionSelectorProps = $props();
 
-  const selectedPosition = $derived<CrewPosition>(
-    crewPositionSchema.safeParse(
-      page.url.searchParams.get(`${type}s`)?.toLowerCase(),
-    ).data ?? "acting",
-  );
-
   const { filterMap } = useFilter();
   const { mode } = useDiscover();
 
-  const { positions: allPositions } = useCreditsList({
+  const { credits, positions: allPositions } = useCreditsList({
     type$: fromRune(() => type),
     slug$: fromRune(() => slug),
     filter$: filterMap,
     mode$: mode,
   });
+
+  const requestedPosition = $derived(parseRequestedPosition(page.url, type));
+  const selectedPosition = $derived(
+    resolveSelectedPosition({ requested: requestedPosition, credits: $credits }),
+  );
 
   const buildPositionHref = (position: CrewPosition) => {
     const url = new URL(page.url.toString());

--- a/projects/client/src/lib/sections/lists/utils/parseRequestedPosition.spec.ts
+++ b/projects/client/src/lib/sections/lists/utils/parseRequestedPosition.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { parseRequestedPosition } from './parseRequestedPosition.ts';
+
+describe('util: parseRequestedPosition', () => {
+  it('should parse a valid position from the type-scoped search param', () => {
+    const url = new URL('https://trakt.tv/people/jane-doe?movies=directing');
+
+    const result = parseRequestedPosition(url, 'movie');
+
+    expect(result).toBe('directing');
+  });
+
+  it('should match the search param case-insensitively', () => {
+    const url = new URL('https://trakt.tv/people/jane-doe?shows=Directing');
+
+    const result = parseRequestedPosition(url, 'show');
+
+    expect(result).toBe('directing');
+  });
+
+  it('should default to acting when the search param is missing', () => {
+    const url = new URL('https://trakt.tv/people/jane-doe');
+
+    const result = parseRequestedPosition(url, 'movie');
+
+    expect(result).toBe('acting');
+  });
+
+  it('should default to acting when the search param is not a known position', () => {
+    const url = new URL('https://trakt.tv/people/jane-doe?movies=bogus');
+
+    const result = parseRequestedPosition(url, 'movie');
+
+    expect(result).toBe('acting');
+  });
+});

--- a/projects/client/src/lib/sections/lists/utils/parseRequestedPosition.ts
+++ b/projects/client/src/lib/sections/lists/utils/parseRequestedPosition.ts
@@ -1,0 +1,14 @@
+import {
+  type CrewPosition,
+  crewPositionSchema,
+} from '$lib/requests/models/CrewPosition.ts';
+import type { MediaType } from '$lib/requests/models/MediaType.ts';
+
+export function parseRequestedPosition(
+  url: URL,
+  type: MediaType,
+): CrewPosition {
+  return crewPositionSchema.safeParse(
+    url.searchParams.get(`${type}s`)?.toLowerCase(),
+  ).data ?? 'acting';
+}

--- a/projects/client/src/lib/sections/lists/utils/resolveSelectedPosition.spec.ts
+++ b/projects/client/src/lib/sections/lists/utils/resolveSelectedPosition.spec.ts
@@ -1,0 +1,78 @@
+import type { CrewPosition } from '$lib/requests/models/CrewPosition.ts';
+import type {
+  MediaCredit,
+  MediaCredits,
+} from '$lib/requests/models/MediaCredits.ts';
+import { describe, expect, it } from 'vitest';
+import { resolveSelectedPosition } from './resolveSelectedPosition.ts';
+
+function creditsOf(
+  counts: Partial<Record<CrewPosition, number>>,
+): MediaCredits {
+  return new Map(
+    Object.entries(counts).map(([position, count]) => [
+      position as CrewPosition,
+      Array(count).fill({}) as MediaCredit[],
+    ]),
+  );
+}
+
+describe('util: resolveSelectedPosition', () => {
+  it('should honor the requested position when it has credits', () => {
+    const credits = creditsOf({ acting: 10, directing: 1 });
+
+    const result = resolveSelectedPosition({
+      requested: 'directing',
+      credits,
+    });
+
+    expect(result).toBe('directing');
+  });
+
+  it('should fall back to the highest-count position when requested has no credits', () => {
+    const credits = creditsOf({ acting: 2, directing: 5 });
+
+    const result = resolveSelectedPosition({ requested: 'writing', credits });
+
+    expect(result).toBe('directing');
+  });
+
+  it('should fall back to self when it is the only credit area', () => {
+    const credits = creditsOf({ self: 3 });
+
+    const result = resolveSelectedPosition({ requested: 'acting', credits });
+
+    expect(result).toBe('self');
+  });
+
+  it('should fall back to unknown when it is the only credit area', () => {
+    const credits = creditsOf({ unknown: 2 });
+
+    const result = resolveSelectedPosition({ requested: 'acting', credits });
+
+    expect(result).toBe('unknown');
+  });
+
+  it('should prefer acting over self even when self has more credits', () => {
+    const credits = creditsOf({ acting: 1, self: 5 });
+
+    const result = resolveSelectedPosition({ requested: 'unknown', credits });
+
+    expect(result).toBe('acting');
+  });
+
+  it('should return the requested position when no credits have loaded yet', () => {
+    const result = resolveSelectedPosition({
+      requested: 'acting',
+      credits: new Map(),
+    });
+
+    expect(result).toBe('acting');
+  });
+
+  it('should return the requested position when credits is undefined', () => {
+    const result = resolveSelectedPosition({ requested: 'acting' });
+
+    expect(result).toBe('acting');
+  });
+});

--- a/projects/client/src/lib/sections/lists/utils/resolveSelectedPosition.ts
+++ b/projects/client/src/lib/sections/lists/utils/resolveSelectedPosition.ts
@@ -1,0 +1,33 @@
+import type { CrewPosition } from '$lib/requests/models/CrewPosition.ts';
+import type { MediaCredits } from '$lib/requests/models/MediaCredits.ts';
+
+const NON_PREFERRED_POSITIONS = new Set<CrewPosition>([
+  'self',
+  'narrator',
+  'unknown',
+]);
+
+type ResolveSelectedPositionParams = {
+  requested: CrewPosition;
+  credits?: MediaCredits;
+};
+
+export function resolveSelectedPosition(
+  { requested, credits }: ResolveSelectedPositionParams,
+): CrewPosition {
+  if (credits?.get(requested)?.length) return requested;
+
+  const available = Array.from(credits?.entries() ?? []).filter(
+    ([, list]) => list.length > 0,
+  );
+  if (available.length === 0) return requested;
+
+  const preferred = available.filter(
+    ([position]) => !NON_PREFERRED_POSITIONS.has(position),
+  );
+  const candidates = preferred.length > 0 ? preferred : available;
+
+  return candidates.reduce((max, current) =>
+    current[1].length > max[1].length ? current : max
+  )[0];
+}


### PR DESCRIPTION
Person summary credits could render an empty section for people whose only credits (for a given media type) are self, narrator, or unknown appearances - e.g. a documentary subject with no acting or crew credits at all. The default department now falls back to whichever department the person actually has credits in, ranked by count, instead of one that may not exist for them.

- Also fixes the department dropdown showing a generic "Position" placeholder instead of hiding itself when a person has zero credits for a media type entirely.

Mirrors the [equivalent fix shipped on iOS](https://github.com/trakt/trakt-apple-internal/pull/305), paired with a [matching fix on trakt-android](https://github.com/trakt/trakt-android/pull/322) in this same pass.

**Verification:**
- [x] `deno task test:unit` passes (new coverage: `resolveSelectedPosition.spec.ts`, `parseRequestedPosition.spec.ts`)
- [x] `deno task check` (svelte-check) is clean
- [x] Manually check the Credits section on a person's summary page, the "view all" drilldown grid, and the department dropdown - ideally for a person whose only credits are self-appearances, and separately for a person with zero credits in one media type entirely

Before:
<img width="1255" height="1280" alt="Screenshot 2026-08-04 at 2 19 26 pm Large" src="https://github.com/user-attachments/assets/939ea518-4662-4456-8e29-44412c91701c" />
After:
<img width="1255" height="1280" alt="Screenshot 2026-08-04 at 2 19 30 pm Large" src="https://github.com/user-attachments/assets/df7b6276-5a75-41b6-927e-0c4a02b489d6" />
