### PR TITLE
refactor(streak): show current streak before previous streak

### DIFF
--- a/projects/client/src/lib/sections/stats/StreakDrawerHost.svelte
+++ b/projects/client/src/lib/sections/stats/StreakDrawerHost.svelte
@@ -55,15 +55,15 @@
 
         <div class="trakt-monthly-stats-grid">
           {@render statCard(
-            $stats.previousStreak,
-            m.label_stats_previous_streak(),
-            m.text_stats_keep_it_going(),
-            toGroupedNumber,
-          )}
-          {@render statCard(
             $stats.currentStreak,
             m.label_stats_current_streak(),
             m.text_this_month(),
+            toGroupedNumber,
+          )}
+          {@render statCard(
+            $stats.previousStreak,
+            m.label_stats_previous_streak(),
+            m.text_stats_keep_it_going(),
             toGroupedNumber,
           )}
           {@render statCard(


### PR DESCRIPTION
Reorders the "Current Streak" and "Previous Streak" stat cards in the streak drawer so current streak comes first, matching trakt-android's card order. No logic change.

Before:
<img width="392" height="336" alt="Screenshot 2026-08-04 at 2 52 45 pm" src="https://github.com/user-attachments/assets/a80d29c9-e2eb-4390-aa00-f9f81a9dad6d" />
After:
<img width="398" height="353" alt="Screenshot 2026-08-04 at 2 52 52 pm" src="https://github.com/user-attachments/assets/5ff267f5-3bf5-4bac-9e13-f084cb1018cc" />

cc @ElMagnea 