### PR TITLE
fix(stats): scope monthly stats header and fix streak subtitles

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -8460,7 +8460,11 @@
     },
     "text_stats_keep_it_going": {
       "default": "Keep it going!",
-      "description": "Motivational sub-label shown below the previous streak stat."
+      "description": "Motivational sub-label shown below the current streak stat."
+    },
+    "text_stats_ended": {
+      "default": "Ended",
+      "description": "Sub-label shown below the previous streak stat, indicating that streak is no longer active."
     },
     "text_stats_out_of": {
       "default": "Out of {count}",

--- a/projects/client/src/lib/sections/stats/StreakDrawerHost.svelte
+++ b/projects/client/src/lib/sections/stats/StreakDrawerHost.svelte
@@ -62,7 +62,7 @@
           {@render statCard(
             $stats.previousStreak,
             m.label_stats_previous_streak(),
-            m.text_this_month(),
+            m.text_stats_ended(),
             toGroupedNumber,
           )}
         </div>

--- a/projects/client/src/lib/sections/stats/StreakDrawerHost.svelte
+++ b/projects/client/src/lib/sections/stats/StreakDrawerHost.svelte
@@ -33,7 +33,6 @@
 
     {#if $stats}
       <section class="trakt-monthly-stats">
-        <span class="bold">{m.header_stats_monthly()}</span>
         {#snippet statCard(
           value: number,
           label: string,
@@ -57,15 +56,20 @@
           {@render statCard(
             $stats.currentStreak,
             m.label_stats_current_streak(),
-            m.text_this_month(),
+            m.text_stats_keep_it_going(),
             toGroupedNumber,
           )}
           {@render statCard(
             $stats.previousStreak,
             m.label_stats_previous_streak(),
-            m.text_stats_keep_it_going(),
+            m.text_this_month(),
             toGroupedNumber,
           )}
+        </div>
+
+        <span class="bold monthly-stats-header">{m.header_stats_monthly()}</span>
+
+        <div class="trakt-monthly-stats-grid">
           {@render statCard(
             $stats.droppedStreaksThisMonth,
             m.label_stats_dropped_streaks(),
@@ -99,13 +103,17 @@
   .trakt-streak-drawer-content {
     display: flex;
     flex-direction: column;
-    gap: var(--gap-m);
+    gap: var(--gap-xl);
   }
 
   .trakt-monthly-stats {
     display: flex;
     flex-direction: column;
     gap: var(--gap-s);
+  }
+
+  .monthly-stats-header {
+    margin-top: var(--gap-xs);
   }
 
   .trakt-monthly-stats-grid {


### PR DESCRIPTION
Current/previous streak are all-time totals, not month-scoped, so grouping them under "Monthly Stats" alongside dropped-streak and active-day counts was misleading.

- Moves the "Monthly Stats" header to sit only above the cards that are actually month-scoped
- Swaps "Keep it going!" onto Current Streak (only makes sense for an active streak) and gives Previous Streak its own "Ended" subtitle

Depends on https://github.com/trakt/trakt-web/pull/3078 — based on that branch, not `main`.

Before/After:
<img height="600" alt="Screenshot 2026-08-04 at 3 52 15 pm" src="https://github.com/user-attachments/assets/51eee624-2663-4d68-9145-49005dd109b3" /> <img height="600" alt="Screenshot 2026-08-04 at 3 51 42 pm" src="https://github.com/user-attachments/assets/79d58bf9-09e0-480e-a64d-3c8ac57f4a39" />

cc @ElMagnea 