### PR TITLE
feat(settings): adds toggle for which duplicate play to keep

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -8862,8 +8862,28 @@
       "description": "Header for the settings section that analyzes the user's watch history for duplicate plays."
     },
     "description_history_analysis": {
-      "default": "Find duplicate plays in your watch history and keep only the most recent watch of each item.",
+      "default": "Find duplicate plays in your watch history and keep only one watch of each item.",
       "description": "Description for the history analysis settings section."
+    },
+    "label_keep_play": {
+      "default": "Keep",
+      "description": "Label for the toggle that picks which play of a duplicate set is kept during history clean up."
+    },
+    "button_text_keep_oldest_play": {
+      "default": "Oldest",
+      "description": "Text for the toggle option that keeps the oldest play of each item. This title should be as short and concise as possible."
+    },
+    "button_label_keep_oldest_play": {
+      "default": "Keep the oldest play of each item",
+      "description": "Aria-label for the toggle option that keeps the oldest play of each item."
+    },
+    "button_text_keep_newest_play": {
+      "default": "Newest",
+      "description": "Text for the toggle option that keeps the newest play of each item. This title should be as short and concise as possible."
+    },
+    "button_label_keep_newest_play": {
+      "default": "Keep the newest play of each item",
+      "description": "Aria-label for the toggle option that keeps the newest play of each item."
     },
     "text_duplicate_plays": {
       "default": "duplicate plays",
@@ -8894,8 +8914,17 @@
       "description": "Title of the confirmation dialog shown before removing duplicate plays from the watch history."
     },
     "warning_prompt_clean_up_history": {
-      "default": "This will permanently remove {count} duplicate plays, keeping only the most recent watch of each item. This cannot be undone.",
-      "description": "Warning prompt shown when a user is about to remove duplicate plays from their watch history.",
+      "default": "This will permanently remove {count} duplicate plays, keeping only the oldest watch of each item. This cannot be undone.",
+      "description": "Warning prompt shown when a user is about to remove duplicate plays from their watch history, keeping the oldest watch.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
+    "warning_prompt_clean_up_history_newest": {
+      "default": "This will permanently remove {count} duplicate plays, keeping only the newest watch of each item. This cannot be undone.",
+      "description": "Warning prompt shown when a user is about to remove duplicate plays from their watch history, keeping the newest watch.",
       "variables": {
         "count": {
           "type": "number"

--- a/projects/client/src/lib/components/toggles/_internal/ToggleIcon.svelte
+++ b/projects/client/src/lib/components/toggles/_internal/ToggleIcon.svelte
@@ -58,6 +58,10 @@
   <HourglassIcon />
 {/if}
 
+{#if option.value === "oldest"}
+  <HourglassIcon />
+{/if}
+
 {#if option.value === "newest"}
   <RecentIcon />
 {/if}

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.spec.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.spec.ts
@@ -33,4 +33,33 @@ describe('mapToConfirmation', () => {
     expect(result.buttonText).toBeTruthy();
     expect(result.message).toBeTruthy();
   });
+
+  describe('for CleanUpHistory', () => {
+    const cleanUpHistory = (keeps: 'oldest' | 'newest') =>
+      mapToConfirmation({
+        type: ConfirmationType.CleanUpHistory,
+        count: 12,
+        keeps,
+      });
+
+    it.each<'oldest' | 'newest'>(['oldest', 'newest'])(
+      'should spell out that the %s play is kept',
+      (keeps) => {
+        const result = cleanUpHistory(keeps);
+
+        expect(result.operation).toBe('destructive');
+        expect(result.message).toContain('12');
+        expect(result.message).toContain(keeps);
+      },
+    );
+
+    it('should warn differently depending on which play is kept', () => {
+      const oldest = cleanUpHistory('oldest');
+      const newest = cleanUpHistory('newest');
+
+      expect(oldest.message).not.toBe(newest.message);
+      expect(oldest.title).toBe(newest.title);
+      expect(oldest.buttonText).toBe(newest.buttonText);
+    });
+  });
 });

--- a/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
+++ b/projects/client/src/lib/features/confirmation/_internal/mapToConfirmation.ts
@@ -183,7 +183,9 @@ const CONFIRMATION_BUILDERS: ConfirmationBuilders = {
   [ConfirmationType.CleanUpHistory]: (props) => ({
     title: m.confirmation_title_clean_up_history(),
     buttonText: m.button_text_clean_up(),
-    message: m.warning_prompt_clean_up_history({ count: props.count }),
+    message: props.keeps === 'oldest'
+      ? m.warning_prompt_clean_up_history({ count: props.count })
+      : m.warning_prompt_clean_up_history_newest({ count: props.count }),
     operation: 'destructive',
   }),
   [ConfirmationType.HideRecommendation]: (props) => ({

--- a/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
+++ b/projects/client/src/lib/features/confirmation/models/ConfirmationParams.ts
@@ -92,6 +92,7 @@ interface ConfirmationParamsMap {
   [ConfirmationType.CleanUpHistory]: {
     type: ConfirmationType.CleanUpHistory;
     count: number;
+    keeps: 'oldest' | 'newest';
   };
   [ConfirmationType.HideRecommendation]: {
     type: ConfirmationType.HideRecommendation;

--- a/projects/client/src/lib/sections/settings/_internal/HistoryAnalysis.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/HistoryAnalysis.svelte
@@ -26,6 +26,8 @@
     getPlaysSummary,
     type PlaysSummary,
   } from "./history-analysis/getPlaysSummary.ts";
+  import type { PlayRetention } from "./history-analysis/PlayRetention.ts";
+  import PlayRetentionToggler from "./history-analysis/PlayRetentionToggler.svelte";
   import SettingsSection from "./SettingsSection.svelte";
 
   const { limits } = useUser();
@@ -48,12 +50,17 @@
     invalidations: InvalidateActionOptions[];
   };
 
+  let retention = $state<PlayRetention>("oldest");
+
   const categories = $derived<AnalysisCategory[]>([
     {
       target: "movies",
       label: m.tag_text_movies(),
       buttonLabel: m.button_label_clean_up_movies(),
-      summary: getPlaysSummary($moviePlays?.data ?? []),
+      summary: getPlaysSummary({
+        entries: $moviePlays?.data ?? [],
+        keep: retention,
+      }),
       isLoading: $moviePlays?.isPending ?? true,
       invalidations: [InvalidateAction.MarkAsWatched("movie")],
     },
@@ -61,7 +68,10 @@
       target: "episodes",
       label: m.tag_text_episodes(),
       buttonLabel: m.button_label_clean_up_episodes(),
-      summary: getPlaysSummary($showPlays?.data ?? []),
+      summary: getPlaysSummary({
+        entries: $showPlays?.data ?? [],
+        keep: retention,
+      }),
       isLoading: $showPlays?.isPending ?? true,
       invalidations: [
         InvalidateAction.MarkAsWatched("show"),
@@ -152,6 +162,11 @@
         />
       {/if}
 
+      <PlayRetentionToggler
+        value={retention}
+        onChange={(value) => (retention = value)}
+      />
+
       <div class="analysis-grid">
         {#each categories as category (category.target)}
           <div
@@ -208,6 +223,7 @@
                     onclick={confirm({
                       type: ConfirmationType.CleanUpHistory,
                       count: category.summary.duplicates,
+                      keeps: retention,
                       onConfirm: () => startCleanUp(category),
                     })}
                   >

--- a/projects/client/src/lib/sections/settings/_internal/history-analysis/PlayRetention.ts
+++ b/projects/client/src/lib/sections/settings/_internal/history-analysis/PlayRetention.ts
@@ -1,0 +1,1 @@
+export type PlayRetention = 'oldest' | 'newest';

--- a/projects/client/src/lib/sections/settings/_internal/history-analysis/PlayRetentionToggler.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/history-analysis/PlayRetentionToggler.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import type { ToggleOption } from "$lib/components/toggles/ToggleOption.ts";
+  import Toggler from "$lib/components/toggles/Toggler.svelte";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import type { PlayRetention } from "./PlayRetention.ts";
+
+  const { value, onChange }: {
+    value: PlayRetention;
+    onChange: (value: PlayRetention) => void;
+  } = $props();
+
+  const options: ToggleOption<PlayRetention>[] = [
+    {
+      value: "oldest",
+      text: m.button_text_keep_oldest_play,
+      label: m.button_label_keep_oldest_play,
+    },
+    {
+      value: "newest",
+      text: m.button_text_keep_newest_play,
+      label: m.button_label_keep_newest_play,
+    },
+  ];
+</script>
+
+<div class="trakt-play-retention-toggler">
+  <span>{m.label_keep_play()}</span>
+  <Toggler {value} {onChange} {options} variant="text" />
+</div>
+
+<style>
+  .trakt-play-retention-toggler {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--gap-xs);
+  }
+</style>

--- a/projects/client/src/lib/sections/settings/_internal/history-analysis/getPlaysSummary.spec.ts
+++ b/projects/client/src/lib/sections/settings/_internal/history-analysis/getPlaysSummary.spec.ts
@@ -1,6 +1,7 @@
 import type { MediaPlays } from '$lib/requests/models/MediaPlays.ts';
 import { describe, expect, it } from 'vitest';
 import { getPlaysSummary } from './getPlaysSummary.ts';
+import type { PlayRetention } from './PlayRetention.ts';
 
 function toEntry(id: number, plays: Array<[number, string]>): MediaPlays {
   return {
@@ -12,9 +13,51 @@ function toEntry(id: number, plays: Array<[number, string]>): MediaPlays {
   };
 }
 
+const REWATCHED_ENTRIES = [
+  toEntry(1, [
+    [100, '2024-01-01T10:00:00.000Z'],
+    [101, '2024-03-01T10:00:00.000Z'],
+    [102, '2024-02-01T10:00:00.000Z'],
+  ]),
+  toEntry(2, [
+    [200, '2024-05-01T10:00:00.000Z'],
+    [201, '2024-04-01T10:00:00.000Z'],
+  ]),
+];
+
+const SHUFFLED_ENTRIES = [
+  toEntry(1, [
+    [102, '2024-02-01T10:00:00.000Z'],
+    [100, '2023-06-01T10:00:00.000Z'],
+    [103, '2024-08-01T10:00:00.000Z'],
+    [101, '2023-12-01T10:00:00.000Z'],
+  ]),
+];
+
+const TIED_ENTRIES = [
+  toEntry(1, [
+    [100, '2024-01-01T10:00:00.000Z'],
+    [101, '2024-01-01T10:00:00.000Z'],
+  ]),
+];
+
+const ASCENDING_ENTRIES = [
+  toEntry(1, [
+    [100, '2024-01-01T10:00:00.000Z'],
+    [101, '2024-02-01T10:00:00.000Z'],
+  ]),
+];
+
+const DESCENDING_ENTRIES = [
+  toEntry(1, [
+    [101, '2024-02-01T10:00:00.000Z'],
+    [100, '2024-01-01T10:00:00.000Z'],
+  ]),
+];
+
 describe('util: getPlaysSummary', () => {
   it('should return an empty summary for no entries', () => {
-    expect(getPlaysSummary([])).toEqual({
+    expect(getPlaysSummary({ entries: [], keep: 'oldest' })).toEqual({
       unique: 0,
       total: 0,
       duplicates: 0,
@@ -23,10 +66,13 @@ describe('util: getPlaysSummary', () => {
   });
 
   it('should not flag single plays as duplicates', () => {
-    const summary = getPlaysSummary([
-      toEntry(1, [[100, '2024-01-01T10:00:00.000Z']]),
-      toEntry(2, [[200, '2024-02-01T10:00:00.000Z']]),
-    ]);
+    const summary = getPlaysSummary({
+      entries: [
+        toEntry(1, [[100, '2024-01-01T10:00:00.000Z']]),
+        toEntry(2, [[200, '2024-02-01T10:00:00.000Z']]),
+      ],
+      keep: 'oldest',
+    });
 
     expect(summary).toEqual({
       unique: 2,
@@ -36,40 +82,99 @@ describe('util: getPlaysSummary', () => {
     });
   });
 
-  it('should keep only the most recent play of each entry', () => {
-    const summary = getPlaysSummary([
-      toEntry(1, [
-        [100, '2024-01-01T10:00:00.000Z'],
-        [101, '2024-03-01T10:00:00.000Z'],
-        [102, '2024-02-01T10:00:00.000Z'],
-      ]),
-      toEntry(2, [
-        [200, '2024-05-01T10:00:00.000Z'],
-        [201, '2024-04-01T10:00:00.000Z'],
-      ]),
-    ]);
+  it.each<[PlayRetention, number[]]>([
+    ['oldest', [102, 101, 200]],
+    ['newest', [100, 102, 201]],
+  ])(
+    'should keep only the %s play of each entry',
+    (keep, duplicateIds) => {
+      const summary = getPlaysSummary({ entries: REWATCHED_ENTRIES, keep });
 
-    expect(summary.unique).toBe(2);
-    expect(summary.total).toBe(5);
-    expect(summary.duplicates).toBe(3);
-    expect(summary.duplicateIds).toEqual([102, 100, 201]);
+      expect(summary.unique).toBe(2);
+      expect(summary.total).toBe(5);
+      expect(summary.duplicates).toBe(3);
+      expect(summary.duplicateIds).toEqual(duplicateIds);
+    },
+  );
+
+  it.each<[PlayRetention, number, number[]]>([
+    ['oldest', 100, [101, 102, 103]],
+    ['newest', 103, [100, 101, 102]],
+  ])(
+    'should never flag the %s play as a duplicate',
+    (keep, keptId, duplicateIds) => {
+      const summary = getPlaysSummary({ entries: SHUFFLED_ENTRIES, keep });
+
+      expect(summary.duplicateIds).not.toContain(keptId);
+      expect(summary.duplicateIds).toEqual(duplicateIds);
+    },
+  );
+
+  it.each<[PlayRetention, number]>([
+    ['oldest', 101],
+    ['newest', 100],
+  ])(
+    'should not depend on the order of incoming plays when keeping the %s',
+    (keep, duplicateId) => {
+      const ascending = getPlaysSummary({ entries: ASCENDING_ENTRIES, keep });
+      const descending = getPlaysSummary({ entries: DESCENDING_ENTRIES, keep });
+
+      expect(ascending.duplicateIds).toEqual([duplicateId]);
+      expect(descending.duplicateIds).toEqual([duplicateId]);
+    },
+  );
+
+  it.each<[PlayRetention, number]>([
+    ['oldest', 101],
+    ['newest', 100],
+  ])(
+    'should fall back to input order when keeping the %s of identical timestamps',
+    (keep, duplicateId) => {
+      const summary = getPlaysSummary({ entries: TIED_ENTRIES, keep });
+
+      expect(summary.duplicates).toBe(1);
+      expect(summary.duplicateIds).toEqual([duplicateId]);
+    },
+  );
+
+  it('should collect duplicates across entries with mixed play counts', () => {
+    const summary = getPlaysSummary({
+      entries: [
+        toEntry(1, [[100, '2024-01-01T10:00:00.000Z']]),
+        toEntry(2, [
+          [201, '2024-04-01T10:00:00.000Z'],
+          [200, '2024-02-01T10:00:00.000Z'],
+        ]),
+        toEntry(3, [
+          [300, '2024-01-15T10:00:00.000Z'],
+          [301, '2024-01-16T10:00:00.000Z'],
+          [302, '2024-01-17T10:00:00.000Z'],
+        ]),
+      ],
+      keep: 'oldest',
+    });
+
+    expect(summary).toEqual({
+      unique: 3,
+      total: 6,
+      duplicates: 3,
+      duplicateIds: [201, 301, 302],
+    });
   });
 
-  it('should not depend on the order of incoming plays', () => {
-    const ascending = getPlaysSummary([
-      toEntry(1, [
-        [100, '2024-01-01T10:00:00.000Z'],
-        [101, '2024-02-01T10:00:00.000Z'],
-      ]),
-    ]);
-    const descending = getPlaysSummary([
-      toEntry(1, [
-        [101, '2024-02-01T10:00:00.000Z'],
-        [100, '2024-01-01T10:00:00.000Z'],
-      ]),
-    ]);
+  it('should report identical counts regardless of which play is kept', () => {
+    const oldest = getPlaysSummary({
+      entries: REWATCHED_ENTRIES,
+      keep: 'oldest',
+    });
+    const newest = getPlaysSummary({
+      entries: REWATCHED_ENTRIES,
+      keep: 'newest',
+    });
 
-    expect(ascending.duplicateIds).toEqual([100]);
-    expect(descending.duplicateIds).toEqual([100]);
+    expect(oldest.unique).toBe(newest.unique);
+    expect(oldest.total).toBe(newest.total);
+    expect(oldest.duplicates).toBe(newest.duplicates);
+    expect(oldest.duplicateIds).not.toEqual(newest.duplicateIds);
   });
 });

--- a/projects/client/src/lib/sections/settings/_internal/history-analysis/getPlaysSummary.ts
+++ b/projects/client/src/lib/sections/settings/_internal/history-analysis/getPlaysSummary.ts
@@ -1,4 +1,5 @@
 import type { MediaPlays } from '$lib/requests/models/MediaPlays.ts';
+import type { PlayRetention } from './PlayRetention.ts';
 
 export type PlaysSummary = {
   unique: number;
@@ -7,18 +8,27 @@ export type PlaysSummary = {
   duplicateIds: number[];
 };
 
+type GetPlaysSummaryProps = {
+  entries: ReadonlyArray<MediaPlays>;
+  keep: PlayRetention;
+};
+
 export function getPlaysSummary(
-  entries: ReadonlyArray<MediaPlays>,
+  { entries, keep }: GetPlaysSummaryProps,
 ): PlaysSummary {
   const duplicateIds = entries.flatMap(({ plays }) => {
     if (plays.length <= 1) {
       return [];
     }
 
-    const [, ...olderPlays] = [...plays].sort(
-      (a, b) => b.watchedAt.getTime() - a.watchedAt.getTime(),
+    const chronological = [...plays].sort(
+      (a, b) => a.watchedAt.getTime() - b.watchedAt.getTime(),
     );
-    return olderPlays.map((play) => play.id);
+    const removable = keep === 'oldest'
+      ? chronological.slice(1)
+      : chronological.slice(0, -1);
+
+    return removable.map((play) => play.id);
   });
 
   const total = entries.reduce((sum, { plays }) => sum + plays.length, 0);


### PR DESCRIPTION
## 🎶 Notes 🎶

- History clean up kept the newest play of each item, dropping the original
  watch date, with no way to choose otherwise
- Adds a toggle above the cards to pick which play survives, defaults to oldest
  - Applies to both movies and episodes
  - Not persisted, so it resets on reload instead of carrying over into a
    destructive action
- Confirmation prompt now spells out which play is kept, it used to hardcode
  "most recent"
- `oldest` needed a case in `ToggleIcon` (hourglass). `newest` was already
  mapped to `RecentIcon` for comment sort, so it picked one up for free

## 👀 Example 👀
<img width="368" height="619" alt="Screenshot 2026-08-04 at 21 04 21" src="https://github.com/user-attachments/assets/82c1d850-6566-4060-ad7f-d7ca57c9871c" />

