### PR TITLE
feat(recommendations): reorder burger menu actions for better UX

### DIFF
--- a/projects/client/src/lib/sections/lists/recommended/RecommendedListItem.svelte
+++ b/projects/client/src/lib/sections/lists/recommended/RecommendedListItem.svelte
@@ -26,10 +26,6 @@
   canDeemphasize
 >
   {#snippet popupActions()}
-    <DefaultMediaPopupActions
-      {media}
-      onListAction={() => (isListsDrawerOpen = true)}
-    />
     <DropdownItem
       onclick={() => (isSourcesDrawerOpen = true)}
       style="flat"
@@ -42,6 +38,10 @@
         <SparkleIcon />
       {/snippet}
     </DropdownItem>
+    <DefaultMediaPopupActions
+      {media}
+      onListAction={() => (isListsDrawerOpen = true)}
+    />
     <HideRecommendationAction {media} />
   {/snippet}
 </DefaultMediaItem>


### PR DESCRIPTION

## Visuals
<img width="236" height="350" alt="Screenshot 2026-08-05 at 15 41 14" src="https://github.com/user-attachments/assets/ade3bc40-1f97-4d0e-a60e-3b8fd9ce9cea" />

Changes to the way the drop-downs look in general, are coming soon.

## Summary
Reorganized the recommendation item burger menu to provide better UX by surfacing the "why this?" information first, allowing users to understand the recommendation before taking action.

**Action order (old → new):**
- Old: Watchlist → Watched → List → Why? → Hide
- New: Why? → Watchlist → Watched → List → Hide

This addresses feedback from PR #2992 where Vlad noted that "why this?" shouldn't be directly next to the destructive "hide" action.

## Test plan
- [ ] Open recommendations section (movies/shows)
- [ ] Open the burger menu on a recommendation card
- [ ] Verify "View recommendation sources" appears first
- [ ] Verify destructive "Hide recommendation" is at the end
- [ ] Verify all actions work as expected

🤖 Generated with Claude Code