### PR TITLE
fix(settings): validate the API application form and report save failures

### DIFF
--- a/.agents/rules/utils.md
+++ b/.agents/rules/utils.md
@@ -201,6 +201,7 @@ safeLocalStorage.setItem('key', value);
 | --------------------------------- | --------------------------------------------------------------------- |
 | `UrlBuilder`                      | Centralised app route factory - use for all internal navigation paths |
 | `buildParamString(params)`        | Serialise record into query string (`?foo=bar&baz=1`)                 |
+| `toUrl(value)`                    | Parse into a `URL`, or `null` when the value is malformed             |
 | `prependHttps(url, placeholder?)` | Ensure URL starts with `https://`                                     |
 | `prependHttpOrHttps(url)`         | Same, but allows `http://` for localhost                              |
 | `setCacheBuster(url)`             | Append `_cb` timestamp to bust CDN caches                             |

--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -10055,9 +10055,75 @@
       "default": "Please enter an application name.",
       "description": "Validation message shown when the API application name is empty."
     },
+    "validation_text_app_name_too_long": {
+      "default": "Keep the name to {count} characters or fewer.",
+      "description": "Validation message shown when the API application name exceeds the maximum length the server accepts.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
+    "validation_text_app_description_too_long": {
+      "default": "Keep the description to {count} characters or fewer.",
+      "description": "Validation message shown when the API application description exceeds the maximum length the server accepts.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
     "validation_text_app_redirect_uris": {
       "default": "Add at least one redirect URI.",
       "description": "Validation message shown when no redirect URI has been provided."
+    },
+    "validation_text_app_redirect_uris_invalid": {
+      "default": "Enter one full redirect URI per line, without a query string or fragment.",
+      "description": "Validation message shown when a redirect URI is not a full URI or carries a query string or fragment."
+    },
+    "validation_text_app_redirect_uris_too_many": {
+      "default": "Add at most {count} redirect URIs.",
+      "description": "Validation message shown when more redirect URIs are listed than the server accepts.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
+    "validation_text_app_redirect_uris_too_long": {
+      "default": "Redirect URIs must total {count} characters or fewer.",
+      "description": "Validation message shown when the combined length of all redirect URIs exceeds what the server accepts.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
+    "validation_text_app_origins_too_many": {
+      "default": "Add at most {count} origins.",
+      "description": "Validation message shown when more JavaScript (CORS) origins are listed than the server accepts.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
+    "validation_text_app_origins_too_long": {
+      "default": "Origins must total {count} characters or fewer.",
+      "description": "Validation message shown when the combined length of all JavaScript (CORS) origins exceeds what the server accepts.",
+      "variables": {
+        "count": {
+          "type": "number"
+        }
+      }
+    },
+    "validation_text_app_origins": {
+      "default": "Enter one origin per line, like https://example.com. No wildcards or paths.",
+      "description": "Validation message shown when a JavaScript (CORS) origin is not a bare http(s) origin."
+    },
+    "error_text_app_save_failed": {
+      "default": "Saving the application failed. Please try again.",
+      "description": "Generic error shown when creating or updating an API application fails unexpectedly."
     },
     "heading_edit_api_application": {
       "default": "Edit application",

--- a/projects/client/src/lib/components/form/FormDatePicker.svelte
+++ b/projects/client/src/lib/components/form/FormDatePicker.svelte
@@ -5,6 +5,9 @@
   import type { FormDatePickerProps } from "./models/FormDatePickerProps";
   import type { ValidationProps } from "./models/ValidationProps";
 
+  const randomId = crypto.randomUUID().slice(0, 8);
+  const errorLabelId = `trakt-date-picker-error-${randomId}`;
+
   const {
     onChange,
     disabled = false,
@@ -37,6 +40,7 @@
       } satisfies ValidationProps)
     : undefined}
   {hasError}
+  {errorLabelId}
 >
   <DatePicker
     {value}

--- a/projects/client/src/lib/components/form/FormInput.spec.ts
+++ b/projects/client/src/lib/components/form/FormInput.spec.ts
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import FormInput from './FormInput.svelte';
+
+describe('component: FormInput', () => {
+  it('should point aria-describedby at the rendered error label', async () => {
+    const { container, findByRole } = render(FormInput, {
+      props: {
+        onChange: () => {},
+        disabled: false,
+        placeholder: '',
+        value: 'nope',
+        validation: {
+          isValid: (value: string) => value === 'ok',
+          errorText: 'Value must be ok.',
+        },
+      },
+    });
+
+    const input = await findByRole('textbox');
+    const describedBy = input.getAttribute('aria-describedby');
+
+    expect(describedBy).not.toBeNull();
+    expect(container.querySelector(`#${describedBy}`)?.textContent?.trim())
+      .toBe('Value must be ok.');
+  });
+});

--- a/projects/client/src/lib/components/form/FormInput.svelte
+++ b/projects/client/src/lib/components/form/FormInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { writable } from "$lib/utils/store/WritableSubject";
   import { onMount } from "svelte";
+  import { createValidationState } from "./_internal/createValidationState.ts";
   import FormElementWrapper from "./_internal/FormElementWrapper.svelte";
   import type { FormInputProps } from "./models/FormInputProps";
 
@@ -19,21 +19,20 @@
 
   let inputElement: HTMLInputElement;
 
-  const errorText = writable<string | undefined>(undefined);
+  const { hasError, validate } = createValidationState(() => validation);
 
   const handleInput = (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
 
-    if (validation) {
-      const isValid = validation.isValid(newValue);
-      errorText.set(isValid ? undefined : validation.errorText);
-      inputElement.setCustomValidity(!isValid ? validation.errorText : "");
-    }
-
+    validate(inputElement, newValue);
     onChange(newValue);
   };
 
   onMount(() => {
+    if (value) {
+      validate(inputElement, value);
+    }
+
     if (!autofocus) return;
 
     requestAnimationFrame(() => {
@@ -43,23 +42,21 @@
       inputElement.focus({ preventScroll: true });
     });
   });
-
-  const hasError = $derived(Boolean($errorText));
 </script>
 
-<FormElementWrapper {validation} {hasError}>
+<FormElementWrapper {validation} hasError={$hasError} {errorLabelId}>
   <input
     bind:this={inputElement}
     class="trakt-form-input"
-    class:has-error={hasError}
+    class:has-error={$hasError}
     type="text"
     {placeholder}
     {disabled}
     {required}
     {value}
     oninput={handleInput}
-    aria-invalid={hasError ? "true" : "false"}
-    aria-describedby={hasError ? errorLabelId : undefined}
+    aria-invalid={$hasError ? "true" : "false"}
+    aria-describedby={$hasError ? errorLabelId : undefined}
   />
 </FormElementWrapper>
 

--- a/projects/client/src/lib/components/form/FormTextArea.svelte
+++ b/projects/client/src/lib/components/form/FormTextArea.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { writable } from "$lib/utils/store/WritableSubject.ts";
   import { onMount } from "svelte";
+  import { createValidationState } from "./_internal/createValidationState.ts";
   import FormElementWrapper from "./_internal/FormElementWrapper.svelte";
   import type { FormInputProps } from "./models/FormInputProps";
 
@@ -22,32 +22,29 @@
 
   let textAreaElement: HTMLTextAreaElement;
 
-  const errorText = writable<string | undefined>(undefined);
+  const { hasError, validate } = createValidationState(() => validation);
 
   const handleInput = (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
 
-    if (validation) {
-      const isValid = validation.isValid(newValue);
-      errorText.set(isValid ? undefined : validation.errorText);
-      textAreaElement.setCustomValidity(!isValid ? validation.errorText : "");
-    }
-
+    validate(textAreaElement, newValue);
     onChange(newValue);
   };
 
   onMount(() => {
+    if (value) {
+      validate(textAreaElement, value);
+    }
+
     if (!autofocus) return;
 
     requestAnimationFrame(() => {
       textAreaElement.focus();
     });
   });
-
-  const hasError = $derived(Boolean($errorText));
 </script>
 
-<FormElementWrapper {validation} {hasError}>
+<FormElementWrapper {validation} hasError={$hasError} {errorLabelId}>
   <textarea
     bind:this={textAreaElement}
     {disabled}
@@ -56,8 +53,8 @@
     {rows}
     {required}
     oninput={handleInput}
-    aria-invalid={hasError ? "true" : "false"}
-    aria-describedby={hasError ? errorLabelId : undefined}
+    aria-invalid={$hasError ? "true" : "false"}
+    aria-describedby={$hasError ? errorLabelId : undefined}
     class="trakt-form-textarea"
   ></textarea>
 </FormElementWrapper>

--- a/projects/client/src/lib/components/form/_internal/FormElementWrapper.svelte
+++ b/projects/client/src/lib/components/form/_internal/FormElementWrapper.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   import type { ValidationProps } from "../models/ValidationProps";
 
-  const randomId = crypto.randomUUID().slice(0, 8);
-  const errorLabelId = `trakt-input-error-${randomId}`;
-
   const {
     children,
     validation,
     hasError,
-  }: { validation?: ValidationProps; hasError: boolean } & ChildrenProps =
-    $props();
+    errorLabelId,
+  }: {
+    validation?: ValidationProps;
+    hasError: boolean;
+    errorLabelId: string;
+  } & ChildrenProps = $props();
 </script>
 
 <div class="trakt-form-element-container">

--- a/projects/client/src/lib/components/form/_internal/createValidationState.ts
+++ b/projects/client/src/lib/components/form/_internal/createValidationState.ts
@@ -1,0 +1,27 @@
+import { writable } from '$lib/utils/store/WritableSubject.ts';
+import type { ValidationProps } from '../models/ValidationProps.ts';
+
+type ValidatableElement = {
+  setCustomValidity: (message: string) => void;
+};
+
+export function createValidationState(
+  getValidation: () => ValidationProps | Nil,
+) {
+  const hasError = writable(false);
+
+  const validate = (element: ValidatableElement, value: string) => {
+    const validation = getValidation();
+
+    if (!validation) {
+      return;
+    }
+
+    const isValid = validation.isValid(value);
+
+    hasError.set(!isValid);
+    element.setCustomValidity(isValid ? '' : validation.errorText);
+  };
+
+  return { hasError, validate };
+}

--- a/projects/client/src/lib/requests/queries/apps/createApiApplicationRequest.ts
+++ b/projects/client/src/lib/requests/queries/apps/createApiApplicationRequest.ts
@@ -10,10 +10,13 @@ type CreateApiApplicationParams = {
   origins: ReadonlyArray<string>;
 } & ApiParams;
 
+export type CreateApiApplicationResult =
+  | { ok: true; application?: ApiApplication }
+  | { ok: false };
+
 /**
  * Registers a new OAuth application for the authenticated user. Resolves to the
- * created {@link ApiApplication} (including its client id/secret) on success, or
- * `null` when the request fails.
+ * created {@link ApiApplication} (including its client id/secret) on success.
  */
 export async function createApiApplicationRequest(
   {
@@ -23,7 +26,7 @@ export async function createApiApplicationRequest(
     redirectUris,
     origins,
   }: CreateApiApplicationParams,
-): Promise<ApiApplication | null> {
+): Promise<CreateApiApplicationResult> {
   const response = await rawApiFetch({
     fetch,
     path: '/v3/users/me/applications',
@@ -40,10 +43,12 @@ export async function createApiApplicationRequest(
   });
 
   if (!response.ok) {
-    return null;
+    return { ok: false };
   }
 
-  return mapToApiApplication(
-    ApiApplicationResponseSchema.parse(await response.json()),
-  );
+  const parsed = ApiApplicationResponseSchema.safeParse(await response.json());
+
+  return parsed.success
+    ? { ok: true, application: mapToApiApplication(parsed.data) }
+    : { ok: true };
 }

--- a/projects/client/src/lib/requests/queries/apps/updateApiApplicationRequest.ts
+++ b/projects/client/src/lib/requests/queries/apps/updateApiApplicationRequest.ts
@@ -8,10 +8,14 @@ type UpdateApiApplicationParams = {
   origins: ReadonlyArray<string>;
 } & ApiParams;
 
+export type UpdateApiApplicationResult = {
+  ok: boolean;
+};
+
 /**
- * Updates the editable fields of an OAuth application the user owns. Resolves
- * to `true` when the update succeeds (HTTP 2xx). Credentials (`client_id`,
- * `client_secret`) and the approval state are never changed by this request.
+ * Updates the editable fields of an OAuth application the user owns.
+ * Credentials (`client_id`, `client_secret`) and the approval state are never
+ * changed by this request.
  */
 export async function updateApiApplicationRequest(
   {
@@ -22,7 +26,7 @@ export async function updateApiApplicationRequest(
     redirectUris,
     origins,
   }: UpdateApiApplicationParams,
-): Promise<boolean> {
+): Promise<UpdateApiApplicationResult> {
   const response = await rawApiFetch({
     fetch,
     path: `/v3/users/me/applications/${id}`,
@@ -38,5 +42,5 @@ export async function updateApiApplicationRequest(
     },
   });
 
-  return response.ok;
+  return { ok: response.ok };
 }

--- a/projects/client/src/lib/sections/settings/ApiApplicationCreator.svelte
+++ b/projects/client/src/lib/sections/settings/ApiApplicationCreator.svelte
@@ -10,15 +10,22 @@
   import SettingsSection from "./_internal/SettingsSection.svelte";
   import SettingsVipUpsell from "./_internal/SettingsVipUpsell.svelte";
 
-  const { createApplication, isCreating } = useCreateApiApplication();
+  const { createApplication, isCreating, error, dismissError } =
+    useCreateApiApplication();
 
   async function handleSubmit(values: ApiApplicationFormValues) {
-    const created = await createApplication(values);
+    const result = await createApplication(values);
 
-    if (created) {
-      // eslint-disable-next-line svelte/no-navigation-without-resolve
-      goto(UrlBuilder.settings.appsApiDetail(created.id));
+    if (!result.ok) {
+      return;
     }
+
+    const destination = result.application
+      ? UrlBuilder.settings.appsApiDetail(result.application.id)
+      : UrlBuilder.settings.appsApi();
+
+    // eslint-disable-next-line svelte/no-navigation-without-resolve
+    goto(destination);
   }
 
   function handleCancel() {
@@ -38,6 +45,8 @@
     crumbHref={UrlBuilder.settings.appsApi()}
     crumbLabel={m.heading_api_applications()}
     isBusy={$isCreating}
+    errorMessage={$error}
+    onDismissError={dismissError}
     confirmButtonText={m.button_text_create()}
     confirmButtonLabel={m.button_label_create_app()}
     onSubmit={handleSubmit}

--- a/projects/client/src/lib/sections/settings/ApiApplicationEditor.svelte
+++ b/projects/client/src/lib/sections/settings/ApiApplicationEditor.svelte
@@ -11,7 +11,8 @@
 
   const { appId }: { appId: number } = $props();
 
-  const { updateApplication, isUpdating } = useUpdateApiApplication();
+  const { updateApplication, isUpdating, error, dismissError } =
+    useUpdateApiApplication();
 
   const appId$ = fromRune(() => appId);
   const { app: app$, isLoading: isLoading$ } = useApiApplication(appId$);
@@ -26,6 +27,10 @@
           originsText: app.origins.join("\n"),
         }
       : undefined,
+  );
+
+  const errorMessage = $derived(
+    $error?.id === appId ? $error.message : undefined,
   );
 
   async function handleSubmit(values: ApiApplicationFormValues) {
@@ -44,18 +49,22 @@
 </script>
 
 {#if app && initial}
-  <ApiApplicationFormSection
-    title={m.heading_edit_api_application()}
-    description={m.description_edit_api_application()}
-    crumbHref={UrlBuilder.settings.appsApiDetail(appId)}
-    crumbLabel={app.name}
-    {initial}
-    isBusy={$isUpdating}
-    confirmButtonText={m.button_text_save()}
-    confirmButtonLabel={m.button_label_save_app()}
-    onSubmit={handleSubmit}
-    onCancel={handleCancel}
-  />
+  {#key appId}
+    <ApiApplicationFormSection
+      title={m.heading_edit_api_application()}
+      description={m.description_edit_api_application()}
+      crumbHref={UrlBuilder.settings.appsApiDetail(appId)}
+      crumbLabel={app.name}
+      {initial}
+      isBusy={$isUpdating}
+      {errorMessage}
+      onDismissError={dismissError}
+      confirmButtonText={m.button_text_save()}
+      confirmButtonLabel={m.button_label_save_app()}
+      onSubmit={handleSubmit}
+      onCancel={handleCancel}
+    />
+  {/key}
 {:else if $isLoading$}
   <ApiApplicationFormSkeleton
     title={m.heading_edit_api_application()}

--- a/projects/client/src/lib/sections/settings/_internal/apps/ApiApplicationForm.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/apps/ApiApplicationForm.svelte
@@ -1,21 +1,34 @@
 <script lang="ts">
+  import DismissibleError from "$lib/components/errors/DismissibleError.svelte";
   import Form from "$lib/components/form/Form.svelte";
   import FormInput from "$lib/components/form/FormInput.svelte";
   import FormTextArea from "$lib/components/form/FormTextArea.svelte";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { ApiApplicationFormProps } from "./ApiApplicationFormProps.ts";
+  import { isValidCorsOrigin } from "./isValidCorsOrigin.ts";
+  import { isValidRedirectUri } from "./isValidRedirectUri.ts";
+  import { toCanonicalOrigin } from "./toCanonicalOrigin.ts";
+
+  const NAME_MAX_LENGTH = 255;
+  const DESCRIPTION_MAX_LENGTH = 255;
+  const REDIRECT_URI_MAX_COUNT = 25;
+  const REDIRECT_URI_MAX_LENGTH = 2048;
+  const ORIGINS_MAX_COUNT = 25;
+  const ORIGINS_MAX_LENGTH = 255;
 
   const {
     initial,
     isBusy = false,
+    errorMessage,
+    onDismissError,
     confirmButtonText,
     confirmButtonLabel,
     onSubmit,
     onCancel,
   }: ApiApplicationFormProps = $props();
 
-  // One-time seed: the parent only mounts this form once `initial` is
-  // available and never swaps it afterwards, so snapshotting is intentional.
+  // One-time seed: a form instance edits a single application, so callers
+  // mount a fresh one per application rather than swapping `initial`.
   // svelte-ignore state_referenced_locally
   const seed = initial;
   let name = $state(seed?.name ?? "");
@@ -31,9 +44,113 @@
 
   const redirectUris = $derived(toLines(redirectUriText));
   const origins = $derived(toLines(originsText));
+  const canonicalOrigins = $derived(origins.map(toCanonicalOrigin));
+
+  const toRedirectUriValue = (uris: ReadonlyArray<string>) => uris.join("\n");
+  const toOriginsValue = (values: ReadonlyArray<string>) =>
+    values.map(toCanonicalOrigin).join(" ");
+
+  const toNameError = (value: string) => {
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+      return m.validation_text_app_name();
+    }
+
+    if (trimmed.length > NAME_MAX_LENGTH) {
+      return m.validation_text_app_name_too_long({ count: NAME_MAX_LENGTH });
+    }
+
+    return null;
+  };
+
+  const toDescriptionError = (value: string) =>
+    value.trim().length > DESCRIPTION_MAX_LENGTH
+      ? m.validation_text_app_description_too_long({
+        count: DESCRIPTION_MAX_LENGTH,
+      })
+      : null;
+
+  const toRedirectUriError = (value: string) => {
+    const uris = toLines(value);
+
+    if (uris.length === 0) {
+      return m.validation_text_app_redirect_uris();
+    }
+
+    if (uris.length > REDIRECT_URI_MAX_COUNT) {
+      return m.validation_text_app_redirect_uris_too_many({
+        count: REDIRECT_URI_MAX_COUNT,
+      });
+    }
+
+    if (toRedirectUriValue(uris).length > REDIRECT_URI_MAX_LENGTH) {
+      return m.validation_text_app_redirect_uris_too_long({
+        count: REDIRECT_URI_MAX_LENGTH,
+      });
+    }
+
+    if (!uris.every(isValidRedirectUri)) {
+      return m.validation_text_app_redirect_uris_invalid();
+    }
+
+    return null;
+  };
+
+  const toOriginsError = (value: string) => {
+    const values = toLines(value);
+
+    if (values.length > ORIGINS_MAX_COUNT) {
+      return m.validation_text_app_origins_too_many({
+        count: ORIGINS_MAX_COUNT,
+      });
+    }
+
+    if (toOriginsValue(values).length > ORIGINS_MAX_LENGTH) {
+      return m.validation_text_app_origins_too_long({
+        count: ORIGINS_MAX_LENGTH,
+      });
+    }
+
+    if (!values.every(isValidCorsOrigin)) {
+      return m.validation_text_app_origins();
+    }
+
+    return null;
+  };
+
+  const nameError = $derived(toNameError(name));
+  const descriptionError = $derived(toDescriptionError(description));
+  const redirectUriError = $derived(toRedirectUriError(redirectUriText));
+  const originsError = $derived(toOriginsError(originsText));
+
+  const nameValidation = $derived({
+    isValid: (value: string) => toNameError(value) === null,
+    errorText: nameError ?? m.validation_text_app_name(),
+  });
+
+  const descriptionValidation = {
+    isValid: (value: string) => toDescriptionError(value) === null,
+    errorText: m.validation_text_app_description_too_long({
+      count: DESCRIPTION_MAX_LENGTH,
+    }),
+  };
+
+  const redirectUriValidation = $derived({
+    isValid: (value: string) => toRedirectUriError(value) === null,
+    errorText: redirectUriError ?? m.validation_text_app_redirect_uris(),
+  });
+
+  const originsValidation = $derived({
+    isValid: (value: string) => toOriginsError(value) === null,
+    errorText: originsError ?? m.validation_text_app_origins(),
+  });
 
   const isValid = $derived(
-    name.trim().length > 0 && redirectUris.length > 0,
+    nameError === null &&
+      descriptionError === null &&
+      redirectUriError === null &&
+      originsError === null,
   );
 
   function handleSubmit() {
@@ -45,7 +162,7 @@
       name: name.trim(),
       description: description.trim() || undefined,
       redirectUris,
-      origins,
+      origins: canonicalOrigins,
     });
   }
 </script>
@@ -70,10 +187,7 @@
         value={name}
         autofocus
         required
-        validation={{
-          isValid: (value) => value.trim().length > 0,
-          errorText: m.validation_text_app_name(),
-        }}
+        validation={nameValidation}
       />
     </div>
 
@@ -85,6 +199,7 @@
         disabled={isBusy}
         value={description}
         rows={3}
+        validation={descriptionValidation}
       />
       <span class="field-hint secondary tag">{m.hint_app_description()}</span>
     </div>
@@ -98,10 +213,7 @@
         value={redirectUriText}
         rows={4}
         required
-        validation={{
-          isValid: (value) => toLines(value).length > 0,
-          errorText: m.validation_text_app_redirect_uris(),
-        }}
+        validation={redirectUriValidation}
       />
       <span class="field-hint secondary tag">{m.hint_app_redirect_uris()}</span>
     </div>
@@ -114,9 +226,14 @@
         disabled={isBusy}
         value={originsText}
         rows={3}
+        validation={originsValidation}
       />
       <span class="field-hint secondary tag">{m.hint_app_origins()}</span>
     </div>
+
+    {#if errorMessage}
+      <DismissibleError message={errorMessage} onDismiss={onDismissError} />
+    {/if}
   </div>
   </Form>
 </div>

--- a/projects/client/src/lib/sections/settings/_internal/apps/ApiApplicationFormProps.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/ApiApplicationFormProps.ts
@@ -8,6 +8,8 @@ export type ApiApplicationFormProps = {
     originsText: string;
   };
   isBusy?: boolean;
+  errorMessage: string | Nil;
+  onDismissError: () => void;
   confirmButtonText: string;
   confirmButtonLabel: string;
   onSubmit: (values: ApiApplicationFormValues) => void;

--- a/projects/client/src/lib/sections/settings/_internal/apps/ApiApplicationFormSection.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/apps/ApiApplicationFormSection.svelte
@@ -10,6 +10,8 @@
     crumbLabel,
     initial,
     isBusy = false,
+    errorMessage,
+    onDismissError,
     confirmButtonText,
     confirmButtonLabel,
     onSubmit,
@@ -25,6 +27,8 @@
   <ApiApplicationForm
     {initial}
     {isBusy}
+    {errorMessage}
+    {onDismissError}
     {confirmButtonText}
     {confirmButtonLabel}
     {onSubmit}

--- a/projects/client/src/lib/sections/settings/_internal/apps/ApiApplicationFormSectionProps.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/ApiApplicationFormSectionProps.ts
@@ -11,6 +11,8 @@ export type ApiApplicationFormSectionProps =
     ApiApplicationFormProps,
     | 'initial'
     | 'isBusy'
+    | 'errorMessage'
+    | 'onDismissError'
     | 'confirmButtonText'
     | 'confirmButtonLabel'
     | 'onSubmit'

--- a/projects/client/src/lib/sections/settings/_internal/apps/isValidCorsOrigin.spec.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/isValidCorsOrigin.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { isValidCorsOrigin } from './isValidCorsOrigin.ts';
+
+describe('util: isValidCorsOrigin', () => {
+  it('should accept bare http(s) origins', () => {
+    expect(isValidCorsOrigin('https://example.com')).toBe(true);
+    expect(isValidCorsOrigin('http://localhost:5173')).toBe(true);
+    expect(isValidCorsOrigin('https://example.com/')).toBe(true);
+    expect(isValidCorsOrigin('https://example.com:8080')).toBe(true);
+  });
+
+  it('should accept origins that canonicalizing will normalize', () => {
+    expect(isValidCorsOrigin('HTTPS://Example.com')).toBe(true);
+    expect(isValidCorsOrigin('https://example.com:443')).toBe(true);
+    expect(isValidCorsOrigin('http://example.com:80')).toBe(true);
+  });
+
+  it('should reject origins with a path, query, or hash', () => {
+    expect(isValidCorsOrigin('https://example.com/callback')).toBe(false);
+    expect(isValidCorsOrigin('https://example.com?query=1')).toBe(false);
+    expect(isValidCorsOrigin('https://example.com#hash')).toBe(false);
+    expect(isValidCorsOrigin('https://example.com//')).toBe(false);
+  });
+
+  it('should reject origins carrying credentials', () => {
+    expect(isValidCorsOrigin('https://user:pass@example.com')).toBe(false);
+    expect(isValidCorsOrigin('https://user@example.com')).toBe(false);
+  });
+
+  it('should reject wildcards, non-http schemes, and malformed values', () => {
+    expect(isValidCorsOrigin('https://*.example.com')).toBe(false);
+    expect(isValidCorsOrigin('ftp://example.com')).toBe(false);
+    expect(isValidCorsOrigin('example.com')).toBe(false);
+  });
+});

--- a/projects/client/src/lib/sections/settings/_internal/apps/isValidCorsOrigin.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/isValidCorsOrigin.ts
@@ -1,0 +1,19 @@
+import { toUrl } from '$lib/utils/url/toUrl.ts';
+
+export function isValidCorsOrigin(value: string): boolean {
+  // `new URL` accepts a wildcard hostname, so it needs rejecting separately.
+  if (value.includes('*')) {
+    return false;
+  }
+
+  const url = toUrl(value);
+  if (!url) {
+    return false;
+  }
+
+  const isHttp = url.protocol === 'http:' || url.protocol === 'https:';
+  const isOriginOnly = url.pathname === '/' && !url.search && !url.hash;
+  const hasCredentials = Boolean(url.username || url.password);
+
+  return isHttp && isOriginOnly && !hasCredentials;
+}

--- a/projects/client/src/lib/sections/settings/_internal/apps/isValidRedirectUri.spec.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/isValidRedirectUri.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { isValidRedirectUri } from './isValidRedirectUri.ts';
+
+describe('util: isValidRedirectUri', () => {
+  it('should accept http(s) URIs with a path', () => {
+    expect(isValidRedirectUri('https://example.com/callback')).toBe(true);
+    expect(isValidRedirectUri('https://example.com')).toBe(true);
+    expect(isValidRedirectUri('http://localhost:5173/auth/callback')).toBe(
+      true,
+    );
+  });
+
+  it('should accept the out-of-band redirect URI', () => {
+    expect(isValidRedirectUri('urn:ietf:wg:oauth:2.0:oob')).toBe(true);
+  });
+
+  it('should accept custom schemes used by native clients', () => {
+    expect(isValidRedirectUri('nuvio://auth')).toBe(true);
+    expect(isValidRedirectUri('app.tivi://callback')).toBe(true);
+  });
+
+  it('should reject URIs with a query string or fragment', () => {
+    expect(isValidRedirectUri('https://example.com/callback?state=1')).toBe(
+      false,
+    );
+    expect(isValidRedirectUri('https://example.com/callback#token')).toBe(
+      false,
+    );
+  });
+
+  it('should reject schemes that can carry inline executable payloads', () => {
+    // skipcq: JS-0087
+    expect(isValidRedirectUri('javascript:alert(1)')).toBe(false);
+    expect(isValidRedirectUri('data:text/html,<script></script>')).toBe(false);
+    expect(isValidRedirectUri('vbscript:msgbox(1)')).toBe(false);
+    expect(isValidRedirectUri('blob:https://example.com/uuid')).toBe(false);
+    expect(isValidRedirectUri('view-source:javascript:alert(1)')).toBe(false);
+    expect(isValidRedirectUri('filesystem:https://example.com/temporary/f'))
+      .toBe(false);
+  });
+
+  it('should reject schemes without an authority', () => {
+    expect(isValidRedirectUri('mailto:someone@example.com')).toBe(false);
+    expect(isValidRedirectUri('nuvio:auth')).toBe(false);
+  });
+
+  it('should reject malformed values', () => {
+    expect(isValidRedirectUri('example.com/callback')).toBe(false);
+    expect(isValidRedirectUri('/callback')).toBe(false);
+  });
+});

--- a/projects/client/src/lib/sections/settings/_internal/apps/isValidRedirectUri.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/isValidRedirectUri.ts
@@ -1,0 +1,22 @@
+import { toUrl } from '$lib/utils/url/toUrl.ts';
+
+const OOB_REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob';
+
+export function isValidRedirectUri(value: string): boolean {
+  if (value === OOB_REDIRECT_URI) {
+    return true;
+  }
+
+  const url = toUrl(value);
+  if (!url) {
+    return false;
+  }
+
+  if (url.search || url.hash) {
+    return false;
+  }
+
+  // Opaque URIs (javascript:, data:, blob:, view-source:) carry an inline
+  // payload instead of an authority; real redirect targets always have one.
+  return value.toLowerCase().startsWith(`${url.protocol}//`);
+}

--- a/projects/client/src/lib/sections/settings/_internal/apps/toCanonicalOrigin.spec.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/toCanonicalOrigin.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { toCanonicalOrigin } from './toCanonicalOrigin.ts';
+
+describe('util: toCanonicalOrigin', () => {
+  it('should leave already canonical origins untouched', () => {
+    expect(toCanonicalOrigin('https://example.com')).toBe(
+      'https://example.com',
+    );
+    expect(toCanonicalOrigin('https://example.com:8080')).toBe(
+      'https://example.com:8080',
+    );
+  });
+
+  it('should lower-case the scheme and host', () => {
+    expect(toCanonicalOrigin('HTTPS://Example.com')).toBe(
+      'https://example.com',
+    );
+  });
+
+  it('should drop a default port and a trailing slash', () => {
+    expect(toCanonicalOrigin('https://example.com:443')).toBe(
+      'https://example.com',
+    );
+    expect(toCanonicalOrigin('http://example.com:80')).toBe(
+      'http://example.com',
+    );
+    expect(toCanonicalOrigin('https://example.com/')).toBe(
+      'https://example.com',
+    );
+  });
+
+  it('should pass unparseable values through untouched', () => {
+    expect(toCanonicalOrigin('example.com')).toBe('example.com');
+  });
+});

--- a/projects/client/src/lib/sections/settings/_internal/apps/toCanonicalOrigin.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/toCanonicalOrigin.ts
@@ -1,0 +1,6 @@
+import { toUrl } from '$lib/utils/url/toUrl.ts';
+
+/** The server matches stored origins against the browser's `Origin` header. */
+export function toCanonicalOrigin(value: string): string {
+  return toUrl(value)?.origin ?? value;
+}

--- a/projects/client/src/lib/sections/settings/_internal/apps/useCreateApiApplication.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/useCreateApiApplication.ts
@@ -1,33 +1,37 @@
-import type { ApiApplication } from '$lib/requests/models/ApiApplication.ts';
+import * as m from '$lib/features/i18n/messages.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
-import { createApiApplicationRequest } from '$lib/requests/queries/apps/createApiApplicationRequest.ts';
+import {
+  createApiApplicationRequest,
+  type CreateApiApplicationResult,
+} from '$lib/requests/queries/apps/createApiApplicationRequest.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
 import { BehaviorSubject } from 'rxjs';
-
-type CreateApiApplicationInput = {
-  name: string;
-  description?: string;
-  redirectUris: ReadonlyArray<string>;
-  origins: ReadonlyArray<string>;
-};
+import type { ApiApplicationFormValues } from './ApiApplicationFormValues.ts';
 
 export function useCreateApiApplication() {
   const isCreating = new BehaviorSubject(false);
+  const error = new BehaviorSubject<string | null>(null);
   const { invalidate } = useInvalidator();
 
   const createApplication = async (
-    input: CreateApiApplicationInput,
-  ): Promise<ApiApplication | null> => {
+    input: ApiApplicationFormValues,
+  ): Promise<CreateApiApplicationResult> => {
     isCreating.next(true);
+    error.next(null);
 
     try {
-      const created = await createApiApplicationRequest(input);
+      const result = await createApiApplicationRequest(input);
 
-      if (created) {
-        await invalidate(InvalidateAction.App.Create);
+      if (!result.ok) {
+        error.next(m.error_text_app_save_failed());
+        return result;
       }
 
-      return created;
+      await invalidate(InvalidateAction.App.Create);
+      return result;
+    } catch {
+      error.next(m.error_text_app_save_failed());
+      return { ok: false };
     } finally {
       isCreating.next(false);
     }
@@ -35,6 +39,8 @@ export function useCreateApiApplication() {
 
   return {
     isCreating: isCreating.asObservable(),
+    error: error.asObservable(),
+    dismissError: () => error.next(null),
     createApplication,
   };
 }

--- a/projects/client/src/lib/sections/settings/_internal/apps/useUpdateApiApplication.ts
+++ b/projects/client/src/lib/sections/settings/_internal/apps/useUpdateApiApplication.ts
@@ -1,3 +1,4 @@
+import * as m from '$lib/features/i18n/messages.ts';
 import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
 import { updateApiApplicationRequest } from '$lib/requests/queries/apps/updateApiApplicationRequest.ts';
 import { useInvalidator } from '$lib/stores/useInvalidator.ts';
@@ -8,23 +9,35 @@ type UpdateApiApplicationInput = {
   id: number;
 } & ApiApplicationFormValues;
 
+type UpdateApiApplicationError = {
+  id: number;
+  message: string;
+};
+
 export function useUpdateApiApplication() {
   const isUpdating = new BehaviorSubject(false);
+  const error = new BehaviorSubject<UpdateApiApplicationError | null>(null);
   const { invalidate } = useInvalidator();
 
   const updateApplication = async (
     input: UpdateApiApplicationInput,
   ): Promise<boolean> => {
     isUpdating.next(true);
+    error.next(null);
 
     try {
-      const updated = await updateApiApplicationRequest(input);
+      const result = await updateApiApplicationRequest(input);
 
-      if (updated) {
-        await invalidate(InvalidateAction.App.Update);
+      if (!result.ok) {
+        error.next({ id: input.id, message: m.error_text_app_save_failed() });
+        return false;
       }
 
-      return updated;
+      await invalidate(InvalidateAction.App.Update);
+      return true;
+    } catch {
+      error.next({ id: input.id, message: m.error_text_app_save_failed() });
+      return false;
     } finally {
       isUpdating.next(false);
     }
@@ -32,6 +45,8 @@ export function useUpdateApiApplication() {
 
   return {
     isUpdating: isUpdating.asObservable(),
+    error: error.asObservable(),
+    dismissError: () => error.next(null),
     updateApplication,
   };
 }

--- a/projects/client/src/lib/utils/url/toUrl.ts
+++ b/projects/client/src/lib/utils/url/toUrl.ts
@@ -1,0 +1,7 @@
+export function toUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Saving an OAuth application with an over-long description or a malformed CORS origin failed with an opaque error: the form validated almost nothing, and the server's raw rejection string was piped straight into the UI.

## Validations added

Limits match `parseApplicationRequest` server-side, measured on the trimmed value to match its `z.string().trim()` rules.

| Field | Rule |
| --- | --- |
| Name | 1–255 characters (was presence-only) |
| Description | ≤ 255 characters (was unvalidated) |
| Redirect URIs | At least one, at most 25, ≤ 2048 characters joined. Each entry a full URI with no query string or fragment; `urn:ietf:wg:oauth:2.0:oob` and native custom schemes accepted, `javascript:` / `data:` / `vbscript:` / `blob:` rejected (was presence-only) |
| JavaScript (CORS) origins | Bare `http(s)` origin per line — no wildcards, paths, query strings, or credentials. At most 25, ≤ 255 characters joined |

Each rule feeds form validity, so **Save** disables with field-level guidance instead of round-tripping to a rejection. Origins are normalised to canonical form on submit, since the server matches them against the browser's `Origin` header.

Two supporting changes: failed requests now surface a generic translated message through `DismissibleError` rather than the raw server string, and `FormInput` / `FormTextArea` validate a pre-filled value on mount so stored values that predate a rule explain why Save is disabled.

Every rule the server enforces now has a client-side counterpart, but `parseApplicationRequest` stays the trust boundary — this only trades an opaque rejection for a field-level message.

## Testing

`isValidRedirectUri`, `isValidCorsOrigin` and `toCanonicalOrigin` have specs. Create and edit forms manually exercised.

https://github.com/user-attachments/assets/fbef8824-350b-45c9-b0a5-1ab9208a418b
