### PR TITLE
fix(stats): show full numbers below 100K instead of abbreviating

### DIFF
--- a/.agents/rules/utils.md
+++ b/.agents/rules/utils.md
@@ -95,6 +95,7 @@ toRelativeHumanDay(today, date, localeKey);
 
 // number
 toHumanNumber(value, locale); // compact notation: 1.2k, 4.5M
+toHumanCount(value, locale); // counts: grouped below 100K (1,234), compact above
 toPercentage(value, locale); // 0.75 -> "75%"
 toTraktRating(rating, locale); // alias for toPercentage
 toHumanCurrency({ price, currency, locale });

--- a/projects/client/src/lib/sections/profile/components/_internal/AllTimeStatTile.svelte
+++ b/projects/client/src/lib/sections/profile/components/_internal/AllTimeStatTile.svelte
@@ -2,7 +2,7 @@
   import LockIcon from "$lib/components/icons/LockIcon.svelte";
   import KpiTile from "$lib/components/kpi/KpiTile.svelte";
   import { languageTag } from "$lib/features/i18n";
-  import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber.ts";
+  import { toHumanCount } from "$lib/utils/formatting/number/toHumanCount.ts";
   import type { AllTimeStatTileProps } from "./AllTimeStatTileProps.ts";
   import StatIcon from "./StatIcon.svelte";
 
@@ -20,7 +20,7 @@
     {:else if value == null}
       <LockIcon />
     {:else}
-      <p>{toHumanNumber(value, languageTag())}</p>
+      <p>{toHumanCount(value, languageTag())}</p>
     {/if}
   </KpiTile>
 </div>

--- a/projects/client/src/lib/sections/profile/components/_internal/WatchStats.svelte
+++ b/projects/client/src/lib/sections/profile/components/_internal/WatchStats.svelte
@@ -2,8 +2,8 @@
   import Stat from "$lib/components/stat/Stat.svelte";
   import { languageTag } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
-  import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration";
-  import { toHumanNumber } from "$lib/utils/formatting/number/toHumanNumber";
+  import { toHumanDuration } from "$lib/utils/formatting/date/toHumanDuration.ts";
+  import { toHumanCount } from "$lib/utils/formatting/number/toHumanCount.ts";
   import StatIcon from "./StatIcon.svelte";
   import type { StatIconKey } from "./StatIconKey.ts";
   import type { StatsCardStats } from "./StatsCardProps.ts";
@@ -28,7 +28,7 @@
     value: number,
     labelFn: ({ count }: { count: string }) => string,
   ) => {
-    const valueLabel = toHumanNumber(value, languageTag());
+    const valueLabel = toHumanCount(value, languageTag());
     return size === "large" ? valueLabel : labelFn({ count: valueLabel });
   };
 
@@ -71,13 +71,13 @@
             },
             {
               present: stats.ratingCount != null,
-              label: toHumanNumber(stats.ratingCount ?? 0, languageTag()),
+              label: toHumanCount(stats.ratingCount ?? 0, languageTag()),
               tagLabel: m.label_stats_ratings(),
               key: "ratings",
             },
             {
               present: stats.commentCount != null,
-              label: toHumanNumber(stats.commentCount ?? 0, languageTag()),
+              label: toHumanCount(stats.commentCount ?? 0, languageTag()),
               tagLabel: m.label_stats_comments(),
               key: "comments",
             },

--- a/projects/client/src/lib/utils/formatting/number/toHumanCount.spec.ts
+++ b/projects/client/src/lib/utils/formatting/number/toHumanCount.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { toHumanCount } from './toHumanCount.ts';
+
+describe('toHumanCount', () => {
+  it('will format 42 as 42', () => {
+    expect(toHumanCount(42)).toBe('42');
+  });
+
+  it('will format 4217 as the grouped number 4,217', () => {
+    expect(toHumanCount(4217)).toBe('4,217');
+  });
+
+  it('will format 99999 as the grouped number 99,999', () => {
+    expect(toHumanCount(99999)).toBe('99,999');
+  });
+
+  it('will format 100000 as the compact number 100K', () => {
+    expect(toHumanCount(100000)).toBe('100K');
+  });
+
+  it('will format 4217000 as the compact number 4.2M', () => {
+    expect(toHumanCount(4217000)).toBe('4.2M');
+  });
+
+  it('will format -4217 as the grouped number -4,217', () => {
+    expect(toHumanCount(-4217)).toBe('-4,217');
+  });
+
+  it('will respect the provided locale', () => {
+    expect(toHumanCount(4217, 'de')).toBe('4.217');
+  });
+});

--- a/projects/client/src/lib/utils/formatting/number/toHumanCount.ts
+++ b/projects/client/src/lib/utils/formatting/number/toHumanCount.ts
@@ -1,0 +1,17 @@
+import type {
+  AvailableLanguage,
+  AvailableLocale,
+} from '$lib/features/i18n/index.ts';
+import { toGroupedNumber } from './toGroupedNumber.ts';
+import { toHumanNumber } from './toHumanNumber.ts';
+
+const compactThreshold = 100_000;
+
+export function toHumanCount(
+  value: number,
+  locale: AvailableLocale | AvailableLanguage | string = 'en',
+): string {
+  return Math.abs(value) < compactThreshold
+    ? toGroupedNumber(value, locale)
+    : toHumanNumber(value, locale);
+}


### PR DESCRIPTION
## Summary

All-time profile stats (plays, episodes watched, ratings, comments, etc.) abbreviated large counts into compact notation like "1.2K", hiding the exact value users wanted to see. Since these counts realistically never exceed 100K, the fix shows the full grouped number below that threshold and only falls back to compact notation for the rare outlier above it, via a new `toHumanCount` helper that leaves the shared `toHumanNumber` (used elsewhere in the app for values that do routinely get large) untouched.

## Alternatives considered

- **Tap/hover tooltip on the abbreviated value**, matching the existing watch-streak heatmap interaction — prototyped (see attached screenshot) but dropped, since abbreviation essentially never triggers for these counts in practice, the tooltip plumbing would be unused complexity for a case that doesn't happen.
- **Lowering the abbreviation threshold globally in `toHumanNumber`** — rejected in favor of a separate `toHumanCount` helper, since `toHumanNumber` is used elsewhere in the app for values that do routinely get large, and changing it would be a much broader behavioral change than this fix calls for.

## Notable context

In several locales (Arabic, Hindi, Russian, Portuguese-BR) the abbreviated form is actually *wider* than the plain number in this range, since their thousand-suffix is a full word (e.g. "тыс.", "हज़ार") rather than a single letter — so abbreviating bought nothing there anyway, beyond the precision loss.

## Test plan

- [ ] Unit tests pass: `deno task test:unit` (covers `toHumanCount` across the 100K boundary and locale variation)
- [x] Visit a profile's all-time stats card and the all-time stats drawer; verify counts under 100K render as full grouped numbers (e.g. `4,217` not `4.2K`)
- [x] Sanity-check a non-`en` locale (e.g. `de` or `fr`) to confirm grouping separators render correctly
- [ ] Confirm the rare case above 100K still abbreviates (can temporarily lower `COMPACT_THRESHOLD` locally to exercise this, or check the new spec)

## Screenshots

Profile Small Before/After (en/ru)
<img width="377" height="159" alt="en s before" src="https://github.com/user-attachments/assets/dab03d85-8ba8-449d-8b27-ee075f33b1f7" />
<img width="380" height="158" alt="en s after" src="https://github.com/user-attachments/assets/6aa6d23d-bb5d-4e5d-927e-1b6ca3ad499e" />
<img width="417" height="164" alt="ru s before" src="https://github.com/user-attachments/assets/201d1863-9b77-48e1-a0f6-ce346b13d473" />
<img width="418" height="174" alt="ru s after" src="https://github.com/user-attachments/assets/4bd6bf11-e6ab-420b-bb35-b925fa8bcd27" />

Profile Large Before/After (en/ru)
<img width="391" height="231" alt="en l before" src="https://github.com/user-attachments/assets/12abdb9d-0680-42bb-aedd-122ec2848d6d" />
<img width="387" height="233" alt="en l after" src="https://github.com/user-attachments/assets/77b01985-7350-477a-a447-aa04cf8d9bcf" />
<img width="393" height="246" alt="ru l before" src="https://github.com/user-attachments/assets/954c33d4-7738-4fa6-9f42-40b05bc2efd7" />
<img width="381" height="238" alt="ru l after" src="https://github.com/user-attachments/assets/1e4849d9-93b0-48cf-bc13-09415137d553" />

Sheet Before/After (en/ru)
<img width="200" alt="en sheet before" src="https://github.com/user-attachments/assets/7cc64ee4-63b5-4e65-829d-486119d8ecc7" /><img width="200" alt="en sheet after" src="https://github.com/user-attachments/assets/44a450c8-c5e8-48e9-b0de-0308e9ac0f21" />

<img width="200" alt="ru sheet before" src="https://github.com/user-attachments/assets/e031fb26-6420-49b6-9655-1176fab78aea" /><img width="200" alt="ru sheet after" src="https://github.com/user-attachments/assets/70196047-44af-47d6-b492-86272bb13d02" />

Alternative - Tooltip (en):
<img width="353" height="238" alt="tooltip" src="https://github.com/user-attachments/assets/c0d98af7-2019-4add-9e9b-d7410e11a357" />

cc @ElMagnea @michaldrabik 