### PR TITLE
fix(settings): preserve localized title capitalization

### DIFF
--- a/projects/client/src/lib/sections/settings/_internal/SettingsBlock.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/SettingsBlock.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  const {
+    title,
+    description,
+    children,
+  }: ChildrenProps & { title: string; description: string } = $props();
+</script>
+
+<div class="trakt-settings-block">
+  <div class="trakt-settings-block-header">
+    <p class="settings-title">{title}</p>
+    <p class="secondary">{description}</p>
+  </div>
+  <div class="trakt-settings-block-content">
+    {@render children()}
+  </div>
+</div>
+
+<style lang="scss">
+  @use "$style/scss/mixins/index" as *;
+
+  .trakt-settings-block-header {
+    display: flex;
+    flex-direction: column;
+
+    gap: var(--gap-xs);
+
+    p.settings-title {
+      transition: font-size var(--transition-increment) ease-in-out;
+      font-size: var(--font-size-title);
+    }
+  }
+
+  .trakt-settings-block,
+  .trakt-settings-block-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-l);
+  }
+</style>


### PR DESCRIPTION
Removes the CSS `capitalize` transformation from settings block titles.

The transformation overrides the capitalization defined in the locale files and can produce incorrect text in languages other than English. For example, the Portuguese (Portugal) translation `Importar do TV Time` was displayed as `Importar Do TV Time`.

Settings titles now preserve the capitalization provided by each translation.

## Pull Request Checklist

- [x] **Clear and Concise Title:** Does your title shine a spotlight on the
      essence of your changes?
- [x] **Detailed Description:** Have you set the stage with a compelling
      narrative that explains the "why" and "how" of your changes?
- [ ] **Screenshots/Videos:** Have you captured the magic with visual evidence
      that showcases your changes in action?
- [ ] **Tests:** Has your code undergone a rigorous dress rehearsal with unit
      tests to ensure it performs flawlessly under pressure?
- [x] **Coding Standards:** Does your code adhere to the project's style guide,
      ensuring it's as elegant as a film score?
- [x] **Commit Messages:** Are your commit messages clear and concise, guiding
      the audience through the evolution of your code?
- [x] **Documentation:** If your changes impact the script, have you updated the
      documentation accordingly?
- [x] **Code Review:** Are you prepared to embrace feedback from the discerning
      eyes of the project maintainers and fellow contributors?