### PR TITLE
feat: add string for qot graph

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2653,6 +2653,24 @@
         }
       }
     },
+    "text_ratings_season_extremes_android": {
+      "default": "Peak S{peak} ({peakRating})  •  Low S{low} ({lowRating})",
+      "description": "Summary line above the season-ratings chart calling out the highest- and lowest-rated seasons. {peak}/{low} are compact season labels (e.g. S4); {peakRating}/{lowRating} percentages strings.",
+      "variables": {
+        "peak": {
+          "type": "string"
+        },
+        "peakRating": {
+          "type": "string"
+        },
+        "low": {
+          "type": "string"
+        },
+        "lowRating": {
+          "type": "string"
+        }
+      }
+    },
     "text_ratings_season_point": {
       "default": "{season} · {rating}%",
       "description": "Tooltip for a point on the season-ratings chart. {season} is a compact season label (e.g. S3); {rating} is a whole-number percentage.",


### PR DESCRIPTION
- adding this one string I need spec. for Android so the definition does not contain `%` which is already a special symbol when resolving stuff on Android