### PR TITLE
fix(i18n): stop baking a literal % into season-ratings message templates

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -2636,8 +2636,8 @@
       "description": "Accessible label for the season-ratings line chart in the ratings breakdown drawer."
     },
     "text_ratings_season_extremes": {
-      "default": "Peak {peak} · {peakRating}% · Low {low} · {lowRating}%",
-      "description": "Summary line above the season-ratings chart calling out the highest- and lowest-rated seasons. {peak}/{low} are compact season labels (e.g. S4); {peakRating}/{lowRating} are whole-number percentages.",
+      "default": "Peak {peak} · {peakRating} · Low {low} · {lowRating}",
+      "description": "Summary line above the season-ratings chart calling out the highest- and lowest-rated seasons. {peak}/{low} are compact season labels (e.g. S4); {peakRating}/{lowRating} are already-formatted whole-number percentages (e.g. \"94%\"), formatted by the caller rather than this template so the % sign's locale-specific spacing (e.g. German's \"94 %\") comes from a locale-aware percent formatter, not a literal % baked into every translation.",
       "variables": {
         "peak": {
           "type": "string"
@@ -2655,7 +2655,7 @@
     },
     "text_ratings_season_extremes_android": {
       "default": "Peak S{peak} ({peakRating})  •  Low S{low} ({lowRating})",
-      "description": "Summary line above the season-ratings chart calling out the highest- and lowest-rated seasons. {peak}/{low} are compact season labels (e.g. S4); {peakRating}/{lowRating} percentages strings.",
+      "description": "Summary line above the season-ratings chart calling out the highest- and lowest-rated seasons, Android's own wording/punctuation for the same message as text_ratings_season_extremes. {peak}/{low} are raw season numbers, not pre-formatted labels — the template itself prepends \"S\". {peakRating}/{lowRating} are already-formatted whole-number percentages (e.g. \"94%\"), formatted by the caller via a locale-aware percent formatter rather than this template, so the % sign's locale-specific spacing (e.g. German's \"94 %\") is correct.",
       "variables": {
         "peak": {
           "type": "string"
@@ -2672,8 +2672,8 @@
       }
     },
     "text_ratings_season_point": {
-      "default": "{season} · {rating}%",
-      "description": "Tooltip for a point on the season-ratings chart. {season} is a compact season label (e.g. S3); {rating} is a whole-number percentage.",
+      "default": "{season} · {rating}",
+      "description": "Tooltip for a point on the season-ratings chart. {season} is a compact season label (e.g. S3); {rating} is an already-formatted whole-number percentage (e.g. \"94%\"), formatted by the caller rather than this template — see text_ratings_season_extremes for why.",
       "variables": {
         "season": {
           "type": "string"

--- a/projects/client/src/lib/sections/summary/components/rating/_internal/SeasonRatingsChart.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/_internal/SeasonRatingsChart.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import LineChart from "$lib/components/charts/LineChart.svelte";
+  import { languageTag } from "$lib/features/i18n";
   import * as m from "$lib/features/i18n/messages.ts";
   import type { Season } from "$lib/requests/models/Season.ts";
+  import { toPercentage } from "$lib/utils/formatting/number/toPercentage.ts";
 
   type SeasonPoint = { season: number; rating: number };
 
@@ -56,9 +58,9 @@
         <span class="meta tag secondary">
           {m.text_ratings_season_extremes({
             peak: seasonLabel(peak.season),
-            peakRating: String(peak.rating),
+            peakRating: toPercentage(peak.rating / 100, languageTag()),
             low: seasonLabel(trough.season),
-            lowRating: String(trough.rating),
+            lowRating: toPercentage(trough.rating / 100, languageTag()),
           })}
         </span>
       {/if}
@@ -77,7 +79,7 @@
           <span class="season-tooltip">
             {m.text_ratings_season_point({
               season: label,
-              rating: String(value),
+              rating: toPercentage(value / 100, languageTag()),
             })}
           </span>
         {/snippet}


### PR DESCRIPTION
## Summary

`text_ratings_season_extremes` and `text_ratings_season_point` (the summary line and tooltip on the season-ratings chart in the ratings breakdown drawer) hardcoded a literal `%` after the rating placeholder, which assumes English's no-space convention. Locales that require a space before the percent sign (German, French, ...) were rendering it incorrectly in every translation. The rating is now formatted by the caller via `toPercentage()` before being interpolated into the message, so the sign's locale-specific spacing comes from `Intl.NumberFormat`, not a literal baked into the template. This matches a fix already shipped on iOS for the same message keys.

Also corrects `text_ratings_season_extremes_android`'s description, which incorrectly documented `{peak}`/`{low}` as pre-formatted labels like `"S4"` when the template itself prepends `S` (they're raw season numbers) — no functional change, since `description` isn't read by the generator, just fixing stale docs while touching this key's neighbor.

## To check

- [ ] @seferturan will the translations get updated as expected to remove the raw % from all of them locally/at crowdin?
- [ ] @michaldrabik was there a reason android uses a different string instead of updating the existing?

## Screenshots
Before/After (German, which has spaces between `number` and `%`)
<img height="261" alt="Screenshot 2026-08-07 at 3 42 36 pm" src="https://github.com/user-attachments/assets/86798e33-0538-43e3-a5d9-845fb9a687a0" />
<img height="261" alt="Screenshot 2026-08-07 at 3 42 05 pm" src="https://github.com/user-attachments/assets/f0c90c71-c856-470a-85e9-d6f6a7418aa4" />

cc @ElMagnea @michaldrabik

Ref: [Android](https://github.com/trakt/trakt-android/pull/332)