### PR TITLE
feat: independent comment language filter

### DIFF
--- a/projects/client/src/lib/sections/summary/components/comments/_internal/CommentLanguageSelect.svelte
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/CommentLanguageSelect.svelte
@@ -2,9 +2,10 @@
   import ActionButton from "$lib/components/buttons/ActionButton.svelte";
   import GlobeIcon from "$lib/components/icons/GlobeIcon.svelte";
   import SingleSelect from "$lib/components/select/SingleSelect.svelte";
-  import { availableLocales, getLocale } from "$lib/features/i18n/index.ts";
+  import { getLocale } from "$lib/features/i18n/index.ts";
   import * as m from "$lib/features/i18n/messages.ts";
   import { COMMENT_LANGUAGE_ALL } from "./commentLanguageAll.ts";
+  import { commentLanguageCodes } from "./commentLanguageCodes.ts";
   import type { CommentLanguageSelectProps } from "./CommentLanguageSelectProps.ts";
 
   const { value, onChange }: CommentLanguageSelectProps = $props();
@@ -16,11 +17,7 @@
     });
     const collator = new Intl.Collator(currentLocale, { sensitivity: "base" });
 
-    const languageOptions = [
-      ...new Set(
-        availableLocales.map((locale) => locale.split("-").at(0) ?? locale),
-      ),
-    ]
+    const languageOptions = [...commentLanguageCodes]
       .map((code) => ({
         value: code,
         label: displayNames.of(code) ?? code,

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/commentLanguageCodes.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/commentLanguageCodes.ts
@@ -1,0 +1,5 @@
+import { availableLocales } from '$lib/features/i18n/index.ts';
+
+export const commentLanguageCodes: ReadonlySet<string> = new Set(
+  availableLocales.map((locale) => locale.split('-').at(0) ?? locale),
+);

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/useCommentLanguage.spec.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/useCommentLanguage.spec.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/features/i18n/index.ts', () => ({
+  languageTag: () => 'en',
+  availableLocales: ['en-US', 'es-ES', 'nl-NL'],
+}));
+
+const STORAGE_KEY = 'trakt-comment-language';
+
+function navigateTo(search: string) {
+  globalThis.history.replaceState({}, '', `/movies/heretic${search}`);
+}
+
+async function loadHook() {
+  vi.resetModules();
+  const { useCommentLanguage } = await import('./useCommentLanguage.svelte.ts');
+
+  return useCommentLanguage();
+}
+
+describe('store: useCommentLanguage', () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+    navigateTo('');
+  });
+
+  describe('without a stored preference', () => {
+    it('should default to the locale language', async () => {
+      const commentLanguage = await loadHook();
+
+      expect(commentLanguage.value).to.equal('en');
+    });
+
+    it('should be overridden by the url search param', async () => {
+      navigateTo('?review_lang=nl');
+      const commentLanguage = await loadHook();
+
+      expect(commentLanguage.value).to.equal('nl');
+    });
+  });
+
+  describe('with a stored preference', () => {
+    it('should prefer the stored language over the locale', async () => {
+      globalThis.localStorage.setItem(STORAGE_KEY, 'es');
+      const commentLanguage = await loadHook();
+
+      expect(commentLanguage.value).to.equal('es');
+    });
+
+    it('should prefer "all" over the locale', async () => {
+      globalThis.localStorage.setItem(STORAGE_KEY, 'all');
+      const commentLanguage = await loadHook();
+
+      expect(commentLanguage.value).to.equal('all');
+      expect(commentLanguage.filter).to.equal(undefined);
+    });
+
+    it('should be overridden by the url search param', async () => {
+      globalThis.localStorage.setItem(STORAGE_KEY, 'es');
+      navigateTo('?review_lang=nl');
+      const commentLanguage = await loadHook();
+
+      expect(commentLanguage.value).to.equal('nl');
+    });
+
+    it('should ignore a language the picker no longer offers', async () => {
+      globalThis.localStorage.setItem(STORAGE_KEY, 'kl');
+      const commentLanguage = await loadHook();
+
+      expect(commentLanguage.value).to.equal('en');
+    });
+  });
+
+  describe('set', () => {
+    it('should persist the selection', async () => {
+      const commentLanguage = await loadHook();
+      commentLanguage.set('nl');
+
+      expect(globalThis.localStorage.getItem(STORAGE_KEY)).to.equal('nl');
+    });
+
+    it('should keep the selection after navigating away', async () => {
+      const commentLanguage = await loadHook();
+      commentLanguage.set('nl');
+
+      navigateTo('');
+
+      expect(commentLanguage.value).to.equal('nl');
+    });
+  });
+});

--- a/projects/client/src/lib/sections/summary/components/comments/_internal/useCommentLanguage.svelte.ts
+++ b/projects/client/src/lib/sections/summary/components/comments/_internal/useCommentLanguage.svelte.ts
@@ -1,28 +1,47 @@
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
 import { languageTag } from '$lib/features/i18n/index.ts';
+import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
 import { COMMENT_LANGUAGE_ALL } from './commentLanguageAll.ts';
+import { commentLanguageCodes } from './commentLanguageCodes.ts';
 
 const REVIEW_LANGUAGE_PARAM = 'review_lang';
+const STORAGE_KEY = 'trakt-comment-language';
+
+function isSupportedLanguage(value: string) {
+  return value === COMMENT_LANGUAGE_ALL || commentLanguageCodes.has(value);
+}
+
+function toStoredPreference() {
+  const stored = safeLocalStorage.getItem(STORAGE_KEY);
+  if (stored == null) return null;
+
+  return isSupportedLanguage(stored) ? stored : null;
+}
+
+let preference = $state<string | null>(toStoredPreference());
 
 /**
- * Comment language filter, backed by a shareable URL search param. Defaults to
- * the user's current locale language when the param is absent. Shared across
- * every comment surface (inline section, drawer, season tab) so a linked URL
- * reproduces the selection.
+ * Comment language filter. Reads the stored preference, overridden by a
+ * shareable URL search param when present so a linked URL reproduces the
+ * selection. Without either, defaults to the user's current locale language.
  *
  * `value` is the picker selection ("all" or a language code); `filter` is the
  * value to pass to the query (undefined for "all", i.e. no filter).
  */
 export function useCommentLanguage() {
   const value = $derived(
-    page.url.searchParams.get(REVIEW_LANGUAGE_PARAM) ?? languageTag(),
+    page.url.searchParams.get(REVIEW_LANGUAGE_PARAM) ?? preference ??
+      languageTag(),
   );
   const filter = $derived(
     value === COMMENT_LANGUAGE_ALL ? undefined : value,
   );
 
   function set(next: string) {
+    preference = next;
+    safeLocalStorage.setItem(STORAGE_KEY, next);
+
     const url = new URL(page.url);
     url.searchParams.set(REVIEW_LANGUAGE_PARAM, next);
     goto(url, { replaceState: true, noScroll: true, keepFocus: true });


### PR DESCRIPTION
The comment/review language filter will no longer derive its default from the app
locale. It now defaults to **All languages** and remembers the user's choice
across sessions and navigation.

### Why?

- Defaulting the filter to the app language meant users browsing in a non-English
locale silently saw a heavily filtered review list - usually always empty (we don't have that big of volume to cover our languages) - with no indication that a filter was applied. Reviews are mostly written in English,
so the app-language default hid the majority of content.

- Language preference for reviews is also a separate concern from UI
language: someone using a Polish interface may still want to read reviews in whatever language has most of them in general. Tying the two together conflated two unrelated settings.

- Finally, the filter was URL-only, so it reset on every navigation. Picking a
language on one media had to be repeated on the next one. Persisting it matches
how other user-level view preferences (collapsed sections, sort togglers)
already behave.