### PR TITLE
fix(spoiler): keep the spoiler box open when expanding the description

### DIFF
--- a/projects/client/src/lib/sections/summary/components/_internal/CollapsableContent.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/CollapsableContent.svelte
@@ -6,13 +6,11 @@
     children,
     labels,
     headerContent,
-    variant = "sibling",
     isCollapsed,
     toggle,
   }: {
     labels: { view: string; hide: string };
     headerContent?: Snippet;
-    variant?: "contain" | "sibling";
     isCollapsed: boolean;
     toggle: () => void;
   } & ChildrenProps = $props();
@@ -20,7 +18,24 @@
   const label = $derived(isCollapsed ? labels.view : labels.hide);
 </script>
 
-{#snippet content()}
+<div
+  class="trakt-collapsable-content-container"
+  class:is-expanded={!isCollapsed}
+>
+  <button
+    class="trakt-collapsable-content-button"
+    aria-expanded={!isCollapsed}
+    onclick={toggle}
+  >
+    <div class="trakt-collapsable-content-header">
+      <p>{label}</p>
+
+      {#if headerContent}
+        {@render headerContent()}
+      {/if}
+    </div>
+  </button>
+
   {#if !isCollapsed}
     <div
       class="trakt-collapsable-content"
@@ -29,69 +44,17 @@
       {@render children()}
     </div>
   {/if}
-{/snippet}
-
-<button
-  class="trakt-collapsable-content-button"
-  aria-label={label}
-  onclick={toggle}
-  class:is-expanded={!isCollapsed}
-  class:is-contained={variant === "contain"}
->
-  <div class="trakt-collapsable-content-header">
-    <p>{label}</p>
-
-    {#if headerContent}
-      {@render headerContent()}
-    {/if}
-  </div>
-
-  {#if variant === "contain"}
-    {@render content()}
-  {/if}
-</button>
-
-{#if variant === "sibling"}
-  {@render content()}
-{/if}
+</div>
 
 <style>
-  .trakt-collapsable-content-button {
-    all: unset;
-    -webkit-tap-highlight-color: transparent;
-
+  .trakt-collapsable-content-container {
     display: flex;
-    justify-content: center;
-
-    padding: var(--ni-8);
-    padding-inline-start: var(--ni-12);
-
-    background-color: transparent;
-
-    border-radius: var(--border-radius-xxl);
-    border: var(--ni-2) solid var(--color-text-secondary);
-
-    .trakt-collapsable-content-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-
-      min-height: var(--ni-16);
-
-      :global(svg) {
-        width: var(--ni-16);
-        height: var(--ni-16);
-        transition: transform var(--transition-increment) ease-in-out;
-      }
-    }
-  }
-
-  .trakt-collapsable-content-button.is-contained {
     flex-direction: column;
 
     color: var(--color-foreground-red);
     background-color: var(--red-900);
 
+    border-radius: var(--border-radius-xxl);
     border: var(--ni-2) solid var(--color-background-red);
 
     transition: var(--transition-increment) ease-in-out;
@@ -111,7 +74,38 @@
     }
   }
 
-  .trakt-collapsable-content {
+  .trakt-collapsable-content-button {
+    all: unset;
+    -webkit-tap-highlight-color: transparent;
+
+    display: flex;
+    justify-content: center;
+
     padding: var(--ni-8);
+    padding-inline-start: var(--ni-12);
+
+    background-color: transparent;
+
+    border-radius: inherit;
+
+    .trakt-collapsable-content-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex: 1;
+
+      min-height: var(--ni-16);
+
+      :global(svg) {
+        width: var(--ni-16);
+        height: var(--ni-16);
+        transition: transform var(--transition-increment) ease-in-out;
+      }
+    }
+  }
+
+  .trakt-collapsable-content {
+    padding-block: 0 var(--ni-12);
+    padding-inline: var(--ni-18) var(--ni-12);
   }
 </style>

--- a/projects/client/src/lib/sections/summary/components/_internal/SpoilerSection.svelte
+++ b/projects/client/src/lib/sections/summary/components/_internal/SpoilerSection.svelte
@@ -22,12 +22,7 @@
 </script>
 
 {#snippet spoiler()}
-  <CollapsableContent
-    {labels}
-    variant="contain"
-    isCollapsed={$isCollapsed}
-    {toggle}
-  >
+  <CollapsableContent {labels} isCollapsed={$isCollapsed} {toggle}>
     {@render children()}
     {#snippet headerContent()}
       <p class="bold trakt-spoiler-alert">

--- a/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
+++ b/projects/client/src/lib/sections/summary/components/episode-drawer/_internal/EpisodeInfoHeader.svelte
@@ -590,7 +590,7 @@
     // height and the tabs below never jump.
     min-height: calc(3 * var(--font-size-text) * 1.5);
 
-    :global(.trakt-collapsable-content-button) {
+    :global(.trakt-collapsable-content-container) {
       width: 100%;
       box-sizing: border-box;
     }


### PR DESCRIPTION
# Summary

Clicking the "more" button inside an expanded spoiler alert box collapsed the whole box instead of expanding the clamped description. The `contain` variant of `CollapsableContent` rendered its content inside the toggle `<button>`, so the nested "more" button was invalid HTML (interactive content inside a button) and its click bubbled up to the container's toggle.

Fixes #3081

# Changes

`CollapsableContent` now renders the `contain` variant as a wrapper `<div>` that carries the spoiler box styling (border, background, color transitions), with the header as the only `<button>` and the content as its sibling. Clicks inside the description no longer reach the toggle, and "Hide description" in the header still collapses the box.

Visual parity is preserved: the header keeps its full-width space-between layout via `flex: 1`, and the content padding compensates for the button padding it previously inherited so the combined inset is unchanged. The toggle button also gains `aria-expanded` since expansion state is no longer conveyed by nesting.

`EpisodeInfoHeader` stretches the spoiler box to full width via a global selector, so the new container class was added alongside the existing button selector there.

# Testing

Verified in the running app on an episode with a long spoiler-hidden description: expanding the description with "more" keeps the box open, header alignment matches the previous layout, and collapsing via the header still works.