### PR TITLE
fix(i18n): remove duplicate button_text_sort_rank/button_label_sort_rank keys

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -4742,14 +4742,6 @@
       "default": "Sort alphabetically",
       "description": "Aria-label for the button that allows users to sort items alphabetically by title."
     },
-    "button_text_sort_rank": {
-      "default": "Rank",
-      "description": "Text for the button that allows users to sort items by their manual rank."
-    },
-    "button_label_sort_rank": {
-      "default": "Sort by rank",
-      "description": "Aria-label for the button that allows users to sort items by their manual rank."
-    },
     "button_label_sort_list": {
       "default": "Sort list",
       "description": "Aria-label for the button that allows users to sort items in their list."


### PR DESCRIPTION
See title!

I think the error (https://github.com/trakt/trakt-web/actions/runs/31238298703/job/93054801040?pr=3104) is maybe wrong, there's already no dupe in the crowdin files, just in the en.json