### PR TITLE
fix: state_unsafe_mutation when a stale query resubscribes inside a reaction

### DIFF
--- a/projects/client/src/lib/features/query/_internal/queryBridge.spec.ts
+++ b/projects/client/src/lib/features/query/_internal/queryBridge.spec.ts
@@ -1,0 +1,83 @@
+import type { CreateQueryOptions } from '$lib/features/query/types.ts';
+import { createStateWriter } from '$test/beds/svelte/createStateWriter.svelte.ts';
+import { runInDerived } from '$test/beds/svelte/runInDerived.svelte.ts';
+import { QueryClient } from '@tanstack/query-core';
+import { config, type Subscription } from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { queryBridge } from './queryBridge.ts';
+
+function buildOptions(): CreateQueryOptions<string, Error> {
+  return {
+    queryKey: ['queryBridge', 'shared'],
+    queryFn: () => Promise.resolve('value'),
+    staleTime: 0,
+  };
+}
+
+function captureUnhandledErrors() {
+  const errors: Array<unknown> = [];
+  const previous = config.onUnhandledError;
+  config.onUnhandledError = (error) => {
+    errors.push(error);
+  };
+
+  return {
+    errors,
+    restore: () => {
+      config.onUnhandledError = previous;
+    },
+  };
+}
+
+function flushUnhandledErrorReports() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('queryBridge', () => {
+  const teardown: Array<() => void> = [];
+
+  afterEach(() => {
+    teardown.splice(0).forEach((fn) => fn());
+  });
+
+  it('should not trip state_unsafe_mutation when a sibling observer subscribes inside a $derived', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    teardown.push(() => client.clear());
+
+    const captured = captureUnhandledErrors();
+    teardown.push(captured.restore);
+
+    const subscriptions: Array<Subscription> = [];
+    teardown.push(() =>
+      subscriptions.forEach((subscription) => subscription.unsubscribe())
+    );
+
+    const writer = createStateWriter();
+    let status = 'pending';
+    subscriptions.push(
+      queryBridge<string, Error>(buildOptions, client)
+        .subscribe((result) => {
+          status = result.status;
+          writer.write();
+        }),
+    );
+
+    await vi.waitFor(() => expect(status).to.equal('success'));
+
+    const writesBefore = writer.writes;
+
+    teardown.push(runInDerived(() => {
+      subscriptions.push(
+        queryBridge<string, Error>(buildOptions, client).subscribe(() => {}),
+      );
+      return true;
+    }));
+
+    await flushUnhandledErrorReports();
+
+    expect(captured.errors).to.deep.equal([]);
+    expect(writer.writes).toBeGreaterThan(writesBefore);
+  });
+});

--- a/projects/client/src/lib/features/query/_internal/queryBridge.ts
+++ b/projects/client/src/lib/features/query/_internal/queryBridge.ts
@@ -17,6 +17,7 @@ import {
   type QueryObserverResult,
 } from '@tanstack/query-core';
 import { Observable, type Subscriber } from 'rxjs';
+import { untrack } from 'svelte';
 
 /**
  * Drive query-core's `QueryObserver` / `InfiniteQueryObserver` directly from
@@ -128,10 +129,12 @@ function bridge<TResult>(
     return NOOP_FN;
   }
 
+  const emit = (result: TResult) => untrack(() => subscriber.next(result));
+
   // Emit current state synchronously so consumers reading immediately after
   // subscribing get a value, matching prior Svelte-store behaviour.
-  subscriber.next(observer.getCurrentResult());
-  const unsubscribe = observer.subscribe((result) => subscriber.next(result));
+  emit(observer.getCurrentResult());
+  const unsubscribe = observer.subscribe(emit);
   // Force a recompute now that a listener is attached. Matches
   // createBaseQuery's post-subscribe `updateResult` - without it, optimistic
   // -> hydrated transitions that resolve synchronously can land before any

--- a/projects/client/src/lib/features/websocket/WSInvalidator.svelte
+++ b/projects/client/src/lib/features/websocket/WSInvalidator.svelte
@@ -18,7 +18,7 @@
   const { importInProgress } = useImportInProgress();
   const { clearInProgress } = useClearInProgress();
 
-  let socket = $state<WebSocket | Nil>(null);
+  let socket: WebSocket | Nil = null;
 
   let pendingActions = new Set<InvalidateActionOptions>();
 
@@ -69,11 +69,14 @@
     }
   }
 
-  token.subscribe(($token) => {
+  const subscription = token.subscribe(($token) => {
     socket?.removeEventListener("message", wsInvalidate);
     socket = createConnection(socket, $token?.value);
     socket?.addEventListener("message", wsInvalidate);
   });
 
-  onDestroy(() => destroySocket(socket));
+  onDestroy(() => {
+    subscription.unsubscribe();
+    destroySocket(socket);
+  });
 </script>

--- a/projects/client/src/lib/features/websocket/createConnection.spec.ts
+++ b/projects/client/src/lib/features/websocket/createConnection.spec.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createConnection } from './createConnection.ts';
+import { createSocket } from './createSocket.ts';
+
+vi.mock('./createSocket.ts', () => ({
+  createSocket: vi.fn(),
+}));
+
+function buildSocket() {
+  const close = vi.fn();
+  return { socket: { close } as unknown as WebSocket, close };
+}
+
+describe('createConnection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should close the previous socket when a token renews', () => {
+    const previous = buildSocket();
+    const next = buildSocket();
+    vi.mocked(createSocket).mockReturnValue(next.socket);
+
+    expect(createConnection(previous.socket, 'renewed')).to.equal(next.socket);
+    expect(previous.close).toHaveBeenCalledOnce();
+  });
+
+  it('should close the previous socket when the token is cleared', () => {
+    const previous = buildSocket();
+
+    expect(createConnection(previous.socket, null)).to.equal(undefined);
+    expect(previous.close).toHaveBeenCalledOnce();
+    expect(createSocket).not.toHaveBeenCalled();
+  });
+
+  it('should open a socket when there is no previous connection', () => {
+    const next = buildSocket();
+    vi.mocked(createSocket).mockReturnValue(next.socket);
+
+    expect(createConnection(null, 'token')).to.equal(next.socket);
+    expect(createSocket).toHaveBeenCalledWith('token');
+  });
+});

--- a/projects/client/src/lib/features/websocket/createConnection.ts
+++ b/projects/client/src/lib/features/websocket/createConnection.ts
@@ -4,16 +4,13 @@ import { destroySocket } from './destroySocket.ts';
 
 export function createConnection(
   previous: WebSocket | Nil,
-  token: string | null | undefined,
+  token: string | Nil,
 ) {
   if (!browser) return;
 
-  if (!token) {
-    destroySocket(previous);
-    return;
-  }
+  destroySocket(previous);
 
-  const connection = createSocket(token);
+  if (!token) return;
 
-  return connection;
+  return createSocket(token);
 }

--- a/projects/client/src/lib/sections/lists/stores/useStableArray.spec.ts
+++ b/projects/client/src/lib/sections/lists/stores/useStableArray.spec.ts
@@ -1,5 +1,12 @@
-import { BehaviorSubject, firstValueFrom, lastValueFrom } from 'rxjs';
-import { describe, expect, it } from 'vitest';
+import { NOOP_FN } from '$lib/utils/constants.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import {
+  BehaviorSubject,
+  firstValueFrom,
+  type Observable,
+  Subject,
+} from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useStableArray } from './useStableArray.ts';
 
 type MockItem = {
@@ -34,6 +41,22 @@ const compareFn = (left: typeof item1, right: typeof item1) =>
   left.show.id === right.show.id;
 
 describe('useStableArray', () => {
+  const subscriptions: Array<{ unsubscribe: () => void }> = [];
+
+  afterEach(() => {
+    subscriptions.splice(0).forEach((subscription) =>
+      subscription.unsubscribe()
+    );
+    vi.useRealTimers();
+  });
+
+  function collect<T>(list: Observable<Array<T>>) {
+    const emissions: Array<Array<T>> = [];
+    subscriptions.push(list.subscribe((value) => emissions.push(value)));
+
+    return () => emissions.at(-1);
+  }
+
   it('should return a store with an empty array', async () => {
     const source = new BehaviorSubject<MockItem[]>([]);
     expect(await firstValueFrom(useStableArray(compareFn, source).list))
@@ -42,49 +65,49 @@ describe('useStableArray', () => {
       );
   });
 
-  it('should update the store with a new item', async () => {
+  it('should update the store with a new item', () => {
     const source = new BehaviorSubject<MockItem[]>([]);
-    const store = useStableArray(compareFn, source);
+    const latest = collect(useStableArray(compareFn, source).list);
 
     source.next([item1]);
 
-    expect(await firstValueFrom(store.list)).toEqual([item1]);
+    expect(latest()).toEqual([item1]);
   });
 
-  it('should update the store with multiple items', async () => {
+  it('should update the store with multiple items', () => {
     const source = new BehaviorSubject<MockItem[]>([]);
-    const store = useStableArray(compareFn, source);
+    const latest = collect(useStableArray(compareFn, source).list);
     const items = [item1, item2];
 
     source.next(items);
 
-    expect(await firstValueFrom(store.list)).toEqual(items);
+    expect(latest()).toEqual(items);
   });
 
-  it('should update the store with the same item', async () => {
+  it('should update the store with the same item', () => {
     const source = new BehaviorSubject<MockItem[]>([]);
-    const store = useStableArray(compareFn, source);
+    const latest = collect(useStableArray(compareFn, source).list);
 
     source.next([item1]);
     source.next([item1]);
 
-    expect(await firstValueFrom(store.list)).toEqual([item1]);
+    expect(latest()).toEqual([item1]);
   });
 
-  it('should update the store with the same item with different data', async () => {
+  it('should update the store with the same item with different data', () => {
     const source = new BehaviorSubject<MockItem[]>([]);
-    const store = useStableArray(compareFn, source);
+    const latest = collect(useStableArray(compareFn, source).list);
 
     const update = { ...item1, title: 'Updated Show 1' };
     source.next([item1]);
     source.next([update]);
 
-    expect(await firstValueFrom(store.list)).toEqual([update]);
+    expect(latest()).toEqual([update]);
   });
 
-  it('should update the store with multiple items with the same item', async () => {
+  it('should update the store with multiple items with the same item', () => {
     const source = new BehaviorSubject<MockItem[]>([]);
-    const store = useStableArray(compareFn, source);
+    const latest = collect(useStableArray(compareFn, source).list);
     const items = [
       item1,
       item1,
@@ -93,73 +116,92 @@ describe('useStableArray', () => {
 
     source.next(items);
 
-    expect(await firstValueFrom(store.list)).toEqual([item1]);
+    expect(latest()).toEqual([item1]);
   });
 
-  it('should insert new item at its server-sorted position when it leads the update', async () => {
+  it('should insert new item at its server-sorted position when it leads the update', () => {
     const source = new BehaviorSubject<MockItem[]>([]);
-    const store = useStableArray(compareFn, source);
+    const latest = collect(useStableArray(compareFn, source).list);
 
     source.next([item1, item2]);
     source.next([item3, item1, item2]);
 
-    queueMicrotask(() => source.complete());
-    expect(await lastValueFrom(store.list, { defaultValue: [] })).toEqual([
+    expect(latest()).toEqual([
       item3,
       item1,
       item2,
     ]);
   });
 
-  it('should insert new item at its server-sorted position when it is in the middle', async () => {
+  it('should insert new item at its server-sorted position when it is in the middle', () => {
     const source = new BehaviorSubject<MockItem[]>([]);
-    const store = useStableArray(compareFn, source);
+    const latest = collect(useStableArray(compareFn, source).list);
 
     source.next([item1, item3]);
     source.next([item1, item2, item3]);
 
-    queueMicrotask(() => source.complete());
-    expect(await lastValueFrom(store.list, { defaultValue: [] })).toEqual([
+    expect(latest()).toEqual([
       item1,
       item2,
       item3,
     ]);
   });
 
-  it('should append new item at the end when server places it last', async () => {
+  it('should append new item at the end when server places it last', () => {
     const source = new BehaviorSubject<MockItem[]>([]);
-    const store = useStableArray(compareFn, source);
+    const latest = collect(useStableArray(compareFn, source).list);
 
     source.next([item1, item2]);
     source.next([item1, item2, item3]);
 
-    queueMicrotask(() => source.complete());
-    expect(await lastValueFrom(store.list, { defaultValue: [] })).toEqual([
+    expect(latest()).toEqual([
       item1,
       item2,
       item3,
     ]);
   });
 
-  it('should remove items that are not in the new list', async () => {
+  it('should remove items that are not in the new list', () => {
     const source = new BehaviorSubject<MockItem[]>([]);
-    const store = useStableArray(compareFn, source);
+    const latest = collect(useStableArray(compareFn, source).list);
 
     source.next([item1, item2]);
     source.next([item3]);
 
-    expect(await firstValueFrom(store.list)).toEqual([item3]);
+    expect(latest()).toEqual([item3]);
   });
 
-  it('should keep the order of the items', async () => {
+  it('should keep the order of the items', () => {
     const source = new BehaviorSubject<MockItem[]>([]);
-    const store = useStableArray(compareFn, source);
+    const latest = collect(useStableArray(compareFn, source).list);
     const update2 = { ...item2, title: 'Updated Show 2' };
 
     source.next([item1, item2, item3]);
     source.next([update2, item1, item3]);
 
-    queueMicrotask(() => source.complete());
-    expect(await lastValueFrom(store.list)).toEqual([item1, update2, item3]);
+    expect(latest()).toEqual([item1, update2, item3]);
+  });
+
+  it('should not subscribe to the source until the list is subscribed to', () => {
+    const source = new Subject<MockItem[]>();
+
+    useStableArray(compareFn, source);
+
+    expect(source.observed).to.equal(false);
+  });
+
+  it('should unsubscribe from the source once the last subscriber leaves', async () => {
+    vi.useFakeTimers();
+
+    const source = new Subject<MockItem[]>();
+    const { list } = useStableArray(compareFn, source);
+
+    const subscription = list.subscribe(NOOP_FN);
+    expect(source.observed).to.equal(true);
+
+    subscription.unsubscribe();
+    await vi.advanceTimersByTimeAsync(time.seconds(1));
+
+    expect(source.observed).to.equal(false);
   });
 });

--- a/projects/client/src/lib/sections/lists/stores/useStableArray.ts
+++ b/projects/client/src/lib/sections/lists/stores/useStableArray.ts
@@ -1,4 +1,5 @@
-import { BehaviorSubject, type Observable } from 'rxjs';
+import { multicast } from '$lib/utils/store/multicast.ts';
+import { type Observable, scan, startWith } from 'rxjs';
 
 export function useStableArray<T>(
   compareFn: (left: T, right: T) => boolean,
@@ -32,20 +33,11 @@ export function useStableArray<T>(
     return updatedList;
   };
 
-  const list = new BehaviorSubject<T[]>([]);
-  let previous: Array<T> = [];
-
-  source.subscribe({
-    next: (update) => {
-      const updated = updateList(previous, update);
-      previous = updated;
-      list.next(updated);
-    },
-    error: (err) => list.error(err),
-    complete: () => list.complete(),
-  });
-
   return {
-    list: list.asObservable(),
+    list: source.pipe(
+      scan(updateList, [] as Array<T>),
+      startWith([] as Array<T>),
+      multicast(),
+    ),
   };
 }

--- a/projects/client/test/beds/svelte/createStateWriter.svelte.ts
+++ b/projects/client/test/beds/svelte/createStateWriter.svelte.ts
@@ -1,0 +1,12 @@
+export function createStateWriter() {
+  let writes = $state(0);
+
+  return {
+    write: () => {
+      writes += 1;
+    },
+    get writes() {
+      return writes;
+    },
+  };
+}

--- a/projects/client/test/beds/svelte/runInDerived.svelte.ts
+++ b/projects/client/test/beds/svelte/runInDerived.svelte.ts
@@ -1,0 +1,7 @@
+export function runInDerived(compute: () => unknown): () => void {
+  return $effect.root(() => {
+    const value = $derived.by(compute);
+    const evaluate = () => value;
+    evaluate();
+  });
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Fixes #3108
- Turned out to be a cross-store cascade, not a component mutating its own state:
  - a `$derived` (or an `{#if}` block) lazily subscribes to a query observable
  - data is stale, so `onSubscribe` refetches and dispatches synchronously
  - that notifies every observer of the query, including already mounted siblings
  - `store_get` only skips its mutation guard for a store's own first sync emission, so the siblings land in the unguarded `set()` while the reaction is still running
- Wrapped the bridge emissions in `untrack`. Stays synchronous, so no ordering change, unlike the microtask deferral in 2aed1605c6 that got reverted.
- Explains why it only shows up after a tab has been sitting open. Needs 2+ live subscribers on the same key, a fresh subscribe inside a reaction, and stale data. WS invalidation and the invalidation poller both trigger it with no user input.
- Confirmed against a source mapped stack from a coworker: bottoms out on `queryBridge.ts:134` -> `useStableArray.ts:42` -> `store.js:64`, which is exactly this path.

Two subscription leaks found while tracing it, both sitting in that same stack:

- `useStableArray` subscribed to its source at construction and never unsubscribed. Callers build it inside `$derived(useList({...}))`, so every re-run leaked another subscription and kept the QueryObserver registered. Swapped the eager subscribe and the mutable accumulator for `scan` + `multicast`, so teardown follows the refcount.
- `createConnection` only closed the previous socket when the token was cleared. Every silent renew opened a new one and left the old one connected, so a long lived tab piled them up. They stayed quiet at least, the message listener is detached before the reassign.
- ⚠️ Neither leak causes the crash on its own. Cleaning them up anyway since both grow with tab uptime.

Testing:

- Regression test per fix, each verified red against the old code and green against the new.
- Had to rewrite the `useStableArray` tests to subscribe before pushing values. The old ones only passed because the eager subscribe had already drained the source, so they were asserting the leak.
- Nothing covering the `$state` -> `let` on `socket` or the `onDestroy` unsubscribe. Both are latent while `WSInvalidator` lives in the root layout and never unmounts, so there is nothing to assert.

One behaviour change worth a look:

- List ordering state now restarts from empty if the list goes unsubscribed for longer than multicast's 1s grace, instead of persisting for the tab's lifetime. Fresh mount gets server order.
- Left the grace at 1s for now. It comes from 54e8c2e87a and was picked for query observer lifecycle, not for this. Easy to bump per call site if it bites.
