### PR TITLE
fix(vip): handle a missing Stripe subscription on manage and cancel

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -7595,6 +7595,14 @@
       "default": "Manage Subscription",
       "description": "Aria-label for the button that allows users to manage their VIP subscription."
     },
+    "text_vip_subscription_missing_title": {
+      "default": "No active subscription",
+      "description": "Title of the snackbar shown when a VIP subscription can no longer be managed or cancelled because the payment provider has no active subscription for the account."
+    },
+    "text_vip_subscription_missing_message": {
+      "default": "We couldn't find an active subscription to manage. It may have already been cancelled. <a>Contact support</a> if you think something's wrong.",
+      "description": "Message of the snackbar shown when a VIP subscription can no longer be managed or cancelled because the payment provider has no active subscription for the account. The text wrapped in <a></a> becomes a link to support and must be kept."
+    },
     "button_text_history": {
       "default": "History",
       "description": "Short text for a button that reveals the VIP payment history. This should be as short as possible."

--- a/projects/client/src/lib/components/link/MessageWithLink.svelte
+++ b/projects/client/src/lib/components/link/MessageWithLink.svelte
@@ -13,4 +13,8 @@
   );
 </script>
 
-{beforeText}<Link {href} {target} {color}>{linkText}</Link>{afterText}
+{#if linkText}
+  {beforeText}<Link {href} {target} {color}>{linkText}</Link>{afterText}
+{:else}
+  {message}
+{/if}

--- a/projects/client/src/lib/components/snackbar/Snackbar.svelte
+++ b/projects/client/src/lib/components/snackbar/Snackbar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import AutoCloseButton from "$lib/components/buttons/AutoCloseButton.svelte";
   import Button from "$lib/components/buttons/Button.svelte";
+  import MessageWithLink from "$lib/components/link/MessageWithLink.svelte";
   import { m } from "$lib/features/i18n/messages.ts";
   import { onMount } from "svelte";
   import { fly } from "svelte/transition";
@@ -16,6 +17,7 @@
     onDismiss: () => void;
     title?: string;
     message: string;
+    href?: string;
     action?: SnackbarAction;
     variant?: "default" | "error";
     dismissDurationMs?: number;
@@ -26,6 +28,7 @@
     onDismiss,
     title,
     message,
+    href,
     action,
     variant = "default",
     dismissDurationMs,
@@ -98,7 +101,13 @@
     {/if}
 
     <div class="snackbar-content">
-      <p class="snackbar-message">{message}</p>
+      <p class="snackbar-message">
+        {#if href}
+          <MessageWithLink {message} {href} target="_blank" />
+        {:else}
+          {message}
+        {/if}
+      </p>
       {@render actionButton()}
       <AutoCloseButton
         onclick={onDismiss}

--- a/projects/client/src/lib/requests/models/ManageSubscriptionResult.ts
+++ b/projects/client/src/lib/requests/models/ManageSubscriptionResult.ts
@@ -1,0 +1,4 @@
+export type ManageSubscriptionResult =
+  | { kind: 'redirect'; url: string }
+  | { kind: 'missing-subscription' }
+  | { kind: 'unavailable' };

--- a/projects/client/src/lib/requests/vip/_internal/isMissingSubscription.ts
+++ b/projects/client/src/lib/requests/vip/_internal/isMissingSubscription.ts
@@ -1,0 +1,5 @@
+const notFound = 404;
+
+export function isMissingSubscription(response: Response): boolean {
+  return response.status === notFound;
+}

--- a/projects/client/src/lib/requests/vip/cancelSubscriptionQuery.spec.ts
+++ b/projects/client/src/lib/requests/vip/cancelSubscriptionQuery.spec.ts
@@ -1,0 +1,35 @@
+import { server } from '$mocks/server.ts';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { cancelSubscriptionQuery } from './cancelSubscriptionQuery.ts';
+
+describe('cancelSubscriptionQuery', () => {
+  it('should report a cancelled subscription', async () => {
+    server.use(
+      http.post(
+        'http://localhost/vip/stripe/cancel',
+        () => new HttpResponse(null, { status: 204 }),
+      ),
+    );
+
+    const result = await cancelSubscriptionQuery();
+
+    expect(result).to.equal(true);
+  });
+
+  it('should return false when there is no active subscription', async () => {
+    server.use(
+      http.post(
+        'http://localhost/vip/stripe/cancel',
+        () =>
+          HttpResponse.json({
+            message: 'No active Stripe subscriptions found',
+          }, { status: 404 }),
+      ),
+    );
+
+    const result = await cancelSubscriptionQuery();
+
+    expect(result).to.equal(false);
+  });
+});

--- a/projects/client/src/lib/requests/vip/cancelSubscriptionQuery.ts
+++ b/projects/client/src/lib/requests/vip/cancelSubscriptionQuery.ts
@@ -1,5 +1,6 @@
 import { rawApiFetch } from '$lib/requests/api.ts';
 import { isValidResponse } from '../../features/query/_internal/isValidResponse.ts';
+import { isMissingSubscription } from './_internal/isMissingSubscription.ts';
 
 export async function cancelSubscriptionQuery(): Promise<boolean> {
   const response = await rawApiFetch({
@@ -9,5 +10,10 @@ export async function cancelSubscriptionQuery(): Promise<boolean> {
     },
   });
 
-  return isValidResponse(response, 'cancelSubscription');
+  if (isMissingSubscription(response)) {
+    return false;
+  }
+
+  isValidResponse(response, 'cancelSubscription');
+  return response.ok;
 }

--- a/projects/client/src/lib/requests/vip/manageSubscriptionQuery.spec.ts
+++ b/projects/client/src/lib/requests/vip/manageSubscriptionQuery.spec.ts
@@ -1,0 +1,38 @@
+import { server } from '$mocks/server.ts';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { manageSubscriptionQuery } from './manageSubscriptionQuery.ts';
+
+const CHECKOUT_URL = 'https://billing.stripe.com/p/session/test';
+const RETURN_URL = 'https://app.trakt.tv/vip';
+
+describe('manageSubscriptionQuery', () => {
+  it('should return the checkout url', async () => {
+    server.use(
+      http.post(
+        'http://localhost/vip/stripe/update',
+        () => HttpResponse.json({ checkout_url: CHECKOUT_URL }),
+      ),
+    );
+
+    const result = await manageSubscriptionQuery({ returnUrl: RETURN_URL });
+
+    expect(result).to.deep.equal({ kind: 'redirect', url: CHECKOUT_URL });
+  });
+
+  it('should report a missing subscription', async () => {
+    server.use(
+      http.post(
+        'http://localhost/vip/stripe/update',
+        () =>
+          HttpResponse.json({
+            message: 'No active Stripe subscriptions found',
+          }, { status: 404 }),
+      ),
+    );
+
+    const result = await manageSubscriptionQuery({ returnUrl: RETURN_URL });
+
+    expect(result).to.deep.equal({ kind: 'missing-subscription' });
+  });
+});

--- a/projects/client/src/lib/requests/vip/manageSubscriptionQuery.ts
+++ b/projects/client/src/lib/requests/vip/manageSubscriptionQuery.ts
@@ -1,6 +1,8 @@
 import { rawApiFetch } from '$lib/requests/api.ts';
+import type { ManageSubscriptionResult } from '$lib/requests/models/ManageSubscriptionResult.ts';
 import z from 'zod';
 import { isValidResponse } from '../../features/query/_internal/isValidResponse.ts';
+import { isMissingSubscription } from './_internal/isMissingSubscription.ts';
 import { isStripeUrl } from './_internal/isStripeUrl.ts';
 
 type ManageSubscriptionParams = {
@@ -15,20 +17,25 @@ const ManageSubscriptionResponseSchema = z.object({
 
 export async function manageSubscriptionQuery(
   { returnUrl }: ManageSubscriptionParams,
-): Promise<string | Nil> {
-  const url = encodeURIComponent(returnUrl);
+): Promise<ManageSubscriptionResult> {
+  const encodedUrl = encodeURIComponent(returnUrl);
 
   const response = await rawApiFetch({
-    path: `/vip/stripe/update?success_url=${url}&cancel_url=${url}`,
+    path:
+      `/vip/stripe/update?success_url=${encodedUrl}&cancel_url=${encodedUrl}`,
     init: {
       method: 'POST',
     },
   });
 
+  if (isMissingSubscription(response)) {
+    return { kind: 'missing-subscription' };
+  }
+
   if (!isValidResponse(response, 'manageSubscription')) {
-    return;
+    return { kind: 'unavailable' };
   }
 
   const body = ManageSubscriptionResponseSchema.parse(await response.json());
-  return body.checkout_url;
+  return { kind: 'redirect', url: body.checkout_url };
 }

--- a/projects/client/src/lib/sections/vip/_internal/AccountDetails.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/AccountDetails.svelte
@@ -79,10 +79,6 @@
     padding: var(--ni-24);
     box-sizing: border-box;
 
-    :global(.trakt-link) {
-      text-decoration: none;
-    }
-
     transition: var(--transition-increment) ease-in-out;
     transition-property: padding;
 

--- a/projects/client/src/lib/sections/vip/_internal/SubscriptionActions.svelte
+++ b/projects/client/src/lib/sections/vip/_internal/SubscriptionActions.svelte
@@ -4,8 +4,10 @@
   import GearIcon from "$lib/components/icons/GearIcon.svelte";
   import RenameIcon from "$lib/components/icons/RenameIcon.svelte";
   import SkullIcon from "$lib/components/icons/SkullIcon.svelte";
+  import Snackbar from "$lib/components/snackbar/Snackbar.svelte";
   import { AnalyticsEvent } from "$lib/features/analytics/events/AnalyticsEvent";
   import { useTrack } from "$lib/features/analytics/useTrack";
+  import { useUser } from "$lib/features/auth/stores/useUser";
   import { ConfirmationType } from "$lib/features/confirmation/models/ConfirmationType";
   import { useConfirm } from "$lib/features/confirmation/useConfirm";
   import { getLocale } from "$lib/features/i18n";
@@ -20,15 +22,27 @@
 
   const { manageSubscription, cancelSubscription, isFetching } = useVip();
   const { track } = useTrack(AnalyticsEvent.VipManage);
+  const { user } = useUser();
 
   const isStripe = $derived(subscription?.gateway === "stripe");
 
+  let isMissingSubscription = $state(false);
+
   const onManage = async () => {
     track();
-    const url = await manageSubscription();
-    if (url) {
-      globalThis.window.location.href = url;
+    const result = await manageSubscription();
+
+    if (result.kind === "redirect") {
+      globalThis.window.location.href = result.url;
+      return;
     }
+
+    isMissingSubscription = result.kind === "missing-subscription";
+  };
+
+  const onCancel = async () => {
+    const isCancelled = await cancelSubscription();
+    isMissingSubscription = !isCancelled;
   };
 
   const renewsOn = $derived(
@@ -43,7 +57,7 @@
     confirm({
       type: ConfirmationType.CancelVip,
       renewsOn,
-      onConfirm: cancelSubscription,
+      onConfirm: onCancel,
     }),
   );
 </script>
@@ -116,3 +130,12 @@
     {/if}
   {/snippet}
 </PopupMenu>
+
+<Snackbar
+  open={isMissingSubscription}
+  onDismiss={() => (isMissingSubscription = false)}
+  title={m.text_vip_subscription_missing_title()}
+  message={m.text_vip_subscription_missing_message()}
+  href={UrlBuilder.og.support($user?.slug)}
+  variant="error"
+/>

--- a/projects/client/src/lib/sections/vip/_internal/useVip.ts
+++ b/projects/client/src/lib/sections/vip/_internal/useVip.ts
@@ -67,8 +67,9 @@ export function useVip() {
 
       isFetching.next(true);
       try {
-        await cancelSubscriptionQuery();
+        const isCancelled = await cancelSubscriptionQuery();
         await invalidate(InvalidateAction.Vip.Canceled);
+        return isCancelled;
       } finally {
         isFetching.next(false);
       }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Clicking Manage or Cancel on `/vip` replaced the whole page with the 404 error page.
- Both `/vip/stripe/update` and `/vip/stripe/cancel` answer 404 `No active Stripe subscriptions found` when Stripe holds no subscription for the customer. `isValidResponse` turned that into a `FetchError`, which dispatches `FETCH_ERROR_EVENT`, and `ErrorProvider` swapped the page for `Error404Page`.
- Treat that 404 as a business outcome instead. Snackbar with a support link, page stays usable.
- `manageSubscriptionQuery` returns a discriminated result now, so the component no longer infers "no subscription" from an empty return. A 204 used to surface the wrong message.
- `cancelSubscriptionQuery` reported `false` on a *successful* cancel. The endpoint returns 204 and `isValidResponse` returns false for 204. Harmless before since the value was discarded, wrong once the component reads it.
- `Snackbar` takes an optional `href` and renders `MessageWithLink`, mirroring `DismissibleError`.
- `MessageWithLink` falls back to plain text when the message has no `<a>` markers. It used to emit an empty anchor with no accessible name.
- Dropped the blanket `:global(.trakt-link) { text-decoration: none; }` from `AccountDetails`. `DropdownItem` already scopes that reset to its own links, so nothing else relied on it, and the support link keeps its underline.
- ⚠️ The menu still offers Manage to accounts Stripe has no subscription for. `/vip/details` derives `renewal` and `cancelled` from `vip_profile_id`, which stays set when a checkout is abandoned after `customer.created` repointed it at a customer that never paid. So the payload claims the subscription renews while Stripe has nothing, and the client has no signal to gate on. Needs an API change, will be tackled separately.