### PR TITLE
fix(streaming): redirect legacy watch now links to the watchnow host

### DIFF
--- a/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.spec.ts
+++ b/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.spec.ts
@@ -191,6 +191,29 @@ describe('util: resolveLegacyRedirect', () => {
     });
   });
 
+  describe('watch now deep links hop to the v2 host', () => {
+    it('should map a watch now link to the watchnow host', () => {
+      expect(resolveLegacyRedirect('/watchnow/265852339')).toBe(
+        'https://watchnow.trakt.tv/watchnow/265852339',
+      );
+    });
+
+    it('should tolerate a trailing slash', () => {
+      expect(resolveLegacyRedirect('/watchnow/265852339/')).toBe(
+        'https://watchnow.trakt.tv/watchnow/265852339',
+      );
+    });
+
+    it.each([
+      '/watchnow',
+      '/watchnow/sources',
+      '/watchnow/sources/us',
+      '/watchnow/movie/1390/justwatch/us/netflix',
+    ])('should leave the rest of the namespace alone: %s', (path) => {
+      expect(resolveLegacyRedirect(path)).toBeNull();
+    });
+  });
+
   describe('live oauth endpoints are never hijacked', () => {
     it.each([
       '/oauth/authorize',

--- a/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.ts
+++ b/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.ts
@@ -189,6 +189,10 @@ const rules: ReadonlyArray<LegacyRule> = [
     to: () => UrlBuilder.home(),
   },
   {
+    pattern: /^\/watchnow\/(\d+)\/?$/,
+    to: (m) => UrlBuilder.og.watchnow(m[1]),
+  },
+  {
     pattern: /^\/officiallist\/([^/]+)\/?$/,
     to: (m) => `/lists/official/${m[1]}`,
   },

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -306,6 +306,7 @@ export const UrlBuilder = {
   og: {
     support: (username?: string) => ogSupportFactory(username),
     forums: () => 'https://forums.trakt.tv/c/trakt',
+    watchnow: (id: string) => `https://watchnow.trakt.tv/watchnow/${id}`,
     widgets: {
       yir: (slug: string, year: string) =>
         `https://widgets.trakt.tv/users/${slug}/yir.jpg?year=${year}`,


### PR DESCRIPTION
## 🎶 Notes 🎶

- `trakt.tv/watchnow/:id` 301s to app.trakt.tv and 404s here, so every watch now link we've mailed out is dead. Hops them on to `watchnow.trakt.tv`, which resolves the id and 302s to the provider
- Numeric ids only. The rest of the namespace (`/watchnow`, `/watchnow/sources`, the lookup paths) keeps 404ing like it does today
- Host lives in `UrlBuilder.og`, next to forums/support/widgets
- 301 like the other legacy rules. The host hop is permanent, the affiliate URL behind it is the watchnow host's own 302
- Mail templates were emitting the wrong host in the first place, fixed in https://github.com/trakt/trakt-website/pull/2402