### PR TITLE
fix: increases reachability and tap areas of mode toggles

### DIFF
--- a/projects/client/src/lib/components/select/SegmentedSelect.svelte
+++ b/projects/client/src/lib/components/select/SegmentedSelect.svelte
@@ -34,6 +34,8 @@
     ),
   );
 
+  const hasExtension = $derived(expandable && Boolean(extension) && expanded);
+
   const collapseFrom = $derived(
     expandable ? options.length - collapsedCount : options.length,
   );
@@ -141,6 +143,7 @@
 
 <div
   class="trakt-segmented-select"
+  class:has-extension={hasExtension}
   role="radiogroup"
   aria-label={ariaLabel}
   data-variant={variant}
@@ -170,11 +173,11 @@
     {/each}
   </div>
 
-  {#if expandable && extension && expanded}
+  {#if hasExtension}
     <div class="segment-extension">
       <div class="extension-divider"></div>
       <div class="extension-content">
-        {@render extension()}
+        {@render extension?.()}
       </div>
     </div>
   {/if}
@@ -184,9 +187,10 @@
   @use "$style/scss/mixins/index" as *;
 
   .trakt-segmented-select {
-    --segment-height: var(--ni-32);
+    --segment-height: var(--segmented-select-segment-height);
     --segment-inset: var(--ni-4);
-    --segment-gap: var(--ni-2);
+    --segment-block-inset: var(--segment-inset);
+    --segment-gap: var(--gap-xs);
     --track-base-radius: var(--segmented-select-radius, var(--border-radius-l));
     --track-radius: var(--track-base-radius);
     --segment-radius: calc(var(--track-base-radius) - var(--segment-inset));
@@ -202,7 +206,7 @@
     display: flex;
     flex-direction: column;
 
-    padding: var(--segment-inset);
+    padding: var(--segment-block-inset) var(--segment-inset);
     border-radius: var(--track-radius);
     background-color: var(
       --segmented-select-background,
@@ -216,6 +220,10 @@
         --segmented-select-radius,
         var(--border-radius-m)
       );
+    }
+
+    &.has-extension {
+      --segment-block-inset: var(--segmented-select-extension-inset);
     }
 
     .segment-row {
@@ -298,8 +306,8 @@
 
       :global(svg) {
         display: block;
-        width: var(--ni-16);
-        height: var(--ni-16);
+        width: var(--ni-18);
+        height: var(--ni-18);
       }
     }
 
@@ -357,6 +365,7 @@
     .segment-row {
       display: inline-flex;
       align-items: center;
+      justify-content: center;
       gap: 0;
     }
 
@@ -489,7 +498,7 @@
   .extension-divider {
     flex-shrink: 0;
     height: var(--border-thickness-xxs);
-    margin-block-start: var(--segment-inset);
+    margin-block-start: var(--segment-block-inset);
     background: var(--color-segmented-track-border);
   }
 

--- a/projects/client/src/lib/features/search/SearchInput.svelte
+++ b/projects/client/src/lib/features/search/SearchInput.svelte
@@ -150,7 +150,7 @@
     &[data-variant="embedded"] {
       --search-input-width: 100%;
       --search-input-height: var(--ni-32);
-      --search-icon-size: var(--ni-16);
+      --search-icon-size: var(--ni-18);
 
       outline: none;
 
@@ -193,7 +193,7 @@
 
       position: absolute;
       z-index: calc(var(--layer-top) + var(--layer-overlay));
-      top: var(--search-icon-offset);
+      top: calc((var(--search-input-height) - var(--search-icon-size)) / 2);
       inset-inline-start: var(--search-icon-offset);
     }
 

--- a/projects/client/src/style/sizing/index.css
+++ b/projects/client/src/style/sizing/index.css
@@ -26,5 +26,10 @@
 
   --toggle-small-width: var(--ni-30);
 
-  --segmented-select-extension-height: calc(var(--ni-40) + var(--ni-4));
+  --segmented-select-segment-height: var(--ni-32);
+  --segmented-select-extension-inset: var(--gap-xs);
+  --segmented-select-extension-height: calc(
+    var(--segmented-select-segment-height) + 2 *
+      var(--segmented-select-extension-inset) + var(--border-thickness-xxs)
+  );
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

- Centers the mode toggles in the mobile search panel, they were left-aligned and awkward to reach with a thumb
- Bigger gap between segments and 18px icons, matching the sizing of the old toggler
- The divider is now a true midline, so the toggle row and the search input each get an identical half
- Applies to every `SegmentedSelect`, so the top navbar and filter sidebar toggles get the same spacing
- Also fixes the embedded search icon offset, it was derived from the icon size so it only centered while the input was exactly twice as tall

## 👀 Examples 👀
Before/after:
<img width="372" height="665" alt="Screenshot 2026-08-12 at 11 50 48" src="https://github.com/user-attachments/assets/0f6d51c9-a09d-4db4-abfa-c4fc4b2fb488" />

<img width="372" height="665" alt="Screenshot 2026-08-12 at 11 50 51" src="https://github.com/user-attachments/assets/5543e7b3-b418-4678-a797-fb1be69a09c6" />

Before/after:
<img width="372" height="665" alt="Screenshot 2026-08-12 at 11 51 02" src="https://github.com/user-attachments/assets/b585a61d-ec61-4b3c-9ed7-70489ea5b0db" />

<img width="372" height="665" alt="Screenshot 2026-08-12 at 11 51 05" src="https://github.com/user-attachments/assets/149fd3f0-0fa7-4cc1-9f27-7b1268ed617c" />

Before/after:
<img width="372" height="665" alt="Screenshot 2026-08-12 at 11 51 11" src="https://github.com/user-attachments/assets/d27730aa-303a-47b1-85e3-8282fc636ec8" />

<img width="372" height="665" alt="Screenshot 2026-08-12 at 11 51 17" src="https://github.com/user-attachments/assets/1562a14c-669e-4d76-9ba0-a9a7dfdd337e" />
