### PR TITLE
fix(collection): fetch minimal collection in pages

### DIFF
--- a/projects/client/src/lib/features/auth/queries/_internal/toCollectionTraktIds.spec.ts
+++ b/projects/client/src/lib/features/auth/queries/_internal/toCollectionTraktIds.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { toCollectionTraktIds } from './toCollectionTraktIds.ts';
+
+describe('util: toCollectionTraktIds', () => {
+  it('should map the response keys to trakt ids', () => {
+    const result = toCollectionTraktIds({
+      '123': '2023-10-01T12:00:00.000Z',
+      '456': '2023-10-02T12:00:00.000Z',
+    });
+
+    expect(result).to.deep.equal([123, 456]);
+  });
+
+  it('should return no ids for an empty response', () => {
+    expect(toCollectionTraktIds({})).to.deep.equal([]);
+    expect(toCollectionTraktIds(undefined)).to.deep.equal([]);
+  });
+
+  it('should drop keys that are not valid ids', () => {
+    const result = toCollectionTraktIds({
+      '123': '2023-10-01T12:00:00.000Z',
+      message: 'something went wrong',
+    });
+
+    expect(result).to.deep.equal([123]);
+  });
+});

--- a/projects/client/src/lib/features/auth/queries/_internal/toCollectionTraktIds.ts
+++ b/projects/client/src/lib/features/auth/queries/_internal/toCollectionTraktIds.ts
@@ -6,5 +6,7 @@ import type {
 export function toCollectionTraktIds(
   response: CollectionMinimalResponse | CollectionMinimalShowResponse | Nil,
 ): number[] {
-  return Object.keys(response ?? {}).map((key) => parseInt(key, 10));
+  return Object.keys(response ?? {})
+    .map((key) => parseInt(key, 10))
+    .filter((id) => Number.isInteger(id));
 }

--- a/projects/client/src/lib/features/auth/queries/currentUserCollectionQuery.spec.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserCollectionQuery.spec.ts
@@ -1,0 +1,32 @@
+import { UserCollectionMappedMock } from '$mocks/data/users/mapped/UserCollectionMappedMock.ts';
+import { createTestBedInfiniteQuery } from '$test/beds/query/createTestBedInfiniteQuery.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { mapToEntries } from '$test/utils/mapToEntries.ts';
+import { describe, expect, it } from 'vitest';
+import { currentUserCollectionQuery } from './currentUserCollectionQuery.ts';
+
+describe('currentUserCollectionQuery', () => {
+  it('should query for collected movies', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createTestBedInfiniteQuery(
+          currentUserCollectionQuery({ type: 'movies', limit: 50 }),
+        ),
+      mapper: mapToEntries,
+    });
+
+    expect(result).to.deep.equal([...UserCollectionMappedMock.movies]);
+  });
+
+  it('should query for collected episodes', async () => {
+    const result = await runQuery({
+      factory: () =>
+        createTestBedInfiniteQuery(
+          currentUserCollectionQuery({ type: 'episodes', limit: 50 }),
+        ),
+      mapper: mapToEntries,
+    });
+
+    expect(result).to.deep.equal([...UserCollectionMappedMock.episodes]);
+  });
+});

--- a/projects/client/src/lib/features/auth/queries/currentUserCollectionQuery.ts
+++ b/projects/client/src/lib/features/auth/queries/currentUserCollectionQuery.ts
@@ -1,44 +1,54 @@
-import z from 'zod';
-import { api, type ApiParams } from '../../../requests/api.ts';
-import { InvalidateAction } from '../../../requests/models/InvalidateAction.ts';
-import { time } from '../../../utils/timing/time.ts';
-import { defineQuery } from '../../query/defineQuery.ts';
+import { defineInfiniteQuery } from '$lib/features/query/defineQuery.ts';
+import { extractPageMeta } from '$lib/requests/_internal/extractPageMeta.ts';
+import { type ApiParams, rawApiFetch } from '$lib/requests/api.ts';
+import { InvalidateAction } from '$lib/requests/models/InvalidateAction.ts';
+import { PaginatableSchemaFactory } from '$lib/requests/models/Paginatable.ts';
+import type { PaginationParams } from '$lib/requests/models/PaginationParams.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import type { CollectionMinimalResponse } from '@trakt/api';
+import { z } from 'zod';
 import { toCollectionTraktIds } from './_internal/toCollectionTraktIds.ts';
 
-const UserCollectionSchema = z.object({
-  movies: z.set(z.number()),
-  episodes: z.set(z.number()),
-});
+type CurrentUserCollectionParams =
+  & {
+    type: 'movies' | 'episodes';
+  }
+  & PaginationParams
+  & ApiParams;
 
-export type UserCollection = z.infer<typeof UserCollectionSchema>;
+// FIXME: use api().sync.collection.minimal[type] once @trakt/api types page & limit
+const currentUserCollectionRequest = async (
+  { fetch, type, page = 1, limit }: CurrentUserCollectionParams,
+) => {
+  const query = new URLSearchParams({
+    page: `${page}`,
+    limit: `${limit}`,
+  });
 
-const currentUserCollectionRequest = (
-  { fetch }: ApiParams,
-  type: 'movies' | 'episodes',
-) =>
-  api({ fetch })
-    .sync
-    .collection
-    .minimal[type]({
-      query: {},
-    });
+  const response = await rawApiFetch({
+    fetch,
+    path: `/sync/collection/minimal/${type}?${query}`,
+  });
 
-export const currentUserCollectionQuery = defineQuery({
+  const body: CollectionMinimalResponse = response.ok
+    ? await response.json()
+    : {};
+
+  return { body, headers: response.headers, status: response.status };
+};
+
+export const currentUserCollectionQuery = defineInfiniteQuery({
   key: 'currentUserCollection',
-  request: (params) =>
-    Promise.all([
-      currentUserCollectionRequest(params, 'movies'),
-      currentUserCollectionRequest(params, 'episodes'),
-    ]),
+  request: currentUserCollectionRequest,
   invalidations: [
     InvalidateAction.Collected('movie'),
     InvalidateAction.Collected('episode'),
   ],
-  dependencies: [],
-  mapper: ([moviesResponse, episodesResponse]) => ({
-    movies: new Set(toCollectionTraktIds(moviesResponse.body)),
-    episodes: new Set(toCollectionTraktIds(episodesResponse.body)),
+  dependencies: (params) => [params.type, params.limit],
+  mapper: (response, { page = 1 }) => ({
+    entries: toCollectionTraktIds(response.body),
+    page: extractPageMeta(response.headers, page),
   }),
-  schema: UserCollectionSchema,
+  schema: PaginatableSchemaFactory(z.number()),
   ttl: time.hours(3),
 });

--- a/projects/client/src/lib/features/auth/stores/useCurrentUserCollection.spec.ts
+++ b/projects/client/src/lib/features/auth/stores/useCurrentUserCollection.spec.ts
@@ -1,0 +1,15 @@
+import { UserCollectionMappedMock } from '$mocks/data/users/mapped/UserCollectionMappedMock.ts';
+import { runQuery } from '$test/beds/query/runQuery.ts';
+import { describe, expect, it } from 'vitest';
+import { useCurrentUserCollection } from './useCurrentUserCollection.ts';
+
+describe('store: useCurrentUserCollection', () => {
+  it('should contain the collected movie and episode ids', async () => {
+    const result = await runQuery({
+      factory: () => useCurrentUserCollection(),
+      waitFor: (collection) => collection != null,
+    });
+
+    expect(result).to.deep.equal(UserCollectionMappedMock);
+  });
+});

--- a/projects/client/src/lib/features/auth/stores/useCurrentUserCollection.ts
+++ b/projects/client/src/lib/features/auth/stores/useCurrentUserCollection.ts
@@ -1,0 +1,42 @@
+import { flattenQueryPages } from '$lib/features/query/flattenQueryPages.ts';
+import { isQuerySettled } from '$lib/features/query/isQuerySettled.ts';
+import { useAllPagesInfiniteQuery } from '$lib/features/query/useQuery.ts';
+import { multicast } from '$lib/utils/store/multicast.ts';
+import {
+  combineLatest,
+  distinctUntilChanged,
+  map,
+  type Observable,
+} from 'rxjs';
+import { currentUserCollectionQuery } from '../queries/currentUserCollectionQuery.ts';
+
+const collectionLimit = 50000;
+
+export type UserCollection = {
+  movies: Set<number>;
+  episodes: Set<number>;
+};
+
+export function useCurrentUserCollection(): Observable<UserCollection | null> {
+  const moviesQuery = useAllPagesInfiniteQuery(
+    currentUserCollectionQuery({ type: 'movies', limit: collectionLimit }),
+  );
+  const episodesQuery = useAllPagesInfiniteQuery(
+    currentUserCollectionQuery({ type: 'episodes', limit: collectionLimit }),
+  );
+
+  return combineLatest([moviesQuery, episodesQuery]).pipe(
+    map(([movies, episodes]) => {
+      if (!isQuerySettled(movies) || !isQuerySettled(episodes)) {
+        return null;
+      }
+
+      return {
+        movies: new Set(flattenQueryPages(movies)),
+        episodes: new Set(flattenQueryPages(episodes)),
+      };
+    }),
+    distinctUntilChanged((prev, curr) => prev === null && curr === null),
+    multicast(),
+  );
+}

--- a/projects/client/src/lib/features/auth/stores/useCurrentUserHistory.ts
+++ b/projects/client/src/lib/features/auth/stores/useCurrentUserHistory.ts
@@ -1,3 +1,5 @@
+import { flattenQueryPages } from '$lib/features/query/flattenQueryPages.ts';
+import { isQuerySettled } from '$lib/features/query/isQuerySettled.ts';
 import { useAllPagesInfiniteQuery } from '$lib/features/query/useQuery.ts';
 import { multicast } from '$lib/utils/store/multicast.ts';
 import { combineLatest, distinctUntilChanged, map, Observable } from 'rxjs';
@@ -24,18 +26,6 @@ function toWatchedMap<T extends { id: number }>(
   return new Map(entries.map((entry) => [entry.id, entry]));
 }
 
-function toQueryMap<T extends { id: number }>(
-  query: { data?: { pages: Array<{ entries: T[] }> } },
-): Map<number, T> {
-  return toWatchedMap(query.data?.pages.flatMap((p) => p.entries) ?? []);
-}
-
-function isSettled(
-  query: { isPending: boolean; isFetchingNextPage: boolean },
-): boolean {
-  return !query.isPending && !query.isFetchingNextPage;
-}
-
 type UseCurrentUserHistoryResult = {
   history: Observable<UserHistory | null>;
   isLoading: Observable<boolean>;
@@ -51,16 +41,13 @@ export function useCurrentUserHistory(): UseCurrentUserHistoryResult {
 
   const history = combineLatest([moviesQuery, showsQuery]).pipe(
     map(([movies, shows]) => {
-      if (!isSettled(movies) || !isSettled(shows)) {
+      if (!isQuerySettled(movies) || !isQuerySettled(shows)) {
         return null;
       }
 
-      const moviesMap = toQueryMap(movies);
-      const showsMap = toQueryMap(shows);
-
       return {
-        movies: moviesMap,
-        shows: showsMap,
+        movies: toWatchedMap(flattenQueryPages(movies)),
+        shows: toWatchedMap(flattenQueryPages(shows)),
       };
     }),
     distinctUntilChanged((prev, curr) => prev === null && curr === null),
@@ -68,7 +55,7 @@ export function useCurrentUserHistory(): UseCurrentUserHistoryResult {
   );
 
   const isLoading = combineLatest([moviesQuery, showsQuery]).pipe(
-    map(([movies, shows]) => !isSettled(movies) || !isSettled(shows)),
+    map(([movies, shows]) => !isQuerySettled(movies) || !isQuerySettled(shows)),
   );
 
   return { history, isLoading };

--- a/projects/client/src/lib/features/auth/stores/useUser.ts
+++ b/projects/client/src/lib/features/auth/stores/useUser.ts
@@ -7,10 +7,6 @@ import { multicast } from '$lib/utils/store/multicast.ts';
 import { map, of, switchMap } from 'rxjs';
 import { getContext, setContext } from 'svelte';
 import {
-  currentUserCollectionQuery,
-  type UserCollection,
-} from '../queries/currentUserCollectionQuery.ts';
-import {
   currentUserCommentReactionsQuery,
   type UserReactions,
 } from '../queries/currentUserCommentReactionsQuery.ts';
@@ -52,6 +48,10 @@ import {
   type UserWatchlist,
 } from '../queries/currentUserWatchlistQuery.ts';
 import { useAuth } from './useAuth.ts';
+import {
+  useCurrentUserCollection,
+  type UserCollection,
+} from './useCurrentUserCollection.ts';
 import {
   useCurrentUserHistory,
   type UserHistory,
@@ -125,7 +125,7 @@ function createUseUserInstance() {
   const userQuerySignal = useQuery(currentUserSettingsQuery());
   const { history: historySignal } = useCurrentUserHistory();
   const watchlistQuerySignal = useQuery(currentUserWatchlistQuery());
-  const collectionQuerySignal = useQuery(currentUserCollectionQuery());
+  const collectionSignal = useCurrentUserCollection();
   const ratingsQuerySignal = useQuery(currentUserRatingsQuery());
   const commentReactionsQuerySignal = useQuery(
     currentUserCommentReactionsQuery(),
@@ -205,9 +205,7 @@ function createUseUserInstance() {
         watchlist: watchlistQuerySignal.pipe(
           map((watchlist) => watchlist.data),
         ),
-        collection: collectionQuerySignal.pipe(
-          map((collection) => collection.data),
-        ),
+        collection: collectionSignal,
         ratings: ratingsQuerySignal.pipe(
           map((ratings) => ratings.data),
         ),

--- a/projects/client/src/lib/features/query/flattenQueryPages.ts
+++ b/projects/client/src/lib/features/query/flattenQueryPages.ts
@@ -1,0 +1,8 @@
+import type { Paginatable } from '$lib/requests/models/Paginatable.ts';
+import type { InfiniteData } from '@tanstack/query-core';
+
+export function flattenQueryPages<T>(
+  query: { data?: InfiniteData<Paginatable<T>> },
+): T[] {
+  return query.data?.pages.flatMap((page) => page.entries) ?? [];
+}

--- a/projects/client/src/lib/features/query/isQuerySettled.ts
+++ b/projects/client/src/lib/features/query/isQuerySettled.ts
@@ -1,0 +1,9 @@
+type SettleableQuery = {
+  isPending: boolean;
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean;
+};
+
+export function isQuerySettled(query: SettleableQuery): boolean {
+  return !query.isPending && !query.isFetchingNextPage && !query.hasNextPage;
+}

--- a/projects/client/src/lib/sections/settings/_internal/ClearData.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/ClearData.svelte
@@ -42,7 +42,7 @@
       case "history":
         return { type: activeSourceType, input: $history ?? undefined };
       case "library":
-        return { type: activeSourceType, input: $collection };
+        return { type: activeSourceType, input: $collection ?? undefined };
     }
   });
 

--- a/projects/client/src/lib/sections/settings/_internal/clear/models/ClearDataInputMap.ts
+++ b/projects/client/src/lib/sections/settings/_internal/clear/models/ClearDataInputMap.ts
@@ -1,6 +1,6 @@
-import type { UserCollection } from '$lib/features/auth/queries/currentUserCollectionQuery.ts';
 import type { UserRatings } from '$lib/features/auth/queries/currentUserRatingsQuery.ts';
 import type { UserWatchlist } from '$lib/features/auth/queries/currentUserWatchlistQuery.ts';
+import type { UserCollection } from '$lib/features/auth/stores/useCurrentUserCollection.ts';
 import type { UserHistory } from '$lib/features/auth/stores/useCurrentUserHistory.ts';
 
 export type ClearDataInputMap = {

--- a/projects/client/src/lib/sections/settings/sync/clearLibrary.ts
+++ b/projects/client/src/lib/sections/settings/sync/clearLibrary.ts
@@ -1,4 +1,4 @@
-import type { UserCollection } from '$lib/features/auth/queries/currentUserCollectionQuery.ts';
+import type { UserCollection } from '$lib/features/auth/stores/useCurrentUserCollection.ts';
 import { rawApiFetch } from '$lib/requests/api.ts';
 import { SYNC_CHUNK_SIZE } from '$lib/sections/settings/sync/constants/index.ts';
 import { chunk } from '$lib/utils/array/chunk.ts';

--- a/projects/client/src/mocks/data/users/mapped/UserCollectionMappedMock.ts
+++ b/projects/client/src/mocks/data/users/mapped/UserCollectionMappedMock.ts
@@ -1,0 +1,6 @@
+import type { UserCollection } from '$lib/features/auth/stores/useCurrentUserCollection.ts';
+
+export const UserCollectionMappedMock: UserCollection = {
+  movies: new Set([123]),
+  episodes: new Set([234]),
+};

--- a/projects/client/src/mocks/handlers/sync.ts
+++ b/projects/client/src/mocks/handlers/sync.ts
@@ -1,3 +1,7 @@
+import type {
+  CollectionMinimalResponse,
+  CollectionMinimalShowResponse,
+} from '@trakt/api';
 import { http, HttpResponse } from 'msw';
 
 import { MediaLibraryResponseMock } from '../data/sync/response/MediaLibraryResponseMock.ts';
@@ -5,6 +9,22 @@ import { UpNextResponseMock } from '../data/sync/response/UpNextResponseMock.ts'
 import { UserPlexEpisodeLibraryResponseMock } from '../data/users/response/UserPlexEpisodeLibraryResponseMock.ts';
 import { UserPlexMovieLibraryResponseMock } from '../data/users/response/UserPlexMovieLibraryResponseMock.ts';
 import { UserPlexShowLibraryResponseMock } from '../data/users/response/UserPlexShowLibraryResponseMock.ts';
+
+function paginatedCollection(
+  request: Request,
+  items: CollectionMinimalResponse | CollectionMinimalShowResponse,
+) {
+  const { searchParams } = new URL(request.url);
+  const page = Number(searchParams.get('page') ?? 1);
+  const limit = searchParams.get('limit');
+
+  return HttpResponse.json(page > 1 ? {} : items, {
+    headers: limit == null ? undefined : {
+      'x-pagination-page': `${page}`,
+      'x-pagination-limit': limit,
+    },
+  });
+}
 
 export const sync = [
   http.post(
@@ -101,20 +121,17 @@ export const sync = [
   ),
   http.get(
     'http://localhost/sync/collection/minimal/movies',
-    () => {
-      return HttpResponse.json(UserPlexMovieLibraryResponseMock);
-    },
+    ({ request }) =>
+      paginatedCollection(request, UserPlexMovieLibraryResponseMock),
   ),
   http.get(
     'http://localhost/sync/collection/minimal/episodes',
-    () => {
-      return HttpResponse.json(UserPlexEpisodeLibraryResponseMock);
-    },
+    ({ request }) =>
+      paginatedCollection(request, UserPlexEpisodeLibraryResponseMock),
   ),
   http.get(
     'http://localhost/sync/collection/minimal/shows',
-    () => {
-      return HttpResponse.json(UserPlexShowLibraryResponseMock);
-    },
+    ({ request }) =>
+      paginatedCollection(request, UserPlexShowLibraryResponseMock),
   ),
 ];


### PR DESCRIPTION
## 🎶 Notes 🎶

- Picking library under Advanced settings > Clear data fetched the whole minimal collection in one go, which times out for users with hundreds of thousands of items
- Fetches it page by page instead, 50k at a time, via `useAllPagesInfiniteQuery`
- Clear button stays disabled with its spinner until every page has landed
- Rails side already shipped in trakt-website (optional `limit`/`page` on the collection reads). No page count headers there by design, so we walk until a page comes back empty
- Goes through `rawApiFetch` for now, `@trakt/api` does not type `page` & `limit` on the minimal collection routes yet. Left a fixme to swap back
- Also extracts `isQuerySettled` & `flattenQueryPages`, now shared with `useCurrentUserHistory` instead of duplicated
  - Its settle check was missing `hasNextPage`, so it could emit a partial history after the first page. Fixed by the shared helper
