### PR TITLE
fix(filter): uses filter presence for empty placeholders

### DIFF
--- a/projects/client/src/lib/features/filters/_internal/getAppliedFilters.spec.ts
+++ b/projects/client/src/lib/features/filters/_internal/getAppliedFilters.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { FilterKey } from '../models/Filter.ts';
+import { getAppliedFilters } from './getAppliedFilters.ts';
+
+describe('getAppliedFilters', () => {
+  it('should return filters that carry a value', () => {
+    const params = new URLSearchParams({ [FilterKey.Genres]: 'action' });
+
+    expect(getAppliedFilters(params).map((filter) => filter.key)).toEqual([
+      FilterKey.Genres,
+    ]);
+  });
+
+  it('should ignore filters with an empty value', () => {
+    const params = new URLSearchParams({ [FilterKey.Genres]: '' });
+
+    expect(getAppliedFilters(params)).toEqual([]);
+  });
+
+  it('should ignore non-filter params', () => {
+    const params = new URLSearchParams({ page: '2' });
+
+    expect(getAppliedFilters(params)).toEqual([]);
+  });
+});

--- a/projects/client/src/lib/features/filters/_internal/getAppliedFilters.ts
+++ b/projects/client/src/lib/features/filters/_internal/getAppliedFilters.ts
@@ -1,0 +1,9 @@
+import { FILTERS } from './constants.ts';
+
+type AppliedFilter = typeof FILTERS[number];
+
+export function getAppliedFilters(
+  params: URLSearchParams,
+): ReadonlyArray<AppliedFilter> {
+  return FILTERS.filter((filter) => Boolean(params.get(filter.key)));
+}

--- a/projects/client/src/lib/features/filters/_internal/hasFilter.spec.ts
+++ b/projects/client/src/lib/features/filters/_internal/hasFilter.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { FilterKey } from '../models/Filter.ts';
+import { hasFilter } from './hasFilter.ts';
+
+describe('hasFilter', () => {
+  it('should report a filter when a filter param is present', () => {
+    const params = new URLSearchParams({ [FilterKey.Genres]: 'action' });
+
+    expect(hasFilter(params)).toBe(true);
+  });
+
+  it('should not report a filter for non-filter params', () => {
+    const params = new URLSearchParams({ page: '2', sort_by: 'rank' });
+
+    expect(hasFilter(params)).toBe(false);
+  });
+
+  it('should not report a filter for empty params', () => {
+    expect(hasFilter(new URLSearchParams())).toBe(false);
+  });
+
+  it('should accept entry tuples', () => {
+    expect(hasFilter([[FilterKey.Streaming, 'netflix']])).toBe(true);
+    expect(hasFilter([['page', '2']])).toBe(false);
+  });
+});

--- a/projects/client/src/lib/features/filters/useFilter.ts
+++ b/projects/client/src/lib/features/filters/useFilter.ts
@@ -5,6 +5,7 @@ import { getAdditionalKeys } from '../../sections/navbar/components/filter/filte
 import { useNavbarState } from '../../sections/navbar/useNavbarState.ts';
 import { useUser } from '../auth/stores/useUser.ts';
 import { FILTERS } from './_internal/constants.ts';
+import { getAppliedFilters } from './_internal/getAppliedFilters.ts';
 import { isDifferentFilterSet } from './_internal/isDifferentFilterSet.ts';
 import { mapToSearchParamValue } from './_internal/mapToSearchParamValue.ts';
 import { useStoredFilters } from './useStoredFilters.ts';
@@ -50,6 +51,17 @@ export function useFilter() {
         return isDifferentFilterSet(defaultFilters, $search);
       }),
     ),
+    isFiltered: combineLatest(
+      [search, state],
+    ).pipe(
+      map(([$search, $state]) => {
+        if (!$state.hasFilters) {
+          return false;
+        }
+
+        return getAppliedFilters($search).length > 0;
+      }),
+    ),
     hasAnyAdvancedFilter: combineLatest(
       [search, state],
     ).pipe(
@@ -71,8 +83,7 @@ export function useFilter() {
           return {};
         }
 
-        return FILTERS
-          .filter((filter) => Boolean($search.get(filter.key)))
+        return getAppliedFilters($search)
           .reduce((filterMap, filter) => {
             filterMap[filter.key] = mapToSearchParamValue({
               filter,

--- a/projects/client/src/lib/features/query/rethrowUnlessCancelled.spec.ts
+++ b/projects/client/src/lib/features/query/rethrowUnlessCancelled.spec.ts
@@ -1,0 +1,19 @@
+import { CancelledError } from '@tanstack/query-core';
+import { describe, expect, it } from 'vitest';
+import { rethrowUnlessCancelled } from './rethrowUnlessCancelled.ts';
+
+describe('rethrowUnlessCancelled', () => {
+  it('should swallow cancellations', () => {
+    expect(() => rethrowUnlessCancelled(new CancelledError())).not.toThrow();
+  });
+
+  it('should rethrow request errors', () => {
+    const error = new Error('Internal Server Error');
+
+    expect(() => rethrowUnlessCancelled(error)).toThrow(error);
+  });
+
+  it('should rethrow non-error rejections', () => {
+    expect(() => rethrowUnlessCancelled('nope')).toThrow();
+  });
+});

--- a/projects/client/src/lib/features/query/rethrowUnlessCancelled.ts
+++ b/projects/client/src/lib/features/query/rethrowUnlessCancelled.ts
@@ -1,0 +1,9 @@
+import { isCancelledError } from '@tanstack/query-core';
+
+export function rethrowUnlessCancelled(error: unknown): void {
+  if (isCancelledError(error)) {
+    return;
+  }
+
+  throw error;
+}

--- a/projects/client/src/lib/features/query/useQuery.ts
+++ b/projects/client/src/lib/features/query/useQuery.ts
@@ -30,6 +30,7 @@ import {
   type QueryOptionsRef,
   reactiveQueryBridge,
 } from './_internal/queryBridge.ts';
+import { rethrowUnlessCancelled } from './rethrowUnlessCancelled.ts';
 
 /**
  * Tracks query invalidation requests.
@@ -202,7 +203,7 @@ export function useAllPagesInfiniteQuery<
         query.hasNextPage &&
         client.getQueryState(props.queryKey)?.fetchStatus === 'idle'
       ) {
-        query.fetchNextPage();
+        query.fetchNextPage().catch(rethrowUnlessCancelled);
       }
     }),
     multicast(),

--- a/projects/client/src/lib/sections/lists/CreditsList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsList.svelte
@@ -32,7 +32,7 @@
   const { title, type, person, positions, drilldownLink }: CreditsListProps =
     $props();
 
-  const { filterMap, hasActiveFilter } = useFilter();
+  const { filterMap, isFiltered } = useFilter();
   const { mode } = useDiscover();
 
   const {
@@ -96,7 +96,7 @@
   {#snippet empty()}
     {#if $isLoading}
       <SkeletonList id={`credits-list-${type}`} variant={$defaultVariant} />
-    {:else if $hasActiveFilter}
+    {:else if $isFiltered}
       <NoFilterResultsPlaceholder />
     {/if}
   {/snippet}

--- a/projects/client/src/lib/sections/lists/CreditsPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/CreditsPaginatedList.svelte
@@ -18,7 +18,7 @@
 
   const { slug, type }: CreditsPaginatedListProps = $props();
 
-  const { filterMap, hasActiveFilter } = useFilter();
+  const { filterMap, isFiltered } = useFilter();
   const { mode } = useDiscover();
 
   const { credits, isLoading } = useCreditsList({
@@ -53,7 +53,7 @@
   {/snippet}
 
   {#snippet empty()}
-    {#if ($hasActiveFilter || !hasMatchingType) && !$isLoading}
+    {#if ($isFiltered || !hasMatchingType) && !$isLoading}
       <NoFilterResultsPlaceholder />
     {/if}
   {/snippet}

--- a/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
+++ b/projects/client/src/lib/sections/lists/drilldown/MediaList.svelte
@@ -55,7 +55,7 @@
   const variant = $derived(externalVariant ?? $defaultVariant);
   const height = $derived(mediaListHeightResolver(variant));
 
-  const { hasActiveFilter } = useFilter();
+  const { hasActiveFilter, isFiltered } = useFilter();
 </script>
 
 {#snippet actions()}
@@ -79,7 +79,7 @@
   {#snippet empty()}
     {#if $isLoading}
       <SkeletonList id={id.scope} {variant} />
-    {:else if $hasActiveFilter}
+    {:else if $isFiltered}
       <NoFilterResultsPlaceholder />
     {:else}
       {@render externalEmpty?.()}

--- a/projects/client/src/lib/sections/lists/history/CreditsHistoryList.svelte
+++ b/projects/client/src/lib/sections/lists/history/CreditsHistoryList.svelte
@@ -16,7 +16,7 @@
     drilldownLink,
   }: { person: PersonSummary; drilldownLink?: string } = $props();
 
-  const { filterMap, hasActiveFilter } = useFilter();
+  const { filterMap, isFiltered } = useFilter();
   const { mode } = useDiscover();
 
   const { list, isLoading } = useHistoryCreditsList({
@@ -53,7 +53,7 @@
   {#snippet empty()}
     {#if $isLoading}
       <SkeletonList id="credits-history-list" variant="portrait" />
-    {:else if $hasActiveFilter}
+    {:else if $isFiltered}
       <NoFilterResultsPlaceholder />
     {:else}
       <p class="secondary">

--- a/projects/client/src/lib/sections/lists/history/CreditsHistoryPaginatedList.svelte
+++ b/projects/client/src/lib/sections/lists/history/CreditsHistoryPaginatedList.svelte
@@ -16,7 +16,7 @@
 
   const { slug, name }: CreditsHistoryPaginatedListProps = $props();
 
-  const { filterMap, hasActiveFilter } = useFilter();
+  const { filterMap, isFiltered } = useFilter();
   const { mode } = useDiscover();
 
   const { list, isLoading } = useHistoryCreditsList({
@@ -42,7 +42,7 @@
   {/snippet}
 
   {#snippet empty()}
-    {#if $hasActiveFilter && !$isLoading}
+    {#if $isFiltered && !$isLoading}
       <NoFilterResultsPlaceholder />
     {:else if $isLoading}
       <LoadingIndicator />

--- a/projects/client/src/lib/sections/lists/stores/usePaginatedListQuery.ts
+++ b/projects/client/src/lib/sections/lists/stores/usePaginatedListQuery.ts
@@ -1,4 +1,5 @@
 import { useInfiniteQuery } from '$lib/features/query/useQuery.ts';
+import { rethrowUnlessCancelled } from '$lib/features/query/rethrowUnlessCancelled.ts';
 import type { Paginatable } from '$lib/requests/models/Paginatable.ts';
 import { toLoadingState } from '$lib/utils/requests/toLoadingState.ts';
 import type { CreateInfiniteQueryOptions } from '$lib/features/query/types.ts';
@@ -46,7 +47,7 @@ export function usePaginatedListQuery<
 
   const fetchNextPage = async () => {
     const { fetchNextPage } = await firstValueFrom(query);
-    await fetchNextPage();
+    await fetchNextPage().catch(rethrowUnlessCancelled);
   };
 
   return {


### PR DESCRIPTION
## 🎶 Notes 🎶

- `hasActiveFilter` only reports filters that differ from your saved defaults, so anyone who saved a filter set got the plain "nothing in this list yet" placeholder on lists their own filters had emptied. The requests still carried those filters, so the lists looked broken.
- Adds `isFiltered` for "a filter is on the request" and points the empty placeholders at it. `hasActiveFilter` keeps its meaning for the reset/save buttons.
- Both `isFiltered` and `filterMap` now derive from `getAppliedFilters`, so the placeholder can't disagree with what was actually sent.
- Filter icon + badge left on `hasActiveFilter` for now, they'll still read unfiltered next to the new placeholder.
- Separate fix: tearing down mid-flight rejected the pending `fetchNextPage` with `CancelledError` and nothing handled it, so it showed up as an uncaught rejection in the console. Only cancellations are swallowed, real errors keep propagating.
