### PR TITLE
fix(summary): opens ratings breakdown from the whole row

### DIFF
--- a/projects/client/src/lib/components/summary/RatingItem.svelte
+++ b/projects/client/src/lib/components/summary/RatingItem.svelte
@@ -28,44 +28,54 @@
   }: RatingItemProps = $props();
 
   const hasValidRating = $derived(rating !== undefined);
-  const ratingLink = $derived(hasValidRating ? url : undefined);
+  const ratingLink = $derived(
+    hasValidRating && layout === "tile" ? url : undefined,
+  );
 </script>
 
-<rating data-layout={layout}>
-  <Link href={ratingLink} target="_blank">
-    <div
-      class="rating-item"
-      data-layout={layout}
-      class:has-valid-rating={hasValidRating}
-    >
-      {@render children()}
-      <div class="rating-info">
-        <div class="rating-value">
-          {#if isLoading}
-            <span class="rating-skeleton" aria-hidden="true"></span>
-          {:else if hasValidRating}
-            <p class="bold">{rating}</p>
-          {:else}
-            <p class="bold">-</p>
-          {/if}
-        </div>
-        {#if style === "default"}
-          <div class="rating-votes">
-            {#if isLoading}
-              <span
-                class="rating-skeleton rating-skeleton-votes"
-                aria-hidden="true"
-              ></span>
-            {:else if hasValidRating}
-              <p class="bold secondary vote-count tag">
-                {@render superscript()}
-              </p>
-            {/if}
-          </div>
+{#snippet item()}
+  <div
+    class="rating-item"
+    data-layout={layout}
+    class:has-valid-rating={hasValidRating}
+  >
+    {@render children()}
+    <div class="rating-info">
+      <div class="rating-value">
+        {#if isLoading}
+          <span class="rating-skeleton" aria-hidden="true"></span>
+        {:else if hasValidRating}
+          <p class="bold">{rating}</p>
+        {:else}
+          <p class="bold">-</p>
         {/if}
       </div>
+      {#if style === "default"}
+        <div class="rating-votes">
+          {#if isLoading}
+            <span
+              class="rating-skeleton rating-skeleton-votes"
+              aria-hidden="true"
+            ></span>
+          {:else if hasValidRating}
+            <p class="bold secondary vote-count tag">
+              {@render superscript()}
+            </p>
+          {/if}
+        </div>
+      {/if}
     </div>
-  </Link>
+  </div>
+{/snippet}
+
+<rating data-layout={layout}>
+  {#if ratingLink}
+    <Link href={ratingLink} target="_blank">
+      {@render item()}
+    </Link>
+  {:else}
+    {@render item()}
+  {/if}
 </rating>
 
 <style lang="scss">
@@ -75,8 +85,7 @@
     display: block;
     height: 100%;
 
-    :global(.trakt-link),
-    :global(.trakt-no-link) {
+    :global(.trakt-link) {
       display: block;
       height: 100%;
     }

--- a/projects/client/src/lib/components/summary/RatingItem.svelte
+++ b/projects/client/src/lib/components/summary/RatingItem.svelte
@@ -7,14 +7,7 @@
     superscript: Snippet;
     url?: string | Nil;
     isLoading?: boolean;
-    // "minimal" drops the vote-count superscript, showing the score alone;
-    // "default" renders it. The compact summary row is minimal, the ratings
-    // drawer is default.
-    style?: "default" | "minimal";
-    // "row" (default) is the compact inline logo → value → votes layout.
-    // "tile" stacks a large logo above the value and sublabel inside a
-    // full-height clickable card, used by the ratings drawer grid.
-    layout?: "row" | "tile";
+    variant?: "row" | "tile";
   } & ChildrenProps;
 
   const {
@@ -23,20 +16,18 @@
     superscript,
     url,
     isLoading = false,
-    style = "default",
-    layout = "row",
+    variant = "row",
   }: RatingItemProps = $props();
 
   const hasValidRating = $derived(rating !== undefined);
-  const ratingLink = $derived(
-    hasValidRating && layout === "tile" ? url : undefined,
-  );
+  const isTile = $derived(variant === "tile");
+  const ratingLink = $derived(hasValidRating && isTile ? url : undefined);
 </script>
 
 {#snippet item()}
   <div
     class="rating-item"
-    data-layout={layout}
+    data-variant={variant}
     class:has-valid-rating={hasValidRating}
   >
     {@render children()}
@@ -50,7 +41,7 @@
           <p class="bold">-</p>
         {/if}
       </div>
-      {#if style === "default"}
+      {#if isTile}
         <div class="rating-votes">
           {#if isLoading}
             <span
@@ -68,7 +59,7 @@
   </div>
 {/snippet}
 
-<rating data-layout={layout}>
+<rating data-variant={variant}>
   {#if ratingLink}
     <Link href={ratingLink} target="_blank">
       {@render item()}
@@ -81,7 +72,7 @@
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  rating[data-layout="tile"] {
+  rating[data-variant="tile"] {
     display: block;
     height: 100%;
 
@@ -154,7 +145,7 @@
       }
     }
 
-    &[data-layout="tile"] {
+    &[data-variant="tile"] {
       flex-direction: column;
       justify-content: center;
       gap: var(--gap-s);
@@ -184,7 +175,7 @@
       line-height: 90%;
     }
 
-    [data-layout="tile"] & {
+    [data-variant="tile"] & {
       flex-direction: column;
       align-items: center;
       gap: var(--gap-xs);

--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -37,19 +37,9 @@
     ratings: MediaRating;
     entry: MediaEntry | EpisodeEntry;
     drilldown?: TraktRatingDrilldown;
-    // Alternative to `drilldown`: open a locally-mounted drawer instead of
-    // navigating via a URL. Used by the episode drawer, which can't route to
-    // a `view=` drawer without replacing itself.
     onDrilldown?: () => void;
-    variant?: "all" | "external";
+    variant?: "summary" | "breakdown";
     isLoading?: boolean;
-    // "minimal" (the default, matching the compact summary row) drops the
-    // vote-count superscripts; "default" renders them, used by the ratings
-    // drawer.
-    style?: "default" | "minimal";
-    // "row" (default) lays sources out inline; "tile" renders each source as a
-    // card in a grid, used by the ratings drawer.
-    layout?: "row" | "tile";
   };
 
   const {
@@ -58,71 +48,60 @@
     entry,
     drilldown,
     onDrilldown,
-    variant = "all",
+    variant = "summary",
     isLoading = false,
-    style = "minimal",
-    layout = "row",
   }: RatingListProps = $props();
 
   const { trakt, imdb, tmdb, rotten, mal, letterboxd } = $derived(
     getDisplayableRatings({ ratings, entry }),
   );
 
+  const isBreakdown = $derived(variant === "breakdown");
+  const isDrilldown = $derived(drilldown != null || onDrilldown != null);
+
+  const itemProps = $derived({
+    isLoading,
+    variant: isBreakdown ? ("tile" as const) : ("row" as const),
+  });
+
   const isMediaEntry = $derived(
     entry.type === "show" || entry.type === "movie",
   );
 
-  // Letterboxd is films-only and lives only in the ratings breakdown, never the
-  // compact summary row. MAL (anime-only) shows wherever externals render.
   const showLetterboxd = $derived(
-    variant === "external" && entry.type === "movie" &&
-      letterboxd?.rating != null,
+    isBreakdown && entry.type === "movie" && letterboxd?.rating != null,
   );
 
-  // Reserve the MAL slot in the skeleton for anime movies/shows, so the row
-  // does not shift when the (anime-only) MAL rating lands. Episodes never carry
-  // a MAL rating, so they are excluded from the reserve.
   const isAnime = $derived(isMediaEntry && entry.genres.includes("anime"));
   const showMal = $derived(mal?.rating != null || (isLoading && isAnime));
 
-  // TMDB lives only in the ratings breakdown, never the compact summary row.
-  const showTmdb = $derived(variant === "external" && tmdb?.rating != null);
-
-  const isDrilldown = $derived(drilldown != null || onDrilldown != null);
+  const showTmdb = $derived(isBreakdown && tmdb?.rating != null);
 </script>
 
 {#snippet voteCount(votes: number | Nil)}
-  {#if layout === "tile"}
+  {#if isBreakdown}
     <WatchersIcon />
   {/if}
   {i18n.voteText(votes ?? 0)}
 {/snippet}
 
-{#snippet traktItem()}
-  <RatingItem
-    rating={trakt?.rating && toTraktRating(trakt.rating, getLocale())}
-    {isLoading}
-    {style}
-    {layout}
-  >
-    <RatingIcon style={toVotesBasedRating(trakt?.votes)} />
-    {#snippet superscript()}
-      {@render voteCount(trakt?.votes)}
-    {/snippet}
-  </RatingItem>
-{/snippet}
-
 {#snippet sources()}
-  {#if variant === "all"}
-    {@render traktItem()}
+  {#if !isBreakdown}
+    <RatingItem
+      rating={trakt?.rating && toTraktRating(trakt.rating, getLocale())}
+      {...itemProps}
+    >
+      <RatingIcon style={toVotesBasedRating(trakt?.votes)} />
+      {#snippet superscript()}
+        {@render voteCount(trakt?.votes)}
+      {/snippet}
+    </RatingItem>
   {/if}
 
   <RatingItem
     rating={imdb?.rating && toIMDBRating(imdb.rating, getLocale())}
     url={imdb?.url}
-    {isLoading}
-    {style}
-    {layout}
+    {...itemProps}
   >
     <IMDBIcon style={toVotesBasedRating(imdb?.votes)} />
     {#snippet superscript()}
@@ -136,9 +115,7 @@
       ? toIMDBRating(mal.rating, getLocale())
       : undefined}
       url={mal?.url}
-      {isLoading}
-      {style}
-      {layout}
+      {...itemProps}
     >
       <MALIcon style={toVotesBasedRating(mal?.votes ?? undefined)} />
       {#snippet superscript()}
@@ -151,9 +128,7 @@
     <RatingItem
       rating={toRottenPercentage(rotten?.critic)}
       url={rotten?.url}
-      {isLoading}
-      {style}
-      {layout}
+      {...itemProps}
     >
       <RottenIcon style={toRottenCriticRating(rotten?.critic)} />
       {#snippet superscript()}
@@ -164,9 +139,7 @@
     <RatingItem
       rating={toRottenPercentage(rotten?.audience)}
       url={rotten?.url}
-      {isLoading}
-      {style}
-      {layout}
+      {...itemProps}
     >
       <PopcornIcon style={toRottenAudienceRating(rotten?.audience)} />
       {#snippet superscript()}
@@ -179,9 +152,7 @@
     <RatingItem
       rating={toIMDBRating(letterboxd.rating, getLocale())}
       url={letterboxd.url}
-      {isLoading}
-      {style}
-      {layout}
+      {...itemProps}
     >
       <LetterboxdIcon style={toVotesBasedRating(letterboxd.votes ?? undefined)} />
       {#snippet superscript()}
@@ -194,9 +165,7 @@
     <RatingItem
       rating={toIMDBRating(tmdb.rating, getLocale())}
       url={tmdb.url}
-      {isLoading}
-      {style}
-      {layout}
+      {...itemProps}
     >
       <TMDBIcon />
       {#snippet superscript()}
@@ -206,7 +175,7 @@
   {/if}
 {/snippet}
 
-<div class="trakt-summary-ratings" data-layout={layout}>
+<div class="trakt-summary-ratings" data-variant={itemProps.variant}>
   {#if isDrilldown}
     <ActionButton
       classList="ratings-drilldown"
@@ -233,9 +202,6 @@
   .trakt-summary-ratings :global(.ratings-drilldown) {
     display: flex;
     align-items: center;
-    // wrap instead of shrinking items: a shrunk RatingItem clips its value and
-    // vote-count under `overflow: clip`. Keeps the row intact as sources grow
-    // (e.g. MAL joining for anime).
     flex-wrap: wrap;
     gap: var(--gap-s);
   }
@@ -245,9 +211,7 @@
       flex: 0 0 auto;
     }
 
-    // Tile layout: equal-column grid of source cards, matching the drawer's
-    // stat-tile surfaces. Overrides the inline flex row above.
-    &[data-layout="tile"] {
+    &[data-variant="tile"] {
       display: grid;
       grid-template-columns: repeat(3, 1fr);
       gap: var(--gap-s);
@@ -257,7 +221,7 @@
       }
     }
 
-    &[data-layout="row"] {
+    &[data-variant="row"] {
       :global(.ratings-drilldown) {
         width: auto;
         height: auto;

--- a/projects/client/src/lib/components/summary/RatingList.svelte
+++ b/projects/client/src/lib/components/summary/RatingList.svelte
@@ -87,6 +87,8 @@
 
   // TMDB lives only in the ratings breakdown, never the compact summary row.
   const showTmdb = $derived(variant === "external" && tmdb?.rating != null);
+
+  const isDrilldown = $derived(drilldown != null || onDrilldown != null);
 </script>
 
 {#snippet voteCount(votes: number | Nil)}
@@ -110,7 +112,7 @@
   </RatingItem>
 {/snippet}
 
-<div class="trakt-summary-ratings" data-layout={layout}>
+{#snippet sources()}
   {#if variant === "all"}
     {@render traktItem()}
   {/if}
@@ -202,27 +204,33 @@
       {/snippet}
     </RatingItem>
   {/if}
+{/snippet}
 
-  {#if onDrilldown || drilldown}
+<div class="trakt-summary-ratings" data-layout={layout}>
+  {#if isDrilldown}
     <ActionButton
-      classList="trakt-ratings-drilldown-button"
+      classList="ratings-drilldown"
       onclick={onDrilldown}
       href={drilldown?.href}
       noscroll={drilldown?.noscroll}
       replacestate={drilldown?.replacestate}
       label={i18n.viewBreakdownLabel()}
       style="ghost"
-      size="small"
+      tooltip={false}
     >
+      {@render sources()}
       <CaretRightIcon />
     </ActionButton>
+  {:else}
+    {@render sources()}
   {/if}
 </div>
 
 <style lang="scss">
   @use "$style/scss/mixins/index" as *;
 
-  .trakt-summary-ratings {
+  .trakt-summary-ratings,
+  .trakt-summary-ratings :global(.ratings-drilldown) {
     display: flex;
     align-items: center;
     // wrap instead of shrinking items: a shrunk RatingItem clips its value and
@@ -230,8 +238,10 @@
     // (e.g. MAL joining for anime).
     flex-wrap: wrap;
     gap: var(--gap-s);
+  }
 
-    :global(> rating) {
+  .trakt-summary-ratings {
+    :global(rating) {
       flex: 0 0 auto;
     }
 
@@ -242,15 +252,34 @@
       grid-template-columns: repeat(3, 1fr);
       gap: var(--gap-s);
 
-      :global(> rating) {
+      :global(rating) {
         flex: initial;
       }
     }
 
-    :global(.trakt-ratings-drilldown-button) {
-      :global(svg) {
-        width: var(--ni-20);
-        height: var(--ni-20);
+    &[data-layout="row"] {
+      :global(.ratings-drilldown) {
+        width: auto;
+        height: auto;
+        min-height: var(--ni-28);
+
+        flex-shrink: 1;
+
+        padding-inline: var(--ni-8);
+        margin-inline: var(--ni-neg-8);
+
+        > :global(svg) {
+          height: var(--font-size-text);
+          width: auto;
+        }
+      }
+
+      :global(.ratings-drilldown:hover) {
+        box-shadow: none;
+      }
+
+      :global(.ratings-drilldown:active) {
+        transform: scale(0.98);
       }
     }
   }

--- a/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
+++ b/projects/client/src/lib/sections/summary/components/rating/RatingsDrawer.svelte
@@ -74,9 +74,7 @@
             <RatingList
               {ratings}
               {entry}
-              variant="external"
-              style="default"
-              layout="tile"
+              variant="breakdown"
               isLoading={$isLoading}
             />
           </div>


### PR DESCRIPTION
## 🎶 Notes 🎶

- The whole ratings row (sources + caret) is now one clickable target that opens the breakdown drawer.
- Individual sources no longer link out from the row. The drawer's cards still do.
- `variant`, `style` and `layout` on `RatingList` were always passed together, so they're collapsed into a single `variant`.

## 👀 Examples 👀

https://github.com/user-attachments/assets/a6ebe5ab-99de-482d-9dc1-79d10b62c702


https://github.com/user-attachments/assets/952756dc-8e50-467a-94b2-eeadd77ae73f

