### PR TITLE
fix(navigation): move the signed-in dashboard to /home

### DIFF
--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -11,6 +11,7 @@ import { handle as handleLegacyRedirect } from '$lib/features/legacy-redirects/h
 import { handle as handleMobileOperatingSystem } from '$lib/features/mobile-os/handle.ts';
 import { handle as handleSearchConfig } from '$lib/features/search/handle.ts';
 import { handle as handleTheme } from '$lib/features/theme/handle.ts';
+import { isAuthorizedToken } from '$lib/features/auth/isAuthorizedToken.ts';
 import { isBotAgent } from '$lib/utils/devices/isBotAgent.ts';
 
 import { SENTRY_DSN } from '$lib/utils/constants.ts';
@@ -29,6 +30,10 @@ const WHITELISTED_HEADERS = new Set([
   'x-pagination-page',
   'x-pagination-page-count',
 ]);
+
+const NO_STORE = 'private, no-store, no-cache, must-revalidate';
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 function hasWebviewParam(url: URL): boolean {
   return Object.values(WEBVIEW_PARAMS).some((param) =>
@@ -55,16 +60,24 @@ export const handleReferrerPolicy: Handle = async ({ event, resolve }) => {
 export const handleCacheControl: Handle = async ({ event, resolve }) => {
   const response = await resolve(event);
 
-  if (!response.headers.get('content-type')?.includes('text/html')) {
+  const isHtml = response.headers.get('content-type')?.includes('text/html') ??
+    false;
+  const isRedirect = REDIRECT_STATUSES.has(response.status);
+
+  if (!isHtml && !isRedirect) {
     return response;
   }
 
   function toCacheControl() {
+    if (isRedirect) {
+      return NO_STORE;
+    }
+
     // A WebView request carries the viewer's VIP token in the URL. Never let a
     // spoofed bot User-Agent promote the response to a public CDN entry (keyed
     // by the token), which would cache one viewer's review for others.
     if (hasWebviewParam(event.url)) {
-      return 'private, no-store, no-cache, must-revalidate';
+      return NO_STORE;
     }
 
     // Verified search engine crawlers (via Cloudflare), full CDN caching for SEO
@@ -76,13 +89,13 @@ export const handleCacheControl: Handle = async ({ event, resolve }) => {
     // Only cache publicly for unauthenticated requests to prevent cache poisoning via spoofed User-Agent
     if (
       isBotAgent(event.request.headers.get('user-agent')) &&
-      !event.locals.oidcAuth
+      !isAuthorizedToken(event.locals.oidcAuth)
     ) {
       // 120 seconds is enough to satisfy Discord without heavily caching stale content
       return 'public, max-age=120, s-maxage=120';
     }
 
-    return 'private, no-store, no-cache, must-revalidate';
+    return NO_STORE;
   }
 
   const clonedHeaders = new Headers(response.headers);

--- a/projects/client/src/lib/components/router/Redirect.svelte
+++ b/projects/client/src/lib/components/router/Redirect.svelte
@@ -5,7 +5,8 @@
   const { to }: { to: string } = $props();
 
   onMount(() => {
-    if (page.url.pathname === to) return;
+    const target = new URL(to, page.url.origin);
+    if (page.url.pathname === target.pathname) return;
     goto(to, {
       replaceState: true,
     });

--- a/projects/client/src/lib/features/auth/isAuthorizedToken.spec.ts
+++ b/projects/client/src/lib/features/auth/isAuthorizedToken.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { isAuthorizedToken } from './isAuthorizedToken.ts';
+
+const NOW = 1_000_000;
+
+describe('util: isAuthorizedToken', () => {
+  it('should reject a missing cookie', () => {
+    expect(isAuthorizedToken(null, NOW)).toBe(false);
+    expect(isAuthorizedToken(undefined, NOW)).toBe(false);
+  });
+
+  it('should reject a cookie without a token', () => {
+    expect(
+      isAuthorizedToken({ token: null, expiresAt: NOW + 1 }, NOW),
+    ).toBe(false);
+  });
+
+  it('should reject a cookie without an expiry', () => {
+    expect(
+      isAuthorizedToken({ token: 'token', expiresAt: null }, NOW),
+    ).toBe(false);
+  });
+
+  it('should reject an expired token', () => {
+    expect(
+      isAuthorizedToken({ token: 'token', expiresAt: NOW - 1 }, NOW),
+    ).toBe(false);
+  });
+
+  it('should reject a token expiring exactly now', () => {
+    expect(
+      isAuthorizedToken({ token: 'token', expiresAt: NOW }, NOW),
+    ).toBe(false);
+  });
+
+  it('should accept an unexpired token', () => {
+    expect(
+      isAuthorizedToken({ token: 'token', expiresAt: NOW + 1 }, NOW),
+    ).toBe(true);
+  });
+});

--- a/projects/client/src/lib/features/auth/isAuthorizedToken.ts
+++ b/projects/client/src/lib/features/auth/isAuthorizedToken.ts
@@ -1,0 +1,12 @@
+import type { OidcAuthToken } from './models/OidcAuthToken.ts';
+
+export function isAuthorizedToken(
+  auth: Nil | OidcAuthToken,
+  now: number = Date.now(),
+): auth is OidcAuthToken & { token: string } {
+  if (!auth?.token) {
+    return false;
+  }
+
+  return (auth.expiresAt ?? 0) > now;
+}

--- a/projects/client/src/lib/features/auth/mapToToken.ts
+++ b/projects/client/src/lib/features/auth/mapToToken.ts
@@ -1,0 +1,12 @@
+import { time } from '$lib/utils/timing/time.ts';
+import type { User } from 'oidc-client-ts';
+import type { Token } from './token/index.ts';
+
+export function mapToToken(user: User | Nil): Token {
+  const expiresAt = user?.expires_at ? time.seconds(user.expires_at) : null;
+
+  return {
+    value: user?.access_token ?? null,
+    expiresAt,
+  };
+}

--- a/projects/client/src/lib/features/auth/postToken.ts
+++ b/projects/client/src/lib/features/auth/postToken.ts
@@ -2,7 +2,7 @@ import type { Token } from '$lib/features/auth/token/index.ts';
 import { retry } from '$lib/utils/retry/retry.ts';
 
 export function postToken({ value, expiresAt }: Token) {
-  retry(
+  return retry(
     () =>
       fetch('/api/store-token', {
         method: 'POST',
@@ -12,5 +12,5 @@ export function postToken({ value, expiresAt }: Token) {
           expiresAt,
         }),
       }),
-  );
+  ).catch(() => null);
 }

--- a/projects/client/src/lib/features/auth/postToken.ts
+++ b/projects/client/src/lib/features/auth/postToken.ts
@@ -1,8 +1,17 @@
 import type { Token } from '$lib/features/auth/token/index.ts';
 import { retry } from '$lib/utils/retry/retry.ts';
 
+// `userLoaded` and the sign-in callback both post the same token, and the
+// callback awaits its POST before navigating. Sharing the in-flight request
+// keeps that await on the critical path from costing a second roundtrip.
+let inflight: { value: string | Nil; promise: Promise<unknown> } | null = null;
+
 export function postToken({ value, expiresAt }: Token) {
-  return retry(
+  if (inflight && inflight.value === value) {
+    return inflight.promise;
+  }
+
+  const promise = retry(
     () =>
       fetch('/api/store-token', {
         method: 'POST',
@@ -12,5 +21,15 @@ export function postToken({ value, expiresAt }: Token) {
           expiresAt,
         }),
       }),
-  ).catch(() => null);
+  )
+    .catch(() => null)
+    .finally(() => {
+      if (inflight?.promise === promise) {
+        inflight = null;
+      }
+    });
+
+  inflight = { value, promise };
+
+  return promise;
 }

--- a/projects/client/src/lib/features/auth/redirectForAudience.spec.ts
+++ b/projects/client/src/lib/features/auth/redirectForAudience.spec.ts
@@ -1,0 +1,137 @@
+import { isRedirect } from '@sveltejs/kit';
+import { describe, expect, it } from 'vitest';
+import { redirectForAudience } from './redirectForAudience.ts';
+
+const AUTHORIZED = { token: 'token', expiresAt: Date.now() + 60_000 };
+const EXPIRED = { token: 'token', expiresAt: Date.now() - 60_000 };
+
+const captureRedirect = (params: Parameters<typeof redirectForAudience>[0]) => {
+  try {
+    redirectForAudience(params);
+    return null;
+  } catch (error) {
+    if (!isRedirect(error)) {
+      throw error;
+    }
+
+    return { status: error.status, location: error.location };
+  }
+};
+
+describe('util: redirectForAudience', () => {
+  describe('for an authenticated page', () => {
+    it('should send an unauthorized viewer to the landing page', () => {
+      expect(
+        captureRedirect({
+          audience: 'authenticated',
+          oidcAuth: null,
+          search: '',
+          isDataRequest: false,
+        }),
+      ).toEqual({ status: 307, location: '/' });
+    });
+
+    it('should treat an expired token as unauthorized', () => {
+      expect(
+        captureRedirect({
+          audience: 'authenticated',
+          oidcAuth: EXPIRED,
+          search: '',
+          isDataRequest: false,
+        }),
+      ).toEqual({ status: 307, location: '/' });
+    });
+
+    it('should preserve the query string', () => {
+      expect(
+        captureRedirect({
+          audience: 'authenticated',
+          oidcAuth: null,
+          search: '?mode=show',
+          isDataRequest: false,
+        }),
+      ).toEqual({ status: 307, location: '/?mode=show' });
+    });
+
+    it('should let an authorized viewer through', () => {
+      expect(
+        captureRedirect({
+          audience: 'authenticated',
+          oidcAuth: AUTHORIZED,
+          search: '',
+          isDataRequest: false,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe('for a public page', () => {
+    it('should send an authorized viewer to the dashboard', () => {
+      expect(
+        captureRedirect({
+          audience: 'public',
+          oidcAuth: AUTHORIZED,
+          search: '',
+          isDataRequest: false,
+        }),
+      ).toEqual({ status: 307, location: '/home' });
+    });
+
+    it('should preserve the query string', () => {
+      expect(
+        captureRedirect({
+          audience: 'public',
+          oidcAuth: AUTHORIZED,
+          search: '?utm_source=newsletter',
+          isDataRequest: false,
+        }),
+      ).toEqual({ status: 307, location: '/home?utm_source=newsletter' });
+    });
+
+    it('should let an unauthorized viewer through', () => {
+      expect(
+        captureRedirect({
+          audience: 'public',
+          oidcAuth: null,
+          search: '',
+          isDataRequest: false,
+        }),
+      ).toBeNull();
+    });
+
+    it('should let a viewer with an expired token through', () => {
+      expect(
+        captureRedirect({
+          audience: 'public',
+          oidcAuth: EXPIRED,
+          search: '',
+          isDataRequest: false,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe('for a client side navigation', () => {
+    it('should leave an authenticated page to the client guard', () => {
+      expect(
+        captureRedirect({
+          audience: 'authenticated',
+          oidcAuth: null,
+          search: '',
+          isDataRequest: true,
+        }),
+      ).toBeNull();
+    });
+
+    it('should leave a public page to the client guard', () => {
+      expect(
+        captureRedirect({
+          audience: 'public',
+          oidcAuth: AUTHORIZED,
+          search: '',
+          isDataRequest: true,
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/projects/client/src/lib/features/auth/redirectForAudience.ts
+++ b/projects/client/src/lib/features/auth/redirectForAudience.ts
@@ -7,11 +7,16 @@ type RedirectForAudienceParams = {
   audience: 'authenticated' | 'public';
   oidcAuth: Nil | OidcAuthToken;
   search: string;
+  isDataRequest: boolean;
 };
 
 export function redirectForAudience(
-  { audience, oidcAuth, search }: RedirectForAudienceParams,
+  { audience, oidcAuth, search, isDataRequest }: RedirectForAudienceParams,
 ) {
+  if (isDataRequest) {
+    return;
+  }
+
   const isAuthorized = isAuthorizedToken(oidcAuth);
 
   if (audience === 'authenticated' && !isAuthorized) {

--- a/projects/client/src/lib/features/auth/redirectForAudience.ts
+++ b/projects/client/src/lib/features/auth/redirectForAudience.ts
@@ -1,0 +1,24 @@
+import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
+import { redirect } from '@sveltejs/kit';
+import { isAuthorizedToken } from './isAuthorizedToken.ts';
+import type { OidcAuthToken } from './models/OidcAuthToken.ts';
+
+type RedirectForAudienceParams = {
+  audience: 'authenticated' | 'public';
+  oidcAuth: Nil | OidcAuthToken;
+  search: string;
+};
+
+export function redirectForAudience(
+  { audience, oidcAuth, search }: RedirectForAudienceParams,
+) {
+  const isAuthorized = isAuthorizedToken(oidcAuth);
+
+  if (audience === 'authenticated' && !isAuthorized) {
+    return redirect(307, `${UrlBuilder.landing()}${search}`);
+  }
+
+  if (audience === 'public' && isAuthorized) {
+    return redirect(307, `${UrlBuilder.home()}${search}`);
+  }
+}

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -1,6 +1,5 @@
 import { browser } from '$app/environment';
 import { FETCH_ERROR_EVENT } from '$lib/features/errors/constants.ts';
-import { time } from '$lib/utils/timing/time.ts';
 import { WorkerMessage } from '$worker/WorkerMessage.ts';
 import { workerRequest } from '$worker/workerRequest.ts';
 import { type User, UserManager } from 'oidc-client-ts';
@@ -9,22 +8,14 @@ import { onMount } from 'svelte';
 import { writeAuthMarker } from '../authMarker.ts';
 import { deriveStandardAuthority } from '../deriveStandardAuthority.ts';
 import { getOidcConfig } from '../getOidcConfig.ts';
+import { mapToToken } from '../mapToToken.ts';
 import { portWorkerAuthSession } from '../portWorkerAuthSession.ts';
+import { postToken } from '../postToken.ts';
 import { resolveOidcAuthority } from '../resolveOidcAuthority.ts';
 import { safeLocalStorage } from '$lib/utils/storage/safeStorage.ts';
 import { setToken, type Token } from '../token/index.ts';
-import { postToken } from './_internal/postToken.ts';
 import type { AuthContextType } from './createAuthContext.ts';
 import { setUserManager } from './userManager.ts';
-
-function mapToToken(user: User | null): Token {
-  const expiresAt = user?.expires_at ? time.seconds(user.expires_at) : null;
-
-  return {
-    value: user?.access_token ?? null,
-    expiresAt,
-  };
-}
 
 type InitializeUserManagerParams = {
   ctx: AuthContextType;
@@ -121,8 +112,18 @@ export function initializeUserManager(
         return;
       }
 
+      if (!user) {
+        if (tokenFromServer) {
+          handleUserEvent(null);
+          return;
+        }
+
+        setAuthState({ token: mapToToken(null), isExpired: true });
+        return;
+      }
+
       const token = mapToToken(user);
-      setAuthState({ token, isExpired: user?.expired ?? true });
+      setAuthState({ token, isExpired: user.expired ?? true });
       syncToken(user);
     };
 

--- a/projects/client/src/lib/features/auth/stores/useGuardedHref.ts
+++ b/projects/client/src/lib/features/auth/stores/useGuardedHref.ts
@@ -41,7 +41,7 @@ export function useGuardedHref(href: string | Nil) {
          * TODO: when we have v3 auth flow we can improve by having a returnUrl
          * this would return real users to what they wanted to access instead of home page after login
          */
-        return authorized ? href : UrlBuilder.home();
+        return authorized ? href : UrlBuilder.landing();
       }),
     );
 

--- a/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.spec.ts
+++ b/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.spec.ts
@@ -159,8 +159,8 @@ describe('util: resolveLegacyRedirect', () => {
 
   describe('top-level pages', () => {
     it('should map dashboard to home', () => {
-      expect(resolveLegacyRedirect('/dashboard')).toBe('/');
-      expect(resolveLegacyRedirect('/dashboard/on_deck')).toBe('/');
+      expect(resolveLegacyRedirect('/dashboard')).toBe('/home');
+      expect(resolveLegacyRedirect('/dashboard/on_deck')).toBe('/home');
     });
 
     it('should map official lists', () => {
@@ -230,14 +230,14 @@ describe('util: resolveLegacyRedirect', () => {
     });
   });
 
-  describe('no sensible target falls back to home', () => {
+  describe('no sensible target falls back to the landing page', () => {
     it.each([
       '/seasons/12345',
       '/episodes/67890',
       '/comments/all/movies',
       '/share/abc123',
       '/tmdb/updates',
-    ])('should redirect %s to home', (path) => {
+    ])('should redirect %s to the landing page', (path) => {
       expect(resolveLegacyRedirect(path)).toBe('/');
     });
   });
@@ -271,6 +271,7 @@ describe('util: resolveLegacyRedirect', () => {
       '/search',
       '/settings/advanced',
       '/',
+      '/home',
     ])('should return null for %s', (path) => {
       expect(resolveLegacyRedirect(path)).toBeNull();
     });

--- a/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.ts
+++ b/projects/client/src/lib/features/legacy-redirects/resolveLegacyRedirect.ts
@@ -223,11 +223,11 @@ const rules: ReadonlyArray<LegacyRule> = [
   // home rather than 404.
   {
     pattern: /^\/seasons\/[^/]+\/?$/,
-    to: () => UrlBuilder.home(),
+    to: () => UrlBuilder.landing(),
   },
   {
     pattern: /^\/episodes\/[^/]+\/?$/,
-    to: () => UrlBuilder.home(),
+    to: () => UrlBuilder.landing(),
   },
   // Numeric-id public list / watchlist: slug can't be reconstructed, so fall
   // back to the signed-in user's lists landing (holds the watchlist and every
@@ -238,15 +238,15 @@ const rules: ReadonlyArray<LegacyRule> = [
   },
   {
     pattern: /^\/comments\/[^/]+\/[^/]+\/?$/,
-    to: () => UrlBuilder.home(),
+    to: () => UrlBuilder.landing(),
   },
   {
     pattern: /^\/share\/[^/]+\/?$/,
-    to: () => UrlBuilder.home(),
+    to: () => UrlBuilder.landing(),
   },
   {
     pattern: /^\/tmdb(?:\/.*)?$/,
-    to: () => UrlBuilder.home(),
+    to: () => UrlBuilder.landing(),
   },
 ];
 

--- a/projects/client/src/lib/pwa/manifest.ts
+++ b/projects/client/src/lib/pwa/manifest.ts
@@ -53,7 +53,7 @@ export const manifest: Partial<ManifestOptions> = {
       purpose: 'any',
     },
   ],
-  start_url: '/',
+  start_url: '/home',
   display: 'standalone',
   theme_color: '#131517',
   background_color: '#131517',

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -140,6 +140,18 @@
 
   const robots = $derived(AUDIENCE_ROBOTS[audience]);
 
+  const AUDIENCE_REDIRECTS: Partial<
+    Record<
+      AudienceProps["audience"],
+      { viewer: AudienceProps["audience"]; to: string }
+    >
+  > = {
+    authenticated: { viewer: "public", to: UrlBuilder.landing() },
+    public: { viewer: "authenticated", to: UrlBuilder.home() },
+  };
+
+  const audienceRedirect = $derived(AUDIENCE_REDIRECTS[audience]);
+
   const isMediaPage = $derived(type === "movie" || type === "show");
 
   const createWebsiteLd = (url: string) => {
@@ -295,9 +307,9 @@
     {/if}
   </RenderFor>
 
-  {#if audience === "authenticated"}
-    <RenderFor audience="public">
-      <Redirect to={UrlBuilder.home()} />
+  {#if audienceRedirect}
+    <RenderFor audience={audienceRedirect.viewer}>
+      <Redirect to={audienceRedirect.to} />
     </RenderFor>
   {/if}
 </FilterScopeSetter>

--- a/projects/client/src/lib/sections/layout/TraktPage.svelte
+++ b/projects/client/src/lib/sections/layout/TraktPage.svelte
@@ -143,14 +143,32 @@
   const AUDIENCE_REDIRECTS: Partial<
     Record<
       AudienceProps["audience"],
-      { viewer: AudienceProps["audience"]; to: string }
+      {
+        viewer: AudienceProps["audience"];
+        to: string;
+        preservesSearch: boolean;
+      }
     >
   > = {
-    authenticated: { viewer: "public", to: UrlBuilder.landing() },
-    public: { viewer: "authenticated", to: UrlBuilder.home() },
+    authenticated: {
+      viewer: "public",
+      to: UrlBuilder.landing(),
+      preservesSearch: false,
+    },
+    public: {
+      viewer: "authenticated",
+      to: UrlBuilder.home(),
+      preservesSearch: true,
+    },
   };
 
   const audienceRedirect = $derived(AUDIENCE_REDIRECTS[audience]);
+
+  const audienceRedirectTo = $derived(
+    audienceRedirect?.preservesSearch
+      ? `${audienceRedirect.to}${page.url.search}`
+      : audienceRedirect?.to,
+  );
 
   const isMediaPage = $derived(type === "movie" || type === "show");
 
@@ -307,9 +325,9 @@
     {/if}
   </RenderFor>
 
-  {#if audienceRedirect}
+  {#if audienceRedirect && audienceRedirectTo}
     <RenderFor audience={audienceRedirect.viewer}>
-      <Redirect to={audienceRedirect.to} />
+      <Redirect to={audienceRedirectTo} />
     </RenderFor>
   {/if}
 </FilterScopeSetter>

--- a/projects/client/src/lib/utils/url/UrlBuilder.ts
+++ b/projects/client/src/lib/utils/url/UrlBuilder.ts
@@ -158,7 +158,8 @@ export const UrlBuilder = {
   startWatching: (user: string, params: Record<string, string | number> = {}) =>
     `/users/${user}/start-watching${buildParamString(sanitizeParams(params))}`,
 
-  home: () => '/',
+  landing: () => '/',
+  home: () => '/home',
   welcome: () => '/welcome',
   shows: () => '/shows',
   discover: (params?: DiscoverUrlParams) => {

--- a/projects/client/src/mocks/handlers/auth.ts
+++ b/projects/client/src/mocks/handlers/auth.ts
@@ -1,0 +1,8 @@
+import { http, HttpResponse } from 'msw';
+
+export const auth = [
+  http.post(
+    '*/api/store-token',
+    () => HttpResponse.json({ ok: true }),
+  ),
+];

--- a/projects/client/src/mocks/server.ts
+++ b/projects/client/src/mocks/server.ts
@@ -1,5 +1,6 @@
 import { setupServer } from 'msw/node';
 import { apps } from './handlers/apps.ts';
+import { auth } from './handlers/auth.ts';
 import { calendars } from './handlers/calendars.ts';
 import { comments } from './handlers/comments.ts';
 import { intl } from './handlers/intl.ts';
@@ -19,6 +20,7 @@ import { watchNow } from './handlers/watchNow.ts';
 
 const handlers = [
   ...apps,
+  ...auth,
   ...users,
   ...movies,
   ...shows,

--- a/projects/client/src/routes/+layout.server.ts
+++ b/projects/client/src/routes/+layout.server.ts
@@ -1,10 +1,11 @@
+import { isAuthorizedToken } from '$lib/features/auth/isAuthorizedToken.ts';
 import type { OidcAuthToken } from '$lib/features/auth/models/OidcAuthToken.ts';
 import { getDeviceType } from '$lib/utils/devices/getDeviceType.ts';
 import { isBotAgent } from '$lib/utils/devices/isBotAgent.ts';
 import type { LayoutServerLoad } from '$types/$types.d.ts';
 
 const getAuth = (auth: Nil | OidcAuthToken) => {
-  if (!auth) {
+  if (!isAuthorizedToken(auth)) {
     return {
       token: null,
       expiresAt: null,

--- a/projects/client/src/routes/+page.server.ts
+++ b/projects/client/src/routes/+page.server.ts
@@ -1,9 +1,10 @@
 import { redirectForAudience } from '$lib/features/auth/redirectForAudience.ts';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = ({ locals, url }) =>
+export const load: PageServerLoad = ({ locals, url, isDataRequest }) =>
   redirectForAudience({
     audience: 'public',
     oidcAuth: locals.oidcAuth,
     search: url.search,
+    isDataRequest,
   });

--- a/projects/client/src/routes/+page.server.ts
+++ b/projects/client/src/routes/+page.server.ts
@@ -1,0 +1,9 @@
+import { redirectForAudience } from '$lib/features/auth/redirectForAudience.ts';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = ({ locals, url }) =>
+  redirectForAudience({
+    audience: 'public',
+    oidcAuth: locals.oidcAuth,
+    search: url.search,
+  });

--- a/projects/client/src/routes/+page.svelte
+++ b/projects/client/src/routes/+page.svelte
@@ -1,78 +1,28 @@
 <script lang="ts">
-  import { useAuth } from "$lib/features/auth/stores/useAuth";
-  import { useDiscover } from "$lib/features/filters/useDiscover";
   import * as m from "$lib/features/i18n/messages.ts";
   import RenderFor from "$lib/guards/RenderFor.svelte";
-  import Banner from "$lib/sections/banner/Banner.svelte";
-  import DashboardDrawer from "$lib/sections/dashboard/DashboardDrawer.svelte";
   import Landing from "$lib/sections/landing/Landing.svelte";
   import MobileLanding from "$lib/sections/landing/MobileLanding.svelte";
   import TraktPage from "$lib/sections/layout/TraktPage.svelte";
-  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
-  import ActivityList from "$lib/sections/lists/activity/ActivityList.svelte";
-  import PersonalHistoryList from "$lib/sections/lists/history/PersonalHistoryList.svelte";
-  import UpNextList from "$lib/sections/lists/progress/UpNextList.svelte";
-  import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
-  import UpcomingList from "$lib/sections/lists/UpcomingList.svelte";
-  import WatchList from "$lib/sections/lists/watchlist/WatchList.svelte";
   import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
-  import StreakCallout from "$lib/sections/stats/StreakCallout.svelte";
   import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
-
-  // FIXME: move to PersonalHistoryList when Profile also supports discover mode
-  const { mode } = useDiscover();
-  const { isAuthorized } = useAuth();
-  const audience = $derived($isAuthorized ? "authenticated" : "public");
-  const pageMode = $derived($isAuthorized ? "default" : "content-only");
 </script>
 
 <TraktPage
-  {audience}
+  audience="public"
   image={DEFAULT_SHARE_COVER}
   title={m.page_title_home()}
   info={{ overview: m.page_description_home() }}
   type="home"
-  mode={pageMode}
-  filterScope="global"
+  mode="content-only"
 >
-  <RenderFor audience="authenticated">
-    <TraktPageCoverSetter />
+  <NavbarStateSetter mode="hidden" />
 
-    <NavbarStateSetter contentToggle="discover" hasFilters />
-
-    <Banner />
-    <UpNextList />
-
-    <WatchList
-      drilldownLabel={m.button_label_view_all_start_watching_items()}
-      type={$mode}
-      intent="start"
-    />
-
-    <StreakCallout />
-    <UpcomingList />
-    <RecommendedList
-      title={m.list_title_recommended()}
-      drilldownLabel={$mode === "show"
-        ? m.button_label_view_all_recommended_shows()
-        : m.button_label_view_all_recommended_movies()}
-      type={$mode}
-    />
-    <PersonalHistoryList mode={$mode} />
-    <ActivityList />
-
-    <DashboardDrawer />
+  <RenderFor audience="public" device={["tablet-sm", "tablet-lg", "desktop"]}>
+    <Landing />
   </RenderFor>
 
-  <RenderFor audience="public">
-    <NavbarStateSetter mode="hidden" />
-
-    <RenderFor audience="public" device={["tablet-sm", "tablet-lg", "desktop"]}>
-      <Landing />
-    </RenderFor>
-
-    <RenderFor audience="public" device={["mobile"]}>
-      <MobileLanding />
-    </RenderFor>
+  <RenderFor audience="public" device={["mobile"]}>
+    <MobileLanding />
   </RenderFor>
 </TraktPage>

--- a/projects/client/src/routes/callback/+page.svelte
+++ b/projects/client/src/routes/callback/+page.svelte
@@ -1,10 +1,21 @@
 <script lang="ts">
+  import { mapToToken } from "$lib/features/auth/mapToToken";
+  import { postToken } from "$lib/features/auth/postToken";
   import { getUserManager } from "$lib/features/auth/stores/userManager";
   import { FETCH_ERROR_EVENT } from "$lib/features/errors/constants";
   import { error as printError } from "$lib/utils/console/print.ts";
   import { setCacheBuster } from "$lib/utils/url/setCacheBuster";
   import { UrlBuilder } from "$lib/utils/url/UrlBuilder";
+  import type { User } from "oidc-client-ts";
   import { onMount } from "svelte";
+
+  const storeSession = async (user: User | Nil) => {
+    if (!user) {
+      return;
+    }
+
+    await postToken(mapToToken(user));
+  };
 
   const navigateToHome = () => {
     const homeUrl = new URL(
@@ -17,6 +28,7 @@
   onMount(() => {
     getUserManager()
       ?.signinCallback()
+      .then(storeSession)
       .then(navigateToHome)
       .catch((error) => {
         printError("Error during sign-in callback:", error);

--- a/projects/client/src/routes/home/+page.server.ts
+++ b/projects/client/src/routes/home/+page.server.ts
@@ -1,0 +1,9 @@
+import { redirectForAudience } from '$lib/features/auth/redirectForAudience.ts';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = ({ locals, url }) =>
+  redirectForAudience({
+    audience: 'authenticated',
+    oidcAuth: locals.oidcAuth,
+    search: url.search,
+  });

--- a/projects/client/src/routes/home/+page.server.ts
+++ b/projects/client/src/routes/home/+page.server.ts
@@ -1,9 +1,10 @@
 import { redirectForAudience } from '$lib/features/auth/redirectForAudience.ts';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = ({ locals, url }) =>
+export const load: PageServerLoad = ({ locals, url, isDataRequest }) =>
   redirectForAudience({
     audience: 'authenticated',
     oidcAuth: locals.oidcAuth,
     search: url.search,
+    isDataRequest,
   });

--- a/projects/client/src/routes/home/+page.svelte
+++ b/projects/client/src/routes/home/+page.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { useDiscover } from "$lib/features/filters/useDiscover";
+  import * as m from "$lib/features/i18n/messages.ts";
+  import Banner from "$lib/sections/banner/Banner.svelte";
+  import DashboardDrawer from "$lib/sections/dashboard/DashboardDrawer.svelte";
+  import TraktPage from "$lib/sections/layout/TraktPage.svelte";
+  import TraktPageCoverSetter from "$lib/sections/layout/TraktPageCoverSetter.svelte";
+  import ActivityList from "$lib/sections/lists/activity/ActivityList.svelte";
+  import PersonalHistoryList from "$lib/sections/lists/history/PersonalHistoryList.svelte";
+  import UpNextList from "$lib/sections/lists/progress/UpNextList.svelte";
+  import RecommendedList from "$lib/sections/lists/recommended/RecommendedList.svelte";
+  import UpcomingList from "$lib/sections/lists/UpcomingList.svelte";
+  import WatchList from "$lib/sections/lists/watchlist/WatchList.svelte";
+  import NavbarStateSetter from "$lib/sections/navbar/NavbarStateSetter.svelte";
+  import StreakCallout from "$lib/sections/stats/StreakCallout.svelte";
+  import { DEFAULT_SHARE_COVER } from "$lib/utils/assets";
+
+  // FIXME: move to PersonalHistoryList when Profile also supports discover mode
+  const { mode } = useDiscover();
+
+  const recommendedDrilldownLabel = $derived(
+    $mode === "show"
+      ? m.button_label_view_all_recommended_shows()
+      : m.button_label_view_all_recommended_movies(),
+  );
+</script>
+
+<TraktPage
+  audience="authenticated"
+  image={DEFAULT_SHARE_COVER}
+  title={m.page_title_home()}
+  filterScope="global"
+>
+  <TraktPageCoverSetter />
+
+  <NavbarStateSetter contentToggle="discover" hasFilters />
+
+  <Banner />
+  <UpNextList />
+
+  <WatchList
+    drilldownLabel={m.button_label_view_all_start_watching_items()}
+    type={$mode}
+    intent="start"
+  />
+
+  <StreakCallout />
+  <UpcomingList />
+  <RecommendedList
+    title={m.list_title_recommended()}
+    drilldownLabel={recommendedDrilldownLabel}
+    type={$mode}
+  />
+  <PersonalHistoryList mode={$mode} />
+  <ActivityList />
+
+  <DashboardDrawer />
+</TraktPage>

--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -151,7 +151,7 @@ const navigationHandler = new StaleWhileRevalidate(navigationOptions);
 
 const landingHandler = new NetworkFirst({
   ...navigationOptions,
-  networkTimeoutSeconds: 3,
+  networkTimeoutSeconds: 1.5,
 });
 
 registerRoute(

--- a/projects/client/src/service-worker.ts
+++ b/projects/client/src/service-worker.ts
@@ -132,13 +132,26 @@ const documentCacheKey = {
   },
 };
 
-// StaleWhileRevalidate for fast cold loads.
-const navigationHandler = new StaleWhileRevalidate({
+const skipRedirectedDocuments = {
+  cacheWillUpdate: ({ response }: { response: Response }) =>
+    Promise.resolve(response.redirected ? null : response),
+};
+
+const navigationOptions = {
   cacheName: CacheKey.navigation,
   plugins: [
     documentCacheKey,
+    skipRedirectedDocuments,
     expiration(time.hours(12)),
   ],
+};
+
+// StaleWhileRevalidate for fast cold loads.
+const navigationHandler = new StaleWhileRevalidate(navigationOptions);
+
+const landingHandler = new NetworkFirst({
+  ...navigationOptions,
+  networkTimeoutSeconds: 3,
 });
 
 registerRoute(
@@ -153,6 +166,10 @@ registerRoute(
       // Remove _cb param and redirect
       url.searchParams.delete('_cb');
       return Response.redirect(url.toString(), 302);
+    }
+
+    if (url.pathname === '/') {
+      return await landingHandler.handle(context);
     }
 
     return await navigationHandler.handle(context);


### PR DESCRIPTION
## 🎶 Notes 🎶

- The landing page could briefly flash for signed in users on `/`. Both the landing and the dashboard lived in the same route, so whenever auth resolved late the visible content repainted in place.
- `/` is now landing only, `/home` holds the dashboard. Server loads redirect both ways off the oidc cookie, so the bounce lands before first paint instead of after.
- Server and client now agree on what an authorized session is (token + expiry, one shared helper). The cookie outlives the oidc storage the client reads (ITP evicts it after 7 idle days), and presence only checks had the server answering "authorized" while the client rendered as public, so the two bounced off each other forever.
- The callback awaits the token post before leaving, otherwise `/home` turns the request away and we land back on the flash we're removing.
- Service worker: `/` is network first, and redirected documents are never cached. A signed out `/home` fetch follows the 307 and comes back as the landing document, which would replay the same flash one route over.
- Redirect responses are stamped `no-store`. Cloudflare keys on URL and doesn't vary on cookie, so a cached `307 / -> /home` would bounce anonymous visitors back and forth and leave the landing page unreachable.
  - This applies to every load level redirect, not just the audience ones. Keeping it broad on purpose: an allowlist of guarded paths fails open the moment a route gets renamed.
- `UrlBuilder.home()` now means `/home`, `landing()` is the new name for `/`. PWA `start_url` follows the dashboard since installs are pinned by manifest id.
- Query params are preserved across the server guards, same as the other `load` redirects. The client side fallback in `TraktPage` drops them.
- ⚠️ The flash was never reliably reproducible, so the fix is reasoned from the mechanism rather than observed. We should keep an eye on prod after this deploys.

