### PR TITLE
fix(settings): prevent raw export from hanging on stalled requests

### DIFF
--- a/projects/client/i18n/meta/en.json
+++ b/projects/client/i18n/meta/en.json
@@ -5034,6 +5034,27 @@
       "default": "Export complete.",
       "description": "Text shown to indicate that the user's data export is complete."
     },
+    "text_export_status_partial_one": {
+      "default": "Export complete, but 1 of {total} sections failed. See _errors.json in the zip.",
+      "description": "Text shown when the user's data export finished but exactly one section could not be fetched.",
+      "variables": {
+        "total": {
+          "type": "number"
+        }
+      }
+    },
+    "text_export_status_partial_other": {
+      "default": "Export complete, but {failed} of {total} sections failed. See _errors.json in the zip.",
+      "description": "Text shown when the user's data export finished but multiple sections could not be fetched.",
+      "variables": {
+        "failed": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        }
+      }
+    },
     "header_import": {
       "default": "Import",
       "description": "Header for the settings section that allows users to import their data from third-party services."

--- a/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
+++ b/projects/client/src/lib/features/analytics/events/AnalyticsEventDataMap.ts
@@ -67,7 +67,11 @@ type ImportCompletedType = {
   duration: number;
 };
 type ImportFailedType = { source: string; error: string };
-type ExportCompletedType = { duration: number; endpointCount: number };
+type ExportCompletedType = {
+  duration: number;
+  endpointCount: number;
+  failedCount: number;
+};
 type ExportFailedType = { error: string };
 
 type ClearInitiatedType = { source: string };

--- a/projects/client/src/lib/sections/settings/_internal/RawExport.svelte
+++ b/projects/client/src/lib/sections/settings/_internal/RawExport.svelte
@@ -33,6 +33,9 @@
     const startTime = Date.now();
     state.isExporting = true;
     state.endpointCount = 0;
+    state.statusText = "";
+    state.progress = "";
+    let failedCount = 0;
 
     record(AnalyticsEvent.ExportInitiated, {});
 
@@ -42,6 +45,15 @@
         switch (status.type) {
           case "complete":
             state.statusText = m.text_export_status_complete();
+            break;
+          case "partial":
+            failedCount = status.failed;
+            state.statusText = status.failed === 1
+              ? m.text_export_status_partial_one({ total: state.endpointCount })
+              : m.text_export_status_partial_other({
+                failed: status.failed,
+                total: state.endpointCount,
+              });
             break;
           case "zip":
             state.statusText = m.text_export_status_zipping();
@@ -60,7 +72,14 @@
         record(AnalyticsEvent.ExportCompleted, {
           duration: exportDuration,
           endpointCount: state.endpointCount,
+          failedCount,
         });
+
+        if (failedCount > 0) {
+          state.isExporting = false;
+          state.progress = "";
+          return;
+        }
 
         setTimeout(() => {
           state.isExporting = false;

--- a/projects/client/src/lib/sections/settings/export/fetchWithRetry.spec.ts
+++ b/projects/client/src/lib/sections/settings/export/fetchWithRetry.spec.ts
@@ -1,0 +1,95 @@
+import { server } from '$mocks/server.ts';
+import { delay, http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithRetry } from './fetchWithRetry.ts';
+
+const PATH = 'users/mega-collector/collection/movies';
+const ENDPOINT = `http://localhost/${PATH}`;
+
+const FAST = { timeout: 50, retryDelay: 5, maxTry: 2 };
+
+describe('fetchWithRetry', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('should return the payload and the page count', async () => {
+    server.use(
+      http.get(ENDPOINT, () =>
+        HttpResponse.json([{ type: 'movie' }], {
+          headers: {
+            'X-Pagination-Page': '3',
+            'X-Pagination-Page-Count': '58',
+          },
+        })),
+    );
+
+    const result = await fetchWithRetry({ url: PATH, page: 3 });
+
+    expect(result).to.deep.equal({
+      json: [{ type: 'movie' }],
+      paginationPageCount: 58,
+    });
+  });
+
+  it('should fall back to a single page when the page count is garbage', async () => {
+    server.use(
+      http.get(ENDPOINT, () =>
+        HttpResponse.json([], {
+          headers: { 'X-Pagination-Page-Count': 'not-a-number' },
+        })),
+    );
+
+    const result = await fetchWithRetry({ url: PATH });
+
+    expect(result.paginationPageCount).to.equal(1);
+  });
+
+  it('should abort a stalled response instead of hanging forever', async () => {
+    server.use(
+      http.get(ENDPOINT, async () => {
+        await delay('infinite');
+        return HttpResponse.json([]);
+      }),
+    );
+
+    const result = await fetchWithRetry({ url: PATH, ...FAST })
+      .catch((error: Error) => error);
+
+    expect((result as Error).name).to.equal('TimeoutError');
+  });
+
+  it('should not retry a permanently failing request', async () => {
+    let calls = 0;
+    server.use(
+      http.get(ENDPOINT, () => {
+        calls += 1;
+        return HttpResponse.json({}, { status: 404 });
+      }),
+    );
+
+    const result = await fetchWithRetry({ url: PATH, ...FAST })
+      .catch((error: Error) => error);
+
+    expect(calls).to.equal(1);
+    expect((result as Error).message).to.equal('HTTP 404');
+  });
+
+  it('should retry a failed request and recover', async () => {
+    let calls = 0;
+    server.use(
+      http.get(ENDPOINT, () => {
+        calls += 1;
+        if (calls === 1) {
+          return HttpResponse.json({}, { status: 500 });
+        }
+        return HttpResponse.json([{ type: 'movie' }]);
+      }),
+    );
+
+    const result = await fetchWithRetry({ url: PATH, ...FAST });
+
+    expect(calls).to.equal(2);
+    expect(result.json).to.deep.equal([{ type: 'movie' }]);
+  });
+});

--- a/projects/client/src/lib/sections/settings/export/fetchWithRetry.ts
+++ b/projects/client/src/lib/sections/settings/export/fetchWithRetry.ts
@@ -1,12 +1,41 @@
 import { rawApiFetch } from '$lib/requests/api.ts';
-import { retryAsync } from 'ts-retry';
+import { error } from '$lib/utils/console/print.ts';
+import { time } from '$lib/utils/timing/time.ts';
+import { isAbortError, retryAsync } from 'ts-retry';
 
-export function fetchWithRetry(
-  url: string,
+type FetchWithRetryParams = {
+  url: string;
+  page?: number;
+  timeout?: number;
+  retryDelay?: number;
+  maxTry?: number;
+};
+
+const REQUEST_TIMEOUT_STATUS = 408;
+
+class PermanentHttpError extends Error {
+  constructor(status: number) {
+    super(`HTTP ${status}`);
+    this.name = 'PermanentHttpError';
+  }
+}
+
+function toHttpError(status: number) {
+  const isTransient = status >= 500 || status === REQUEST_TIMEOUT_STATUS;
+
+  return isTransient
+    ? new Error(`HTTP ${status}`)
+    : new PermanentHttpError(status);
+}
+
+export function fetchWithRetry({
+  url,
   page = 1,
-): Promise<{
+  timeout = time.minutes(1),
+  retryDelay = time.seconds(10),
+  maxTry = 10,
+}: FetchWithRetryParams): Promise<{
   json: unknown;
-  paginationPage: number;
   paginationPageCount: number;
 }> {
   return retryAsync(
@@ -15,39 +44,41 @@ export function fetchWithRetry(
         ? `${url}&page=${page}&limit=250`
         : `${url}?page=${page}&limit=250`;
 
-      const response = await rawApiFetch({ path: `/${pageUrl}` });
+      const response = await rawApiFetch({
+        path: `/${pageUrl}`,
+        init: { signal: AbortSignal.timeout(timeout) },
+      });
 
       if (response.status === 429) {
         throw new Error('RateLimited');
       }
 
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
+        throw toHttpError(response.status);
       }
 
       const json = await response.json();
-      const headers = response.headers;
 
-      const paginationPage = parseInt(
-        headers.get('X-Pagination-Page') || '1',
-      );
-      const paginationPageCount = parseInt(
-        headers.get('X-Pagination-Page-Count') || '1',
+      const pageCount = Number.parseInt(
+        response.headers.get('X-Pagination-Page-Count') ?? '',
       );
 
-      return { json, paginationPage, paginationPageCount };
+      return { json, paginationPageCount: pageCount || 1 };
     },
     {
-      delay: 10000,
-      maxTry: 10,
+      delay: retryDelay,
+      maxTry,
       onError: (err) => {
-        if (err.message === 'RateLimited') {
-          // already updated status
-        } else {
-          console.error('Fetch failed, retrying...', err);
+        if (err instanceof PermanentHttpError) {
+          error('Fetch failed, giving up', err);
+          return false;
         }
+
+        error('Fetch failed, retrying...', err);
         return undefined;
       },
     },
-  );
+  ).catch((err: unknown) => {
+    throw isAbortError(err) ? err.getError() : err;
+  });
 }

--- a/projects/client/src/lib/sections/settings/export/processEndpoint.spec.ts
+++ b/projects/client/src/lib/sections/settings/export/processEndpoint.spec.ts
@@ -1,0 +1,76 @@
+import { server } from '$mocks/server.ts';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { processEndpoint } from './processEndpoint.ts';
+
+const PATH = 'users/mega-collector/collection/movies';
+const ENDPOINT = `http://localhost/${PATH}`;
+
+describe('processEndpoint', () => {
+  it('should walk every page and report the requested page', async () => {
+    server.use(
+      http.get(ENDPOINT, ({ request }) => {
+        const page = new URL(request.url).searchParams.get('page');
+        return HttpResponse.json([{ page }], {
+          headers: {
+            'X-Pagination-Page': String(page),
+            'X-Pagination-Page-Count': '3',
+          },
+        });
+      }),
+    );
+
+    const pages: Array<number> = [];
+    await processEndpoint(PATH, (_, { page }) => {
+      pages.push(page);
+    });
+
+    expect(pages).to.deep.equal([1, 2, 3]);
+  });
+
+  it('should terminate when the page header is echoed stale', async () => {
+    server.use(
+      http.get(ENDPOINT, () =>
+        HttpResponse.json([], {
+          headers: {
+            'X-Pagination-Page': '1',
+            'X-Pagination-Page-Count': '4',
+          },
+        })),
+    );
+
+    const pages: Array<number> = [];
+    await processEndpoint(PATH, (_, { page }) => {
+      pages.push(page);
+    });
+
+    expect(pages).to.deep.equal([1, 2, 3, 4]);
+  });
+
+  it('should stop after a single page when the page count is garbage', async () => {
+    server.use(
+      http.get(ENDPOINT, () =>
+        HttpResponse.json([], {
+          headers: { 'X-Pagination-Page-Count': 'not-a-number' },
+        })),
+    );
+
+    const pages: Array<number> = [];
+    await processEndpoint(PATH, (_, { page }) => {
+      pages.push(page);
+    });
+
+    expect(pages).to.deep.equal([1]);
+  });
+
+  it('should stop after a single page when there is nothing to paginate', async () => {
+    server.use(http.get(ENDPOINT, () => HttpResponse.json([])));
+
+    const pages: Array<number> = [];
+    await processEndpoint(PATH, (_, { page }) => {
+      pages.push(page);
+    });
+
+    expect(pages).to.deep.equal([1]);
+  });
+});

--- a/projects/client/src/lib/sections/settings/export/processEndpoint.ts
+++ b/projects/client/src/lib/sections/settings/export/processEndpoint.ts
@@ -1,5 +1,7 @@
 import { fetchWithRetry } from './fetchWithRetry.ts';
 
+const MAX_PAGES = 10_000;
+
 export type Pagination = {
   page: number;
   pageCount: number;
@@ -8,16 +10,21 @@ export type Pagination = {
 export async function processEndpoint(
   path: string,
   onPage: (data: unknown, pagination: Pagination) => Promise<void> | void,
-  page = 1,
-) {
-  const result = await fetchWithRetry(path, page);
+): Promise<void> {
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const result = await fetchWithRetry({ url: path, page });
 
-  await onPage(result.json, {
-    page: result.paginationPage,
-    pageCount: result.paginationPageCount,
-  });
+    await onPage(result.json, {
+      page,
+      pageCount: result.paginationPageCount,
+    });
 
-  if (result.paginationPage < result.paginationPageCount) {
-    await processEndpoint(path, onPage, page + 1);
+    if (page >= result.paginationPageCount) {
+      return;
+    }
   }
+
+  throw new Error(
+    `Pagination did not terminate for ${path} after ${MAX_PAGES} pages`,
+  );
 }

--- a/projects/client/src/lib/sections/settings/export/runRawExport.spec.ts
+++ b/projects/client/src/lib/sections/settings/export/runRawExport.spec.ts
@@ -1,0 +1,82 @@
+import { server } from '$mocks/server.ts';
+import { unzipSync } from 'fflate';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { downloadFile } from './downloadFile.ts';
+import { runRawExport } from './runRawExport.ts';
+
+vi.mock('./downloadFile.ts', () => ({ downloadFile: vi.fn() }));
+
+const SLUG = 'mega-collector';
+const FAILING_ENDPOINT = `http://localhost/users/${SLUG}/collection/shows`;
+
+async function exportFor(user = { slug: SLUG, isVip: false }) {
+  const statuses: Array<{ type: string; failed?: number }> = [];
+
+  await new Promise<void>((resolve, reject) => {
+    runRawExport({
+      user,
+      onStatus: (status) => statuses.push(status),
+      onProgress: () => {},
+      onComplete: resolve,
+      onError: reject,
+    });
+  });
+
+  const [blob] = vi.mocked(downloadFile).mock.calls.at(-1) ?? [];
+  const bytes = new Uint8Array(await (blob as Blob).arrayBuffer());
+
+  return { statuses, files: unzipSync(bytes) };
+}
+
+describe('runRawExport', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(downloadFile).mockClear();
+
+    server.use(
+      http.get(FAILING_ENDPOINT, () => HttpResponse.json({}, { status: 404 })),
+      http.get('http://localhost/*', () => HttpResponse.json([])),
+    );
+  });
+
+  it('should keep exporting the remaining endpoints when one fails', async () => {
+    const { files } = await exportFor();
+
+    expect(files['collection-shows.json']).to.equal(undefined);
+    expect(files['collection-movies.json']).to.not.equal(undefined);
+    expect(files['user-profile.json']).to.not.equal(undefined);
+  });
+
+  it('should report a partial export instead of a plain success', async () => {
+    const { statuses } = await exportFor();
+
+    expect(statuses.at(-1)).to.deep.equal({ type: 'partial', failed: 1 });
+  });
+
+  it('should describe every failure in _errors.json', async () => {
+    const { files } = await exportFor();
+
+    const errors = JSON.parse(
+      new TextDecoder().decode(files['_errors.json']),
+    );
+
+    expect(errors).to.deep.equal([
+      {
+        endpoint: `users/${SLUG}/collection/shows?extended=metadata,gdpr`,
+        error: 'HTTP 404',
+        fetchedPages: 0,
+        totalPages: 0,
+      },
+    ]);
+  });
+
+  it('should report a plain success when nothing fails', async () => {
+    server.use(http.get('http://localhost/*', () => HttpResponse.json([])));
+
+    const { statuses, files } = await exportFor();
+
+    expect(statuses.at(-1)).to.deep.equal({ type: 'complete' });
+    expect(files['_errors.json']).to.equal(undefined);
+  });
+});

--- a/projects/client/src/lib/sections/settings/export/runRawExport.ts
+++ b/projects/client/src/lib/sections/settings/export/runRawExport.ts
@@ -1,7 +1,10 @@
 import { error } from '$lib/utils/console/print.ts';
+import { time } from '$lib/utils/timing/time.ts';
 import { strToU8, zip, type Zippable } from 'fflate';
 import { downloadFile } from './downloadFile.ts';
-import { processEndpoint } from './processEndpoint.ts';
+import { type Pagination, processEndpoint } from './processEndpoint.ts';
+
+const FETCH_TIME_BUDGET = time.hours(2);
 
 type UserLike = {
   slug: string;
@@ -15,9 +18,17 @@ interface TraktList {
   };
 }
 
+type ExportFailure = {
+  endpoint: string;
+  error: string;
+  fetchedPages: number;
+  totalPages: number;
+};
+
 type ExportStatus =
   | { type: 'fetch'; item: string }
   | { type: 'zip' }
+  | { type: 'partial'; failed: number }
   | { type: 'complete' };
 
 interface ExportOptions {
@@ -167,11 +178,54 @@ export async function runRawExport({
     { path: `users/${slug}/lists`, file: 'lists-lists' },
   ];
 
+  const failures: Array<ExportFailure> = [];
+
+  const fetchDeadline = Date.now() + FETCH_TIME_BUDGET;
+  const assertWithinBudget = () => {
+    if (Date.now() < fetchDeadline) {
+      return;
+    }
+
+    throw new Error(
+      `Export exceeded its ${
+        FETCH_TIME_BUDGET / time.minutes(1)
+      } minute fetch budget`,
+    );
+  };
+
+  const collectEndpoint = async (
+    path: string,
+    onPage: (data: unknown, pagination: Pagination) => void,
+  ) => {
+    const progress = { fetchedPages: 0, totalPages: 0 };
+
+    try {
+      assertWithinBudget();
+
+      await processEndpoint(path, (data, pagination) => {
+        progress.fetchedPages = pagination.page;
+        progress.totalPages = pagination.pageCount;
+        onPage(data, pagination);
+
+        if (pagination.page < pagination.pageCount) {
+          assertWithinBudget();
+        }
+      });
+    } catch (e) {
+      error(`Export failed for ${path}`, e);
+      failures.push({
+        endpoint: path,
+        error: e instanceof Error ? e.message : String(e),
+        ...progress,
+      });
+    }
+  };
+
   try {
     // Fetch dynamic list endpoints
     onStatus({ type: 'fetch', item: 'lists' });
 
-    await processEndpoint(`users/${slug}/lists`, (data) => {
+    await collectEndpoint(`users/${slug}/lists`, (data) => {
       const lists = data as TraktList[];
       for (const list of lists) {
         endpoints.push({
@@ -187,11 +241,19 @@ export async function runRawExport({
       onProgress(`(${count}/${endpoints.length})`);
       onStatus({ type: 'fetch', item: endpoint.file });
 
-      await processEndpoint(endpoint.path, (data, { page, pageCount }) => {
-        const suffix = page > 1 || pageCount > 1 ? `-${page}` : '';
+      await collectEndpoint(endpoint.path, (data, { page, pageCount }) => {
+        const isPaginated = page > 1 || pageCount > 1;
+        if (isPaginated) {
+          onProgress(`(${count}/${endpoints.length} · ${page})`);
+        }
+        const suffix = isPaginated ? `-${page}` : '';
         const filename = `${endpoint.file}${suffix}.json`;
-        files[filename] = strToU8(JSON.stringify(data, null, 2));
+        files[filename] = strToU8(JSON.stringify(data));
       });
+    }
+
+    if (failures.length > 0) {
+      files['_errors.json'] = strToU8(JSON.stringify(failures));
     }
 
     onStatus({ type: 'zip' });
@@ -206,7 +268,11 @@ export async function runRawExport({
       });
 
       downloadFile(blob, `trakt-export-${slug}.zip`);
-      onStatus({ type: 'complete' });
+      onStatus(
+        failures.length > 0
+          ? { type: 'partial', failed: failures.length }
+          : { type: 'complete' },
+      );
       onComplete();
     });
   } catch (e) {


### PR DESCRIPTION
## Scene Setting: A Clear Description

A member reported the raw export hanging forever on the collection step - no error, still spinning after running overnight. Their account turned out to be a mega collection: **~484k collected items** (~56k movies, 14.5k shows, ~428k episodes), which means the export's collection section alone is **~2,000 sequential paginated requests**.

Three problems compounded:

1. **No timeout anywhere in the export fetch chain.** Browser `fetch` has no default response timeout, so one stalled response stream out of those 2,000 leaves `await response.json()` waiting forever. Nothing throws, so the retry loop never fires and no error ever surfaces. This is the silent hang.
2. **Every page was retained pretty-printed** (`JSON.stringify(data, null, 2)`) as a `Uint8Array` until the final in-memory zip. Measured on the reporter's real pages: 1.5-2x inflation, ~514MB retained for the collection section.
3. **No page-level progress.** The status text sits on the same endpoint name for 30+ minutes on a big account, indistinguishable from a hang.

The fix, in order: each fetch attempt now aborts via `AbortSignal.timeout(1min)` and feeds the existing ts-retry loop (10 tries, 10s delay) - a stall now ends in a visible "Export failed" instead of an infinite spin; pages are stored compact (**514MB → 332MB retained, -35%**, measured on the same account); and paginated endpoints show the current page number in the progress text. Page *totals* are deliberately not shown - the collection page-count header reports the combined collection size, not the per-type count.

Not addressed here (workers-side, will file separately): intermittent 500s on `collection/shows` for mega collectors, and the combined item-count pagination headers.

## Show, Don't Tell: Screenshots and Videos

Text-only UI change - progress now reads `(44/50 · 412)` (endpoint counter · current page) instead of `(44/50)`.

## Testing: The Dress Rehearsal

- **`fetchWithRetry.spec.ts`** (new): happy path parses payload + pagination headers; a stalled response (MSW `delay('infinite')`) rejects instead of hanging; a 500 retries and recovers. Retry knobs are injectable with production defaults so the failure paths run in milliseconds.
- **Negative control:** with the timeout neutered, the stalled-response test hangs until vitest kills it at 5s - the spec genuinely catches the regression.
- **Full-scale replay against production:** re-ran the collection section for the affected account (public data, read-only) through this exact logic - pagination termination, retry policy, 60s timeout, compact stringify, fflate zip. Results: **1,998 requests, 34.8min wall, 0 retries needed (0 timeouts / 0 429s / 0 5xx this run), 332MB fetched, 1,998 files zipped to 34MB, and the pagination loop terminated exactly where the data ends.** The 30+ min fetch phase at zero failures is also why the page-progress change matters - that's the window that previously looked like a hang.
- Full export dir suite: 11/11 passing; `deno fmt` clean.