### PR TITLE
fix(navigation): treat a lapsed access token as a signed in session

### DIFF
--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -11,7 +11,7 @@ import { handle as handleLegacyRedirect } from '$lib/features/legacy-redirects/h
 import { handle as handleMobileOperatingSystem } from '$lib/features/mobile-os/handle.ts';
 import { handle as handleSearchConfig } from '$lib/features/search/handle.ts';
 import { handle as handleTheme } from '$lib/features/theme/handle.ts';
-import { isAuthorizedToken } from '$lib/features/auth/isAuthorizedToken.ts';
+import { hasAuthSession } from '$lib/features/auth/hasAuthSession.ts';
 import { isBotAgent } from '$lib/utils/devices/isBotAgent.ts';
 
 import { SENTRY_DSN } from '$lib/utils/constants.ts';
@@ -89,7 +89,7 @@ export const handleCacheControl: Handle = async ({ event, resolve }) => {
     // Only cache publicly for unauthenticated requests to prevent cache poisoning via spoofed User-Agent
     if (
       isBotAgent(event.request.headers.get('user-agent')) &&
-      !isAuthorizedToken(event.locals.oidcAuth)
+      !hasAuthSession(event.locals.oidcAuth)
     ) {
       // 120 seconds is enough to satisfy Discord without heavily caching stale content
       return 'public, max-age=120, s-maxage=120';

--- a/projects/client/src/lib/features/auth/components/AuthProvider.svelte
+++ b/projects/client/src/lib/features/auth/components/AuthProvider.svelte
@@ -9,12 +9,14 @@
   type AuthProviderProps = {
     isAuthorized: boolean;
     accessToken: string | null;
+    hasServerSession: boolean;
   } & ChildrenProps;
 
   const {
     children,
     isAuthorized: isAuthorizedOidc,
     accessToken,
+    hasServerSession,
   }: AuthProviderProps = $props();
 
   // The SSR flag describes the document, not the viewer: a cache-replayed
@@ -46,6 +48,7 @@
     initializeUserManager({
       ctx,
       tokenFromServer: accessToken,
+      hasServerSession,
       // Only skip the gate for a session we actually found. Ungating an
       // unauthorized tree renders children in this same cycle, and their
       // `onMount` runs before ours - so `/callback` would reach for

--- a/projects/client/src/lib/features/auth/hasAuthSession.spec.ts
+++ b/projects/client/src/lib/features/auth/hasAuthSession.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { hasAuthSession } from './hasAuthSession.ts';
+
+describe('util: hasAuthSession', () => {
+  it('should return false when there is no cookie', () => {
+    expect(hasAuthSession(null)).toBe(false);
+    expect(hasAuthSession(undefined)).toBe(false);
+  });
+
+  it('should return false when the cookie carries no token', () => {
+    expect(hasAuthSession({ token: null, expiresAt: 1 })).toBe(false);
+  });
+
+  it('should return true regardless of expiry', () => {
+    expect(hasAuthSession({ token: 'token', expiresAt: null })).toBe(true);
+    expect(hasAuthSession({ token: 'token', expiresAt: 0 })).toBe(true);
+  });
+});

--- a/projects/client/src/lib/features/auth/hasAuthSession.ts
+++ b/projects/client/src/lib/features/auth/hasAuthSession.ts
@@ -1,0 +1,7 @@
+import type { OidcAuthToken } from './models/OidcAuthToken.ts';
+
+export function hasAuthSession(
+  auth: Nil | OidcAuthToken,
+): auth is OidcAuthToken & { token: string } {
+  return Boolean(auth?.token);
+}

--- a/projects/client/src/lib/features/auth/redirectForAudience.spec.ts
+++ b/projects/client/src/lib/features/auth/redirectForAudience.spec.ts
@@ -2,8 +2,8 @@ import { isRedirect } from '@sveltejs/kit';
 import { describe, expect, it } from 'vitest';
 import { redirectForAudience } from './redirectForAudience.ts';
 
-const AUTHORIZED = { token: 'token', expiresAt: Date.now() + 60_000 };
-const EXPIRED = { token: 'token', expiresAt: Date.now() - 60_000 };
+const FRESH_SESSION = { token: 'token', expiresAt: 2_000_000 };
+const LAPSED_SESSION = { token: 'token', expiresAt: 1_000_000 };
 
 const captureRedirect = (params: Parameters<typeof redirectForAudience>[0]) => {
   try {
@@ -31,15 +31,15 @@ describe('util: redirectForAudience', () => {
       ).toEqual({ status: 307, location: '/' });
     });
 
-    it('should treat an expired token as unauthorized', () => {
+    it('should keep a viewer whose access token has lapsed', () => {
       expect(
         captureRedirect({
           audience: 'authenticated',
-          oidcAuth: EXPIRED,
+          oidcAuth: LAPSED_SESSION,
           search: '',
           isDataRequest: false,
         }),
-      ).toEqual({ status: 307, location: '/' });
+      ).toBeNull();
     });
 
     it('should preserve the query string', () => {
@@ -57,7 +57,7 @@ describe('util: redirectForAudience', () => {
       expect(
         captureRedirect({
           audience: 'authenticated',
-          oidcAuth: AUTHORIZED,
+          oidcAuth: FRESH_SESSION,
           search: '',
           isDataRequest: false,
         }),
@@ -70,7 +70,7 @@ describe('util: redirectForAudience', () => {
       expect(
         captureRedirect({
           audience: 'public',
-          oidcAuth: AUTHORIZED,
+          oidcAuth: FRESH_SESSION,
           search: '',
           isDataRequest: false,
         }),
@@ -81,7 +81,7 @@ describe('util: redirectForAudience', () => {
       expect(
         captureRedirect({
           audience: 'public',
-          oidcAuth: AUTHORIZED,
+          oidcAuth: FRESH_SESSION,
           search: '?utm_source=newsletter',
           isDataRequest: false,
         }),
@@ -99,11 +99,22 @@ describe('util: redirectForAudience', () => {
       ).toBeNull();
     });
 
-    it('should let a viewer with an expired token through', () => {
+    it('should send a viewer whose access token has lapsed to the dashboard', () => {
       expect(
         captureRedirect({
           audience: 'public',
-          oidcAuth: EXPIRED,
+          oidcAuth: LAPSED_SESSION,
+          search: '',
+          isDataRequest: false,
+        }),
+      ).toEqual({ status: 307, location: '/home' });
+    });
+
+    it('should let a viewer with no token through', () => {
+      expect(
+        captureRedirect({
+          audience: 'public',
+          oidcAuth: { token: null, expiresAt: null },
           search: '',
           isDataRequest: false,
         }),
@@ -127,7 +138,7 @@ describe('util: redirectForAudience', () => {
       expect(
         captureRedirect({
           audience: 'public',
-          oidcAuth: AUTHORIZED,
+          oidcAuth: FRESH_SESSION,
           search: '',
           isDataRequest: true,
         }),

--- a/projects/client/src/lib/features/auth/redirectForAudience.ts
+++ b/projects/client/src/lib/features/auth/redirectForAudience.ts
@@ -1,6 +1,6 @@
 import { UrlBuilder } from '$lib/utils/url/UrlBuilder.ts';
 import { redirect } from '@sveltejs/kit';
-import { isAuthorizedToken } from './isAuthorizedToken.ts';
+import { hasAuthSession } from './hasAuthSession.ts';
 import type { OidcAuthToken } from './models/OidcAuthToken.ts';
 
 type RedirectForAudienceParams = {
@@ -17,13 +17,15 @@ export function redirectForAudience(
     return;
   }
 
-  const isAuthorized = isAuthorizedToken(oidcAuth);
+  // The cookie carries the access token's expiry, which lapses between visits,
+  // so routing keys off session presence rather than validity.
+  const hasSession = hasAuthSession(oidcAuth);
 
-  if (audience === 'authenticated' && !isAuthorized) {
+  if (audience === 'authenticated' && !hasSession) {
     return redirect(307, `${UrlBuilder.landing()}${search}`);
   }
 
-  if (audience === 'public' && isAuthorized) {
+  if (audience === 'public' && hasSession) {
     return redirect(307, `${UrlBuilder.home()}${search}`);
   }
 }

--- a/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
+++ b/projects/client/src/lib/features/auth/stores/initializeUserManager.ts
@@ -20,12 +20,19 @@ import { setUserManager } from './userManager.ts';
 type InitializeUserManagerParams = {
   ctx: AuthContextType;
   tokenFromServer?: string | null;
+  /** Whether a session cookie reached the server, valid or lapsed. */
+  hasServerSession?: boolean;
   /** Skip the `manager.getUser()` gate when the caller already seeded `ctx`. */
   isResolved?: boolean;
 };
 
 export function initializeUserManager(
-  { ctx, tokenFromServer, isResolved = false }: InitializeUserManagerParams,
+  {
+    ctx,
+    tokenFromServer,
+    hasServerSession = false,
+    isResolved = false,
+  }: InitializeUserManagerParams,
 ) {
   if (!browser) {
     return {
@@ -113,7 +120,9 @@ export function initializeUserManager(
       }
 
       if (!user) {
-        if (tokenFromServer) {
+        // A cookie the client cannot back with a session keeps the server
+        // routing this viewer as signed in, and nothing else clears it.
+        if (hasServerSession) {
           handleUserEvent(null);
           return;
         }

--- a/projects/client/src/routes/+layout.server.ts
+++ b/projects/client/src/routes/+layout.server.ts
@@ -1,3 +1,4 @@
+import { hasAuthSession } from '$lib/features/auth/hasAuthSession.ts';
 import { isAuthorizedToken } from '$lib/features/auth/isAuthorizedToken.ts';
 import type { OidcAuthToken } from '$lib/features/auth/models/OidcAuthToken.ts';
 import { getDeviceType } from '$lib/utils/devices/getDeviceType.ts';
@@ -5,11 +6,16 @@ import { isBotAgent } from '$lib/utils/devices/isBotAgent.ts';
 import type { LayoutServerLoad } from '$types/$types.d.ts';
 
 const getAuth = (auth: Nil | OidcAuthToken) => {
+  // Presence and validity are separate: routing keys off the former, but a
+  // cookie whose token has lapsed must not seed the client with a dead token.
+  const hasSession = hasAuthSession(auth);
+
   if (!isAuthorizedToken(auth)) {
     return {
       token: null,
       expiresAt: null,
       isAuthorized: false,
+      hasSession,
     };
   }
 
@@ -17,6 +23,7 @@ const getAuth = (auth: Nil | OidcAuthToken) => {
     token: auth.token,
     expiresAt: auth.expiresAt,
     isAuthorized: true,
+    hasSession,
   };
 };
 

--- a/projects/client/src/routes/+layout.svelte
+++ b/projects/client/src/routes/+layout.svelte
@@ -152,6 +152,7 @@
         <AuthProvider
           isAuthorized={data.oidcAuth.isAuthorized}
           accessToken={data.oidcAuth.token}
+          hasServerSession={data.oidcAuth.hasSession}
         >
           <SearchShortcut />
           <WSInvalidator />

--- a/projects/client/test/beds/_internal/TestProvider.svelte
+++ b/projects/client/test/beds/_internal/TestProvider.svelte
@@ -19,6 +19,7 @@
   <AuthProvider
     isAuthorized={$isAuthorized}
     accessToken={OidcUserMock.access_token}
+    hasServerSession={$isAuthorized}
   >
     <FeatureFlagProvider>
       <ToastProvider>


### PR DESCRIPTION
## 🎶 Notes 🎶

- Follow up on #3124. The landing page still flashed on prod before redirecting to `/home`, and sometimes it didn't redirect at all until a refresh.
- Cause: the audience guard checked the cookie's expiry, but the cookie carries the **access token's** expiry and those lapse constantly (hence `automaticSilentRenew` and the focus time renew). A returning viewer had a present but expired cookie, so the server called them unauthorized and served the landing page. Only then did the client renew, post a fresh token and redirect.
  - Verified on prod: unexpired cookie 307s, expired cookie gets a 200 with the landing page.
  - Also explains the "needs a refresh" part. The renewed cookie from load 1 is what makes load 2 redirect properly, so it looked intermittent.
- Fix: routing keys off session presence instead, via a `hasAuthSession` helper that sits next to the existing `isAuthorizedToken`. Expiry still applies where token validity actually matters, so `+layout.server.ts` won't hand out an expired token, and the bot cache branch still refuses to publicly cache an authorized response.
- The client now clears a cookie it cannot back with a session. Otherwise a cookie with no matching OIDC session keeps the server routing that viewer as signed in, and nothing else clears it.
- Confirmed against a preview build with crafted cookies: fresh session at `/` 307s to `/home`, a **lapsed** one now does too (it used to serve the landing page at 200), a token-less one still gets the landing page, and `/home` with a lapsed cookie renders the dashboard without bouncing. Covered by spec too.

### Considered and dropped

- Also tried flipping the routes, dashboard at `/` and landing at `/landing`, to skip the redirect for signed-in viewers. Dropped it: Google currently indexes the apex as `app.trakt.tv` with the landing copy, and the flip moved that to `app.trakt.tv/landing`. Not worth it for one edge-local hop. Kept on `backup/flip-approach-b` locally.
- The end state that gets both is one route at `/` serving both bodies with no redirect at all, which is roughly how it worked before #3124. That needs SSR's `isAuthorized` to be presence-based too, and that flag gates every `RenderFor audience` and every authorized query, so it wants its own PR and a signed-in smoke test. Will follow up.

Not fixed here, worth its own issue: `FilterProvider` fires a `goto` on first load when the URL has no `mode`, and that aborts a client-side `<Redirect>` mounted in the same cycle. That's what turned the missing server redirect into "stuck on `/`". `/` and `/home` are both resolved server-side so they're safe, but every other `audience="authenticated"` page still leans on the client guard alone and renders blank if it loses the race. Same race the comment in `users/[user]/library/+page.ts` warns about.
