### PR TITLE
fix(auth): never publicly cache the session dependent root

### DIFF
--- a/projects/client/src/hooks.server.ts
+++ b/projects/client/src/hooks.server.ts
@@ -3,6 +3,7 @@ import { handle as handleAssetFallback } from '$lib/features/asset-fallback/hand
 import { handle as handleAuth } from '$lib/features/auth/handle.ts';
 import { handle as handleBotVerification } from '$lib/features/bot-verification/handle.ts';
 import { handle as handleCacheBust } from '$lib/features/cache-bust/handle.ts';
+import { resolveCacheControl } from '$lib/features/cache-control/resolveCacheControl.ts';
 import { handle as handleDeployment } from '$lib/features/deployment/handle.ts';
 import { handle as handleDevice } from '$lib/features/devices/handle.ts';
 import { handle as handleLocale } from '$lib/features/i18n/handle.ts';
@@ -30,8 +31,6 @@ const WHITELISTED_HEADERS = new Set([
   'x-pagination-page',
   'x-pagination-page-count',
 ]);
-
-const NO_STORE = 'private, no-store, no-cache, must-revalidate';
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
@@ -68,38 +67,15 @@ export const handleCacheControl: Handle = async ({ event, resolve }) => {
     return response;
   }
 
-  function toCacheControl() {
-    if (isRedirect) {
-      return NO_STORE;
-    }
-
-    // A WebView request carries the viewer's VIP token in the URL. Never let a
-    // spoofed bot User-Agent promote the response to a public CDN entry (keyed
-    // by the token), which would cache one viewer's review for others.
-    if (hasWebviewParam(event.url)) {
-      return NO_STORE;
-    }
-
-    // Verified search engine crawlers (via Cloudflare), full CDN caching for SEO
-    if (event.locals.isLegitimateBot) {
-      return 'public, max-age=3600, s-maxage=3600';
-    }
-
-    // Social bots (Discord, Slack, etc.), allow a short cache so strict crawlers (Discord) will render embeds
-    // Only cache publicly for unauthenticated requests to prevent cache poisoning via spoofed User-Agent
-    if (
-      isBotAgent(event.request.headers.get('user-agent')) &&
-      !hasAuthSession(event.locals.oidcAuth)
-    ) {
-      // 120 seconds is enough to satisfy Discord without heavily caching stale content
-      return 'public, max-age=120, s-maxage=120';
-    }
-
-    return NO_STORE;
-  }
-
   const clonedHeaders = new Headers(response.headers);
-  const cacheControl = toCacheControl();
+  const cacheControl = resolveCacheControl({
+    pathname: event.url.pathname,
+    isRedirect,
+    hasWebviewParam: hasWebviewParam(event.url),
+    isLegitimateBot: event.locals.isLegitimateBot,
+    isSocialBot: isBotAgent(event.request.headers.get('user-agent')),
+    hasSession: hasAuthSession(event.locals.oidcAuth),
+  });
   clonedHeaders.set('Cache-Control', cacheControl);
 
   return new Response(response.body, {

--- a/projects/client/src/lib/features/cache-control/resolveCacheControl.spec.ts
+++ b/projects/client/src/lib/features/cache-control/resolveCacheControl.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCacheControl } from './resolveCacheControl.ts';
+
+const NO_STORE = 'private, no-store, no-cache, must-revalidate';
+
+const resolve = (
+  overrides: Partial<Parameters<typeof resolveCacheControl>[0]>,
+) =>
+  resolveCacheControl({
+    pathname: '/movies',
+    isRedirect: false,
+    hasWebviewParam: false,
+    isLegitimateBot: false,
+    isSocialBot: false,
+    hasSession: false,
+    ...overrides,
+  });
+
+describe('util: resolveCacheControl', () => {
+  describe('for a session dependent path', () => {
+    it('should never publicly cache / for a social bot', () => {
+      expect(resolve({ pathname: '/', isSocialBot: true })).toBe(NO_STORE);
+    });
+
+    it('should never publicly cache / for a verified crawler', () => {
+      expect(resolve({ pathname: '/', isLegitimateBot: true })).toBe(NO_STORE);
+    });
+  });
+
+  describe('for a public path', () => {
+    it('should keep the short public cache for social bots', () => {
+      expect(resolve({ isSocialBot: true }))
+        .toBe('public, max-age=120, s-maxage=120');
+    });
+
+    it('should keep the long public cache for verified crawlers', () => {
+      expect(resolve({ isLegitimateBot: true }))
+        .toBe('public, max-age=3600, s-maxage=3600');
+    });
+
+    it('should not publicly cache a social bot request with a session', () => {
+      expect(resolve({ isSocialBot: true, hasSession: true })).toBe(NO_STORE);
+    });
+  });
+
+  it('should never store a redirect', () => {
+    expect(resolve({ isRedirect: true, isLegitimateBot: true })).toBe(NO_STORE);
+  });
+
+  it('should never store a webview response', () => {
+    expect(resolve({ hasWebviewParam: true, isLegitimateBot: true }))
+      .toBe(NO_STORE);
+  });
+
+  it('should not store a regular browser response', () => {
+    expect(resolve({})).toBe(NO_STORE);
+  });
+});

--- a/projects/client/src/lib/features/cache-control/resolveCacheControl.ts
+++ b/projects/client/src/lib/features/cache-control/resolveCacheControl.ts
@@ -1,0 +1,53 @@
+const NO_STORE = 'private, no-store, no-cache, must-revalidate';
+
+const SESSION_DEPENDENT_PATHS = new Set(['/']);
+
+type ResolveCacheControlParams = {
+  pathname: string;
+  isRedirect: boolean;
+  hasWebviewParam: boolean;
+  isLegitimateBot: boolean;
+  isSocialBot: boolean;
+  hasSession: boolean;
+};
+
+export function resolveCacheControl({
+  pathname,
+  isRedirect,
+  hasWebviewParam,
+  isLegitimateBot,
+  isSocialBot,
+  hasSession,
+}: ResolveCacheControlParams): string {
+  if (isRedirect) {
+    return NO_STORE;
+  }
+
+  // A WebView request carries the viewer's VIP token in the URL. Never let a
+  // spoofed bot User-Agent promote the response to a public CDN entry (keyed
+  // by the token), which would cache one viewer's review for others.
+  if (hasWebviewParam) {
+    return NO_STORE;
+  }
+
+  // The response body depends on the session, and no `Vary` keys the shared
+  // cache on it. A public entry would be replayed to the wrong audience.
+  if (SESSION_DEPENDENT_PATHS.has(pathname)) {
+    return NO_STORE;
+  }
+
+  // Verified search engine crawlers (via Cloudflare), full CDN caching for SEO
+  if (isLegitimateBot) {
+    return 'public, max-age=3600, s-maxage=3600';
+  }
+
+  // Social bots (Discord, Slack, etc.), allow a short cache so strict crawlers
+  // (Discord) will render embeds. Only cache publicly for unauthenticated
+  // requests to prevent cache poisoning via spoofed User-Agent.
+  if (isSocialBot && !hasSession) {
+    // 120 seconds is enough to satisfy Discord without heavily caching stale content
+    return 'public, max-age=120, s-maxage=120';
+  }
+
+  return NO_STORE;
+}


### PR DESCRIPTION
## 🎶 Notes 🎶

- Signed-in viewers sometimes got a blank page at `/`, parked on `/?mode=media`. This is the second of the two causes behind that; #3130 fixed the other one.
- Cause: a social bot hitting `/` without a cookie got `public, max-age=120, s-maxage=120`, and the only `Vary` is `accept-encoding`. Cloudflare then replayed that signed-out landing page to **every** request for `/`, signed-in ones included, and rewrote the browser TTL to 24 hours.
  - Reproducible in two requests: Discordbot UA on `/?probe=x` gets the public cache-control, then the same URL with a valid session cookie comes back `cf-cache-status: HIT` with the bot's landing page.
  - Why it goes blank rather than just wrong: `/` is `audience="public"`, so `RenderFor` renders nothing for a viewer the client considers signed in, and the corrective client redirect loses the race against the `goto` FilterProvider fires on first load.
  - Also explains the intermittency and why a refresh doesn't help but "disable cache" does.
- Fix: never publicly cache `/`.
  - Covers **both** bot branches. The verified-crawler one was worse, an hour instead of two minutes.
  - `/` is the only route this can reach. Every other session-dependent page is `audience="authenticated"`, so a bot gets a redirect, and redirects are already never stored.
  - Keyed on the path, not on the audience guard. If we later collapse `/` back into a single route serving both bodies, it can't silently reopen.
- Pulled the decision out into `resolveCacheControl` so it's actually covered. `hooks.server.ts` can't be imported under vitest at all, `@sentry/sveltekit` pulls in `$app` and fails to resolve, which is how this shipped untested in the first place.
- Verified against a preview build: `/` returns `no-store` for Discordbot, Googlebot, and with a session cookie. `/about` and `/discover` still get `public, max-age=120`, so embeds keep working.
- ⚠️ Browsers that already hold a poisoned copy keep it for up to 24h from when they got it. Bounded and self-draining, a hard reload clears it, and no new poisoning happens after this deploys. The edge drains within 120s.

Two follow-ups, both worth doing properly rather than patching here:

- `FilterProvider`'s first-load `goto` still aborts a client-side `<Redirect>` in the same cycle, which is what turns a stale document into a blank page instead of a self-correcting redirect. Right fix is awaiting `navigating.complete` before restoring filters, so it defers instead of clobbering. Small, but it runs in the root layout on every page load and needs a signed-in session to verify. Affects all 27 `audience="authenticated"` pages, not just this one.
- `/vip` and `/search` are `audience="authenticated"` with no load guard, so they hand a signed-out crawler an empty body, and that empty body is publicly cached for 120s. Both are in the sitemap. Same class, milder symptom. Probably wants those pages viewable signed out rather than a denylist entry, so it needs a product call first.
